### PR TITLE
Force local Chrome/CDP traffic onto IPv4 loopback

### DIFF
--- a/sidecar/browser.go
+++ b/sidecar/browser.go
@@ -60,7 +60,7 @@ func newCDPClient(port int) (*cdpClient, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	url := fmt.Sprintf("http://localhost:%d/json", port)
+	url := localCDPHTTPURL(port, "/json")
 	req, _ := http.NewRequestWithContext(ctx, "GET", url, nil)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -87,6 +87,7 @@ func newCDPClient(port int) (*cdpClient, error) {
 	if wsURL == "" {
 		return nil, fmt.Errorf("no CDP page target found on port %d", port)
 	}
+	wsURL = preferIPv4Loopback(wsURL)
 
 	conn, _, err := websocket.Dial(ctx, wsURL, nil)
 	if err != nil {

--- a/sidecar/local_urls.go
+++ b/sidecar/local_urls.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"fmt"
+	"net/url"
+)
+
+const localLoopbackIPv4 = "127.0.0.1"
+
+func localCDPHTTPURL(port int, path string) string {
+	return fmt.Sprintf("http://%s:%d%s", localLoopbackIPv4, port, path)
+}
+
+func preferIPv4Loopback(raw string) string {
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return raw
+	}
+	if parsed.Hostname() != "localhost" {
+		return raw
+	}
+
+	if port := parsed.Port(); port != "" {
+		parsed.Host = netJoinHostPort(localLoopbackIPv4, port)
+	} else {
+		parsed.Host = localLoopbackIPv4
+	}
+	return parsed.String()
+}
+
+func netJoinHostPort(host, port string) string {
+	return host + ":" + port
+}

--- a/sidecar/local_urls_test.go
+++ b/sidecar/local_urls_test.go
@@ -1,0 +1,26 @@
+package main
+
+import "testing"
+
+func TestLocalCDPHTTPURLUsesIPv4Loopback(t *testing.T) {
+	got := localCDPHTTPURL(9222, "/json/version")
+	want := "http://127.0.0.1:9222/json/version"
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}
+
+func TestPreferIPv4LoopbackRewritesLocalhostWSURL(t *testing.T) {
+	got := preferIPv4Loopback("ws://localhost:9222/devtools/page/abc")
+	want := "ws://127.0.0.1:9222/devtools/page/abc"
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}
+
+func TestPreferIPv4LoopbackLeavesNonLocalhostUntouched(t *testing.T) {
+	input := "wss://brain.example.com/sidecar/connect"
+	if got := preferIPv4Loopback(input); got != input {
+		t.Fatalf("expected %q, got %q", input, got)
+	}
+}

--- a/sidecar/platform_darwin.go
+++ b/sidecar/platform_darwin.go
@@ -39,7 +39,7 @@ func launchChromeIfNeeded(cfg *SidecarConfig) {
 	}
 
 	// Check if Chrome is already listening
-	url := fmt.Sprintf("http://localhost:%d/json/version", port)
+	url := localCDPHTTPURL(port, "/json/version")
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 	req, _ := http.NewRequestWithContext(ctx, "GET", url, nil)

--- a/sidecar/platform_linux.go
+++ b/sidecar/platform_linux.go
@@ -46,7 +46,7 @@ func launchChromeIfNeeded(cfg *SidecarConfig) {
 	}
 
 	// Check if Chrome is already listening
-	url := fmt.Sprintf("http://localhost:%d/json/version", port)
+	url := localCDPHTTPURL(port, "/json/version")
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 	req, _ := http.NewRequestWithContext(ctx, "GET", url, nil)

--- a/sidecar/platform_windows.go
+++ b/sidecar/platform_windows.go
@@ -47,7 +47,7 @@ func launchChromeIfNeeded(cfg *SidecarConfig) {
 	}
 
 	// Check if Chrome is already listening
-	url := fmt.Sprintf("http://localhost:%d/json/version", port)
+	url := localCDPHTTPURL(port, "/json/version")
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 	req, _ := http.NewRequestWithContext(ctx, "GET", url, nil)


### PR DESCRIPTION
## Summary
- route local Chrome DevTools HTTP probes through `127.0.0.1`
- rewrite localhost websocket debugger URLs to IPv4 loopback before dialing
- add focused sidecar tests for the local loopback helpers

## Why
WSL2 and mixed IPv4/IPv6 hosts can resolve `localhost` differently between Chrome and the sidecar, which breaks browser automation startup.

## Verification
- go test ./... (sidecar)
