### PR TITLE
fix(daemon): resolve cross-platform boot failures by replacing POSIX flock on Windows

### DIFF
--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -3,7 +3,7 @@ import { loadConfig, saveConfig } from './loader.ts';
 import { DEFAULT_CONFIG } from './types.ts';
 import { existsSync } from 'node:fs';
 import { unlink } from 'node:fs/promises';
-import { join } from 'node:path';
+import { join, isAbsolute } from 'node:path';
 
 const TEST_CONFIG_PATH = '/tmp/jarvis-test-config.yaml';
 
@@ -151,8 +151,8 @@ daemon:
     const config = await loadConfig(TEST_CONFIG_PATH);
     expect(config.daemon.data_dir).not.toContain('~');
     expect(config.daemon.db_path).not.toContain('~');
-    expect(config.daemon.data_dir).toMatch(/^(\/|[a-zA-Z]:\\\\)/);
-    expect(config.daemon.db_path).toMatch(/^(\/|[a-zA-Z]:\\\\)/);
+    expect(isAbsolute(config.daemon.data_dir)).toBe(true);
+    expect(isAbsolute(config.daemon.db_path)).toBe(true);
   });
 });
 

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -151,8 +151,8 @@ daemon:
     const config = await loadConfig(TEST_CONFIG_PATH);
     expect(config.daemon.data_dir).not.toContain('~');
     expect(config.daemon.db_path).not.toContain('~');
-    expect(config.daemon.data_dir).toMatch(/^\//);
-    expect(config.daemon.db_path).toMatch(/^\//);
+    expect(config.daemon.data_dir).toMatch(/^(\/|[a-zA-Z]:\\\\)/);
+    expect(config.daemon.db_path).toMatch(/^(\/|[a-zA-Z]:\\\\)/);
   });
 });
 

--- a/src/daemon/pid.test.ts
+++ b/src/daemon/pid.test.ts
@@ -1,6 +1,6 @@
 import { test, expect, describe, beforeEach, afterEach } from 'bun:test';
 import { join } from 'node:path';
