### PR TITLE
fix(sidecar-windows): improve app launch and CDP attachment reliability

### DIFF
--- a/sidecar/browser.go
+++ b/sidecar/browser.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -56,34 +58,44 @@ func getCDP(cfg *SidecarConfig) (*cdpClient, error) {
 }
 
 func newCDPClient(port int) (*cdpClient, error) {
-	// Get the first page's WebSocket URL from Chrome's /json endpoint
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	url := fmt.Sprintf("http://localhost:%d/json", port)
-	req, _ := http.NewRequestWithContext(ctx, "GET", url, nil)
-	resp, err := http.DefaultClient.Do(req)
+	targets, err := fetchCDPTargets(ctx, port)
 	if err != nil {
 		return nil, fmt.Errorf("Chrome not running on port %d — launch Chrome with --remote-debugging-port=%d: %w", port, port, err)
-	}
-	defer resp.Body.Close()
-
-	body, _ := io.ReadAll(resp.Body)
-	var targets []struct {
-		WebSocketDebuggerUrl string `json:"webSocketDebuggerUrl"`
-		Type                 string `json:"type"`
-	}
-	if err := json.Unmarshal(body, &targets); err != nil {
-		return nil, fmt.Errorf("parse CDP targets: %w", err)
 	}
 
 	wsURL := ""
 	for _, t := range targets {
-		if t.Type == "page" && t.WebSocketDebuggerUrl != "" {
-			wsURL = t.WebSocketDebuggerUrl
-			break
+		if t.Type != "page" || t.WebSocketDebuggerUrl == "" {
+			continue
+		}
+		u := strings.ToLower(t.URL)
+		// Skip non-user pages that frequently break automation attachment.
+		if strings.HasPrefix(u, "chrome://") || strings.HasPrefix(u, "devtools://") || strings.HasPrefix(u, "chrome-extension://") {
+			continue
+		}
+		wsURL = t.WebSocketDebuggerUrl
+		break
+	}
+
+	if wsURL == "" {
+		for _, t := range targets {
+			if t.Type == "page" && t.WebSocketDebuggerUrl != "" {
+				wsURL = t.WebSocketDebuggerUrl
+				break
+			}
 		}
 	}
+
+	if wsURL == "" {
+		newTargetURL, targetErr := createCDPTarget(ctx, port, "about:blank")
+		if targetErr == nil {
+			wsURL = newTargetURL
+		}
+	}
+
 	if wsURL == "" {
 		return nil, fmt.Errorf("no CDP page target found on port %d", port)
 	}
@@ -104,6 +116,49 @@ func newCDPClient(port int) (*cdpClient, error) {
 	go c.readLoop()
 
 	return c, nil
+}
+
+type cdpTarget struct {
+	WebSocketDebuggerUrl string `json:"webSocketDebuggerUrl"`
+	Type                 string `json:"type"`
+	URL                  string `json:"url"`
+}
+
+func fetchCDPTargets(ctx context.Context, port int) ([]cdpTarget, error) {
+	url := fmt.Sprintf("http://localhost:%d/json", port)
+	req, _ := http.NewRequestWithContext(ctx, "GET", url, nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	var targets []cdpTarget
+	if err := json.Unmarshal(body, &targets); err != nil {
+		return nil, fmt.Errorf("parse CDP targets: %w", err)
+	}
+	return targets, nil
+}
+
+func createCDPTarget(ctx context.Context, port int, pageURL string) (string, error) {
+	createURL := fmt.Sprintf("http://localhost:%d/json/new?%s", port, url.QueryEscape(pageURL))
+	req, _ := http.NewRequestWithContext(ctx, "GET", createURL, nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	var target cdpTarget
+	if err := json.Unmarshal(body, &target); err != nil {
+		return "", fmt.Errorf("parse created CDP target: %w", err)
+	}
+	if target.WebSocketDebuggerUrl == "" {
+		return "", fmt.Errorf("created CDP target missing websocket URL")
+	}
+	return target.WebSocketDebuggerUrl, nil
 }
 
 func (c *cdpClient) readLoop() {

--- a/sidecar/browser.go
+++ b/sidecar/browser.go
@@ -126,14 +126,23 @@ type cdpTarget struct {
 
 func fetchCDPTargets(ctx context.Context, port int) ([]cdpTarget, error) {
 	url := fmt.Sprintf("http://localhost:%d/json", port)
-	req, _ := http.NewRequestWithContext(ctx, "GET", url, nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build CDP targets request: %w", err)
+	}
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
 	defer resp.Body.Close()
 
-	body, _ := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read CDP targets body: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("CDP targets returned status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
 	var targets []cdpTarget
 	if err := json.Unmarshal(body, &targets); err != nil {
 		return nil, fmt.Errorf("parse CDP targets: %w", err)
@@ -143,14 +152,23 @@ func fetchCDPTargets(ctx context.Context, port int) ([]cdpTarget, error) {
 
 func createCDPTarget(ctx context.Context, port int, pageURL string) (string, error) {
 	createURL := fmt.Sprintf("http://localhost:%d/json/new?%s", port, url.QueryEscape(pageURL))
-	req, _ := http.NewRequestWithContext(ctx, "GET", createURL, nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", createURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("build CDP target create request: %w", err)
+	}
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return "", err
 	}
 	defer resp.Body.Close()
 
-	body, _ := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("read created CDP target body: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", fmt.Errorf("create CDP target returned status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
 	var target cdpTarget
 	if err := json.Unmarshal(body, &target); err != nil {
 		return "", fmt.Errorf("parse created CDP target: %w", err)

--- a/sidecar/desktop_windows.go
+++ b/sidecar/desktop_windows.go
@@ -218,6 +218,7 @@ $exe = '%s'
 $argLine = '%s'
 
 $p = $null
+$launchedViaShell = $false
 $errors = New-Object System.Collections.Generic.List[string]
 
 function Try-Launch([string]$filePath, [string]$argumentLine) {
@@ -230,7 +231,7 @@ function Try-Launch([string]$filePath, [string]$argumentLine) {
 try {
 	$p = Try-Launch $exe $argLine
 } catch {
-	$errors.Add($_.Exception.Message)
+	[void]$errors.Add($_.Exception.Message)
 }
 
 $normalized = [System.IO.Path]::GetFileNameWithoutExtension($exe).ToLowerInvariant()
@@ -239,27 +240,31 @@ if (-not $p -and $normalized -eq 'spotify') {
 	try {
 		$p = Try-Launch 'spotify:' $argLine
 	} catch {
-		$errors.Add($_.Exception.Message)
+		[void]$errors.Add($_.Exception.Message)
 	}
 }
 
-if (-not $p -and $exe -match '^[a-zA-Z0-9._-]+$') {
+if (-not $p -and $exe -match '^[a-zA-Z0-9._-]+$' -and [string]::IsNullOrWhiteSpace($argLine)) {
 	try {
 		$cmdArgs = '/c start "" ' + $exe
-		if (-not [string]::IsNullOrWhiteSpace($argLine)) {
-			$cmdArgs += ' ' + $argLine
-		}
-		$p = Start-Process -FilePath 'cmd.exe' -ArgumentList $cmdArgs -PassThru -ErrorAction Stop
+		Start-Process -FilePath 'cmd.exe' -ArgumentList $cmdArgs -ErrorAction Stop | Out-Null
+		$launchedViaShell = $true
 	} catch {
-		$errors.Add($_.Exception.Message)
+		[void]$errors.Add($_.Exception.Message)
 	}
 }
 
 if (-not $p) {
-	throw ('Unable to launch app "' + $exe + '". Attempts: ' + ($errors -join ' | '))
+	if (-not $launchedViaShell) {
+		throw ('Unable to launch app "' + $exe + '". Attempts: ' + ($errors -join ' | '))
+	}
 }
 
-@{ success=$true; pid=$p.Id; name=$p.ProcessName } | ConvertTo-Json -Compress
+if ($launchedViaShell) {
+	@{ success=$true; pid=$null; name=$exe; shell_fallback=$true } | ConvertTo-Json -Compress
+} else {
+	@{ success=$true; pid=$p.Id; name=$p.ProcessName } | ConvertTo-Json -Compress
+}
 `, escaped, escapedArgs)
 
 	out, err := runPS(script, 10*time.Second)

--- a/sidecar/desktop_windows.go
+++ b/sidecar/desktop_windows.go
@@ -210,15 +210,57 @@ func handleLaunchApp(params map[string]any) (*RPCResult, error) {
 	args, _ := params["args"].(string)
 
 	escaped := strings.ReplaceAll(executable, "'", "''")
-	argsClause := ""
-	if args != "" {
-		argsClause = fmt.Sprintf("-ArgumentList '%s'", strings.ReplaceAll(args, "'", "''"))
-	}
+	escapedArgs := strings.ReplaceAll(args, "'", "''")
 
+	// Resolve common app aliases/URIs first, then fall back to shell launch for bare names.
 	script := fmt.Sprintf(`
-$p = Start-Process -FilePath '%s' %s -PassThru
+$exe = '%s'
+$argLine = '%s'
+
+$p = $null
+$errors = New-Object System.Collections.Generic.List[string]
+
+function Try-Launch([string]$filePath, [string]$argumentLine) {
+	if ([string]::IsNullOrWhiteSpace($argumentLine)) {
+		return Start-Process -FilePath $filePath -PassThru -ErrorAction Stop
+	}
+	return Start-Process -FilePath $filePath -ArgumentList $argumentLine -PassThru -ErrorAction Stop
+}
+
+try {
+	$p = Try-Launch $exe $argLine
+} catch {
+	$errors.Add($_.Exception.Message)
+}
+
+$normalized = [System.IO.Path]::GetFileNameWithoutExtension($exe).ToLowerInvariant()
+
+if (-not $p -and $normalized -eq 'spotify') {
+	try {
+		$p = Try-Launch 'spotify:' $argLine
+	} catch {
+		$errors.Add($_.Exception.Message)
+	}
+}
+
+if (-not $p -and $exe -match '^[a-zA-Z0-9._-]+$') {
+	try {
+		$cmdArgs = '/c start "" ' + $exe
+		if (-not [string]::IsNullOrWhiteSpace($argLine)) {
+			$cmdArgs += ' ' + $argLine
+		}
+		$p = Start-Process -FilePath 'cmd.exe' -ArgumentList $cmdArgs -PassThru -ErrorAction Stop
+	} catch {
+		$errors.Add($_.Exception.Message)
+	}
+}
+
+if (-not $p) {
+	throw ('Unable to launch app "' + $exe + '". Attempts: ' + ($errors -join ' | '))
+}
+
 @{ success=$true; pid=$p.Id; name=$p.ProcessName } | ConvertTo-Json -Compress
-`, escaped, argsClause)
+`, escaped, escapedArgs)
 
 	out, err := runPS(script, 10*time.Second)
 	if err != nil {

--- a/sidecar/platform_windows.go
+++ b/sidecar/platform_windows.go
@@ -7,7 +7,9 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"time"
 )
@@ -64,7 +66,7 @@ func launchChromeIfNeeded(cfg *SidecarConfig) {
 
 	profileDir := cfg.Browser.ProfileDir
 	if profileDir == "" {
-		profileDir = fmt.Sprintf(`%%TEMP%%\jarvis-chrome-profile`)
+		profileDir = filepath.Join(os.TempDir(), "jarvis-chrome-profile")
 	}
 
 	for _, chromePath := range chromePaths {
@@ -72,6 +74,9 @@ func launchChromeIfNeeded(cfg *SidecarConfig) {
 			fmt.Sprintf("--remote-debugging-port=%d", port),
 			fmt.Sprintf("--user-data-dir=%s", profileDir),
 			"--no-first-run",
+			"--no-default-browser-check",
+			"--disable-sync",
+			"--disable-features=ChromeWhatsNewUI",
 			"about:blank",
 		)
 		if err := cmd.Start(); err == nil {


### PR DESCRIPTION
## Summary
- Improves Windows app launch fallback behavior.
- Improves browser CDP target attach reliability.

## Why
- Reduces flaky Windows automation failures.

## Key Changes
- Windows desktop launch fallback handling.
- CDP target selection/attach flow hardening.

## Validation
- Branch pushed and check status green in branch list.