### PR TITLE
Add dashboard and settings update flow

### DIFF
--- a/bin/jarvis.ts
+++ b/bin/jarvis.ts
@@ -17,16 +17,12 @@ import { readFileSync, existsSync, openSync } from 'node:fs';
 import { spawn } from 'node:child_process';
 import { acquireLock, releaseLock, isLocked, getLogPath } from '../src/daemon/pid.ts';
 import { c } from '../src/cli/helpers.ts';
+import { getJarvisVersion, runJarvisUpdate } from '../src/cli/update.ts';
 
 const PACKAGE_ROOT = join(import.meta.dir, '..');
 
 function getVersion(): string {
-  try {
-    const pkg = JSON.parse(readFileSync(join(PACKAGE_ROOT, 'package.json'), 'utf-8'));
-    return pkg.version || '0.0.0';
-  } catch {
-    return '0.0.0';
-  }
+  return getJarvisVersion();
 }
 
 function printHelp(): void {
@@ -267,79 +263,13 @@ function cmdLogs(args: string[]): void {
 }
 
 async function cmdUpdate(): Promise<void> {
-  console.log(c.cyan('Checking for updates...\n'));
-
-  // Get current version
-  const currentVersion = getVersion();
-  console.log(`  Current version: ${c.bold(currentVersion)}`);
-
-  // Check if daemon is running (we'll restart it after update)
-  const wasRunning = isLocked();
-
-  // Stop daemon if running
-  if (wasRunning) {
-    console.log(c.dim('  Stopping daemon before update...'));
-    try {
-      process.kill(wasRunning, 'SIGTERM');
-      releaseLock();
-      await new Promise(resolve => setTimeout(resolve, 1000));
-    } catch {
-      releaseLock();
-    }
-  }
-
-  // Update via git pull + bun install (not npm — package is not published)
-  console.log('');
-  const gitPull = Bun.spawnSync(['git', 'pull', '--ff-only'], {
-    cwd: PACKAGE_ROOT,
-    stdio: ['ignore', 'pipe', 'pipe'],
-    env: { ...process.env },
-  });
-
-  if (gitPull.exitCode !== 0) {
-    const stderr = gitPull.stderr.toString();
-    // If not a git repo, try the install dir
-    const installDir = join(require('node:os').homedir(), '.jarvis', 'daemon');
-    const gitPull2 = Bun.spawnSync(['git', 'pull', '--ff-only'], {
-      cwd: installDir,
-      stdio: ['ignore', 'pipe', 'pipe'],
-      env: { ...process.env },
-    });
-
-    if (gitPull2.exitCode !== 0) {
-      console.log(c.red('✗ Update failed (git pull):'));
-      console.log(c.dim(`  ${gitPull2.stderr.toString().trim() || stderr.trim()}`));
-      if (wasRunning) {
-        console.log(c.dim('\n  Restarting daemon...'));
-        await cmdStart(['--no-open']);
-      }
-      process.exit(1);
-    }
-  }
-
-  // Reinstall dependencies
-  const bunInstall = Bun.spawnSync(['bun', 'install'], {
-    cwd: PACKAGE_ROOT,
-    stdio: ['ignore', 'pipe', 'pipe'],
-    env: { ...process.env },
-  });
-
-  if (bunInstall.exitCode !== 0) {
-    console.log(c.yellow('! Dependencies may need manual refresh: bun install'));
-  }
-
-  // Get new version
-  const newVersion = getVersion();
-  if (newVersion === currentVersion) {
-    console.log(c.green(`✓ Already on the latest version (${currentVersion})`));
-  } else {
-    console.log(c.green(`✓ Updated: ${currentVersion} → ${newVersion}`));
-  }
-
-  // Restart daemon if it was running
-  if (wasRunning) {
-    console.log(c.dim('\nRestarting daemon...'));
-    await cmdStart(['--no-open']);
+  try {
+    await runJarvisUpdate();
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.log(c.red('✗ Update failed:'));
+    console.log(c.dim(`  ${message}`));
+    process.exit(1);
   }
 }
 

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -1,0 +1,139 @@
+import { join } from 'node:path';
+import { readFileSync, existsSync, openSync } from 'node:fs';
+import { spawn } from 'node:child_process';
+import { isLocked, releaseLock, getLogPath } from '../daemon/pid.ts';
+import { c } from './helpers.ts';
+import { setSetting } from '../vault/settings.ts';
+
+const PACKAGE_ROOT = join(import.meta.dir, '..', '..');
+
+export function getJarvisVersion(): string {
+  try {
+    const pkg = JSON.parse(readFileSync(join(PACKAGE_ROOT, 'package.json'), 'utf-8'));
+    return pkg.version || '0.0.0';
+  } catch {
+    return '0.0.0';
+  }
+}
+
+export type JarvisUpdateResult = {
+  previousVersion: string;
+  currentVersion: string;
+  changed: boolean;
+};
+
+function writeUpdateState(status: 'queued' | 'in_progress' | 'success' | 'error', message: string): void {
+  setSetting('jarvis.update.status', status);
+  setSetting('jarvis.update.message', message);
+  setSetting('jarvis.update.updated_at', String(Date.now()));
+}
+
+export async function runJarvisUpdate(): Promise<JarvisUpdateResult> {
+  console.log(c.cyan('Checking for updates...\n'));
+
+  const previousVersion = getJarvisVersion();
+  console.log(`  Current version: ${c.bold(previousVersion)}`);
+
+  writeUpdateState('in_progress', `Updating from ${previousVersion}...`);
+  setSetting('jarvis.update.started_at', String(Date.now()));
+  setSetting('jarvis.update.last_from_version', previousVersion);
+
+  const wasRunning = isLocked();
+
+  if (wasRunning) {
+    console.log(c.dim('  Stopping daemon before update...'));
+    try {
+      process.kill(wasRunning, 'SIGTERM');
+      releaseLock();
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+    } catch {
+      releaseLock();
+    }
+  }
+
+  console.log('');
+  const gitPull = Bun.spawnSync(['git', 'pull', '--ff-only'], {
+    cwd: PACKAGE_ROOT,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: { ...process.env },
+  });
+
+  if (gitPull.exitCode !== 0) {
+    const stderr = gitPull.stderr.toString();
+    const installDir = join(require('node:os').homedir(), '.jarvis', 'daemon');
+    const gitPullFallback = Bun.spawnSync(['git', 'pull', '--ff-only'], {
+      cwd: installDir,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: { ...process.env },
+    });
+
+    if (gitPullFallback.exitCode !== 0) {
+      const detail = gitPullFallback.stderr.toString().trim() || stderr.trim() || 'git pull failed';
+      writeUpdateState('error', detail);
+      if (wasRunning) {
+        console.log(c.dim('\n  Restarting daemon...'));
+        await restartAfterUpdate();
+      }
+      throw new Error(detail);
+    }
+  }
+
+  const bunInstall = Bun.spawnSync(['bun', 'install'], {
+    cwd: PACKAGE_ROOT,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: { ...process.env },
+  });
+
+  if (bunInstall.exitCode !== 0) {
+    console.log(c.yellow('! Dependencies may need manual refresh: bun install'));
+  }
+
+  const currentVersion = getJarvisVersion();
+  const changed = currentVersion !== previousVersion;
+
+  if (changed) {
+    console.log(c.green(`✓ Updated: ${previousVersion} → ${currentVersion}`));
+  } else {
+    console.log(c.green(`✓ Already on the latest version (${previousVersion})`));
+  }
+
+  writeUpdateState(
+    'success',
+    changed
+      ? `Updated from ${previousVersion} to ${currentVersion}.`
+      : `Already on the latest version (${currentVersion}).`,
+  );
+  setSetting('jarvis.update.last_to_version', currentVersion);
+  setSetting('jarvis.update.completed_at', String(Date.now()));
+
+  if (wasRunning) {
+    console.log(c.dim('\nRestarting daemon...'));
+    await restartAfterUpdate();
+  }
+
+  return { previousVersion, currentVersion, changed };
+}
+
+async function restartAfterUpdate(): Promise<void> {
+  const logPath = getLogPath();
+  const logFd = openSync(logPath, 'a');
+  const child = spawn('bun', [join(PACKAGE_ROOT, 'bin/jarvis.ts'), 'start', '--no-open'], {
+    detached: true,
+    stdio: ['ignore', logFd, logFd],
+    env: { ...process.env },
+  });
+  child.unref();
+  await new Promise((resolve) => setTimeout(resolve, 500));
+}
+
+if (import.meta.main) {
+  try {
+    await runJarvisUpdate();
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    writeUpdateState('error', message);
+    console.error(c.red(`✗ Update failed:`));
+    console.error(c.dim(`  ${message}`));
+    process.exit(1);
+  }
+}

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -1,5 +1,5 @@
 import { join } from 'node:path';
-import { readFileSync, existsSync, openSync } from 'node:fs';
+import { readFileSync, openSync } from 'node:fs';
 import { spawn } from 'node:child_process';
 import { isLocked, releaseLock, getLogPath } from '../daemon/pid.ts';
 import { c } from './helpers.ts';

--- a/src/daemon/api-routes.ts
+++ b/src/daemon/api-routes.ts
@@ -616,7 +616,12 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
 
     '/api/system/update/dismiss': {
       POST: async (req: Request) => {
-        const body = await req.json() as { version?: string };
+        let body: { version?: string };
+        try {
+          body = await req.json() as { version?: string };
+        } catch {
+          return error('Invalid JSON in request body.', 400);
+        }
         const status = await getUpdateStatus(false);
         const version = body.version ?? status.latest_version;
         if (!version) return error('No update version is available to dismiss.');

--- a/src/daemon/api-routes.ts
+++ b/src/daemon/api-routes.ts
@@ -93,6 +93,11 @@ import {
   getCapturesInRange,
 } from '../vault/awareness.ts';
 import type { SuggestionType } from '../awareness/types.ts';
+import {
+  dismissUpdate,
+  getUpdateStatus,
+  startUpdateJob,
+} from './update-manager.ts';
 
 export type ApiContext = {
   healthMonitor: HealthMonitor;
@@ -596,6 +601,29 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
       },
     },
 
+    '/api/system/update': {
+      GET: async (req: Request) => {
+        const params = getSearchParams(req);
+        const refresh = params.get('refresh') === '1';
+        return json(await getUpdateStatus(refresh));
+      },
+      POST: async () => {
+        const result = await startUpdateJob();
+        if (!result.ok) return error(result.message, 409);
+        return json(result);
+      },
+    },
+
+    '/api/system/update/dismiss': {
+      POST: async (req: Request) => {
+        const body = await req.json() as { version?: string };
+        const status = await getUpdateStatus(false);
+        const version = body.version ?? status.latest_version;
+        if (!version) return error('No update version is available to dismiss.');
+        dismissUpdate(version);
+        return json({ ok: true, message: `Dismissed update ${version}.` });
+      },
+    },
     // --- LLM Configuration (DB + encrypted keychain) ---
     '/api/config/llm': {
       GET: async () => {

--- a/src/daemon/update-manager.test.ts
+++ b/src/daemon/update-manager.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { compareVersions, getUpdateStatus } from './update-manager.ts';
+import { initDatabase, closeDb } from '../vault/schema.ts';
+import { deleteSetting, setSetting } from '../vault/settings.ts';
+
+describe('update-manager', () => {
+  beforeEach(() => {
+    initDatabase(':memory:');
+  });
+
+  afterEach(() => {
+    closeDb();
+  });
+
+  test('compareVersions handles segment length differences', () => {
+    expect(compareVersions('1.2.0', '1.2')).toBe(0);
+    expect(compareVersions('1.2.1', '1.2')).toBe(1);
+    expect(compareVersions('1.2', '1.2.1')).toBe(-1);
+  });
+
+  test('compareVersions handles prereleases', () => {
+    expect(compareVersions('1.2.0', '1.2.0-beta.1')).toBe(1);
+    expect(compareVersions('1.2.0-beta.2', '1.2.0-beta.1')).toBe(1);
+    expect(compareVersions('1.2.0-alpha', '1.2.0-beta')).toBe(-1);
+  });
+
+  test('getUpdateStatus hides popup when latest version was dismissed', async () => {
+    setSetting('jarvis.update.latest_version', '0.9.9');
+    setSetting('jarvis.update.latest_name', 'v0.9.9');
+    setSetting('jarvis.update.latest_url', 'https://github.com/vierisid/jarvis/releases/tag/v0.9.9');
+    setSetting('jarvis.update.latest_published_at', '2026-03-31T00:00:00Z');
+    setSetting('jarvis.update.last_checked_at', String(Date.now()));
+    setSetting('jarvis.update.dismissed_version', '0.9.9');
+    setSetting('jarvis.update.status', 'idle');
+
+    const status = await getUpdateStatus(false);
+
+    expect(status.latest_version).toBe('0.9.9');
+    expect(status.has_update).toBe(true);
+    expect(status.popup_visible).toBe(false);
+  });
+
+  test('getUpdateStatus exposes cached release when refresh is not required', async () => {
+    setSetting('jarvis.update.latest_version', '0.9.9');
+    setSetting('jarvis.update.latest_name', 'Jarvis v0.9.9');
+    setSetting('jarvis.update.latest_url', 'https://github.com/vierisid/jarvis/releases/tag/v0.9.9');
+    setSetting('jarvis.update.latest_published_at', '2026-03-31T00:00:00Z');
+    setSetting('jarvis.update.last_checked_at', String(Date.now()));
+    deleteSetting('jarvis.update.dismissed_version');
+
+    const status = await getUpdateStatus(false);
+
+    expect(status.latest_name).toBe('Jarvis v0.9.9');
+    expect(status.latest_url).toContain('v0.9.9');
+    expect(status.popup_visible).toBe(true);
+  });
+});

--- a/src/daemon/update-manager.ts
+++ b/src/daemon/update-manager.ts
@@ -1,0 +1,216 @@
+import { join } from 'node:path';
+import { mkdirSync, openSync } from 'node:fs';
+import { spawn } from 'node:child_process';
+import { getSetting, setSetting } from '../vault/settings.ts';
+import { getJarvisVersion } from '../cli/update.ts';
+
+const PACKAGE_ROOT = join(import.meta.dir, '..', '..');
+const RELEASES_LATEST_URL = 'https://api.github.com/repos/vierisid/jarvis/releases/latest';
+const CHECK_INTERVAL_MS = 15 * 60 * 1000;
+
+type LatestRelease = {
+  version: string;
+  name: string;
+  url: string;
+  publishedAt: string | null;
+  notes: string | null;
+};
+
+export type UpdateStatusPayload = {
+  current_version: string;
+  latest_version: string | null;
+  latest_name: string | null;
+  latest_url: string | null;
+  latest_published_at: string | null;
+  has_update: boolean;
+  popup_visible: boolean;
+  dismissed_version: string | null;
+  last_checked_at: number | null;
+  check_error: string | null;
+  update_status: string;
+  update_message: string | null;
+  update_started_at: number | null;
+  update_completed_at: number | null;
+};
+
+function normalizeVersion(version: string): string {
+  return version.trim().replace(/^v/i, '');
+}
+
+function parseVersion(version: string): { core: number[]; prerelease: string[] } {
+  const normalized = normalizeVersion(version);
+  const [coreRaw = '0', prereleaseRaw] = normalized.split('-', 2);
+  const core = coreRaw.split('.').map((part) => Number.parseInt(part, 10) || 0);
+  const prerelease = prereleaseRaw ? prereleaseRaw.split('.') : [];
+  return { core, prerelease };
+}
+
+export function compareVersions(a: string, b: string): number {
+  const av = parseVersion(a);
+  const bv = parseVersion(b);
+  const maxLen = Math.max(av.core.length, bv.core.length);
+  for (let i = 0; i < maxLen; i += 1) {
+    const ai = av.core[i] ?? 0;
+    const bi = bv.core[i] ?? 0;
+    if (ai !== bi) return ai > bi ? 1 : -1;
+  }
+
+  if (av.prerelease.length === 0 && bv.prerelease.length > 0) return 1;
+  if (av.prerelease.length > 0 && bv.prerelease.length === 0) return -1;
+
+  const maxPreLen = Math.max(av.prerelease.length, bv.prerelease.length);
+  for (let i = 0; i < maxPreLen; i += 1) {
+    const aPart = av.prerelease[i];
+    const bPart = bv.prerelease[i];
+    if (aPart === undefined) return -1;
+    if (bPart === undefined) return 1;
+    const aNum = Number(aPart);
+    const bNum = Number(bPart);
+    const bothNumeric = Number.isFinite(aNum) && Number.isFinite(bNum);
+    if (bothNumeric && aNum !== bNum) return aNum > bNum ? 1 : -1;
+    if (!bothNumeric && aPart !== bPart) return aPart > bPart ? 1 : -1;
+  }
+
+  return 0;
+}
+
+async function fetchLatestRelease(): Promise<LatestRelease> {
+  const res = await fetch(RELEASES_LATEST_URL, {
+    headers: {
+      Accept: 'application/vnd.github+json',
+      'User-Agent': 'jarvis-update-checker',
+    },
+  });
+
+  if (!res.ok) {
+    throw new Error(`GitHub release check failed (${res.status})`);
+  }
+
+  const body = await res.json() as {
+    tag_name?: string;
+    name?: string;
+    html_url?: string;
+    published_at?: string;
+    body?: string;
+  };
+
+  if (!body.tag_name) {
+    throw new Error('GitHub release payload did not include a tag name');
+  }
+
+  const version = normalizeVersion(body.tag_name);
+  const release: LatestRelease = {
+    version,
+    name: body.name?.trim() || `v${version}`,
+    url: body.html_url?.trim() || 'https://github.com/vierisid/jarvis/releases',
+    publishedAt: body.published_at ?? null,
+    notes: body.body ?? null,
+  };
+
+  setSetting('jarvis.update.latest_version', release.version);
+  setSetting('jarvis.update.latest_name', release.name);
+  setSetting('jarvis.update.latest_url', release.url);
+  setSetting('jarvis.update.latest_published_at', release.publishedAt ?? '');
+  setSetting('jarvis.update.last_checked_at', String(Date.now()));
+  setSetting('jarvis.update.check_error', '');
+
+  return release;
+}
+
+function getCachedLatestRelease(): LatestRelease | null {
+  const version = getSetting('jarvis.update.latest_version');
+  if (!version) return null;
+
+  return {
+    version,
+    name: getSetting('jarvis.update.latest_name') || `v${version}`,
+    url: getSetting('jarvis.update.latest_url') || 'https://github.com/vierisid/jarvis/releases',
+    publishedAt: getSetting('jarvis.update.latest_published_at') || null,
+    notes: null,
+  };
+}
+
+async function resolveLatestRelease(forceRefresh: boolean): Promise<LatestRelease | null> {
+  const lastCheckedAt = Number.parseInt(getSetting('jarvis.update.last_checked_at') ?? '', 10);
+  const isFresh = Number.isFinite(lastCheckedAt) && (Date.now() - lastCheckedAt) < CHECK_INTERVAL_MS;
+
+  if (!forceRefresh && isFresh) {
+    return getCachedLatestRelease();
+  }
+
+  try {
+    return await fetchLatestRelease();
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    setSetting('jarvis.update.check_error', message);
+    setSetting('jarvis.update.last_checked_at', String(Date.now()));
+    return getCachedLatestRelease();
+  }
+}
+
+export async function getUpdateStatus(forceRefresh = false): Promise<UpdateStatusPayload> {
+  const currentVersion = getJarvisVersion();
+  const latest = await resolveLatestRelease(forceRefresh);
+  const latestVersion = latest?.version ?? null;
+  const dismissedVersion = getSetting('jarvis.update.dismissed_version');
+  const hasUpdate = latestVersion ? compareVersions(latestVersion, currentVersion) > 0 : false;
+  const popupVisible = hasUpdate && dismissedVersion !== latestVersion;
+
+  return {
+    current_version: currentVersion,
+    latest_version: latestVersion,
+    latest_name: latest?.name ?? null,
+    latest_url: latest?.url ?? null,
+    latest_published_at: latest?.publishedAt ?? null,
+    has_update: hasUpdate,
+    popup_visible: popupVisible,
+    dismissed_version: dismissedVersion,
+    last_checked_at: Number.parseInt(getSetting('jarvis.update.last_checked_at') ?? '', 10) || null,
+    check_error: getSetting('jarvis.update.check_error'),
+    update_status: getSetting('jarvis.update.status') || 'idle',
+    update_message: getSetting('jarvis.update.message'),
+    update_started_at: Number.parseInt(getSetting('jarvis.update.started_at') ?? '', 10) || null,
+    update_completed_at: Number.parseInt(getSetting('jarvis.update.completed_at') ?? '', 10) || null,
+  };
+}
+
+export function dismissUpdate(version: string): void {
+  setSetting('jarvis.update.dismissed_version', normalizeVersion(version));
+}
+
+export async function startUpdateJob(): Promise<{ ok: boolean; message: string }> {
+  const status = getSetting('jarvis.update.status');
+  if (status === 'queued' || status === 'in_progress') {
+    return { ok: false, message: 'An update is already in progress.' };
+  }
+
+  const latest = await resolveLatestRelease(false);
+  setSetting('jarvis.update.status', 'queued');
+  setSetting('jarvis.update.message', latest?.version ? `Scheduling update to ${latest.version}...` : 'Scheduling update...');
+  setSetting('jarvis.update.started_at', String(Date.now()));
+  setSetting('jarvis.update.completed_at', '');
+
+  const logsDir = join(process.env.HOME ?? join(PACKAGE_ROOT, '..'), '.jarvis', 'logs');
+  mkdirSync(logsDir, { recursive: true });
+  const logPath = join(logsDir, 'update.log');
+  const logFd = openSync(logPath, 'a');
+
+  const child = spawn(
+    'bash',
+    ['-lc', 'sleep 1; bun run src/cli/update.ts'],
+    {
+      cwd: PACKAGE_ROOT,
+      detached: true,
+      stdio: ['ignore', logFd, logFd],
+      env: { ...process.env },
+    },
+  );
+  child.unref();
+
+  return {
+    ok: true,
+    message: latest?.version
+      ? `Starting update to ${latest.version}. The dashboard will reconnect after JARVIS restarts.`
+      : 'Starting update. The dashboard will reconnect after JARVIS restarts.',
+  };
+}

--- a/src/daemon/update-manager.ts
+++ b/src/daemon/update-manager.ts
@@ -1,5 +1,6 @@
 import { join } from 'node:path';
-import { mkdirSync, openSync } from 'node:fs';
+import { closeSync, mkdirSync, openSync } from 'node:fs';
+import { homedir } from 'node:os';
 import { spawn } from 'node:child_process';
 import { getSetting, setSetting } from '../vault/settings.ts';
 import { getJarvisVersion } from '../cli/update.ts';
@@ -7,6 +8,8 @@ import { getJarvisVersion } from '../cli/update.ts';
 const PACKAGE_ROOT = join(import.meta.dir, '..', '..');
 const RELEASES_LATEST_URL = 'https://api.github.com/repos/vierisid/jarvis/releases/latest';
 const CHECK_INTERVAL_MS = 15 * 60 * 1000;
+const RELEASE_CHECK_TIMEOUT_MS = 10_000;
+let updateJobStarting = false;
 
 type LatestRelease = {
   version: string;
@@ -75,46 +78,62 @@ export function compareVersions(a: string, b: string): number {
 }
 
 async function fetchLatestRelease(): Promise<LatestRelease> {
-  const res = await fetch(RELEASES_LATEST_URL, {
-    headers: {
-      Accept: 'application/vnd.github+json',
-      'User-Agent': 'jarvis-update-checker',
-    },
-  });
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), RELEASE_CHECK_TIMEOUT_MS);
 
-  if (!res.ok) {
-    throw new Error(`GitHub release check failed (${res.status})`);
+  try {
+    const res = await fetch(RELEASES_LATEST_URL, {
+      signal: controller.signal,
+      headers: {
+        Accept: 'application/vnd.github+json',
+        'User-Agent': 'jarvis-update-checker',
+      },
+    });
+
+    if (!res.ok) {
+      throw new Error(`GitHub release check failed (${res.status})`);
+    }
+
+    const body = await res.json() as {
+      tag_name?: string;
+      name?: string;
+      html_url?: string;
+      published_at?: string;
+      body?: string;
+    };
+
+    if (!body.tag_name) {
+      throw new Error('GitHub release payload did not include a tag name');
+    }
+
+    const version = normalizeVersion(body.tag_name);
+    const release: LatestRelease = {
+      version,
+      name: body.name?.trim() || `v${version}`,
+      url: body.html_url?.trim() || 'https://github.com/vierisid/jarvis/releases',
+      publishedAt: body.published_at ?? null,
+      notes: body.body ?? null,
+    };
+
+    setSetting('jarvis.update.latest_version', release.version);
+    setSetting('jarvis.update.latest_name', release.name);
+    setSetting('jarvis.update.latest_url', release.url);
+    setSetting('jarvis.update.latest_published_at', release.publishedAt ?? '');
+    setSetting('jarvis.update.last_checked_at', String(Date.now()));
+    setSetting('jarvis.update.check_error', '');
+
+    return release;
+  } catch (err) {
+    const isAbort = err instanceof Error && err.name === 'AbortError';
+    const message = isAbort
+      ? 'Timed out while checking for updates'
+      : (err instanceof Error ? err.message : 'Unknown error while checking for updates');
+    setSetting('jarvis.update.last_checked_at', String(Date.now()));
+    setSetting('jarvis.update.check_error', message);
+    throw err;
+  } finally {
+    clearTimeout(timeoutId);
   }
-
-  const body = await res.json() as {
-    tag_name?: string;
-    name?: string;
-    html_url?: string;
-    published_at?: string;
-    body?: string;
-  };
-
-  if (!body.tag_name) {
-    throw new Error('GitHub release payload did not include a tag name');
-  }
-
-  const version = normalizeVersion(body.tag_name);
-  const release: LatestRelease = {
-    version,
-    name: body.name?.trim() || `v${version}`,
-    url: body.html_url?.trim() || 'https://github.com/vierisid/jarvis/releases',
-    publishedAt: body.published_at ?? null,
-    notes: body.body ?? null,
-  };
-
-  setSetting('jarvis.update.latest_version', release.version);
-  setSetting('jarvis.update.latest_name', release.name);
-  setSetting('jarvis.update.latest_url', release.url);
-  setSetting('jarvis.update.latest_published_at', release.publishedAt ?? '');
-  setSetting('jarvis.update.last_checked_at', String(Date.now()));
-  setSetting('jarvis.update.check_error', '');
-
-  return release;
 }
 
 function getCachedLatestRelease(): LatestRelease | null {
@@ -179,38 +198,57 @@ export function dismissUpdate(version: string): void {
 }
 
 export async function startUpdateJob(): Promise<{ ok: boolean; message: string }> {
+  if (updateJobStarting) {
+    return { ok: false, message: 'An update is already being scheduled.' };
+  }
+
   const status = getSetting('jarvis.update.status');
   if (status === 'queued' || status === 'in_progress') {
     return { ok: false, message: 'An update is already in progress.' };
   }
 
-  const latest = await resolveLatestRelease(false);
-  setSetting('jarvis.update.status', 'queued');
-  setSetting('jarvis.update.message', latest?.version ? `Scheduling update to ${latest.version}...` : 'Scheduling update...');
-  setSetting('jarvis.update.started_at', String(Date.now()));
-  setSetting('jarvis.update.completed_at', '');
+  updateJobStarting = true;
+  try {
+    const latest = await resolveLatestRelease(false);
+    setSetting('jarvis.update.status', 'queued');
+    setSetting('jarvis.update.message', latest?.version ? `Scheduling update to ${latest.version}...` : 'Scheduling update...');
+    setSetting('jarvis.update.started_at', String(Date.now()));
+    setSetting('jarvis.update.completed_at', '');
 
-  const logsDir = join(process.env.HOME ?? join(PACKAGE_ROOT, '..'), '.jarvis', 'logs');
-  mkdirSync(logsDir, { recursive: true });
-  const logPath = join(logsDir, 'update.log');
-  const logFd = openSync(logPath, 'a');
+    const logsDir = join(homedir(), '.jarvis', 'logs');
+    mkdirSync(logsDir, { recursive: true });
+    const logPath = join(logsDir, 'update.log');
+    const logFd = openSync(logPath, 'a');
 
-  const child = spawn(
-    'bash',
-    ['-lc', 'sleep 1; bun run src/cli/update.ts'],
-    {
-      cwd: PACKAGE_ROOT,
-      detached: true,
-      stdio: ['ignore', logFd, logFd],
-      env: { ...process.env },
-    },
-  );
-  child.unref();
+    try {
+      const child = spawn(
+        'bash',
+        ['-lc', 'sleep 1; bun run src/cli/update.ts'],
+        {
+          cwd: PACKAGE_ROOT,
+          detached: true,
+          stdio: ['ignore', logFd, logFd],
+          env: { ...process.env },
+        },
+      );
+      child.unref();
+    } finally {
+      closeSync(logFd);
+    }
 
-  return {
-    ok: true,
-    message: latest?.version
-      ? `Starting update to ${latest.version}. The dashboard will reconnect after JARVIS restarts.`
-      : 'Starting update. The dashboard will reconnect after JARVIS restarts.',
-  };
+    return {
+      ok: true,
+      message: latest?.version
+        ? `Starting update to ${latest.version}. The dashboard will reconnect after JARVIS restarts.`
+        : 'Starting update. The dashboard will reconnect after JARVIS restarts.',
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to schedule update.';
+    setSetting('jarvis.update.status', 'error');
+    setSetting('jarvis.update.message', message);
+    setSetting('jarvis.update.completed_at', String(Date.now()));
+    return { ok: false, message };
+  } finally {
+    updateJobStarting = false;
+  }
 }

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -23,9 +23,9 @@ const SitesPage = React.lazy(() => import("./pages/SitesPage"));
 
 type Route = "dashboard" | "chat" | "tasks" | "pipeline" | "memory" | "calendar" | "office" | "knowledge" | "command" | "authority" | "awareness" | "workflows" | "goals" | "sites" | "settings";
 
-export type SettingsSection = "general" | "llm" | "channels" | "integrations" | "sidecar";
+export type SettingsSection = "general" | "llm" | "channels" | "integrations" | "sidecar" | "update";
 
-const SETTINGS_SECTIONS: SettingsSection[] = ["general", "llm", "channels", "integrations", "sidecar"];
+const SETTINGS_SECTIONS: SettingsSection[] = ["general", "llm", "channels", "integrations", "sidecar", "update"];
 
 function getRoute(): Route {
   const hash = window.location.hash.replace("#/", "");
@@ -96,6 +96,7 @@ const SETTINGS_NAV: { section: SettingsSection; label: string }[] = [
   { section: "channels", label: "Channels" },
   { section: "integrations", label: "Integrations" },
   { section: "sidecar", label: "Sidecar" },
+  { section: "update", label: "Update" },
 ];
 
 /* ================================================================

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -23,9 +23,9 @@ const SitesPage = React.lazy(() => import("./pages/SitesPage"));
 
 type Route = "dashboard" | "chat" | "tasks" | "pipeline" | "memory" | "calendar" | "office" | "knowledge" | "command" | "authority" | "awareness" | "workflows" | "goals" | "sites" | "settings";
 
-export type SettingsSection = "general" | "llm" | "channels" | "integrations" | "sidecar" | "update";
+export type SettingsSection = "general" | "profile" | "llm" | "channels" | "integrations" | "sidecar" | "update";
 
-const SETTINGS_SECTIONS: SettingsSection[] = ["general", "llm", "channels", "integrations", "sidecar", "update"];
+const SETTINGS_SECTIONS: SettingsSection[] = ["general", "profile", "llm", "channels", "integrations", "sidecar", "update"];
 
 function getRoute(): Route {
   const hash = window.location.hash.replace("#/", "");
@@ -92,6 +92,7 @@ const NAV_MORE: NavEntry[] = [
 
 const SETTINGS_NAV: { section: SettingsSection; label: string }[] = [
   { section: "general", label: "General" },
+  { section: "profile", label: "Profile" },
   { section: "llm", label: "LLM" },
   { section: "channels", label: "Channels" },
   { section: "integrations", label: "Integrations" },

--- a/ui/src/components/settings/UpdatePanel.tsx
+++ b/ui/src/components/settings/UpdatePanel.tsx
@@ -1,27 +1,18 @@
-import React, { useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { api, useApiData } from "../../hooks/useApi";
-
-type UpdateInfo = {
-  current_version: string;
-  latest_version: string | null;
-  latest_name: string | null;
-  latest_url: string | null;
-  latest_published_at: string | null;
-  has_update: boolean;
-  popup_visible: boolean;
-  dismissed_version: string | null;
-  last_checked_at: number | null;
-  check_error: string | null;
-  update_status: string;
-  update_message: string | null;
-  update_started_at: number | null;
-  update_completed_at: number | null;
-};
+import type { UpdateInfo } from "../../types/update";
 
 export function UpdatePanel() {
   const { data, loading, error, refetch } = useApiData<UpdateInfo>("/api/system/update", []);
   const [phase, setPhase] = useState<"idle" | "checking" | "updating">("idle");
   const [message, setMessage] = useState<{ text: string; type: "success" | "error" } | null>(null);
+  const refetchTimerRef = useRef<number | null>(null);
+
+  useEffect(() => () => {
+    if (refetchTimerRef.current !== null) {
+      window.clearTimeout(refetchTimerRef.current);
+    }
+  }, []);
 
   const checkForUpdates = async () => {
     setPhase("checking");
@@ -53,7 +44,13 @@ export function UpdatePanel() {
         method: "POST",
       });
       setMessage({ text: res.message, type: "success" });
-      setTimeout(() => refetch(), 1500);
+      if (refetchTimerRef.current !== null) {
+        window.clearTimeout(refetchTimerRef.current);
+      }
+      refetchTimerRef.current = window.setTimeout(() => {
+        refetchTimerRef.current = null;
+        refetch();
+      }, 1500);
     } catch (err) {
       setMessage({
         text: err instanceof Error ? err.message : "Failed to start update.",

--- a/ui/src/components/settings/UpdatePanel.tsx
+++ b/ui/src/components/settings/UpdatePanel.tsx
@@ -1,0 +1,295 @@
+import React, { useState } from "react";
+import { api, useApiData } from "../../hooks/useApi";
+
+type UpdateInfo = {
+  current_version: string;
+  latest_version: string | null;
+  latest_name: string | null;
+  latest_url: string | null;
+  latest_published_at: string | null;
+  has_update: boolean;
+  popup_visible: boolean;
+  dismissed_version: string | null;
+  last_checked_at: number | null;
+  check_error: string | null;
+  update_status: string;
+  update_message: string | null;
+  update_started_at: number | null;
+  update_completed_at: number | null;
+};
+
+export function UpdatePanel() {
+  const { data, loading, error, refetch } = useApiData<UpdateInfo>("/api/system/update", []);
+  const [phase, setPhase] = useState<"idle" | "checking" | "updating">("idle");
+  const [message, setMessage] = useState<{ text: string; type: "success" | "error" } | null>(null);
+
+  const checkForUpdates = async () => {
+    setPhase("checking");
+    setMessage(null);
+    try {
+      const status = await api<UpdateInfo>("/api/system/update?refresh=1");
+      setMessage({
+        text: status.has_update
+          ? `Update available: ${status.latest_version}.`
+          : `You are already on the latest version (${status.current_version}).`,
+        type: "success",
+      });
+      refetch();
+    } catch (err) {
+      setMessage({
+        text: err instanceof Error ? err.message : "Failed to check for updates.",
+        type: "error",
+      });
+    } finally {
+      setPhase("idle");
+    }
+  };
+
+  const startUpdate = async () => {
+    setPhase("updating");
+    setMessage(null);
+    try {
+      const res = await api<{ ok: boolean; message: string }>("/api/system/update", {
+        method: "POST",
+      });
+      setMessage({ text: res.message, type: "success" });
+      setTimeout(() => refetch(), 1500);
+    } catch (err) {
+      setMessage({
+        text: err instanceof Error ? err.message : "Failed to start update.",
+        type: "error",
+      });
+    } finally {
+      setPhase("idle");
+    }
+  };
+
+  if (loading) {
+    return <div style={cardStyle}><span style={mutedTextStyle}>Loading update status...</span></div>;
+  }
+
+  if (error && !data) {
+    return (
+      <div style={cardStyle}>
+        <div style={{ ...messageStyle, color: "var(--j-error)", borderColor: "rgba(248, 113, 113, 0.22)", background: "rgba(248, 113, 113, 0.08)", marginBottom: 0 }}>
+          {error}
+        </div>
+      </div>
+    );
+  }
+
+  if (!data) {
+    return <div style={cardStyle}><span style={mutedTextStyle}>Update controls unavailable.</span></div>;
+  }
+
+  const isBusy = data.update_status === "queued" || data.update_status === "in_progress";
+
+  return (
+    <div style={cardStyle}>
+      <div style={headerRowStyle}>
+        <div>
+          <h3 style={headerStyle}>Release Updates</h3>
+          <div style={subtleStyle}>
+            Check the latest GitHub release and trigger the built-in `jarvis update` flow from the dashboard.
+          </div>
+        </div>
+        <span
+          style={{
+            ...statusBadgeStyle,
+            color: data.has_update ? "var(--j-accent)" : "var(--j-success)",
+            borderColor: data.has_update ? "rgba(0, 212, 255, 0.28)" : "rgba(52, 211, 153, 0.25)",
+            background: data.has_update ? "rgba(0, 212, 255, 0.10)" : "rgba(52, 211, 153, 0.10)",
+          }}
+        >
+          {data.has_update ? "Update Available" : "Up To Date"}
+        </span>
+      </div>
+
+      <div style={infoGridStyle}>
+        <InfoRow label="Current version" value={data.current_version} />
+        <InfoRow label="Latest release" value={data.latest_version ?? "Unknown"} />
+        <InfoRow
+          label="Published"
+          value={data.latest_published_at ? new Date(data.latest_published_at).toLocaleString() : "Unknown"}
+        />
+        <InfoRow
+          label="Last checked"
+          value={data.last_checked_at ? new Date(data.last_checked_at).toLocaleString() : "Never"}
+        />
+        <InfoRow label="Update status" value={formatStatus(data.update_status)} />
+      </div>
+
+      {data.latest_url && (
+        <a href={data.latest_url} target="_blank" rel="noreferrer" style={linkStyle}>
+          Open release notes
+        </a>
+      )}
+
+      {(message || data.update_message || data.check_error || error) && (
+        <div style={{
+          ...messageStyle,
+          color: message?.type === "error" || data.check_error || error ? "var(--j-error)" : "var(--j-success)",
+          borderColor: message?.type === "error" || data.check_error || error ? "rgba(248, 113, 113, 0.22)" : "rgba(52, 211, 153, 0.22)",
+          background: message?.type === "error" || data.check_error || error ? "rgba(248, 113, 113, 0.08)" : "rgba(52, 211, 153, 0.08)",
+        }}>
+          {message?.text ?? data.check_error ?? error ?? data.update_message}
+        </div>
+      )}
+
+      <div style={actionsStyle}>
+        <button
+          type="button"
+          onClick={checkForUpdates}
+          disabled={phase !== "idle"}
+          style={{
+            ...secondaryButtonStyle,
+            opacity: phase !== "idle" ? 0.6 : 1,
+            cursor: phase !== "idle" ? "not-allowed" : "pointer",
+          }}
+        >
+          {phase === "checking" ? "Checking..." : "Search for Update"}
+        </button>
+        <button
+          type="button"
+          onClick={startUpdate}
+          disabled={!data.has_update || phase !== "idle" || isBusy}
+          style={{
+            ...buttonStyle,
+            opacity: !data.has_update || phase !== "idle" || isBusy ? 0.55 : 1,
+            cursor: !data.has_update || phase !== "idle" || isBusy ? "not-allowed" : "pointer",
+          }}
+        >
+          {isBusy || phase === "updating" ? "Updating..." : "Update JARVIS"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function formatStatus(status: string): string {
+  if (status === "in_progress") return "In progress";
+  if (status === "queued") return "Queued";
+  if (status === "success") return "Completed";
+  if (status === "error") return "Failed";
+  return "Idle";
+}
+
+function InfoRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div style={infoRowStyle}>
+      <span style={infoLabelStyle}>{label}</span>
+      <span style={infoValueStyle}>{value}</span>
+    </div>
+  );
+}
+
+const cardStyle: React.CSSProperties = {
+  padding: "20px",
+  background: "var(--j-surface)",
+  border: "1px solid var(--j-border)",
+  borderRadius: "8px",
+};
+
+const headerRowStyle: React.CSSProperties = {
+  display: "flex",
+  justifyContent: "space-between",
+  gap: "16px",
+  alignItems: "flex-start",
+  marginBottom: "16px",
+  flexWrap: "wrap",
+};
+
+const headerStyle: React.CSSProperties = {
+  fontSize: "14px",
+  fontWeight: 600,
+  color: "var(--j-text)",
+  margin: 0,
+};
+
+const subtleStyle: React.CSSProperties = {
+  fontSize: "12px",
+  lineHeight: 1.5,
+  color: "var(--j-text-muted)",
+  marginTop: "6px",
+  maxWidth: "560px",
+};
+
+const mutedTextStyle: React.CSSProperties = {
+  color: "var(--j-text-muted)",
+  fontSize: "13px",
+};
+
+const statusBadgeStyle: React.CSSProperties = {
+  padding: "5px 10px",
+  borderRadius: "999px",
+  border: "1px solid var(--j-border)",
+  fontSize: "11px",
+  fontWeight: 600,
+  textTransform: "uppercase",
+  letterSpacing: "0.05em",
+};
+
+const infoGridStyle: React.CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  gap: "10px",
+  marginBottom: "14px",
+};
+
+const infoRowStyle: React.CSSProperties = {
+  display: "flex",
+  justifyContent: "space-between",
+  gap: "12px",
+  fontSize: "13px",
+};
+
+const infoLabelStyle: React.CSSProperties = {
+  color: "var(--j-text-dim)",
+};
+
+const infoValueStyle: React.CSSProperties = {
+  color: "var(--j-text)",
+};
+
+const messageStyle: React.CSSProperties = {
+  fontSize: "12px",
+  border: "1px solid transparent",
+  borderRadius: "8px",
+  padding: "10px 12px",
+  marginBottom: "16px",
+  marginTop: "16px",
+};
+
+const actionsStyle: React.CSSProperties = {
+  display: "flex",
+  gap: "10px",
+  flexWrap: "wrap",
+  marginTop: "16px",
+};
+
+const buttonStyle: React.CSSProperties = {
+  border: "1px solid rgba(0, 212, 255, 0.28)",
+  background: "rgba(0, 212, 255, 0.12)",
+  color: "var(--j-accent)",
+  borderRadius: "8px",
+  padding: "10px 14px",
+  fontSize: "13px",
+  fontWeight: 600,
+};
+
+const secondaryButtonStyle: React.CSSProperties = {
+  border: "1px solid var(--j-border)",
+  background: "transparent",
+  color: "var(--j-text-muted)",
+  borderRadius: "8px",
+  padding: "10px 14px",
+  fontSize: "13px",
+  fontWeight: 500,
+};
+
+const linkStyle: React.CSSProperties = {
+  color: "var(--j-accent)",
+  textDecoration: "none",
+  fontSize: "12px",
+  fontWeight: 500,
+};

--- a/ui/src/components/settings/UserProfilePanel.tsx
+++ b/ui/src/components/settings/UserProfilePanel.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+
+export function UserProfilePanel() {
+  return (
+    <div
+      style={{
+        padding: "20px",
+        background: "var(--j-surface)",
+        border: "1px solid var(--j-border)",
+        borderRadius: "8px",
+      }}
+    >
+      <h3 style={{ margin: 0, fontSize: "14px", fontWeight: 600, color: "var(--j-text)" }}>
+        User Profile
+      </h3>
+      <p style={{ margin: "8px 0 0", fontSize: "12px", lineHeight: 1.6, color: "var(--j-text-muted)" }}>
+        Profile controls are available after merging the latest settings updates.
+      </p>
+    </div>
+  );
+}

--- a/ui/src/pages/DashboardPage.tsx
+++ b/ui/src/pages/DashboardPage.tsx
@@ -48,6 +48,23 @@ type WorkflowData = {
   status: string;
 };
 
+type UpdateInfo = {
+  current_version: string;
+  latest_version: string | null;
+  latest_name: string | null;
+  latest_url: string | null;
+  latest_published_at: string | null;
+  has_update: boolean;
+  popup_visible: boolean;
+  dismissed_version: string | null;
+  last_checked_at: number | null;
+  check_error: string | null;
+  update_status: string;
+  update_message: string | null;
+  update_started_at: number | null;
+  update_completed_at: number | null;
+};
+
 /* ================================================================
    PROPS
    ================================================================ */
@@ -974,6 +991,38 @@ function GoalsPanel({ goals }: { goals: GoalData[] }) {
   );
 }
 
+function UpdateToast({
+  update,
+  onDismiss,
+  onUpdate,
+  busy,
+}: {
+  update: UpdateInfo;
+  onDismiss: () => void;
+  onUpdate: () => void;
+  busy: boolean;
+}) {
+  if (!update.latest_version) return null;
+
+  return (
+    <div className="db-update-toast" role="dialog" aria-live="polite" aria-label="JARVIS update available">
+      <div className="db-update-toast-eyebrow">Release Update</div>
+      <div className="db-update-toast-title">JARVIS {update.latest_version} is available.</div>
+      <div className="db-update-toast-copy">
+        A newer GitHub release was found. Update now to install {update.latest_version}.
+      </div>
+      <div className="db-update-toast-actions">
+        <button className="db-update-toast-btn db-update-toast-btn-secondary" onClick={onDismiss}>
+          Not now
+        </button>
+        <button className="db-update-toast-btn db-update-toast-btn-primary" onClick={onUpdate} disabled={busy}>
+          {busy ? "Updating..." : "Update"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
 /* ================================================================
    DASHBOARD PAGE — root export, data fetching
    ================================================================ */
@@ -984,6 +1033,15 @@ export default function DashboardPage({ messages, isConnected, voice, agentActiv
   const [entityCount, setEntityCount] = useState(0);
   const [goals, setGoals] = useState<GoalData[]>([]);
   const [workflows, setWorkflows] = useState<WorkflowData[]>([]);
+  const [updateInfo, setUpdateInfo] = useState<UpdateInfo | null>(null);
+  const [updateBusy, setUpdateBusy] = useState(false);
+
+  const fetchUpdateInfo = useCallback(async (refresh = false) => {
+    try {
+      const data = await api<UpdateInfo>(`/api/system/update${refresh ? "?refresh=1" : ""}`);
+      setUpdateInfo(data);
+    } catch { /* keep previous */ }
+  }, []);
 
   // Fetch agents (poll every 5s)
   const fetchAgents = useCallback(async () => {
@@ -1033,19 +1091,22 @@ export default function DashboardPage({ messages, isConnected, voice, agentActiv
     fetchEntities();
     fetchGoals();
     fetchWorkflows();
-  }, [fetchAgents, fetchHealth, fetchEntities, fetchGoals, fetchWorkflows]);
+    fetchUpdateInfo();
+  }, [fetchAgents, fetchHealth, fetchEntities, fetchGoals, fetchWorkflows, fetchUpdateInfo]);
 
   // Polling intervals
   useEffect(() => {
     const agentIv = setInterval(fetchAgents, 5000);
     const healthIv = setInterval(fetchHealth, 10000);
     const entityIv = setInterval(fetchEntities, 30000);
+    const updateIv = setInterval(() => { fetchUpdateInfo(false); }, 60000);
     return () => {
       clearInterval(agentIv);
       clearInterval(healthIv);
       clearInterval(entityIv);
+      clearInterval(updateIv);
     };
-  }, [fetchAgents, fetchHealth, fetchEntities]);
+  }, [fetchAgents, fetchHealth, fetchEntities, fetchUpdateInfo]);
 
   // Re-fetch on WS events
   useEffect(() => {
@@ -1056,9 +1117,42 @@ export default function DashboardPage({ messages, isConnected, voice, agentActiv
     if (workflowEvents.length > 0) fetchWorkflows();
   }, [workflowEvents.length, fetchWorkflows]);
 
+  const dismissUpdate = useCallback(async () => {
+    if (!updateInfo?.latest_version) return;
+    try {
+      await api<{ ok: boolean; message: string }>("/api/system/update/dismiss", {
+        method: "POST",
+        body: JSON.stringify({ version: updateInfo.latest_version }),
+      });
+      setUpdateInfo((prev) => prev ? { ...prev, popup_visible: false, dismissed_version: prev.latest_version } : prev);
+    } catch { /* ignore */ }
+  }, [updateInfo]);
+
+  const startUpdate = useCallback(async () => {
+    setUpdateBusy(true);
+    try {
+      await api<{ ok: boolean; message: string }>("/api/system/update", {
+        method: "POST",
+      });
+      setUpdateInfo((prev) => prev ? {
+        ...prev,
+        popup_visible: false,
+        update_status: "queued",
+        update_message: prev.latest_version ? `Starting update to ${prev.latest_version}...` : "Starting update...",
+      } : prev);
+    } catch {
+      fetchUpdateInfo(false);
+    } finally {
+      setUpdateBusy(false);
+    }
+  }, [fetchUpdateInfo]);
+
   return (
     <div className="dashboard">
       <Atmosphere />
+      {updateInfo?.has_update && updateInfo.popup_visible && (
+        <UpdateToast update={updateInfo} onDismiss={dismissUpdate} onUpdate={startUpdate} busy={updateBusy} />
+      )}
       <div className="db-scroll">
         <div className="db-inner">
           <HeroRow agents={agents} health={health} entityCount={entityCount} workflowCount={workflows.length} />

--- a/ui/src/pages/DashboardPage.tsx
+++ b/ui/src/pages/DashboardPage.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useCallback, useRef } from "react";
 import { api } from "../hooks/useApi";
 import type { ChatMessage, AgentActivityEvent, GoalEvent, WorkflowEvent } from "../hooks/useWebSocket";
 import type { UseVoiceReturn } from "../hooks/useVoice";
+import type { UpdateInfo } from "../types/update";
 import "../styles/dashboard.css";
 
 /* ================================================================
@@ -46,23 +47,6 @@ type WorkflowData = {
   id: string;
   name: string;
   status: string;
-};
-
-type UpdateInfo = {
-  current_version: string;
-  latest_version: string | null;
-  latest_name: string | null;
-  latest_url: string | null;
-  latest_published_at: string | null;
-  has_update: boolean;
-  popup_visible: boolean;
-  dismissed_version: string | null;
-  last_checked_at: number | null;
-  check_error: string | null;
-  update_status: string;
-  update_message: string | null;
-  update_started_at: number | null;
-  update_completed_at: number | null;
 };
 
 /* ================================================================
@@ -1005,7 +989,7 @@ function UpdateToast({
   if (!update.latest_version) return null;
 
   return (
-    <div className="db-update-toast" role="dialog" aria-live="polite" aria-label="JARVIS update available">
+    <div className="db-update-toast" role="status" aria-live="polite" aria-label="JARVIS update available">
       <div className="db-update-toast-eyebrow">Release Update</div>
       <div className="db-update-toast-title">JARVIS {update.latest_version} is available.</div>
       <div className="db-update-toast-copy">

--- a/ui/src/pages/SettingsPage.tsx
+++ b/ui/src/pages/SettingsPage.tsx
@@ -7,6 +7,7 @@ import { RolePanel } from "../components/settings/RolePanel";
 import { IntegrationsPanel } from "../components/settings/IntegrationsPanel";
 import { ChannelsPanel } from "../components/settings/ChannelsPanel";
 import { SidecarPanel } from "../components/settings/SidecarPanel";
+import { UpdatePanel } from "../components/settings/UpdatePanel";
 
 const SECTION_META: Record<SettingsSection, { title: string; subtitle: string }> = {
   general: { title: "General", subtitle: "Personality, role, and heartbeat configuration" },
@@ -14,6 +15,7 @@ const SECTION_META: Record<SettingsSection, { title: string; subtitle: string }>
   channels: { title: "Communication Channels", subtitle: "Telegram, Discord, voice transcription, and text-to-speech" },
   integrations: { title: "Integrations", subtitle: "Third-party service connections" },
   sidecar: { title: "Sidecar", subtitle: "Remote machine control via Go sidecar agents" },
+  update: { title: "Update", subtitle: "Check GitHub releases and install the latest JARVIS build" },
 };
 
 export default function SettingsPage({ section }: { section: SettingsSection }) {
@@ -51,6 +53,7 @@ export default function SettingsPage({ section }: { section: SettingsSection }) 
           {section === "channels" && <ChannelsPanel />}
           {section === "integrations" && <IntegrationsPanel />}
           {section === "sidecar" && <SidecarPanel />}
+          {section === "update" && <UpdatePanel />}
         </div>
       </div>
     </div>

--- a/ui/src/pages/SettingsPage.tsx
+++ b/ui/src/pages/SettingsPage.tsx
@@ -8,9 +8,11 @@ import { IntegrationsPanel } from "../components/settings/IntegrationsPanel";
 import { ChannelsPanel } from "../components/settings/ChannelsPanel";
 import { SidecarPanel } from "../components/settings/SidecarPanel";
 import { UpdatePanel } from "../components/settings/UpdatePanel";
+import { UserProfilePanel } from "../components/settings/UserProfilePanel";
 
 const SECTION_META: Record<SettingsSection, { title: string; subtitle: string }> = {
   general: { title: "General", subtitle: "Personality, role, and heartbeat configuration" },
+  profile: { title: "Know Your User", subtitle: "Capture durable user context so JARVIS starts with the right background" },
   llm: { title: "LLM Configuration", subtitle: "Manage AI providers, models, and API keys" },
   channels: { title: "Communication Channels", subtitle: "Telegram, Discord, voice transcription, and text-to-speech" },
   integrations: { title: "Integrations", subtitle: "Third-party service connections" },
@@ -49,6 +51,7 @@ export default function SettingsPage({ section }: { section: SettingsSection }) 
               <HeartbeatPanel />
             </>
           )}
+          {section === "profile" && <UserProfilePanel />}
           {section === "llm" && <LLMPanel />}
           {section === "channels" && <ChannelsPanel />}
           {section === "integrations" && <IntegrationsPanel />}

--- a/ui/src/styles/dashboard.css
+++ b/ui/src/styles/dashboard.css
@@ -1002,6 +1002,7 @@
     rgba(10, 14, 24, 0.94);
   border: 1px solid rgba(96,165,250,0.18);
   box-shadow: 0 20px 60px rgba(0,0,0,0.38), 0 0 0 1px rgba(139,92,246,0.08) inset;
+  -webkit-backdrop-filter: blur(18px);
   backdrop-filter: blur(18px);
   animation: db-materialize 320ms cubic-bezier(0.16,1,0.3,1);
 }

--- a/ui/src/styles/dashboard.css
+++ b/ui/src/styles/dashboard.css
@@ -988,3 +988,84 @@
   stroke-dasharray: 16;
   animation: db-flowPulse var(--fp) linear infinite;
 }
+
+.db-update-toast {
+  position: fixed;
+  right: 24px;
+  bottom: 24px;
+  z-index: 40;
+  width: min(360px, calc(100vw - 32px));
+  padding: 16px 16px 14px;
+  border-radius: 14px;
+  background:
+    linear-gradient(180deg, rgba(17,24,39,0.96), rgba(10,15,26,0.98)),
+    rgba(10, 14, 24, 0.94);
+  border: 1px solid rgba(96,165,250,0.18);
+  box-shadow: 0 20px 60px rgba(0,0,0,0.38), 0 0 0 1px rgba(139,92,246,0.08) inset;
+  backdrop-filter: blur(18px);
+  animation: db-materialize 320ms cubic-bezier(0.16,1,0.3,1);
+}
+
+.db-update-toast-eyebrow {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: rgba(96,165,250,0.72);
+  margin-bottom: 8px;
+}
+
+.db-update-toast-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text-1);
+  margin-bottom: 8px;
+}
+
+.db-update-toast-copy {
+  font-size: 12px;
+  line-height: 1.6;
+  color: var(--text-2);
+}
+
+.db-update-toast-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  margin-top: 14px;
+}
+
+.db-update-toast-btn {
+  border-radius: 8px;
+  padding: 9px 12px;
+  font-size: 12px;
+  font-weight: 600;
+  border: 1px solid transparent;
+  cursor: pointer;
+}
+
+.db-update-toast-btn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.db-update-toast-btn-primary {
+  background: rgba(96,165,250,0.14);
+  color: #8cc8ff;
+  border-color: rgba(96,165,250,0.24);
+}
+
+.db-update-toast-btn-secondary {
+  background: rgba(255,255,255,0.03);
+  color: var(--text-2);
+  border-color: rgba(255,255,255,0.08);
+}
+
+@media (max-width: 720px) {
+  .db-update-toast {
+    right: 16px;
+    left: 16px;
+    bottom: 16px;
+    width: auto;
+  }
+}

--- a/ui/src/types/update.ts
+++ b/ui/src/types/update.ts
@@ -1,0 +1,16 @@
+export type UpdateInfo = {
+  current_version: string;
+  latest_version: string | null;
+  latest_name: string | null;
+  latest_url: string | null;
+  latest_published_at: string | null;
+  has_update: boolean;
+  popup_visible: boolean;
+  dismissed_version: string | null;
+  last_checked_at: number | null;
+  check_error: string | null;
+  update_status: string;
+  update_message: string | null;
+  update_started_at: number | null;
+  update_completed_at: number | null;
+};


### PR DESCRIPTION
## What changed
- added a release update service that checks the latest GitHub release for `vierisid/jarvis`, compares it to the locally installed version, and caches status for the dashboard
- added dashboard update toast UI that appears on the Dashboard when a newer release is available, with `Update` and `Not now` actions
- added a new `Settings > Update` tab with release status, manual update checks, release notes link, and a button to trigger the update flow
- extracted the existing CLI updater into a reusable module and wired the daemon API to launch it safely in the background from the dashboard

## Why
Users needed an in-product way to see when a new JARVIS release exists and install it without dropping back to the terminal.

## Impact
- dashboard users now get a corner popup when a newer release is available
- dismissing `Not now` suppresses the popup for that specific release version
- updates can be triggered from either the dashboard popup or the new settings tab

## Validation
- `bun run build:ui`
- `bun x tsc -p tsconfig.json --noEmit`
- repo pre-commit hook test suite: 435 passing tests