-import { homedir } from 'node:os';
+import { homedir, tmpdir } from 'node:os';
 import { existsSync, readFileSync, writeFileSync, unlinkSync, mkdirSync } from 'node:fs';
 import {
   acquireLock,
@@ -15,8 +15,8 @@ import {
 const JARVIS_DIR = join(homedir(), '.jarvis');
 const LOCK_PATH = join(JARVIS_DIR, 'jarvis.pid');
 const PID_MODULE = join(import.meta.dir, 'pid.ts');
-const READY_SIGNAL = '/tmp/jarvis-test-lock-ready';
-const HOLDER_SCRIPT = '/tmp/jarvis-test-lock-holder.ts';
+const READY_SIGNAL = join(tmpdir(), 'jarvis-test-lock-ready');
+const HOLDER_SCRIPT = join(tmpdir(), 'jarvis-test-lock-holder.ts');
 
 function cleanup(): void {
   releaseLock();
@@ -32,10 +32,10 @@ async function spawnLockHolder(): Promise<{ proc: ReturnType<typeof Bun.spawn>; 
   try { unlinkSync(READY_SIGNAL); } catch {}
 
   writeFileSync(HOLDER_SCRIPT, `
-import { acquireLock } from '${PID_MODULE}';
+import { acquireLock } from ${JSON.stringify(PID_MODULE)};
 import { writeFileSync } from 'node:fs';
 const ok = acquireLock(process.pid);
-writeFileSync('${READY_SIGNAL}', ok ? String(process.pid) : 'FAIL');
+writeFileSync(${JSON.stringify(READY_SIGNAL)}, ok ? String(process.pid) : 'FAIL');
 await Bun.sleep(60000);
 `);
 

--- a/src/daemon/pid.ts
+++ b/src/daemon/pid.ts
@@ -33,12 +33,18 @@ const LOG_PATH = join(LOG_DIR, 'jarvis.log');
 // system headers — works on Linux, macOS, and any POSIX platform
 // without hardcoding a shared library path.
 
-const { symbols: flock } = cc({
-  source: flockSource,
-  symbols: {
-    do_flock: { args: ['i32', 'i32'], returns: 'i32' },
-  },
-});
+const isWindows = process.platform === 'win32';
+
+let flock: any = null;
+if (!isWindows) {
+  const lib = cc({
+    source: flockSource,
+    symbols: {
+      do_flock: { args: ['i32', 'i32'], returns: 'i32' },
+    },
+  });
+  flock = lib.symbols;
+}
 
 const LOCK_EX = 2;  // Exclusive lock
 const LOCK_NB = 4;  // Non-blocking
@@ -61,14 +67,28 @@ export function acquireLock(pid: number): boolean {
   try {
     mkdirSync(JARVIS_DIR, { recursive: true });
 
+    if (isWindows) {
+      const existingPid = readPid();
+      if (existingPid !== null && existingPid !== pid) {
+        try {
+          process.kill(existingPid, 0);
+          return false;
+        } catch {
+          // Process not running, stale lock file
+        }
+      }
+    }
+
     // Open (or create) the lock file — don't truncate before locking
     const fd = openSync(LOCK_PATH, constants.O_WRONLY | constants.O_CREAT, 0o644);
 
     // Try non-blocking exclusive lock
-    const result = flock.do_flock(fd, LOCK_EX | LOCK_NB);
-    if (result !== 0) {
-      closeSync(fd);
-      return false;
+    if (!isWindows) {
+      const result = flock.do_flock(fd, LOCK_EX | LOCK_NB);
+      if (result !== 0) {
+        closeSync(fd);
+        return false;
+      }
     }
 
     // Lock acquired — truncate and write PID for display purposes
@@ -99,17 +119,28 @@ export function isLocked(): number | null {
   }
 
   try {
-    // Try non-blocking exclusive lock to probe
-    const result = flock.do_flock(fd, LOCK_EX | LOCK_NB);
-    if (result === 0) {
-      // Lock acquired — no daemon running. Release immediately.
-      flock.do_flock(fd, LOCK_UN);
-      closeSync(fd);
-      return null;
+    if (!isWindows) {
+      // Try non-blocking exclusive lock to probe
+      const result = flock.do_flock(fd, LOCK_EX | LOCK_NB);
+      if (result === 0) {
+        // Lock acquired — no daemon running. Release immediately.
+        flock.do_flock(fd, LOCK_UN);
+        closeSync(fd);
+        return null;
+      }
     }
-    // Lock held by another process — daemon is running
+    
+    // Lock held by another process (or we are on Windows) — daemon is running
     closeSync(fd);
     const pid = readPid();
+
+    if (isWindows && pid !== null) {
+      try {
+        process.kill(pid, 0);
+      } catch {
+        return null;
+      }
+    }
 
     // Container safety: if PID is 1 and we're inside a container,
     // the lock file is stale from a previous container lifecycle

--- a/src/daemon/pid.ts
+++ b/src/daemon/pid.ts
@@ -64,6 +64,8 @@ let lockFd: number | null = null;
  * Returns true if the lock was acquired, false if another instance holds it.
  */
 export function acquireLock(pid: number): boolean {
+  if (lockFd !== null) return false;
+
   try {
     mkdirSync(JARVIS_DIR, { recursive: true });
 


### PR DESCRIPTION
## Context & The Problem
When cloning and attempting to boot the JARVIS daemon natively on a Windows OS (`win32` platform), the process crashes during startup or status checks. 

The original locking logic inside `src/daemon/pid.ts` relied entirely on the POSIX-native subset (`<sys/file.h>` and `flock()`). Because the `bun:ffi` embedded TinyCC compiler cannot locate these POSIX headers natively on a Windows system, the daemon immediately crashes with `include file 'sys/file.h' not found`. 

Additionally, a few unit tests natively expected Unix environment norms (like strict `/` paths and hardcoded `/tmp` directories) which caused tests to artificially fail on Windows machines.

## What This PR Does
This Pull Request fully unblocks native Windows local setups by introducing OS-aware locking and platform-independent testing validations:

1. **Daemon PID Locking (`src/daemon/pid.ts`)**
   - Automatically bypasses the C-level `do_flock` injection on `process.platform === 'win32'`.
   - On Windows, we implement an alternative stale-lock check which interrogates the existing `.jarvis/jarvis.pid` file using `process.kill(pid, 0)` to verify actual process livelihood instead of relying on file descriptors.
   - Guarded internal state to prevent double lock acquisitions on the same instance `lockFd`.

2. **Test Robustness (`src/daemon/pid.test.ts` & `src/config/loader.test.ts`)**
   - Replaced hardcoded `/tmp` fallback paths with `node:os.tmpdir()` to prevent `ENOENT` crashes when testing on Windows.
   - Refactored regex configurations relying on `^\/` (Unix absolute paths) to use `node:path.isAbsolute()` which comprehensively verifies absolute paths natively across all host types without regex parsing limitations.

## How Has This Been Tested?
- **Locally on Windows 11**: Verified `bun run bin/jarvis.ts status` passes cleanly without C compiler failures. Verified `jarvis start -d` properly populates the tracking daemon without false positives.
- Run `bun test` locally against `pid.test.ts` and `loader.test.ts`. Ensured `cross-process locking` blocks function correctly using `os.tmpdir()` with Node IPC scripts.

## Motivation and Impact
JARVIS is billed as a reliable desktop copilot that interacts heavily with Windows UI Automation. Without this PR, Windows users are essentially forced to run the system in Docker containers natively avoiding any of the powerful cross-OS hooks. This establishes out-of-the-box Windows OS compatibility parity.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have fixed or added corresponding unit tests alongside these changes
- [x] New and existing unit tests pass locally with my changes