### PR TITLE
Auto-route desktop tools to connected sidecars

### DIFF
--- a/src/actions/tools/desktop.test.ts
+++ b/src/actions/tools/desktop.test.ts
@@ -1,5 +1,29 @@
-import { test, expect, describe } from 'bun:test';
+import { test, expect, describe, beforeEach, afterEach } from 'bun:test';
 import { DESKTOP_TOOLS } from './desktop.ts';
+import { setSidecarManagerRef, resolveDefaultSidecar } from './sidecar-route.ts';
+import type { SidecarInfo, SidecarCapability } from '../../sidecar/types.ts';
+
+/**
+ * Minimal mock of SidecarManager for routing tests.
+ * Only implements listSidecars() — dispatchRPC is not needed for resolution logic.
+ */
+function createMockManager(sidecars: SidecarInfo[]) {
+  return {
+    listSidecars: () => sidecars,
+    // Stub the rest of the Service interface so TS is happy
+    dispatchRPC: async () => { throw new Error('mock: dispatchRPC not wired'); },
+  } as any;
+}
+
+function makeSidecar(overrides: Partial<SidecarInfo> & { id: string; name: string }): SidecarInfo {
+  return {
+    enrolled_at: '2024-01-01T00:00:00Z',
+    last_seen_at: null,
+    status: 'enrolled',
+    connected: false,
+    ...overrides,
+  };
+}
 
 describe('DESKTOP_TOOLS', () => {
   test('contains 9 desktop tools', () => {
@@ -46,10 +70,149 @@ describe('DESKTOP_TOOLS', () => {
     }
   });
 
-  test('returns not-implemented error without target (local execution stub)', async () => {
+  test('returns sidecar-not-initialized error without target when manager is null', async () => {
+    // Ensure no manager is set (default state)
+    setSidecarManagerRef(null as any);
     for (const tool of DESKTOP_TOOLS) {
       const result = await tool.execute({});
-      expect(String(result)).toContain('not yet implemented');
+      expect(String(result)).toContain('Sidecar system not initialized');
+    }
+  });
+});
+
+describe('resolveDefaultSidecar', () => {
+  afterEach(() => {
+    // Reset to null after each test
+    setSidecarManagerRef(null as any);
+  });
+
+  test('returns error when sidecar manager is not initialized', () => {
+    setSidecarManagerRef(null as any);
+    const result = resolveDefaultSidecar('desktop');
+    expect('error' in result).toBe(true);
+    if ('error' in result) {
+      expect(result.error).toContain('not initialized');
+    }
+  });
+
+  test('returns error when no sidecars are enrolled', () => {
+    setSidecarManagerRef(createMockManager([]));
+    const result = resolveDefaultSidecar('desktop');
+    expect('error' in result).toBe(true);
+    if ('error' in result) {
+      expect(result.error).toContain('No sidecars enrolled');
+    }
+  });
+
+  test('returns error when sidecars enrolled but none connected', () => {
+    setSidecarManagerRef(createMockManager([
+      makeSidecar({ id: 's1', name: 'my-pc', connected: false, capabilities: ['desktop'] }),
+    ]));
+    const result = resolveDefaultSidecar('desktop');
+    expect('error' in result).toBe(true);
+    if ('error' in result) {
+      expect(result.error).toContain('No sidecars are currently connected');
+      expect(result.error).toContain('1 sidecar(s) enrolled but offline');
+    }
+  });
+
+  test('returns error when connected but no matching capability', () => {
+    setSidecarManagerRef(createMockManager([
+      makeSidecar({ id: 's1', name: 'my-pc', connected: true, capabilities: ['terminal', 'filesystem'] }),
+    ]));
+    const result = resolveDefaultSidecar('desktop');
+    expect('error' in result).toBe(true);
+    if ('error' in result) {
+      expect(result.error).toContain('No connected sidecar has the "desktop" capability');
+      expect(result.error).toContain('terminal');
+    }
+  });
+
+  test('returns sidecar when exactly one connected with matching capability', () => {
+    const sidecar = makeSidecar({ id: 's1', name: 'my-pc', connected: true, capabilities: ['desktop', 'terminal'] });
+    setSidecarManagerRef(createMockManager([sidecar]));
+    const result = resolveDefaultSidecar('desktop');
+    expect('sidecar' in result).toBe(true);
+    if ('sidecar' in result) {
+      expect(result.sidecar.id).toBe('s1');
+      expect(result.sidecar.name).toBe('my-pc');
+    }
+  });
+
+  test('returns error when multiple connected sidecars have matching capability', () => {
+    setSidecarManagerRef(createMockManager([
+      makeSidecar({ id: 's1', name: 'home-pc', connected: true, capabilities: ['desktop'] }),
+      makeSidecar({ id: 's2', name: 'work-pc', connected: true, capabilities: ['desktop'] }),
+    ]));
+    const result = resolveDefaultSidecar('desktop');
+    expect('error' in result).toBe(true);
+    if ('error' in result) {
+      expect(result.error).toContain('Multiple sidecars');
+      expect(result.error).toContain('home-pc');
+      expect(result.error).toContain('work-pc');
+      expect(result.error).toContain('Specify a "target"');
+    }
+  });
+
+  test('excludes sidecars with unavailable capability from auto-resolution', () => {
+    setSidecarManagerRef(createMockManager([
+      makeSidecar({
+        id: 's1', name: 'my-pc', connected: true,
+        capabilities: ['desktop'],
+        unavailable_capabilities: [{ name: 'desktop', reason: 'accessibility not enabled' }],
+      }),
+    ]));
+    const result = resolveDefaultSidecar('desktop');
+    expect('error' in result).toBe(true);
+    if ('error' in result) {
+      // Should not find the sidecar since its desktop capability is unavailable
+      expect(result.error).toContain('No connected sidecar has the "desktop" capability');
+    }
+  });
+
+  test('resolves correct sidecar when one has capability unavailable and another does not', () => {
+    setSidecarManagerRef(createMockManager([
+      makeSidecar({
+        id: 's1', name: 'broken-pc', connected: true,
+        capabilities: ['desktop'],
+        unavailable_capabilities: [{ name: 'desktop', reason: 'no accessibility' }],
+      }),
+      makeSidecar({
+        id: 's2', name: 'working-pc', connected: true,
+        capabilities: ['desktop'],
+      }),
+    ]));
+    const result = resolveDefaultSidecar('desktop');
+    expect('sidecar' in result).toBe(true);
+    if ('sidecar' in result) {
+      expect(result.sidecar.id).toBe('s2');
+      expect(result.sidecar.name).toBe('working-pc');
+    }
+  });
+
+  test('resolves screenshot capability independently from desktop', () => {
+    setSidecarManagerRef(createMockManager([
+      makeSidecar({ id: 's1', name: 'my-pc', connected: true, capabilities: ['screenshot'] }),
+    ]));
+    const desktopResult = resolveDefaultSidecar('desktop');
+    expect('error' in desktopResult).toBe(true);
+
+    const screenshotResult = resolveDefaultSidecar('screenshot');
+    expect('sidecar' in screenshotResult).toBe(true);
+    if ('sidecar' in screenshotResult) {
+      expect(screenshotResult.sidecar.id).toBe('s1');
+    }
+  });
+
+  test('ignores offline sidecars even if they have the capability', () => {
+    setSidecarManagerRef(createMockManager([
+      makeSidecar({ id: 's1', name: 'offline-pc', connected: false, capabilities: ['desktop'] }),
+      makeSidecar({ id: 's2', name: 'online-pc', connected: true, capabilities: ['desktop'] }),
+    ]));
+    const result = resolveDefaultSidecar('desktop');
+    expect('sidecar' in result).toBe(true);
+    if ('sidecar' in result) {
+      expect(result.sidecar.id).toBe('s2');
     }
   });
 });

--- a/src/actions/tools/desktop.ts
+++ b/src/actions/tools/desktop.ts
@@ -1,26 +1,18 @@
 /**
- * Desktop Tools — Desktop Automation via Sidecar RPC or Local Execution
+ * Desktop Tools — Desktop Automation via Sidecar RPC
  *
- * 9 tools for controlling desktop applications. Each tool accepts a `target`
- * parameter to route to a specific sidecar. Without `target`, attempts local
- * execution (currently stub — TODO: implement per-platform AppController).
- * Respects --no-local-tools flag.
+ * 9 tools for controlling desktop applications. Each tool accepts an optional
+ * `target` parameter to route to a specific sidecar. Without `target`, the
+ * tool auto-resolves to the single connected sidecar that has the required
+ * capability (desktop or screenshot). When the choice is ambiguous or no
+ * sidecar is available, a clear error guides the user.
  *
  * The same tools work on all platforms (Windows, macOS, Linux). The sidecar
  * handles platform-specific implementation details internally.
  */
 
 import type { ToolDefinition, ToolResult } from './registry.ts';
-import { routeToSidecar } from './sidecar-route.ts';
-import { isNoLocalTools } from './local-tools-guard.ts';
-
-const LOCAL_NOT_IMPLEMENTED = 'Error: Local desktop tool execution is not yet implemented. Specify a "target" sidecar to route this command to a remote machine, or use list_sidecars to see available sidecars.';
-const LOCAL_DISABLED_MSG = 'Error: Local tool execution is disabled (--no-local-tools). Specify a "target" sidecar to route this command to a remote machine. Use list_sidecars to see available sidecars.';
-
-function localGuard(): string {
-  if (isNoLocalTools()) return LOCAL_DISABLED_MSG;
-  return LOCAL_NOT_IMPLEMENTED;
-}
+import { routeToSidecarOrDefault } from './sidecar-route.ts';
 
 // --- Tool definitions ---
 
@@ -31,16 +23,13 @@ export const desktopListWindowsTool: ToolDefinition = {
   parameters: {
     target: {
       type: 'string',
-      description: 'Sidecar name or ID to route this command to (omit for local execution)',
+      description: 'Sidecar name or ID to route this command to (omit to auto-select an available sidecar)',
       required: false,
     },
   },
   execute: async (params) => {
     const target = params.target as string | undefined;
-    if (target) {
-      return routeToSidecar(target, 'list_windows', params, 'desktop');
-    }
-    return localGuard();
+    return routeToSidecarOrDefault(target, 'list_windows', params, 'desktop');
   },
 };
 
@@ -51,7 +40,7 @@ export const desktopSnapshotTool: ToolDefinition = {
   parameters: {
     target: {
       type: 'string',
-      description: 'Sidecar name or ID to route this command to (omit for local execution)',
+      description: 'Sidecar name or ID to route this command to (omit to auto-select an available sidecar)',
       required: false,
     },
     pid: {
@@ -67,10 +56,7 @@ export const desktopSnapshotTool: ToolDefinition = {
   },
   execute: async (params) => {
     const target = params.target as string | undefined;
-    if (target) {
-      return routeToSidecar(target, 'get_window_tree', params, 'desktop');
-    }
-    return localGuard();
+    return routeToSidecarOrDefault(target, 'get_window_tree', params, 'desktop');
   },
 };
 
@@ -81,7 +67,7 @@ export const desktopClickTool: ToolDefinition = {
   parameters: {
     target: {
       type: 'string',
-      description: 'Sidecar name or ID to route this command to (omit for local execution)',
+      description: 'Sidecar name or ID to route this command to (omit to auto-select an available sidecar)',
       required: false,
     },
     element_id: {
@@ -102,10 +88,7 @@ export const desktopClickTool: ToolDefinition = {
   },
   execute: async (params) => {
     const target = params.target as string | undefined;
-    if (target) {
-      return routeToSidecar(target, 'click_element', params, 'desktop');
-    }
-    return localGuard();
+    return routeToSidecarOrDefault(target, 'click_element', params, 'desktop');
   },
 };
 
@@ -116,7 +99,7 @@ export const desktopTypeTool: ToolDefinition = {
   parameters: {
     target: {
       type: 'string',
-      description: 'Sidecar name or ID to route this command to (omit for local execution)',
+      description: 'Sidecar name or ID to route this command to (omit to auto-select an available sidecar)',
       required: false,
     },
     text: {
@@ -132,10 +115,7 @@ export const desktopTypeTool: ToolDefinition = {
   },
   execute: async (params) => {
     const target = params.target as string | undefined;
-    if (target) {
-      return routeToSidecar(target, 'type_text', params, 'desktop');
-    }
-    return localGuard();
+    return routeToSidecarOrDefault(target, 'type_text', params, 'desktop');
   },
 };
 
@@ -146,7 +126,7 @@ export const desktopPressKeysTool: ToolDefinition = {
   parameters: {
     target: {
       type: 'string',
-      description: 'Sidecar name or ID to route this command to (omit for local execution)',
+      description: 'Sidecar name or ID to route this command to (omit to auto-select an available sidecar)',
       required: false,
     },
     keys: {
@@ -157,10 +137,7 @@ export const desktopPressKeysTool: ToolDefinition = {
   },
   execute: async (params) => {
     const target = params.target as string | undefined;
-    if (target) {
-      return routeToSidecar(target, 'press_keys', params, 'desktop');
-    }
-    return localGuard();
+    return routeToSidecarOrDefault(target, 'press_keys', params, 'desktop');
   },
 };
 
@@ -171,7 +148,7 @@ export const desktopLaunchAppTool: ToolDefinition = {
   parameters: {
     target: {
       type: 'string',
-      description: 'Sidecar name or ID to route this command to (omit for local execution)',
+      description: 'Sidecar name or ID to route this command to (omit to auto-select an available sidecar)',
       required: false,
     },
     executable: {
@@ -187,10 +164,7 @@ export const desktopLaunchAppTool: ToolDefinition = {
   },
   execute: async (params) => {
     const target = params.target as string | undefined;
-    if (target) {
-      return routeToSidecar(target, 'launch_app', params, 'desktop');
-    }
-    return localGuard();
+    return routeToSidecarOrDefault(target, 'launch_app', params, 'desktop');
   },
 };
 
@@ -201,7 +175,7 @@ export const desktopScreenshotTool: ToolDefinition = {
   parameters: {
     target: {
       type: 'string',
-      description: 'Sidecar name or ID to route this command to (omit for local execution)',
+      description: 'Sidecar name or ID to route this command to (omit to auto-select an available sidecar)',
       required: false,
     },
     pid: {
@@ -212,10 +186,7 @@ export const desktopScreenshotTool: ToolDefinition = {
   },
   execute: async (params) => {
     const target = params.target as string | undefined;
-    if (target) {
-      return routeToSidecar(target, 'capture_screen', params, 'screenshot');
-    }
-    return localGuard();
+    return routeToSidecarOrDefault(target, 'capture_screen', params, 'screenshot');
   },
 };
 
@@ -226,7 +197,7 @@ export const desktopFocusWindowTool: ToolDefinition = {
   parameters: {
     target: {
       type: 'string',
-      description: 'Sidecar name or ID to route this command to (omit for local execution)',
+      description: 'Sidecar name or ID to route this command to (omit to auto-select an available sidecar)',
       required: false,
     },
     pid: {
@@ -237,10 +208,7 @@ export const desktopFocusWindowTool: ToolDefinition = {
   },
   execute: async (params) => {
     const target = params.target as string | undefined;
-    if (target) {
-      return routeToSidecar(target, 'focus_window', params, 'desktop');
-    }
-    return localGuard();
+    return routeToSidecarOrDefault(target, 'focus_window', params, 'desktop');
   },
 };
 
@@ -251,7 +219,7 @@ export const desktopFindElementTool: ToolDefinition = {
   parameters: {
     target: {
       type: 'string',
-      description: 'Sidecar name or ID to route this command to (omit for local execution)',
+      description: 'Sidecar name or ID to route this command to (omit to auto-select an available sidecar)',
       required: false,
     },
     pid: {
@@ -282,10 +250,7 @@ export const desktopFindElementTool: ToolDefinition = {
   },
   execute: async (params) => {
     const target = params.target as string | undefined;
-    if (target) {
-      return routeToSidecar(target, 'find_element', params, 'desktop');
-    }
-    return localGuard();
+    return routeToSidecarOrDefault(target, 'find_element', params, 'desktop');
   },
 };
 

--- a/src/actions/tools/sidecar-route.ts
+++ b/src/actions/tools/sidecar-route.ts
@@ -45,6 +45,84 @@ function findSidecar(nameOrId: string, sidecars: SidecarInfo[]): SidecarInfo | n
 }
 
 /**
+ * Resolve a default sidecar for a given capability when no explicit target is provided.
+ *
+ * Returns the sidecar if exactly one connected sidecar has the capability.
+ * Returns an error message otherwise with actionable guidance.
+ */
+export function resolveDefaultSidecar(
+  requiredCapability: SidecarCapability,
+): { sidecar: SidecarInfo } | { error: string } {
+  if (!sidecarManager) {
+    return { error: 'Error: Sidecar system not initialized.' };
+  }
+
+  const sidecars = sidecarManager.listSidecars();
+  const connected = sidecars.filter((s) => s.connected);
+
+  // Filter to connected sidecars that have the capability and it is not unavailable
+  const capable = connected.filter(
+    (s) =>
+      s.capabilities?.includes(requiredCapability) &&
+      !s.unavailable_capabilities?.some((u) => u.name === requiredCapability),
+  );
+
+  if (capable.length === 1) {
+    return { sidecar: capable[0]! };
+  }
+
+  if (capable.length > 1) {
+    const names = capable.map((s) => s.name).join(', ');
+    return {
+      error: `Error: Multiple sidecars have the "${requiredCapability}" capability: ${names}. Specify a "target" to choose one.`,
+    };
+  }
+
+  // No capable sidecars found — build a helpful message
+  if (connected.length === 0) {
+    if (sidecars.length === 0) {
+      return { error: 'Error: No sidecars enrolled. Use list_sidecars to check sidecar availability.' };
+    }
+    return {
+      error: `Error: No sidecars are currently connected. ${sidecars.length} sidecar(s) enrolled but offline. Use list_sidecars to check status.`,
+    };
+  }
+
+  // Connected but none with the right capability
+  const availCaps = [...new Set(connected.flatMap((s) => s.capabilities ?? []))];
+  return {
+    error: `Error: No connected sidecar has the "${requiredCapability}" capability. Connected sidecar capabilities: ${availCaps.join(', ') || 'none'}. The sidecar may need "${requiredCapability}" enabled in its config.`,
+  };
+}
+
+/**
+ * Route an RPC call to a sidecar, with automatic default resolution.
+ *
+ * If `target` is provided, routes to that specific sidecar (existing behavior).
+ * If `target` is omitted, auto-resolves to the single connected sidecar
+ * that has the required capability. Returns an actionable error if the
+ * choice is ambiguous (multiple candidates) or impossible (none available).
+ */
+export async function routeToSidecarOrDefault(
+  target: string | undefined,
+  method: string,
+  params: Record<string, unknown>,
+  requiredCapability: SidecarCapability,
+): Promise<string> {
+  if (target) {
+    return routeToSidecar(target, method, params, requiredCapability);
+  }
+
+  const resolved = resolveDefaultSidecar(requiredCapability);
+  if ('error' in resolved) {
+    return resolved.error;
+  }
+
+  // Route using sidecar ID (exact match, no ambiguity)
+  return routeToSidecar(resolved.sidecar.id, method, params, requiredCapability);
+}
+
+/**
  * Route an RPC call to a sidecar. Returns the result string, or an error message.
  *
  * @param target - Sidecar name or ID


### PR DESCRIPTION
## Summary
- auto-route desktop tools to the single connected sidecar with the required capability when no explicit target is provided
- keep explicit target routing intact and return clearer errors for no-sidecar, offline, and ambiguous cases
- add regression coverage around default routing, capability filtering, and screenshot handling

## Validation
- bunx tsc --noEmit
- bun run build:ui
- bun test