### PR TITLE
Make onboarding safer for WSL2 and piped installs

### DIFF
--- a/src/cli/helpers.ts
+++ b/src/cli/helpers.ts
@@ -95,6 +95,10 @@ export function ask(question: string, defaultValue?: string): Promise<string> {
  * Ask for a secret (API key, token). Masks input with asterisks.
  */
 export function askSecret(question: string): Promise<string> {
+  if (!process.stdin.isTTY) {
+    return ask(question);
+  }
+
   return new Promise((resolve) => {
     const r = getRL();
     process.stdout.write(`${c.cyan('?')} ${question}: `);

--- a/src/cli/onboard.ts
+++ b/src/cli/onboard.ts
@@ -20,6 +20,7 @@ import { runDependencyCheck } from './deps.ts';
 import { initDatabase, closeDb } from '../vault/schema.ts';
 import { saveUserProfile } from '../vault/user-profile.ts';
 import { USER_PROFILE_QUESTIONS, normalizeUserProfileAnswers } from '../user/profile.ts';
+import { DEFAULT_OLLAMA_BASE_URL, normalizeOllamaBaseUrl } from '../llm/ollama.ts';
 
 const JARVIS_DIR = join(homedir(), '.jarvis');
 const CONFIG_PATH = join(JARVIS_DIR, 'config.yaml');
@@ -275,7 +276,7 @@ export async function runOnboard(): Promise<void> {
     if (config.llm.openrouter) config.llm.openrouter.model = model;
 
   } else if (provider === 'ollama') {
-    const url = await ask('Ollama base URL', config.llm.ollama?.base_url ?? 'http://localhost:11434');
+    const url = await ask('Ollama base URL', config.llm.ollama?.base_url ?? DEFAULT_OLLAMA_BASE_URL);
 
     const currentModel = config.llm.ollama?.model ?? 'llama3';
     const ollamaModels = [
@@ -316,17 +317,44 @@ export async function runOnboard(): Promise<void> {
         manager.registerProvider(new OllamaProvider(config.llm.ollama?.base_url, config.llm.ollama?.model));
       }
 
+      if (!manager.getProvider(provider)) {
+        if (provider === 'ollama') {
+          throw new Error('Ollama was selected, but no Ollama configuration was captured.');
+        }
+        throw new Error(`No ${provider} credentials were captured. Re-enter the API key or edit ~/.jarvis/config.yaml manually.`);
+      }
+
       manager.setPrimary(provider);
-      const resp = await Promise.race([
-        manager.chat(
-          [{ role: 'user', content: 'Say "JARVIS online" in 3 words.' }],
-          { max_tokens: 20 },
-        ),
-        new Promise<never>((_, reject) =>
-          setTimeout(() => reject(new Error('Connection timed out (15s)')), 15_000),
-        ),
-      ]);
-      spin.stop(`Connected! Model: ${resp.model}`);
+
+      if (provider === 'ollama') {
+        const ollamaBaseUrl = normalizeOllamaBaseUrl(config.llm.ollama?.base_url);
+        const response = await Promise.race([
+          fetch(`${ollamaBaseUrl}/api/tags`),
+          new Promise<never>((_, reject) =>
+            setTimeout(() => reject(new Error('Connection timed out (10s)')), 10_000),
+          ),
+        ]);
+
+        if (!response.ok) {
+          const errorText = await response.text();
+          throw new Error(`Ollama API error (${response.status}): ${errorText}`);
+        }
+
+        const data = await response.json() as { models?: Array<{ name?: string }> };
+        const modelCount = data.models?.length ?? 0;
+        spin.stop(`Connected to Ollama at ${ollamaBaseUrl} (${modelCount} model${modelCount === 1 ? '' : 's'})`);
+      } else {
+        const resp = await Promise.race([
+          manager.chat(
+            [{ role: 'user', content: 'Say "JARVIS online" in 3 words.' }],
+            { max_tokens: 20 },
+          ),
+          new Promise<never>((_, reject) =>
+            setTimeout(() => reject(new Error('Connection timed out (15s)')), 15_000),
+          ),
+        ]);
+        spin.stop(`Connected! Model: ${resp.model}`);
+      }
     } catch (err) {
       spin.stop();
       printErr(`Connection failed: ${err}`);
@@ -378,7 +406,7 @@ export async function runOnboard(): Promise<void> {
       } else if (fb === 'ollama') {
         const setupOllama = await askYesNo('Configure Ollama as fallback?', false);
         if (setupOllama) {
-          const url = await ask('Ollama URL', 'http://localhost:11434');
+          const url = await ask('Ollama URL', DEFAULT_OLLAMA_BASE_URL);
           const model = await ask('Ollama model', 'llama3');
           config.llm.ollama = { base_url: url, model };
         }

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -107,7 +107,7 @@ llm:
       model: 'gemini-3-flash-preview',
     };
     testConfig.llm.ollama = {
-      base_url: 'http://localhost:11434',
+      base_url: 'http://127.0.0.1:11434',
       model: 'llama3.1',
     };
 
@@ -157,7 +157,7 @@ describe('Default Config', () => {
     expect(DEFAULT_CONFIG.llm.openai?.model).toBe('gpt-5.4');
     expect(DEFAULT_CONFIG.llm.gemini?.model).toBe('gemini-3-flash-preview');
     expect(DEFAULT_CONFIG.llm.ollama?.model).toBe('llama3');
-    expect(DEFAULT_CONFIG.llm.ollama?.base_url).toBe('http://localhost:11434');
+    expect(DEFAULT_CONFIG.llm.ollama?.base_url).toBe('http://127.0.0.1:11434');
   });
 });
 

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -249,7 +249,7 @@ export const DEFAULT_CONFIG: JarvisConfig = {
       model: 'gemini-3-flash-preview',
     },
     ollama: {
-      base_url: 'http://localhost:11434',
+      base_url: 'http://127.0.0.1:11434',
       model: 'llama3',
     },
     openrouter: {

--- a/src/daemon/llm-settings.ts
+++ b/src/daemon/llm-settings.ts
@@ -12,7 +12,7 @@ import { AnthropicProvider } from '../llm/anthropic.ts';
 import { OpenAIProvider } from '../llm/openai.ts';
 import { GroqProvider } from '../llm/groq.ts';
 import { GeminiProvider } from '../llm/gemini.ts';
-import { OllamaProvider } from '../llm/ollama.ts';
+import { DEFAULT_OLLAMA_BASE_URL, OllamaProvider } from '../llm/ollama.ts';
 import { OpenRouterProvider } from '../llm/openrouter.ts';
 import type { LLMProvider } from '../llm/provider.ts';
 import type { LLMManager } from '../llm/manager.ts';
@@ -60,7 +60,7 @@ export function getLLMSettings(config: JarvisConfig): LLMSettingsResponse {
   const groqModel = getSetting(SETTING_GROQ_MODEL) ?? config.llm.groq?.model ?? 'llama-3.3-70b-versatile';
   const geminiModel = getSetting(SETTING_GEMINI_MODEL) ?? config.llm.gemini?.model ?? 'gemini-3-flash-preview';
   const ollamaModel = getSetting(SETTING_OLLAMA_MODEL) ?? config.llm.ollama?.model ?? 'llama3';
-  const ollamaBaseUrl = getSetting(SETTING_OLLAMA_BASE_URL) ?? config.llm.ollama?.base_url ?? 'http://localhost:11434';
+  const ollamaBaseUrl = getSetting(SETTING_OLLAMA_BASE_URL) ?? config.llm.ollama?.base_url ?? DEFAULT_OLLAMA_BASE_URL;
 
   const openrouterModel = getSetting(SETTING_OPENROUTER_MODEL) ?? config.llm.openrouter?.model ?? 'anthropic/claude-sonnet-4';
 
@@ -307,7 +307,7 @@ export function mergeLLMSettingsIntoConfig(config: JarvisConfig): void {
       model: dbOllamaModel ?? config.llm.ollama?.model,
       base_url: (!process.env.JARVIS_OLLAMA_URL && dbOllamaUrl)
         ? dbOllamaUrl
-        : (config.llm.ollama?.base_url ?? 'http://localhost:11434'),
+        : (config.llm.ollama?.base_url ?? DEFAULT_OLLAMA_BASE_URL),
     };
   }
 


### PR DESCRIPTION
## Summary
- let secret prompts fall back to the interactive TTY path during piped setup runs
- prefer `http://127.0.0.1:11434` for default Ollama settings in onboarding/config
- improve the Ollama onboarding connectivity check for local installs

## Why
Piped installer sessions were losing provider API keys, and WSL2 loopback differences made the default Ollama setup brittle.

## Verification
- bun test src/config/loader.test.ts src/llm/provider.test.ts
- bunx tsc --noEmit
