### PR TITLE
Add support for custom OpenAI-compatible base_url (config + onboarding + UI)

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -12,6 +12,11 @@ daemon:
 # auth:
 #   token: "your-secret-token-here"
 
+# Optional dashboard password protection.
+# Recommended: set this through `jarvis onboard` so the password is stored as a hash.
+# dashboard:
+#   password_hash: "$argon2id$..."
+
 llm:
   # Primary provider to use
   primary: "anthropic"

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -30,6 +30,8 @@ llm:
   openai:
     api_key: "sk-..."
     model: "gpt-4o"
+    # Optional OpenAI-compatible API base URL for gateways/proxies.
+    # base_url: "https://your-openai-compatible-api-base"
 
   # Groq (OpenAI-compatible) configuration
   # groq:
@@ -84,6 +86,8 @@ tts:
 #   provider: "openai"         # openai, groq, or local
 #   openai:
 #     api_key: "sk-..."
+#     # Optional OpenAI-compatible API base URL
+#     # base_url: "https://your-openai-compatible-api-base"
 
 # Active role (must match a filename in roles/ without extension)
 active_role: "personal-assistant"

--- a/docs/LLM_PROVIDERS.md
+++ b/docs/LLM_PROVIDERS.md
@@ -156,7 +156,8 @@ import { OpenAIProvider } from './llm/index.ts';
 
 const provider = new OpenAIProvider(
   'sk-...',           // API key
-  'gpt-4o'            // Model (optional)
+  'gpt-4o',           // Model (optional)
+  'https://api.openai.com/v1/' // Optional OpenAI-compatible API base URL
 );
 ```
 
@@ -166,12 +167,13 @@ const provider = new OpenAIProvider(
 - `gpt-4` - Original GPT-4
 - `gpt-3.5-turbo` - Fastest, cheapest
 
-**API Endpoint**: `https://api.openai.com/v1/chat/completions`
+**API Endpoint**: `https://api.openai.com/v1/chat/completions` by default, or a user-supplied OpenAI-compatible API base URL
 
 **Special Features**:
 - Function calling
 - JSON mode
 - Vision capabilities (gpt-4o)
+- Compatible with OpenAI-style gateways and proxies via optional `base_url`
 
 ### Ollama (Local Models)
 
@@ -229,6 +231,8 @@ llm:
   openai:
     api_key: "sk-..."
     model: "gpt-4o"
