### PR TITLE
Follow-ups to #61: correctness fixes and polish for the Agents tab

### DIFF
--- a/src/actions/tools/agents.ts
+++ b/src/actions/tools/agents.ts
@@ -23,6 +23,13 @@ export type AgentToolDeps = {
   onProgress?: ProgressCallback;
 };
 
+export class HttpError extends Error {
+  constructor(public status: number, message: string) {
+    super(message);
+    this.name = 'HttpError';
+  }
+}
+
 // Track scoped registries for persistent agents so they can be reused across tasks
 const agentRegistries = new Map<string, ReturnType<typeof createScopedToolRegistry>>();
 
@@ -37,17 +44,17 @@ export type PersistentAgentSummary = {
 
 export function spawnPersistentAgent(deps: AgentToolDeps, specialistId: string) {
   if (!specialistId) {
-    throw new Error('A specialist role is required to spawn an agent.');
+    throw new HttpError(400, 'A specialist role is required to spawn an agent.');
   }
 
   const role = deps.specialists.get(specialistId);
   if (!role) {
-    throw new Error(`Unknown specialist "${specialistId}". Available: ${Array.from(deps.specialists.keys()).join(', ')}`);
+    throw new HttpError(400, `Unknown specialist "${specialistId}". Available: ${Array.from(deps.specialists.keys()).join(', ')}`);
   }
 
   const primary = deps.orchestrator.getPrimary();
   if (!primary) {
-    throw new Error('No primary agent exists');
+    throw new HttpError(503, 'No primary agent exists');
   }
 
   const agent = deps.orchestrator.spawnSubAgent(primary.id, role);
@@ -77,19 +84,19 @@ export async function assignPersistentAgentTask(
   params: { agentId: string; task: string; context?: string }
 ) {
   const { agentId, task, context = '' } = params;
-  if (!agentId) throw new Error('"agentId" is required');
-  if (!task) throw new Error('"task" is required');
+  if (!agentId) throw new HttpError(400, '"agentId" is required');
+  if (!task) throw new HttpError(400, '"task" is required');
 
   const agent = deps.orchestrator.getAgent(agentId);
-  if (!agent) throw new Error(`Agent "${agentId}" not found. Use list to see active agents.`);
+  if (!agent) throw new HttpError(404, `Agent "${agentId}" not found. Use list to see active agents.`);
 
   if (deps.taskManager.isAgentBusy(agentId)) {
-    throw new Error(`Agent "${agent.agent.role.name}" is already running a task.`);
+    throw new HttpError(409, `Agent "${agent.agent.role.name}" is already running a task.`);
   }
 
   const scopedRegistry = agentRegistries.get(agentId);
   if (!scopedRegistry) {
-    throw new Error(`No tool registry for agent "${agentId}". Was it spawned via manage_agents?`);
+    throw new HttpError(500, `No tool registry for agent "${agentId}". Was it spawned via manage_agents?`);
   }
 
   deps.onProgress?.({
@@ -151,16 +158,16 @@ export function listPersistentAgents(deps: AgentToolDeps) {
 }
 
 export function terminatePersistentAgent(deps: AgentToolDeps, agentId: string) {
-  if (!agentId) throw new Error('"agentId" is required');
+  if (!agentId) throw new HttpError(400, '"agentId" is required');
 
   if (deps.orchestrator.getPrimary()?.id === agentId) {
-    throw new Error('Cannot terminate the primary agent.');
+    throw new HttpError(400, 'Cannot terminate the primary agent.');
   }
 
   const agent = deps.orchestrator.getAgent(agentId);
-  if (!agent) throw new Error(`Agent "${agentId}" not found`);
+  if (!agent) throw new HttpError(404, `Agent "${agentId}" not found`);
   if (!agentRegistries.has(agentId)) {
-    throw new Error(`Agent "${agentId}" is not a persistent managed agent.`);
+    throw new HttpError(404, `Agent "${agentId}" is not a persistent managed agent.`);
   }
 
   const name = agent.agent.role.name;

--- a/src/actions/tools/agents.ts
+++ b/src/actions/tools/agents.ts
@@ -153,6 +153,10 @@ export function listPersistentAgents(deps: AgentToolDeps) {
 export function terminatePersistentAgent(deps: AgentToolDeps, agentId: string) {
   if (!agentId) throw new Error('"agentId" is required');
 
+  if (deps.orchestrator.getPrimary()?.id === agentId) {
+    throw new Error('Cannot terminate the primary agent.');
+  }
+
   const agent = deps.orchestrator.getAgent(agentId);
   if (!agent) throw new Error(`Agent "${agentId}" not found`);
   if (!agentRegistries.has(agentId)) {

--- a/src/daemon/api-routes.ts
+++ b/src/daemon/api-routes.ts
@@ -663,6 +663,7 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
       },
     },
 
+    // Bun.serve matches literal paths (e.g. /api/agents/specialists) before patterns, so order is irrelevant.
     '/api/agents/:id': {
       DELETE: (req: Request & { params: { id: string } }) => {
         try {

--- a/src/daemon/api-routes.ts
+++ b/src/daemon/api-routes.ts
@@ -195,10 +195,9 @@ function buildAgentSnapshots(ctx: ApiContext) {
   const agents = orchestrator.getAllAgents().map((agent) => {
     const base = agent.toJSON();
     const latestTask = latestTaskByAgent.get(agent.id);
-    const busy = busyAgents.has(agent.id) || base.status === 'active' || Boolean(base.current_task);
     return {
       ...base,
-      busy,
+      busy: busyAgents.has(agent.id),
       latest_task: latestTask ? {
         id: latestTask.id,
         status: latestTask.status,
@@ -626,12 +625,9 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
           }
 
           const latestTask = taskManager.getAgentTask(spawned.agent.id);
-          const busy = taskManager.isAgentBusy(spawned.agent.id)
-            || spawned.agent.status === 'active'
-            || Boolean(spawned.agent.agent.current_task);
           return json({
             ...spawned.agent.toJSON(),
-            busy,
+            busy: taskManager.isAgentBusy(spawned.agent.id),
             latest_task: latestTask ? {
               id: latestTask.id,
               status: latestTask.status,

--- a/src/daemon/api-routes.ts
+++ b/src/daemon/api-routes.ts
@@ -43,6 +43,7 @@ import {
 } from '../vault/content-pipeline.ts';
 import {
   assignPersistentAgentTask,
+  HttpError,
   listPersistentAgents,
   spawnPersistentAgent,
   terminatePersistentAgent,
@@ -157,6 +158,11 @@ function json(data: unknown, status = 200): Response {
 
 function error(message: string, status = 400): Response {
   return json({ error: message }, status);
+}
+
+function errorFromException(err: unknown): Response {
+  if (err instanceof HttpError) return error(err.message, err.status);
+  return error(err instanceof Error ? err.message : String(err), 500);
 }
 
 function getSearchParams(req: Request): URLSearchParams {
@@ -639,7 +645,7 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
             assignment,
           }, 201);
         } catch (err) {
-          return error(err instanceof Error ? err.message : String(err));
+          return errorFromException(err);
         }
       },
     },
@@ -670,7 +676,7 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
           };
           return json(terminatePersistentAgent(deps, req.params.id));
         } catch (err) {
-          return error(err instanceof Error ? err.message : String(err));
+          return errorFromException(err);
         }
       },
     },

--- a/ui/src/components/office/OrbitalView.tsx
+++ b/ui/src/components/office/OrbitalView.tsx
@@ -259,25 +259,27 @@ export default function OrbitalView({ agents, agentActivity }: Props) {
 
         {/* Center Orb — Personal Assistant */}
         <div className="ag-center-orb" style={{ left: "50%", top: "48%" }}>
-          <div
-            className="ag-orb-ring-outer"
-            style={{
-              width: "116px",
-              height: "116px",
-              top: "50%",
-              left: "50%",
-            }}
-          />
-          <div
-            className="ag-orb-ring-inner"
-            style={{
-              width: "96px",
-              height: "96px",
-              top: "50%",
-              left: "50%",
-            }}
-          />
-          <div className="ag-orb-core">🤖</div>
+          <div className="ag-orb-cluster">
+            <div
+              className="ag-orb-ring-outer"
+              style={{
+                width: "116px",
+                height: "116px",
+                top: "50%",
+                left: "50%",
+              }}
+            />
+            <div
+              className="ag-orb-ring-inner"
+              style={{
+                width: "96px",
+                height: "96px",
+                top: "50%",
+                left: "50%",
+              }}
+            />
+            <div className="ag-orb-core">🤖</div>
+          </div>
           <div className="ag-orb-label">Personal Assistant</div>
           <div className="ag-orb-badge">PRIMARY · AUTH 5</div>
         </div>

--- a/ui/src/pages/OfficePage.tsx
+++ b/ui/src/pages/OfficePage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useState, useEffect, useCallback, useRef } from "react";
 import { api } from "../hooks/useApi";
 import type { AgentActivityEvent } from "../hooks/useWebSocket";
 import CommandCenterView from "../components/office/CommandCenterView";
@@ -47,6 +47,7 @@ export default function OfficePage({ agentActivity }: Props) {
   const [selectedSpecialist, setSelectedSpecialist] = useState("software-engineer");
   const [spawnTask, setSpawnTask] = useState("");
   const [spawnContext, setSpawnContext] = useState("");
+  const dialogRef = useRef<HTMLDivElement | null>(null);
 
   const fetchAgents = useCallback(async () => {
     try {
@@ -85,6 +86,19 @@ export default function OfficePage({ agentActivity }: Props) {
     const timer = setTimeout(() => setSpawnMessage(null), 4000);
     return () => clearTimeout(timer);
   }, [spawnMessage]);
+
+  useEffect(() => {
+    if (spawnOpen) dialogRef.current?.focus();
+  }, [spawnOpen]);
+
+  useEffect(() => {
+    if (!spawnOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && !spawning) setSpawnOpen(false);
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [spawnOpen, spawning]);
 
   function getLive(roleId: string): LiveAgentInfo | null {
     return (
@@ -265,6 +279,8 @@ export default function OfficePage({ agentActivity }: Props) {
 
       {spawnMessage && (
         <div
+          role="status"
+          aria-live="polite"
           style={{
             position: "fixed",
             right: "24px",
@@ -300,6 +316,11 @@ export default function OfficePage({ agentActivity }: Props) {
           }}
         >
           <div
+            ref={dialogRef}
+            tabIndex={-1}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="spawn-dialog-title"
             onClick={(e) => e.stopPropagation()}
             style={{
               width: "min(560px, 100%)",
@@ -311,18 +332,21 @@ export default function OfficePage({ agentActivity }: Props) {
               padding: "20px",
               boxShadow: "0 24px 80px rgba(0,0,0,0.4)",
               flexShrink: 0,
+              outline: "none",
             }}
           >
             <div style={{ display: "flex", justifyContent: "space-between", gap: "12px", alignItems: "flex-start" }}>
               <div>
-                <div style={{ color: "var(--text-1)", fontSize: "16px", fontWeight: 600 }}>Spawn Agent</div>
+                <div id="spawn-dialog-title" style={{ color: "var(--text-1)", fontSize: "16px", fontWeight: 600 }}>Spawn Agent</div>
                 <div style={{ color: "var(--text-3)", fontSize: "12px", marginTop: "6px", lineHeight: 1.6 }}>
                   Create a persistent specialist and optionally assign a task immediately.
                 </div>
               </div>
               <button
+                type="button"
                 onClick={() => setSpawnOpen(false)}
                 disabled={spawning}
+                aria-label="Close"
                 style={modalDismissButtonStyle}
               >
                 ×

--- a/ui/src/pages/OfficePage.tsx
+++ b/ui/src/pages/OfficePage.tsx
@@ -80,6 +80,12 @@ export default function OfficePage({ agentActivity }: Props) {
     return () => clearInterval(interval);
   }, [fetchAgents, fetchSpecialists]);
 
+  useEffect(() => {
+    if (!spawnMessage) return;
+    const timer = setTimeout(() => setSpawnMessage(null), 4000);
+    return () => clearTimeout(timer);
+  }, [spawnMessage]);
+
   function getLive(roleId: string): LiveAgentInfo | null {
     return (
       liveAgents.find(

--- a/ui/src/pages/OfficePage.tsx
+++ b/ui/src/pages/OfficePage.tsx
@@ -392,10 +392,3 @@ export default function OfficePage({ agentActivity }: Props) {
     </div>
   );
 }
-
-const metaCardStyle: React.CSSProperties = {
-  border: "1px solid rgba(255,255,255,0.08)",
-  borderRadius: "12px",
-  background: "rgba(255,255,255,0.025)",
-  padding: "12px 14px",
-};

--- a/ui/src/pages/OfficePage.tsx
+++ b/ui/src/pages/OfficePage.tsx
@@ -48,16 +48,6 @@ export default function OfficePage({ agentActivity }: Props) {
   const [spawnTask, setSpawnTask] = useState("");
   const [spawnContext, setSpawnContext] = useState("");
 
-  function isAgentActive(agent: AgentWithLive): boolean {
-    if (agent.isPrimary) return true;
-    return Boolean(
-      agent.live?.busy
-      || agent.live?.status === "active"
-      || agent.live?.current_task
-      || agent.live?.latest_task?.status === "running"
-    );
-  }
-
   const fetchAgents = useCallback(async () => {
     try {
       const data = await api<LiveAgentInfo[]>("/api/agents");
@@ -114,7 +104,7 @@ export default function OfficePage({ agentActivity }: Props) {
     : allAgents;
 
   // Stats
-  const activeCount = allAgents.filter((agent) => isAgentActive(agent)).length;
+  const activeCount = allAgents.filter((a) => a.isPrimary || a.live?.busy).length;
   const totalCount = AGENT_ROSTER.length;
 
   const selectedSpecialistMeta = specialists.find((specialist) => specialist.id === selectedSpecialist) ?? null;

--- a/ui/src/pages/OfficePage.tsx
+++ b/ui/src/pages/OfficePage.tsx
@@ -281,19 +281,7 @@ export default function OfficePage({ agentActivity }: Props) {
         <div
           role="status"
           aria-live="polite"
-          style={{
-            position: "fixed",
-            right: "24px",
-            top: "24px",
-            zIndex: 40,
-            maxWidth: "360px",
-            padding: "10px 12px",
-            borderRadius: "10px",
-            border: `1px solid ${spawnMessage.type === "error" ? "rgba(248,113,113,0.28)" : "rgba(52,211,153,0.28)"}`,
-            background: spawnMessage.type === "error" ? "rgba(248,113,113,0.10)" : "rgba(52,211,153,0.10)",
-            color: spawnMessage.type === "error" ? "var(--rose)" : "var(--emerald)",
-            fontSize: "12px",
-          }}
+          className={`ag-spawn-toast${spawnMessage.type === "error" ? " error" : ""}`}
         >
           {spawnMessage.text}
         </div>
@@ -301,19 +289,8 @@ export default function OfficePage({ agentActivity }: Props) {
 
       {spawnOpen && (
         <div
+          className="ag-spawn-overlay"
           onClick={() => !spawning && setSpawnOpen(false)}
-          style={{
-            position: "fixed",
-            inset: 0,
-            background: "rgba(3,6,12,0.72)",
-            backdropFilter: "blur(8px)",
-            zIndex: 50,
-            display: "flex",
-            alignItems: "flex-start",
-            justifyContent: "center",
-            padding: "20px",
-            overflowY: "auto",
-          }}
         >
           <div
             ref={dialogRef}
@@ -321,24 +298,13 @@ export default function OfficePage({ agentActivity }: Props) {
             role="dialog"
             aria-modal="true"
             aria-labelledby="spawn-dialog-title"
+            className="ag-spawn-dialog"
             onClick={(e) => e.stopPropagation()}
-            style={{
-              width: "min(560px, 100%)",
-              marginTop: "40px",
-              marginBottom: "40px",
-              background: "rgba(9,13,22,0.98)",
-              border: "1px solid rgba(255,255,255,0.08)",
-              borderRadius: "18px",
-              padding: "20px",
-              boxShadow: "0 24px 80px rgba(0,0,0,0.4)",
-              flexShrink: 0,
-              outline: "none",
-            }}
           >
-            <div style={{ display: "flex", justifyContent: "space-between", gap: "12px", alignItems: "flex-start" }}>
+            <div className="ag-spawn-dialog-header">
               <div>
-                <div id="spawn-dialog-title" style={{ color: "var(--text-1)", fontSize: "16px", fontWeight: 600 }}>Spawn Agent</div>
-                <div style={{ color: "var(--text-3)", fontSize: "12px", marginTop: "6px", lineHeight: 1.6 }}>
+                <div id="spawn-dialog-title" className="ag-spawn-dialog-title">Spawn Agent</div>
+                <div className="ag-spawn-dialog-subtitle">
                   Create a persistent specialist and optionally assign a task immediately.
                 </div>
               </div>
@@ -347,39 +313,22 @@ export default function OfficePage({ agentActivity }: Props) {
                 onClick={() => setSpawnOpen(false)}
                 disabled={spawning}
                 aria-label="Close"
-                style={modalDismissButtonStyle}
+                className="ag-spawn-dialog-close"
               >
                 ×
               </button>
             </div>
 
-            <div style={{ display: "flex", flexDirection: "column", gap: "14px", marginTop: "18px" }}>
-              <div style={fieldLabelStyle}>
+            <div className="ag-spawn-dialog-body">
+              <div className="ag-spawn-field-label">
                 Specialist
-                <div style={{ display: "flex", flexDirection: "column", gap: "6px" }}>
+                <div className="ag-spawn-specialist-list">
                   {specialists.map((specialist) => (
                     <button
                       key={specialist.id}
                       type="button"
                       onClick={() => setSelectedSpecialist(specialist.id)}
-                      style={{
-                        display: "flex",
-                        alignItems: "center",
-                        gap: "10px",
-                        padding: "10px 12px",
-                        borderRadius: "10px",
-                        border: selectedSpecialist === specialist.id
-                          ? "1px solid rgba(34,211,238,0.4)"
-                          : "1px solid rgba(255,255,255,0.08)",
-                        background: selectedSpecialist === specialist.id
-                          ? "rgba(34,211,238,0.1)"
-                          : "rgba(255,255,255,0.03)",
-                        color: "var(--text-1)",
-                        cursor: "pointer",
-                        textAlign: "left",
-                        fontSize: "13px",
-                        fontWeight: selectedSpecialist === specialist.id ? 600 : 400,
-                      }}
+                      className={`ag-spawn-specialist-btn${selectedSpecialist === specialist.id ? " selected" : ""}`}
                     >
                       {specialist.name}
                     </button>
@@ -388,40 +337,52 @@ export default function OfficePage({ agentActivity }: Props) {
               </div>
 
               {selectedSpecialistMeta && (
-                <div style={{ color: "var(--text-3)", fontSize: "11px", lineHeight: 1.5, marginTop: "-6px" }}>
+                <div className="ag-spawn-specialist-meta">
                   {selectedSpecialistMeta.description}
                   {" · "}Auth {selectedSpecialistMeta.authority_level} · {selectedSpecialistMeta.tools.length} tools
                 </div>
               )}
 
-              <label style={fieldLabelStyle}>
+              <label className="ag-spawn-field-label">
                 Task
                 <textarea
                   value={spawnTask}
                   onChange={(e) => setSpawnTask(e.target.value)}
                   rows={2}
                   placeholder="Optional. Leave blank to spawn the agent in idle mode."
-                  style={{ ...fieldStyle, resize: "vertical", minHeight: "60px" }}
+                  className="ag-spawn-field-input"
+                  style={{ minHeight: "60px" }}
                 />
               </label>
 
-              <label style={fieldLabelStyle}>
+              <label className="ag-spawn-field-label">
                 Context
                 <textarea
                   value={spawnContext}
                   onChange={(e) => setSpawnContext(e.target.value)}
                   rows={2}
                   placeholder="Optional background context for the task."
-                  style={{ ...fieldStyle, resize: "vertical", minHeight: "48px" }}
+                  className="ag-spawn-field-input"
+                  style={{ minHeight: "48px" }}
                 />
               </label>
             </div>
 
-            <div style={{ display: "flex", justifyContent: "flex-end", gap: "10px", marginTop: "18px" }}>
-              <button onClick={() => setSpawnOpen(false)} disabled={spawning} style={modalSecondaryButtonStyle}>
+            <div className="ag-spawn-dialog-footer">
+              <button
+                type="button"
+                onClick={() => setSpawnOpen(false)}
+                disabled={spawning}
+                className="ag-spawn-btn-secondary"
+              >
                 Cancel
               </button>
-              <button onClick={handleSpawn} disabled={spawning || !selectedSpecialistMeta} style={modalPrimaryButtonStyle}>
+              <button
+                type="button"
+                onClick={handleSpawn}
+                disabled={spawning || !selectedSpecialistMeta}
+                className="ag-spawn-btn-primary"
+              >
                 {spawning ? "Spawning..." : spawnTask.trim() ? "Spawn And Assign" : "Spawn Agent"}
               </button>
             </div>
@@ -432,65 +393,9 @@ export default function OfficePage({ agentActivity }: Props) {
   );
 }
 
-const fieldLabelStyle: React.CSSProperties = {
-  display: "flex",
-  flexDirection: "column",
-  gap: "8px",
-  color: "var(--text-2)",
-  fontSize: "12px",
-  fontWeight: 600,
-};
-
-const fieldStyle: React.CSSProperties = {
-  width: "100%",
-  background: "rgba(255,255,255,0.03)",
-  border: "1px solid rgba(255,255,255,0.08)",
-  borderRadius: "10px",
-  color: "var(--text-1)",
-  colorScheme: "dark",
-  fontSize: "13px",
-  padding: "12px 14px",
-  outline: "none",
-};
-
 const metaCardStyle: React.CSSProperties = {
   border: "1px solid rgba(255,255,255,0.08)",
   borderRadius: "12px",
   background: "rgba(255,255,255,0.025)",
   padding: "12px 14px",
-};
-
-const modalPrimaryButtonStyle: React.CSSProperties = {
-  border: "1px solid rgba(34,211,238,0.24)",
-  background: "rgba(34,211,238,0.14)",
-  color: "var(--cyan)",
-  borderRadius: "10px",
-  padding: "10px 14px",
-  fontSize: "12px",
-  fontWeight: 600,
-  cursor: "pointer",
-};
-
-const modalSecondaryButtonStyle: React.CSSProperties = {
-  border: "1px solid rgba(255,255,255,0.08)",
-  background: "transparent",
-  color: "var(--text-2)",
-  borderRadius: "10px",
-  padding: "10px 14px",
-  fontSize: "12px",
-  fontWeight: 500,
-  cursor: "pointer",
-};
-
-const modalDismissButtonStyle: React.CSSProperties = {
-  width: "32px",
-  height: "32px",
-  borderRadius: "999px",
-  border: "1px solid rgba(255,255,255,0.12)",
-  background: "rgba(255,255,255,0.06)",
-  color: "var(--text-1)",
-  fontSize: "18px",
-  lineHeight: 1,
-  cursor: "pointer",
-  flexShrink: 0,
 };

--- a/ui/src/styles/agents.css
+++ b/ui/src/styles/agents.css
@@ -1513,7 +1513,7 @@
   position: fixed;
   right: 24px;
   top: 24px;
-  z-index: 40;
+  z-index: 310;
   max-width: 360px;
   padding: 10px 12px;
   border-radius: 10px;
@@ -1529,12 +1529,13 @@
 }
 
 /* === Spawn modal === */
+/* z-index must beat .ag-header (200), .ag-stats-bar (190), .ag-tab-bar (180). */
 .ag-spawn-overlay {
   position: fixed;
   inset: 0;
   background: rgba(3, 6, 12, 0.72);
   backdrop-filter: blur(8px);
-  z-index: 50;
+  z-index: 300;
   display: flex;
   align-items: flex-start;
   justify-content: center;

--- a/ui/src/styles/agents.css
+++ b/ui/src/styles/agents.css
@@ -1124,6 +1124,14 @@
   z-index: 20;
 }
 
+/* Anchors the rings to the core's footprint so they center on the emoji,
+   not on the middle of the core + label + badge stack. */
+.ag-orb-cluster {
+  position: relative;
+  width: 80px;
+  height: 80px;
+}
+
 .ag-orb-ring-outer {
   position: absolute;
   border-radius: 50%;

--- a/ui/src/styles/agents.css
+++ b/ui/src/styles/agents.css
@@ -1507,3 +1507,173 @@
   from { opacity: 0; transform: scale(0.92) translateY(6px); }
   to   { opacity: 1; transform: scale(1) translateY(0); }
 }
+
+/* === Spawn toast === */
+.ag-spawn-toast {
+  position: fixed;
+  right: 24px;
+  top: 24px;
+  z-index: 40;
+  max-width: 360px;
+  padding: 10px 12px;
+  border-radius: 10px;
+  font-size: 12px;
+  border: 1px solid rgba(52, 211, 153, 0.28);
+  background: rgba(52, 211, 153, 0.10);
+  color: var(--emerald);
+}
+.ag-spawn-toast.error {
+  border-color: rgba(248, 113, 113, 0.28);
+  background: rgba(248, 113, 113, 0.10);
+  color: var(--rose);
+}
+
+/* === Spawn modal === */
+.ag-spawn-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(3, 6, 12, 0.72);
+  backdrop-filter: blur(8px);
+  z-index: 50;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 20px;
+  overflow-y: auto;
+}
+
+.ag-spawn-dialog {
+  width: min(560px, 100%);
+  margin: 40px 0;
+  background: rgba(9, 13, 22, 0.98);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 18px;
+  padding: 20px;
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.4);
+  flex-shrink: 0;
+  outline: none;
+}
+
+.ag-spawn-dialog-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: flex-start;
+}
+.ag-spawn-dialog-title {
+  color: var(--text-1);
+  font-size: 16px;
+  font-weight: 600;
+}
+.ag-spawn-dialog-subtitle {
+  color: var(--text-3);
+  font-size: 12px;
+  margin-top: 6px;
+  line-height: 1.6;
+}
+.ag-spawn-dialog-close {
+  width: 32px;
+  height: 32px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--text-1);
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+.ag-spawn-dialog-close:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.ag-spawn-dialog-body {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  margin-top: 18px;
+}
+.ag-spawn-field-label {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  color: var(--text-2);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.ag-spawn-specialist-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.ag-spawn-specialist-btn {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--text-1);
+  cursor: pointer;
+  text-align: left;
+  font-size: 13px;
+  font-weight: 400;
+}
+.ag-spawn-specialist-btn.selected {
+  border-color: rgba(34, 211, 238, 0.4);
+  background: rgba(34, 211, 238, 0.1);
+  font-weight: 600;
+}
+.ag-spawn-specialist-meta {
+  color: var(--text-3);
+  font-size: 11px;
+  line-height: 1.5;
+  margin-top: -6px;
+}
+
+.ag-spawn-field-input {
+  width: 100%;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 10px;
+  color: var(--text-1);
+  color-scheme: dark;
+  font-size: 13px;
+  padding: 12px 14px;
+  outline: none;
+  resize: vertical;
+}
+
+.ag-spawn-dialog-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  margin-top: 18px;
+}
+.ag-spawn-btn-primary,
+.ag-spawn-btn-secondary {
+  border-radius: 10px;
+  padding: 10px 14px;
+  font-size: 12px;
+  cursor: pointer;
+}
+.ag-spawn-btn-primary {
+  border: 1px solid rgba(34, 211, 238, 0.24);
+  background: rgba(34, 211, 238, 0.14);
+  color: var(--cyan);
+  font-weight: 600;
+}
+.ag-spawn-btn-secondary {
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: transparent;
+  color: var(--text-2);
+  font-weight: 500;
+}
+.ag-spawn-btn-primary:disabled,
+.ag-spawn-btn-secondary:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}


### PR DESCRIPTION
Changes

  - Unified "busy" semantics — single source (TaskManager) instead of three disagreeing definitions across the backend
  snapshot and UI filters. Primary no longer reports busy while idle.
  - Explicit guard against terminating the primary agent (was masked by an incidental "not a persistent managed agent"
  error).
  - Proper HTTP status codes on agent endpoints (400/404/409/500/503) via a small HttpError class, instead of blanket
  400.
  - Spawn modal a11y: role="dialog" + aria-modal + aria-labelledby, Escape handler, autofocus on open, aria-label on ×,
  aria-live toast.
  - Spawn modal styling: inline styles moved into agents.css; z-index raised above header/stats/tabs (was rendering
  behind them).
  - Spawn toast auto-dismisses after 4s.
  - Orbital view: primary orb rings were ~27px below the emoji core (centered on flex-column midpoint, not core).
  Wrapped rings+core in .ag-orb-cluster; now sub-pixel aligned.
  - Cleanup: removed dead metaCardStyle; documented Bun.serve route precedence above /api/agents/:id.

  Test plan

  - bun test (485 pass) and bunx tsc --noEmit clean on every commit
  - Backend endpoints verified via curl — status codes, busy semantics, primary-guard, sub-agent busy→idle transition
  - Orbital view re-measured via Chrome DevTools — ring and core centers aligned to sub-pixel
  - Manual UI pass remaining: keyboard focus, screen reader, toast timing, visual parity