### PR TITLE
Fix local desktop tool execution

### DIFF
--- a/src/actions/app-control/desktop-controller.ts
+++ b/src/actions/app-control/desktop-controller.ts
@@ -24,6 +24,8 @@ export type FlatElement = {
   value: string | null;
   depth: number;
   isEnabled: boolean;
+  bounds: UIElement['bounds'];
+  properties: Record<string, unknown>;
 };
 
 const DEFAULT_PORT = 9224;
@@ -147,7 +149,7 @@ export class DesktopController implements AppController {
    * Get a snapshot of a window's UI elements with sequential [id]s.
    * If no PID given, snapshots the active window.
    */
-  async snapshot(pid?: number): Promise<DesktopSnapshot> {
+  async snapshot(pid?: number, depth: number = 5): Promise<DesktopSnapshot> {
     await this.ensureConnected();
 
     // Get target window
@@ -159,7 +161,7 @@ export class DesktopController implements AppController {
     }
 
     // Get UI tree
-    const result = await this.send('getWindowTree', { pid: targetPid, depth: 5 }) as any;
+    const result = await this.send('getWindowTree', { pid: targetPid, depth }) as any;
 
     // Flatten tree into sequential IDs
     this.elementCache.clear();
@@ -405,6 +407,8 @@ export class DesktopController implements AppController {
         value: el.value || null,
         depth,
         isEnabled: el.isEnabled !== false,
+        bounds: uiElement.bounds,
+        properties: uiElement.properties,
       });
 
       // Recurse into children

--- a/src/actions/app-control/linux.ts
+++ b/src/actions/app-control/linux.ts
@@ -52,17 +52,8 @@ export class LinuxAppController implements AppController {
   }
 
   async getWindowTree(pid: number): Promise<UIElement[]> {
-    // TODO: Implement using AT-SPI2 (Assistive Technology Service Provider Interface)
-    // This requires complex bindings to the AT-SPI D-Bus interface
-    // For now, return empty array with informative error
-    console.warn(
-      `getWindowTree not yet implemented for Linux.\n` +
-      `Requires AT-SPI2 integration via D-Bus. Consider using:\n` +
-      `  - python-atspi library\n` +
-      `  - Accerciser tool for exploration\n` +
-      `  - Direct D-Bus bindings`
-    );
-    return [];
+    const window = await this.getWindowByPid(pid);
+    return [this.toWindowElement(window)];
   }
 
   async listWindows(): Promise<WindowInfo[]> {
@@ -123,10 +114,29 @@ export class LinuxAppController implements AppController {
     await this.ensureTool('xdotool');
 
     try {
+      const action = typeof element.properties.action === 'string' ? element.properties.action : 'click';
+      const pid = typeof element.properties.pid === 'number' ? element.properties.pid : null;
+
+      if (action === 'focus') {
+        if (pid === null) {
+          throw new Error('Element is missing a PID, cannot focus window');
+        }
+        await this.focusWindow(pid);
+        return;
+      }
+
       const centerX = element.bounds.x + element.bounds.width / 2;
       const centerY = element.bounds.y + element.bounds.height / 2;
 
       await $`xdotool mousemove ${Math.round(centerX)} ${Math.round(centerY)}`;
+      if (action === 'double_click') {
+        await $`xdotool click --repeat 2 1`;
+        return;
+      }
+      if (action === 'right_click') {
+        await $`xdotool click 3`;
+        return;
+      }
       await $`xdotool click 1`;
     } catch (error) {
       throw new Error(`Failed to click element: ${error instanceof Error ? error.message : String(error)}`);
@@ -221,6 +231,31 @@ export class LinuxAppController implements AppController {
     }
   }
 
+  async launchApp(executable: string, args?: string): Promise<object> {
+    if (!executable.trim()) {
+      throw new Error('Executable is required');
+    }
+
+    try {
+      const proc = Bun.spawn(
+        [executable, ...this.parseCommandArgs(args)],
+        {
+          stdin: 'ignore',
+          stdout: 'ignore',
+          stderr: 'ignore',
+        },
+      );
+
+      return {
+        pid: proc.pid,
+        executable,
+        args: args ?? '',
+      };
+    } catch (error) {
+      throw new Error(`Failed to launch app: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
   private async findWindowByPid(pid: number): Promise<string> {
     const windowIds = (await $`xdotool search --name "."`.text())
       .split('\n')
@@ -240,6 +275,40 @@ export class LinuxAppController implements AppController {
     }
 
     throw new Error(`No window found for PID ${pid}`);
+  }
+
+  private async getWindowByPid(pid: number): Promise<WindowInfo> {
+    const windows = await this.listWindows();
+    const match = windows.find((window) => window.pid === pid);
+    if (!match) {
+      throw new Error(`No window found for PID ${pid}`);
+    }
+    return match;
+  }
+
+  private toWindowElement(window: WindowInfo): UIElement {
+    return {
+      id: '1',
+      role: 'window',
+      name: window.title,
+      value: null,
+      bounds: window.bounds,
+      children: [],
+      properties: {
+        pid: window.pid,
+        className: window.className,
+        focused: window.focused,
+      },
+    };
+  }
+
+  private parseCommandArgs(args?: string): string[] {
+    if (!args?.trim()) {
+      return [];
+    }
+
+    const parts = args.match(/"[^"]*"|'[^']*'|\S+/g) ?? [];
+    return parts.map((part) => part.replace(/^['"]|['"]$/g, ''));
   }
 
   private extractXpropValue(output: string, property: string): string | null {

--- a/src/actions/tools/desktop.test.ts
+++ b/src/actions/tools/desktop.test.ts
@@ -1,31 +1,83 @@
-import { test, expect, describe, beforeEach, afterEach } from 'bun:test';
-import { DESKTOP_TOOLS } from './desktop.ts';
-import { setSidecarManagerRef, resolveDefaultSidecar } from './sidecar-route.ts';
-import type { SidecarInfo, SidecarCapability } from '../../sidecar/types.ts';
+import { afterEach, beforeEach, test, expect, describe } from 'bun:test';
+import type { AppController, UIElement, WindowInfo } from '../app-control/interface.ts';
+import { setNoLocalTools } from './local-tools-guard.ts';
+import {
+  DESKTOP_TOOLS,
+  __resetLocalDesktopStateForTests,
+  __setLocalDesktopControllerFactoryForTests,
+} from './desktop.ts';
 
-/**
- * Minimal mock of SidecarManager for routing tests.
- * Only implements listSidecars() — dispatchRPC is not needed for resolution logic.
- */
-function createMockManager(sidecars: SidecarInfo[]) {
+type FakeController = AppController & {
+  launches: Array<{ executable: string; args?: string }>;
+};
+
+function createFakeElement(): UIElement {
   return {
-    listSidecars: () => sidecars,
-    // Stub the rest of the Service interface so TS is happy
-    dispatchRPC: async () => { throw new Error('mock: dispatchRPC not wired'); },
-  } as any;
+    id: 'root',
+    role: 'window',
+    name: 'Calculator',
+    value: null,
+    bounds: { x: 10, y: 20, width: 300, height: 200 },
+    children: [],
+    properties: {
+      pid: 42,
+      className: 'calc',
+    },
+  };
 }
 
-function makeSidecar(overrides: Partial<SidecarInfo> & { id: string; name: string }): SidecarInfo {
+function createFakeWindow(): WindowInfo {
   return {
-    enrolled_at: '2024-01-01T00:00:00Z',
-    last_seen_at: null,
-    status: 'enrolled',
-    connected: false,
-    ...overrides,
+    pid: 42,
+    title: 'Calculator',
+    className: 'calc',
+    bounds: { x: 10, y: 20, width: 300, height: 200 },
+    focused: true,
+  };
+}
+
+function createFakeController(): FakeController {
+  const launches: Array<{ executable: string; args?: string }> = [];
+  return {
+    launches,
+    async getActiveWindow() {
+      return createFakeWindow();
+    },
+    async getWindowTree() {
+      return [createFakeElement()];
+    },
+    async listWindows() {
+      return [createFakeWindow()];
+    },
+    async clickElement() {},
+    async typeText() {},
+    async pressKeys() {},
+    async captureScreen() {
+      return Buffer.from('png-data');
+    },
+    async captureWindow() {
+      return Buffer.from('png-data');
+    },
+    async focusWindow() {},
+    async launchApp(executable: string, args?: string) {
+      launches.push({ executable, args });
+      return { pid: 9001, executable, args: args ?? '' };
+    },
   };
 }
 
 describe('DESKTOP_TOOLS', () => {
+  beforeEach(() => {
+    setNoLocalTools(false);
+    __resetLocalDesktopStateForTests();
+    __setLocalDesktopControllerFactoryForTests(() => createFakeController());
+  });
+
+  afterEach(() => {
+    setNoLocalTools(false);
+    __setLocalDesktopControllerFactoryForTests(null);
+  });
+
   test('contains 9 desktop tools', () => {
     expect(DESKTOP_TOOLS).toHaveLength(9);
   });
@@ -70,149 +122,53 @@ describe('DESKTOP_TOOLS', () => {
     }
   });
 
-  test('returns sidecar-not-initialized error without target when manager is null', async () => {
-    // Ensure no manager is set (default state)
-    setSidecarManagerRef(null as any);
-    for (const tool of DESKTOP_TOOLS) {
-      const result = await tool.execute({});
-      expect(String(result)).toContain('Sidecar system not initialized');
-    }
-  });
-});
-
-describe('resolveDefaultSidecar', () => {
-  afterEach(() => {
-    // Reset to null after each test
-    setSidecarManagerRef(null as any);
+  test('desktop_list_windows uses the local controller', async () => {
+    const tool = DESKTOP_TOOLS.find((entry) => entry.name === 'desktop_list_windows');
+    const result = await tool!.execute({});
+    expect(String(result)).toContain('PID 42');
+    expect(String(result)).toContain('Calculator');
   });
 
-  test('returns error when sidecar manager is not initialized', () => {
-    setSidecarManagerRef(null as any);
-    const result = resolveDefaultSidecar('desktop');
-    expect('error' in result).toBe(true);
-    if ('error' in result) {
-      expect(result.error).toContain('not initialized');
-    }
+  test('desktop_snapshot caches local elements for follow-up actions', async () => {
+    const snapshotTool = DESKTOP_TOOLS.find((entry) => entry.name === 'desktop_snapshot');
+    const clickTool = DESKTOP_TOOLS.find((entry) => entry.name === 'desktop_click');
+
+    const snapshot = await snapshotTool!.execute({});
+    expect(String(snapshot)).toContain('[1] window');
+
+    const clickResult = await clickTool!.execute({ element_id: 1 });
+    expect(clickResult).toBe('Clicked element [1] with action "click".');
   });
 
-  test('returns error when no sidecars are enrolled', () => {
-    setSidecarManagerRef(createMockManager([]));
-    const result = resolveDefaultSidecar('desktop');
-    expect('error' in result).toBe(true);
-    if ('error' in result) {
-      expect(result.error).toContain('No sidecars enrolled');
-    }
+  test('desktop_launch_app uses local launch support', async () => {
+    const tool = DESKTOP_TOOLS.find((entry) => entry.name === 'desktop_launch_app');
+    const result = await tool!.execute({ executable: 'xcalc', args: '--help' });
+    expect(String(result)).toContain('"executable": "xcalc"');
+    expect(String(result)).toContain('"args": "--help"');
   });
 
-  test('returns error when sidecars enrolled but none connected', () => {
-    setSidecarManagerRef(createMockManager([
-      makeSidecar({ id: 's1', name: 'my-pc', connected: false, capabilities: ['desktop'] }),
-    ]));
-    const result = resolveDefaultSidecar('desktop');
-    expect('error' in result).toBe(true);
-    if ('error' in result) {
-      expect(result.error).toContain('No sidecars are currently connected');
-      expect(result.error).toContain('1 sidecar(s) enrolled but offline');
-    }
+  test('desktop_screenshot returns a tool result locally', async () => {
+    const tool = DESKTOP_TOOLS.find((entry) => entry.name === 'desktop_screenshot');
+    const result = await tool!.execute({});
+    expect(result).toEqual({
+      content: [
+        { type: 'text', text: 'Desktop screenshot captured.' },
+        {
+          type: 'image',
+          source: {
+            type: 'base64',
+            media_type: 'image/png',
+            data: Buffer.from('png-data').toString('base64'),
+          },
+        },
+      ],
+    });
   });
 
-  test('returns error when connected but no matching capability', () => {
-    setSidecarManagerRef(createMockManager([
-      makeSidecar({ id: 's1', name: 'my-pc', connected: true, capabilities: ['terminal', 'filesystem'] }),
-    ]));
-    const result = resolveDefaultSidecar('desktop');
-    expect('error' in result).toBe(true);
-    if ('error' in result) {
-      expect(result.error).toContain('No connected sidecar has the "desktop" capability');
-      expect(result.error).toContain('terminal');
-    }
-  });
-
-  test('returns sidecar when exactly one connected with matching capability', () => {
-    const sidecar = makeSidecar({ id: 's1', name: 'my-pc', connected: true, capabilities: ['desktop', 'terminal'] });
-    setSidecarManagerRef(createMockManager([sidecar]));
-    const result = resolveDefaultSidecar('desktop');
-    expect('sidecar' in result).toBe(true);
-    if ('sidecar' in result) {
-      expect(result.sidecar.id).toBe('s1');
-      expect(result.sidecar.name).toBe('my-pc');
-    }
-  });
-
-  test('returns error when multiple connected sidecars have matching capability', () => {
-    setSidecarManagerRef(createMockManager([
-      makeSidecar({ id: 's1', name: 'home-pc', connected: true, capabilities: ['desktop'] }),
-      makeSidecar({ id: 's2', name: 'work-pc', connected: true, capabilities: ['desktop'] }),
-    ]));
-    const result = resolveDefaultSidecar('desktop');
-    expect('error' in result).toBe(true);
-    if ('error' in result) {
-      expect(result.error).toContain('Multiple sidecars');
-      expect(result.error).toContain('home-pc');
-      expect(result.error).toContain('work-pc');
-      expect(result.error).toContain('Specify a "target"');
-    }
-  });
-
-  test('excludes sidecars with unavailable capability from auto-resolution', () => {
-    setSidecarManagerRef(createMockManager([
-      makeSidecar({
-        id: 's1', name: 'my-pc', connected: true,
-        capabilities: ['desktop'],
-        unavailable_capabilities: [{ name: 'desktop', reason: 'accessibility not enabled' }],
-      }),
-    ]));
-    const result = resolveDefaultSidecar('desktop');
-    expect('error' in result).toBe(true);
-    if ('error' in result) {
-      // Should not find the sidecar since its desktop capability is unavailable
-      expect(result.error).toContain('No connected sidecar has the "desktop" capability');
-    }
-  });
-
-  test('resolves correct sidecar when one has capability unavailable and another does not', () => {
-    setSidecarManagerRef(createMockManager([
-      makeSidecar({
-        id: 's1', name: 'broken-pc', connected: true,
-        capabilities: ['desktop'],
-        unavailable_capabilities: [{ name: 'desktop', reason: 'no accessibility' }],
-      }),
-      makeSidecar({
-        id: 's2', name: 'working-pc', connected: true,
-        capabilities: ['desktop'],
-      }),
-    ]));
-    const result = resolveDefaultSidecar('desktop');
-    expect('sidecar' in result).toBe(true);
-    if ('sidecar' in result) {
-      expect(result.sidecar.id).toBe('s2');
-      expect(result.sidecar.name).toBe('working-pc');
-    }
-  });
-
-  test('resolves screenshot capability independently from desktop', () => {
-    setSidecarManagerRef(createMockManager([
-      makeSidecar({ id: 's1', name: 'my-pc', connected: true, capabilities: ['screenshot'] }),
-    ]));
-    const desktopResult = resolveDefaultSidecar('desktop');
-    expect('error' in desktopResult).toBe(true);
-
-    const screenshotResult = resolveDefaultSidecar('screenshot');
-    expect('sidecar' in screenshotResult).toBe(true);
-    if ('sidecar' in screenshotResult) {
-      expect(screenshotResult.sidecar.id).toBe('s1');
-    }
-  });
-
-  test('ignores offline sidecars even if they have the capability', () => {
-    setSidecarManagerRef(createMockManager([
-      makeSidecar({ id: 's1', name: 'offline-pc', connected: false, capabilities: ['desktop'] }),
-      makeSidecar({ id: 's2', name: 'online-pc', connected: true, capabilities: ['desktop'] }),
-    ]));
-    const result = resolveDefaultSidecar('desktop');
-    expect('sidecar' in result).toBe(true);
-    if ('sidecar' in result) {
-      expect(result.sidecar.id).toBe('s2');
-    }
+  test('respects --no-local-tools for desktop tools', async () => {
+    setNoLocalTools(true);
+    const tool = DESKTOP_TOOLS.find((entry) => entry.name === 'desktop_list_windows');
+    const result = await tool!.execute({});
+    expect(String(result)).toContain('Local tool execution is disabled');
   });
 });

--- a/src/actions/tools/desktop.test.ts
+++ b/src/actions/tools/desktop.test.ts
@@ -9,6 +9,7 @@ import {
 
 type FakeController = AppController & {
   launches: Array<{ executable: string; args?: string }>;
+  clickedActions: string[];
 };
 
 function createFakeElement(): UIElement {
@@ -38,8 +39,45 @@ function createFakeWindow(): WindowInfo {
 
 function createFakeController(): FakeController {
   const launches: Array<{ executable: string; args?: string }> = [];
+  const clickedActions: string[] = [];
   return {
     launches,
+    clickedActions,
+    async getActiveWindow() {
+      return createFakeWindow();
+    },
+    async getWindowTree() {
+      return [createFakeElement()];
+    },
+    async listWindows() {
+      return [createFakeWindow()];
+    },
+    async clickElement(element) {
+      clickedActions.push(String(element.properties.action ?? 'click'));
+    },
+    async typeText() {},
+    async pressKeys() {},
+    async captureScreen() {
+      return Buffer.from('png-data');
+    },
+    async captureWindow() {
+      return Buffer.from('png-data');
+    },
+    async focusWindow() {},
+    async launchApp(executable: string, args?: string) {
+      launches.push({ executable, args });
+      return { pid: 9001, executable, args: args ?? '' };
+    },
+  };
+}
+
+function createSnapshotController() {
+  const clickedIds: number[] = [];
+  let lastDepth: number | undefined;
+
+  return {
+    clickedIds,
+    lastDepth: () => lastDepth,
     async getActiveWindow() {
       return createFakeWindow();
     },
@@ -59,9 +97,29 @@ function createFakeController(): FakeController {
       return Buffer.from('png-data');
     },
     async focusWindow() {},
-    async launchApp(executable: string, args?: string) {
-      launches.push({ executable, args });
-      return { pid: 9001, executable, args: args ?? '' };
+    async snapshot(_pid?: number, depth?: number) {
+      lastDepth = depth;
+      return {
+        window: { pid: 42, title: 'Calculator', className: 'calc' },
+        elements: [
+          {
+            id: 7,
+            role: 'button',
+            name: 'Equals',
+            value: null,
+            depth: 1,
+            properties: {
+              className: 'calc-button',
+              automationId: 'equals-button',
+            },
+          },
+        ],
+        totalElements: 1,
+      };
+    },
+    async clickById(elementId: number) {
+      clickedIds.push(elementId);
+      return `Clicked ${elementId}`;
     },
   };
 }
@@ -138,6 +196,58 @@ describe('DESKTOP_TOOLS', () => {
 
     const clickResult = await clickTool!.execute({ element_id: 1 });
     expect(clickResult).toBe('Clicked element [1] with action "click".');
+  });
+
+  test('desktop_click supports local action variants on tree-based controllers', async () => {
+    const controller = createFakeController();
+    __setLocalDesktopControllerFactoryForTests(() => controller);
+    const snapshotTool = DESKTOP_TOOLS.find((entry) => entry.name === 'desktop_snapshot');
+    const clickTool = DESKTOP_TOOLS.find((entry) => entry.name === 'desktop_click');
+
+    await snapshotTool!.execute({});
+    await clickTool!.execute({ element_id: 1, action: 'double_click' });
+    await clickTool!.execute({ element_id: 1, action: 'right_click' });
+    await clickTool!.execute({ element_id: 1, action: 'focus' });
+
+    expect(controller.clickedActions).toEqual(['double_click', 'right_click', 'focus']);
+  });
+
+  test('desktop_click returns unsupported actions for snapshot-based controllers', async () => {
+    const controller = createSnapshotController();
+    __setLocalDesktopControllerFactoryForTests(() => controller);
+    const snapshotTool = DESKTOP_TOOLS.find((entry) => entry.name === 'desktop_snapshot');
+    const clickTool = DESKTOP_TOOLS.find((entry) => entry.name === 'desktop_click');
+
+    await snapshotTool!.execute({});
+    const result = await clickTool!.execute({ element_id: 7, action: 'double_click' });
+
+    expect(result).toBe('Error: Local desktop action "double_click" is not supported by this platform controller.');
+    expect(controller.clickedIds).toEqual([]);
+  });
+
+  test('desktop_snapshot honors depth and omits unknown bounds for snapshot controllers', async () => {
+    const controller = createSnapshotController();
+    __setLocalDesktopControllerFactoryForTests(() => controller);
+    const snapshotTool = DESKTOP_TOOLS.find((entry) => entry.name === 'desktop_snapshot');
+
+    const result = await snapshotTool!.execute({ depth: 3 });
+
+    expect(controller.lastDepth()).toBe(3);
+    expect(String(result)).toContain('[7] button "Equals" class="calc-button"');
+    expect(String(result)).not.toContain('bounds=');
+  });
+
+  test('desktop_find_element matches snapshot controller properties', async () => {
+    const controller = createSnapshotController();
+    __setLocalDesktopControllerFactoryForTests(() => controller);
+    const findTool = DESKTOP_TOOLS.find((entry) => entry.name === 'desktop_find_element');
+
+    const result = await findTool!.execute({
+      automation_id: 'equals-button',
+      class_name: 'calc-button',
+    });
+
+    expect(result).toBe('[7] button "Equals"');
   });
 
   test('desktop_launch_app uses local launch support', async () => {

--- a/src/actions/tools/desktop.ts
+++ b/src/actions/tools/desktop.ts
@@ -1,18 +1,262 @@
 /**
- * Desktop Tools — Desktop Automation via Sidecar RPC
+ * Desktop Tools — Desktop Automation via Sidecar RPC or Local Execution
  *
- * 9 tools for controlling desktop applications. Each tool accepts an optional
- * `target` parameter to route to a specific sidecar. Without `target`, the
- * tool auto-resolves to the single connected sidecar that has the required
- * capability (desktop or screenshot). When the choice is ambiguous or no
- * sidecar is available, a clear error guides the user.
+ * 9 tools for controlling desktop applications. Each tool accepts a `target`
+ * parameter to route to a specific sidecar. Without `target`, executes locally
+ * via the platform AppController when available. Respects --no-local-tools flag.
  *
  * The same tools work on all platforms (Windows, macOS, Linux). The sidecar
  * handles platform-specific implementation details internally.
  */
 
+import type { AppController, UIElement, WindowInfo } from '../app-control/interface.ts';
+import { getAppController } from '../app-control/interface.ts';
 import type { ToolDefinition, ToolResult } from './registry.ts';
-import { routeToSidecarOrDefault } from './sidecar-route.ts';
+import { routeToSidecar } from './sidecar-route.ts';
+import { isNoLocalTools, LOCAL_DISABLED_MSG } from './local-tools-guard.ts';
+
+type FlatSnapshotElement = {
+  id: number;
+  role: string;
+  name: string;
+  value: string | null;
+  depth: number;
+  bounds: UIElement['bounds'];
+  properties: Record<string, unknown>;
+};
+
+type LocalSnapshot = {
+  window: { pid: number; title: string; className: string };
+  elements: FlatSnapshotElement[];
+  totalElements: number;
+};
+
+type SnapshotCapableController = AppController & {
+  snapshot?: (pid?: number) => Promise<{
+    window: { pid: number; title: string; className: string };
+    elements: Array<{
+      id: number;
+      role: string;
+      name: string;
+      value: string | null;
+      depth: number;
+      isEnabled?: boolean;
+    }>;
+    totalElements: number;
+  }>;
+  clickById?: (elementId: number) => Promise<string>;
+  typeById?: (elementId: number | undefined, text: string) => Promise<string>;
+  screenshotBase64?: (pid?: number) => Promise<{ base64: string; mimeType: string }>;
+};
+
+let localControllerFactory: () => AppController = () => getAppController();
+let localElementCache = new Map<number, UIElement>();
+let lastLocalSnapshot: LocalSnapshot | null = null;
+
+export function __setLocalDesktopControllerFactoryForTests(factory: (() => AppController) | null): void {
+  localControllerFactory = factory ?? (() => getAppController());
+  __resetLocalDesktopStateForTests();
+}
+
+export function __resetLocalDesktopStateForTests(): void {
+  localElementCache.clear();
+  lastLocalSnapshot = null;
+}
+
+function isToolDisabled(): string | null {
+  if (isNoLocalTools()) {
+    return LOCAL_DISABLED_MSG;
+  }
+  return null;
+}
+
+function getLocalController(): SnapshotCapableController {
+  return localControllerFactory() as SnapshotCapableController;
+}
+
+function formatBounds(bounds: WindowInfo['bounds']): string {
+  return `${bounds.x},${bounds.y} ${bounds.width}x${bounds.height}`;
+}
+
+function formatWindows(windows: WindowInfo[]): string {
+  if (windows.length === 0) {
+    return 'No visible windows found.';
+  }
+
+  return windows
+    .map((window) => {
+      const focused = window.focused ? ' [focused]' : '';
+      return `PID ${window.pid}${focused} | ${window.title || '(untitled)'} | class=${window.className || 'unknown'} | bounds=${formatBounds(window.bounds)}`;
+    })
+    .join('\n');
+}
+
+function flattenElements(
+  elements: UIElement[],
+  depthLimit: number,
+  depth: number,
+  flattened: FlatSnapshotElement[],
+): void {
+  if (depth > depthLimit) {
+    return;
+  }
+
+  for (const element of elements) {
+    const numericId = flattened.length + 1;
+    localElementCache.set(numericId, element);
+    flattened.push({
+      id: numericId,
+      role: element.role,
+      name: element.name,
+      value: element.value,
+      depth,
+      bounds: element.bounds,
+      properties: element.properties,
+    });
+
+    if (element.children.length > 0) {
+      flattenElements(element.children, depthLimit, depth + 1, flattened);
+    }
+  }
+}
+
+async function buildLocalSnapshot(controller: SnapshotCapableController, pid?: number, depth: number = 8): Promise<LocalSnapshot> {
+  if (typeof controller.snapshot === 'function') {
+    const snap = await controller.snapshot(pid);
+    lastLocalSnapshot = {
+      window: snap.window,
+      elements: snap.elements.map((element) => ({
+        id: element.id,
+        role: element.role,
+        name: element.name,
+        value: element.value,
+        depth: element.depth,
+        bounds: { x: 0, y: 0, width: 0, height: 0 },
+        properties: { isEnabled: element.isEnabled ?? true },
+      })),
+      totalElements: snap.totalElements,
+    };
+    return lastLocalSnapshot;
+  }
+
+  localElementCache.clear();
+
+  const window = pid !== undefined
+    ? (await controller.listWindows()).find((entry) => entry.pid === pid) ?? null
+    : await controller.getActiveWindow();
+
+  if (!window) {
+    throw new Error(`No window found for PID ${pid}`);
+  }
+
+  const elements = await controller.getWindowTree(window.pid);
+  const flattened: FlatSnapshotElement[] = [];
+  flattenElements(elements, depth, 0, flattened);
+
+  lastLocalSnapshot = {
+    window: { pid: window.pid, title: window.title, className: window.className },
+    elements: flattened,
+    totalElements: flattened.length,
+  };
+  return lastLocalSnapshot;
+}
+
+function formatSnapshot(snapshot: LocalSnapshot): string {
+  const lines = [
+    `Window: ${snapshot.window.title || '(untitled)'}`,
+    `PID: ${snapshot.window.pid}`,
+    `Class: ${snapshot.window.className || 'unknown'}`,
+    '',
+  ];
+
+  if (snapshot.elements.length === 0) {
+    lines.push('(no UI elements found)');
+    return lines.join('\n');
+  }
+
+  lines.push(`--- UI Elements (${snapshot.elements.length}/${snapshot.totalElements}) ---`);
+  for (const element of snapshot.elements) {
+    const details: string[] = [];
+    if (element.name) details.push(`"${element.name}"`);
+    if (element.value) details.push(`value="${element.value}"`);
+    const className = typeof element.properties.className === 'string' ? element.properties.className : null;
+    if (className) details.push(`class="${className}"`);
+    details.push(`bounds=${formatBounds(element.bounds)}`);
+    lines.push(`${'  '.repeat(element.depth)}[${element.id}] ${element.role || 'element'}${details.length > 0 ? ` ${details.join(' ')}` : ''}`);
+  }
+
+  return lines.join('\n');
+}
+
+function ensureCachedElement(elementId: number): UIElement {
+  const element = localElementCache.get(elementId);
+  if (!element) {
+    throw new Error(`Element [${elementId}] not found. Run desktop_snapshot first.`);
+  }
+  return element;
+}
+
+function withAction(element: UIElement, action?: string): UIElement {
+  if (!action || action === 'click') {
+    return element;
+  }
+
+  return {
+    ...element,
+    properties: {
+      ...element.properties,
+      action,
+    },
+  };
+}
+
+function unsupportedAction(action: string): string {
+  return `Error: Local desktop action "${action}" is not supported by this platform controller.`;
+}
+
+async function executeLocal<T>(fn: (controller: SnapshotCapableController) => Promise<T>): Promise<T | string> {
+  const disabled = isToolDisabled();
+  if (disabled) {
+    return disabled;
+  }
+
+  try {
+    return await fn(getLocalController());
+  } catch (error) {
+    return `Error: ${error instanceof Error ? error.message : String(error)}`;
+  }
+}
+
+function normalizeKeys(keys: string): string[] {
+  return keys
+    .split(',')
+    .map((key) => key.trim())
+    .filter(Boolean);
+}
+
+function matchesElement(element: FlatSnapshotElement, params: Record<string, unknown>): boolean {
+  const expectedName = typeof params.name === 'string' ? params.name : null;
+  const expectedRole = typeof params.control_type === 'string' ? params.control_type.toLowerCase() : null;
+  const expectedAutomationId = typeof params.automation_id === 'string' ? params.automation_id : null;
+  const expectedClassName = typeof params.class_name === 'string' ? params.class_name : null;
+
+  if (expectedName && element.name !== expectedName) return false;
+  if (expectedRole && element.role.toLowerCase() !== expectedRole) return false;
+  if (expectedAutomationId && element.properties.automationId !== expectedAutomationId) return false;
+  if (expectedClassName && element.properties.className !== expectedClassName) return false;
+
+  return true;
+}
+
+function formatElementMatches(matches: FlatSnapshotElement[]): string {
+  if (matches.length === 0) {
+    return 'No matching elements found.';
+  }
+
+  return matches
+    .map((element) => `[${element.id}] ${element.role || 'element'} "${element.name || '(unnamed)'}"`)
+    .join('\n');
+}
 
 // --- Tool definitions ---
 
@@ -23,13 +267,16 @@ export const desktopListWindowsTool: ToolDefinition = {
   parameters: {
     target: {
       type: 'string',
-      description: 'Sidecar name or ID to route this command to (omit to auto-select an available sidecar)',
+      description: 'Sidecar name or ID to route this command to (omit for local execution)',
       required: false,
     },
   },
   execute: async (params) => {
     const target = params.target as string | undefined;
-    return routeToSidecarOrDefault(target, 'list_windows', params, 'desktop');
+    if (target) {
+      return routeToSidecar(target, 'list_windows', params, 'desktop');
+    }
+    return executeLocal(async (controller) => formatWindows(await controller.listWindows()));
   },
 };
 
@@ -40,7 +287,7 @@ export const desktopSnapshotTool: ToolDefinition = {
   parameters: {
     target: {
       type: 'string',
-      description: 'Sidecar name or ID to route this command to (omit to auto-select an available sidecar)',
+      description: 'Sidecar name or ID to route this command to (omit for local execution)',
       required: false,
     },
     pid: {
@@ -56,7 +303,13 @@ export const desktopSnapshotTool: ToolDefinition = {
   },
   execute: async (params) => {
     const target = params.target as string | undefined;
-    return routeToSidecarOrDefault(target, 'get_window_tree', params, 'desktop');
+    if (target) {
+      return routeToSidecar(target, 'get_window_tree', params, 'desktop');
+    }
+    return executeLocal(async (controller) => {
+      const snapshot = await buildLocalSnapshot(controller, params.pid as number | undefined, (params.depth as number | undefined) ?? 8);
+      return formatSnapshot(snapshot);
+    });
   },
 };
 
@@ -67,7 +320,7 @@ export const desktopClickTool: ToolDefinition = {
   parameters: {
     target: {
       type: 'string',
-      description: 'Sidecar name or ID to route this command to (omit to auto-select an available sidecar)',
+      description: 'Sidecar name or ID to route this command to (omit for local execution)',
       required: false,
     },
     element_id: {
@@ -88,7 +341,21 @@ export const desktopClickTool: ToolDefinition = {
   },
   execute: async (params) => {
     const target = params.target as string | undefined;
-    return routeToSidecarOrDefault(target, 'click_element', params, 'desktop');
+    if (target) {
+      return routeToSidecar(target, 'click_element', params, 'desktop');
+    }
+    return executeLocal(async (controller) => {
+      const action = (params.action as string | undefined) ?? 'click';
+      if (typeof controller.clickById === 'function' && action === 'click') {
+        return controller.clickById(params.element_id as number);
+      }
+      if (!['click', 'double_click', 'right_click', 'focus'].includes(action)) {
+        return unsupportedAction(action);
+      }
+      const element = withAction(ensureCachedElement(params.element_id as number), action);
+      await controller.clickElement(element);
+      return `Clicked element [${params.element_id}] with action "${action}".`;
+    });
   },
 };
 
@@ -99,7 +366,7 @@ export const desktopTypeTool: ToolDefinition = {
   parameters: {
     target: {
       type: 'string',
-      description: 'Sidecar name or ID to route this command to (omit to auto-select an available sidecar)',
+      description: 'Sidecar name or ID to route this command to (omit for local execution)',
       required: false,
     },
     text: {
@@ -115,7 +382,23 @@ export const desktopTypeTool: ToolDefinition = {
   },
   execute: async (params) => {
     const target = params.target as string | undefined;
-    return routeToSidecarOrDefault(target, 'type_text', params, 'desktop');
+    if (target) {
+      return routeToSidecar(target, 'type_text', params, 'desktop');
+    }
+    return executeLocal(async (controller) => {
+      const elementId = params.element_id as number | undefined;
+      if (typeof controller.typeById === 'function') {
+        return controller.typeById(elementId, params.text as string);
+      }
+      if (elementId !== undefined) {
+        await controller.clickElement(ensureCachedElement(elementId));
+        await Bun.sleep(100);
+      }
+      await controller.typeText(params.text as string);
+      return elementId !== undefined
+        ? `Typed "${params.text as string}" into element [${elementId}].`
+        : `Typed "${params.text as string}".`;
+    });
   },
 };
 
@@ -126,7 +409,7 @@ export const desktopPressKeysTool: ToolDefinition = {
   parameters: {
     target: {
       type: 'string',
-      description: 'Sidecar name or ID to route this command to (omit to auto-select an available sidecar)',
+      description: 'Sidecar name or ID to route this command to (omit for local execution)',
       required: false,
     },
     keys: {
@@ -137,7 +420,14 @@ export const desktopPressKeysTool: ToolDefinition = {
   },
   execute: async (params) => {
     const target = params.target as string | undefined;
-    return routeToSidecarOrDefault(target, 'press_keys', params, 'desktop');
+    if (target) {
+      return routeToSidecar(target, 'press_keys', params, 'desktop');
+    }
+    return executeLocal(async (controller) => {
+      const keys = normalizeKeys(params.keys as string);
+      await controller.pressKeys(keys);
+      return `Pressed keys: ${keys.join('+')}`;
+    });
   },
 };
 
@@ -148,7 +438,7 @@ export const desktopLaunchAppTool: ToolDefinition = {
   parameters: {
     target: {
       type: 'string',
-      description: 'Sidecar name or ID to route this command to (omit to auto-select an available sidecar)',
+      description: 'Sidecar name or ID to route this command to (omit for local execution)',
       required: false,
     },
     executable: {
@@ -164,7 +454,16 @@ export const desktopLaunchAppTool: ToolDefinition = {
   },
   execute: async (params) => {
     const target = params.target as string | undefined;
-    return routeToSidecarOrDefault(target, 'launch_app', params, 'desktop');
+    if (target) {
+      return routeToSidecar(target, 'launch_app', params, 'desktop');
+    }
+    return executeLocal(async (controller) => {
+      if (typeof controller.launchApp !== 'function') {
+        throw new Error(`Local app launch is not supported on ${process.platform}`);
+      }
+      const result = await controller.launchApp(params.executable as string, params.args as string | undefined);
+      return typeof result === 'string' ? result : JSON.stringify(result, null, 2);
+    });
   },
 };
 
@@ -175,7 +474,7 @@ export const desktopScreenshotTool: ToolDefinition = {
   parameters: {
     target: {
       type: 'string',
-      description: 'Sidecar name or ID to route this command to (omit to auto-select an available sidecar)',
+      description: 'Sidecar name or ID to route this command to (omit for local execution)',
       required: false,
     },
     pid: {
@@ -186,7 +485,31 @@ export const desktopScreenshotTool: ToolDefinition = {
   },
   execute: async (params) => {
     const target = params.target as string | undefined;
-    return routeToSidecarOrDefault(target, 'capture_screen', params, 'screenshot');
+    if (target) {
+      return routeToSidecar(target, 'capture_screen', params, 'screenshot');
+    }
+    return executeLocal(async (controller) => {
+      let base64: string;
+      let mimeType = 'image/png';
+
+      if (typeof controller.screenshotBase64 === 'function') {
+        const image = await controller.screenshotBase64(params.pid as number | undefined);
+        base64 = image.base64;
+        mimeType = image.mimeType;
+      } else {
+        const buffer = params.pid !== undefined
+          ? await controller.captureWindow(params.pid as number)
+          : await controller.captureScreen();
+        base64 = buffer.toString('base64');
+      }
+
+      return {
+        content: [
+          { type: 'text' as const, text: 'Desktop screenshot captured.' },
+          { type: 'image' as const, source: { type: 'base64' as const, media_type: mimeType, data: base64 } },
+        ],
+      } satisfies ToolResult;
+    });
   },
 };
 
@@ -197,7 +520,7 @@ export const desktopFocusWindowTool: ToolDefinition = {
   parameters: {
     target: {
       type: 'string',
-      description: 'Sidecar name or ID to route this command to (omit to auto-select an available sidecar)',
+      description: 'Sidecar name or ID to route this command to (omit for local execution)',
       required: false,
     },
     pid: {
@@ -208,7 +531,13 @@ export const desktopFocusWindowTool: ToolDefinition = {
   },
   execute: async (params) => {
     const target = params.target as string | undefined;
-    return routeToSidecarOrDefault(target, 'focus_window', params, 'desktop');
+    if (target) {
+      return routeToSidecar(target, 'focus_window', params, 'desktop');
+    }
+    return executeLocal(async (controller) => {
+      await controller.focusWindow(params.pid as number);
+      return `Focused window PID ${params.pid as number}.`;
+    });
   },
 };
 
@@ -219,7 +548,7 @@ export const desktopFindElementTool: ToolDefinition = {
   parameters: {
     target: {
       type: 'string',
-      description: 'Sidecar name or ID to route this command to (omit to auto-select an available sidecar)',
+      description: 'Sidecar name or ID to route this command to (omit for local execution)',
       required: false,
     },
     pid: {
@@ -250,7 +579,16 @@ export const desktopFindElementTool: ToolDefinition = {
   },
   execute: async (params) => {
     const target = params.target as string | undefined;
-    return routeToSidecarOrDefault(target, 'find_element', params, 'desktop');
+    if (target) {
+      return routeToSidecar(target, 'find_element', params, 'desktop');
+    }
+    return executeLocal(async (controller) => {
+      if (!params.name && !params.control_type && !params.automation_id && !params.class_name) {
+        throw new Error('At least one search filter is required.');
+      }
+      const snapshot = await buildLocalSnapshot(controller, params.pid as number | undefined);
+      return formatElementMatches(snapshot.elements.filter((element) => matchesElement(element, params)));
+    });
   },
 };
 

--- a/src/actions/tools/desktop.ts
+++ b/src/actions/tools/desktop.ts
@@ -21,7 +21,7 @@ type FlatSnapshotElement = {
   name: string;
   value: string | null;
   depth: number;
-  bounds: UIElement['bounds'];
+  bounds: UIElement['bounds'] | null;
   properties: Record<string, unknown>;
 };
 
@@ -32,7 +32,7 @@ type LocalSnapshot = {
 };
 
 type SnapshotCapableController = AppController & {
-  snapshot?: (pid?: number) => Promise<{
+  snapshot?: (pid?: number, depth?: number) => Promise<{
     window: { pid: number; title: string; className: string };
     elements: Array<{
       id: number;
@@ -41,6 +41,8 @@ type SnapshotCapableController = AppController & {
       value: string | null;
       depth: number;
       isEnabled?: boolean;
+      bounds?: UIElement['bounds'];
+      properties?: Record<string, unknown>;
     }>;
     totalElements: number;
   }>;
@@ -121,8 +123,10 @@ function flattenElements(
 }
 
 async function buildLocalSnapshot(controller: SnapshotCapableController, pid?: number, depth: number = 8): Promise<LocalSnapshot> {
+  localElementCache.clear();
+
   if (typeof controller.snapshot === 'function') {
-    const snap = await controller.snapshot(pid);
+    const snap = await controller.snapshot(pid, depth);
     lastLocalSnapshot = {
       window: snap.window,
       elements: snap.elements.map((element) => ({
@@ -131,15 +135,16 @@ async function buildLocalSnapshot(controller: SnapshotCapableController, pid?: n
         name: element.name,
         value: element.value,
         depth: element.depth,
-        bounds: { x: 0, y: 0, width: 0, height: 0 },
-        properties: { isEnabled: element.isEnabled ?? true },
+        bounds: element.bounds ?? null,
+        properties: {
+          ...(element.properties ?? {}),
+          isEnabled: element.isEnabled ?? true,
+        },
       })),
       totalElements: snap.totalElements,
     };
     return lastLocalSnapshot;
   }
-
-  localElementCache.clear();
 
   const window = pid !== undefined
     ? (await controller.listWindows()).find((entry) => entry.pid === pid) ?? null
@@ -181,7 +186,7 @@ function formatSnapshot(snapshot: LocalSnapshot): string {
     if (element.value) details.push(`value="${element.value}"`);
     const className = typeof element.properties.className === 'string' ? element.properties.className : null;
     if (className) details.push(`class="${className}"`);
-    details.push(`bounds=${formatBounds(element.bounds)}`);
+    if (element.bounds) details.push(`bounds=${formatBounds(element.bounds)}`);
     lines.push(`${'  '.repeat(element.depth)}[${element.id}] ${element.role || 'element'}${details.length > 0 ? ` ${details.join(' ')}` : ''}`);
   }
 
@@ -346,11 +351,14 @@ export const desktopClickTool: ToolDefinition = {
     }
     return executeLocal(async (controller) => {
       const action = (params.action as string | undefined) ?? 'click';
-      if (typeof controller.clickById === 'function' && action === 'click') {
-        return controller.clickById(params.element_id as number);
-      }
       if (!['click', 'double_click', 'right_click', 'focus'].includes(action)) {
         return unsupportedAction(action);
+      }
+      if (typeof controller.clickById === 'function') {
+        if (action !== 'click') {
+          return unsupportedAction(action);
+        }
+        return controller.clickById(params.element_id as number);
       }
       const element = withAction(ensureCachedElement(params.element_id as number), action);
       await controller.clickElement(element);


### PR DESCRIPTION
## Summary
- wire local desktop tools to the platform app controller instead of returning a stub error
- add Linux local support for window-level snapshots, click actions, and app launching
- cover the local desktop execution path with focused tests

## Validation
- bun test
- bun run build:ui