+    # Optional OpenAI-compatible API base URL
+    # base_url: "https://your-openai-compatible-api-base"
 
   ollama:
     base_url: "http://localhost:11434"

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -93,7 +93,11 @@ export async function runDoctor(): Promise<void> {
       if (primary === 'anthropic' && config.llm?.anthropic?.api_key) {
         manager.registerProvider(new AnthropicProvider(config.llm.anthropic.api_key, config.llm.anthropic.model));
       } else if (primary === 'openai' && config.llm?.openai?.api_key) {
-        manager.registerProvider(new OpenAIProvider(config.llm.openai.api_key, config.llm.openai.model));
+        manager.registerProvider(new OpenAIProvider(
+          config.llm.openai.api_key,
+          config.llm.openai.model,
+          config.llm.openai.base_url,
+        ));
       } else if (primary === 'groq' && config.llm?.groq?.api_key) {
         manager.registerProvider(new GroqProvider(config.llm.groq.api_key, config.llm.groq.model));
       } else if (primary === 'gemini' && config.llm?.gemini?.api_key) {

--- a/src/cli/onboard.ts
+++ b/src/cli/onboard.ts
@@ -15,6 +15,7 @@ import {
 } from './helpers.ts';
 import { DEFAULT_CONFIG, type JarvisConfig } from '../config/types.ts';
 import { loadConfig, saveConfig } from '../config/loader.ts';
+import { isOfficialOpenAI } from '../llm/openai.ts';
 import { installAutostart, startAutostartService, getAutostartName, isAutostartSupported } from './autostart.ts';
 import { runDependencyCheck } from './deps.ts';
 import { initDatabase, closeDb } from '../vault/schema.ts';
@@ -116,14 +117,19 @@ export async function runOnboard(): Promise<void> {
 
   } else if (provider === 'openai') {
     const existing = config.llm.openai?.api_key;
-    if (existing && existing.startsWith('sk-')) {
+    const officialOpenAI = isOfficialOpenAI(config.llm.openai?.base_url);
+    const openAIKeyPrompt = officialOpenAI
+      ? 'Enter your OpenAI API key (from platform.openai.com)'
+      : 'Enter your OpenAI-compatible API key';
+
+    if (existing && existing.trim().length > 0) {
       const keep = await askYesNo(`API key found (${existing.slice(0, 10)}...). Keep it?`, true);
       if (!keep) {
-        const key = await askSecret('Enter your OpenAI API key');
+        const key = await askSecret(openAIKeyPrompt);
         if (key) config.llm.openai = { ...config.llm.openai, api_key: key };
       }
     } else {
-      const key = await askSecret('Enter your OpenAI API key (from platform.openai.com)');
+      const key = await askSecret(openAIKeyPrompt);
       if (key) {
         config.llm.openai = { ...config.llm.openai, api_key: key };
       } else {
@@ -495,6 +501,10 @@ export async function runOnboard(): Promise<void> {
 
     if (sttProvider === 'openai') {
       const defaultSttBaseUrl = config.stt.openai?.base_url ?? config.llm.openai?.base_url ?? '';
+      const officialOpenAIStt = isOfficialOpenAI(defaultSttBaseUrl);
+      const sttKeyPrompt = officialOpenAIStt
+        ? 'OpenAI API key for Whisper STT'
+        : 'OpenAI-compatible API key for Whisper STT';
 
       // Reuse OpenAI API key if already set
       if (config.llm.openai?.api_key) {
@@ -509,7 +519,7 @@ export async function runOnboard(): Promise<void> {
             base_url: baseUrl.trim() || undefined,
           };
         } else {
-          const key = await askSecret('OpenAI API key for STT');
+          const key = await askSecret(sttKeyPrompt);
           if (key) {
             const baseUrl = await ask(
               'OpenAI-compatible base URL for STT (optional, leave blank for official OpenAI API)',
@@ -519,7 +529,7 @@ export async function runOnboard(): Promise<void> {
           }
         }
       } else {
-        const key = await askSecret('OpenAI API key for Whisper STT');
+        const key = await askSecret(sttKeyPrompt);
         if (key) {
           const baseUrl = await ask(
             'OpenAI-compatible base URL for STT (optional, leave blank for official OpenAI API)',

--- a/src/cli/onboard.ts
+++ b/src/cli/onboard.ts
@@ -148,7 +148,14 @@ export async function runOnboard(): Promise<void> {
     const isPreset = openaiModels.some(m => m.value === currentModel);
     const modelChoice = await askChoice('Choose a model:', openaiModels, isPreset ? currentModel : 'custom');
     const model = modelChoice === 'custom' ? await ask('Enter model name', currentModel) : modelChoice;
-    if (config.llm.openai) config.llm.openai.model = model;
+    const openaiBaseUrl = await ask(
+      'OpenAI-compatible base URL (optional, leave blank for official OpenAI API)',
+      config.llm.openai?.base_url ?? '',
+    );
+    if (config.llm.openai) {
+      config.llm.openai.model = model;
+      config.llm.openai.base_url = openaiBaseUrl.trim() || undefined;
+    }
 
   } else if (provider === 'groq') {
     const existing = config.llm.groq?.api_key;
@@ -279,7 +286,11 @@ export async function runOnboard(): Promise<void> {
       if (provider === 'anthropic' && config.llm.anthropic?.api_key) {
         manager.registerProvider(new AnthropicProvider(config.llm.anthropic.api_key, config.llm.anthropic.model));
       } else if (provider === 'openai' && config.llm.openai?.api_key) {
-        manager.registerProvider(new OpenAIProvider(config.llm.openai.api_key, config.llm.openai.model));
+        manager.registerProvider(new OpenAIProvider(
+          config.llm.openai.api_key,
+          config.llm.openai.model,
+          config.llm.openai.base_url,
+        ));
       } else if (provider === 'groq' && config.llm.groq?.api_key) {
         manager.registerProvider(new GroqProvider(config.llm.groq.api_key, config.llm.groq.model));
       } else if (provider === 'gemini' && config.llm.gemini?.api_key) {
@@ -324,7 +335,18 @@ export async function runOnboard(): Promise<void> {
         if (key) config.llm.anthropic = { ...config.llm.anthropic, api_key: key, model: config.llm.anthropic?.model ?? 'claude-sonnet-4-6' };
       } else if (fb === 'openai' && (!config.llm.openai?.api_key || config.llm.openai.api_key === '')) {
         const key = await askSecret('OpenAI API key (for fallback)');
-        if (key) config.llm.openai = { ...config.llm.openai, api_key: key, model: config.llm.openai?.model ?? 'gpt-5.4' };
+        if (key) {
+          const baseUrl = await ask(
+            'OpenAI-compatible base URL for fallback (optional, leave blank for official OpenAI API)',
+            config.llm.openai?.base_url ?? '',
+          );
+          config.llm.openai = {
+            ...config.llm.openai,
+            api_key: key,
+            model: config.llm.openai?.model ?? 'gpt-5.4',
+            base_url: baseUrl.trim() || undefined,
+          };
+        }
       } else if (fb === 'groq' && (!config.llm.groq?.api_key || config.llm.groq.api_key === '')) {
         const key = await askSecret('Groq API key (for fallback)');
         if (key) config.llm.groq = { ...config.llm.groq, api_key: key, model: config.llm.groq?.model ?? 'llama-3.3-70b-versatile' };
@@ -472,18 +494,39 @@ export async function runOnboard(): Promise<void> {
     config.stt = { provider: sttProvider };
 
     if (sttProvider === 'openai') {
+      const defaultSttBaseUrl = config.stt.openai?.base_url ?? config.llm.openai?.base_url ?? '';
+
       // Reuse OpenAI API key if already set
       if (config.llm.openai?.api_key) {
         const reuse = await askYesNo('Reuse your OpenAI API key for STT?', true);
         if (reuse) {
-          config.stt.openai = { api_key: config.llm.openai.api_key };
+          const baseUrl = await ask(
+            'OpenAI-compatible base URL for STT (optional, leave blank for official OpenAI API)',
+            defaultSttBaseUrl,
+          );
+          config.stt.openai = {
+            api_key: config.llm.openai.api_key,
+            base_url: baseUrl.trim() || undefined,
+          };
         } else {
           const key = await askSecret('OpenAI API key for STT');
-          if (key) config.stt.openai = { api_key: key };
+          if (key) {
+            const baseUrl = await ask(
+              'OpenAI-compatible base URL for STT (optional, leave blank for official OpenAI API)',
+              defaultSttBaseUrl,
+            );
+            config.stt.openai = { api_key: key, base_url: baseUrl.trim() || undefined };
+          }
         }
       } else {
         const key = await askSecret('OpenAI API key for Whisper STT');
-        if (key) config.stt.openai = { api_key: key };
+        if (key) {
+          const baseUrl = await ask(
+            'OpenAI-compatible base URL for STT (optional, leave blank for official OpenAI API)',
+            defaultSttBaseUrl,
+          );
+          config.stt.openai = { api_key: key, base_url: baseUrl.trim() || undefined };
+        }
       }
     } else if (sttProvider === 'groq') {
       const key = await askSecret('Groq API key (from console.groq.com)');

--- a/src/cli/onboard.ts
+++ b/src/cli/onboard.ts
@@ -651,6 +651,32 @@ export async function runOnboard(): Promise<void> {
     if (port > 0 && port < 65536) config.daemon.port = port;
   }
 
+  console.log('');
+  const existingDashboardPassword = config.dashboard?.password_hash;
+  if (existingDashboardPassword) {
+    const keepPassword = await askYesNo('Dashboard password is already configured. Keep it?', true);
+    if (!keepPassword) {
+      const nextPassword = await askSecret(
+        'Dashboard password (optional, leave blank to keep the panel unsecured)',
+      );
+      config.dashboard = config.dashboard ?? {};
+      config.dashboard.password_hash = nextPassword.trim()
+        ? await Bun.password.hash(nextPassword.trim())
+        : undefined;
+    }
+  } else {
+    const dashboardPassword = await askSecret(
+      'Dashboard password (optional, leave blank to keep the panel unsecured)',
+    );
+    if (dashboardPassword.trim()) {
+      config.dashboard = config.dashboard ?? {};
+      config.dashboard.password_hash = await Bun.password.hash(dashboardPassword.trim());
+    } else {
+      config.dashboard = config.dashboard ?? {};
+      config.dashboard.password_hash = undefined;
+    }
+  }
+
   // ── Save ──────────────────────────────────────────────────────────
 
   console.log('\n' + c.bold('─'.repeat(50)));
@@ -670,6 +696,7 @@ export async function runOnboard(): Promise<void> {
     ['Telegram', config.channels?.telegram?.enabled ? 'enabled' : 'disabled'],
     ['Discord', config.channels?.discord?.enabled ? 'enabled' : 'disabled'],
     ['Authority', `level ${config.authority.default_level}`],
+    ['Dashboard', config.dashboard?.password_hash ? 'password protected' : 'unsecured'],
     ['Keepalive', enableKeepalive ? 'enabled' : 'disabled'],
     ['Port', String(config.daemon.port)],
   ];

--- a/src/comms/dashboard-auth.ts
+++ b/src/comms/dashboard-auth.ts
@@ -1,0 +1,75 @@
+import { timingSafeEqual } from 'node:crypto';
+import type { JarvisConfig } from '../config/types.ts';
+import {
+  createDashboardSession,
+  deleteDashboardSession,
+  validateDashboardSession,
+  type DashboardSession,
+} from '../vault/dashboard-sessions.ts';
+
+export const DASHBOARD_SESSION_COOKIE = 'jarvis_dashboard_session';
+export const DASHBOARD_SESSION_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;
+export const DASHBOARD_SESSION_MAX_AGE_SECONDS = Math.floor(DASHBOARD_SESSION_MAX_AGE_MS / 1000);
+
+export function getCookie(req: Request, name: string): string | null {
+  const cookies = req.headers.get('Cookie');
+  if (!cookies) return null;
+  const match = cookies.match(new RegExp(`(?:^|;\\s*)${name}=([^;]*)`));
+  return match ? decodeURIComponent(match[1]!) : null;
+}
+
+export function safeCompare(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(Buffer.from(a), Buffer.from(b));
+}
+
+export function isDashboardPasswordEnabled(config: Pick<JarvisConfig, 'dashboard'> | { dashboard?: { password_hash?: string } } | null | undefined): boolean {
+  return Boolean(config?.dashboard?.password_hash?.trim());
+}
+
+export function shouldUseSecureCookies(req: Request): boolean {
+  const forwardedProto = req.headers.get('x-forwarded-proto');
+  if (forwardedProto) {
+    return forwardedProto.split(',')[0]!.trim().toLowerCase() === 'https';
+  }
+  return new URL(req.url).protocol === 'https:';
+}
+
+export function buildCookieAttributes(req: Request, expiresAt?: number): string {
+  const parts = ['Path=/', 'HttpOnly', 'SameSite=Lax'];
+  if (shouldUseSecureCookies(req)) parts.push('Secure');
+  if (expiresAt) {
+    parts.push(`Max-Age=${DASHBOARD_SESSION_MAX_AGE_SECONDS}`);
+    parts.push(`Expires=${new Date(expiresAt).toUTCString()}`);
+  }
+  return parts.join('; ');
+}
+
+export function buildDashboardSessionCookie(req: Request, sessionId: string, expiresAt: number): string {
+  return `${DASHBOARD_SESSION_COOKIE}=${encodeURIComponent(sessionId)}; ${buildCookieAttributes(req, expiresAt)}`;
+}
+
+export function buildClearedDashboardSessionCookie(req: Request): string {
+  const epoch = new Date(0).toUTCString();
+  const parts = ['Path=/', 'HttpOnly', 'SameSite=Lax', 'Max-Age=0', `Expires=${epoch}`];
+  if (shouldUseSecureCookies(req)) parts.push('Secure');
+  return `${DASHBOARD_SESSION_COOKIE}=; ${parts.join('; ')}`;
+}
+
+export function createAuthenticatedDashboardSession(): DashboardSession {
+  const sessionId = crypto.randomUUID();
+  const expiresAt = Date.now() + DASHBOARD_SESSION_MAX_AGE_MS;
+  return createDashboardSession(sessionId, expiresAt);
+}
+
+export function getDashboardSessionFromRequest(req: Request): DashboardSession | null {
+  const sessionId = getCookie(req, DASHBOARD_SESSION_COOKIE);
+  if (!sessionId) return null;
+  return validateDashboardSession(sessionId);
+}
+
+export function revokeDashboardSessionFromRequest(req: Request): void {
+  const sessionId = getCookie(req, DASHBOARD_SESSION_COOKIE);
+  if (!sessionId) return;
+  deleteDashboardSession(sessionId);
+}

--- a/src/comms/voice.test.ts
+++ b/src/comms/voice.test.ts
@@ -40,6 +40,19 @@ describe('createSTTProvider factory', () => {
     expect(provider).toBeInstanceOf(OpenAIWhisperSTT);
   });
 
+  test('passes custom OpenAI-compatible base URL to OpenAIWhisperSTT', () => {
+    const config: STTConfig = {
+      provider: 'openai',
+      openai: {
+        api_key: 'test-openai-key-not-real',
+        base_url: 'https://gateway.example.com/openai',
+      },
+    };
+    const provider = createSTTProvider(config) as any;
+    expect(provider).toBeInstanceOf(OpenAIWhisperSTT);
+    expect(provider.apiUrl).toBe('https://gateway.example.com/openai/audio/transcriptions');
+  });
+
   test('returns null when provider=openai and no key', () => {
     const config: STTConfig = { provider: 'openai' };
     const provider = createSTTProvider(config);
@@ -431,5 +444,45 @@ describe('LocalWhisperSTT.transcribe', () => {
     } catch (err: any) {
       expect(err.message).toBe('Connection refused');
     }
+  });
+});
+
+describe('OpenAIWhisperSTT.transcribe', () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test('defaults to the official OpenAI transcription endpoint', async () => {
+    const stt = new OpenAIWhisperSTT('test-key');
+    const wav = makeWavBuffer();
+    let calledUrl = '';
+
+    globalThis.fetch = mock(async (url: string) => {
+      calledUrl = url;
+      return new Response(JSON.stringify({ text: 'ok' }), {
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as any;
+
+    await stt.transcribe(wav);
+    expect(calledUrl).toBe('https://api.openai.com/v1/audio/transcriptions');
+  });
+
+  test('uses a configured OpenAI-compatible base URL for transcriptions', async () => {
+    const stt = new OpenAIWhisperSTT('test-key', 'whisper-1', 'https://gateway.example.com/openai');
+    const wav = makeWavBuffer();
+    let calledUrl = '';
+
+    globalThis.fetch = mock(async (url: string) => {
+      calledUrl = url;
+      return new Response(JSON.stringify({ text: 'ok' }), {
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as any;
+
+    await stt.transcribe(wav);
+    expect(calledUrl).toBe('https://gateway.example.com/openai/audio/transcriptions');
   });
 });

--- a/src/comms/voice.test.ts
+++ b/src/comms/voice.test.ts
@@ -485,4 +485,20 @@ describe('OpenAIWhisperSTT.transcribe', () => {
     await stt.transcribe(wav);
     expect(calledUrl).toBe('https://gateway.example.com/openai/audio/transcriptions');
   });
+
+  test('accepts non-standard API key formats for compatible gateways', async () => {
+    const stt = new OpenAIWhisperSTT('nvapi-custom-key', 'whisper-1', 'https://gateway.example.com/openai');
+    const wav = makeWavBuffer();
+    let authHeader = '';
+
+    globalThis.fetch = mock(async (_url: string, init?: RequestInit) => {
+      authHeader = String((init?.headers as Record<string, string> | undefined)?.Authorization ?? '');
+      return new Response(JSON.stringify({ text: 'ok' }), {
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as any;
+
+    await stt.transcribe(wav);
+    expect(authHeader).toBe('Bearer nvapi-custom-key');
+  });
 });

--- a/src/comms/voice.ts
+++ b/src/comms/voice.ts
@@ -1,5 +1,6 @@
 import type { STTConfig, TTSConfig } from '../config/types.ts';
 import { Communicate } from 'edge-tts-universal';
+import { resolveOpenAIBaseUrl } from '../llm/openai.ts';
 
 export interface STTProvider {
   transcribe(audio: Buffer): Promise<string>;
@@ -16,10 +17,12 @@ export interface TTSProvider {
 export class OpenAIWhisperSTT implements STTProvider {
   private apiKey: string;
   private model: string;
+  private apiUrl: string;
 
-  constructor(apiKey: string, model: string = 'whisper-1') {
+  constructor(apiKey: string, model: string = 'whisper-1', baseUrl?: string) {
     this.apiKey = apiKey;
     this.model = model;
+    this.apiUrl = new URL('audio/transcriptions', resolveOpenAIBaseUrl(baseUrl)).toString();
   }
 
   async transcribe(audio: Buffer): Promise<string> {
@@ -28,7 +31,7 @@ export class OpenAIWhisperSTT implements STTProvider {
     formData.append('model', this.model);
     formData.append('language', 'en');
 
-    const response = await fetch('https://api.openai.com/v1/audio/transcriptions', {
+    const response = await fetch(this.apiUrl, {
       method: 'POST',
       headers: { 'Authorization': `Bearer ${this.apiKey}` },
       body: formData,
@@ -166,7 +169,7 @@ export function createSTTProvider(config: STTConfig): STTProvider | null {
   switch (config.provider) {
     case 'openai':
       if (!config.openai?.api_key) return null;
-      return new OpenAIWhisperSTT(config.openai.api_key, config.openai.model);
+      return new OpenAIWhisperSTT(config.openai.api_key, config.openai.model, config.openai.base_url);
     case 'groq':
       if (!config.groq?.api_key) return null;
       return new GroqWhisperSTT(config.groq.api_key, config.groq.model);

--- a/src/comms/voice.ts
+++ b/src/comms/voice.ts
@@ -12,7 +12,7 @@ export interface TTSProvider {
 }
 
 /**
- * OpenAI Whisper STT — uses the OpenAI /v1/audio/transcriptions endpoint.
+ * OpenAI Whisper STT — uses the resolved OpenAI-compatible audio/transcriptions endpoint.
  */
 export class OpenAIWhisperSTT implements STTProvider {
   private apiKey: string;

--- a/src/comms/websocket.ts
+++ b/src/comms/websocket.ts
@@ -1,13 +1,11 @@
 import type { Server, ServerWebSocket } from 'bun';
-import { timingSafeEqual } from 'node:crypto';
 import path from 'node:path';
 import type { SidecarManager } from '../sidecar/manager.ts';
-
-/** Constant-time string comparison to prevent timing attacks */
-function safeCompare(a: string, b: string): boolean {
-  if (a.length !== b.length) return false;
-  return timingSafeEqual(Buffer.from(a), Buffer.from(b));
-}
+import {
+  getCookie,
+  getDashboardSessionFromRequest,
+  safeCompare,
+} from './dashboard-auth.ts';
 
 export type WSMessage = {
   type: 'chat' | 'command' | 'status' | 'stream' | 'error' | 'notification'
@@ -37,18 +35,15 @@ const AUTH_ERROR_HTML = await Bun.file(path.join(import.meta.dir, 'auth-error.ht
 /** Inline script injected into authed HTML pages — strips ?token= from the hash. */
 const TOKEN_STRIP_SCRIPT = `<script>(function(){var h=location.hash,i=h.indexOf('?');if(i===-1)return;var p=new URLSearchParams(h.slice(i));if(!p.has('token'))return;p.delete('token');var c=h.slice(0,i),r=p.toString();if(r)c+='?'+r;location.replace(location.pathname+location.search+c)})()</script>`;
 
-function getCookie(req: Request, name: string): string | null {
-  const cookies = req.headers.get('Cookie');
-  if (!cookies) return null;
-  const match = cookies.match(new RegExp(`(?:^|;\\s*)${name}=([^;]*)`));
-  return match ? decodeURIComponent(match[1]!) : null;
-}
-
 function isPublicRoute(pathname: string, method: string): boolean {
   return (
     pathname === '/health' ||
     pathname === '/sidecar/connect' ||
     pathname === '/api/sidecars/.well-known/jwks.json' ||
+    pathname === '/api/auth/login' ||
+    pathname === '/api/auth/logout' ||
+    pathname === '/api/auth/session' ||
+    pathname === '/api/auth/google/callback' ||
     pathname.startsWith('/api/webhooks/') ||
     method === 'OPTIONS'
   );
@@ -88,6 +83,7 @@ export class WebSocketServer {
   private publicDir: string | null = null;
   private sidecarManager: SidecarManager | null = null;
   private authToken: string | null = null;
+  private dashboardPasswordHash: string | null = null;
   private corsOrigin: string | null = null;
   private proxyLimiter = new ProxyRateLimiter();
 
@@ -98,6 +94,10 @@ export class WebSocketServer {
 
   setAuthToken(token: string): void {
     this.authToken = token;
+  }
+
+  setDashboardPasswordHash(passwordHash?: string | null): void {
+    this.dashboardPasswordHash = passwordHash?.trim() || null;
   }
 
   setHandler(handler: WSClientHandler): void {
@@ -177,10 +177,56 @@ export class WebSocketServer {
         }
 
         // 1. Auth check (if configured)
-        if (self.authToken && !isPublicRoute(pathname, req.method)) {
-          const cookieToken = getCookie(req, 'token');
-          if (!cookieToken || !safeCompare(cookieToken, self.authToken)) {
+        const tokenAuthEnabled = Boolean(self.authToken);
+        const passwordAuthEnabled = Boolean(self.dashboardPasswordHash);
+        const dashboardAuthEnabled = tokenAuthEnabled || passwordAuthEnabled;
+        const cookieToken = tokenAuthEnabled ? getCookie(req, 'token') : null;
+        const hasValidToken = Boolean(
+          tokenAuthEnabled &&
+          self.authToken &&
+          cookieToken &&
+          safeCompare(cookieToken, self.authToken),
+        );
+        const queryToken = tokenAuthEnabled ? url.searchParams.get('token') : null;
+        const hasValidQueryToken = Boolean(
+          tokenAuthEnabled &&
+          self.authToken &&
+          queryToken &&
+          safeCompare(queryToken, self.authToken),
+        );
+        const session = passwordAuthEnabled ? getDashboardSessionFromRequest(req) : null;
+        const isAuthenticated = hasValidToken || Boolean(session);
+        const wantsJsonUnauthorized = pathname.startsWith('/api/') || pathname === '/ws';
+
+        if (dashboardAuthEnabled && !isPublicRoute(pathname, req.method) && hasValidQueryToken) {
+          const cleanParams = new URLSearchParams(url.searchParams);
+          cleanParams.delete('token');
+          const qs = cleanParams.toString();
+          const redirectTo = pathname + (qs ? '?' + qs : '');
+          return new Response(null, {
+            status: 302,
+            headers: {
+              'Location': redirectTo || '/',
+              'Set-Cookie': `token=${queryToken}; Path=/; SameSite=Lax; HttpOnly`,
+            },
+          });
+        }
+
+        if (dashboardAuthEnabled && !isPublicRoute(pathname, req.method)) {
+          if (wantsJsonUnauthorized && !isAuthenticated) {
+            return Response.json({ error: 'Unauthorized' }, { status: 401 });
+          }
+          if (!passwordAuthEnabled && !isAuthenticated) {
+            return new Response(AUTH_ERROR_HTML, {
+              status: 401,
+              headers: { 'Content-Type': 'text/html' },
+            });
+          }
+        }
+
+        
             // Check ?token= query param — set cookie via Set-Cookie and redirect
+        /*
             const queryToken = url.searchParams.get('token');
             if (queryToken && safeCompare(queryToken, self.authToken)) {
               const cleanParams = new URLSearchParams(url.searchParams);
@@ -204,7 +250,8 @@ export class WebSocketServer {
               headers: { 'Content-Type': 'text/html' },
             });
           }
-        }
+        */
+        
 
         // 2. WebSocket upgrade — validate Origin to block cross-origin connections
         //    (e.g., dev server iframes on different ports attempting ws://localhost:3142/ws)
@@ -299,6 +346,12 @@ export class WebSocketServer {
 
         // 5a. Overlay widget (served from ui/ source, not dist/)
         if (pathname === '/overlay' && self.staticDir) {
+          if (dashboardAuthEnabled && !isAuthenticated) {
+            return new Response(AUTH_ERROR_HTML, {
+              status: 401,
+              headers: { 'Content-Type': 'text/html' },
+            });
+          }
           // overlay.html lives in the ui/ source directory (parent of dist/)
           const overlayPath = path.join(self.staticDir, '..', 'overlay.html');
           const overlayFile = Bun.file(overlayPath);
@@ -355,6 +408,9 @@ export class WebSocketServer {
         //    This handles absolute paths (/src/main.tsx, /node_modules/...) that
         //    frameworks emit and that don't match any JARVIS route.
         if (self.siteProxy) {
+          if (dashboardAuthEnabled && !isAuthenticated) {
+            return new Response('Unauthorized', { status: 401 });
+          }
           // WebSocket upgrade (e.g. Vite HMR)
           if (req.headers.get('upgrade')?.toLowerCase() === 'websocket') {
             const targetUrl = self.siteProxy.getWebSocketTargetFromCookie(req, pathname);

--- a/src/config/README.md
+++ b/src/config/README.md
@@ -94,6 +94,7 @@ llm: {
   openai?: {
     api_key: string;
     model?: string;      // Default: gpt-4o
+    base_url?: string;   // Optional OpenAI-compatible API base URL
   };
 
   // Ollama (local models) configuration
@@ -168,6 +169,7 @@ llm:
   openai:
     api_key: ""
     model: "gpt-4o"
+    # base_url: "https://your-openai-compatible-api-base"
   ollama:
     base_url: "http://localhost:11434"
     model: "llama3"

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -31,6 +31,7 @@ describe('Config Loader', () => {
     const testConfig = structuredClone(DEFAULT_CONFIG);
     testConfig.daemon.port = 9999;
     testConfig.llm.primary = 'openai';
+    testConfig.dashboard = { password_hash: '$2b$test-hash' };
 
     await saveConfig(testConfig, TEST_CONFIG_PATH);
     expect(existsSync(TEST_CONFIG_PATH)).toBe(true);
@@ -38,6 +39,7 @@ describe('Config Loader', () => {
     const loaded = await loadConfig(TEST_CONFIG_PATH);
     expect(loaded.daemon.port).toBe(9999);
     expect(loaded.llm.primary).toBe('openai');
+    expect(loaded.dashboard?.password_hash).toBe('$2b$test-hash');
   });
 
   test('deep merges partial config with defaults', async () => {
@@ -111,6 +113,7 @@ describe('Default Config', () => {
     expect(DEFAULT_CONFIG.llm.gemini?.model).toBe('gemini-3-flash-preview');
     expect(DEFAULT_CONFIG.llm.ollama?.model).toBe('llama3');
     expect(DEFAULT_CONFIG.llm.ollama?.base_url).toBe('http://localhost:11434');
+    expect(DEFAULT_CONFIG.dashboard?.password_hash).toBeUndefined();
   });
 });
 

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -31,6 +31,11 @@ describe('Config Loader', () => {
     const testConfig = structuredClone(DEFAULT_CONFIG);
     testConfig.daemon.port = 9999;
     testConfig.llm.primary = 'openai';
+    testConfig.llm.openai = {
+      api_key: testConfig.llm.openai?.api_key ?? '',
+      model: testConfig.llm.openai?.model,
+      base_url: 'https://api.openai.com/v1',
+    };
 
     await saveConfig(testConfig, TEST_CONFIG_PATH);
     expect(existsSync(TEST_CONFIG_PATH)).toBe(true);
@@ -38,6 +43,7 @@ describe('Config Loader', () => {
     const loaded = await loadConfig(TEST_CONFIG_PATH);
     expect(loaded.daemon.port).toBe(9999);
     expect(loaded.llm.primary).toBe('openai');
+    expect(loaded.llm.openai?.base_url).toBe('https://api.openai.com/v1');
   });
 
   test('deep merges partial config with defaults', async () => {
@@ -108,6 +114,7 @@ describe('Default Config', () => {
   test('has correct LLM defaults', () => {
     expect(DEFAULT_CONFIG.llm.anthropic?.model).toBe('claude-sonnet-4-6');
     expect(DEFAULT_CONFIG.llm.openai?.model).toBe('gpt-5.4');
+    expect(DEFAULT_CONFIG.llm.openai?.base_url).toBeUndefined();
     expect(DEFAULT_CONFIG.llm.gemini?.model).toBe('gemini-3-flash-preview');
     expect(DEFAULT_CONFIG.llm.ollama?.model).toBe('llama3');
     expect(DEFAULT_CONFIG.llm.ollama?.base_url).toBe('http://localhost:11434');

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -25,7 +25,7 @@ export type ChannelConfig = {
 
 export type STTConfig = {
   provider: 'openai' | 'groq' | 'local';
-  openai?: { api_key: string; model?: string };
+  openai?: { api_key: string; model?: string; base_url?: string };
   groq?: { api_key: string; model?: string };
   local?: { endpoint: string; model?: string; server_type?: 'whisper_cpp' | 'openai_compatible' };
 };
@@ -148,7 +148,7 @@ export type JarvisConfig = {
     primary: string;  // provider name
     fallback: string[];
     anthropic?: { api_key: string; model?: string };
-    openai?: { api_key: string; model?: string };
+    openai?: { api_key: string; model?: string; base_url?: string };
     groq?: { api_key: string; model?: string };
     gemini?: { api_key: string; model?: string };
     ollama?: { base_url?: string; model?: string };

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -124,6 +124,11 @@ export type AuthConfig = {
   token?: string;
 };
 
+export type DashboardConfig = {
+  /** Password hash for dashboard login. If unset, password auth is disabled. */
+  password_hash?: string;
+};
+
 export type UserConfig = {
   name?: string;
 };
@@ -138,6 +143,7 @@ export type JarvisConfig = {
     brain_domain?: string;
   };
   auth?: AuthConfig;
+  dashboard?: DashboardConfig;
   google?: GoogleConfig;
   channels?: ChannelConfig;
   stt?: STTConfig;
@@ -182,6 +188,7 @@ export const DEFAULT_CONFIG: JarvisConfig = {
     data_dir: '~/.jarvis',
     db_path: '~/.jarvis/jarvis.db',
   },
+  dashboard: {},
   channels: {
     telegram: { enabled: false, bot_token: '', allowed_users: [] },
     discord: { enabled: false, bot_token: '', allowed_users: [] },

--- a/src/daemon/agent-service.ts
+++ b/src/daemon/agent-service.ts
@@ -344,7 +344,8 @@ export class AgentService implements Service, IAgentService {
     if (llm.openai?.api_key) {
       const provider = new OpenAIProvider(
         llm.openai.api_key,
-        llm.openai.model
+        llm.openai.model,
+        llm.openai.base_url,
       );
       this.llmManager.registerProvider(provider);
       hasProvider = true;

--- a/src/daemon/api-routes.ts
+++ b/src/daemon/api-routes.ts
@@ -24,6 +24,16 @@ import { findEntities, getEntity, searchEntitiesByName } from '../vault/entities
 import { findFacts } from '../vault/facts.ts';
 import { findRelationships, getEntityRelationships } from '../vault/relationships.ts';
 import { getDb } from '../vault/schema.ts';
+import {
+  buildClearedDashboardSessionCookie,
+  buildDashboardSessionCookie,
+  createAuthenticatedDashboardSession,
+  getCookie,
+  getDashboardSessionFromRequest,
+  isDashboardPasswordEnabled,
+  revokeDashboardSessionFromRequest,
+  safeCompare,
+} from '../comms/dashboard-auth.ts';
 import { findCommitments, getUpcoming, createCommitment, getCommitment, updateCommitmentStatus, reorderCommitments } from '../vault/commitments.ts';
 import { getOrCreateConversation, getMessages, getRecentConversation } from '../vault/conversations.ts';
 import { getRecentObservations } from '../vault/observations.ts';
@@ -151,8 +161,8 @@ export function setCorsOrigin(port: number, host = 'localhost') {
   };
 }
 
-function json(data: unknown, status = 200): Response {
-  return Response.json(data, { status, headers: CORS });
+function json(data: unknown, status = 200, headers: Record<string, string> = {}): Response {
+  return Response.json(data, { status, headers: { ...CORS, ...headers } });
 }
 
 function error(message: string, status = 400): Response {
@@ -224,6 +234,65 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
     // --- Health ---
     '/api/health': {
       GET: () => json(ctx.healthMonitor.getHealth()),
+    },
+
+    // --- Dashboard Auth ---
+    '/api/auth/session': {
+      GET: (req: Request) => {
+        const passwordEnabled = isDashboardPasswordEnabled(ctx.config);
+        const tokenEnabled = Boolean(ctx.config.auth?.token);
+        const session = passwordEnabled ? getDashboardSessionFromRequest(req) : null;
+        const tokenCookie = tokenEnabled ? getCookie(req, 'token') : null;
+        const tokenAuthenticated = Boolean(
+          tokenEnabled &&
+          ctx.config.auth?.token &&
+          tokenCookie &&
+          safeCompare(tokenCookie, ctx.config.auth.token),
+        );
+        return json({
+          password_enabled: passwordEnabled,
+          token_enabled: tokenEnabled,
+          authenticated: tokenAuthenticated || (passwordEnabled ? Boolean(session) : true),
+          expires_at: session?.expires_at ?? null,
+        });
+      },
+    },
+
+    '/api/auth/login': {
+      POST: async (req: Request) => {
+        if (!isDashboardPasswordEnabled(ctx.config) || !ctx.config.dashboard?.password_hash) {
+          return error('Dashboard password authentication is not configured', 400);
+        }
+
+        try {
+          const body = await req.json() as { password?: string };
+          const password = body.password?.trim() ?? '';
+          if (!password) return error('Password is required', 400);
+
+          const valid = await Bun.password.verify(password, ctx.config.dashboard.password_hash);
+          if (!valid) return error('Invalid password', 401);
+
+          const session = createAuthenticatedDashboardSession();
+          return json({
+            ok: true,
+            authenticated: true,
+            expires_at: session.expires_at,
+          }, 200, {
+            'Set-Cookie': buildDashboardSessionCookie(req, session.id, session.expires_at),
+          });
+        } catch {
+          return error('Invalid request body');
+        }
+      },
+    },
+
+    '/api/auth/logout': {
+      POST: (req: Request) => {
+        revokeDashboardSessionFromRequest(req);
+        return json({ ok: true }, 200, {
+          'Set-Cookie': buildClearedDashboardSessionCookie(req),
+        });
+      },
     },
 
     // --- Vault: Entities ---
@@ -774,7 +843,66 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
           authority: config.authority,
           heartbeat: config.heartbeat,
           active_role: config.active_role,
+          dashboard: {
+            password_enabled: isDashboardPasswordEnabled(config),
+          },
         });
+      },
+    },
+
+    '/api/config/dashboard-auth': {
+      GET: () => {
+        return json({
+          password_enabled: isDashboardPasswordEnabled(ctx.config),
+        });
+      },
+      POST: async (req: Request) => {
+        try {
+          const body = await req.json() as { password?: string; disable?: boolean };
+          const disable = body.disable === true;
+          const nextPassword = body.password?.trim() ?? '';
+
+          if (!disable && nextPassword.length === 0) {
+            return error('Password is required unless disabling dashboard protection.');
+          }
+
+          const { loadConfig, saveConfig } = await import('../config/loader.ts');
+          const freshConfig = await loadConfig();
+          freshConfig.dashboard = freshConfig.dashboard ?? {};
+
+          if (disable) {
+            freshConfig.dashboard.password_hash = undefined;
+            await saveConfig(freshConfig);
+            ctx.config.dashboard = freshConfig.dashboard;
+            ctx.wsService?.setDashboardPasswordHash(undefined);
+            revokeDashboardSessionFromRequest(req);
+            return json({
+              ok: true,
+              password_enabled: false,
+              message: 'Dashboard password disabled.',
+            }, 200, {
+              'Set-Cookie': buildClearedDashboardSessionCookie(req),
+            });
+          }
+
+          freshConfig.dashboard.password_hash = await Bun.password.hash(nextPassword);
+          await saveConfig(freshConfig);
+          ctx.config.dashboard = freshConfig.dashboard;
+          ctx.wsService?.setDashboardPasswordHash(freshConfig.dashboard.password_hash);
+
+          const session = createAuthenticatedDashboardSession();
+          return json({
+            ok: true,
+            password_enabled: true,
+            message: 'Dashboard password saved.',
+            expires_at: session.expires_at,
+          }, 200, {
+            'Set-Cookie': buildDashboardSessionCookie(req, session.id, session.expires_at),
+          });
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          return error(`Failed to save dashboard password: ${msg}`, 500);
+        }
       },
     },
 

--- a/src/daemon/dashboard-auth.test.ts
+++ b/src/daemon/dashboard-auth.test.ts
@@ -1,0 +1,170 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { closeDb, getDb, initDatabase } from '../vault/schema.ts';
+import { WebSocketServer } from '../comms/websocket.ts';
+import { createApiRoutes, type ApiContext } from './api-routes.ts';
+import { DASHBOARD_SESSION_COOKIE } from '../comms/dashboard-auth.ts';
+
+const PASSWORD = 'shielded-panel';
+
+type TestServer = {
+  port: number;
+  server: WebSocketServer;
+};
+
+function createContext(passwordHash: string): ApiContext {
+  return {
+    healthMonitor: {
+      getHealth: () => ({ status: 'ok' }),
+    } as any,
+    agentService: {} as any,
+    config: {
+      daemon: {
+        port: 3142,
+        data_dir: '~/.jarvis',
+        db_path: '~/.jarvis/jarvis.db',
+      },
+      llm: {
+        primary: 'anthropic',
+        fallback: ['openai', 'ollama'],
+        anthropic: { api_key: '', model: 'claude-sonnet-4-6' },
+        openai: { api_key: '', model: 'gpt-5.4' },
+        gemini: { api_key: '', model: 'gemini-3-flash-preview' },
+        ollama: { base_url: 'http://localhost:11434', model: 'llama3' },
+      },
+      personality: {
+        assistant_name: 'Jarvis',
+        core_traits: ['loyal'],
+      },
+      authority: {
+        default_level: 3,
+        governed_categories: ['send_email'],
+      },
+      active_role: 'personal-assistant',
+      dashboard: {
+        password_hash: passwordHash,
+      },
+    } as any,
+  };
+}
+
+async function startTestServer(port: number, passwordHash: string): Promise<TestServer> {
+  const server = new WebSocketServer(port);
+  server.setDashboardPasswordHash(passwordHash);
+  server.setApiRoutes({
+    ...(createApiRoutes(createContext(passwordHash)) as Record<string, any>),
+    '/api/protected': {
+      GET: () => Response.json({ ok: true }),
+    },
+  });
+  server.start();
+  return { port, server };
+}
+
+function extractCookie(setCookie: string | null): string {
+  expect(setCookie).toBeTruthy();
+  return setCookie!.split(';')[0]!;
+}
+
+describe('dashboard password auth', () => {
+  let currentPort = 3160;
+  let passwordHash: string;
+  const activeServers: WebSocketServer[] = [];
+
+  beforeEach(async () => {
+    initDatabase(':memory:');
+    passwordHash = await Bun.password.hash(PASSWORD);
+  });
+
+  afterEach(() => {
+    for (const server of activeServers.splice(0)) {
+      if (server.isRunning()) server.stop();
+    }
+    closeDb();
+  });
+
+  test('login succeeds with correct password and grants access to protected API', async () => {
+    const { port, server } = await startTestServer(currentPort++, passwordHash);
+    activeServers.push(server);
+
+    const login = await fetch(`http://localhost:${port}/api/auth/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ password: PASSWORD }),
+    });
+    expect(login.status).toBe(200);
+
+    const cookie = extractCookie(login.headers.get('set-cookie'));
+    const session = await login.json() as any;
+    expect(session.authenticated).toBe(true);
+    expect(typeof session.expires_at).toBe('number');
+
+    const protectedRes = await fetch(`http://localhost:${port}/api/protected`, {
+      headers: { Cookie: cookie },
+    });
+    expect(protectedRes.status).toBe(200);
+    expect(await protectedRes.json()).toEqual({ ok: true });
+  });
+
+  test('login fails with incorrect password', async () => {
+    const { port, server } = await startTestServer(currentPort++, passwordHash);
+    activeServers.push(server);
+
+    const login = await fetch(`http://localhost:${port}/api/auth/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ password: 'wrong-password' }),
+    });
+    expect(login.status).toBe(401);
+    const body = await login.json() as any;
+    expect(body.error).toBe('Invalid password');
+  });
+
+  test('protected endpoint rejects unauthenticated requests', async () => {
+    const { port, server } = await startTestServer(currentPort++, passwordHash);
+    activeServers.push(server);
+
+    const res = await fetch(`http://localhost:${port}/api/protected`);
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: 'Unauthorized' });
+  });
+
+  test('expired sessions are rejected', async () => {
+    const { port, server } = await startTestServer(currentPort++, passwordHash);
+    activeServers.push(server);
+
+    getDb().prepare(`
+      INSERT INTO dashboard_sessions (id, created_at, expires_at)
+      VALUES (?, ?, ?)
+    `).run('expired-session', Date.now() - 10_000, Date.now() - 1_000);
+
+    const res = await fetch(`http://localhost:${port}/api/protected`, {
+      headers: { Cookie: `${DASHBOARD_SESSION_COOKIE}=expired-session` },
+    });
+    expect(res.status).toBe(401);
+  });
+
+  test('logout invalidates the session and clears the cookie', async () => {
+    const { port, server } = await startTestServer(currentPort++, passwordHash);
+    activeServers.push(server);
+
+    const login = await fetch(`http://localhost:${port}/api/auth/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ password: PASSWORD }),
+    });
+    const cookie = extractCookie(login.headers.get('set-cookie'));
+
+    const logout = await fetch(`http://localhost:${port}/api/auth/logout`, {
+      method: 'POST',
+      headers: { Cookie: cookie },
+    });
+    expect(logout.status).toBe(200);
+    expect(logout.headers.get('set-cookie')).toContain(`${DASHBOARD_SESSION_COOKIE}=`);
+    expect(logout.headers.get('set-cookie')).toContain('Max-Age=0');
+
+    const protectedRes = await fetch(`http://localhost:${port}/api/protected`, {
+      headers: { Cookie: cookie },
+    });
+    expect(protectedRes.status).toBe(401);
+  });
+});

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -488,13 +488,19 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
     const uiPublicDir = path.join(import.meta.dir, '../../ui/public');
     wsService.setPublicDir(uiPublicDir);
 
-    // 9c. Configure auth token if set
+    // 9c. Configure dashboard auth
     const authToken = jarvisConfig.auth?.token;
+    const dashboardPasswordHash = jarvisConfig.dashboard?.password_hash;
     if (authToken) {
       wsService.setAuthToken(authToken);
-      console.log('[Daemon] Auth token configured — dashboard routes require ?token= or cookie');
-    } else {
-      console.warn('[Daemon] No auth token configured — dashboard is open to anyone on the network');
+      console.log('[Daemon] Auth token configured — dashboard routes accept ?token= or token cookie');
+    }
+    if (dashboardPasswordHash) {
+      wsService.setDashboardPasswordHash(dashboardPasswordHash);
+      console.log('[Daemon] Dashboard password authentication enabled');
+    }
+    if (!authToken && !dashboardPasswordHash) {
+      console.warn('[Daemon] No dashboard authentication configured — panel is open to anyone on the network');
     }
 
     // 9b. Apply --no-local-tools flag if set

--- a/src/daemon/llm-settings.test.ts
+++ b/src/daemon/llm-settings.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { testLLMProvider } from './llm-settings.ts';
+import { DEFAULT_CONFIG, type JarvisConfig } from '../config/types.ts';
+
+function makeConfig(): JarvisConfig {
+  return structuredClone(DEFAULT_CONFIG);
+}
+
+describe('testLLMProvider', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    globalThis.fetch = mock(async (_url: string) => {
+      return new Response(JSON.stringify({
+        id: 'cmpl_test',
+        object: 'chat.completion',
+        created: Date.now(),
+        model: 'gpt-test',
+        choices: [
+          {
+            index: 0,
+            message: { role: 'assistant', content: 'OK' },
+            finish_reason: 'stop',
+          },
+        ],
+        usage: {
+          prompt_tokens: 1,
+          completion_tokens: 1,
+          total_tokens: 2,
+        },
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }) as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test('uses the official OpenAI endpoint when no base URL is configured', async () => {
+    const config = makeConfig();
+    const result = await testLLMProvider(
+      {
+        provider: 'openai',
+        api_key: 'sk-test-key',
+        model: 'gpt-5.4',
+      },
+      config,
+    );
+
+    expect(result.ok).toBe(true);
+
+    const fetchMock = globalThis.fetch as unknown as ReturnType<typeof mock>;
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('https://api.openai.com/v1/chat/completions');
+  });
+
+  test('uses custom compatible base URLs without assuming an OpenAI key prefix', async () => {
+    const config = makeConfig();
+    const result = await testLLMProvider(
+      {
+        provider: 'openai',
+        api_key: 'nvapi-custom-key',
+        model: 'gpt-5.4',
+        base_url: 'https://gateway.example.com/openai',
+      },
+      config,
+    );
+
+    expect(result.ok).toBe(true);
+
+    const fetchMock = globalThis.fetch as unknown as ReturnType<typeof mock>;
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('https://gateway.example.com/openai/chat/completions');
+  });
+});

--- a/src/daemon/llm-settings.ts
+++ b/src/daemon/llm-settings.ts
@@ -29,6 +29,7 @@ const SETTING_PRIMARY = 'llm.primary';
 const SETTING_FALLBACK = 'llm.fallback';
 const SETTING_ANTHROPIC_MODEL = 'llm.anthropic.model';
 const SETTING_OPENAI_MODEL = 'llm.openai.model';
+const SETTING_OPENAI_BASE_URL = 'llm.openai.base_url';
 const SETTING_GROQ_MODEL = 'llm.groq.model';
 const SETTING_GEMINI_MODEL = 'llm.gemini.model';
 const SETTING_OLLAMA_MODEL = 'llm.ollama.model';
@@ -39,7 +40,7 @@ export type LLMSettingsResponse = {
   primary: string;
   fallback: string[];
   anthropic: { model: string; has_api_key: boolean } | null;
-  openai: { model: string; has_api_key: boolean } | null;
+  openai: { model: string; has_api_key: boolean; base_url?: string } | null;
   groq: { model: string; has_api_key: boolean } | null;
   gemini: { model: string; has_api_key: boolean } | null;
   ollama: { base_url: string; model: string } | null;
@@ -57,6 +58,7 @@ export function getLLMSettings(config: JarvisConfig): LLMSettingsResponse {
 
   const anthropicModel = getSetting(SETTING_ANTHROPIC_MODEL) ?? config.llm.anthropic?.model ?? 'claude-sonnet-4-6';
   const openaiModel = getSetting(SETTING_OPENAI_MODEL) ?? config.llm.openai?.model ?? 'gpt-5.4';
+  const openaiBaseUrl = getSetting(SETTING_OPENAI_BASE_URL) ?? config.llm.openai?.base_url;
   const groqModel = getSetting(SETTING_GROQ_MODEL) ?? config.llm.groq?.model ?? 'llama-3.3-70b-versatile';
   const geminiModel = getSetting(SETTING_GEMINI_MODEL) ?? config.llm.gemini?.model ?? 'gemini-3-flash-preview';
   const ollamaModel = getSetting(SETTING_OLLAMA_MODEL) ?? config.llm.ollama?.model ?? 'llama3';
@@ -74,7 +76,7 @@ export function getLLMSettings(config: JarvisConfig): LLMSettingsResponse {
     primary,
     fallback,
     anthropic: { model: anthropicModel, has_api_key: hasAnthropicKey },
-    openai: { model: openaiModel, has_api_key: hasOpenaiKey },
+    openai: { model: openaiModel, has_api_key: hasOpenaiKey, ...(openaiBaseUrl ? { base_url: openaiBaseUrl } : {}) },
     groq: { model: groqModel, has_api_key: hasGroqKey },
     gemini: { model: geminiModel, has_api_key: hasGeminiKey },
     ollama: { base_url: ollamaBaseUrl, model: ollamaModel },
@@ -91,7 +93,7 @@ export function saveLLMSettings(
     primary?: string;
     fallback?: string[];
     anthropic?: { api_key?: string; model?: string };
-    openai?: { api_key?: string; model?: string };
+    openai?: { api_key?: string; model?: string; base_url?: string };
     groq?: { api_key?: string; model?: string };
     gemini?: { api_key?: string; model?: string };
     ollama?: { base_url?: string; model?: string };
@@ -125,8 +127,26 @@ export function saveLLMSettings(
 
   // OpenAI
   if (body.openai) {
+    if (body.openai.base_url !== undefined) {
+      const trimmedBaseUrl = body.openai.base_url.trim();
+      if (trimmedBaseUrl) {
+        try {
+          new URL(trimmedBaseUrl);
+        } catch {
+          throw new Error(`Invalid OpenAI base URL: ${trimmedBaseUrl}`);
+        }
+      }
+    }
     if (body.openai.model) {
       setSetting(SETTING_OPENAI_MODEL, body.openai.model);
+    }
+    if (body.openai.base_url !== undefined) {
+      const trimmedBaseUrl = body.openai.base_url.trim();
+      if (trimmedBaseUrl) {
+        setSetting(SETTING_OPENAI_BASE_URL, trimmedBaseUrl);
+      } else {
+        setSetting(SETTING_OPENAI_BASE_URL, '');
+      }
     }
     if (body.openai.api_key) {
       setSecret(KEY_OPENAI, body.openai.api_key);
@@ -134,6 +154,9 @@ export function saveLLMSettings(
     config.llm.openai = {
       ...config.llm.openai,
       model: body.openai.model ?? config.llm.openai?.model,
+      base_url: body.openai.base_url !== undefined
+        ? (body.openai.base_url.trim() || undefined)
+        : config.llm.openai?.base_url,
       api_key: body.openai.api_key ?? getOpenAIApiKey(config) ?? '',
     };
   }
@@ -261,14 +284,18 @@ export function mergeLLMSettingsIntoConfig(config: JarvisConfig): void {
 
   // OpenAI
   const dbOpenaiModel = getSetting(SETTING_OPENAI_MODEL);
+  const dbOpenaiBaseUrl = getSetting(SETTING_OPENAI_BASE_URL);
   const keychainOpenaiKey = getSecret(KEY_OPENAI);
-  if (dbOpenaiModel || keychainOpenaiKey) {
+  if (dbOpenaiModel || dbOpenaiBaseUrl !== null || keychainOpenaiKey) {
     config.llm.openai = {
       ...config.llm.openai,
       api_key: (!process.env.JARVIS_OPENAI_KEY && keychainOpenaiKey)
         ? keychainOpenaiKey
         : (config.llm.openai?.api_key ?? ''),
       model: dbOpenaiModel ?? config.llm.openai?.model,
+      base_url: dbOpenaiBaseUrl !== null
+        ? (dbOpenaiBaseUrl || undefined)
+        : config.llm.openai?.base_url,
     };
   }
 
@@ -338,7 +365,7 @@ export function hotReloadLLMProviders(config: JarvisConfig, llmManager: LLMManag
     console.log('[LLM] Hot-reloaded Anthropic provider');
   }
   if (llm.openai?.api_key) {
-    providers.push(new OpenAIProvider(llm.openai.api_key, llm.openai.model));
+    providers.push(new OpenAIProvider(llm.openai.api_key, llm.openai.model, llm.openai.base_url));
     console.log('[LLM] Hot-reloaded OpenAI provider');
   }
   if (llm.groq?.api_key) {
@@ -386,7 +413,11 @@ export async function testLLMProvider(
     } else if (opts.provider === 'openai') {
       const key = opts.api_key || getSecret(KEY_OPENAI) || config.llm.openai?.api_key;
       if (!key) return { ok: false, error: 'API key required' };
-      instance = new OpenAIProvider(key, opts.model ?? config.llm.openai?.model);
+      instance = new OpenAIProvider(
+        key,
+        opts.model ?? config.llm.openai?.model,
+        opts.base_url ?? config.llm.openai?.base_url,
+      );
     } else if (opts.provider === 'groq') {
       const key = opts.api_key || getSecret(KEY_GROQ) || config.llm.groq?.api_key;
       if (!key) return { ok: false, error: 'API key required' };

--- a/src/daemon/ws-service.ts
+++ b/src/daemon/ws-service.ts
@@ -131,6 +131,10 @@ export class WebSocketService implements Service {
     this.wsServer.setAuthToken(token);
   }
 
+  setDashboardPasswordHash(passwordHash?: string | null): void {
+    this.wsServer.setDashboardPasswordHash(passwordHash);
+  }
+
   async start(): Promise<void> {
     this._status = 'starting';
 

--- a/src/llm/openai.ts
+++ b/src/llm/openai.ts
@@ -79,15 +79,35 @@ type OpenAIStreamChunk = {
   }>;
 };
 
+const DEFAULT_OPENAI_BASE_URL = 'https://api.openai.com/v1/';
+
+export function resolveOpenAIBaseUrl(baseUrl?: string): URL {
+  const trimmed = baseUrl?.trim();
+  const rawBaseUrl = trimmed && trimmed.length > 0 ? trimmed : DEFAULT_OPENAI_BASE_URL;
+  const resolved = new URL(rawBaseUrl);
+
+  if (!resolved.pathname.endsWith('/')) {
+    resolved.pathname = `${resolved.pathname}/`;
+  }
+
+  return resolved;
+}
+
 export class OpenAIProvider implements LLMProvider {
   name = 'openai';
   private apiKey: string;
   private defaultModel: string;
-  private apiUrl = 'https://api.openai.com/v1/chat/completions';
+  private baseUrl: string;
+  private apiUrl: string;
+  private modelsUrl: string;
 
-  constructor(apiKey: string, defaultModel = 'gpt-4o') {
+  constructor(apiKey: string, defaultModel = 'gpt-4o', baseUrl?: string) {
     this.apiKey = apiKey;
     this.defaultModel = defaultModel;
+    const resolvedBaseUrl = resolveOpenAIBaseUrl(baseUrl);
+    this.baseUrl = resolvedBaseUrl.toString();
+    this.apiUrl = new URL('chat/completions', resolvedBaseUrl).toString();
+    this.modelsUrl = new URL('models', resolvedBaseUrl).toString();
   }
 
   async chat(messages: LLMMessage[], options: LLMOptions = {}): Promise<LLMResponse> {
@@ -269,7 +289,7 @@ export class OpenAIProvider implements LLMProvider {
 
   async listModels(): Promise<string[]> {
     try {
-      const response = await fetch('https://api.openai.com/v1/models', {
+      const response = await fetch(this.modelsUrl, {
         headers: {
           'Authorization': `Bearer ${this.apiKey}`,
         },
@@ -282,7 +302,6 @@ export class OpenAIProvider implements LLMProvider {
       const data = await response.json() as { data: Array<{ id: string }> };
       return data.data
         .map(m => m.id)
-        .filter(id => id.startsWith('gpt-'))
         .sort();
     } catch (err) {
       // Fallback to known models if API call fails

--- a/src/llm/openai.ts
+++ b/src/llm/openai.ts
@@ -80,6 +80,7 @@ type OpenAIStreamChunk = {
 };
 
 const DEFAULT_OPENAI_BASE_URL = 'https://api.openai.com/v1/';
+const OFFICIAL_OPENAI_HOSTNAME = 'api.openai.com';
 
 export function resolveOpenAIBaseUrl(baseUrl?: string): URL {
   const trimmed = baseUrl?.trim();
@@ -91,6 +92,17 @@ export function resolveOpenAIBaseUrl(baseUrl?: string): URL {
   }
 
   return resolved;
+}
+
+export function isOfficialOpenAI(baseUrl?: string): boolean {
+  const trimmed = baseUrl?.trim();
+  if (!trimmed) return true;
+
+  try {
+    return resolveOpenAIBaseUrl(trimmed).hostname === OFFICIAL_OPENAI_HOSTNAME;
+  } catch {
+    return false;
+  }
 }
 
 export class OpenAIProvider implements LLMProvider {

--- a/src/llm/provider.test.ts
+++ b/src/llm/provider.test.ts
@@ -1,6 +1,6 @@
 import { test, expect, describe, beforeEach, afterEach, mock } from 'bun:test';
 import { AnthropicProvider } from './anthropic.ts';
-import { OpenAIProvider } from './openai.ts';
+import { OpenAIProvider, resolveOpenAIBaseUrl } from './openai.ts';
 import { GroqProvider } from './groq.ts';
 import { OllamaProvider } from './ollama.ts';
 import { OpenRouterProvider } from './openrouter.ts';
@@ -131,6 +131,18 @@ describe('Provider URLs', () => {
     expect(provider.apiUrl).toBe('https://api.openai.com/v1/chat/completions');
   });
 
+  test('OpenAIProvider uses custom compatible base URL as the request base', () => {
+    const provider = new OpenAIProvider('test-key', 'test-model', 'https://gateway.example.com/v1/') as any;
+    expect(provider.baseUrl).toBe('https://gateway.example.com/v1/');
+    expect(provider.apiUrl).toBe('https://gateway.example.com/v1/chat/completions');
+  });
+
+  test('OpenAIProvider preserves custom path prefixes in compatible base URLs', () => {
+    const provider = new OpenAIProvider('test-key', 'test-model', 'https://gateway.example.com/openai/') as any;
+    expect(provider.baseUrl).toBe('https://gateway.example.com/openai/');
+    expect(provider.apiUrl).toBe('https://gateway.example.com/openai/chat/completions');
+  });
+
   test('OpenRouterProvider uses correct API URL', () => {
     const provider = new OpenRouterProvider('test-key') as any;
     expect(provider.apiUrl).toBe('https://openrouter.ai/api/v1/chat/completions');
@@ -149,6 +161,24 @@ describe('Provider URLs', () => {
   test('OllamaProvider removes trailing slash from base URL', () => {
     const provider = new OllamaProvider('http://localhost:11434/') as any;
     expect(provider.baseUrl).toBe('http://localhost:11434');
+  });
+});
+
+describe('OpenAI base URL resolution', () => {
+  test('uses official OpenAI API when omitted', () => {
+    expect(resolveOpenAIBaseUrl().toString()).toBe('https://api.openai.com/v1/');
+  });
+
+  test('adds a trailing slash so relative endpoints resolve consistently', () => {
+    expect(resolveOpenAIBaseUrl('https://gateway.example.com/v1').toString()).toBe('https://gateway.example.com/v1/');
+  });
+
+  test('preserves the provided base path', () => {
+    expect(resolveOpenAIBaseUrl('https://gateway.example.com/openai').toString()).toBe('https://gateway.example.com/openai/');
+  });
+
+  test('rejects invalid URLs', () => {
+    expect(() => resolveOpenAIBaseUrl('not-a-url')).toThrow();
   });
 });
 

--- a/src/llm/provider.test.ts
+++ b/src/llm/provider.test.ts
@@ -1,6 +1,6 @@
 import { test, expect, describe, beforeEach, afterEach, mock } from 'bun:test';
 import { AnthropicProvider } from './anthropic.ts';
-import { OpenAIProvider, resolveOpenAIBaseUrl } from './openai.ts';
+import { OpenAIProvider, isOfficialOpenAI, resolveOpenAIBaseUrl } from './openai.ts';
 import { GroqProvider } from './groq.ts';
 import { OllamaProvider } from './ollama.ts';
 import { OpenRouterProvider } from './openrouter.ts';
@@ -179,6 +179,15 @@ describe('OpenAI base URL resolution', () => {
 
   test('rejects invalid URLs', () => {
     expect(() => resolveOpenAIBaseUrl('not-a-url')).toThrow();
+  });
+
+  test('treats the default endpoint as official OpenAI', () => {
+    expect(isOfficialOpenAI()).toBe(true);
+    expect(isOfficialOpenAI('https://api.openai.com/v1')).toBe(true);
+  });
+
+  test('treats custom compatible gateways as non-official OpenAI', () => {
+    expect(isOfficialOpenAI('https://gateway.example.com/openai')).toBe(false);
   });
 });
 

--- a/src/llm/test.ts
+++ b/src/llm/test.ts
@@ -26,7 +26,8 @@ async function testProviders() {
   if (config.llm.openai?.api_key) {
     const openai = new OpenAIProvider(
       config.llm.openai.api_key,
-      config.llm.openai.model
+      config.llm.openai.model,
+      config.llm.openai.base_url,
     );
     manager.registerProvider(openai);
     console.log('Registered OpenAI provider');

--- a/src/vault/dashboard-sessions.ts
+++ b/src/vault/dashboard-sessions.ts
@@ -1,0 +1,44 @@
+import { getDb } from './schema.ts';
+
+export type DashboardSession = {
+  id: string;
+  created_at: number;
+  expires_at: number;
+};
+
+export function createDashboardSession(id: string, expiresAt: number): DashboardSession {
+  const now = Date.now();
+  getDb().prepare(`
+    INSERT INTO dashboard_sessions (id, created_at, expires_at)
+    VALUES (?, ?, ?)
+  `).run(id, now, expiresAt);
+  return { id, created_at: now, expires_at: expiresAt };
+}
+
+export function getDashboardSession(id: string): DashboardSession | null {
+  const row = getDb().prepare(`
+    SELECT id, created_at, expires_at
+    FROM dashboard_sessions
+    WHERE id = ?
+  `).get(id) as DashboardSession | null;
+  return row ?? null;
+}
+
+export function deleteDashboardSession(id: string): void {
+  getDb().prepare('DELETE FROM dashboard_sessions WHERE id = ?').run(id);
+}
+
+export function deleteExpiredDashboardSessions(now = Date.now()): void {
+  getDb().prepare('DELETE FROM dashboard_sessions WHERE expires_at <= ?').run(now);
+}
+
+export function validateDashboardSession(id: string, now = Date.now()): DashboardSession | null {
+  deleteExpiredDashboardSessions(now);
+  const session = getDashboardSession(id);
+  if (!session) return null;
+  if (session.expires_at <= now) {
+    deleteDashboardSession(id);
+    return null;
+  }
+  return session;
+}

--- a/src/vault/schema.ts
+++ b/src/vault/schema.ts
@@ -656,6 +656,16 @@ function createTables(db: Database): void {
     )
   `);
 
+  // Dashboard sessions: server-side auth sessions for the panel
+  db.run(`
+    CREATE TABLE IF NOT EXISTS dashboard_sessions (
+      id TEXT PRIMARY KEY,
+      created_at INTEGER NOT NULL,
+      expires_at INTEGER NOT NULL
+    )
+  `);
+  db.run(`CREATE INDEX IF NOT EXISTS idx_dashboard_sessions_expires ON dashboard_sessions(expires_at)`);
+
   // Documents table: vault-stored documents created by JARVIS
   db.run(`
     CREATE TABLE IF NOT EXISTS documents (

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,11 +1,11 @@
-import React, { useState, useEffect } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { useWebSocket } from "./hooks/useWebSocket";
 import { useVoice } from "./hooks/useVoice";
+import { api } from "./hooks/useApi";
 import "./styles/sidebar.css";
 
 import ChatPage from "./pages/ChatPage";
 
-// Lazy page imports
 const TasksPage = React.lazy(() => import("./pages/TasksPage"));
 const PipelinePage = React.lazy(() => import("./pages/PipelinePage"));
 const KnowledgePage = React.lazy(() => import("./pages/KnowledgePage"));
@@ -24,6 +24,13 @@ const SitesPage = React.lazy(() => import("./pages/SitesPage"));
 type Route = "dashboard" | "chat" | "tasks" | "pipeline" | "memory" | "calendar" | "office" | "knowledge" | "command" | "authority" | "awareness" | "workflows" | "goals" | "sites" | "settings";
 
 export type SettingsSection = "general" | "profile" | "llm" | "channels" | "integrations" | "sidecar";
+
+type DashboardAuthStatus = {
+  password_enabled: boolean;
+  token_enabled: boolean;
+  authenticated: boolean;
+  expires_at: number | null;
+};
 
 const SETTINGS_SECTIONS: SettingsSection[] = ["general", "profile", "llm", "channels", "integrations", "sidecar"];
 
@@ -47,6 +54,24 @@ function getSettingsSection(): SettingsSection {
   return "general";
 }
 
+function FullScreenStatus({ label }: { label: string }) {
+  return (
+    <div style={{
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+      minHeight: "100vh",
+      background: "#07070A",
+      color: "var(--j-text-dim)",
+      fontSize: "14px",
+      letterSpacing: "0.08em",
+      textTransform: "uppercase",
+    }}>
+      {label}
+    </div>
+  );
+}
+
 function PageFallback() {
   return (
     <div style={{
@@ -62,32 +87,29 @@ function PageFallback() {
   );
 }
 
-/* ================================================================
-   NAV ITEMS CONFIG — icon, label, route, grouped
-   ================================================================ */
 type NavEntry = { icon: string; label: string; route: Route };
 
 const NAV_CORE: NavEntry[] = [
-  { icon: "\u25C7", label: "Dashboard",  route: "dashboard" },
-  { icon: "\u25CE", label: "Chat",       route: "chat" },
-  { icon: "\u25C6", label: "Goals",      route: "goals" },
-  { icon: "\u2B21", label: "Workflows",  route: "workflows" },
-  { icon: "\u25A0", label: "Sites",      route: "sites" },
+  { icon: "\u25C7", label: "Dashboard", route: "dashboard" },
+  { icon: "\u25CE", label: "Chat", route: "chat" },
+  { icon: "\u25C6", label: "Goals", route: "goals" },
+  { icon: "\u2B21", label: "Workflows", route: "workflows" },
+  { icon: "\u25A0", label: "Sites", route: "sites" },
 ];
 
 const NAV_INTEL: NavEntry[] = [
-  { icon: "\u25B3", label: "Agents",     route: "office" },
-  { icon: "\u2726", label: "Tasks",      route: "tasks" },
-  { icon: "\u25A3", label: "Authority",  route: "authority" },
-  { icon: "\u25C8", label: "Memory",     route: "memory" },
+  { icon: "\u25B3", label: "Agents", route: "office" },
+  { icon: "\u2726", label: "Tasks", route: "tasks" },
+  { icon: "\u25A3", label: "Authority", route: "authority" },
+  { icon: "\u25C8", label: "Memory", route: "memory" },
 ];
 
 const NAV_MORE: NavEntry[] = [
-  { icon: "\u25B6", label: "Pipeline",   route: "pipeline" },
-  { icon: "\u25A1", label: "Calendar",   route: "calendar" },
-  { icon: "\u25CB", label: "Knowledge",  route: "knowledge" },
-  { icon: "\u25A3", label: "Command",    route: "command" },
-  { icon: "\u25CE", label: "Awareness",  route: "awareness" },
+  { icon: "\u25B6", label: "Pipeline", route: "pipeline" },
+  { icon: "\u25A1", label: "Calendar", route: "calendar" },
+  { icon: "\u25CB", label: "Knowledge", route: "knowledge" },
+  { icon: "\u25A3", label: "Command", route: "command" },
+  { icon: "\u25CE", label: "Awareness", route: "awareness" },
 ];
 
 const SETTINGS_NAV: { section: SettingsSection; label: string }[] = [
@@ -99,16 +121,226 @@ const SETTINGS_NAV: { section: SettingsSection; label: string }[] = [
   { section: "sidecar", label: "Sidecar" },
 ];
 
-/* ================================================================
-   APP
-   ================================================================ */
 export function App() {
+  const [authStatus, setAuthStatus] = useState<DashboardAuthStatus | null>(null);
+  const [authLoading, setAuthLoading] = useState(true);
+  const [authError, setAuthError] = useState<string | null>(null);
+
+  const refreshAuth = useCallback(async () => {
+    setAuthLoading(true);
+    try {
+      const status = await api<DashboardAuthStatus>("/api/auth/session");
+      setAuthStatus(status);
+      setAuthError(null);
+    } catch (err) {
+      setAuthError(err instanceof Error ? err.message : "Failed to load dashboard auth state");
+    } finally {
+      setAuthLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    refreshAuth();
+  }, [refreshAuth]);
+
+  if (authLoading && !authStatus) {
+    return <FullScreenStatus label="Loading dashboard..." />;
+  }
+
+  if (!authStatus) {
+    return <FullScreenStatus label={authError ?? "Dashboard unavailable"} />;
+  }
+
+  if (authStatus.password_enabled && !authStatus.authenticated) {
+    return <LoginGate loading={authLoading} error={authError} onAuthenticated={refreshAuth} />;
+  }
+
+  return <AuthenticatedAppShell authStatus={authStatus} onLoggedOut={refreshAuth} />;
+}
+
+function LoginGate({
+  loading,
+  error,
+  onAuthenticated,
+}: {
+  loading: boolean;
+  error: string | null;
+  onAuthenticated: () => Promise<void>;
+}) {
+  const [password, setPassword] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setSubmitting(true);
+    setFormError(null);
+    try {
+      await api("/api/auth/login", {
+        method: "POST",
+        body: JSON.stringify({ password }),
+      });
+      setPassword("");
+      await onAuthenticated();
+    } catch (err) {
+      setFormError(err instanceof Error ? err.message : "Login failed");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div style={{
+      minHeight: "100vh",
+      background: "radial-gradient(circle at top, rgba(68,110,255,0.18), transparent 35%), #07070A",
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+      padding: "24px",
+      color: "var(--j-text)",
+    }}>
+      <div style={{
+        width: "100%",
+        maxWidth: "420px",
+        background: "rgba(11, 13, 20, 0.92)",
+        border: "1px solid rgba(255,255,255,0.08)",
+        borderRadius: "18px",
+        padding: "28px",
+        boxShadow: "0 24px 80px rgba(0,0,0,0.38)",
+      }}>
+        <div style={{ marginBottom: "20px" }}>
+          <div style={{
+            fontSize: "12px",
+            letterSpacing: "0.16em",
+            textTransform: "uppercase",
+            color: "var(--j-text-dim)",
+            marginBottom: "10px",
+          }}>
+            J.A.R.V.I.S.
+          </div>
+          <h1 style={{ margin: 0, fontSize: "28px", fontWeight: 600 }}>Dashboard Login</h1>
+          <p style={{ margin: "10px 0 0", color: "var(--j-text-dim)", lineHeight: 1.5 }}>
+            This panel is protected by the admin password.
+          </p>
+        </div>
+
+        <form onSubmit={handleSubmit} style={{ display: "grid", gap: "14px" }}>
+          <label style={{ display: "grid", gap: "8px" }}>
+            <span style={{ fontSize: "13px", color: "var(--j-text-dim)" }}>Password</span>
+            <input
+              type="password"
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+              autoFocus
+              autoComplete="current-password"
+              style={{
+                width: "100%",
+                padding: "12px 14px",
+                borderRadius: "10px",
+                border: "1px solid rgba(255,255,255,0.12)",
+                background: "rgba(255,255,255,0.04)",
+                color: "var(--j-text)",
+                outline: "none",
+              }}
+            />
+          </label>
+
+          {(formError || error) && (
+            <div style={{
+              padding: "10px 12px",
+              borderRadius: "10px",
+              background: "rgba(255, 78, 78, 0.12)",
+              color: "#ffb4b4",
+              fontSize: "13px",
+            }}>
+              {formError || error}
+            </div>
+          )}
+
+          <button
+            type="submit"
+            disabled={submitting || loading || password.trim().length === 0}
+            style={{
+              border: "none",
+              borderRadius: "10px",
+              padding: "12px 16px",
+              background: submitting || loading ? "rgba(113, 132, 255, 0.55)" : "#7184ff",
+              color: "#fff",
+              fontWeight: 600,
+              cursor: submitting || loading ? "wait" : "pointer",
+            }}
+          >
+            {submitting ? "Signing in..." : "Sign in"}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+function AuthControls({
+  passwordEnabled,
+  onLogout,
+}: {
+  passwordEnabled: boolean;
+  onLogout: () => Promise<void>;
+}) {
+  const [loggingOut, setLoggingOut] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  if (!passwordEnabled) return null;
+
+  const handleLogout = async () => {
+    setLoggingOut(true);
+    setError(null);
+    try {
+      await api("/api/auth/logout", { method: "POST" });
+      await onLogout();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Logout failed");
+    } finally {
+      setLoggingOut(false);
+    }
+  };
+
+  return (
+    <div style={{ marginTop: "12px", display: "grid", gap: "8px" }}>
+      <button
+        onClick={handleLogout}
+        disabled={loggingOut}
+        style={{
+          width: "100%",
+          border: "1px solid rgba(255,255,255,0.08)",
+          borderRadius: "10px",
+          background: "rgba(255,255,255,0.03)",
+          color: "var(--j-text)",
+          padding: "10px 12px",
+          cursor: loggingOut ? "wait" : "pointer",
+        }}
+      >
+        {loggingOut ? "Signing out..." : "Logout"}
+      </button>
+      {error && (
+        <div style={{ color: "#ffb4b4", fontSize: "12px", lineHeight: 1.4 }}>
+          {error}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function AuthenticatedAppShell({
+  authStatus,
+  onLoggedOut,
+}: {
+  authStatus: DashboardAuthStatus | null;
+  onLoggedOut: () => Promise<void>;
+}) {
   const [route, setRoute] = useState<Route>(getRoute);
   const [settingsSection, setSettingsSection] = useState<SettingsSection>(getSettingsSection);
   const ws = useWebSocket();
   const voice = useVoice({ wsRef: ws.wsRef });
 
-  // Wire voice callbacks into WS hook
   useEffect(() => {
     ws.voiceCallbacksRef.current = {
       onTTSBinary: voice.handleTTSBinary,
@@ -116,7 +348,7 @@ export function App() {
       onTTSEnd: voice.handleTTSEnd,
       onError: voice.handleError,
     };
-  }, [voice.handleTTSBinary, voice.handleTTSStart, voice.handleTTSEnd, voice.handleError]);
+  }, [voice.handleError, voice.handleTTSBinary, voice.handleTTSEnd, voice.handleTTSStart, ws.voiceCallbacksRef]);
 
   useEffect(() => {
     const onHashChange = () => {
@@ -127,27 +359,23 @@ export function App() {
     return () => window.removeEventListener("hashchange", onHashChange);
   }, []);
 
-  // Set default hash if none
   useEffect(() => {
     if (!window.location.hash) {
       window.location.hash = "#/dashboard";
     }
   }, []);
 
-  const navigate = (r: Route) => {
-    window.location.hash = `#/${r}`;
+  const navigate = (nextRoute: Route) => {
+    window.location.hash = `#/${nextRoute}`;
   };
 
   return (
     <div style={{ display: "flex", height: "100vh", width: "100vw", background: "#07070A" }}>
-      {/* Sidebar — The Spine */}
       <nav className="sidebar" role="navigation" aria-label="Primary navigation">
-
-        {/* Logo orb */}
         <div className="sidebar-logo-row">
           <div
             className="sidebar-logo"
-            title="JARVIS v0.2 Alpha"
+            title="JARVIS dashboard"
             role="img"
             aria-label="JARVIS logo"
             onClick={() => navigate("dashboard")}
@@ -156,9 +384,7 @@ export function App() {
         </div>
         <div className="sidebar-logo-gap" />
 
-        {/* Navigation */}
         <div className="sidebar-nav">
-          {/* CORE group */}
           {NAV_CORE.map((item) => (
             <SidebarNavItem
               key={item.route}
@@ -171,7 +397,6 @@ export function App() {
 
           <div className="sidebar-group-divider" aria-hidden="true" />
 
-          {/* INTEL group */}
           {NAV_INTEL.map((item) => (
             <SidebarNavItem
               key={item.route}
@@ -184,7 +409,6 @@ export function App() {
 
           <div className="sidebar-group-divider" aria-hidden="true" />
 
-          {/* MORE group */}
           {NAV_MORE.map((item) => (
             <SidebarNavItem
               key={item.route}
@@ -197,7 +421,6 @@ export function App() {
 
           <div className="sidebar-group-divider" aria-hidden="true" />
 
-          {/* Settings */}
           <SidebarNavItem
             icon={"\u2699"}
             label="Settings"
@@ -209,7 +432,6 @@ export function App() {
             }}
           />
 
-          {/* Settings sub-items — only visible when expanded + settings active */}
           <div className={`sidebar-settings-sub ${route === "settings" ? "open" : ""}`}>
             {SETTINGS_NAV.map(({ section, label }) => (
               <button
@@ -223,7 +445,6 @@ export function App() {
           </div>
         </div>
 
-        {/* Health dot */}
         <div className="sidebar-health-row">
           <div
             className={`sidebar-health ${ws.isConnected ? "connected" : "disconnected"}`}
@@ -234,9 +455,13 @@ export function App() {
             {ws.isConnected ? "Online" : "Disconnected"}
           </span>
         </div>
+
+        <AuthControls
+          passwordEnabled={Boolean(authStatus?.password_enabled)}
+          onLogout={onLoggedOut}
+        />
       </nav>
 
-      {/* Main Content */}
       <main style={{ flex: 1, overflow: "hidden", display: "flex", flexDirection: "column" }}>
         <React.Suspense fallback={<PageFallback />}>
           {route === "dashboard" && <DashboardPage messages={ws.messages} isConnected={ws.isConnected} voice={voice} agentActivity={ws.agentActivity} goalEvents={ws.goalEvents} workflowEvents={ws.workflowEvents} />}
@@ -260,9 +485,6 @@ export function App() {
   );
 }
 
-/* ================================================================
-   SIDEBAR NAV ITEM
-   ================================================================ */
 function SidebarNavItem({ icon, label, active, onClick }: {
   icon: string;
   label: string;

--- a/ui/src/components/settings/DashboardSecurityPanel.tsx
+++ b/ui/src/components/settings/DashboardSecurityPanel.tsx
@@ -1,0 +1,280 @@
+import React, { useMemo, useState } from "react";
+import { api, useApiData } from "../../hooks/useApi";
+
+type DashboardSecurityConfig = {
+  password_enabled: boolean;
+};
+
+export function DashboardSecurityPanel() {
+  const { data, loading, error, refetch } = useApiData<DashboardSecurityConfig>("/api/config/dashboard-auth", []);
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [message, setMessage] = useState<{ text: string; type: "success" | "error" } | null>(null);
+
+  const passwordsMatch = useMemo(() => {
+    if (confirmPassword.length === 0) return true;
+    return password === confirmPassword;
+  }, [confirmPassword, password]);
+
+  const savePassword = async () => {
+    if (!password.trim()) {
+      setMessage({ text: "Enter a password first.", type: "error" });
+      return;
+    }
+    if (!passwordsMatch) {
+      setMessage({ text: "Passwords do not match.", type: "error" });
+      return;
+    }
+
+    setSaving(true);
+    setMessage(null);
+    try {
+      const res = await api<{ message: string }>("/api/config/dashboard-auth", {
+        method: "POST",
+        body: JSON.stringify({ password }),
+      });
+      setPassword("");
+      setConfirmPassword("");
+      setMessage({ text: res.message, type: "success" });
+      await refetch();
+    } catch (err) {
+      setMessage({
+        text: err instanceof Error ? err.message : "Failed to save dashboard password.",
+        type: "error",
+      });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const disablePassword = async () => {
+    setSaving(true);
+    setMessage(null);
+    try {
+      const res = await api<{ message: string }>("/api/config/dashboard-auth", {
+        method: "POST",
+        body: JSON.stringify({ disable: true }),
+      });
+      setPassword("");
+      setConfirmPassword("");
+      setMessage({ text: res.message, type: "success" });
+      await refetch();
+    } catch (err) {
+      setMessage({
+        text: err instanceof Error ? err.message : "Failed to disable dashboard password.",
+        type: "error",
+      });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading && !data) {
+    return <div style={cardStyle}><span style={mutedTextStyle}>Loading dashboard security...</span></div>;
+  }
+
+  return (
+    <div style={cardStyle}>
+      <div style={headerRowStyle}>
+        <div>
+          <h3 style={headerStyle}>Dashboard Security</h3>
+          <div style={subtleStyle}>
+            Protect the panel with a single admin password. Sessions are stored server-side and expire after 30 days.
+          </div>
+        </div>
+        <span
+          style={{
+            ...statusBadgeStyle,
+            color: data?.password_enabled ? "var(--j-warning)" : "var(--j-text-muted)",
+            borderColor: data?.password_enabled ? "rgba(251, 191, 36, 0.26)" : "var(--j-border)",
+            background: data?.password_enabled ? "rgba(251, 191, 36, 0.10)" : "rgba(255,255,255,0.03)",
+          }}
+        >
+          {data?.password_enabled ? "Protected" : "Open"}
+        </span>
+      </div>
+
+      <div style={fieldGroupStyle}>
+        <label style={labelStyle}>
+          Password
+          <input
+            type="password"
+            autoComplete="new-password"
+            value={password}
+            onChange={(event) => setPassword(event.target.value)}
+            placeholder={data?.password_enabled ? "Enter a new password" : "Set a dashboard password"}
+            style={inputStyle}
+          />
+        </label>
+
+        <label style={labelStyle}>
+          Confirm Password
+          <input
+            type="password"
+            autoComplete="new-password"
+            value={confirmPassword}
+            onChange={(event) => setConfirmPassword(event.target.value)}
+            placeholder="Re-enter the password"
+            style={inputStyle}
+          />
+        </label>
+
+        {!passwordsMatch && (
+          <div style={{ ...messageStyle, color: "var(--j-error)", borderColor: "rgba(248, 113, 113, 0.22)", background: "rgba(248, 113, 113, 0.08)" }}>
+            Passwords must match before saving.
+          </div>
+        )}
+      </div>
+
+      {message && (
+        <div style={{
+          ...messageStyle,
+          color: message.type === "success" ? "var(--j-success)" : "var(--j-error)",
+          borderColor: message.type === "success" ? "rgba(52, 211, 153, 0.22)" : "rgba(248, 113, 113, 0.22)",
+          background: message.type === "success" ? "rgba(52, 211, 153, 0.08)" : "rgba(248, 113, 113, 0.08)",
+        }}>
+          {message.text}
+        </div>
+      )}
+
+      {error && !message && (
+        <div style={{ ...messageStyle, color: "var(--j-error)", borderColor: "rgba(248, 113, 113, 0.22)", background: "rgba(248, 113, 113, 0.08)" }}>
+          {error}
+        </div>
+      )}
+
+      <div style={actionsStyle}>
+        <button
+          type="button"
+          onClick={savePassword}
+          disabled={saving || !password.trim() || !passwordsMatch}
+          style={{
+            ...primaryButtonStyle,
+            opacity: saving || !password.trim() || !passwordsMatch ? 0.55 : 1,
+            cursor: saving || !password.trim() || !passwordsMatch ? "not-allowed" : "pointer",
+          }}
+        >
+          {saving ? "Saving..." : data?.password_enabled ? "Update Password" : "Enable Password"}
+        </button>
+
+        <button
+          type="button"
+          onClick={disablePassword}
+          disabled={saving || !data?.password_enabled}
+          style={{
+            ...secondaryButtonStyle,
+            opacity: saving || !data?.password_enabled ? 0.55 : 1,
+            cursor: saving || !data?.password_enabled ? "not-allowed" : "pointer",
+          }}
+        >
+          Disable Protection
+        </button>
+      </div>
+    </div>
+  );
+}
+
+const cardStyle: React.CSSProperties = {
+  padding: "20px",
+  background: "var(--j-surface)",
+  border: "1px solid var(--j-border)",
+  borderRadius: "8px",
+};
+
+const headerRowStyle: React.CSSProperties = {
+  display: "flex",
+  justifyContent: "space-between",
+  gap: "16px",
+  alignItems: "flex-start",
+  marginBottom: "16px",
+  flexWrap: "wrap",
+};
+
+const headerStyle: React.CSSProperties = {
+  fontSize: "14px",
+  fontWeight: 600,
+  color: "var(--j-text)",
+  margin: 0,
+};
+
+const subtleStyle: React.CSSProperties = {
+  fontSize: "12px",
+  lineHeight: 1.5,
+  color: "var(--j-text-muted)",
+  marginTop: "6px",
+  maxWidth: "560px",
+};
+
+const statusBadgeStyle: React.CSSProperties = {
+  padding: "5px 10px",
+  borderRadius: "999px",
+  border: "1px solid var(--j-border)",
+  fontSize: "11px",
+  fontWeight: 600,
+  textTransform: "uppercase",
+  letterSpacing: "0.05em",
+};
+
+const fieldGroupStyle: React.CSSProperties = {
+  display: "grid",
+  gap: "12px",
+  marginBottom: "16px",
+};
+
+const labelStyle: React.CSSProperties = {
+  display: "grid",
+  gap: "6px",
+  fontSize: "12px",
+  color: "var(--j-text-dim)",
+};
+
+const inputStyle: React.CSSProperties = {
+  width: "100%",
+  borderRadius: "8px",
+  border: "1px solid var(--j-border)",
+  background: "var(--j-bg)",
+  color: "var(--j-text)",
+  padding: "10px 12px",
+  fontSize: "13px",
+  outline: "none",
+};
+
+const messageStyle: React.CSSProperties = {
+  fontSize: "12px",
+  border: "1px solid transparent",
+  borderRadius: "8px",
+  padding: "10px 12px",
+  marginBottom: "16px",
+};
+
+const actionsStyle: React.CSSProperties = {
+  display: "flex",
+  gap: "10px",
+  flexWrap: "wrap",
+};
+
+const primaryButtonStyle: React.CSSProperties = {
+  border: "1px solid rgba(0, 212, 255, 0.28)",
+  background: "rgba(0, 212, 255, 0.12)",
+  color: "var(--j-accent)",
+  borderRadius: "8px",
+  padding: "10px 14px",
+  fontSize: "13px",
+  fontWeight: 600,
+};
+
+const secondaryButtonStyle: React.CSSProperties = {
+  border: "1px solid var(--j-border)",
+  background: "transparent",
+  color: "var(--j-text-muted)",
+  borderRadius: "8px",
+  padding: "10px 14px",
+  fontSize: "13px",
+  fontWeight: 500,
+};
+
+const mutedTextStyle: React.CSSProperties = {
+  color: "var(--j-text-muted)",
+  fontSize: "13px",
+};

--- a/ui/src/components/settings/LLMPanel.tsx
+++ b/ui/src/components/settings/LLMPanel.tsx
@@ -5,7 +5,7 @@ type LLMConfig = {
   primary: string;
   fallback: string[];
   anthropic: { model: string; has_api_key: boolean } | null;
-  openai: { model: string; has_api_key: boolean } | null;
+  openai: { model: string; has_api_key: boolean; base_url?: string } | null;
   groq: { model: string; has_api_key: boolean } | null;
   gemini: { model: string; has_api_key: boolean } | null;
   ollama: { base_url: string; model: string } | null;
@@ -102,6 +102,7 @@ export function LLMPanel() {
   const [openaiKey, setOpenaiKey] = useState("");
   const [openaiModel, setOpenaiModel] = useState("gpt-5.4");
   const [openaiCustomModel, setOpenaiCustomModel] = useState("");
+  const [openaiBaseUrl, setOpenaiBaseUrl] = useState("");
 
   // Groq
   const [groqKey, setGroqKey] = useState("");
@@ -147,6 +148,7 @@ export function LLMPanel() {
       }
     }
     if (config.openai) {
+      setOpenaiBaseUrl(config.openai.base_url ?? "");
       const m = config.openai.model;
       if (OPENAI_MODELS.includes(m)) {
         setOpenaiModel(m);
@@ -215,6 +217,7 @@ export function LLMPanel() {
         },
         openai: {
           model: resolveModel(openaiModel, openaiCustomModel),
+          base_url: openaiBaseUrl,
           ...(openaiKey ? { api_key: openaiKey } : {}),
         },
         groq: {
@@ -264,6 +267,7 @@ export function LLMPanel() {
       } else if (provider === "openai") {
         body.api_key = openaiKey || undefined;
         body.model = resolveModel(openaiModel, openaiCustomModel);
+        body.base_url = openaiBaseUrl;
       } else if (provider === "groq") {
         body.api_key = groqKey || undefined;
         body.model = resolveModel(groqModel, groqCustomModel);
@@ -381,6 +385,11 @@ export function LLMPanel() {
           onFallbackToggle={() => toggleFallback("openai")}
           expanded={!!expanded.openai}
           onToggleExpand={() => setExpanded((s) => ({ ...s, openai: !s.openai }))}
+          baseUrl={openaiBaseUrl}
+          onBaseUrlChange={setOpenaiBaseUrl}
+          baseUrlLabel="OpenAI-Compatible Base URL"
+          baseUrlPlaceholder="Leave blank for official OpenAI API"
+          baseUrlHelpText="Optional. Use the OpenAI-compatible API base URL exposed by your gateway or proxy."
         />
 
         <ProviderSection
@@ -505,6 +514,9 @@ type ProviderSectionProps = {
   hideApiKey?: boolean;
   baseUrl?: string;
   onBaseUrlChange?: (v: string) => void;
+  baseUrlLabel?: string;
+  baseUrlPlaceholder?: string;
+  baseUrlHelpText?: string;
 };
 
 function ToggleSwitch({ checked, onChange, disabled }: { checked: boolean; onChange: () => void; disabled?: boolean }) {
@@ -551,7 +563,7 @@ function ProviderSection({
   models, testing, testResult, onTest,
   isFallback, onFallbackToggle,
   expanded, onToggleExpand,
-  hideApiKey, baseUrl, onBaseUrlChange,
+  hideApiKey, baseUrl, onBaseUrlChange, baseUrlLabel, baseUrlPlaceholder, baseUrlHelpText,
 }: ProviderSectionProps) {
   return (
     <div style={providerCardStyle}>
@@ -603,14 +615,17 @@ function ProviderSection({
 
           {baseUrl !== undefined && onBaseUrlChange && (
             <div>
-              <div style={fieldLabelStyle}>Base URL</div>
+              <div style={fieldLabelStyle}>{baseUrlLabel ?? "Base URL"}</div>
               <input
                 type="text"
                 value={baseUrl}
                 onChange={(e) => onBaseUrlChange(e.target.value)}
-                placeholder="http://localhost:11434"
+                placeholder={baseUrlPlaceholder ?? "http://localhost:11434"}
                 style={inputStyle}
               />
+              {baseUrlHelpText && (
+                <div style={{ ...fieldHelpStyle, marginTop: "4px" }}>{baseUrlHelpText}</div>
+              )}
             </div>
           )}
 
@@ -698,6 +713,12 @@ const fieldLabelStyle: React.CSSProperties = {
   fontSize: "11px",
   color: "var(--j-text-muted)",
   marginBottom: "4px",
+};
+
+const fieldHelpStyle: React.CSSProperties = {
+  fontSize: "11px",
+  color: "var(--j-text-muted)",
+  lineHeight: 1.4,
 };
 
 const providerCardStyle: React.CSSProperties = {

--- a/ui/src/hooks/useApi.ts
+++ b/ui/src/hooks/useApi.ts
@@ -7,6 +7,7 @@ export async function api<T>(
   opts?: RequestInit
 ): Promise<T> {
   const res = await fetch(`${BASE}${path}`, {
+    credentials: "same-origin",
     headers: { "Content-Type": "application/json", ...opts?.headers },
     ...opts,
   });

--- a/ui/src/pages/SettingsPage.tsx
+++ b/ui/src/pages/SettingsPage.tsx
@@ -9,6 +9,7 @@ import { ChannelsPanel } from "../components/settings/ChannelsPanel";
 import { SidecarPanel } from "../components/settings/SidecarPanel";
 import { UserProfilePanel } from "../components/settings/UserProfilePanel";
 import { ServicePanel } from "../components/settings/ServicePanel";
+import { DashboardSecurityPanel } from "../components/settings/DashboardSecurityPanel";
 
 const SECTION_META: Record<SettingsSection, { title: string; subtitle: string }> = {
   general: { title: "General", subtitle: "Personality, role, and heartbeat configuration" },
@@ -46,6 +47,7 @@ export default function SettingsPage({ section }: { section: SettingsSection }) 
           {section === "general" && (
             <>
               <ServicePanel />
+              <DashboardSecurityPanel />
               <PersonalityPanel />
               <RolePanel />
               <HeartbeatPanel />


### PR DESCRIPTION
This PR adds support for configuring a custom OpenAI-compatible `base_url` and fixes an issue with API key validation that prevented usage with non-OpenAI providers.

The goal is to allow seamless integration with OpenAI-compatible APIs (such as proxies or third-party providers) while preserving the default OpenAI behavior. 
It's, 
- Add optional `llm.openai.base_url` configuration
- Support configuring the base URL during onboarding
- Expose the base URL in the dashboard settings UI
- Ensure the OpenAI provider uses the configured base URL at runtime
- Fix API key validation logic:
  - remove strict OpenAI-specific key format assumptions (e.g. `sk-...`)
  - skip format validation when using a custom base URL
- Update documentation and config examples

## Behavior

- If no `base_url` is provided → default OpenAI API is used
- If a custom `base_url` is provided → requests are sent to that endpoint
- API key format is no longer assumed for custom providers
- Connection testing relies on actual API responses instead of key format
- Custom base URL support is fully optional
- This improves compatibility with OpenAI-compatible ecosystems without increasing complexity


## TODO

- Test and validate onboarding flow for base_url configuration