### PR TITLE
Restore chat context between turns

### DIFF
--- a/src/agents/agent.ts
+++ b/src/agents/agent.ts
@@ -104,6 +104,10 @@ export class AgentInstance {
     this.messageHistory.push({ role, content });
   }
 
+  setMessages(messages: LLMMessage[]): void {
+    this.messageHistory = [...messages];
+  }
+
   getMessages(): LLMMessage[] {
     return [...this.messageHistory];
   }

--- a/src/agents/agent.ts
+++ b/src/agents/agent.ts
@@ -1,5 +1,4 @@
 import type { RoleDefinition } from '../roles/types.ts';
-import type { LLMMessage } from '../llm/provider.ts';
 
 export type AgentStatus = 'active' | 'idle' | 'terminated';
 
@@ -21,6 +20,11 @@ export type Agent = {
   authority: AuthorityBounds;
   memory_scope: string[];
   created_at: number;
+};
+
+export type AgentChatMessage = {
+  role: 'system' | 'user' | 'assistant';
+  content: string;
 };
 
 /**
@@ -56,7 +60,7 @@ function mergeAuthority(
 
 export class AgentInstance {
   public readonly agent: Agent;
-  private messageHistory: LLMMessage[];
+  private messageHistory: AgentChatMessage[];
 
   constructor(
     role: RoleDefinition,
@@ -104,11 +108,11 @@ export class AgentInstance {
     this.messageHistory.push({ role, content });
   }
 
-  setMessages(messages: LLMMessage[]): void {
+  setMessages(messages: AgentChatMessage[]): void {
     this.messageHistory = [...messages];
   }
 
-  getMessages(): LLMMessage[] {
+  getMessages(): AgentChatMessage[] {
     return [...this.messageHistory];
   }
 

--- a/src/daemon/agent-service.test.ts
+++ b/src/daemon/agent-service.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { AgentService } from './agent-service.ts';
+import { DEFAULT_CONFIG } from '../config/types.ts';
+import { addMessage, getOrCreateConversation } from '../vault/conversations.ts';
+import { closeDb, initDatabase } from '../vault/schema.ts';
+import type { LLMMessage, LLMOptions, LLMProvider, LLMResponse, LLMStreamEvent } from '../llm/provider.ts';
+
+class RecordingProvider implements LLMProvider {
+  name = 'recording';
+  calls: LLMMessage[][] = [];
+
+  async chat(messages: LLMMessage[], _options?: LLMOptions): Promise<LLMResponse> {
+    this.calls.push(messages.map((message) => ({ ...message })));
+    return {
+      content: 'Got it.',
+      tool_calls: [],
+      usage: { input_tokens: 1, output_tokens: 1 },
+      model: 'recording',
+      finish_reason: 'stop',
+    };
+  }
+
+  async *stream(_messages: LLMMessage[], _options?: LLMOptions): AsyncIterable<LLMStreamEvent> {
+    throw new Error('Streaming not used in this test');
+  }
+
+  async listModels(): Promise<string[]> {
+    return ['recording'];
+  }
+}
+
+describe('AgentService conversation context', () => {
+  beforeEach(() => {
+    initDatabase(':memory:');
+  });
+
+  afterEach(async () => {
+    closeDb();
+  });
+
+  test('rehydrates recent channel conversation before handling the next message', async () => {
+    const config = structuredClone(DEFAULT_CONFIG);
+    config.llm = {
+      primary: 'recording',
+      fallback: [],
+    };
+
+    const service = new AgentService(config);
+    await service.start();
+    const provider = new RecordingProvider();
+    service.getLLMManager().registerProvider(provider);
+    service.getLLMManager().setPrimary('recording');
+
+    const conversation = getOrCreateConversation('websocket');
+    addMessage(conversation.id, { role: 'user', content: 'Help me plan a trip to Tokyo.' });
+    addMessage(conversation.id, { role: 'assistant', content: 'Sure — what dates are you considering?' });
+    addMessage(conversation.id, { role: 'user', content: 'Next April.' });
+
+    const primary = service.getOrchestrator().getPrimary();
+    primary?.setMessages([]);
+
+    const response = await service.handleMessage('Next April.', 'websocket');
+
+    expect(response).toBe('Got it.');
+    expect(primary?.getMessages()).toEqual([
+      { role: 'user', content: 'Help me plan a trip to Tokyo.' },
+      { role: 'assistant', content: 'Sure — what dates are you considering?' },
+      { role: 'user', content: 'Next April.' },
+      { role: 'assistant', content: 'Got it.' },
+    ]);
+    expect(provider.calls.length).toBeGreaterThan(0);
+    expect(provider.calls[0]?.slice(1)).toEqual([
+      { role: 'user', content: 'Help me plan a trip to Tokyo.' },
+      { role: 'assistant', content: 'Sure — what dates are you considering?' },
+      { role: 'user', content: 'Next April.' },
+    ]);
+
+    await service.stop();
+  });
+});

--- a/src/daemon/agent-service.test.ts
+++ b/src/daemon/agent-service.test.ts
@@ -8,6 +8,7 @@ import type { LLMMessage, LLMOptions, LLMProvider, LLMResponse, LLMStreamEvent }
 class RecordingProvider implements LLMProvider {
   name = 'recording';
   calls: LLMMessage[][] = [];
+  streamCalls: LLMMessage[][] = [];
 
   async chat(messages: LLMMessage[], _options?: LLMOptions): Promise<LLMResponse> {
     this.calls.push(messages.map((message) => ({ ...message })));
@@ -20,8 +21,19 @@ class RecordingProvider implements LLMProvider {
     };
   }
 
-  async *stream(_messages: LLMMessage[], _options?: LLMOptions): AsyncIterable<LLMStreamEvent> {
-    throw new Error('Streaming not used in this test');
+  async *stream(messages: LLMMessage[], _options?: LLMOptions): AsyncIterable<LLMStreamEvent> {
+    this.streamCalls.push(messages.map((message) => ({ ...message })));
+    yield { type: 'text', text: 'Got it.' };
+    yield {
+      type: 'done',
+      response: {
+        content: 'Got it.',
+        tool_calls: [],
+        usage: { input_tokens: 1, output_tokens: 1 },
+        model: 'recording',
+        finish_reason: 'stop',
+      },
+    };
   }
 
   async listModels(): Promise<string[]> {
@@ -70,6 +82,63 @@ describe('AgentService conversation context', () => {
     ]);
     expect(provider.calls.length).toBeGreaterThan(0);
     expect(provider.calls[0]?.slice(1)).toEqual([
+      { role: 'user', content: 'Help me plan a trip to Tokyo.' },
+      { role: 'assistant', content: 'Sure — what dates are you considering?' },
+      { role: 'user', content: 'Next April.' },
+    ]);
+
+    await service.stop();
+  });
+
+  test('rehydrates recent channel conversation before streaming the next message', async () => {
+    const config = structuredClone(DEFAULT_CONFIG);
+    config.llm = {
+      primary: 'recording',
+      fallback: [],
+    };
+
+    const service = new AgentService(config);
+    await service.start();
+    const provider = new RecordingProvider();
+    service.getLLMManager().registerProvider(provider);
+    service.getLLMManager().setPrimary('recording');
+
+    const conversation = getOrCreateConversation('websocket');
+    addMessage(conversation.id, { role: 'user', content: 'Help me plan a trip to Tokyo.' });
+    addMessage(conversation.id, { role: 'assistant', content: 'Sure — what dates are you considering?' });
+    addMessage(conversation.id, { role: 'user', content: 'Next April.' });
+
+    const primary = service.getOrchestrator().getPrimary();
+    primary?.setMessages([]);
+
+    const { stream, onComplete } = service.streamMessage('Next April.', 'websocket');
+    const events: LLMStreamEvent[] = [];
+    for await (const event of stream) {
+      events.push(event);
+    }
+    await onComplete('Got it.');
+
+    expect(events).toEqual([
+      { type: 'text', text: 'Got it.' },
+      {
+        type: 'done',
+        response: {
+          content: 'Got it.',
+          tool_calls: [],
+          usage: { input_tokens: 1, output_tokens: 1 },
+          model: 'recording',
+          finish_reason: 'stop',
+        },
+      },
+    ]);
+    expect(primary?.getMessages()).toEqual([
+      { role: 'user', content: 'Help me plan a trip to Tokyo.' },
+      { role: 'assistant', content: 'Sure — what dates are you considering?' },
+      { role: 'user', content: 'Next April.' },
+      { role: 'assistant', content: 'Got it.' },
+    ]);
+    expect(provider.streamCalls.length).toBeGreaterThan(0);
+    expect(provider.streamCalls[0]?.slice(1)).toEqual([
       { role: 'user', content: 'Help me plan a trip to Tokyo.' },
       { role: 'assistant', content: 'Sure — what dates are you considering?' },
       { role: 'user', content: 'Next April.' },

--- a/src/daemon/agent-service.ts
+++ b/src/daemon/agent-service.ts
@@ -21,6 +21,7 @@ import { GeminiProvider } from '../llm/gemini.ts';
 import { OllamaProvider } from '../llm/ollama.ts';
 import { OpenRouterProvider } from '../llm/openrouter.ts';
 import { AgentOrchestrator } from '../agents/orchestrator.ts';
+import type { AgentChatMessage } from '../agents/agent.ts';
 import { loadRole } from '../roles/loader.ts';
 import { ToolRegistry } from '../actions/tools/registry.ts';
 import { BUILTIN_TOOLS, browser } from '../actions/tools/builtin.ts';
@@ -55,7 +56,7 @@ import { getKnowledgeForMessage } from '../vault/retrieval.ts';
 import { formatUserProfileForPrompt } from '../user/profile.ts';
 import { getUserProfile } from '../vault/user-profile.ts';
 import { getWebappInstructionsForMessage } from '../vault/webapp-templates.ts';
-import { getMessages, getRecentConversation } from '../vault/conversations.ts';
+import { getRecentConversation } from '../vault/conversations.ts';
 import type { ResearchQueue } from './research-queue.ts';
 import type { IAgentService } from './agent-service-interface.ts';
 import type { AuthorityEngine } from '../authority/engine.ts';
@@ -485,7 +486,8 @@ export class AgentService implements Service, IAgentService {
         return;
       }
 
-      const restored = getMessages(recent.conversation.id, { limit: PRIMARY_HISTORY_LIMIT })
+      const restored: AgentChatMessage[] = recent.messages
+        .slice(-PRIMARY_HISTORY_LIMIT)
         .filter((message) => message.role === 'user' || message.role === 'assistant')
         .map((message) => ({
           role: message.role,

--- a/src/daemon/agent-service.ts
+++ b/src/daemon/agent-service.ts
@@ -55,10 +55,13 @@ import { getKnowledgeForMessage } from '../vault/retrieval.ts';
 import { formatUserProfileForPrompt } from '../user/profile.ts';
 import { getUserProfile } from '../vault/user-profile.ts';
 import { getWebappInstructionsForMessage } from '../vault/webapp-templates.ts';
+import { getMessages, getRecentConversation } from '../vault/conversations.ts';
 import type { ResearchQueue } from './research-queue.ts';
 import type { IAgentService } from './agent-service-interface.ts';
 import type { AuthorityEngine } from '../authority/engine.ts';
 import { getSidecarManager } from '../actions/tools/sidecar-route.ts';
+
+const PRIMARY_HISTORY_LIMIT = 40;
 
 export class AgentService implements Service, IAgentService {
   name = 'agent';
@@ -247,6 +250,8 @@ export class AgentService implements Service, IAgentService {
     stream: AsyncIterable<LLMStreamEvent>;
     onComplete: (fullText: string) => Promise<void>;
   } {
+    this.syncPrimaryConversationHistory(channel, text);
+
     let systemPrompt = this.buildFullSystemPrompt(channel, text);
     if (siteContext) {
       systemPrompt += '\n\n' + siteContext;
@@ -274,6 +279,8 @@ export class AgentService implements Service, IAgentService {
    * Non-streaming message handler. Returns full response string.
    */
   async handleMessage(text: string, channel: string = 'websocket'): Promise<string> {
+    this.syncPrimaryConversationHistory(channel, text);
+
     const systemPrompt = this.buildFullSystemPrompt(channel, text);
 
     const response = await this.orchestrator.processMessage(systemPrompt, text);
@@ -463,6 +470,39 @@ export class AgentService implements Service, IAgentService {
     const personalityPrompt = personalityToPrompt(channelPersonality);
 
     return `${rolePrompt}\n\n${personalityPrompt}`;
+  }
+
+  private syncPrimaryConversationHistory(channel: string, pendingUserMessage?: string): void {
+    const primary = this.orchestrator.getPrimary();
+    if (!primary) {
+      return;
+    }
+
+    try {
+      const recent = getRecentConversation(channel);
+      if (!recent) {
+        primary.setMessages([]);
+        return;
+      }
+
+      const restored = getMessages(recent.conversation.id, { limit: PRIMARY_HISTORY_LIMIT })
+        .filter((message) => message.role === 'user' || message.role === 'assistant')
+        .map((message) => ({
+          role: message.role,
+          content: message.content,
+        }));
+
+      if (pendingUserMessage && restored.length > 0) {
+        const last = restored[restored.length - 1];
+        if (last?.role === 'user' && last.content === pendingUserMessage) {
+          restored.pop();
+        }
+      }
+
+      primary.setMessages(restored);
+    } catch (err) {
+      console.error('[AgentService] Error restoring conversation context:', err);
+    }
   }
 
   private buildHeartbeatPrompt(coalescedEvents?: string): string {


### PR DESCRIPTION
## Summary
- restore recent channel conversation history from the vault into the primary agent before each turn
- avoid duplicating the inbound user message while rehydrating prompt history
- add a regression test covering empty in-memory state with existing persisted conversation

## Validation
- bun test
- bun run build:ui