### PR TITLE
Fix: ProcessMonitor pipeline handling on Windows and improve Jarvis core stability

### DIFF
--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -3,7 +3,7 @@ import { loadConfig, saveConfig } from './loader.ts';
 import { DEFAULT_CONFIG } from './types.ts';
 import { existsSync } from 'node:fs';
 import { unlink } from 'node:fs/promises';
-import { join } from 'node:path';
+import { join, isAbsolute } from 'node:path';
 
 const TEST_CONFIG_PATH = '/tmp/jarvis-test-config.yaml';
 
@@ -151,8 +151,8 @@ daemon:
     const config = await loadConfig(TEST_CONFIG_PATH);
     expect(config.daemon.data_dir).not.toContain('~');
     expect(config.daemon.db_path).not.toContain('~');
-    expect(config.daemon.data_dir).toMatch(/^(\/|[a-zA-Z]:\\\\)/);
-    expect(config.daemon.db_path).toMatch(/^(\/|[a-zA-Z]:\\\\)/);
+    expect(isAbsolute(config.daemon.data_dir)).toBe(true);
+    expect(isAbsolute(config.daemon.db_path)).toBe(true);
   });
 });
 

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -151,8 +151,8 @@ daemon:
     const config = await loadConfig(TEST_CONFIG_PATH);
     expect(config.daemon.data_dir).not.toContain('~');
     expect(config.daemon.db_path).not.toContain('~');
-    expect(config.daemon.data_dir).toMatch(/^\//);
-    expect(config.daemon.db_path).toMatch(/^\//);
+    expect(config.daemon.data_dir).toMatch(/^(\/|[a-zA-Z]:\\\\)/);
+    expect(config.daemon.db_path).toMatch(/^(\/|[a-zA-Z]:\\\\)/);
   });
 });
 

--- a/src/daemon/pid.test.ts
+++ b/src/daemon/pid.test.ts
@@ -1,6 +1,6 @@
 import { test, expect, describe, beforeEach, afterEach } from 'bun:test';
 import { join } from 'node:path';
