### PR TITLE
feat(authority): sync live role authority and add connect greeting

### DIFF
--- a/src/daemon/api-routes.ts
+++ b/src/daemon/api-routes.ts
@@ -146,6 +146,12 @@ function getSearchParams(req: Request): URLSearchParams {
   return new URL(req.url).searchParams;
 }
 
+async function syncActiveRoleAuthorityLevel(ctx: ApiContext, authorityLevel: number): Promise<void> {
+  const primary = ctx.agentService.getOrchestrator().getPrimary();
+  if (!primary?.agent?.role) return;
+  primary.agent.role.authority_level = authorityLevel;
+}
+
 /**
  * Create all API route handlers.
  */
@@ -1363,6 +1369,10 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
             learning: currentConfig.learning,
           };
           await saveConfig(freshConfig);
+
+          if (body.default_level !== undefined) {
+            await syncActiveRoleAuthorityLevel(ctx, currentConfig.default_level);
+          }
 
           return json({ ok: true, config: currentConfig });
         } catch (err) {

--- a/src/daemon/api-routes.ts
+++ b/src/daemon/api-routes.ts
@@ -150,6 +150,9 @@ async function syncActiveRoleAuthorityLevel(ctx: ApiContext, authorityLevel: num
   const primary = ctx.agentService.getOrchestrator().getPrimary();
   if (!primary?.agent?.role) return;
   primary.agent.role.authority_level = authorityLevel;
+  if (primary.agent.authority) {
+    primary.agent.authority.max_authority_level = authorityLevel;
+  }
 }
 
 /**

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -296,6 +296,7 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
       ? null
       : new ObserverService(reactor, coalescer, googleAuth ?? undefined);
     const wsService = new WebSocketService(config.port, agentService);
+    wsService.setWelcomeUserName(jarvisConfig.user?.name);
 
     // 5b. Create channel service for external comms (Telegram, Discord)
     const channelService = new ChannelService(jarvisConfig, agentService);

--- a/src/daemon/ws-service.ts
+++ b/src/daemon/ws-service.ts
@@ -42,6 +42,7 @@ export class WebSocketService implements Service {
   private sttProvider: STTProvider | null = null;
   private voiceSessions = new Map<ServerWebSocket<unknown>, VoiceSession>();
   private siteBuilderService: import('../sites/service.ts').SiteBuilderService | null = null;
+  private welcomeUserName: string | null = null;
 
   constructor(port: number, agentService: AgentService) {
     this.port = port;
@@ -91,6 +92,11 @@ export class WebSocketService implements Service {
     console.log('[WSService] TTS provider set');
   }
 
+  setWelcomeUserName(name?: string): void {
+    const trimmed = (name ?? '').trim();
+    this.welcomeUserName = trimmed.length > 0 ? trimmed : null;
+  }
+
   /**
    * Set the STT provider for voice input transcription.
    */
@@ -138,8 +144,11 @@ export class WebSocketService implements Service {
       this.wsServer.setHandler({
         onMessage: (msg, ws) => this.routeMessage(msg, ws),
         onBinaryMessage: (data, ws) => this.handleVoiceAudio(data, ws),
-        onConnect: (_ws) => {
+        onConnect: (ws) => {
           console.log('[WSService] Client connected');
+          this.greetClientOnConnect(ws).catch((err) => {
+            console.error('[WSService] Client greeting failed:', err);
+          });
         },
         onDisconnect: (ws) => {
           // Clean up any pending voice session for this client
@@ -167,6 +176,43 @@ export class WebSocketService implements Service {
 
   status(): ServiceStatus {
     return this._status;
+  }
+
+  private async greetClientOnConnect(ws: ServerWebSocket<unknown>): Promise<void> {
+    const name = this.welcomeUserName ?? 'there';
+    const greeting = `Hi ${name}, how can I help you today?`;
+
+    this.wsServer.sendToClient(ws, {
+      type: 'notification',
+      payload: {
+        source: 'assistant_message',
+        text: greeting,
+      },
+      timestamp: Date.now(),
+    });
+
+    if (!this.ttsProvider) return;
+
+    const requestId = `welcome-${Date.now()}`;
+    this.wsServer.sendToClient(ws, {
+      type: 'tts_start',
+      payload: { requestId },
+      id: requestId,
+      timestamp: Date.now(),
+    });
+
+    try {
+      for await (const chunk of this.ttsProvider.synthesizeStream(greeting)) {
+        this.wsServer.sendBinary(ws, chunk);
+      }
+    } finally {
+      this.wsServer.sendToClient(ws, {
+        type: 'tts_end',
+        payload: { requestId },
+        id: requestId,
+        timestamp: Date.now(),
+      });
+    }
   }
 
   /**

--- a/src/daemon/ws-service.ts
+++ b/src/daemon/ws-service.ts
@@ -183,9 +183,9 @@ export class WebSocketService implements Service {
     const greeting = `Hi ${name}, how can I help you today?`;
 
     this.wsServer.sendToClient(ws, {
-      type: 'notification',
+      type: 'chat',
       payload: {
-        source: 'assistant_message',
+        source: 'proactive',
         text: greeting,
       },
       timestamp: Date.now(),
@@ -193,7 +193,7 @@ export class WebSocketService implements Service {
 
     if (!this.ttsProvider) return;
 
-    const requestId = `welcome-${Date.now()}`;
+    const requestId = `welcome-${crypto.randomUUID()}`;
     this.wsServer.sendToClient(ws, {
       type: 'tts_start',
       payload: { requestId },
@@ -203,15 +203,20 @@ export class WebSocketService implements Service {
 
     try {
       for await (const chunk of this.ttsProvider.synthesizeStream(greeting)) {
+        if (!this.wsServer.getClients().has(ws)) {
+          break;
+        }
         this.wsServer.sendBinary(ws, chunk);
       }
     } finally {
-      this.wsServer.sendToClient(ws, {
-        type: 'tts_end',
-        payload: { requestId },
-        id: requestId,
-        timestamp: Date.now(),
-      });
+      if (this.wsServer.getClients().has(ws)) {
+        this.wsServer.sendToClient(ws, {
+          type: 'tts_end',
+          payload: { requestId },
+          id: requestId,
+          timestamp: Date.now(),
+        });
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- Syncs authority default level updates into active runtime role.
- Adds websocket connect greeting (with optional TTS if configured).

## Why
- Keeps authority settings consistent at runtime.
- Improves first-connect user experience.

## Key Changes
- Authority config update path now applies runtime role sync.
- Websocket connect flow sends greeting and optional TTS.
- Daemon passes user name into websocket service.

## Validation
- Branch recut to clean baseline with scoped changes only.
- Typecheck passed.
- Branch force-updated on fork.