### PR TITLE
Show a visible notice when the sidecar disconnects

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -238,6 +238,47 @@ export function App() {
 
       {/* Main Content */}
       <main style={{ flex: 1, overflow: "hidden", display: "flex", flexDirection: "column" }}>
+        {ws.notices.length > 0 ? (
+          <div style={{ padding: "14px 18px 0" }}>
+            {ws.notices.map((notice) => (
+              <div
+                key={notice.id}
+                style={{
+                  display: "flex",
+                  alignItems: "flex-start",
+                  gap: "12px",
+                  padding: "12px 14px",
+                  marginBottom: "10px",
+                  borderRadius: "12px",
+                  border: "1px solid rgba(251, 191, 36, 0.35)",
+                  background: "rgba(251, 191, 36, 0.12)",
+                  color: "#FDE68A",
+                }}
+              >
+                <div style={{ fontSize: "18px", lineHeight: 1 }}>⚠</div>
+                <div style={{ flex: 1 }}>
+                  <div style={{ fontSize: "13px", fontWeight: 700 }}>{notice.title}</div>
+                  <div style={{ fontSize: "13px", color: "rgba(255,255,255,0.82)", marginTop: "2px" }}>{notice.text}</div>
+                </div>
+                <button
+                  onClick={() => ws.dismissNotice(notice.id)}
+                  style={{
+                    border: "none",
+                    background: "transparent",
+                    color: "rgba(255,255,255,0.72)",
+                    cursor: "pointer",
+                    fontSize: "18px",
+                    lineHeight: 1,
+                  }}
+                  aria-label="Dismiss notice"
+                  title="Dismiss notice"
+                >
+                  ×
+                </button>
+              </div>
+            ))}
+          </div>
+        ) : null}
         <React.Suspense fallback={<PageFallback />}>
           {route === "dashboard" && <DashboardPage messages={ws.messages} isConnected={ws.isConnected} voice={voice} agentActivity={ws.agentActivity} goalEvents={ws.goalEvents} workflowEvents={ws.workflowEvents} />}
           {route === "chat" && <ChatPage messages={ws.messages} isConnected={ws.isConnected} sendMessage={ws.sendMessage} voice={voice} />}

--- a/ui/src/hooks/useWebSocket.ts
+++ b/ui/src/hooks/useWebSocket.ts
@@ -112,6 +112,42 @@ export type SiteEvent = {
   timestamp: number;
 };
 
+export type SystemNotice = {
+  id: string;
+  title: string;
+  text: string;
+  level: "warning";
+};
+
+type SidecarEventPayload = {
+  source?: string;
+  event?: {
+    type?: string;
+    reason?: string;
+  };
+};
+
+function createSidecarNotice(payload: SidecarEventPayload, timestamp?: number): ChatMessage & { notice?: SystemNotice } {
+  const reason = payload.event?.reason?.trim();
+  const notice: SystemNotice = {
+    id: crypto.randomUUID(),
+    title: "Sidecar offline",
+    text: reason
+      ? `Jarvis sidecar disconnected: ${reason}. Dashboard features may be delayed until it reconnects.`
+      : "Jarvis sidecar disconnected. Dashboard features may be delayed until it reconnects.",
+    level: "warning",
+  };
+
+  return {
+    id: crypto.randomUUID(),
+    role: "system",
+    content: notice.text,
+    timestamp,
+    source: "system_notification",
+    notice,
+  };
+}
+
 export function useWebSocket() {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [isConnected, setIsConnected] = useState(false);
@@ -121,6 +157,7 @@ export function useWebSocket() {
   const [workflowEvents, setWorkflowEvents] = useState<WorkflowEvent[]>([]);
   const [goalEvents, setGoalEvents] = useState<GoalEvent[]>([]);
   const [siteEvents, setSiteEvents] = useState<SiteEvent[]>([]);
+  const [notices, setNotices] = useState<SystemNotice[]>([]);
   const wsRef = useRef<WebSocket | null>(null);
   const streamBufferRef = useRef<string>("");
   const streamIdRef = useRef<string | null>(null);
@@ -386,6 +423,12 @@ export function useWebSocket() {
           // so no need to duplicate here — just log for debugging
           console.log("[WS] Awareness suggestion:", awarenessEvent.data.title);
         }
+      } else if (payload.source === "sidecar_event" && payload.event?.type === "sidecar_disconnect") {
+        const noticeMessage = createSidecarNotice(payload, msg.timestamp);
+        if (noticeMessage.notice) {
+          setNotices((prev) => [noticeMessage.notice!, ...prev.filter((item) => item.text !== noticeMessage.notice!.text)].slice(0, 3));
+        }
+        setMessages((prev) => [...prev, noticeMessage]);
       } else if (payload.source === "assistant_message" && payload.text) {
         setMessages((prev) => [
           ...prev,
@@ -457,8 +500,12 @@ export function useWebSocket() {
     []
   );
 
+  const dismissNotice = useCallback((noticeId: string) => {
+    setNotices((prev) => prev.filter((notice) => notice.id !== noticeId));
+  }, []);
+
   return {
-    messages, isConnected, sendMessage, taskEvents, contentEvents, agentActivity, workflowEvents, goalEvents, siteEvents,
+    messages, isConnected, sendMessage, taskEvents, contentEvents, agentActivity, workflowEvents, goalEvents, siteEvents, notices, dismissNotice,
     wsRef,
     voiceCallbacksRef,
   };


### PR DESCRIPTION
## Summary
- surface sidecar disconnect events as visible dashboard notices
- mirror the notice into the chat feed as a system message
- let users dismiss the banner after they see it

## Validation
- Not run here because the repo has existing broader source build/typecheck issues unrelated to this change.