### PR TITLE
Add awareness usage estimate to the dashboard

### DIFF
--- a/src/awareness/service.ts
+++ b/src/awareness/service.ts
@@ -147,6 +147,68 @@ export class AwarenessService implements Service {
     return this.analytics.getLiveContext(this.contextTracker, this._status === 'running');
   }
 
+  getUsageEstimate(): {
+    capturesPerHour: number;
+    estimatedVisionCallsPerHour: number;
+    estimatedTokensPerHour: number;
+    note: string;
+  } {
+    const capturesPerHour = Math.max(1, Math.round(3600000 / Math.max(this.config.capture_interval_ms, 1000)));
+    if (!this.config.cloud_vision_enabled) {
+      return {
+        capturesPerHour,
+        estimatedVisionCallsPerHour: 0,
+        estimatedTokensPerHour: 0,
+        note: 'Cloud vision is disabled, so awareness will not spend LLM vision tokens.',
+      };
+    }
+
+    const estimatedVisionCallsPerHour = Math.max(
+      1,
+      Math.min(capturesPerHour, Math.round(3600000 / Math.max(this.config.cloud_vision_cooldown_ms, 1000)))
+    );
+
+    return {
+      capturesPerHour,
+      estimatedVisionCallsPerHour,
+      estimatedTokensPerHour: estimatedVisionCallsPerHour * 1400,
+      note: 'Estimate is a worst-case approximation based on your capture rate and cloud-vision cooldown.',
+    };
+  }
+
+  getUsageEstimate(): {
+    capturesPerHour: number;
+    estimatedVisionCallsPerHour: number;
+    estimatedTokensPerHour: number;
+    note: string;
+  } {
+    const capturesPerHour = Math.max(1, Math.round(3600000 / Math.max(this.config.capture_interval_ms, 1000)));
+    if (!this.config.cloud_vision_enabled) {
+      return {
+        capturesPerHour,
+        estimatedVisionCallsPerHour: 0,
+        estimatedTokensPerHour: 0,
+        note: 'Cloud vision is disabled, so awareness will not spend LLM vision tokens.',
+      };
+    }
+
+    const estimatedVisionCallsPerHour = Math.max(
+      1,
+      Math.min(
+        capturesPerHour,
+        Math.round(3600000 / Math.max(this.config.cloud_vision_cooldown_ms, 1000))
+      )
+    );
+    const estimatedTokensPerHour = estimatedVisionCallsPerHour * 1400;
+
+    return {
+      capturesPerHour,
+      estimatedVisionCallsPerHour,
+      estimatedTokensPerHour,
+      note: 'Estimate is a worst-case approximation based on your capture rate and cloud-vision cooldown.',
+    };
+  }
+
   getCurrentSession() {
     return this.contextTracker.getCurrentSession();
   }

--- a/src/awareness/service.ts
+++ b/src/awareness/service.ts
@@ -176,39 +176,6 @@ export class AwarenessService implements Service {
     };
   }
 
-  getUsageEstimate(): {
-    capturesPerHour: number;
-    estimatedVisionCallsPerHour: number;
-    estimatedTokensPerHour: number;
-    note: string;
-  } {
-    const capturesPerHour = Math.max(1, Math.round(3600000 / Math.max(this.config.capture_interval_ms, 1000)));
-    if (!this.config.cloud_vision_enabled) {
-      return {
-        capturesPerHour,
-        estimatedVisionCallsPerHour: 0,
-        estimatedTokensPerHour: 0,
-        note: 'Cloud vision is disabled, so awareness will not spend LLM vision tokens.',
-      };
-    }
-
-    const estimatedVisionCallsPerHour = Math.max(
-      1,
-      Math.min(
-        capturesPerHour,
-        Math.round(3600000 / Math.max(this.config.cloud_vision_cooldown_ms, 1000))
-      )
-    );
-    const estimatedTokensPerHour = estimatedVisionCallsPerHour * 1400;
-
-    return {
-      capturesPerHour,
-      estimatedVisionCallsPerHour,
-      estimatedTokensPerHour,
-      note: 'Estimate is a worst-case approximation based on your capture rate and cloud-vision cooldown.',
-    };
-  }
-
   getCurrentSession() {
     return this.contextTracker.getCurrentSession();
   }

