### PR TITLE
Fix spawn agent flow and live status

### DIFF
--- a/src/actions/tools/agents.ts
+++ b/src/actions/tools/agents.ts
@@ -26,6 +26,149 @@ export type AgentToolDeps = {
 // Track scoped registries for persistent agents so they can be reused across tasks
 const agentRegistries = new Map<string, ReturnType<typeof createScopedToolRegistry>>();
 
+export type PersistentAgentSummary = {
+  agent_id: string;
+  name: string;
+  specialist: string;
+  status: string;
+  current_task: string | null;
+  busy: boolean;
+};
+
+export function spawnPersistentAgent(deps: AgentToolDeps, specialistId: string) {
+  if (!specialistId) {
+    throw new Error('A specialist role is required to spawn an agent.');
+  }
+
+  const role = deps.specialists.get(specialistId);
+  if (!role) {
+    throw new Error(`Unknown specialist "${specialistId}". Available: ${Array.from(deps.specialists.keys()).join(', ')}`);
+  }
+
+  const primary = deps.orchestrator.getPrimary();
+  if (!primary) {
+    throw new Error('No primary agent exists');
+  }
+
+  const agent = deps.orchestrator.spawnSubAgent(primary.id, role);
+  const scopedRegistry = createScopedToolRegistry(agent.agent.authority.allowed_tools);
+  agentRegistries.set(agent.id, scopedRegistry);
+
+  // A persistent agent should start idle until it has a task.
+  agent.idle();
+
+  console.log(`[ManageAgents] Spawned ${role.name} (${agent.id}) with ${scopedRegistry.count()} tools`);
+
+  return {
+    agent,
+    summary: {
+      agent_id: agent.id,
+      name: role.name,
+      specialist: specialistId,
+      status: agent.status,
+      tools_available: scopedRegistry.count(),
+      tool_categories: agent.agent.authority.allowed_tools,
+    },
+  };
+}
+
+export async function assignPersistentAgentTask(
+  deps: AgentToolDeps,
+  params: { agentId: string; task: string; context?: string }
+) {
+  const { agentId, task, context = '' } = params;
+  if (!agentId) throw new Error('"agentId" is required');
+  if (!task) throw new Error('"task" is required');
+
+  const agent = deps.orchestrator.getAgent(agentId);
+  if (!agent) throw new Error(`Agent "${agentId}" not found. Use list to see active agents.`);
+
+  if (deps.taskManager.isAgentBusy(agentId)) {
+    throw new Error(`Agent "${agent.agent.role.name}" is already running a task.`);
+  }
+
+  const scopedRegistry = agentRegistries.get(agentId);
+  if (!scopedRegistry) {
+    throw new Error(`No tool registry for agent "${agentId}". Was it spawned via manage_agents?`);
+  }
+
+  deps.onProgress?.({
+    type: 'text',
+    agentName: agent.agent.role.name,
+    agentId,
+    data: `[Assigning task to ${agent.agent.role.name}...]`,
+  });
+
+  const taskId = deps.taskManager.launch({
+    agent,
+    task,
+    context,
+    llmManager: deps.llmManager,
+    toolRegistry: scopedRegistry,
+    onProgress: deps.onProgress,
+  });
+
+  console.log(`[ManageAgents] Assigned task ${taskId} to ${agent.agent.role.name}`);
+
+  return {
+    task_id: taskId,
+    agent_id: agentId,
+    agent_name: agent.agent.role.name,
+    status: 'running',
+    message: `Task assigned to ${agent.agent.role.name}. Use status or collect to check progress.`,
+  };
+}
+
+export function listPersistentAgents(deps: AgentToolDeps) {
+  const allAgents = deps.orchestrator.getAllAgents();
+  const primary = deps.orchestrator.getPrimary();
+  const subAgents = allAgents.filter(a => a.id !== primary?.id);
+
+  const agents: PersistentAgentSummary[] = subAgents.map(a => ({
+    agent_id: a.id,
+    name: a.agent.role.name,
+    specialist: a.agent.role.id,
+    status: a.agent.status,
+    current_task: a.agent.current_task,
+    busy: deps.taskManager.isAgentBusy(a.id),
+  }));
+
+  const tasks = deps.taskManager.listTasks().map(t => ({
+    task_id: t.id,
+    agent_name: t.agentName,
+    status: t.status,
+    task: t.task.slice(0, 100),
+    elapsed_seconds: Math.round(((t.completedAt ?? Date.now()) - t.startedAt) / 1000),
+  }));
+
+  return {
+    active_agents: agents.length,
+    agents,
+    tasks_total: tasks.length,
+    tasks_running: tasks.filter(t => t.status === 'running').length,
+    tasks,
+  };
+}
+
+export function terminatePersistentAgent(deps: AgentToolDeps, agentId: string) {
+  if (!agentId) throw new Error('"agentId" is required');
+
+  const agent = deps.orchestrator.getAgent(agentId);
+  if (!agent) throw new Error(`Agent "${agentId}" not found`);
+
+  const name = agent.agent.role.name;
+  agentRegistries.delete(agentId);
+  deps.orchestrator.terminateAgent(agentId);
+
+  console.log(`[ManageAgents] Terminated ${name} (${agentId})`);
+
+  return {
+    terminated: agentId,
+    name,
+    message: `${name} terminated.`,
+  };
+}
+
 export function createManageAgentsTool(deps: AgentToolDeps): ToolDefinition {
   return {
     name: 'manage_agents',
@@ -103,83 +246,24 @@ export function createManageAgentsTool(deps: AgentToolDeps): ToolDefinition {
 }
 
 function handleSpawn(deps: AgentToolDeps, params: Record<string, unknown>): string {
-  const specialistId = params.specialist as string;
-  if (!specialistId) {
-    return 'Error: "specialist" is required for spawn. Available: ' + Array.from(deps.specialists.keys()).join(', ');
+  try {
+    const specialistId = params.specialist as string;
+    return JSON.stringify(spawnPersistentAgent(deps, specialistId).summary);
+  } catch (err) {
+    return `Error: ${err instanceof Error ? err.message : String(err)}`;
   }
-
-  const role = deps.specialists.get(specialistId);
-  if (!role) {
-    return `Error: Unknown specialist "${specialistId}". Available: ${Array.from(deps.specialists.keys()).join(', ')}`;
-  }
-
-  const primary = deps.orchestrator.getPrimary();
-  if (!primary) {
-    return 'Error: No primary agent exists';
-  }
-
-  const agent = deps.orchestrator.spawnSubAgent(primary.id, role);
-  const scopedRegistry = createScopedToolRegistry(agent.agent.authority.allowed_tools);
-  agentRegistries.set(agent.id, scopedRegistry);
-
-  console.log(`[ManageAgents] Spawned ${role.name} (${agent.id}) with ${scopedRegistry.count()} tools`);
-
-  return JSON.stringify({
-    agent_id: agent.id,
-    name: role.name,
-    specialist: specialistId,
-    status: 'idle',
-    tools_available: scopedRegistry.count(),
-    tool_categories: agent.agent.authority.allowed_tools,
-  });
 }
 
 async function handleAssign(deps: AgentToolDeps, params: Record<string, unknown>): Promise<string> {
-  const agentId = params.agent_id as string;
-  const task = params.task as string;
-  const context = (params.context as string) || '';
-
-  if (!agentId) return 'Error: "agent_id" is required for assign';
-  if (!task) return 'Error: "task" is required for assign';
-
-  const agent = deps.orchestrator.getAgent(agentId);
-  if (!agent) return `Error: Agent "${agentId}" not found. Use list to see active agents.`;
-
-  if (deps.taskManager.isAgentBusy(agentId)) {
-    return `Error: Agent "${agent.agent.role.name}" is already running a task. Wait for it to finish or terminate it.`;
+  try {
+    return JSON.stringify(await assignPersistentAgentTask(deps, {
+      agentId: params.agent_id as string,
+      task: params.task as string,
+      context: params.context as string | undefined,
+    }));
+  } catch (err) {
+    return `Error: ${err instanceof Error ? err.message : String(err)}`;
   }
-
-  const scopedRegistry = agentRegistries.get(agentId);
-  if (!scopedRegistry) {
-    return `Error: No tool registry for agent "${agentId}". Was it spawned via manage_agents?`;
-  }
-
-  // Notify progress
-  deps.onProgress?.({
-    type: 'text',
-    agentName: agent.agent.role.name,
-    agentId,
-    data: `[Assigning task to ${agent.agent.role.name}...]`,
-  });
-
-  const taskId = deps.taskManager.launch({
-    agent,
-    task,
-    context,
-    llmManager: deps.llmManager,
-    toolRegistry: scopedRegistry,
-    onProgress: deps.onProgress,
-  });
-
-  console.log(`[ManageAgents] Assigned task ${taskId} to ${agent.agent.role.name}`);
-
-  return JSON.stringify({
-    task_id: taskId,
-    agent_id: agentId,
-    agent_name: agent.agent.role.name,
-    status: 'running',
-    message: `Task assigned to ${agent.agent.role.name}. Use status or collect to check progress.`,
-  });
 }
 
 function handleStatus(deps: AgentToolDeps, params: Record<string, unknown>): string {
@@ -264,58 +348,13 @@ function handleCollect(deps: AgentToolDeps, params: Record<string, unknown>): st
 }
 
 function handleList(deps: AgentToolDeps): string {
-  const allAgents = deps.orchestrator.getAllAgents();
-  const primary = deps.orchestrator.getPrimary();
-
-  // Filter to sub-agents only (not the primary)
-  const subAgents = allAgents.filter(a => a.id !== primary?.id);
-
-  const agents = subAgents.map(a => ({
-    agent_id: a.id,
-    name: a.agent.role.name,
-    specialist: a.agent.role.id,
-    status: a.agent.status,
-    current_task: a.agent.current_task,
-    busy: deps.taskManager.isAgentBusy(a.id),
-  }));
-
-  const tasks = deps.taskManager.listTasks().map(t => ({
-    task_id: t.id,
-    agent_name: t.agentName,
-    status: t.status,
-    task: t.task.slice(0, 100),
-    elapsed_seconds: Math.round(((t.completedAt ?? Date.now()) - t.startedAt) / 1000),
-  }));
-
-  return JSON.stringify({
-    active_agents: agents.length,
-    agents,
-    tasks_total: tasks.length,
-    tasks_running: tasks.filter(t => t.status === 'running').length,
-    tasks,
-  });
+  return JSON.stringify(listPersistentAgents(deps));
 }
 
 function handleTerminate(deps: AgentToolDeps, params: Record<string, unknown>): string {
-  const agentId = params.agent_id as string;
-  if (!agentId) return 'Error: "agent_id" is required for terminate';
-
-  const agent = deps.orchestrator.getAgent(agentId);
-  if (!agent) return `Error: Agent "${agentId}" not found`;
-
-  const name = agent.agent.role.name;
-
-  // Clean up registry
-  agentRegistries.delete(agentId);
-
-  // Terminate via orchestrator (cascades to children)
-  deps.orchestrator.terminateAgent(agentId);
-
-  console.log(`[ManageAgents] Terminated ${name} (${agentId})`);
-
-  return JSON.stringify({
-    terminated: agentId,
-    name,
-    message: `${name} terminated.`,
-  });
+  try {
+    return JSON.stringify(terminatePersistentAgent(deps, params.agent_id as string));
+  } catch (err) {
+    return `Error: ${err instanceof Error ? err.message : String(err)}`;
+  }
 }

--- a/src/agents/sub-agent-runner.ts
+++ b/src/agents/sub-agent-runner.ts
@@ -289,6 +289,8 @@ export async function runSubAgent(opts: RunSubAgentOptions): Promise<SubAgentRes
       toolsUsed: [...new Set(toolsUsed)],
       tokensUsed: totalUsage,
     };
+  } finally {
+    agent.idle();
   }
 }
 

--- a/src/daemon/agent-service.ts
+++ b/src/daemon/agent-service.ts
@@ -119,6 +119,10 @@ export class AgentService implements Service, IAgentService {
     return this.taskManager;
   }
 
+  getSpecialists(): Map<string, RoleDefinition> {
+    return new Map(this.specialists);
+  }
+
   async start(): Promise<void> {
     this._status = 'starting';
 

--- a/src/daemon/api-routes.ts
+++ b/src/daemon/api-routes.ts
@@ -35,6 +35,12 @@ import {
   addAttachment, getAttachment, getAttachments, deleteAttachment,
   CONTENT_STAGES, CONTENT_TYPES,
 } from '../vault/content-pipeline.ts';
+import {
+  assignPersistentAgentTask,
+  listPersistentAgents,
+  spawnPersistentAgent,
+  terminatePersistentAgent,
+} from '../actions/tools/agents.ts';
 
 import { mkdirSync, existsSync } from 'node:fs';
 import path from 'node:path';
@@ -530,8 +536,96 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
     '/api/agents': {
       GET: () => {
         const orchestrator = ctx.agentService.getOrchestrator();
-        const agents = orchestrator.getAllAgents().map((a) => a.toJSON());
+        const taskManager = ctx.agentService.getTaskManager();
+        const agents = orchestrator.getAllAgents().map((a) => {
+          const latestTask = taskManager?.getAgentTask(a.id);
+          return {
+            ...a.toJSON(),
+            busy: taskManager?.isAgentBusy(a.id) ?? false,
+            latest_task: latestTask ? {
+              id: latestTask.id,
+              status: latestTask.status,
+              task: latestTask.task,
+              started_at: latestTask.startedAt,
+              completed_at: latestTask.completedAt,
+            } : null,
+          };
+        });
         return json(agents);
+      },
+      POST: async (req: Request) => {
+        try {
+          const taskManager = ctx.agentService.getTaskManager();
+          if (!taskManager) return error('Persistent agents are not available.', 503);
+
+          const body = await req.json() as { specialist?: string; task?: string; context?: string };
+          const deps = {
+            orchestrator: ctx.agentService.getOrchestrator(),
+            llmManager: ctx.agentService.getLLMManager(),
+            specialists: ctx.agentService.getSpecialists(),
+            taskManager,
+          };
+
+          const spawned = spawnPersistentAgent(deps, body.specialist ?? '');
+          let assignment: Awaited<ReturnType<typeof assignPersistentAgentTask>> | null = null;
+
+          if (body.task?.trim()) {
+            assignment = await assignPersistentAgentTask(deps, {
+              agentId: spawned.agent.id,
+              task: body.task.trim(),
+              context: body.context?.trim(),
+            });
+          }
+
+          const latestTask = taskManager.getAgentTask(spawned.agent.id);
+          return json({
+            ...spawned.agent.toJSON(),
+            busy: taskManager.isAgentBusy(spawned.agent.id),
+            latest_task: latestTask ? {
+              id: latestTask.id,
+              status: latestTask.status,
+              task: latestTask.task,
+              started_at: latestTask.startedAt,
+              completed_at: latestTask.completedAt,
+            } : null,
+            spawned: spawned.summary,
+            assignment,
+          }, 201);
+        } catch (err) {
+          return error(err instanceof Error ? err.message : String(err));
+        }
+      },
+    },
+
+    '/api/agents/specialists': {
+      GET: () => {
+        const specialists = Array.from(ctx.agentService.getSpecialists().values()).map((role) => ({
+          id: role.id,
+          name: role.name,
+          description: role.description,
+          authority_level: role.authority_level,
+          tools: role.tools,
+        }));
+        return json({ specialists });
+      },
+    },
+
+    '/api/agents/:id': {
+      DELETE: (req: Request) => {
+        try {
+          const taskManager = ctx.agentService.getTaskManager();
+          if (!taskManager) return error('Persistent agents are not available.', 503);
+          const id = new URL(req.url).pathname.split('/').pop() ?? '';
+          const deps = {
+            orchestrator: ctx.agentService.getOrchestrator(),
+            llmManager: ctx.agentService.getLLMManager(),
+            specialists: ctx.agentService.getSpecialists(),
+            taskManager,
+          };
+          return json(terminatePersistentAgent(deps, id));
+        } catch (err) {
+          return error(err instanceof Error ? err.message : String(err));
+        }
       },
     },
 
@@ -552,20 +646,13 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
     '/api/agents/tasks': {
       GET: () => {
         const tm = ctx.agentService.getTaskManager();
-        if (!tm) return json({ tasks: [] });
-        const tasks = tm.listTasks().map(t => ({
-          id: t.id,
-          agent_id: t.agentId,
-          agent_name: t.agentName,
-          specialist: t.specialistId,
-          task: t.task,
-          status: t.status,
-          started_at: t.startedAt,
-          completed_at: t.completedAt,
-          success: t.result?.success ?? null,
-          elapsed_ms: (t.completedAt ?? Date.now()) - t.startedAt,
+        if (!tm) return json({ tasks: [], agents: [] });
+        return json(listPersistentAgents({
+          orchestrator: ctx.agentService.getOrchestrator(),
+          llmManager: ctx.agentService.getLLMManager(),
+          specialists: ctx.agentService.getSpecialists(),
+          taskManager: tm,
         }));
-        return json({ tasks });
       },
     },
 

--- a/src/daemon/api-routes.ts
+++ b/src/daemon/api-routes.ts
@@ -537,11 +537,36 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
       GET: () => {
         const orchestrator = ctx.agentService.getOrchestrator();
         const taskManager = ctx.agentService.getTaskManager();
+        type AgentTask = {
+          id: string;
+          agentId: string;
+          status: string;
+          task: string;
+          startedAt: number;
+          completedAt?: number | null;
+        };
+        const latestTaskByAgent = new Map<string, AgentTask>();
+        const busyAgents = new Set<string>();
+
+        if (taskManager) {
+          for (const task of taskManager.listTasks()) {
+            if (!task.agentId) continue;
+            if (!task.completedAt) {
+              busyAgents.add(task.agentId);
+            }
+
+            const existing = latestTaskByAgent.get(task.agentId);
+            if (!existing || task.startedAt >= existing.startedAt) {
+              latestTaskByAgent.set(task.agentId, task);
+            }
+          }
+        }
+
         const agents = orchestrator.getAllAgents().map((a) => {
-          const latestTask = taskManager?.getAgentTask(a.id);
+          const latestTask = latestTaskByAgent.get(a.id);
           return {
             ...a.toJSON(),
-            busy: taskManager?.isAgentBusy(a.id) ?? false,
+            busy: busyAgents.has(a.id),
             latest_task: latestTask ? {
               id: latestTask.id,
               status: latestTask.status,
@@ -646,7 +671,15 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
     '/api/agents/tasks': {
       GET: () => {
         const tm = ctx.agentService.getTaskManager();
-        if (!tm) return json({ tasks: [], agents: [] });
+        if (!tm) {
+          return json({
+            active_agents: 0,
+            agents: [],
+            tasks_total: 0,
+            tasks_running: 0,
+            tasks: [],
+          });
+        }
         return json(listPersistentAgents({
           orchestrator: ctx.agentService.getOrchestrator(),
           llmManager: ctx.agentService.getLLMManager(),

--- a/ui/src/components/office/CommandCenterView.tsx
+++ b/ui/src/components/office/CommandCenterView.tsx
@@ -7,6 +7,14 @@ export type LiveAgentInfo = {
   status: "active" | "idle" | "terminated";
   current_task: string | null;
   created_at: number;
+  busy?: boolean;
+  latest_task?: {
+    id: string;
+    status: string;
+    task: string;
+    started_at: number;
+    completed_at: number | null;
+  } | null;
 };
 
 export type AgentWithLive = {
@@ -84,7 +92,8 @@ function AuthorityBar({
 
 function AgentCard({ agent }: { agent: AgentWithLive }) {
   const { live, isPrimary } = agent;
-  const isActive = live?.status === "active";
+  const isBusy = Boolean(live?.busy);
+  const isActive = isPrimary || isBusy;
 
   const cardClass = [
     "ag-card",
@@ -98,7 +107,7 @@ function AgentCard({ agent }: { agent: AgentWithLive }) {
   if (isPrimary) {
     statusLabel = "Primary";
     statusClass = "ag-status-badge primary-status";
-  } else if (isActive) {
+  } else if (isBusy) {
     statusLabel = "Active";
     statusClass = "ag-status-badge active";
   } else {
@@ -106,7 +115,7 @@ function AgentCard({ agent }: { agent: AgentWithLive }) {
     statusClass = "ag-status-badge idle";
   }
 
-  const currentTask = live?.current_task ?? null;
+  const currentTask = live?.current_task ?? live?.latest_task?.task ?? null;
   const sinceTs = live?.created_at ?? null;
 
   let timeLabel = "";
@@ -147,10 +156,10 @@ function AgentCard({ agent }: { agent: AgentWithLive }) {
 
 export default function CommandCenterView({ agents, agentActivity }: Props) {
   const activeAgents = agents.filter(
-    (a) => a.isPrimary || a.live?.status === "active"
+    (a) => a.isPrimary || a.live?.busy
   );
   const idleAgents = agents.filter(
-    (a) => !a.isPrimary && a.live?.status !== "active"
+    (a) => !a.isPrimary && !a.live?.busy
   );
 
   // Duplicate events for seamless scrolling loop

--- a/ui/src/components/office/OrbitalView.tsx
+++ b/ui/src/components/office/OrbitalView.tsx
@@ -102,7 +102,7 @@ export default function OrbitalView({ agents, agentActivity }: Props) {
   const [selectedRoleId, setSelectedRoleId] = useState<string | null>(null);
 
   const activeAgents = agents.filter(
-    (a) => !a.isPrimary && a.live?.status === "active"
+    (a) => !a.isPrimary && a.live?.busy
   );
   const activeCount = activeAgents.length + 1; // +1 for PA (always active)
 
@@ -287,7 +287,7 @@ export default function OrbitalView({ agents, agentActivity }: Props) {
           const pos = ORBITAL_POSITIONS[agent.roleId];
           if (!pos) return null;
 
-          const isActive = agent.live?.status === "active";
+          const isActive = Boolean(agent.live?.busy);
           const ring = pos.ring as "inner" | "outer";
 
           let bubbleClass = "ag-node-bubble";

--- a/ui/src/components/office/OrbitalView.tsx
+++ b/ui/src/components/office/OrbitalView.tsx
@@ -345,7 +345,7 @@ export default function OrbitalView({ agents, agentActivity }: Props) {
 
           const leftPct = pctToNum(pos.left);
           const topPct = pctToNum(pos.top);
-          const isActive = selectedAgent.live?.status === "active";
+          const isActive = Boolean(selectedAgent.live?.busy);
 
           // Place the card near the node but avoid overflow
           const cardLeft = leftPct > 60 ? `${leftPct - 22}%` : `${leftPct + 4}%`;

--- a/ui/src/pages/OfficePage.tsx
+++ b/ui/src/pages/OfficePage.tsx
@@ -27,11 +27,25 @@ type Props = {
 };
 
 type TabId = "command" | "orbital";
+type SpecialistInfo = {
+  id: string;
+  name: string;
+  description: string;
+  authority_level: number;
+  tools: string[];
+};
 
 export default function OfficePage({ agentActivity }: Props) {
   const [liveAgents, setLiveAgents] = useState<LiveAgentInfo[]>([]);
+  const [specialists, setSpecialists] = useState<SpecialistInfo[]>([]);
   const [activeTab, setActiveTab] = useState<TabId>("command");
   const [search, setSearch] = useState("");
+  const [spawnOpen, setSpawnOpen] = useState(false);
+  const [spawning, setSpawning] = useState(false);
+  const [spawnMessage, setSpawnMessage] = useState<{ text: string; type: "error" | "success" } | null>(null);
+  const [selectedSpecialist, setSelectedSpecialist] = useState("software-engineer");
+  const [spawnTask, setSpawnTask] = useState("");
+  const [spawnContext, setSpawnContext] = useState("");
 
   const fetchAgents = useCallback(async () => {
     try {
@@ -42,11 +56,28 @@ export default function OfficePage({ agentActivity }: Props) {
     }
   }, []);
 
+  const fetchSpecialists = useCallback(async () => {
+    try {
+      const data = await api<{ specialists: SpecialistInfo[] }>("/api/agents/specialists");
+      setSpecialists(data.specialists);
+      if (data.specialists.length > 0) {
+        setSelectedSpecialist((prev) => (
+          data.specialists.some((specialist) => specialist.id === prev)
+            ? prev
+            : data.specialists[0]!.id
+        ));
+      }
+    } catch {
+      /* keep previous */
+    }
+  }, []);
+
   useEffect(() => {
     fetchAgents();
+    fetchSpecialists();
     const interval = setInterval(fetchAgents, 5000);
     return () => clearInterval(interval);
-  }, [fetchAgents]);
+  }, [fetchAgents, fetchSpecialists]);
 
   function getLive(roleId: string): LiveAgentInfo | null {
     return (
@@ -73,9 +104,41 @@ export default function OfficePage({ agentActivity }: Props) {
 
   // Stats
   const activeCount = allAgents.filter(
-    (a) => a.isPrimary || a.live?.status === "active"
+    (a) => a.isPrimary || a.live?.busy
   ).length;
   const totalCount = AGENT_ROSTER.length;
+
+  const selectedSpecialistMeta = specialists.find((specialist) => specialist.id === selectedSpecialist) ?? null;
+
+  const handleSpawn = async () => {
+    setSpawning(true);
+    setSpawnMessage(null);
+    try {
+      const result = await api<{ assignment?: { message?: string } | null }>("/api/agents", {
+        method: "POST",
+        body: JSON.stringify({
+          specialist: selectedSpecialist,
+          task: spawnTask.trim() || undefined,
+          context: spawnContext.trim() || undefined,
+        }),
+      });
+      setSpawnMessage({
+        text: result.assignment?.message ?? "Agent spawned successfully.",
+        type: "success",
+      });
+      setSpawnTask("");
+      setSpawnContext("");
+      setSpawnOpen(false);
+      fetchAgents();
+    } catch (err) {
+      setSpawnMessage({
+        text: err instanceof Error ? err.message : "Failed to spawn agent.",
+        type: "error",
+      });
+    } finally {
+      setSpawning(false);
+    }
+  };
 
   return (
     <div className="ag-page">
@@ -97,7 +160,7 @@ export default function OfficePage({ agentActivity }: Props) {
             onChange={(e) => setSearch(e.target.value)}
           />
         </div>
-        <button className="ag-spawn-btn">
+        <button className="ag-spawn-btn" onClick={() => setSpawnOpen(true)}>
           <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
             <path d="M6 1v10M1 6h10" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
           </svg>
@@ -180,6 +243,191 @@ export default function OfficePage({ agentActivity }: Props) {
           agentActivity={agentActivity}
         />
       )}
+
+      {spawnMessage && (
+        <div
+          style={{
+            position: "fixed",
+            right: "24px",
+            top: "24px",
+            zIndex: 40,
+            maxWidth: "360px",
+            padding: "10px 12px",
+            borderRadius: "10px",
+            border: `1px solid ${spawnMessage.type === "error" ? "rgba(248,113,113,0.28)" : "rgba(52,211,153,0.28)"}`,
+            background: spawnMessage.type === "error" ? "rgba(248,113,113,0.10)" : "rgba(52,211,153,0.10)",
+            color: spawnMessage.type === "error" ? "var(--rose)" : "var(--emerald)",
+            fontSize: "12px",
+          }}
+        >
+          {spawnMessage.text}
+        </div>
+      )}
+
+      {spawnOpen && (
+        <div
+          onClick={() => !spawning && setSpawnOpen(false)}
+          style={{
+            position: "fixed",
+            inset: 0,
+            background: "rgba(3,6,12,0.72)",
+            backdropFilter: "blur(8px)",
+            zIndex: 50,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            padding: "20px",
+          }}
+        >
+          <div
+            onClick={(e) => e.stopPropagation()}
+            style={{
+              width: "min(560px, 100%)",
+              background: "rgba(9,13,22,0.98)",
+              border: "1px solid rgba(255,255,255,0.08)",
+              borderRadius: "18px",
+              padding: "20px",
+              boxShadow: "0 24px 80px rgba(0,0,0,0.4)",
+            }}
+          >
+            <div style={{ display: "flex", justifyContent: "space-between", gap: "12px", alignItems: "flex-start" }}>
+              <div>
+                <div style={{ color: "var(--text-1)", fontSize: "16px", fontWeight: 600 }}>Spawn Agent</div>
+                <div style={{ color: "var(--text-3)", fontSize: "12px", marginTop: "6px", lineHeight: 1.6 }}>
+                  Create a persistent specialist and optionally assign a task immediately.
+                </div>
+              </div>
+              <button
+                onClick={() => setSpawnOpen(false)}
+                disabled={spawning}
+                style={modalDismissButtonStyle}
+              >
+                ×
+              </button>
+            </div>
+
+            <div style={{ display: "flex", flexDirection: "column", gap: "14px", marginTop: "18px" }}>
+              <label style={fieldLabelStyle}>
+                Specialist
+                <select
+                  value={selectedSpecialist}
+                  onChange={(e) => setSelectedSpecialist(e.target.value)}
+                  style={fieldStyle}
+                >
+                  {specialists.map((specialist) => (
+                    <option key={specialist.id} value={specialist.id}>
+                      {specialist.name}
+                    </option>
+                  ))}
+                </select>
+              </label>
+
+              {selectedSpecialistMeta && (
+                <div style={metaCardStyle}>
+                  <div style={{ color: "var(--text-2)", fontSize: "12px", lineHeight: 1.6 }}>
+                    {selectedSpecialistMeta.description}
+                  </div>
+                  <div style={{ color: "var(--text-3)", fontSize: "11px", marginTop: "8px" }}>
+                    Auth {selectedSpecialistMeta.authority_level} · {selectedSpecialistMeta.tools.length} tools
+                  </div>
+                </div>
+              )}
+
+              <label style={fieldLabelStyle}>
+                Task
+                <textarea
+                  value={spawnTask}
+                  onChange={(e) => setSpawnTask(e.target.value)}
+                  rows={4}
+                  placeholder="Optional. Leave blank to spawn the agent in idle mode."
+                  style={{ ...fieldStyle, resize: "vertical", minHeight: "110px" }}
+                />
+              </label>
+
+              <label style={fieldLabelStyle}>
+                Context
+                <textarea
+                  value={spawnContext}
+                  onChange={(e) => setSpawnContext(e.target.value)}
+                  rows={3}
+                  placeholder="Optional background context for the task."
+                  style={{ ...fieldStyle, resize: "vertical", minHeight: "84px" }}
+                />
+              </label>
+            </div>
+
+            <div style={{ display: "flex", justifyContent: "flex-end", gap: "10px", marginTop: "18px" }}>
+              <button onClick={() => setSpawnOpen(false)} disabled={spawning} style={modalSecondaryButtonStyle}>
+                Cancel
+              </button>
+              <button onClick={handleSpawn} disabled={spawning || !selectedSpecialist} style={modalPrimaryButtonStyle}>
+                {spawning ? "Spawning..." : spawnTask.trim() ? "Spawn And Assign" : "Spawn Agent"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }
+
+const fieldLabelStyle: React.CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  gap: "8px",
+  color: "var(--text-2)",
+  fontSize: "12px",
+  fontWeight: 600,
+};
+
+const fieldStyle: React.CSSProperties = {
+  width: "100%",
+  background: "rgba(255,255,255,0.03)",
+  border: "1px solid rgba(255,255,255,0.08)",
+  borderRadius: "10px",
+  color: "var(--text-1)",
+  fontSize: "13px",
+  padding: "12px 14px",
+  outline: "none",
+};
+
+const metaCardStyle: React.CSSProperties = {
+  border: "1px solid rgba(255,255,255,0.08)",
+  borderRadius: "12px",
+  background: "rgba(255,255,255,0.025)",
+  padding: "12px 14px",
+};
+
+const modalPrimaryButtonStyle: React.CSSProperties = {
+  border: "1px solid rgba(34,211,238,0.24)",
+  background: "rgba(34,211,238,0.14)",
+  color: "var(--cyan)",
+  borderRadius: "10px",
+  padding: "10px 14px",
+  fontSize: "12px",
+  fontWeight: 600,
+  cursor: "pointer",
+};
+
+const modalSecondaryButtonStyle: React.CSSProperties = {
+  border: "1px solid rgba(255,255,255,0.08)",
+  background: "transparent",
+  color: "var(--text-2)",
+  borderRadius: "10px",
+  padding: "10px 14px",
+  fontSize: "12px",
+  fontWeight: 500,
+  cursor: "pointer",
+};
+
+const modalDismissButtonStyle: React.CSSProperties = {
+  width: "30px",
+  height: "30px",
+  borderRadius: "999px",
+  border: "1px solid rgba(255,255,255,0.08)",
+  background: "transparent",
+  color: "var(--text-3)",
+  fontSize: "18px",
+  lineHeight: 1,
+  cursor: "pointer",
+};

--- a/ui/src/pages/OfficePage.tsx
+++ b/ui/src/pages/OfficePage.tsx
@@ -43,7 +43,7 @@ export default function OfficePage({ agentActivity }: Props) {
   const [spawnOpen, setSpawnOpen] = useState(false);
   const [spawning, setSpawning] = useState(false);
   const [spawnMessage, setSpawnMessage] = useState<{ text: string; type: "error" | "success" } | null>(null);
-  const [selectedSpecialist, setSelectedSpecialist] = useState("software-engineer");
+  const [selectedSpecialist, setSelectedSpecialist] = useState("");
   const [spawnTask, setSpawnTask] = useState("");
   const [spawnContext, setSpawnContext] = useState("");
 
@@ -66,6 +66,8 @@ export default function OfficePage({ agentActivity }: Props) {
             ? prev
             : data.specialists[0]!.id
         ));
+      } else {
+        setSelectedSpecialist("");
       }
     } catch {
       /* keep previous */
@@ -109,6 +111,7 @@ export default function OfficePage({ agentActivity }: Props) {
   const totalCount = AGENT_ROSTER.length;
 
   const selectedSpecialistMeta = specialists.find((specialist) => specialist.id === selectedSpecialist) ?? null;
+  const canSpawn = selectedSpecialist.length > 0;
 
   const handleSpawn = async () => {
     setSpawning(true);
@@ -160,7 +163,7 @@ export default function OfficePage({ agentActivity }: Props) {
             onChange={(e) => setSearch(e.target.value)}
           />
         </div>
-        <button className="ag-spawn-btn" onClick={() => setSpawnOpen(true)}>
+        <button className="ag-spawn-btn" onClick={() => setSpawnOpen(true)} disabled={!canSpawn}>
           <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
             <path d="M6 1v10M1 6h10" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
           </svg>
@@ -314,6 +317,11 @@ export default function OfficePage({ agentActivity }: Props) {
                   onChange={(e) => setSelectedSpecialist(e.target.value)}
                   style={fieldStyle}
                 >
+                  {specialists.length === 0 && (
+                    <option value="" disabled>
+                      No specialists available
+                    </option>
+                  )}
                   {specialists.map((specialist) => (
                     <option key={specialist.id} value={specialist.id}>
                       {specialist.name}
@@ -321,6 +329,14 @@ export default function OfficePage({ agentActivity }: Props) {
                   ))}
                 </select>
               </label>
+
+              {specialists.length === 0 && (
+                <div style={metaCardStyle}>
+                  <div style={{ color: "var(--text-2)", fontSize: "12px", lineHeight: 1.6 }}>
+                    Specialist discovery is unavailable right now. Reload the page once the daemon finishes initializing.
+                  </div>
+                </div>
+              )}
 
               {selectedSpecialistMeta && (
                 <div style={metaCardStyle}>
@@ -360,7 +376,7 @@ export default function OfficePage({ agentActivity }: Props) {
               <button onClick={() => setSpawnOpen(false)} disabled={spawning} style={modalSecondaryButtonStyle}>
                 Cancel
               </button>
-              <button onClick={handleSpawn} disabled={spawning || !selectedSpecialist} style={modalPrimaryButtonStyle}>
+              <button onClick={handleSpawn} disabled={spawning || !canSpawn} style={modalPrimaryButtonStyle}>
                 {spawning ? "Spawning..." : spawnTask.trim() ? "Spawn And Assign" : "Spawn Agent"}
               </button>
             </div>


### PR DESCRIPTION
## What Changed
- restores the Agents tab spawn flow by wiring the UI to a real backend spawn endpoint
- exposes specialist discovery plus persistent agent spawn and terminate APIs
- reports live busy state and latest task metadata so Command Center and Orbital views reflect actual agent activity
- resets persistent sub-agents back to idle after task completion instead of leaving them stuck as active

## Why
The Agents tab had a non-functional spawn action and unreliable live-status rendering. The UI looked interactive, but key actions were not connected to working backend behavior.

## Impact
Users can spawn specialists from the Agents tab again and see more accurate active/idle state across the office views.

## Validation
- `bun run build:ui`
- `./node_modules/.bin/tsc -p tsconfig.json --noEmit`
