### PR TITLE
Fix sidecar brain host overrides

### DIFF
--- a/sidecar/client.go
+++ b/sidecar/client.go
@@ -7,8 +7,10 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"net/url"
 	"os"
 	"runtime"
+	"strings"
 	"sync"
 	"time"
 
@@ -42,6 +44,9 @@ func NewSidecarClient(config *SidecarConfig) (*SidecarClient, error) {
 	if err != nil {
 		return nil, fmt.Errorf("decode token: %w", err)
 	}
+	if override := normalizeBrainOverride(config.Brain); override != "" {
+		claims.Brain = override
+	}
 
 	client := &SidecarClient{
 		config:         config,
@@ -51,6 +56,33 @@ func NewSidecarClient(config *SidecarConfig) (*SidecarClient, error) {
 	client.runPreflight()
 	client.handlers = NewHandlerRegistry(config, client.availableCaps, client.reloadConfig)
 	return client, nil
+}
+
+func normalizeBrainOverride(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return ""
+	}
+	if strings.HasPrefix(trimmed, "ws://") || strings.HasPrefix(trimmed, "wss://") {
+		return trimmed
+	}
+	if strings.HasPrefix(trimmed, "http://") || strings.HasPrefix(trimmed, "https://") {
+		u, err := url.Parse(trimmed)
+		if err != nil || u.Host == "" {
+			return trimmed
+		}
+		wsScheme := "ws"
+		if u.Scheme == "https" {
+			wsScheme = "wss"
+		}
+		return fmt.Sprintf("%s://%s/sidecar/connect", wsScheme, u.Host)
+	}
+
+	wsScheme := "wss"
+	if strings.Contains(trimmed, "localhost") || strings.Contains(trimmed, "127.0.0.1") || strings.Contains(trimmed, ":") {
+		wsScheme = "ws"
+	}
+	return fmt.Sprintf("%s://%s/sidecar/connect", wsScheme, trimmed)
 }
 
 func (c *SidecarClient) Start(ctx context.Context) {

--- a/sidecar/client_test.go
+++ b/sidecar/client_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+)
+
+func fakeToken(t *testing.T, claims SidecarTokenClaims) string {
+	t.Helper()
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none","typ":"JWT"}`))
+	payloadBytes, err := json.Marshal(claims)
+	if err != nil {
+		t.Fatalf("marshal claims: %v", err)
+	}
+	payload := base64.RawURLEncoding.EncodeToString(payloadBytes)
+	return header + "." + payload + ".sig"
+}
+
+func TestNewSidecarClientUsesConfigBrainOverride(t *testing.T) {
+	cfg := testConfig()
+	cfg.Token = fakeToken(t, SidecarTokenClaims{
+		Sub:   "sidecar:test",
+		Jti:   "jti",
+		Sid:   "sid",
+		Name:  "test",
+		Brain: "ws://127.0.0.1:3142/sidecar/connect",
+		JWKS:  "http://127.0.0.1:3142/api/sidecars/.well-known/jwks.json",
+		Iat:   1,
+	})
+	cfg.Brain = "10.0.0.25:3142"
+
+	client, err := NewSidecarClient(cfg)
+	if err != nil {
+		t.Fatalf("NewSidecarClient returned error: %v", err)
+	}
+
+	if client.claims.Brain != "ws://10.0.0.25:3142/sidecar/connect" {
+		t.Fatalf("expected config brain override, got %q", client.claims.Brain)
+	}
+}
+
+func TestNormalizeBrainOverrideAcceptsHTTPOrigin(t *testing.T) {
+	got := normalizeBrainOverride("https://brain.example.com")
+	want := "wss://brain.example.com/sidecar/connect"
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}

--- a/sidecar/types.go
+++ b/sidecar/types.go
@@ -95,6 +95,7 @@ type SidecarCapabilitiesUpdate struct {
 // SidecarConfig is the YAML config file structure.
 type SidecarConfig struct {
 	Token        string              `yaml:"token"`
+	Brain        string              `yaml:"brain"`
 	Capabilities []SidecarCapability `yaml:"capabilities"`
 	Terminal     TerminalConfig      `yaml:"terminal"`
 	Filesystem   FilesystemConfig    `yaml:"filesystem"`

--- a/src/daemon/api-routes.ts
+++ b/src/daemon/api-routes.ts
@@ -2432,7 +2432,13 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
           if (!ctx.sidecarManager) return error('Sidecar manager not available', 503);
           const body = await req.json() as { name?: string };
           if (!body.name) return error('Missing "name" field');
-          const result = await ctx.sidecarManager.enrollSidecar(body.name);
+          const forwardedProto = req.headers.get('x-forwarded-proto')?.split(',')[0]?.trim();
+          const forwardedHost = req.headers.get('x-forwarded-host')?.split(',')[0]?.trim();
+          const requestUrl = new URL(req.url);
+          const host = forwardedHost || req.headers.get('host') || requestUrl.host;
+          const protocol = forwardedProto || requestUrl.protocol.replace(':', '');
+          const enrollmentOrigin = host ? `${protocol}://${host}` : undefined;
+          const result = await ctx.sidecarManager.enrollSidecar(body.name, enrollmentOrigin);
           return json(result, 201);
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);

--- a/src/sidecar/manager.test.ts
+++ b/src/sidecar/manager.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from 'bun:test';
+import { SidecarManager } from './manager.ts';
+
+describe('SidecarManager enrollment URLs', () => {
+  test('uses explicit request origin when provided', () => {
+    const manager = new SidecarManager('/tmp/jarvis-sidecar-manager-test') as any;
+    const urls = manager.buildEnrollmentUrls('https://brain.example.com');
+
+    expect(urls.brainWs).toBe('wss://brain.example.com/sidecar/connect');
+    expect(urls.jwksUrl).toBe('https://brain.example.com/api/sidecars/.well-known/jwks.json');
+  });
+
+  test('preserves ws/http style URLs for local hosts', () => {
+    const manager = new SidecarManager('/tmp/jarvis-sidecar-manager-test') as any;
+    const urls = manager.buildEnrollmentUrls('10.0.0.25:3142');
+
+    expect(urls.brainWs).toBe('ws://10.0.0.25:3142/sidecar/connect');
+    expect(urls.jwksUrl).toBe('http://10.0.0.25:3142/api/sidecars/.well-known/jwks.json');
+  });
+});

--- a/src/sidecar/manager.ts
+++ b/src/sidecar/manager.ts
@@ -227,7 +227,7 @@ export class SidecarManager implements Service {
   /**
    * Enroll a new sidecar. Returns the signed JWT enrollment token.
    */
-  async enrollSidecar(name: string): Promise<{ token: string; sidecar: SidecarRecord }> {
+  async enrollSidecar(name: string, enrollmentOrigin?: string): Promise<{ token: string; sidecar: SidecarRecord }> {
     if (!this.privateKey) throw new Error('SidecarManager not started');
     if (!this.brainUrl) throw new Error('Brain URL not configured — call setBrainUrl() first');
 
@@ -250,13 +250,7 @@ export class SidecarManager implements Service {
     const id = generateId();
     const tokenId = generateId();
 
-    // Determine protocol based on brain URL
-    const isSecure = !this.brainUrl.includes('localhost') && !this.brainUrl.match(/:\d+$/);
-    const wsProtocol = isSecure ? 'wss' : 'ws';
-    const httpProtocol = isSecure ? 'https' : 'http';
-
-    const brainWs = `${wsProtocol}://${this.brainUrl}/sidecar/connect`;
-    const jwksUrl = `${httpProtocol}://${this.brainUrl}/api/sidecars/.well-known/jwks.json`;
+    const { brainWs, jwksUrl } = this.buildEnrollmentUrls(enrollmentOrigin || this.brainUrl);
 
     // Sign JWT
     const token = await new SignJWT({
@@ -281,6 +275,29 @@ export class SidecarManager implements Service {
     console.log(`[SidecarManager] Enrolled sidecar "${trimmed}" (${id})`);
 
     return { token, sidecar };
+  }
+
+  private buildEnrollmentUrls(brainBase: string): { brainWs: string; jwksUrl: string } {
+    const normalized = brainBase.trim();
+
+    if (/^https?:\/\//.test(normalized) || /^wss?:\/\//.test(normalized)) {
+      const parsed = new URL(normalized);
+      const host = parsed.host;
+      const wsProtocol = parsed.protocol === 'https:' || parsed.protocol === 'wss:' ? 'wss' : 'ws';
+      const httpProtocol = parsed.protocol === 'wss:' ? 'https' : parsed.protocol === 'ws:' ? 'http' : parsed.protocol.replace(':', '');
+      return {
+        brainWs: `${wsProtocol}://${host}/sidecar/connect`,
+        jwksUrl: `${httpProtocol}://${host}/api/sidecars/.well-known/jwks.json`,
+      };
+    }
+
+    const isSecure = !normalized.includes('localhost') && !normalized.match(/:\d+$/);
+    const wsProtocol = isSecure ? 'wss' : 'ws';
+    const httpProtocol = isSecure ? 'https' : 'http';
+    return {
+      brainWs: `${wsProtocol}://${normalized}/sidecar/connect`,
+      jwksUrl: `${httpProtocol}://${normalized}/api/sidecars/.well-known/jwks.json`,
+    };
   }
 
   // --------------- Registry (DB queries) ---------------
@@ -539,4 +556,3 @@ export class SidecarManager implements Service {
     };
   }
 }
-


### PR DESCRIPTION
## Summary
- build sidecar enrollment URLs from the actual request host when available instead of always falling back to localhost
- let the Go sidecar honor a brain override from ~/.jarvis-sidecar/config.yaml
- add regression tests for daemon-side enrollment URL generation and Go sidecar config overrides

## Testing
- bun test src/sidecar/manager.test.ts
- cd sidecar && /usr/local/go/bin/go test ./...
