### PR TITLE
Fix speech wake self-trigger loop

### DIFF
--- a/ui/src/hooks/useVoice.test.ts
+++ b/ui/src/hooks/useVoice.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test";
+import { matchesSpeechWakePhrase } from "./useVoice.ts";
+
+describe("matchesSpeechWakePhrase", () => {
+  test("accepts direct wake phrases", () => {
+    expect(matchesSpeechWakePhrase("Jarvis")).toBe(true);
+    expect(matchesSpeechWakePhrase("hey jarvis")).toBe(true);
+    expect(matchesSpeechWakePhrase("Jarvis, stop")).toBe(true);
+    expect(matchesSpeechWakePhrase("Hey Jarvis, hold on")).toBe(true);
+  });
+
+  test("rejects longer sentences that merely mention jarvis", () => {
+    expect(matchesSpeechWakePhrase("Jarvis is already working on that")).toBe(false);
+    expect(matchesSpeechWakePhrase("Can you tell Jarvis to send that")).toBe(false);
+    expect(matchesSpeechWakePhrase("I said Jarvis in the middle of a sentence")).toBe(false);
+    expect(matchesSpeechWakePhrase("Hey Jarvis can you help")).toBe(false);
+  });
+});

--- a/ui/src/hooks/useVoice.ts
+++ b/ui/src/hooks/useVoice.ts
@@ -1,5 +1,37 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 
+const SPEECH_WAKE_INTERRUPT_COMMANDS = new Set([
+  "stop",
+  "wait",
+  "pause",
+  "listen",
+  "quiet",
+  "sorry",
+  "question",
+  "hold on",
+  "one sec",
+  "one second",
+]);
+
+export function matchesSpeechWakePhrase(transcript: string): boolean {
+  const normalized = transcript
+    .toLowerCase()
+    .replace(/[.,!?;:]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+
+  if (!normalized) return false;
+  if (normalized === "jarvis" || normalized === "hey jarvis") return true;
+
+  const prefix = normalized.startsWith("hey jarvis ") ? "hey jarvis " : normalized.startsWith("jarvis ") ? "jarvis " : null;
+  if (!prefix) return false;
+
+  const remainder = normalized.slice(prefix.length).trim();
+  if (!remainder) return true;
+
+  return SPEECH_WAKE_INTERRUPT_COMMANDS.has(remainder);
+}
+
 export type VoiceState =
   | "idle"           // listening for wake word (if enabled) or waiting for PTT
   | "wake_detected"  // brief visual feedback before recording starts
@@ -218,7 +250,7 @@ export function useVoice({ wsRef, wakeWordEnabled = true }: UseVoiceOptions): Us
         for (let i = event.resultIndex; i < event.results.length; i++) {
           const transcript = String(event.results[i]?.[0]?.transcript || "").toLowerCase().trim();
           if (!transcript) continue;
-          if (transcript.includes("hey jarvis") || transcript === "jarvis" || transcript.includes(" jarvis")) {
+          if (matchesSpeechWakePhrase(transcript)) {
             console.log(`[Voice] Speech wake phrase detected: "${transcript}"`);
             if (voiceStateRef.current === "speaking") {
               cancelTTSRef.current();


### PR DESCRIPTION
## Summary
- tighten the browser speech wake matcher to only trigger on short direct Jarvis wake phrases
- prevent Jarvis TTS lines that mention its own name from interrupting playback and restarting capture
- add a regression test for accepted wake phrases vs longer sentences that just mention Jarvis

## Testing
- bun test ui/src/hooks/useVoice.test.ts
- bun test