### PR TITLE
Harden tool call validation for weaker models

### DIFF
--- a/src/agents/orchestrator.test.ts
+++ b/src/agents/orchestrator.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from 'bun:test';
+import { AgentOrchestrator } from './orchestrator.ts';
+import type { RoleDefinition } from '../roles/types.ts';
+import type { LLMMessage, LLMOptions, LLMProvider, LLMResponse, LLMStreamEvent } from '../llm/provider.ts';
+import { LLMManager } from '../llm/manager.ts';
+import { ToolRegistry, type ToolDefinition } from '../actions/tools/registry.ts';
+
+const TEST_ROLE: RoleDefinition = {
+  id: 'tester',
+  name: 'Test Agent',
+  description: 'Exercises orchestrator tool validation.',
+  responsibilities: ['Execute requested actions'],
+  autonomous_actions: ['Use tools when needed'],
+  approval_required: [],
+  kpis: [],
+  communication_style: {
+    tone: 'direct',
+    verbosity: 'concise',
+    formality: 'casual',
+  },
+  heartbeat_instructions: 'No-op.',
+  sub_roles: [],
+  tools: ['desktop_launch_app'],
+  authority_level: 5,
+};
+
+class ScriptedProvider implements LLMProvider {
+  name = 'scripted';
+  calls: LLMMessage[][] = [];
+
+  constructor(private readonly responses: LLMResponse[]) {}
+
+  async chat(messages: LLMMessage[], _options?: LLMOptions): Promise<LLMResponse> {
+    this.calls.push(messages.map((message) => ({ ...message })));
+    const next = this.responses.shift();
+    if (!next) {
+      throw new Error('No scripted response left');
+    }
+    return next;
+  }
+
+  async *stream(_messages: LLMMessage[], _options?: LLMOptions): AsyncIterable<LLMStreamEvent> {
+    throw new Error('Stream not used in this test');
+  }
+
+  async listModels(): Promise<string[]> {
+    return ['scripted'];
+  }
+}
+
+describe('AgentOrchestrator', () => {
+  test('retries when a response claims tool execution without any tool call', async () => {
+    const provider = new ScriptedProvider([
+      {
+        content: "I've opened Notes and typed your reminder.",
+        tool_calls: [],
+        usage: { input_tokens: 10, output_tokens: 10 },
+        model: 'scripted',
+        finish_reason: 'stop',
+      },
+      {
+        content: '',
+        tool_calls: [{ id: 'tc1', name: 'desktop_launch_app', arguments: { app_name: 'Notes' } }],
+        usage: { input_tokens: 10, output_tokens: 10 },
+        model: 'scripted',
+        finish_reason: 'tool_use',
+      },
+      {
+        content: 'Done.',
+        tool_calls: [],
+        usage: { input_tokens: 10, output_tokens: 10 },
+        model: 'scripted',
+        finish_reason: 'stop',
+      },
+    ]);
+
+    const llmManager = new LLMManager();
+    llmManager.registerProvider(provider);
+
+    const toolRegistry = new ToolRegistry();
+    const executions: Record<string, unknown>[] = [];
+    const launchTool: ToolDefinition = {
+      name: 'desktop_launch_app',
+      description: 'Launch a desktop app.',
+      category: 'desktop',
+      parameters: {
+        app_name: {
+          type: 'string',
+          description: 'App name',
+          required: true,
+        },
+      },
+      execute: async (params) => {
+        executions.push(params);
+        return 'launched';
+      },
+    };
+    toolRegistry.register(launchTool);
+
+    const orchestrator = new AgentOrchestrator();
+    orchestrator.setLLMManager(llmManager);
+    orchestrator.setToolRegistry(toolRegistry);
+    orchestrator.createPrimary(TEST_ROLE);
+
+    const result = await orchestrator.processMessage('Use tools honestly.', 'Open Notes.');
+
+    expect(result).toBe('Done.');
+    expect(executions).toEqual([{ app_name: 'Notes' }]);
+    expect(provider.calls).toHaveLength(3);
+    expect(provider.calls[1]?.some((message) => message.role === 'system' && typeof message.content === 'string' && message.content.includes('described tool actions'))).toBe(true);
+  });
+});

