### PR TITLE
Fallback to the next provider when the primary fails

### DIFF
--- a/src/llm/manager.ts
+++ b/src/llm/manager.ts
@@ -57,6 +57,15 @@ export class LLMManager {
     return [...this.providers.keys()];
   }
 
+  private getProviderSequence(primaryOverride?: string | null): string[] {
+    const primary = primaryOverride && this.providers.has(primaryOverride) ? primaryOverride : this.primaryProvider;
+    return [primary, ...this.fallbackChain.filter((name) => name !== primary)];
+  }
+
+  private formatFailure(providerName: string, errors: string[]): string {
+    return `Provider '${providerName}' failed after ${LLMManager.MAX_RETRIES_PER_PROVIDER} attempts:\n${errors.map((error) => `  ${error}`).join('\n')}`;
+  }
+
   /**
    * Atomically replace all providers. Safe for in-flight requests because
    * JS is single-threaded and the map assignment is atomic.
@@ -91,16 +100,16 @@ export class LLMManager {
    */
   private shouldRetry(error: unknown): boolean {
     if (!(error instanceof Error)) return false;
-    
+
     const msg = error.message.toLowerCase();
     // Retry on network/timeout errors, not on auth/validation errors
-    return msg.includes('timeout') || 
-           msg.includes('econnrefused') || 
-           msg.includes('enotfound') ||
-           msg.includes('network') ||
-           msg.includes('temporarily unavailable') ||
-           msg.includes('429') ||  // rate limit
-           msg.includes('503');    // service unavailable
+    return msg.includes('timeout') ||
+      msg.includes('econnrefused') ||
+      msg.includes('enotfound') ||
+      msg.includes('network') ||
+      msg.includes('temporarily unavailable') ||
+      msg.includes('429') ||  // rate limit
+      msg.includes('503');    // service unavailable
   }
 
   /**
@@ -112,115 +121,107 @@ export class LLMManager {
     overridePrimary: string | null,
     options?: LLMOptions
   ): Promise<LLMResponse> {
-    const providerName = overridePrimary && this.providers.has(overridePrimary) ? overridePrimary : this.primaryProvider;
-    const provider = this.providers.get(providerName);
-    if (!provider) {
-      throw new Error(`Provider '${providerName}' not registered`);
-    }
+    const failures: string[] = [];
 
-    const errors: string[] = [];
-    for (let attempt = 1; attempt <= LLMManager.MAX_RETRIES_PER_PROVIDER; attempt++) {
-      try {
-        const result = await this.withTimeout(provider.chat(messages, options), providerName);
-        if (LLMManager.isDebugging && attempt > 1) {
-          console.log(`[DEBUG] LLM ${providerName} succeeded on retry attempt ${attempt}`);
-        }
-        return result;
-      } catch (err) {
-        const errorMsg = err instanceof Error ? err.message : String(err);
-        errors.push(`attempt ${attempt}: ${errorMsg}`);
-        
-        const shouldRetry = this.shouldRetry(err);
-        console.error(
-          `[LLM] Provider ${providerName} failed (attempt ${attempt}/${LLMManager.MAX_RETRIES_PER_PROVIDER})${!shouldRetry ? ' [no retry]' : ''}: ${errorMsg}`
-        );
-        
-        // Don't retry on fatal errors (auth, validation)
-        if (!shouldRetry && attempt > 1) break;
+    for (const providerName of this.getProviderSequence(overridePrimary)) {
+      const provider = this.providers.get(providerName);
+      if (!provider) {
+        failures.push(`Provider '${providerName}' not registered`);
+        continue;
       }
+
+      const errors: string[] = [];
+      for (let attempt = 1; attempt <= LLMManager.MAX_RETRIES_PER_PROVIDER; attempt++) {
+        try {
+          const result = await this.withTimeout(provider.chat(messages, options), providerName);
+          if (LLMManager.isDebugging && attempt > 1) {
+            console.log(`[DEBUG] LLM ${providerName} succeeded on retry attempt ${attempt}`);
+          }
+          return result;
+        } catch (err) {
+          const errorMsg = err instanceof Error ? err.message : String(err);
+          errors.push(`attempt ${attempt}: ${errorMsg}`);
+
+          const shouldRetry = this.shouldRetry(err);
+          console.error(
+            `[LLM] Provider ${providerName} failed (attempt ${attempt}/${LLMManager.MAX_RETRIES_PER_PROVIDER})${!shouldRetry ? ' [no retry]' : ''}: ${errorMsg}`
+          );
+
+          if (!shouldRetry) break;
+        }
+      }
+
+      failures.push(this.formatFailure(providerName, errors));
     }
 
-    throw new Error(
-      `Provider '${providerName}' failed after ${LLMManager.MAX_RETRIES_PER_PROVIDER} attempts:\n${errors.map(e => `  ${e}`).join('\n')}`
-    );
+    throw new Error(failures.join('\n\n'));
   }
 
   async chat(messages: LLMMessage[], options?: LLMOptions): Promise<LLMResponse> {
-    const providerName = this.primaryProvider;
-    const provider = this.providers.get(providerName);
-    if (!provider) {
-      throw new Error(`Provider '${providerName}' not registered`);
-    }
-
-    const errors: string[] = [];
-    for (let attempt = 1; attempt <= LLMManager.MAX_RETRIES_PER_PROVIDER; attempt++) {
-      try {
-        const result = await this.withTimeout(provider.chat(messages, options), providerName);
-        if (LLMManager.isDebugging && attempt > 1) {
-          console.log(`[DEBUG] LLM ${providerName} succeeded on retry attempt ${attempt}`);
-        }
-        return result;
-      } catch (err) {
-        const errorMsg = err instanceof Error ? err.message : String(err);
-        errors.push(`attempt ${attempt}: ${errorMsg}`);
-        
-        const shouldRetry = this.shouldRetry(err);
-        console.error(
-          `[LLM] Provider ${providerName} failed (attempt ${attempt}/${LLMManager.MAX_RETRIES_PER_PROVIDER})${!shouldRetry ? ' [no retry]' : ''}: ${errorMsg}`
-        );
-        
-        if (!shouldRetry && attempt > 1) break;
-      }
-    }
-
-    throw new Error(
-      `Provider '${providerName}' failed after ${LLMManager.MAX_RETRIES_PER_PROVIDER} attempts:\n${errors.map(e => `  ${e}`).join('\n')}`
-    );
+    return this.chatWithOverride(messages, null, options);
   }
 
   async *stream(messages: LLMMessage[], options?: LLMOptions): AsyncIterable<LLMStreamEvent> {
-    const providerName = this.primaryProvider;
-    const provider = this.providers.get(providerName);
-    if (!provider) {
-      yield { type: 'error', error: `Provider '${providerName}' not registered` };
-      return;
-    }
+    const failures: string[] = [];
 
-    const errors: string[] = [];
-    for (let attempt = 1; attempt <= LLMManager.MAX_RETRIES_PER_PROVIDER; attempt++) {
-      try {
-        let hasError = false;
-        for await (const event of provider.stream(messages, options)) {
-          if (event.type === 'error') {
-            hasError = true;
-            errors.push(`attempt ${attempt}: ${event.error}`);
-            console.error(
-              `[LLM] Provider ${providerName} stream error (attempt ${attempt}/${LLMManager.MAX_RETRIES_PER_PROVIDER}): ${event.error}`
-            );
-            break;
-          }
-          yield event;
-        }
-
-        if (!hasError) {
-          return;
-        }
-      } catch (err) {
-        const errorMsg = err instanceof Error ? err.message : String(err);
-        errors.push(`attempt ${attempt}: ${errorMsg}`);
-        
-        const shouldRetry = this.shouldRetry(err);
-        console.error(
-          `[LLM] Provider ${providerName} stream failed (attempt ${attempt}/${LLMManager.MAX_RETRIES_PER_PROVIDER})${!shouldRetry ? ' [no retry]' : ''}: ${errorMsg}`
-        );
-        
-        if (!shouldRetry && attempt > 1) break;
+    for (const providerName of this.getProviderSequence()) {
+      const provider = this.providers.get(providerName);
+      if (!provider) {
+        failures.push(`Provider '${providerName}' not registered`);
+        continue;
       }
+
+      const errors: string[] = [];
+      for (let attempt = 1; attempt <= LLMManager.MAX_RETRIES_PER_PROVIDER; attempt++) {
+        let emittedContent = false;
+        try {
+          let hasError = false;
+          for await (const event of provider.stream(messages, options)) {
+            if (event.type === 'error') {
+              hasError = true;
+              errors.push(`attempt ${attempt}: ${event.error}`);
+              console.error(
+                `[LLM] Provider ${providerName} stream error (attempt ${attempt}/${LLMManager.MAX_RETRIES_PER_PROVIDER}): ${event.error}`
+              );
+              if (emittedContent) {
+                yield { type: 'error', error: this.formatFailure(providerName, errors) };
+                return;
+              }
+              break;
+            }
+            if (event.type === 'text' || event.type === 'tool_call') {
+              emittedContent = true;
+            }
+            yield event;
+          }
+
+          if (!hasError) {
+            return;
+          }
+        } catch (err) {
+          const errorMsg = err instanceof Error ? err.message : String(err);
+          errors.push(`attempt ${attempt}: ${errorMsg}`);
+
+          const shouldRetry = this.shouldRetry(err);
+          console.error(
+            `[LLM] Provider ${providerName} stream failed (attempt ${attempt}/${LLMManager.MAX_RETRIES_PER_PROVIDER})${!shouldRetry ? ' [no retry]' : ''}: ${errorMsg}`
+          );
+
+          if (emittedContent) {
+            yield { type: 'error', error: this.formatFailure(providerName, errors) };
+            return;
+          }
+
+          if (!shouldRetry) break;
+        }
+      }
+
+      failures.push(this.formatFailure(providerName, errors));
     }
 
     yield {
       type: 'error',
-      error: `Provider '${providerName}' failed after ${LLMManager.MAX_RETRIES_PER_PROVIDER} attempts:\n${errors.map(e => `  ${e}`).join('\n')}`,
+      error: failures.join('\n\n'),
     };
   }
 }

--- a/src/llm/provider.test.ts
+++ b/src/llm/provider.test.ts
@@ -36,6 +36,8 @@ describe('LLM Provider Types', () => {
 });
 
 describe('LLMManager', () => {
+  const sampleMessages: LLMMessage[] = [{ role: 'user', content: 'Hello' }];
+
   test('can register providers', () => {
     const manager = new LLMManager();
     const anthropic = new AnthropicProvider('test-key');
@@ -92,6 +94,105 @@ describe('LLMManager', () => {
 
     manager.registerProvider(anthropic);
     expect(() => manager.setFallbackChain(['nonexistent'])).toThrow();
+  });
+
+  test('falls back to the next provider for chat failures', async () => {
+    const manager = new LLMManager();
+    const primary = {
+      name: 'primary',
+      listModels: async () => ['primary-model'],
+      chat: async () => {
+        throw new Error('401 invalid_api_key');
+      },
+      async *stream() {
+        yield { type: 'error' as const, error: '401 invalid_api_key' };
+      },
+    };
+    const fallback = {
+      name: 'fallback',
+      listModels: async () => ['fallback-model'],
+      chat: async () => ({
+        content: 'fallback ok',
+        tool_calls: [],
+        usage: { input_tokens: 1, output_tokens: 1 },
+        model: 'fallback-model',
+        finish_reason: 'stop' as const,
+      }),
+      async *stream() {
+        yield { type: 'text' as const, text: 'fallback ok' };
+        yield {
+          type: 'done' as const,
+          response: {
+            content: 'fallback ok',
+            tool_calls: [],
+            usage: { input_tokens: 1, output_tokens: 1 },
+            model: 'fallback-model',
+            finish_reason: 'stop' as const,
+          },
+        };
+      },
+    };
+
+    manager.registerProvider(primary);
+    manager.registerProvider(fallback);
+    manager.setPrimary('primary');
+    manager.setFallbackChain(['fallback']);
+
+    const response = await manager.chat(sampleMessages);
+    expect(response.content).toBe('fallback ok');
+    expect(response.model).toBe('fallback-model');
+  });
+
+  test('falls back to the next provider for stream failures before output', async () => {
+    const manager = new LLMManager();
+    const primary = {
+      name: 'primary',
+      listModels: async () => ['primary-model'],
+      chat: async () => {
+        throw new Error('503 temporarily unavailable');
+      },
+      async *stream() {
+        yield { type: 'error' as const, error: '503 temporarily unavailable' };
+      },
+    };
+    const fallback = {
+      name: 'fallback',
+      listModels: async () => ['fallback-model'],
+      chat: async () => ({
+        content: 'fallback stream ok',
+        tool_calls: [],
+        usage: { input_tokens: 1, output_tokens: 1 },
+        model: 'fallback-model',
+        finish_reason: 'stop' as const,
+      }),
+      async *stream() {
+        yield { type: 'text' as const, text: 'fallback stream ok' };
+        yield {
+          type: 'done' as const,
+          response: {
+            content: 'fallback stream ok',
+            tool_calls: [],
+            usage: { input_tokens: 1, output_tokens: 1 },
+            model: 'fallback-model',
+            finish_reason: 'stop' as const,
+          },
+        };
+      },
+    };
+
+    manager.registerProvider(primary);
+    manager.registerProvider(fallback);
+    manager.setPrimary('primary');
+    manager.setFallbackChain(['fallback']);
+
+    const events = [];
+    for await (const event of manager.stream(sampleMessages)) {
+      events.push(event);
+    }
+
+    expect(events.some((event) => event.type === 'text' && event.text === 'fallback stream ok')).toBe(true);
+    expect(events.some((event) => event.type === 'done')).toBe(true);
+    expect(events.some((event) => event.type === 'error')).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary
- walk the configured fallback chain for chat requests when the primary provider fails
- apply the same behavior to streaming responses before any content is emitted
- add focused tests covering fallback chat and fallback stream behavior

## Validation
- bun test src/llm/provider.test.ts