### PR TITLE
Fix YAML config persistence and parser edge cases

### DIFF
--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -74,6 +74,53 @@ llm:
     expect(loaded.authority).toBeDefined();
     expect(loaded.active_role).toBeDefined();
   });
+
+  test('saves YAML without forcing quoted keys', async () => {
+    await saveConfig(DEFAULT_CONFIG, TEST_CONFIG_PATH);
+    const text = await Bun.file(TEST_CONFIG_PATH).text();
+
+    expect(text).toContain('daemon:');
+    expect(text).toContain('channels:');
+    expect(text).not.toContain('"daemon":');
+    expect(text).not.toContain('"channels":');
+  });
+
+  test('round-trips channel config and multi-provider fallbacks', async () => {
+    const testConfig = structuredClone(DEFAULT_CONFIG);
+    testConfig.channels = {
+      telegram: {
+        enabled: true,
+        bot_token: 'telegram-token',
+        allowed_users: [12345],
+      },
+      discord: {
+        enabled: true,
+        bot_token: 'discord-token',
+        allowed_users: ['user-1'],
+        guild_id: 'guild-123',
+      },
+    };
+    testConfig.llm.primary = 'ollama';
+    testConfig.llm.fallback = ['gemini', 'openai'];
+    testConfig.llm.gemini = {
+      api_key: 'gemini-key',
+      model: 'gemini-3-flash-preview',
+    };
+    testConfig.llm.ollama = {
+      base_url: 'http://localhost:11434',
+      model: 'llama3.1',
+    };
+
+    await saveConfig(testConfig, TEST_CONFIG_PATH);
+    const loaded = await loadConfig(TEST_CONFIG_PATH);
+
+    expect(loaded.channels?.discord?.enabled).toBe(true);
+    expect(loaded.channels?.discord?.guild_id).toBe('guild-123');
+    expect(loaded.llm.primary).toBe('ollama');
+    expect(loaded.llm.fallback).toEqual(['gemini', 'openai']);
+    expect(loaded.llm.gemini?.model).toBe('gemini-3-flash-preview');
+    expect(loaded.llm.ollama?.model).toBe('llama3.1');
+  });
 });
 
 describe('Default Config', () => {

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -112,10 +112,14 @@ export async function loadConfig(configPath?: string): Promise<JarvisConfig> {
 
   // File exists — parse errors should be fatal
   const text = await file.text();
-  const parsed = YAML.parse(text);  // throws YAMLParseError on bad syntax
+  const doc = YAML.parseDocument(text, { merge: true });
+  if (doc.errors.length > 0) {
+    throw new Error(doc.errors.map((entry) => entry.message).join('\n'));
+  }
+  const parsed = (doc.toJS() ?? {}) as Partial<JarvisConfig>;
 
   // Deep merge with defaults to ensure all required fields exist
-  const config = deepMerge(DEFAULT_CONFIG, parsed) as JarvisConfig;
+  const config = deepMerge(structuredClone(DEFAULT_CONFIG), parsed) as JarvisConfig;
 
   // Expand tilde in paths
   config.daemon.data_dir = expandTilde(config.daemon.data_dir);
@@ -137,7 +141,8 @@ export async function saveConfig(
     const yaml = YAML.stringify(config, {
       indent: 2,
       lineWidth: 100,
-      defaultStringType: 'QUOTE_DOUBLE',
+      defaultStringType: 'PLAIN',
+      defaultKeyType: 'PLAIN',
     });
 
     await Bun.write(path, yaml);


### PR DESCRIPTION
## Summary
- load config documents through the YAML document API before merging with defaults
- save config files without forcing quoted keys
- add round-trip coverage for channel config and multi-provider fallback settings

## Validation
- bun test src/config/loader.test.ts