### PR TITLE
Fail cleanly when sidecar app launch cannot resolve

### DIFF
--- a/sidecar/desktop_darwin.go
+++ b/sidecar/desktop_darwin.go
@@ -314,62 +314,75 @@ func handleLaunchApp(params map[string]any) (*RPCResult, error) {
 	if executable == "" {
 		return nil, fmt.Errorf("missing required parameter: executable")
 	}
-	args, _ := params["args"].(string)
+	args, err := extractArgs(params)
+	if err != nil {
+		return nil, fmt.Errorf("launch_app: %w", err)
+	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
 	// Use "open -a" for .app bundles; fall back to direct exec for plain binaries
-	var cmd *exec.Cmd
 	if strings.HasSuffix(executable, ".app") || !strings.Contains(executable, "/") {
 		// Looks like an app name or .app bundle — use open -a
+		var cmd *exec.Cmd
 		if args != "" {
 			cmd = exec.CommandContext(ctx, "open", "-a", executable, "--args", args)
 		} else {
 			cmd = exec.CommandContext(ctx, "open", "-a", executable)
 		}
-	} else {
-		// Absolute/relative path to a binary
-		if args != "" {
-			cmd = exec.CommandContext(ctx, executable, strings.Fields(args)...)
-		} else {
-			cmd = exec.CommandContext(ctx, executable)
+
+		if err := cmd.Run(); err != nil {
+			return nil, fmt.Errorf("launch_app: open -a %q failed: %w", executable, err)
 		}
-		// Run detached so the sidecar doesn't wait for the child process to exit
-		cmd.Start() //nolint:errcheck
-		// Give it a moment to start, then look up PID
+
+		// Wait briefly for the app to register, then resolve its PID
 		time.Sleep(500 * time.Millisecond)
 
-		// Resolve PID via pgrep using the base name
 		name := executable
-		if idx := strings.LastIndex(executable, "/"); idx >= 0 {
-			name = executable[idx+1:]
+		if strings.HasSuffix(name, ".app") {
+			name = name[:len(name)-4]
 		}
+		if idx := strings.LastIndex(name, "/"); idx >= 0 {
+			name = name[idx+1:]
+		}
+
 		pgrepOut, _ := exec.Command("pgrep", "-n", name).Output()
 		pidStr := strings.TrimSpace(string(pgrepOut))
 		pid, _ := strconv.Atoi(pidStr)
+		if pid == 0 {
+			return nil, fmt.Errorf("launch_app: open -a %q succeeded but process PID could not be resolved via pgrep %q", executable, name)
+		}
 		return &RPCResult{Result: map[string]any{"success": true, "pid": pid, "name": name}}, nil
 	}
 
-	if err := cmd.Run(); err != nil {
-		return nil, fmt.Errorf("launch_app failed: %w", err)
+	// Absolute/relative path to a binary — start detached
+	var cmd *exec.Cmd
+	if args != "" {
+		cmd = exec.CommandContext(ctx, executable, strings.Fields(args)...)
+	} else {
+		cmd = exec.CommandContext(ctx, executable)
 	}
 
-	// Wait briefly for the app to start, then resolve its PID
-	time.Sleep(500 * time.Millisecond)
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("launch_app: failed to start %q: %w", executable, err)
+	}
 
-	// Strip .app suffix for pgrep name lookup
+	// Detach: don't wait, let the child run independently
+	go func() { _ = cmd.Wait() }()
+
+	pid := 0
+	if cmd.Process != nil {
+		pid = cmd.Process.Pid
+	}
+	if pid == 0 {
+		return nil, fmt.Errorf("launch_app: started %q but could not obtain process ID", executable)
+	}
+
 	name := executable
-	if strings.HasSuffix(name, ".app") {
-		name = name[:len(name)-4]
+	if idx := strings.LastIndex(executable, "/"); idx >= 0 {
+		name = executable[idx+1:]
 	}
-	if idx := strings.LastIndex(name, "/"); idx >= 0 {
-		name = name[idx+1:]
-	}
-
-	pgrepOut, _ := exec.Command("pgrep", "-n", name).Output()
-	pidStr := strings.TrimSpace(string(pgrepOut))
-	pid, _ := strconv.Atoi(pidStr)
 
 	return &RPCResult{Result: map[string]any{"success": true, "pid": pid, "name": name}}, nil
 }

--- a/sidecar/desktop_linux.go
+++ b/sidecar/desktop_linux.go
@@ -434,7 +434,10 @@ func handleLaunchApp(params map[string]any) (*RPCResult, error) {
 	if executable == "" {
 		return nil, fmt.Errorf("missing required parameter: executable")
 	}
-	argsStr, _ := params["args"].(string)
+	argsStr, err := extractArgs(params)
+	if err != nil {
+		return nil, fmt.Errorf("launch_app: %w", err)
+	}
 
 	var cmdArgs []string
 	if argsStr != "" {
@@ -449,7 +452,7 @@ func handleLaunchApp(params map[string]any) (*RPCResult, error) {
 	cmd.Stderr = nil
 
 	if err := cmd.Start(); err != nil {
-		return nil, fmt.Errorf("launch_app failed to start %q: %w", executable, err)
+		return nil, fmt.Errorf("launch_app: failed to start %q: %w", executable, err)
 	}
 
 	// Detach: don't wait, let the child run independently
@@ -458,6 +461,9 @@ func handleLaunchApp(params map[string]any) (*RPCResult, error) {
 	pid := 0
 	if cmd.Process != nil {
 		pid = cmd.Process.Pid
+	}
+	if pid == 0 {
+		return nil, fmt.Errorf("launch_app: started %q but could not obtain process ID", executable)
 	}
 
 	// Derive a display name from the executable path

--- a/sidecar/desktop_windows.go
+++ b/sidecar/desktop_windows.go
@@ -207,7 +207,10 @@ func handleLaunchApp(params map[string]any) (*RPCResult, error) {
 	if executable == "" {
 		return nil, fmt.Errorf("missing required parameter: executable")
 	}
-	args, _ := params["args"].(string)
+	args, err := extractArgs(params)
+	if err != nil {
+		return nil, fmt.Errorf("launch_app: %w", err)
+	}
 
 	escaped := strings.ReplaceAll(executable, "'", "''")
 	argsClause := ""

--- a/sidecar/handlers.go
+++ b/sidecar/handlers.go
@@ -420,3 +420,36 @@ func handleGetSystemInfo(params map[string]any) (*RPCResult, error) {
 		"go_version": runtime.Version(),
 	}}, nil
 }
+
+// --- Launch-App Helpers ---
+
+// extractArgs extracts the "args" parameter from an RPC params map.
+// It accepts:
+//   - string:  returned as-is (e.g. "--verbose --output /tmp/foo")
+//   - []any:   each element is fmt.Sprint'd and joined with spaces
+//   - missing: returns ("", nil)
+//
+// Returns an error if "args" is present but has an unsupported type,
+// so callers never silently ignore a malformed request.
+func extractArgs(params map[string]any) (string, error) {
+	raw, exists := params["args"]
+	if !exists || raw == nil {
+		return "", nil
+	}
+	switch v := raw.(type) {
+	case string:
+		return v, nil
+	case []any:
+		parts := make([]string, 0, len(v))
+		for i, elem := range v {
+			s, ok := elem.(string)
+			if !ok {
+				return "", fmt.Errorf("args[%d]: expected string, got %T", i, elem)
+			}
+			parts = append(parts, s)
+		}
+		return strings.Join(parts, " "), nil
+	default:
+		return "", fmt.Errorf("args: expected string or array, got %T", raw)
+	}
+}

--- a/sidecar/handlers_test.go
+++ b/sidecar/handlers_test.go
@@ -137,3 +137,169 @@ func TestListDirectory(t *testing.T) {
 		}
 	})
 }
+
+// ── extractArgs tests ────────────────────────────────────────────────
+
+func TestExtractArgs(t *testing.T) {
+	t.Run("missing args key returns empty string", func(t *testing.T) {
+		s, err := extractArgs(map[string]any{"executable": "/bin/ls"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if s != "" {
+			t.Errorf("expected empty string, got %q", s)
+		}
+	})
+
+	t.Run("nil args returns empty string", func(t *testing.T) {
+		s, err := extractArgs(map[string]any{"args": nil})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if s != "" {
+			t.Errorf("expected empty string, got %q", s)
+		}
+	})
+
+	t.Run("string args pass through", func(t *testing.T) {
+		s, err := extractArgs(map[string]any{"args": "--verbose --output /tmp/foo"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if s != "--verbose --output /tmp/foo" {
+			t.Errorf("expected pass-through, got %q", s)
+		}
+	})
+
+	t.Run("empty string args pass through", func(t *testing.T) {
+		s, err := extractArgs(map[string]any{"args": ""})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if s != "" {
+			t.Errorf("expected empty string, got %q", s)
+		}
+	})
+
+	t.Run("array of strings joins with spaces", func(t *testing.T) {
+		s, err := extractArgs(map[string]any{
+			"args": []any{"--verbose", "--output", "/tmp/foo"},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if s != "--verbose --output /tmp/foo" {
+			t.Errorf("expected joined string, got %q", s)
+		}
+	})
+
+	t.Run("empty array returns empty string", func(t *testing.T) {
+		s, err := extractArgs(map[string]any{"args": []any{}})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if s != "" {
+			t.Errorf("expected empty string, got %q", s)
+		}
+	})
+
+	t.Run("array with non-string element returns error", func(t *testing.T) {
+		_, err := extractArgs(map[string]any{
+			"args": []any{"--verbose", 42},
+		})
+		if err == nil {
+			t.Fatal("expected error for non-string array element")
+		}
+	})
+
+	t.Run("unsupported type returns error", func(t *testing.T) {
+		_, err := extractArgs(map[string]any{"args": 123})
+		if err == nil {
+			t.Fatal("expected error for unsupported type")
+		}
+	})
+
+	t.Run("bool type returns error", func(t *testing.T) {
+		_, err := extractArgs(map[string]any{"args": true})
+		if err == nil {
+			t.Fatal("expected error for bool type")
+		}
+	})
+}
+
+// ── launch_app parameter validation tests ────────────────────────────
+
+func TestLaunchAppMissingExecutable(t *testing.T) {
+	_, err := handleLaunchApp(map[string]any{})
+	if err == nil {
+		t.Fatal("expected error for missing executable")
+	}
+}
+
+func TestLaunchAppEmptyExecutable(t *testing.T) {
+	_, err := handleLaunchApp(map[string]any{"executable": ""})
+	if err == nil {
+		t.Fatal("expected error for empty executable")
+	}
+}
+
+func TestLaunchAppBadArgsType(t *testing.T) {
+	// args as a number should fail cleanly, not be silently cast
+	_, err := handleLaunchApp(map[string]any{
+		"executable": "/bin/echo",
+		"args":       42,
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid args type")
+	}
+}
+
+func TestLaunchAppNonexistentBinary(t *testing.T) {
+	_, err := handleLaunchApp(map[string]any{
+		"executable": "/nonexistent/binary/that/does/not/exist",
+	})
+	if err == nil {
+		t.Fatal("expected error for nonexistent binary")
+	}
+}
+
+func TestLaunchAppSuccessReturnsNonZeroPid(t *testing.T) {
+	// Use a real binary that exists and exits quickly
+	result, err := handleLaunchApp(map[string]any{
+		"executable": "/bin/sleep",
+		"args":       "0.1",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	m := result.Result.(map[string]any)
+	pid, ok := m["pid"].(int)
+	if !ok {
+		t.Fatalf("pid is not int: %T", m["pid"])
+	}
+	if pid == 0 {
+		t.Error("expected non-zero pid on success")
+	}
+	if m["success"] != true {
+		t.Error("expected success: true")
+	}
+}
+
+func TestLaunchAppArrayArgs(t *testing.T) {
+	// JSON-decoded arrays come as []any — verify they work
+	result, err := handleLaunchApp(map[string]any{
+		"executable": "/bin/sleep",
+		"args":       []any{"0.1"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	m := result.Result.(map[string]any)
+	pid, ok := m["pid"].(int)
+	if !ok {
+		t.Fatalf("pid is not int: %T", m["pid"])
+	}
+	if pid == 0 {
+		t.Error("expected non-zero pid on success with array args")
+	}
+}


### PR DESCRIPTION
## Summary
- make launch_app fail instead of returning success with pid 0 when the launched process cannot be verified
- normalize sidecar launch args parsing across handlers and reject invalid arg shapes cleanly
- add handler tests for bad args, missing executables, and successful launches with real pids

## Validation
- go build ./...
- go test -v -count=1 ./...
- tsc --noEmit