### PR TITLE
Ask for the real dashboard URL during sidecar enrollment

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,8 @@ Paste and run the copied command on the machine where you installed the sidecar:
 jarvis-sidecar --token <your-token>
 ```
 
+The first enrollment run prompts for the dashboard URL before saving the sidecar config. Press Enter to keep the URL from the token, or enter your reverse-proxied dashboard URL if this machine should connect somewhere other than the default.
+
 The sidecar saves the token locally, so on subsequent runs you just need:
 
 ```bash

--- a/docs/sidecar/SIDECAR_AUTHENTICATION.md
+++ b/docs/sidecar/SIDECAR_AUTHENTICATION.md
@@ -78,7 +78,7 @@ The brain creates a signed JWT containing:
 
 ### Step 3: User Copies Token to Sidecar
 
-The dashboard displays the JWT as a copyable string. The user pastes it into the sidecar process configuration (e.g., `~/.jarvis-sidecar/config.yaml`).
+The dashboard displays the JWT as a copyable string. The user runs `jarvis-sidecar --token <jwt>` on the target machine. During first-run onboarding, the sidecar prompts for the dashboard URL before saving `~/.jarvis-sidecar/config.yaml`, which lets the user override the token's default URL for reverse-proxied deployments.
 
 ### Step 4: Sidecar Verifies Token
 

--- a/sidecar/README.md
+++ b/sidecar/README.md
@@ -25,6 +25,8 @@ GOOS=windows go build -o jarvis-sidecar.exe .
 ./jarvis-sidecar
 ```
 
+On first enrollment, the sidecar prompts for the dashboard URL before saving `~/.jarvis-sidecar/config.yaml`. Press Enter to keep the URL embedded in the token, or provide your reverse-proxied dashboard URL to override it.
+
 ## File Structure
 
 ### Core
@@ -32,7 +34,7 @@ GOOS=windows go build -o jarvis-sidecar.exe .
 | File | Purpose |
 |---|---|
 | `main.go` | Entry point, flag parsing, signal handling |
-| `config.go` | YAML config loading/saving (`~/.jarvis/sidecar.yaml`) |
+| `config.go` | YAML config loading/saving (`~/.jarvis-sidecar/config.yaml`) |
 | `types.go` | Shared types: capabilities, RPC messages, config structs |
 | `client.go` | WebSocket client, reconnect loop, preflight integration |
 | `handlers.go` | RPC handler registry (terminal, filesystem, clipboard, screenshot, config, system info) |

--- a/sidecar/client.go
+++ b/sidecar/client.go
@@ -64,7 +64,16 @@ func normalizeBrainOverride(raw string) string {
 		return ""
 	}
 	if strings.HasPrefix(trimmed, "ws://") || strings.HasPrefix(trimmed, "wss://") {
-		return trimmed
+		u, err := url.Parse(trimmed)
+		if err != nil || u.Host == "" {
+			return trimmed
+		}
+		if u.Path == "" || u.Path == "/" {
+			u.Path = "/sidecar/connect"
+		}
+		u.RawQuery = ""
+		u.Fragment = ""
+		return u.String()
 	}
 	if strings.HasPrefix(trimmed, "http://") || strings.HasPrefix(trimmed, "https://") {
 		u, err := url.Parse(trimmed)
@@ -75,14 +84,40 @@ func normalizeBrainOverride(raw string) string {
 		if u.Scheme == "https" {
 			wsScheme = "wss"
 		}
-		return fmt.Sprintf("%s://%s/sidecar/connect", wsScheme, u.Host)
+		path := strings.TrimRight(u.Path, "/")
+		if !strings.HasSuffix(path, "/sidecar/connect") {
+			path += "/sidecar/connect"
+		}
+		if path == "" {
+			path = "/sidecar/connect"
+		}
+		u.Scheme = wsScheme
+		u.Path = path
+		u.RawPath = ""
+		u.RawQuery = ""
+		u.Fragment = ""
+		return u.String()
 	}
 
 	wsScheme := "wss"
 	if strings.Contains(trimmed, "localhost") || strings.Contains(trimmed, "127.0.0.1") || strings.Contains(trimmed, ":") {
 		wsScheme = "ws"
 	}
-	return fmt.Sprintf("%s://%s/sidecar/connect", wsScheme, trimmed)
+
+	host := trimmed
+	path := ""
+	if slash := strings.Index(trimmed, "/"); slash >= 0 {
+		host = trimmed[:slash]
+		path = trimmed[slash:]
+	}
+	path = strings.TrimRight(path, "/")
+	if !strings.HasSuffix(path, "/sidecar/connect") {
+		path += "/sidecar/connect"
+	}
+	if path == "" {
+		path = "/sidecar/connect"
+	}
+	return fmt.Sprintf("%s://%s%s", wsScheme, host, path)
 }
 
 func (c *SidecarClient) Start(ctx context.Context) {

--- a/sidecar/client_test.go
+++ b/sidecar/client_test.go
@@ -47,3 +47,19 @@ func TestNormalizeBrainOverrideAcceptsHTTPOrigin(t *testing.T) {
 		t.Fatalf("expected %q, got %q", want, got)
 	}
 }
+
+func TestNormalizeBrainOverridePreservesReverseProxyPath(t *testing.T) {
+	got := normalizeBrainOverride("https://brain.example.com/jarvis")
+	want := "wss://brain.example.com/jarvis/sidecar/connect"
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}
+
+func TestNormalizeBrainOverrideAddsMissingWebsocketPath(t *testing.T) {
+	got := normalizeBrainOverride("wss://brain.example.com")
+	want := "wss://brain.example.com/sidecar/connect"
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}

--- a/sidecar/main.go
+++ b/sidecar/main.go
@@ -19,7 +19,7 @@ func main() {
 		fmt.Println(`jarvis-sidecar — Jarvis sidecar client (Go)
 
 Usage:
