### PR TITLE
Add Puter-backed Claude chat mode

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -25,6 +25,7 @@ llm:
   anthropic:
     api_key: "sk-ant-..."
     model: "claude-sonnet-4-5-20250929"
+    use_puter: false  # Browser Chat page only; uses Puter sign-in instead of an Anthropic API key
 
   # OpenAI (GPT) configuration
   openai:

--- a/package.json
+++ b/package.json
@@ -53,12 +53,14 @@
     "@codemirror/view": "^6.40.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
+    "@xenova/transformers": "^2.17.2",
     "@xyflow/react": "^12.10.1",
     "codemirror": "^6.0.2",
     "discord.js": "^14.25.1",
     "edge-tts-universal": "^1.4.0",
     "highlight.js": "^11.11.1",
     "jose": "^6.2.0",
+    "onnxruntime-web": "^1.20.1",
     "openwakeword-wasm-browser": "^0.1.1",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
@@ -68,9 +70,7 @@
     "sharp": "^0.34.5",
     "tailwindcss": "^4.2.1",
     "tesseract.js": "^7.0.0",
-    "yaml": "^2.7.0",
-    "@xenova/transformers": "^2.17.2",
-    "onnxruntime-web": "^1.20.1"
+    "yaml": "^2.7.0"
   },
   "devDependencies": {
     "@types/bun": "latest"

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -155,7 +155,7 @@ export type JarvisConfig = {
   llm: {
     primary: string;  // provider name
     fallback: string[];
-    anthropic?: { api_key: string; model?: string };
+    anthropic?: { api_key: string; model?: string; use_puter?: boolean };
     openai?: { api_key: string; model?: string };
     groq?: { api_key: string; model?: string };
     gemini?: { api_key: string; model?: string };
@@ -235,6 +235,7 @@ export const DEFAULT_CONFIG: JarvisConfig = {
     anthropic: {
       api_key: '',
       model: 'claude-sonnet-4-6',
+      use_puter: false,
     },
     openai: {
       api_key: '',

--- a/src/daemon/llm-settings.ts
+++ b/src/daemon/llm-settings.ts
@@ -28,6 +28,7 @@ const KEY_OPENROUTER = 'llm.openrouter.api_key';
 const SETTING_PRIMARY = 'llm.primary';
 const SETTING_FALLBACK = 'llm.fallback';
 const SETTING_ANTHROPIC_MODEL = 'llm.anthropic.model';
+const SETTING_ANTHROPIC_USE_PUTER = 'llm.anthropic.use_puter';
 const SETTING_OPENAI_MODEL = 'llm.openai.model';
 const SETTING_GROQ_MODEL = 'llm.groq.model';
 const SETTING_GEMINI_MODEL = 'llm.gemini.model';
@@ -38,7 +39,7 @@ const SETTING_OPENROUTER_MODEL = 'llm.openrouter.model';
 export type LLMSettingsResponse = {
   primary: string;
   fallback: string[];
-  anthropic: { model: string; has_api_key: boolean } | null;
+  anthropic: { model: string; has_api_key: boolean; use_puter: boolean } | null;
   openai: { model: string; has_api_key: boolean } | null;
   groq: { model: string; has_api_key: boolean } | null;
   gemini: { model: string; has_api_key: boolean } | null;
@@ -56,6 +57,10 @@ export function getLLMSettings(config: JarvisConfig): LLMSettingsResponse {
   const fallback = fallbackRaw ? JSON.parse(fallbackRaw) : config.llm.fallback;
 
   const anthropicModel = getSetting(SETTING_ANTHROPIC_MODEL) ?? config.llm.anthropic?.model ?? 'claude-sonnet-4-6';
+  const dbAnthropicUsePuter = getSetting(SETTING_ANTHROPIC_USE_PUTER);
+  const anthropicUsePuter = dbAnthropicUsePuter === null
+    ? !!config.llm.anthropic?.use_puter
+    : dbAnthropicUsePuter === 'true';
   const openaiModel = getSetting(SETTING_OPENAI_MODEL) ?? config.llm.openai?.model ?? 'gpt-5.4';
   const groqModel = getSetting(SETTING_GROQ_MODEL) ?? config.llm.groq?.model ?? 'llama-3.3-70b-versatile';
   const geminiModel = getSetting(SETTING_GEMINI_MODEL) ?? config.llm.gemini?.model ?? 'gemini-3-flash-preview';
@@ -73,7 +78,7 @@ export function getLLMSettings(config: JarvisConfig): LLMSettingsResponse {
   return {
     primary,
     fallback,
-    anthropic: { model: anthropicModel, has_api_key: hasAnthropicKey },
+    anthropic: { model: anthropicModel, has_api_key: hasAnthropicKey, use_puter: anthropicUsePuter },
     openai: { model: openaiModel, has_api_key: hasOpenaiKey },
     groq: { model: groqModel, has_api_key: hasGroqKey },
     gemini: { model: geminiModel, has_api_key: hasGeminiKey },
@@ -90,7 +95,7 @@ export function saveLLMSettings(
   body: {
     primary?: string;
     fallback?: string[];
-    anthropic?: { api_key?: string; model?: string };
+    anthropic?: { api_key?: string; model?: string; use_puter?: boolean };
     openai?: { api_key?: string; model?: string };
     groq?: { api_key?: string; model?: string };
     gemini?: { api_key?: string; model?: string };
@@ -113,12 +118,16 @@ export function saveLLMSettings(
     if (body.anthropic.model) {
       setSetting(SETTING_ANTHROPIC_MODEL, body.anthropic.model);
     }
+    if (body.anthropic.use_puter !== undefined) {
+      setSetting(SETTING_ANTHROPIC_USE_PUTER, String(body.anthropic.use_puter));
+    }
     if (body.anthropic.api_key) {
       setSecret(KEY_ANTHROPIC, body.anthropic.api_key);
     }
     config.llm.anthropic = {
       ...config.llm.anthropic,
       model: body.anthropic.model ?? config.llm.anthropic?.model,
+      use_puter: body.anthropic.use_puter ?? config.llm.anthropic?.use_puter ?? false,
       api_key: body.anthropic.api_key ?? getAnthropicApiKey(config) ?? '',
     };
   }
@@ -248,14 +257,18 @@ export function mergeLLMSettingsIntoConfig(config: JarvisConfig): void {
 
   // Anthropic
   const dbAnthropicModel = getSetting(SETTING_ANTHROPIC_MODEL);
+  const dbAnthropicUsePuter = getSetting(SETTING_ANTHROPIC_USE_PUTER);
   const keychainAnthropicKey = getSecret(KEY_ANTHROPIC);
-  if (dbAnthropicModel || keychainAnthropicKey) {
+  if (dbAnthropicModel || dbAnthropicUsePuter !== null || keychainAnthropicKey) {
     config.llm.anthropic = {
       ...config.llm.anthropic,
       api_key: (!process.env.JARVIS_API_KEY && keychainAnthropicKey)
         ? keychainAnthropicKey
         : (config.llm.anthropic?.api_key ?? ''),
       model: dbAnthropicModel ?? config.llm.anthropic?.model,
+      use_puter: dbAnthropicUsePuter === null
+        ? (config.llm.anthropic?.use_puter ?? false)
+        : dbAnthropicUsePuter === 'true',
     };
   }
 

--- a/ui/index.html
+++ b/ui/index.html
@@ -11,6 +11,7 @@
 </head>
 <body>
   <div id="root"></div>
+  <script src="https://js.puter.com/v2/"></script>
   <script type="module" src="./src/main.tsx"></script>
 </body>
 </html>

--- a/ui/src/components/chat/MessageBubble.tsx
+++ b/ui/src/components/chat/MessageBubble.tsx
@@ -37,6 +37,7 @@ export function MessageBubble({ message }: Props) {
   const isUser = message.role === "user";
   const isSystem = message.role === "system";
   const timestamp = new Date(message.timestamp).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit" });
+  const senderName = message.source === "puter" ? "Claude (Puter)" : "JARVIS";
 
   // System messages — notification cards
   if (isSystem) {
@@ -69,7 +70,7 @@ export function MessageBubble({ message }: Props) {
       {!isUser && (
         <div className="chat-sender">
           <div className="chat-sender-orb" />
-          <span className="chat-sender-name">JARVIS</span>
+          <span className="chat-sender-name">{senderName}</span>
           <span className="chat-sender-ts">{timestamp}</span>
         </div>
       )}

--- a/ui/src/components/settings/LLMPanel.tsx
+++ b/ui/src/components/settings/LLMPanel.tsx
@@ -4,7 +4,7 @@ import { useApiData, api } from "../../hooks/useApi";
 type LLMConfig = {
   primary: string;
   fallback: string[];
-  anthropic: { model: string; has_api_key: boolean } | null;
+  anthropic: { model: string; has_api_key: boolean; use_puter: boolean } | null;
   openai: { model: string; has_api_key: boolean } | null;
   groq: { model: string; has_api_key: boolean } | null;
   gemini: { model: string; has_api_key: boolean } | null;
@@ -104,6 +104,7 @@ export function LLMPanel() {
   const [anthropicKey, setAnthropicKey] = useState("");
   const [anthropicModel, setAnthropicModel] = useState("claude-sonnet-4-5-20250929");
   const [anthropicCustomModel, setAnthropicCustomModel] = useState("");
+  const [anthropicUsePuter, setAnthropicUsePuter] = useState(false);
 
   // OpenAI
   const [openaiKey, setOpenaiKey] = useState("");
@@ -150,6 +151,7 @@ export function LLMPanel() {
 
     if (config.anthropic) {
       const m = config.anthropic.model;
+      setAnthropicUsePuter(config.anthropic.use_puter);
       if (ANTHROPIC_MODELS.includes(m)) {
         setAnthropicModel(m);
         setAnthropicCustomModel("");
@@ -235,6 +237,7 @@ export function LLMPanel() {
         fallback,
         anthropic: {
           model: resolveModel(anthropicModel, anthropicCustomModel),
+          use_puter: anthropicUsePuter,
           ...(anthropicKey ? { api_key: anthropicKey } : {}),
         },
         openai: {
@@ -370,6 +373,11 @@ export function LLMPanel() {
             </option>
           ))}
         </select>
+        {primary === "anthropic" && anthropicUsePuter && !(config.anthropic?.has_api_key || anthropicKey) && (
+          <div style={{ ...warningStyle, marginTop: "10px", marginBottom: 0 }}>
+            Free Version (Puter) powers only the browser Chat page. Keep another server-backed provider configured if you want daemon-side agents, tools, and automation to stay available.
+          </div>
+        )}
       </div>
 
       <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
@@ -377,7 +385,7 @@ export function LLMPanel() {
           name="Anthropic"
           provider="anthropic"
           isPrimary={primary === "anthropic"}
-          hasKey={config.anthropic?.has_api_key ?? false}
+          hasKey={(config.anthropic?.has_api_key ?? false) || anthropicUsePuter}
           apiKey={anthropicKey}
           onApiKeyChange={setAnthropicKey}
           model={anthropicModel}
@@ -392,6 +400,31 @@ export function LLMPanel() {
           onFallbackToggle={() => toggleFallback("anthropic")}
           expanded={!!expanded.anthropic}
           onToggleExpand={() => setExpanded((s) => ({ ...s, anthropic: !s.anthropic }))}
+          testDisabled={anthropicUsePuter}
+          extraContent={(
+            <label
+              style={{
+                display: "flex",
+                alignItems: "flex-start",
+                justifyContent: "space-between",
+                gap: "12px",
+                padding: "8px 10px",
+                borderRadius: "6px",
+                border: "1px solid rgba(0, 212, 255, 0.14)",
+                background: "rgba(0, 212, 255, 0.04)",
+              }}
+            >
+              <div>
+                <div style={{ ...fieldLabelStyle, marginBottom: "2px", color: "var(--j-text)" }}>
+                  Free Version (Puter)
+                </div>
+                <div style={{ fontSize: "12px", color: "var(--j-text-dim)", lineHeight: 1.45 }}>
+                  Uses Puter sign-in for free Claude access on the Chat page instead of an Anthropic API key.
+                </div>
+              </div>
+              <ToggleSwitch checked={anthropicUsePuter} onChange={() => setAnthropicUsePuter((value) => !value)} />
+            </label>
+          )}
         />
 
         <ProviderSection
@@ -559,6 +592,8 @@ type ProviderSectionProps = {
   hideApiKey?: boolean;
   baseUrl?: string;
   onBaseUrlChange?: (v: string) => void;
+  testDisabled?: boolean;
+  extraContent?: React.ReactNode;
 };
 
 function ToggleSwitch({ checked, onChange, disabled }: { checked: boolean; onChange: () => void; disabled?: boolean }) {
@@ -605,7 +640,7 @@ function ProviderSection({
   models, testing, testResult, onTest,
   isFallback, onFallbackToggle,
   expanded, onToggleExpand,
-  hideApiKey, baseUrl, onBaseUrlChange,
+  hideApiKey, baseUrl, onBaseUrlChange, testDisabled, extraContent,
 }: ProviderSectionProps) {
   return (
     <div style={providerCardStyle}>
@@ -689,6 +724,8 @@ function ProviderSection({
             </div>
           </div>
 
+          {extraContent}
+
           <div style={{ display: "flex", alignItems: "center", gap: "8px", marginTop: "4px" }}>
             {!isPrimary && (
               <label
@@ -707,7 +744,7 @@ function ProviderSection({
               </label>
             )}
             <div style={{ marginLeft: "auto", display: "flex", alignItems: "center", gap: "8px" }}>
-              <button onClick={onTest} disabled={testing} style={testBtnStyle}>
+              <button onClick={onTest} disabled={testing || testDisabled} style={testBtnStyle}>
                 {testing ? "Testing..." : "Test Connection"}
               </button>
               {testResult && (
@@ -804,6 +841,16 @@ const saveBtnStyle: React.CSSProperties = {
   borderRadius: "6px",
   color: "var(--j-accent)",
   cursor: "pointer",
+};
+
+const warningStyle: React.CSSProperties = {
+  padding: "8px 10px",
+  fontSize: "12px",
+  lineHeight: 1.45,
+  color: "#FDE68A",
+  background: "rgba(251, 191, 36, 0.08)",
+  border: "1px solid rgba(251, 191, 36, 0.22)",
+  borderRadius: "6px",
 };
 
 const primaryBadgeStyle: React.CSSProperties = {

--- a/ui/src/pages/ChatPage.tsx
+++ b/ui/src/pages/ChatPage.tsx
@@ -1,9 +1,30 @@
-import React from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { ChatMessage } from "../hooks/useWebSocket";
 import type { UseVoiceReturn } from "../hooks/useVoice";
 import { MessageList } from "../components/chat/MessageList";
 import { ChatInput } from "../components/chat/ChatInput";
+import { useApiData } from "../hooks/useApi";
 import "../styles/chat.css";
+
+type PuterClient = {
+  onAuth?: (() => void | Promise<void>) | null;
+  getUser: () => Promise<unknown>;
+  ui: {
+    authenticateWithPuter: () => Promise<void>;
+  };
+  ai: {
+    chat: (
+      messages: Array<{ role: "user" | "assistant"; content: string }>,
+      options: { model: string; stream: boolean },
+    ) => Promise<unknown>;
+  };
+};
+
+declare global {
+  interface Window {
+    puter?: PuterClient;
+  }
+}
 
 type ChatPageProps = {
   messages: ChatMessage[];
@@ -12,7 +33,216 @@ type ChatPageProps = {
   voice?: UseVoiceReturn;
 };
 
+function extractPuterText(part: unknown): string {
+  if (typeof part === "string") return part;
+  if (!part || typeof part !== "object") return "";
+
+  const record = part as Record<string, unknown>;
+  if (typeof record.text === "string") return record.text;
+  if (record.delta && typeof record.delta === "object") {
+    const delta = record.delta as Record<string, unknown>;
+    if (typeof delta.text === "string") return delta.text;
+  }
+  if (record.message && typeof record.message === "object") {
+    const message = record.message as Record<string, unknown>;
+    if (typeof message.content === "string") return message.content;
+    if (Array.isArray(message.content)) {
+      for (const entry of message.content) {
+        if (entry && typeof entry === "object") {
+          const text = (entry as Record<string, unknown>).text;
+          if (typeof text === "string") {
+            return text;
+          }
+        }
+      }
+    }
+  }
+
+  return "";
+}
+
 export default function ChatPage({ messages, isConnected, sendMessage, voice }: ChatPageProps) {
+  const { data: llmConfig } = useApiData<{ anthropic: { model: string; use_puter: boolean } | null }>("/api/config/llm", []);
+  const [puterMessages, setPuterMessages] = useState<ChatMessage[]>([]);
+  const [puterBusy, setPuterBusy] = useState(false);
+  const [puterUser, setPuterUser] = useState<string | null>(null);
+  const puterRef = useRef<PuterClient | null>(null);
+  const puterMode = !!llmConfig?.anthropic?.use_puter;
+
+  const getPuter = useCallback(async () => {
+    if (puterRef.current) return puterRef.current;
+    if (window.puter) {
+      puterRef.current = window.puter;
+      return window.puter;
+    }
+
+    await new Promise<void>((resolve, reject) => {
+      const existing = document.querySelector<HTMLScriptElement>('script[data-puter-sdk="true"]');
+      if (existing) {
+        existing.addEventListener("load", () => resolve(), { once: true });
+        existing.addEventListener("error", () => reject(new Error("Failed to load Puter SDK.")), { once: true });
+        return;
+      }
+
+      const script = document.createElement("script");
+      script.src = "https://js.puter.com/v2/";
+      script.async = true;
+      script.dataset.puterSdk = "true";
+      script.addEventListener("load", () => resolve(), { once: true });
+      script.addEventListener("error", () => reject(new Error("Failed to load Puter SDK.")), { once: true });
+      document.body.appendChild(script);
+    });
+
+    if (!window.puter) {
+      throw new Error("Failed to load Puter SDK.");
+    }
+
+    puterRef.current = window.puter;
+    return window.puter;
+  }, []);
+
+  const syncPuterUser = useCallback(async () => {
+    const puter = await getPuter();
+    try {
+      const user = await puter.getUser();
+      if (user && typeof user === "object") {
+        const profile = user as Record<string, unknown>;
+        setPuterUser(
+          typeof profile.username === "string" ? profile.username
+            : typeof profile.name === "string" ? profile.name
+            : typeof profile.email === "string" ? profile.email
+            : "Connected",
+        );
+        return true;
+      }
+    } catch {
+      // Expected until the browser signs the user into Puter.
+    }
+
+    setPuterUser(null);
+    return false;
+  }, [getPuter]);
+
+  useEffect(() => {
+    if (!puterMode) return;
+
+    let cancelled = false;
+    (async () => {
+      const puter = await getPuter();
+      puter.onAuth = async () => {
+        if (!cancelled) {
+          await syncPuterUser();
+        }
+      };
+      await syncPuterUser();
+    })().catch(() => {
+      if (!cancelled) {
+        setPuterUser(null);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [getPuter, puterMode, syncPuterUser]);
+
+  const ensurePuterAuth = useCallback(async () => {
+    if (await syncPuterUser()) return;
+    const puter = await getPuter();
+    await puter.ui.authenticateWithPuter();
+    await syncPuterUser();
+  }, [getPuter, syncPuterUser]);
+
+  const appendPuterChunk = useCallback((messageId: string, chunk: string) => {
+    if (!chunk) return;
+    setPuterMessages((prev) => prev.map((message) => (
+      message.id === messageId
+        ? { ...message, content: `${message.content}${chunk}`, isStreaming: true }
+        : message
+    )));
+  }, []);
+
+  const finalizePuterMessage = useCallback((messageId: string) => {
+    setPuterMessages((prev) => prev.map((message) => (
+      message.id === messageId
+        ? { ...message, isStreaming: false }
+        : message
+    )));
+  }, []);
+
+  const handlePuterSend = useCallback(async (text: string) => {
+    if (puterBusy) return;
+
+    const userMessage: ChatMessage = {
+      id: crypto.randomUUID(),
+      role: "user",
+      content: text,
+      timestamp: Date.now(),
+      source: "puter",
+    };
+    const assistantMessageId = crypto.randomUUID();
+    let historySnapshot: ChatMessage[] = [];
+
+    setPuterMessages((prev) => {
+      historySnapshot = [...prev, userMessage];
+      return [
+        ...historySnapshot,
+        {
+          id: assistantMessageId,
+          role: "assistant",
+          content: "",
+          timestamp: Date.now(),
+          source: "puter",
+          isStreaming: true,
+        },
+      ];
+    });
+
+    setPuterBusy(true);
+    try {
+      await ensurePuterAuth();
+      const puter = await getPuter();
+      const model = llmConfig?.anthropic?.model ?? "claude-sonnet-4-6";
+      const response = await puter.ai.chat(
+        historySnapshot
+          .filter((message): message is ChatMessage & { role: "user" | "assistant" } => (
+            message.role === "user" || message.role === "assistant"
+          ))
+          .map((message) => ({ role: message.role, content: message.content })),
+        { model, stream: true },
+      );
+
+      if (response && typeof (response as AsyncIterable<unknown>)[Symbol.asyncIterator] === "function") {
+        for await (const part of response as AsyncIterable<unknown>) {
+          appendPuterChunk(assistantMessageId, extractPuterText(part));
+        }
+      } else {
+        appendPuterChunk(assistantMessageId, extractPuterText(response));
+      }
+
+      finalizePuterMessage(assistantMessageId);
+    } catch (err) {
+      setPuterMessages((prev) => prev
+        .filter((message) => message.id !== assistantMessageId)
+        .concat({
+          id: crypto.randomUUID(),
+          role: "system",
+          content: err instanceof Error ? err.message : "Puter Claude request failed.",
+          timestamp: Date.now(),
+          source: "error",
+        }));
+    } finally {
+      setPuterBusy(false);
+    }
+  }, [appendPuterChunk, ensurePuterAuth, finalizePuterMessage, getPuter, llmConfig?.anthropic?.model, puterBusy]);
+
+  const activeMessages = useMemo(
+    () => (puterMode ? puterMessages : messages),
+    [messages, puterMessages, puterMode],
+  );
+
+  const effectiveConnected = puterMode ? true : isConnected;
+  const effectiveVoice = puterMode ? undefined : voice;
   const voiceStatus = voice
     ? voice.voiceState === "speaking" || voice.ttsAudioPlaying
       ? "JARVIS is speaking..."
@@ -59,7 +289,7 @@ export default function ChatPage({ messages, isConnected, sendMessage, voice }: 
       </div>
 
       {/* Connection status bar */}
-      {!isConnected && (
+      {!puterMode && !isConnected && (
         <div className="chat-status-bar chat-status-disconnected">
           <span className="chat-status-dot chat-status-dot-recording" />
           Disconnected from JARVIS. Reconnecting...
@@ -67,28 +297,37 @@ export default function ChatPage({ messages, isConnected, sendMessage, voice }: 
       )}
 
       {/* Voice status bar */}
-      {voiceStatus && (
+      {voiceStatus && !puterMode && (
         <div className="chat-status-bar chat-status-voice">
           <span className={`chat-status-dot ${voice?.voiceState === "recording" ? "chat-status-dot-recording" : "chat-status-dot-voice"}`} />
           {voiceStatus}
         </div>
       )}
 
+      {puterMode && (
+        <div className="chat-status-bar chat-status-voice" style={{ justifyContent: "space-between", gap: "12px" }}>
+          <span>Free Version (Puter) is active. Claude replies stream directly to this page after browser sign-in.</span>
+          <span style={{ color: "var(--j-text-dim)", whiteSpace: "nowrap" }}>
+            {puterUser ? `Connected as ${puterUser}` : "Sign in on first message"}
+          </span>
+        </div>
+      )}
+
       {/* Messages */}
-      <MessageList messages={messages} />
+      <MessageList messages={activeMessages} />
 
       {/* Input */}
       <ChatInput
-        onSend={sendMessage}
-        disabled={!isConnected}
-        voice={voice ? {
-          voiceState: voice.voiceState,
-          startRecording: voice.startRecording,
-          stopRecording: voice.stopRecording,
-          isMicAvailable: voice.isMicAvailable,
-          isWakeWordReady: voice.isWakeWordReady,
-          ttsAudioPlaying: voice.ttsAudioPlaying,
-          cancelTTS: voice.cancelTTS,
+        onSend={puterMode ? handlePuterSend : sendMessage}
+        disabled={puterMode ? puterBusy : !effectiveConnected}
+        voice={effectiveVoice ? {
+          voiceState: effectiveVoice.voiceState,
+          startRecording: effectiveVoice.startRecording,
+          stopRecording: effectiveVoice.stopRecording,
+          isMicAvailable: effectiveVoice.isMicAvailable,
+          isWakeWordReady: effectiveVoice.isWakeWordReady,
+          ttsAudioPlaying: effectiveVoice.ttsAudioPlaying,
+          cancelTTS: effectiveVoice.cancelTTS,
         } : undefined}
       />
     </div>


### PR DESCRIPTION
Summary:
- add a persisted Free Version (Puter) toggle under Anthropic settings
- route Chat page Claude messages through Puter after browser auth when that toggle is enabled
- clarify that Puter mode is browser-chat only and label Puter replies distinctly in chat

Validation:
- bun test
- bun x tsc --noEmit
- bun run build:ui
- manual browser check on localhost:4142: toggle rendered, Chat page entered Puter mode, and first message opened the Puter auth popup before Cloudflare human verification