### PR TITLE
Reduce LLM request bloat and fail over more gracefully

### DIFF
--- a/src/actions/tools/builtin.ts
+++ b/src/actions/tools/builtin.ts
@@ -32,13 +32,21 @@ export { setNoLocalTools, isNoLocalTools, setDefaultCwd } from './local-tools-gu
  * Convert a ToolDefinition's parameters to JSON Schema for LLM tool use.
  */
 export function toolDefToLLMTool(tool: ToolDefinition): LLMTool {
+  const compact = (text: string, maxLen: number): string => {
+    const normalized = text.replace(/\s+/g, ' ').trim();
+    if (normalized.length <= maxLen) return normalized;
+    const sentence = normalized.match(/^(.{1,120}?[.!?])(?:\s|$)/)?.[1];
+    if (sentence && sentence.length <= maxLen) return sentence;
+    return normalized.slice(0, maxLen - 1).trimEnd() + '…';
+  };
+
   const properties: Record<string, unknown> = {};
   const required: string[] = [];
 
   for (const [name, param] of Object.entries(tool.parameters)) {
     properties[name] = {
       type: param.type,
-      description: param.description,
+      description: compact(param.description, 96),
     };
     if (param.required) {
       required.push(name);
@@ -47,7 +55,7 @@ export function toolDefToLLMTool(tool: ToolDefinition): LLMTool {
 
   return {
     name: tool.name,
-    description: tool.description,
+    description: compact(tool.description, 160),
     parameters: {
       type: 'object',
       properties,

--- a/src/llm/anthropic.ts
+++ b/src/llm/anthropic.ts
@@ -55,6 +55,7 @@ type AnthropicStreamEvent =
 
 const MAX_RETRIES = 0;
 const RETRY_BASE_DELAY_MS = 5000; // 5s, 10s, 20s
+const DEFAULT_MAX_TOKENS = 2048;
 
 export class AnthropicProvider implements LLMProvider {
   name = 'anthropic';
@@ -106,7 +107,7 @@ export class AnthropicProvider implements LLMProvider {
   }
 
   async chat(messages: LLMMessage[], options: LLMOptions = {}): Promise<LLMResponse> {
-    const { model = this.defaultModel, temperature, max_tokens = 16384, tools, tool_choice } = options;
+    const { model = this.defaultModel, temperature, max_tokens = DEFAULT_MAX_TOKENS, tools, tool_choice } = options;
 
     // Compact history for Claude's context window
     const budget = calculateHistoryBudget(200000);
@@ -132,7 +133,7 @@ export class AnthropicProvider implements LLMProvider {
   }
 
   async *stream(messages: LLMMessage[], options: LLMOptions = {}): AsyncIterable<LLMStreamEvent> {
-    const { model = this.defaultModel, temperature, max_tokens = 16384, tools, tool_choice } = options;
+    const { model = this.defaultModel, temperature, max_tokens = DEFAULT_MAX_TOKENS, tools, tool_choice } = options;
 
     // Compact history for Claude's context window
     const budget = calculateHistoryBudget(200000);

--- a/src/llm/gemini.ts
+++ b/src/llm/gemini.ts
@@ -52,6 +52,7 @@ type GeminiStreamChunk = {
 
 const MAX_RETRIES = 0;
 const RETRY_BASE_DELAY_MS = 5000;
+const DEFAULT_MAX_TOKENS = 2048;
 
 export class GeminiProvider implements LLMProvider {
   name = 'gemini';
@@ -89,7 +90,7 @@ export class GeminiProvider implements LLMProvider {
   }
 
   async chat(messages: LLMMessage[], options: LLMOptions = {}): Promise<LLMResponse> {
-    const { model = this.defaultModel, temperature, max_tokens, tools, tool_choice } = options;
+    const { model = this.defaultModel, temperature, max_tokens = DEFAULT_MAX_TOKENS, tools, tool_choice } = options;
     const url = `${this.baseUrl}/models/${model}:generateContent?key=${this.apiKey}`;
 
     // Compact history for Gemini's context limits
@@ -103,7 +104,7 @@ export class GeminiProvider implements LLMProvider {
 
     const generationConfig: Record<string, unknown> = {};
     if (temperature !== undefined) generationConfig.temperature = temperature;
-    if (max_tokens !== undefined) generationConfig.maxOutputTokens = max_tokens;
+    generationConfig.maxOutputTokens = max_tokens;
     if (Object.keys(generationConfig).length > 0) body.generationConfig = generationConfig;
 
     if (tools && tools.length > 0) {
@@ -116,7 +117,7 @@ export class GeminiProvider implements LLMProvider {
   }
 
   async *stream(messages: LLMMessage[], options: LLMOptions = {}): AsyncIterable<LLMStreamEvent> {
-    const { model = this.defaultModel, temperature, max_tokens, tools, tool_choice } = options;
+    const { model = this.defaultModel, temperature, max_tokens = DEFAULT_MAX_TOKENS, tools, tool_choice } = options;
     const url = `${this.baseUrl}/models/${model}:streamGenerateContent?alt=sse&key=${this.apiKey}`;
 
     // Compact history for Gemini's context limits
@@ -130,7 +131,7 @@ export class GeminiProvider implements LLMProvider {
 
     const generationConfig: Record<string, unknown> = {};
     if (temperature !== undefined) generationConfig.temperature = temperature;
-    if (max_tokens !== undefined) generationConfig.maxOutputTokens = max_tokens;
+    generationConfig.maxOutputTokens = max_tokens;
     if (Object.keys(generationConfig).length > 0) body.generationConfig = generationConfig;
 
     if (tools && tools.length > 0) {

--- a/src/llm/groq.ts
+++ b/src/llm/groq.ts
@@ -90,6 +90,7 @@ export class GroqProvider implements LLMProvider {
   private static readonly MAX_ASSISTANT_MESSAGE_CHARS = 3_500;
   private static readonly MAX_TOOL_MESSAGE_CHARS = 2_000;
   private static readonly MIN_RECENT_MESSAGES = 6;
+  private static readonly DEFAULT_MAX_TOKENS = 2048;
 
   constructor(apiKey: string, defaultModel = 'llama-3.3-70b-versatile') {
     this.apiKey = apiKey;
@@ -290,7 +291,7 @@ export class GroqProvider implements LLMProvider {
     stream: boolean,
     promptBudget: number
   ): Record<string, unknown> {
-    const { model = this.defaultModel, temperature, max_tokens, tools } = options;
+    const { model = this.defaultModel, temperature, max_tokens = GroqProvider.DEFAULT_MAX_TOKENS, tools } = options;
     const body: Record<string, unknown> = {
       model,
       messages: this.convertMessages(this.compactMessages(messages, promptBudget, tools)),
@@ -298,7 +299,7 @@ export class GroqProvider implements LLMProvider {
 
     if (stream) body.stream = true;
     if (temperature !== undefined) body.temperature = temperature;
-    if (max_tokens !== undefined) body.max_completion_tokens = max_tokens;
+    body.max_completion_tokens = max_tokens;
     if (tools && tools.length > 0) {
       body.tools = this.convertTools(tools);
       body.tool_choice = 'auto';

--- a/src/llm/manager.ts
+++ b/src/llm/manager.ts
@@ -10,9 +10,11 @@ export class LLMManager {
   private providers: Map<string, LLMProvider> = new Map();
   private primaryProvider = '';
   private fallbackChain: string[] = [];
+  private providerCooldowns: Map<string, number> = new Map();
   private static readonly MAX_RETRIES_PER_PROVIDER = 3;
   private static readonly REQUEST_TIMEOUT_MS = 90000; // 90 second timeout for LLM calls
   private static readonly isDebugging = process.env.JARVIS_LOG_LEVEL === 'debug' || process.env.DEBUG_LLM === 'true';
+  private static readonly DEFAULT_RATE_LIMIT_COOLDOWN_MS = 15 * 60 * 1000;
 
   constructor() {}
 
@@ -103,13 +105,58 @@ export class LLMManager {
 
     const msg = error.message.toLowerCase();
     // Retry on network/timeout errors, not on auth/validation errors
-    return msg.includes('timeout') ||
+    return (msg.includes('timeout') ||
       msg.includes('econnrefused') ||
       msg.includes('enotfound') ||
       msg.includes('network') ||
       msg.includes('temporarily unavailable') ||
-      msg.includes('429') ||  // rate limit
-      msg.includes('503');    // service unavailable
+      msg.includes('503')) && !this.extractRateLimitCooldownMs(error);
+  }
+
+  private getCooldownUntil(providerName: string): number | null {
+    const until = this.providerCooldowns.get(providerName);
+    if (!until) return null;
+    if (Date.now() >= until) {
+      this.providerCooldowns.delete(providerName);
+      return null;
+    }
+    return until;
+  }
+
+  private formatCooldown(providerName: string): string | null {
+    const until = this.getCooldownUntil(providerName);
+    if (!until) return null;
+    const remainingMs = Math.max(0, until - Date.now());
+    const totalSeconds = Math.ceil(remainingMs / 1000);
+    const hours = Math.floor(totalSeconds / 3600);
+    const minutes = Math.floor((totalSeconds % 3600) / 60);
+    const seconds = totalSeconds % 60;
+    const parts: string[] = [];
+    if (hours > 0) parts.push(`${hours}h`);
+    if (minutes > 0) parts.push(`${minutes}m`);
+    if (seconds > 0 || parts.length === 0) parts.push(`${seconds}s`);
+    return `Provider '${providerName}' temporarily skipped due to rate limit (${parts.join(' ')} remaining)`;
+  }
+
+  private extractRateLimitCooldownMs(error: unknown): number | null {
+    if (!(error instanceof Error)) return null;
+    const msg = error.message.toLowerCase();
+    if (!msg.includes('rate limit') && !msg.includes('429')) {
+      return null;
+    }
+
+    const original = error.message;
+    const tryAgainMatch = original.match(/try again in\s+((?:(?:\d+(?:\.\d+)?)h)?(?:(?:\d+(?:\.\d+)?)m)?(?:(?:\d+(?:\.\d+)?)s)?)/i);
+    const durationText = tryAgainMatch?.[1]?.trim();
+    const parsed = durationText ? this.parseDurationMs(durationText) : 0;
+    return parsed > 0 ? parsed : LLMManager.DEFAULT_RATE_LIMIT_COOLDOWN_MS;
+  }
+
+  private parseDurationMs(raw: string): number {
+    const hours = parseFloat(raw.match(/(\d+(?:\.\d+)?)h/i)?.[1] ?? '0');
+    const minutes = parseFloat(raw.match(/(\d+(?:\.\d+)?)m/i)?.[1] ?? '0');
+    const seconds = parseFloat(raw.match(/(\d+(?:\.\d+)?)s/i)?.[1] ?? '0');
+    return Math.round((hours * 3600 + minutes * 60 + seconds) * 1000);
   }
 
   /**
@@ -124,6 +171,12 @@ export class LLMManager {
     const failures: string[] = [];
 
     for (const providerName of this.getProviderSequence(overridePrimary)) {
+      const cooldownMessage = this.formatCooldown(providerName);
+      if (cooldownMessage) {
+        failures.push(cooldownMessage);
+        continue;
+      }
+
       const provider = this.providers.get(providerName);
       if (!provider) {
         failures.push(`Provider '${providerName}' not registered`);
@@ -141,6 +194,11 @@ export class LLMManager {
         } catch (err) {
           const errorMsg = err instanceof Error ? err.message : String(err);
           errors.push(`attempt ${attempt}: ${errorMsg}`);
+
+          const cooldownMs = this.extractRateLimitCooldownMs(err);
+          if (cooldownMs) {
+            this.providerCooldowns.set(providerName, Date.now() + cooldownMs);
+          }
 
           const shouldRetry = this.shouldRetry(err);
           console.error(
@@ -165,6 +223,12 @@ export class LLMManager {
     const failures: string[] = [];
 
     for (const providerName of this.getProviderSequence()) {
+      const cooldownMessage = this.formatCooldown(providerName);
+      if (cooldownMessage) {
+        failures.push(cooldownMessage);
+        continue;
+      }
+
       const provider = this.providers.get(providerName);
       if (!provider) {
         failures.push(`Provider '${providerName}' not registered`);
@@ -201,6 +265,11 @@ export class LLMManager {
         } catch (err) {
           const errorMsg = err instanceof Error ? err.message : String(err);
           errors.push(`attempt ${attempt}: ${errorMsg}`);
+
+          const cooldownMs = this.extractRateLimitCooldownMs(err);
+          if (cooldownMs) {
+            this.providerCooldowns.set(providerName, Date.now() + cooldownMs);
+          }
 
           const shouldRetry = this.shouldRetry(err);
           console.error(

--- a/src/llm/ollama.ts
+++ b/src/llm/ollama.ts
@@ -71,14 +71,59 @@ type OllamaModelInfo = {
   digest: string;
 };
 
+export const DEFAULT_OLLAMA_BASE_URL = 'http://127.0.0.1:11434';
+
+export function normalizeOllamaBaseUrl(baseUrl = DEFAULT_OLLAMA_BASE_URL): string {
+  const trimmed = baseUrl.trim().replace(/\/$/, '');
+  if (!trimmed) return DEFAULT_OLLAMA_BASE_URL;
+
+  try {
+    const parsed = new URL(trimmed);
+    if (parsed.hostname === 'localhost') {
+      parsed.hostname = '127.0.0.1';
+    }
+    return parsed.toString().replace(/\/$/, '');
+  } catch {
+    return trimmed;
+  }
+}
+
 export class OllamaProvider implements LLMProvider {
   name = 'ollama';
   private baseUrl: string;
   private defaultModel: string;
 
-  constructor(baseUrl = 'http://localhost:11434', defaultModel = 'llama3') {
-    this.baseUrl = baseUrl.replace(/\/$/, ''); // Remove trailing slash
+  constructor(baseUrl = DEFAULT_OLLAMA_BASE_URL, defaultModel = 'llama3') {
+    this.baseUrl = normalizeOllamaBaseUrl(baseUrl);
     this.defaultModel = defaultModel;
+  }
+
+  private async sendRequest(body: Record<string, unknown>, allowToolRetry: boolean): Promise<Response> {
+    const response = await fetch(`${this.baseUrl}/api/chat`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok && allowToolRetry) {
+      const errorText = await response.text();
+      if (response.status === 400 && errorText.includes('does not support tools')) {
+        const retryBody = { ...body };
+        delete retryBody.tools;
+        return fetch(`${this.baseUrl}/api/chat`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(retryBody),
+        });
+      }
+      throw new Error(`Ollama API error (${response.status}): ${errorText}`);
+    }
+
+    return response;
   }
 
   async chat(messages: LLMMessage[], options: LLMOptions = {}): Promise<LLMResponse> {
@@ -102,13 +147,7 @@ export class OllamaProvider implements LLMProvider {
       body.tools = this.convertTools(tools);
     }
 
-    const response = await fetch(`${this.baseUrl}/api/chat`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify(body),
-    });
+    const response = await this.sendRequest(body, !!(tools && tools.length > 0));
 
     if (!response.ok) {
       const errorText = await response.text();
@@ -140,13 +179,13 @@ export class OllamaProvider implements LLMProvider {
       body.tools = this.convertTools(tools);
     }
 
-    const response = await fetch(`${this.baseUrl}/api/chat`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify(body),
-    });
+    let response: Response;
+    try {
+      response = await this.sendRequest(body, !!(tools && tools.length > 0));
+    } catch (err) {
+      yield { type: 'error', error: err instanceof Error ? err.message : String(err) };
+      return;
+    }
 
     if (!response.ok) {
       const errorText = await response.text();

--- a/src/llm/openai.ts
+++ b/src/llm/openai.ts
@@ -84,6 +84,7 @@ export class OpenAIProvider implements LLMProvider {
   private apiKey: string;
   private defaultModel: string;
   private apiUrl = 'https://api.openai.com/v1/chat/completions';
+  private static readonly DEFAULT_MAX_TOKENS = 2048;
 
   constructor(apiKey: string, defaultModel = 'gpt-4o') {
     this.apiKey = apiKey;
@@ -91,7 +92,7 @@ export class OpenAIProvider implements LLMProvider {
   }
 
   async chat(messages: LLMMessage[], options: LLMOptions = {}): Promise<LLMResponse> {
-    const { model = this.defaultModel, temperature, max_tokens, tools, tool_choice } = options;
+    const { model = this.defaultModel, temperature, max_tokens = OpenAIProvider.DEFAULT_MAX_TOKENS, tools, tool_choice } = options;
 
     // Compact history for large contexts (128k token limit)
     const budget = calculateHistoryBudget(128000);
@@ -103,7 +104,7 @@ export class OpenAIProvider implements LLMProvider {
     };
 
     if (temperature !== undefined) body.temperature = temperature;
-    if (max_tokens !== undefined) body.max_tokens = max_tokens;
+    body.max_tokens = max_tokens;
     if (tools && tools.length > 0) {
       body.tools = this.convertTools(tools);
       body.tool_choice = tool_choice || 'auto';  // Enable tool calling
@@ -128,7 +129,7 @@ export class OpenAIProvider implements LLMProvider {
   }
 
   async *stream(messages: LLMMessage[], options: LLMOptions = {}): AsyncIterable<LLMStreamEvent> {
-    const { model = this.defaultModel, temperature, max_tokens, tools, tool_choice } = options;
+    const { model = this.defaultModel, temperature, max_tokens = OpenAIProvider.DEFAULT_MAX_TOKENS, tools, tool_choice } = options;
 
     // Compact history for large contexts (128k token limit)
     const budget = calculateHistoryBudget(128000);
@@ -141,7 +142,7 @@ export class OpenAIProvider implements LLMProvider {
     };
 
     if (temperature !== undefined) body.temperature = temperature;
-    if (max_tokens !== undefined) body.max_tokens = max_tokens;
+    body.max_tokens = max_tokens;
     if (tools && tools.length > 0) {
       body.tools = this.convertTools(tools);
       body.tool_choice = tool_choice || 'auto';  // Enable tool calling

--- a/src/llm/openrouter.ts
+++ b/src/llm/openrouter.ts
@@ -84,6 +84,7 @@ export class OpenRouterProvider implements LLMProvider {
   private apiKey: string;
   private defaultModel: string;
   private apiUrl = 'https://openrouter.ai/api/v1/chat/completions';
+  private static readonly DEFAULT_MAX_TOKENS = 2048;
 
   constructor(apiKey: string, defaultModel = 'anthropic/claude-sonnet-4') {
     this.apiKey = apiKey;
@@ -91,7 +92,7 @@ export class OpenRouterProvider implements LLMProvider {
   }
 
   async chat(messages: LLMMessage[], options: LLMOptions = {}): Promise<LLMResponse> {
-    const { model = this.defaultModel, temperature, max_tokens, tools, tool_choice } = options;
+    const { model = this.defaultModel, temperature, max_tokens = OpenRouterProvider.DEFAULT_MAX_TOKENS, tools, tool_choice } = options;
 
     // Compact history for better reliability across routed models
     const budget = calculateHistoryBudget(100000);
@@ -103,7 +104,7 @@ export class OpenRouterProvider implements LLMProvider {
     };
 
     if (temperature !== undefined) body.temperature = temperature;
-    if (max_tokens !== undefined) body.max_tokens = max_tokens;
+    body.max_tokens = max_tokens;
     if (tools && tools.length > 0) {
       body.tools = this.convertTools(tools);
       body.tool_choice = tool_choice || 'auto';
@@ -130,7 +131,7 @@ export class OpenRouterProvider implements LLMProvider {
   }
 
   async *stream(messages: LLMMessage[], options: LLMOptions = {}): AsyncIterable<LLMStreamEvent> {
-    const { model = this.defaultModel, temperature, max_tokens, tools, tool_choice } = options;
+    const { model = this.defaultModel, temperature, max_tokens = OpenRouterProvider.DEFAULT_MAX_TOKENS, tools, tool_choice } = options;
 
     // Compact history for better reliability across routed models
     const budget = calculateHistoryBudget(100000);
@@ -143,7 +144,7 @@ export class OpenRouterProvider implements LLMProvider {
     };
 
     if (temperature !== undefined) body.temperature = temperature;
-    if (max_tokens !== undefined) body.max_tokens = max_tokens;
+    body.max_tokens = max_tokens;
     if (tools && tools.length > 0) {
       body.tools = this.convertTools(tools);
       body.tool_choice = tool_choice || 'auto';

--- a/src/llm/provider.test.ts
+++ b/src/llm/provider.test.ts
@@ -200,6 +200,56 @@ describe('LLMManager', () => {
     expect(events.some((event) => event.type === 'done')).toBe(true);
     expect(events.some((event) => event.type === 'error')).toBe(false);
   });
+
+  test('temporarily cools down rate-limited providers', async () => {
+    const manager = new LLMManager();
+    let primaryCalls = 0;
+    const primary = {
+      name: 'primary',
+      listModels: async () => ['primary-model'],
+      chat: async () => {
+        primaryCalls += 1;
+        throw new Error('429 rate_limit_exceeded: Please try again in 2m30s');
+      },
+      async *stream() {
+        yield { type: 'error' as const, error: '429 rate_limit_exceeded: Please try again in 2m30s' };
+      },
+    };
+    const fallback = {
+      name: 'fallback',
+      listModels: async () => ['fallback-model'],
+      chat: async () => ({
+        content: 'fallback ok',
+        tool_calls: [],
+        usage: { input_tokens: 1, output_tokens: 1 },
+        model: 'fallback-model',
+        finish_reason: 'stop' as const,
+      }),
+      async *stream() {
+        yield { type: 'text' as const, text: 'fallback ok' };
+        yield {
+          type: 'done' as const,
+          response: {
+            content: 'fallback ok',
+            tool_calls: [],
+            usage: { input_tokens: 1, output_tokens: 1 },
+            model: 'fallback-model',
+            finish_reason: 'stop' as const,
+          },
+        };
+      },
+    };
+
+    manager.registerProvider(primary);
+    manager.registerProvider(fallback);
+    manager.setPrimary('primary');
+    manager.setFallbackChain(['fallback']);
+
+    await manager.chat(sampleMessages);
+    await manager.chat(sampleMessages);
+
+    expect(primaryCalls).toBe(1);
+  });
 });
 
 describe('Message Types', () => {
@@ -250,12 +300,17 @@ describe('Provider URLs', () => {
 
   test('OllamaProvider uses correct base URL', () => {
     const provider = new OllamaProvider() as any;
-    expect(provider.baseUrl).toBe('http://localhost:11434');
+    expect(provider.baseUrl).toBe('http://127.0.0.1:11434');
   });
 
   test('OllamaProvider removes trailing slash from base URL', () => {
     const provider = new OllamaProvider('http://localhost:11434/') as any;
-    expect(provider.baseUrl).toBe('http://localhost:11434');
+    expect(provider.baseUrl).toBe('http://127.0.0.1:11434');
+  });
+
+  test('OllamaProvider normalizes localhost to IPv4 loopback', () => {
+    const provider = new OllamaProvider('http://localhost:11434') as any;
+    expect(provider.baseUrl).toBe('http://127.0.0.1:11434');
   });
 
   test('NVIDIAProvider uses correct API URL', () => {
@@ -299,7 +354,7 @@ describe('Default Models', () => {
     const anthropic = new AnthropicProvider('key', 'custom-model') as any;
     const openai = new OpenAIProvider('key', 'custom-model') as any;
     const groq = new GroqProvider('key', 'custom-model') as any;
-    const ollama = new OllamaProvider('http://localhost:11434', 'custom-model') as any;
+    const ollama = new OllamaProvider('http://127.0.0.1:11434', 'custom-model') as any;
     const openrouter = new OpenRouterProvider('key', 'custom-model') as any;
 
     expect(anthropic.defaultModel).toBe('custom-model');
@@ -613,5 +668,57 @@ describe('Groq request shaping', () => {
     expect(response.content).toContain('retry ok');
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(JSON.stringify(secondBody).length).toBeLessThan(JSON.stringify(firstBody).length);
+  });
+});
+
+describe('Ollama tool fallback', () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test('retries without tools when model does not support them', async () => {
+    globalThis.fetch = mock(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body));
+      if (body.tools) {
+        return new Response(
+          JSON.stringify({ error: 'registry.ollama.ai/library/llama3:latest does not support tools' }),
+          { status: 400, headers: { 'Content-Type': 'application/json' } },
+        );
+      }
+
+      return new Response(JSON.stringify({
+        model: 'llama3',
+        created_at: new Date().toISOString(),
+        message: { role: 'assistant', content: 'fallback ok' },
+        done: true,
+        prompt_eval_count: 12,
+        eval_count: 6,
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+    }) as unknown as typeof fetch;
+
+    const provider = new OllamaProvider('http://127.0.0.1:11434', 'llama3');
+    const response = await provider.chat(
+      [{ role: 'user', content: 'Hello' }],
+      {
+        tools: [
+          {
+            name: 'weather_lookup',
+            description: 'Look up weather',
+            parameters: { type: 'object', properties: {}, required: [] },
+          },
+        ],
+      },
+    );
+
+    expect(response.content).toBe('fallback ok');
+    const fetchMock = globalThis.fetch as unknown as ReturnType<typeof mock>;
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    const firstBody = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body));
+    const secondBody = JSON.parse(String(fetchMock.mock.calls[1]?.[1]?.body));
+    expect(firstBody.tools).toBeDefined();
+    expect(secondBody.tools).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
- compact tool metadata before sending it to providers
- cap default provider output budgets to reduce surprise token spend
- cool down rate-limited providers instead of retrying them immediately
- retry Ollama requests without tools when the selected local model does not support tool calling

## Why
Large requests were burning through paid-provider quotas, Groq rate limits were poisoning the fallback chain, and local Ollama models without tool support were hard-failing every agent turn.

## Verification
- bun test src/llm/provider.test.ts src/config/loader.test.ts
- bunx tsc --noEmit
