### PR TITLE
Run doctor after core onboarding succeeds

### DIFF
--- a/bin/jarvis.ts
+++ b/bin/jarvis.ts
@@ -224,7 +224,11 @@ function cmdStatus(): void {
 
 async function cmdOnboard(): Promise<void> {
   const { runOnboard } = await import('../src/cli/onboard.ts');
+  const { runDoctor } = await import('../src/cli/doctor.ts');
   await runOnboard();
+  console.log('');
+  console.log(c.cyan('Running JARVIS doctor...'));
+  await runDoctor();
 }
 
 async function cmdDoctor(): Promise<void> {


### PR DESCRIPTION
## Summary
- run `jarvis doctor` automatically after the main `jarvis onboard` flow succeeds
- keep the behavior in the core CLI so users get immediate feedback even without the installer

## Validation
- bun run bin/jarvis.ts help | head -12