--- a/src/agents/orchestrator.ts
+++ b/src/agents/orchestrator.ts
@@ -15,6 +15,17 @@ import { getActionForTool } from '../authority/tool-action-map.ts';
 
 const MAX_TOOL_ITERATIONS = 200;
 const MAX_TOOL_RESULT_CHARS = 6000; // Cap individual tool results to control context size
+const TOOLLESS_ACTION_WARNING = 'Your previous reply described tool actions as if they already happened, but no tool call was emitted. Do not narrate imaginary actions. If you need to act, emit the appropriate tool call. If you did not act, say that plainly.';
+const TOOLLESS_ACTION_PATTERNS = [
+  /\b(?:i|i've|i have|we)\s+(?:opened|launched|clicked|typed|pressed|saved|wrote|created|sent|filled|focused|navigated|scrolled|captured|took|uploaded|downloaded)\b/i,
+  /\b(?:done|finished)\s+(?:that|it)\b/i,
+];
+
+function responseClaimsExecutedAction(text: string): boolean {
+  const normalized = text.trim();
+  if (!normalized) return false;
+  return TOOLLESS_ACTION_PATTERNS.some((pattern) => pattern.test(normalized));
+}
 
 export class AgentOrchestrator {
   private hierarchy: AgentHierarchy;
@@ -228,6 +239,7 @@ export class AgentOrchestrator {
 
     const tools = this.getLLMTools();
     let finalText = '';
+    let toolValidationRetryUsed = false;
 
     // Tool execution loop
     for (let iteration = 0; iteration < MAX_TOOL_ITERATIONS; iteration++) {
@@ -265,8 +277,23 @@ export class AgentOrchestrator {
         continue;
       }
 
+      if (
+        tools &&
+        tools.length > 0 &&
+        !toolValidationRetryUsed &&
+        llmResponse.tool_calls.length === 0 &&
+        responseClaimsExecutedAction(llmResponse.content)
+      ) {
+        toolValidationRetryUsed = true;
+        messages.push({ role: 'assistant', content: llmResponse.content });
+        messages.push({ role: 'system', content: TOOLLESS_ACTION_WARNING });
+        continue;
+      }
+
       // No tool calls — this is the final response
-      finalText = llmResponse.content;
+      finalText = toolValidationRetryUsed && responseClaimsExecutedAction(llmResponse.content)
+        ? 'I could not verify that action because the selected model described tool use without actually calling a tool. Please retry with a stronger tool-calling model or confirm the action manually.'
+        : llmResponse.content;
 
       // Warn on truncation
       if (llmResponse.finish_reason === 'length') {
@@ -323,6 +350,7 @@ export class AgentOrchestrator {
     const totalUsage = { input_tokens: 0, output_tokens: 0 };
     let finalText = '';
     let responseModel = 'unknown';
+    let toolValidationRetryUsed = false;
 
     // Tool execution loop
     for (let iteration = 0; iteration < MAX_TOOL_ITERATIONS; iteration++) {
@@ -361,9 +389,37 @@ export class AgentOrchestrator {
         };
       }
 
+      if (
+        tools &&
+        tools.length > 0 &&
+        !toolValidationRetryUsed &&
+        toolCalls.length === 0 &&
+        responseClaimsExecutedAction(accumulatedText)
+      ) {
+        toolValidationRetryUsed = true;
+        const retryNotice = '\n[Tool execution could not be verified. Retrying with stricter tool-use instructions.]\n';
+        finalText += retryNotice;
+        yield { type: 'text', text: retryNotice };
+        messages.push({
+          role: 'assistant',
+          content: accumulatedText,
+        });
+        messages.push({
+          role: 'system',
+          content: TOOLLESS_ACTION_WARNING,
+        });
+        continue;
+      }
+
       // No tool calls — this is the final response
       if (toolCalls.length === 0) {
-        finalText += accumulatedText;
+        if (toolValidationRetryUsed && responseClaimsExecutedAction(accumulatedText)) {
+          const warning = 'I could not verify that action because the selected model described tool use without actually calling a tool.';
+          finalText += warning;
+          yield { type: 'text', text: warning };
+        } else {
+          finalText += accumulatedText;
+        }
 
         // Check if we stopped due to token limit (truncation)
         const wasLength = doneResponse?.finish_reason === 'length';

--- a/src/daemon/llm-settings.ts
+++ b/src/daemon/llm-settings.ts
@@ -14,7 +14,7 @@ import { GroqProvider } from '../llm/groq.ts';
 import { GeminiProvider } from '../llm/gemini.ts';
 import { OllamaProvider } from '../llm/ollama.ts';
 import { OpenRouterProvider } from '../llm/openrouter.ts';
-import type { LLMProvider } from '../llm/provider.ts';
+import type { LLMProvider, LLMTool } from '../llm/provider.ts';
 import type { LLMManager } from '../llm/manager.ts';
 
 // Keychain key names
@@ -44,6 +44,26 @@ export type LLMSettingsResponse = {
   gemini: { model: string; has_api_key: boolean } | null;
   ollama: { base_url: string; model: string } | null;
   openrouter: { model: string; has_api_key: boolean } | null;
+};
+
+type ToolSupportProbeResult = {
+  supports_tools: boolean;
+  warning?: string;
+};
+
+const TOOL_SUPPORT_PROBE: LLMTool = {
+  name: 'confirm_tool_support',
+  description: 'A no-op tool used only to verify that the selected model can emit a tool call.',
+  parameters: {
+    type: 'object',
+    properties: {
+      status: {
+        type: 'string',
+        description: 'Always set this to ok',
+      },
+    },
+    required: ['status'],
+  },
 };
 
 /**
@@ -375,7 +395,7 @@ export async function testLLMProvider(
     base_url?: string;
   },
   config: JarvisConfig,
-): Promise<{ ok: boolean; model?: string; error?: string }> {
+): Promise<{ ok: boolean; model?: string; error?: string; supports_tools?: boolean; warning?: string }> {
   try {
     let instance: LLMProvider;
 
@@ -412,8 +432,46 @@ export async function testLLMProvider(
       [{ role: 'user', content: 'Say OK' }],
       { max_tokens: 5 },
     );
-    return { ok: true, model: resp.model };
+    const toolSupport = await probeToolCallingSupport(instance);
+    return {
+      ok: true,
+      model: resp.model,
+      supports_tools: toolSupport.supports_tools,
+      warning: toolSupport.warning,
+    };
   } catch (err) {
     return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+async function probeToolCallingSupport(instance: LLMProvider): Promise<ToolSupportProbeResult> {
+  try {
+    const response = await instance.chat(
+      [
+        {
+          role: 'user',
+          content: 'Call the confirm_tool_support tool with status set to ok. Do not answer with plain text.',
+        },
+      ],
+      {
+        max_tokens: 32,
+        tools: [TOOL_SUPPORT_PROBE],
+        tool_choice: 'required',
+      },
+    );
+
+    if (response.tool_calls.length > 0) {
+      return { supports_tools: true };
+    }
+
+    return {
+      supports_tools: false,
+      warning: 'This model answered in text instead of emitting a required tool call. Desktop and browser automation may be unreliable.',
+    };
+  } catch (err) {
+    return {
+      supports_tools: false,
+      warning: `This model did not pass the tool-calling check. Desktop and browser automation may be unreliable. (${err instanceof Error ? err.message : String(err)})`,
+    };
   }
 }

--- a/src/roles/prompt-builder.ts
+++ b/src/roles/prompt-builder.ts
@@ -65,6 +65,7 @@ export function buildSystemPrompt(role: RoleDefinition, context?: PromptContext)
   sections.push(`Formality: ${role.communication_style.formality}.`);
   sections.push('');
   sections.push('**Task Acknowledgment**: When asked to perform a task that requires tool use, ALWAYS give a brief acknowledgment first (e.g., "On it.", "Let me check.", "I\'ll look into that.") before using any tools. Never silently start executing tools — the user should know you understood their request.');
+  sections.push('**Tool Honesty**: Never claim you opened, clicked, typed, launched, saved, sent, or changed anything unless you actually emitted the corresponding tool call in that turn. If you did not use a tool, describe the limitation or next step instead of implying success.');
   sections.push('');
 
   // KPIs

--- a/src/roles/tool-guide.ts
+++ b/src/roles/tool-guide.ts
@@ -18,6 +18,9 @@ export function buildToolGuide(hasSidecars: boolean): string {
   // --- Tools ---
   lines.push('## Tools');
   lines.push('');
+  lines.push('Never describe a tool action as already completed unless you actually call the tool in the same turn.');
+  lines.push('If tool calling is unavailable or fails, say that plainly instead of pretending the action happened.');
+  lines.push('');
 
   if (hasSidecars) {
     lines.push('These tools work locally by default. To run on a remote machine, pass the `target` parameter with a sidecar name or ID.');

--- a/ui/src/components/settings/LLMPanel.tsx
+++ b/ui/src/components/settings/LLMPanel.tsx
@@ -12,7 +12,7 @@ type LLMConfig = {
   openrouter: { model: string; has_api_key: boolean } | null;
 };
 
-type TestResult = { ok: boolean; model?: string; error?: string };
+type TestResult = { ok: boolean; model?: string; error?: string; supports_tools?: boolean; warning?: string };
 
 const ANTHROPIC_MODELS = [
   "claude-opus-4-6",
@@ -338,6 +338,11 @@ export function LLMPanel() {
             </option>
           ))}
         </select>
+        {(primary === "ollama" || fallback.includes("ollama")) && (
+          <div style={warningStyle}>
+            Local/open-source models can be inconsistent at tool calling. Test the provider before relying on desktop or browser automation, and expect some models to narrate actions instead of executing them.
+          </div>
+        )}
       </div>
 
       <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
@@ -663,6 +668,11 @@ function ProviderSection({
               )}
             </div>
           </div>
+          {((provider === "ollama" && !testResult?.warning) || testResult?.warning) && (
+            <div style={{ ...warningStyle, marginTop: "8px", marginBottom: 0 }}>
+              {testResult?.warning ?? "Tool calling quality depends heavily on the selected local model. If automation matters, run Test Connection and verify the tool-use warning before relying on it."}
+            </div>
+          )}
         </div>
       )}
     </div>
@@ -750,6 +760,17 @@ const saveBtnStyle: React.CSSProperties = {
   borderRadius: "6px",
   color: "var(--j-accent)",
   cursor: "pointer",
+};
+
+const warningStyle: React.CSSProperties = {
+  marginTop: "8px",
+  padding: "8px 10px",
+  fontSize: "12px",
+  lineHeight: 1.45,
+  color: "#FDE68A",
+  background: "rgba(251, 191, 36, 0.08)",
+  border: "1px solid rgba(251, 191, 36, 0.22)",
+  borderRadius: "6px",
 };
 
 const primaryBadgeStyle: React.CSSProperties = {


### PR DESCRIPTION
## Summary
- retry once when a response claims tool actions without emitting any tool call
- strengthen the prompt and tool guide so action claims must be backed by actual tool use
- surface tool-calling warnings in the LLM settings UI and test endpoint, especially for local models

## Validation
- bun test src/agents/orchestrator.test.ts
- bun run build:ui