--- a/src/daemon/api-routes.ts
+++ b/src/daemon/api-routes.ts
@@ -1612,6 +1612,7 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
           status: ctx.awarenessService.status(),
           enabled: ctx.awarenessService.isEnabled(),
           liveContext: ctx.awarenessService.getLiveContext(),
+          usageEstimate: ctx.awarenessService.getUsageEstimate(),
         });
       },
     },

--- a/ui/src/pages/AwarenessPage.tsx
+++ b/ui/src/pages/AwarenessPage.tsx
@@ -21,6 +21,12 @@ type AwarenessStatus = {
     suggestionsToday: number;
     isRunning: boolean;
   };
+  usageEstimate: {
+    capturesPerHour: number;
+    estimatedVisionCallsPerHour: number;
+    estimatedTokensPerHour: number;
+    note: string;
+  };
 };
 
 export default function AwarenessPage() {
@@ -64,6 +70,7 @@ export default function AwarenessPage() {
   const sessionMinutes = liveCtx?.currentSession ? Math.floor(liveCtx.currentSession.durationMs / 60000) : 0;
   const capturesHr = liveCtx?.capturesLastHour ?? 0;
   const suggestionsDay = liveCtx?.suggestionsToday ?? 0;
+  const usageEstimate = status?.usageEstimate;
 
   return (
     <div className="aw-page">
@@ -101,6 +108,17 @@ export default function AwarenessPage() {
           <div className="aw-stat-value" style={{ color: "#FBBF24" }}>{suggestionsDay}</div>
         </div>
         <div className="aw-stat">
+          <div className="aw-stat-label">Estimated Tokens / Hour</div>
+          <div className="aw-stat-value" style={{ color: "#34D399" }}>
+            {enabled ? `~${(usageEstimate?.estimatedTokensPerHour ?? 0).toLocaleString()}` : "0"}
+          </div>
+          <div className="aw-stat-sub">
+            {enabled
+              ? `${usageEstimate?.estimatedVisionCallsPerHour ?? 0}/hr worst case`
+              : "Enable awareness to estimate usage"}
+          </div>
+        </div>
+        <div className="aw-stat">
           <div className="aw-stat-label">Session</div>
           <div className="aw-stat-value" style={{ color: "#22D3EE", fontSize: sessionTopic ? 14 : 20 }}>
             {sessionTopic || (sessionMinutes > 0 ? `${sessionMinutes}m` : "—")}
@@ -108,6 +126,24 @@ export default function AwarenessPage() {
           {sessionTopic && sessionMinutes > 0 && <div className="aw-stat-sub">{sessionMinutes}m active</div>}
         </div>
       </div>
+
+      {usageEstimate ? (
+        <div
+          style={{
+            marginTop: "14px",
+            padding: "12px 14px",
+            borderRadius: "12px",
+            border: "1px solid rgba(52, 211, 153, 0.22)",
+            background: "rgba(15, 118, 110, 0.18)",
+            color: "rgba(255,255,255,0.86)",
+            fontSize: "13px",
+          }}
+        >
+          <strong style={{ color: "#A7F3D0" }}>Usage estimate</strong>{" "}
+          Awareness samples about {usageEstimate.capturesPerHour}/hr and may escalate up to{" "}
+          {usageEstimate.estimatedVisionCallsPerHour}/hr for cloud vision. {usageEstimate.note}
+        </div>
+      ) : null}
 
       {/* Tabs */}
       <div className="aw-tabs">


### PR DESCRIPTION
## Summary
- add a backend awareness usage estimate for captures, cloud vision calls, and tokens per hour
- expose the estimate from the awareness status API
- show the estimate in the Awareness page before users enable the feature

## Validation
- Not run here because the repo has existing broader source build/typecheck issues unrelated to this change.