-import { homedir } from 'node:os';
+import { homedir, tmpdir } from 'node:os';
 import { existsSync, readFileSync, writeFileSync, unlinkSync, mkdirSync } from 'node:fs';
 import {
   acquireLock,
@@ -15,8 +15,8 @@ import {
 const JARVIS_DIR = join(homedir(), '.jarvis');
 const LOCK_PATH = join(JARVIS_DIR, 'jarvis.pid');
 const PID_MODULE = join(import.meta.dir, 'pid.ts');
-const READY_SIGNAL = '/tmp/jarvis-test-lock-ready';
-const HOLDER_SCRIPT = '/tmp/jarvis-test-lock-holder.ts';
+const READY_SIGNAL = join(tmpdir(), 'jarvis-test-lock-ready');
+const HOLDER_SCRIPT = join(tmpdir(), 'jarvis-test-lock-holder.ts');
 
 function cleanup(): void {
   releaseLock();
@@ -32,10 +32,10 @@ async function spawnLockHolder(): Promise<{ proc: ReturnType<typeof Bun.spawn>; 
   try { unlinkSync(READY_SIGNAL); } catch {}
 
   writeFileSync(HOLDER_SCRIPT, `
-import { acquireLock } from '${PID_MODULE}';
+import { acquireLock } from ${JSON.stringify(PID_MODULE)};
 import { writeFileSync } from 'node:fs';
 const ok = acquireLock(process.pid);
-writeFileSync('${READY_SIGNAL}', ok ? String(process.pid) : 'FAIL');
+writeFileSync(${JSON.stringify(READY_SIGNAL)}, ok ? String(process.pid) : 'FAIL');
 await Bun.sleep(60000);
 `);
 

--- a/src/daemon/pid.ts
+++ b/src/daemon/pid.ts
@@ -33,12 +33,18 @@ const LOG_PATH = join(LOG_DIR, 'jarvis.log');
 // system headers — works on Linux, macOS, and any POSIX platform
 // without hardcoding a shared library path.
 
-const { symbols: flock } = cc({
-  source: flockSource,
-  symbols: {
-    do_flock: { args: ['i32', 'i32'], returns: 'i32' },
-  },
-});
+const isWindows = process.platform === 'win32';
+
+let flock: any = null;
+if (!isWindows) {
+  const lib = cc({
+    source: flockSource,
+    symbols: {
+      do_flock: { args: ['i32', 'i32'], returns: 'i32' },
+    },
+  });
+  flock = lib.symbols;
+}
 
 const LOCK_EX = 2;  // Exclusive lock
 const LOCK_NB = 4;  // Non-blocking
@@ -61,14 +67,28 @@ export function acquireLock(pid: number): boolean {
   try {
     mkdirSync(JARVIS_DIR, { recursive: true });
 
+    if (isWindows) {
+      const existingPid = readPid();
+      if (existingPid !== null && existingPid !== pid) {
+        try {
+          process.kill(existingPid, 0);
+          return false;
+        } catch {
+          // Process not running, stale lock file
+        }
+      }
+    }
+
     // Open (or create) the lock file — don't truncate before locking
     const fd = openSync(LOCK_PATH, constants.O_WRONLY | constants.O_CREAT, 0o644);
 
     // Try non-blocking exclusive lock
-    const result = flock.do_flock(fd, LOCK_EX | LOCK_NB);
-    if (result !== 0) {
-      closeSync(fd);
-      return false;
+    if (!isWindows) {
+      const result = flock.do_flock(fd, LOCK_EX | LOCK_NB);
+      if (result !== 0) {
+        closeSync(fd);
+        return false;
+      }
     }
 
     // Lock acquired — truncate and write PID for display purposes
@@ -99,17 +119,28 @@ export function isLocked(): number | null {
   }
 
   try {
-    // Try non-blocking exclusive lock to probe
-    const result = flock.do_flock(fd, LOCK_EX | LOCK_NB);
-    if (result === 0) {
-      // Lock acquired — no daemon running. Release immediately.
-      flock.do_flock(fd, LOCK_UN);
-      closeSync(fd);
-      return null;
+    if (!isWindows) {
+      // Try non-blocking exclusive lock to probe
+      const result = flock.do_flock(fd, LOCK_EX | LOCK_NB);
+      if (result === 0) {
+        // Lock acquired — no daemon running. Release immediately.
+        flock.do_flock(fd, LOCK_UN);
+        closeSync(fd);
+        return null;
+      }
     }
-    // Lock held by another process — daemon is running
+    
+    // Lock held by another process (or we are on Windows) — daemon is running
     closeSync(fd);
     const pid = readPid();
+
+    if (isWindows && pid !== null) {
+      try {
+        process.kill(pid, 0);
+      } catch {
+        return null;
+      }
+    }
 
     // Container safety: if PID is 1 and we're inside a container,
     // the lock file is stale from a previous container lifecycle

--- a/src/daemon/pid.ts
+++ b/src/daemon/pid.ts
@@ -64,6 +64,8 @@ let lockFd: number | null = null;
  * Returns true if the lock was acquired, false if another instance holds it.
  */
 export function acquireLock(pid: number): boolean {
+  if (lockFd !== null) return false;
+
   try {
     mkdirSync(JARVIS_DIR, { recursive: true });
 

--- a/src/observers/processes.ts
+++ b/src/observers/processes.ts
@@ -143,7 +143,7 @@ export class ProcessMonitor implements Observer {
         return this.parsePS(output);
       } else if (platform === 'win32') {
         // Use PowerShell for Windows
-        const result = await Bun.$`powershell.exe Get-Process | Select-Object Id,Name,CPU,WorkingSet | ConvertTo-Csv -NoTypeInformation`.quiet();
+        const result = await Bun.$`powershell.exe -Command "Get-Process | Select-Object Id,Name,CPU,WorkingSet | ConvertTo-Csv -NoTypeInformation"`.quiet();
         const output = result.stdout.toString();
 
         return this.parseWindowsPS(output);


### PR DESCRIPTION
## Description
This PR resolves a critical startup crash and process monitoring failure on Windows platforms. It fixes how PowerShell commands are executed by the Bun shell within `ProcessMonitor` and builds upon the recent POSIX compatibility fixes.

### Changes Included
- **`src/observers/processes.ts`**: Fixed a bug where Bun's internal shell incorrectly interpreted the PowerShell `|` pipeline operator as its own. Wrapped the PowerShell polling command (`Get-Process | Select-Object ...`) within the `-Command` argument wrapper, ensuring that it is passed entirely to the native PowerShell executable.
- (Includes previous Windows compatibility commits on this branch such as the `pid.ts` lockwork and absolute path fixtures for test suites).

### Motivation
When running the daemon heavily on Windows via `bun run dev`, the system throws an exit code due to `Select-Object` being unrecognized by the Bun internal shell instance. Correctly formatting the command allows the ProcessMonitor to function natively using Windows PowerShell without external shell scripts.

## Verification
- Validated daemon startup using `npm run dev` and `bun run dev` on Windows 11.
- Ensured no lingering lockfiles or port 3142 binding errors from stalled child processes.
- Process polling logs show correctly populated arrays rather than shell execution errors.
- Pre-commit test suites passed successfully.