-  jarvis-sidecar --token <jwt>    Enroll and start (saves token to config)
+  jarvis-sidecar --token <jwt>    Enroll, answer onboarding prompts, and start
   jarvis-sidecar                  Start using saved token
   jarvis-sidecar --help           Show this help`)
 		os.Exit(0)
@@ -31,7 +31,9 @@ Usage:
 	}
 
 	if *token != "" {
-		cfg.Token = *token
+		if err := applyEnrollmentToken(cfg, *token, os.Stdin, os.Stdout, isInteractiveTerminal(os.Stdin) && isInteractiveTerminal(os.Stdout)); err != nil {
+			log.Fatalf("[sidecar] Failed to apply enrollment token: %v", err)
+		}
 		if err := SaveConfig(cfg); err != nil {
 			log.Fatalf("[sidecar] Failed to save config: %v", err)
 		}
@@ -61,4 +63,12 @@ Usage:
 	}()
 
 	client.Start(ctx)
+}
+
+func isInteractiveTerminal(file *os.File) bool {
+	info, err := file.Stat()
+	if err != nil {
+		return false
+	}
+	return (info.Mode() & os.ModeCharDevice) != 0
 }

--- a/sidecar/onboarding.go
+++ b/sidecar/onboarding.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"net/url"
+	"strings"
+)
+
+func applyEnrollmentToken(cfg *SidecarConfig, token string, in io.Reader, out io.Writer, interactive bool) error {
+	cfg.Token = token
+
+	claims, err := DecodeJWTPayload(token)
+	if err != nil {
+		return fmt.Errorf("decode enrollment token: %w", err)
+	}
+
+	if interactive {
+		if err := promptDashboardOverride(cfg, claims, in, out); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func promptDashboardOverride(cfg *SidecarConfig, claims *SidecarTokenClaims, in io.Reader, out io.Writer) error {
+	existing := strings.TrimSpace(cfg.Brain)
+	suggested := existing
+	if suggested == "" && claims != nil {
+		suggested = dashboardURLFromBrainEndpoint(claims.Brain)
+	}
+
+	fmt.Fprintln(out, "[sidecar] Sidecar onboarding")
+	switch {
+	case suggested != "" && existing != "":
+		fmt.Fprintf(out, "[sidecar] Dashboard URL [%s]: ", suggested)
+	case suggested != "":
+		fmt.Fprintf(out, "[sidecar] Dashboard URL (press Enter to use the token default) [%s]: ", suggested)
+	default:
+		fmt.Fprint(out, "[sidecar] Dashboard URL (optional, press Enter to use the token default): ")
+	}
+
+	answer, err := bufio.NewReader(in).ReadString('\n')
+	if err != nil && err != io.EOF {
+		return fmt.Errorf("read dashboard url: %w", err)
+	}
+
+	answer = strings.TrimSpace(answer)
+	if answer != "" {
+		cfg.Brain = answer
+		return nil
+	}
+
+	if existing == "" {
+		cfg.Brain = ""
+	}
+
+	return nil
+}
+
+func dashboardURLFromBrainEndpoint(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return ""
+	}
+
+	parsed, err := url.Parse(trimmed)
+	if err != nil || parsed.Host == "" {
+		return trimmed
+	}
+
+	switch parsed.Scheme {
+	case "ws":
+		parsed.Scheme = "http"
+	case "wss":
+		parsed.Scheme = "https"
+	}
+
+	path := strings.TrimSuffix(strings.TrimRight(parsed.Path, "/"), "/sidecar/connect")
+	parsed.Path = path
+	parsed.RawPath = ""
+	parsed.RawQuery = ""
+	parsed.Fragment = ""
+
+	if parsed.Path == "" {
+		return fmt.Sprintf("%s://%s", parsed.Scheme, parsed.Host)
+	}
+
+	return parsed.String()
+}

--- a/sidecar/onboarding_test.go
+++ b/sidecar/onboarding_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestApplyEnrollmentTokenUsesPromptedDashboardURL(t *testing.T) {
+	cfg := testConfig()
+	token := fakeToken(t, SidecarTokenClaims{
+		Sub:   "sidecar:test",
+		Jti:   "jti",
+		Sid:   "sid",
+		Name:  "test",
+		Brain: "ws://127.0.0.1:3142/sidecar/connect",
+		JWKS:  "http://127.0.0.1:3142/api/sidecars/.well-known/jwks.json",
+		Iat:   1,
+	})
+
+	var out bytes.Buffer
+	if err := applyEnrollmentToken(cfg, token, strings.NewReader("https://brain.example.com\n"), &out, true); err != nil {
+		t.Fatalf("applyEnrollmentToken returned error: %v", err)
+	}
+
+	if cfg.Token != token {
+		t.Fatalf("expected token to be saved on config")
+	}
+	if cfg.Brain != "https://brain.example.com" {
+		t.Fatalf("expected prompted dashboard URL override, got %q", cfg.Brain)
+	}
+	if !strings.Contains(out.String(), "Dashboard URL") {
+		t.Fatalf("expected onboarding prompt output, got %q", out.String())
+	}
+}
+
+func TestApplyEnrollmentTokenBlankInputUsesTokenDefault(t *testing.T) {
+	cfg := testConfig()
+	token := fakeToken(t, SidecarTokenClaims{
+		Sub:   "sidecar:test",
+		Jti:   "jti",
+		Sid:   "sid",
+		Name:  "test",
+		Brain: "wss://brain.example.com/jarvis/sidecar/connect",
+		JWKS:  "https://brain.example.com/jarvis/api/sidecars/.well-known/jwks.json",
+		Iat:   1,
+	})
+
+	if err := applyEnrollmentToken(cfg, token, strings.NewReader("\n"), &bytes.Buffer{}, true); err != nil {
+		t.Fatalf("applyEnrollmentToken returned error: %v", err)
+	}
+
+	if cfg.Brain != "" {
+		t.Fatalf("expected blank input to keep token default, got %q", cfg.Brain)
+	}
+}
+
+func TestDashboardURLFromBrainEndpointPreservesProxyPath(t *testing.T) {
+	got := dashboardURLFromBrainEndpoint("wss://brain.example.com/jarvis/sidecar/connect")
+	want := "https://brain.example.com/jarvis"
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}


### PR DESCRIPTION
## Summary
- prompt for the dashboard URL during `jarvis-sidecar --token` onboarding
- persist the chosen URL through the existing sidecar config override
- document the new first-run behavior and cover it with sidecar tests

## Why
Reverse-proxied deployments should not fail because the sidecar silently assumes a localhost-style dashboard URL.

## Verification
- go test ./... (sidecar)
