### PR TITLE
Add dashboard controls for the 24/7 JARVIS service

### DIFF
--- a/src/cli/autostart.ts
+++ b/src/cli/autostart.ts
@@ -9,6 +9,7 @@
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 import { Buffer } from 'node:buffer';
+import { spawn } from 'node:child_process';
 import { existsSync, mkdirSync, writeFileSync, unlinkSync } from 'node:fs';
 import { c, printOk, printErr, printWarn } from './helpers.ts';
 
@@ -122,6 +123,20 @@ async function startSystemdService(): Promise<boolean> {
     return true;
   } catch (err) {
     printErr(`Failed to start systemd service: ${err}`);
+    return false;
+  }
+}
+
+function scheduleSystemdRestart(): boolean {
+  try {
+    const child = spawn('bash', ['-lc', 'sleep 1; systemctl --user restart jarvis.service >/dev/null 2>&1'], {
+      detached: true,
+      stdio: 'ignore',
+      env: { ...process.env },
+    });
+    child.unref();
+    return true;
+  } catch {
     return false;
   }
 }
@@ -274,6 +289,24 @@ async function startLaunchdService(): Promise<boolean> {
   }
 }
 
+function scheduleLaunchdRestart(): boolean {
+  try {
+    const uid = process.getuid?.();
+    const command = uid != null
+      ? `sleep 1; launchctl kickstart -k gui/${uid}/ai.jarvis.daemon >/dev/null 2>&1`
+      : `sleep 1; launchctl kickstart -k gui/$(id -u)/ai.jarvis.daemon >/dev/null 2>&1`;
+    const child = spawn('bash', ['-lc', command], {
+      detached: true,
+      stdio: 'ignore',
+      env: { ...process.env },
+    });
+    child.unref();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 async function uninstallLaunchd(): Promise<boolean> {
   try {
     if (existsSync(LAUNCHD_PLIST)) {
@@ -313,6 +346,20 @@ export async function startAutostartService(): Promise<boolean> {
     return startLaunchdService();
   }
   return startSystemdService();
+}
+
+/**
+ * Schedule a restart of the installed autostart service without blocking
+ * the current process. Useful when the API call is served by that service.
+ */
+export function scheduleAutostartRestart(): boolean {
+  if (process.platform === 'darwin') {
+    return scheduleLaunchdRestart();
+  }
+  if (process.platform === 'linux') {
+    return scheduleSystemdRestart();
+  }
+  return false;
 }
 
 /**

--- a/src/cli/autostart.ts
+++ b/src/cli/autostart.ts
@@ -13,6 +13,36 @@ import { spawn } from 'node:child_process';
 import { existsSync, mkdirSync, writeFileSync, unlinkSync } from 'node:fs';
 import { c, printOk, printErr, printWarn } from './helpers.ts';
 
+function canSpawnBinary(binary: string): boolean {
+  try {
+    return Boolean(Bun.which(binary));
+  } catch {
+    return false;
+  }
+}
+
+function spawnDetachedShell(command: string, requiredBinaries: string[]): boolean {
+  if (!requiredBinaries.every(canSpawnBinary)) {
+    return false;
+  }
+
+  try {
+    const child = spawn('bash', ['-lc', command], {
+      detached: true,
+      stdio: 'ignore',
+      env: { ...process.env },
+    });
+    if (child.pid == null) {
+      return false;
+    }
+    child.once('error', () => {});
+    child.unref();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function getBunPath(): string {
   try {
     return Bun.which('bun') ?? 'bun';
@@ -128,17 +158,10 @@ async function startSystemdService(): Promise<boolean> {
 }
 
 function scheduleSystemdRestart(): boolean {
-  try {
-    const child = spawn('bash', ['-lc', 'sleep 1; systemctl --user restart jarvis.service >/dev/null 2>&1'], {
-      detached: true,
-      stdio: 'ignore',
-      env: { ...process.env },
-    });
-    child.unref();
-    return true;
-  } catch {
-    return false;
-  }
+  return spawnDetachedShell(
+    'sleep 1; systemctl --user restart jarvis.service >/dev/null 2>&1',
+    ['bash', 'systemctl'],
+  );
 }
 
 async function uninstallSystemd(): Promise<boolean> {
@@ -290,21 +313,11 @@ async function startLaunchdService(): Promise<boolean> {
 }
 
 function scheduleLaunchdRestart(): boolean {
-  try {
-    const uid = process.getuid?.();
-    const command = uid != null
-      ? `sleep 1; launchctl kickstart -k gui/${uid}/ai.jarvis.daemon >/dev/null 2>&1`
-      : `sleep 1; launchctl kickstart -k gui/$(id -u)/ai.jarvis.daemon >/dev/null 2>&1`;
-    const child = spawn('bash', ['-lc', command], {
-      detached: true,
-      stdio: 'ignore',
-      env: { ...process.env },
-    });
-    child.unref();
-    return true;
-  } catch {
-    return false;
-  }
+  const uid = process.getuid?.();
+  const command = uid != null
+    ? `sleep 1; launchctl kickstart -k gui/${uid}/ai.jarvis.daemon >/dev/null 2>&1`
+    : `sleep 1; launchctl kickstart -k gui/$(id -u)/ai.jarvis.daemon >/dev/null 2>&1`;
+  return spawnDetachedShell(command, ['bash', 'launchctl']);
 }
 
 async function uninstallLaunchd(): Promise<boolean> {

--- a/src/daemon/api-routes.ts
+++ b/src/daemon/api-routes.ts
@@ -784,7 +784,7 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
         const keepaliveSupported = process.platform === 'darwin' || process.platform === 'linux';
         return json({
           platform: process.platform,
-          manager: getAutostartName(),
+          manager: keepaliveSupported ? getAutostartName() : 'unsupported',
           installed,
           keepalive_supported: keepaliveSupported,
           restart_supported: keepaliveSupported && installed,

--- a/src/daemon/api-routes.ts
+++ b/src/daemon/api-routes.ts
@@ -105,6 +105,11 @@ import {
   getCapturesInRange,
 } from '../vault/awareness.ts';
 import type { SuggestionType } from '../awareness/types.ts';
+import {
+  getAutostartName,
+  isAutostartInstalled,
+  scheduleAutostartRestart,
+} from '../cli/autostart.ts';
 
 export type ApiContext = {
   healthMonitor: HealthMonitor;
@@ -769,6 +774,39 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
           authority: config.authority,
           heartbeat: config.heartbeat,
           active_role: config.active_role,
+        });
+      },
+    },
+
+    '/api/system/autostart': {
+      GET: () => {
+        const installed = isAutostartInstalled();
+        const keepaliveSupported = process.platform === 'darwin' || process.platform === 'linux';
+        return json({
+          platform: process.platform,
+          manager: getAutostartName(),
+          installed,
+          keepalive_supported: keepaliveSupported,
+          restart_supported: keepaliveSupported && installed,
+        });
+      },
+    },
+
+    '/api/system/autostart/restart': {
+      POST: () => {
+        if (!(process.platform === 'darwin' || process.platform === 'linux')) {
+          return error('24/7 restart is not supported on this platform.', 400);
+        }
+        if (!isAutostartInstalled()) {
+          return error('JARVIS keepalive mode is not installed yet.', 400);
+        }
+        const scheduled = scheduleAutostartRestart();
+        if (!scheduled) {
+          return error('Failed to schedule keepalive service restart.');
+        }
+        return json({
+          ok: true,
+          message: `Restarting the JARVIS 24/7 ${getAutostartName()} service.`,
         });
       },
     },

--- a/ui/src/components/settings/ServicePanel.tsx
+++ b/ui/src/components/settings/ServicePanel.tsx
@@ -1,0 +1,233 @@
+import React, { useState } from "react";
+import { api, useApiData } from "../../hooks/useApi";
+
+type AutostartStatus = {
+  platform: string;
+  manager: string;
+  installed: boolean;
+  keepalive_supported: boolean;
+  restart_supported: boolean;
+};
+
+export function ServicePanel() {
+  const { data, loading, error, refetch } = useApiData<AutostartStatus>("/api/system/autostart", []);
+  const [phase, setPhase] = useState<"idle" | "restarting">("idle");
+  const [message, setMessage] = useState<{ text: string; type: "success" | "error" } | null>(null);
+
+  const restartService = async () => {
+    setPhase("restarting");
+    setMessage(null);
+    try {
+      const res = await api<{ ok: boolean; message: string }>("/api/system/autostart/restart", {
+        method: "POST",
+      });
+      setMessage({ text: res.message, type: "success" });
+      setTimeout(() => refetch(), 2500);
+    } catch (err) {
+      setMessage({
+        text: err instanceof Error ? err.message : "Failed to restart service.",
+        type: "error",
+      });
+    } finally {
+      setPhase("idle");
+    }
+  };
+
+  if (loading) {
+    return <div style={cardStyle}><span style={mutedTextStyle}>Loading service controls...</span></div>;
+  }
+
+  if (error && !data) {
+    return (
+      <div style={cardStyle}>
+        <div style={{ ...messageStyle, color: "var(--j-error)", borderColor: "rgba(248, 113, 113, 0.22)", background: "rgba(248, 113, 113, 0.08)", marginBottom: 0 }}>
+          {error}
+        </div>
+      </div>
+    );
+  }
+
+  if (!data) {
+    return <div style={cardStyle}><span style={mutedTextStyle}>Service controls unavailable.</span></div>;
+  }
+
+  return (
+    <div style={cardStyle}>
+      <div style={headerRowStyle}>
+        <div>
+          <h3 style={headerStyle}>24/7 Service</h3>
+          <div style={subtleStyle}>
+            Manage the keepalive service that keeps JARVIS running after the terminal closes.
+          </div>
+        </div>
+        <span
+          style={{
+            ...statusBadgeStyle,
+            color: data.installed ? "var(--j-success)" : "var(--j-text-muted)",
+            borderColor: data.installed ? "rgba(52, 211, 153, 0.25)" : "var(--j-border)",
+            background: data.installed ? "rgba(52, 211, 153, 0.10)" : "rgba(255,255,255,0.03)",
+          }}
+        >
+          {data.installed ? "Installed" : "Not Installed"}
+        </span>
+      </div>
+
+      <div style={infoGridStyle}>
+        <InfoRow label="Manager" value={data.manager} />
+        <InfoRow label="Platform" value={data.platform} />
+        <InfoRow
+          label="Restart"
+          value={data.restart_supported ? "Available" : data.keepalive_supported ? "Install keepalive first" : "Not supported"}
+        />
+      </div>
+
+      {message && (
+        <div style={{
+          ...messageStyle,
+          color: message.type === "success" ? "var(--j-success)" : "var(--j-error)",
+          borderColor: message.type === "success" ? "rgba(52, 211, 153, 0.22)" : "rgba(248, 113, 113, 0.22)",
+          background: message.type === "success" ? "rgba(52, 211, 153, 0.08)" : "rgba(248, 113, 113, 0.08)",
+        }}>
+          {message.text}
+        </div>
+      )}
+
+      {error && !message && (
+        <div style={{ ...messageStyle, color: "var(--j-error)", borderColor: "rgba(248, 113, 113, 0.22)", background: "rgba(248, 113, 113, 0.08)" }}>
+          {error}
+        </div>
+      )}
+
+      <div style={actionsStyle}>
+        <button
+          type="button"
+          onClick={restartService}
+          disabled={!data.restart_supported || phase === "restarting"}
+          style={{
+            ...buttonStyle,
+            opacity: !data.restart_supported || phase === "restarting" ? 0.55 : 1,
+            cursor: !data.restart_supported || phase === "restarting" ? "not-allowed" : "pointer",
+          }}
+        >
+          {phase === "restarting" ? "Restarting..." : "Restart 24/7 JARVIS"}
+        </button>
+        <button type="button" onClick={refetch} style={secondaryButtonStyle}>
+          Refresh Status
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function InfoRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div style={infoRowStyle}>
+      <span style={infoLabelStyle}>{label}</span>
+      <span style={infoValueStyle}>{value}</span>
+    </div>
+  );
+}
+
+const cardStyle: React.CSSProperties = {
+  padding: "20px",
+  background: "var(--j-surface)",
+  border: "1px solid var(--j-border)",
+  borderRadius: "8px",
+};
+
+const headerRowStyle: React.CSSProperties = {
+  display: "flex",
+  justifyContent: "space-between",
+  gap: "16px",
+  alignItems: "flex-start",
+  marginBottom: "16px",
+  flexWrap: "wrap",
+};
+
+const headerStyle: React.CSSProperties = {
+  fontSize: "14px",
+  fontWeight: 600,
+  color: "var(--j-text)",
+  margin: 0,
+};
+
+const subtleStyle: React.CSSProperties = {
+  fontSize: "12px",
+  lineHeight: 1.5,
+  color: "var(--j-text-muted)",
+  marginTop: "6px",
+  maxWidth: "560px",
+};
+
+const mutedTextStyle: React.CSSProperties = {
+  color: "var(--j-text-muted)",
+  fontSize: "13px",
+};
+
+const statusBadgeStyle: React.CSSProperties = {
+  padding: "5px 10px",
+  borderRadius: "999px",
+  border: "1px solid var(--j-border)",
+  fontSize: "11px",
+  fontWeight: 600,
+  textTransform: "uppercase",
+  letterSpacing: "0.05em",
+};
+
+const infoGridStyle: React.CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  gap: "10px",
+  marginBottom: "16px",
+};
+
+const infoRowStyle: React.CSSProperties = {
+  display: "flex",
+  justifyContent: "space-between",
+  gap: "12px",
+  fontSize: "13px",
+};
+
+const infoLabelStyle: React.CSSProperties = {
+  color: "var(--j-text-dim)",
+};
+
+const infoValueStyle: React.CSSProperties = {
+  color: "var(--j-text)",
+  textTransform: "capitalize",
+};
+
+const messageStyle: React.CSSProperties = {
+  fontSize: "12px",
+  border: "1px solid transparent",
+  borderRadius: "8px",
+  padding: "10px 12px",
+  marginBottom: "16px",
+};
+
+const actionsStyle: React.CSSProperties = {
+  display: "flex",
+  gap: "10px",
+  flexWrap: "wrap",
+};
+
+const buttonStyle: React.CSSProperties = {
+  border: "1px solid rgba(0, 212, 255, 0.28)",
+  background: "rgba(0, 212, 255, 0.12)",
+  color: "var(--j-accent)",
+  borderRadius: "8px",
+  padding: "10px 14px",
+  fontSize: "13px",
+  fontWeight: 600,
+};
+
+const secondaryButtonStyle: React.CSSProperties = {
+  border: "1px solid var(--j-border)",
+  background: "transparent",
+  color: "var(--j-text-muted)",
+  borderRadius: "8px",
+  padding: "10px 14px",
+  fontSize: "13px",
+  fontWeight: 500,
+  cursor: "pointer",
+};

--- a/ui/src/components/settings/ServicePanel.tsx
+++ b/ui/src/components/settings/ServicePanel.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { api, useApiData } from "../../hooks/useApi";
 
 type AutostartStatus = {
@@ -13,6 +13,15 @@ export function ServicePanel() {
   const { data, loading, error, refetch } = useApiData<AutostartStatus>("/api/system/autostart", []);
   const [phase, setPhase] = useState<"idle" | "restarting">("idle");
   const [message, setMessage] = useState<{ text: string; type: "success" | "error" } | null>(null);
+  const refreshTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (refreshTimerRef.current) {
+        clearTimeout(refreshTimerRef.current);
+      }
+    };
+  }, []);
 
   const restartService = async () => {
     setPhase("restarting");
@@ -22,13 +31,19 @@ export function ServicePanel() {
         method: "POST",
       });
       setMessage({ text: res.message, type: "success" });
-      setTimeout(() => refetch(), 2500);
+      if (refreshTimerRef.current) {
+        clearTimeout(refreshTimerRef.current);
+      }
+      refreshTimerRef.current = setTimeout(async () => {
+        await refetch();
+        setPhase("idle");
+        refreshTimerRef.current = null;
+      }, 2500);
     } catch (err) {
       setMessage({
         text: err instanceof Error ? err.message : "Failed to restart service.",
         type: "error",
       });
-    } finally {
       setPhase("idle");
     }
   };

--- a/ui/src/pages/SettingsPage.tsx
+++ b/ui/src/pages/SettingsPage.tsx
@@ -8,6 +8,7 @@ import { IntegrationsPanel } from "../components/settings/IntegrationsPanel";
 import { ChannelsPanel } from "../components/settings/ChannelsPanel";
 import { SidecarPanel } from "../components/settings/SidecarPanel";
 import { UserProfilePanel } from "../components/settings/UserProfilePanel";
+import { ServicePanel } from "../components/settings/ServicePanel";
 
 const SECTION_META: Record<SettingsSection, { title: string; subtitle: string }> = {
   general: { title: "General", subtitle: "Personality, role, and heartbeat configuration" },
@@ -44,6 +45,7 @@ export default function SettingsPage({ section }: { section: SettingsSection }) 
         <div style={{ display: "flex", flexDirection: "column", gap: "20px" }}>
           {section === "general" && (
             <>
+              <ServicePanel />
               <PersonalityPanel />
               <RolePanel />
               <HeartbeatPanel />


### PR DESCRIPTION
## What changed

This PR adds the dashboard-side management for the keepalive service.

- adds `GET /api/system/autostart`
- adds `POST /api/system/autostart/restart`
- adds a `24/7 Service` panel under `Settings > General`
- adds safe self-restart scheduling for the managed service
- keeps the service panel error state from looking like an infinite loading state when the API request fails

## Why

PR #56 mixed the onboarding keepalive flow with the dashboard service controls and other unrelated preview work. This PR keeps the UI/API management layer isolated.

## Validation

- not re-run end-to-end in this clean worktree because the repo's pre-commit/test environment is currently incomplete there (`edge-tts-universal` missing)
- `bunx tsc --noEmit` in the clean worktree currently stops on the repo's `baseUrl` deprecation warning in `tsconfig.json`
