### PR TITLE
Add Cerebras and LiteLLM providers

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -31,6 +31,17 @@ llm:
     api_key: "sk-..."
     model: "gpt-4o"
 
+  # Cerebras (OpenAI-compatible) configuration
+  # cerebras:
+  #   api_key: "csk-..."
+  #   model: "gpt-oss-120b"
+
+  # LiteLLM gateway (OpenAI-compatible proxy) configuration
+  # litellm:
+  #   api_key: "sk-optional"
+  #   base_url: "http://localhost:4000/v1"
+  #   model: "openai/gpt-4o-mini"
+
   # Groq (OpenAI-compatible) configuration
   # groq:
   #   api_key: "gsk_..."

--- a/scripts/setup-config.ts
+++ b/scripts/setup-config.ts
@@ -19,6 +19,8 @@ import {
   LLMManager,
   AnthropicProvider,
   OpenAIProvider,
+  CerebrasProvider,
+  LiteLLMProvider,
   OllamaProvider,
 } from '../src/llm/index.ts';
 
@@ -126,6 +128,47 @@ async function testProviders(config: any): Promise<void> {
     console.log('○ OpenAI: Not configured');
   }
 
+  // Test Cerebras
+  if (config.llm.cerebras?.api_key) {
+    if (config.llm.cerebras.api_key === '') {
+      console.log('⚠️  Cerebras: API key not set');
+    } else {
+      try {
+        const provider = new CerebrasProvider(
+          config.llm.cerebras.api_key,
+          config.llm.cerebras.model
+        );
+        const models = await provider.listModels();
+        manager.registerProvider(provider);
+        console.log(`✓ Cerebras: Connected (${models.length} models available)`);
+        hasProvider = true;
+      } catch (err) {
+        console.log(`✗ Cerebras: Connection failed - ${err}`);
+      }
+    }
+  } else {
+    console.log('○ Cerebras: Not configured');
+  }
+
+  // Test LiteLLM
+  if (config.llm.litellm?.base_url) {
+    try {
+      const provider = new LiteLLMProvider(
+        config.llm.litellm.base_url,
+        config.llm.litellm.model,
+        config.llm.litellm.api_key ?? ''
+      );
+      const models = await provider.listModels();
+      manager.registerProvider(provider);
+      console.log(`✓ LiteLLM: Connected (${models.length} models available)`);
+      hasProvider = true;
+    } catch (err) {
+      console.log(`✗ LiteLLM: Connection failed - ${err}`);
+    }
+  } else {
+    console.log('○ LiteLLM: Not configured');
+  }
+
   // Test Ollama
   if (config.llm.ollama) {
     try {
@@ -150,7 +193,7 @@ async function testProviders(config: any): Promise<void> {
 
   if (!hasProvider) {
     console.log('⚠️  No working providers found!');
-    console.log('   Please add at least one API key to your config.\n');
+    console.log('   Please add at least one provider configuration to your config.\n');
     return;
   }
 

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -68,6 +68,8 @@ export async function runDoctor(): Promise<void> {
 
     if (primary === 'ollama') {
       results.push({ name: 'LLM Provider', status: 'ok', message: `ollama (${providerConfig?.model ?? 'llama3'})` });
+    } else if (primary === 'litellm' && providerConfig?.base_url) {
+      results.push({ name: 'LLM Provider', status: 'ok', message: `litellm (${providerConfig.model ?? 'openai/gpt-4o-mini'} @ ${providerConfig.base_url})` });
     } else if (providerConfig?.api_key && providerConfig.api_key !== '') {
       results.push({
         name: 'LLM Provider',
@@ -86,7 +88,7 @@ export async function runDoctor(): Promise<void> {
   if (config) {
     const spin = startSpinner('Testing LLM connectivity...');
     try {
-      const { LLMManager, AnthropicProvider, OpenAIProvider, GroqProvider, GeminiProvider, OllamaProvider, OpenRouterProvider } = await import('../llm/index.ts');
+      const { LLMManager, AnthropicProvider, OpenAIProvider, CerebrasProvider, LiteLLMProvider, GroqProvider, GeminiProvider, OllamaProvider, OpenRouterProvider } = await import('../llm/index.ts');
       const manager = new LLMManager();
       const primary = config.llm?.primary ?? 'anthropic';
 
@@ -94,6 +96,10 @@ export async function runDoctor(): Promise<void> {
         manager.registerProvider(new AnthropicProvider(config.llm.anthropic.api_key, config.llm.anthropic.model));
       } else if (primary === 'openai' && config.llm?.openai?.api_key) {
         manager.registerProvider(new OpenAIProvider(config.llm.openai.api_key, config.llm.openai.model));
+      } else if (primary === 'cerebras' && config.llm?.cerebras?.api_key) {
+        manager.registerProvider(new CerebrasProvider(config.llm.cerebras.api_key, config.llm.cerebras.model));
+      } else if (primary === 'litellm' && config.llm?.litellm?.base_url) {
+        manager.registerProvider(new LiteLLMProvider(config.llm.litellm.base_url, config.llm.litellm.model, config.llm.litellm.api_key ?? ''));
       } else if (primary === 'groq' && config.llm?.groq?.api_key) {
         manager.registerProvider(new GroqProvider(config.llm.groq.api_key, config.llm.groq.model));
       } else if (primary === 'gemini' && config.llm?.gemini?.api_key) {

--- a/src/cli/onboard.ts
+++ b/src/cli/onboard.ts
@@ -74,6 +74,8 @@ export async function runOnboard(): Promise<void> {
   const provider = await askChoice('Choose your primary LLM provider:', [
     { label: 'Anthropic (Claude)', value: 'anthropic' as const, description: 'Best quality, recommended' },
     { label: 'OpenAI (GPT)', value: 'openai' as const, description: 'Good alternative' },
+    { label: 'Cerebras', value: 'cerebras' as const, description: 'Fast OpenAI-compatible Cerebras inference' },
+    { label: 'LiteLLM', value: 'litellm' as const, description: 'OpenAI-compatible proxy/gateway for many providers' },
     { label: 'Google (Gemini)', value: 'gemini' as const, description: 'Google AI models' },
     { label: 'Ollama (Local)', value: 'ollama' as const, description: 'Free, runs locally' },
     { label: 'OpenRouter', value: 'openrouter' as const, description: 'Access hundreds of models via single API key' },
@@ -160,6 +162,70 @@ export async function runOnboard(): Promise<void> {
     const modelChoice = await askChoice('Choose a model:', openaiModels, isPreset ? currentModel : 'custom');
     const model = modelChoice === 'custom' ? await ask('Enter model name', currentModel) : modelChoice;
     if (config.llm.openai) config.llm.openai.model = model;
+
+  } else if (provider === 'cerebras') {
+    const existing = config.llm.cerebras?.api_key;
+    if (existing && existing.length > 5) {
+      const keep = await askYesNo(`API key found (${existing.slice(0, 10)}...). Keep it?`, true);
+      if (!keep) {
+        const key = await askSecret('Enter your Cerebras API key');
+        if (key) config.llm.cerebras = { ...config.llm.cerebras, api_key: key };
+      }
+    } else {
+      const configureNow = await askYesNo('Add your Cerebras API key now?', true);
+      if (configureNow) {
+        const key = await askSecret('Enter your Cerebras API key (from inference.cerebras.ai)');
+        if (key) {
+          config.llm.cerebras = { ...config.llm.cerebras, api_key: key };
+        } else {
+          printWarn('No API key set. JARVIS won\'t work without one.');
+        }
+      } else {
+        printWarn('No API key set. JARVIS won\'t work without one.');
+      }
+    }
+
+    const currentModel = config.llm.cerebras?.model ?? 'gpt-oss-120b';
+    const cerebrasModels = [
+      { label: 'GPT-OSS 120B', value: 'gpt-oss-120b', description: 'Open-weight flagship on Cerebras' },
+      { label: 'Llama 3.3 70B', value: 'llama-3.3-70b', description: 'Balanced large instruct model' },
+      { label: 'Llama 4 Scout 17B', value: 'llama-4-scout-17b-16e-instruct', description: 'Smaller fast instruct model' },
+      { label: 'Qwen 3 235B', value: 'qwen-3-235b-a22b-instruct-2507', description: 'Large multilingual instruct model' },
+      { label: 'Custom', value: 'custom', description: 'Enter model name manually' },
+    ];
+    const isPreset = cerebrasModels.some(m => m.value === currentModel);
+    const modelChoice = await askChoice('Choose a model:', cerebrasModels, isPreset ? currentModel : 'custom');
+    const model = modelChoice === 'custom' ? await ask('Enter model name', currentModel) : modelChoice;
+    if (config.llm.cerebras) config.llm.cerebras.model = model;
+
+  } else if (provider === 'litellm') {
+    const baseUrl = await ask('LiteLLM base URL', config.llm.litellm?.base_url ?? 'http://localhost:4000/v1');
+    const existing = config.llm.litellm?.api_key;
+    if (existing && existing.length > 0) {
+      const keep = await askYesNo('LiteLLM API key found. Keep it?', true);
+      if (!keep) {
+        const key = await askSecret('Enter your LiteLLM API key (leave blank if your gateway is open)');
+        config.llm.litellm = { ...config.llm.litellm, base_url: baseUrl, api_key: key };
+      } else {
+        config.llm.litellm = { ...config.llm.litellm, base_url: baseUrl, api_key: existing };
+      }
+    } else {
+      const key = await askSecret('Enter your LiteLLM API key (leave blank if your gateway is open)');
+      config.llm.litellm = { ...config.llm.litellm, base_url: baseUrl, api_key: key };
+    }
+
+    const currentModel = config.llm.litellm?.model ?? 'openai/gpt-4o-mini';
+    const litellmModels = [
+      { label: 'OpenAI GPT-4o Mini', value: 'openai/gpt-4o-mini', description: 'Common LiteLLM gateway default' },
+      { label: 'Anthropic Claude Sonnet', value: 'anthropic/claude-3-5-sonnet-latest', description: 'Anthropic routed through LiteLLM' },
+      { label: 'Groq Llama 3.3 70B', value: 'groq/llama-3.3-70b-versatile', description: 'Groq routed through LiteLLM' },
+      { label: 'Ollama Llama 3.1', value: 'ollama/llama3.1', description: 'Local Ollama routed through LiteLLM' },
+      { label: 'Custom', value: 'custom', description: 'Enter model name manually' },
+    ];
+    const isPreset = litellmModels.some(m => m.value === currentModel);
+    const modelChoice = await askChoice('Choose a model:', litellmModels, isPreset ? currentModel : 'custom');
+    const model = modelChoice === 'custom' ? await ask('Enter model name', currentModel) : modelChoice;
+    config.llm.litellm = { ...config.llm.litellm, base_url: baseUrl, model };
 
   } else if (provider === 'groq') {
     const existing = config.llm.groq?.api_key;
@@ -299,13 +365,17 @@ export async function runOnboard(): Promise<void> {
   if (testConn) {
     const spin = startSpinner('Testing connection...');
     try {
-      const { LLMManager, AnthropicProvider, OpenAIProvider, GroqProvider, GeminiProvider, OllamaProvider, OpenRouterProvider } = await import('../llm/index.ts');
+      const { LLMManager, AnthropicProvider, OpenAIProvider, CerebrasProvider, LiteLLMProvider, GroqProvider, GeminiProvider, OllamaProvider, OpenRouterProvider } = await import('../llm/index.ts');
       const manager = new LLMManager();
 
       if (provider === 'anthropic' && config.llm.anthropic?.api_key) {
         manager.registerProvider(new AnthropicProvider(config.llm.anthropic.api_key, config.llm.anthropic.model));
       } else if (provider === 'openai' && config.llm.openai?.api_key) {
         manager.registerProvider(new OpenAIProvider(config.llm.openai.api_key, config.llm.openai.model));
+      } else if (provider === 'cerebras' && config.llm.cerebras?.api_key) {
+        manager.registerProvider(new CerebrasProvider(config.llm.cerebras.api_key, config.llm.cerebras.model));
+      } else if (provider === 'litellm' && config.llm.litellm?.base_url) {
+        manager.registerProvider(new LiteLLMProvider(config.llm.litellm.base_url, config.llm.litellm.model, config.llm.litellm.api_key ?? ''));
       } else if (provider === 'groq' && config.llm.groq?.api_key) {
         manager.registerProvider(new GroqProvider(config.llm.groq.api_key, config.llm.groq.model));
       } else if (provider === 'gemini' && config.llm.gemini?.api_key) {
@@ -335,7 +405,7 @@ export async function runOnboard(): Promise<void> {
   }
 
   // Fallback providers
-  config.llm.fallback = ['anthropic', 'openai', 'gemini', 'ollama', 'openrouter', 'groq'].filter(p => p !== provider);
+  config.llm.fallback = ['anthropic', 'openai', 'cerebras', 'litellm', 'gemini', 'ollama', 'openrouter', 'groq'].filter(p => p !== provider);
 
   // ── Step 3: Fallback API Keys ─────────────────────────────────────
 
@@ -356,6 +426,24 @@ export async function runOnboard(): Promise<void> {
         if (configureProvider) {
           const key = await askSecret('OpenAI API key (for fallback)');
           if (key) config.llm.openai = { ...config.llm.openai, api_key: key, model: config.llm.openai?.model ?? 'gpt-5.4' };
+        }
+      } else if (fb === 'cerebras' && (!config.llm.cerebras?.api_key || config.llm.cerebras.api_key === '')) {
+        const configureProvider = await askYesNo('Configure Cerebras as a fallback provider?', false);
+        if (configureProvider) {
+          const key = await askSecret('Cerebras API key (for fallback)');
+          if (key) config.llm.cerebras = { ...config.llm.cerebras, api_key: key, model: config.llm.cerebras?.model ?? 'gpt-oss-120b' };
+        }
+      } else if (fb === 'litellm') {
+        const configureProvider = await askYesNo('Configure LiteLLM as a fallback provider?', false);
+        if (configureProvider) {
+          const url = await ask('LiteLLM URL', config.llm.litellm?.base_url ?? 'http://localhost:4000/v1');
+          const key = await askSecret('LiteLLM API key (leave blank if open)');
+          config.llm.litellm = {
+            ...config.llm.litellm,
+            base_url: url,
+            api_key: key,
+            model: config.llm.litellm?.model ?? 'openai/gpt-4o-mini',
+          };
         }
       } else if (fb === 'groq' && (!config.llm.groq?.api_key || config.llm.groq.api_key === '')) {
         const configureProvider = await askYesNo('Configure Groq as a fallback provider?', false);

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -70,6 +70,21 @@ function applyEnvOverrides(config: JarvisConfig): void {
     config.llm.openai.api_key = env.JARVIS_OPENAI_KEY;
   }
 
+  if (env.JARVIS_CEREBRAS_KEY) {
+    if (!config.llm.cerebras) config.llm.cerebras = { api_key: '', model: 'gpt-oss-120b' };
+    config.llm.cerebras.api_key = env.JARVIS_CEREBRAS_KEY;
+  }
+
+  if (env.JARVIS_LITELLM_KEY) {
+    if (!config.llm.litellm) config.llm.litellm = { api_key: '', base_url: 'http://localhost:4000/v1', model: 'openai/gpt-4o-mini' };
+    config.llm.litellm.api_key = env.JARVIS_LITELLM_KEY;
+  }
+
+  if (env.JARVIS_LITELLM_URL) {
+    if (!config.llm.litellm) config.llm.litellm = { api_key: '', base_url: 'http://localhost:4000/v1', model: 'openai/gpt-4o-mini' };
+    config.llm.litellm.base_url = env.JARVIS_LITELLM_URL;
+  }
+
   if (env.JARVIS_GROQ_KEY) {
     if (!config.llm.groq) config.llm.groq = { api_key: '', model: 'llama-3.3-70b-versatile' };
     config.llm.groq.api_key = env.JARVIS_GROQ_KEY;

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -157,6 +157,8 @@ export type JarvisConfig = {
     fallback: string[];
     anthropic?: { api_key: string; model?: string };
     openai?: { api_key: string; model?: string };
+    cerebras?: { api_key: string; model?: string };
+    litellm?: { api_key?: string; base_url?: string; model?: string };
     groq?: { api_key: string; model?: string };
     gemini?: { api_key: string; model?: string };
     ollama?: { base_url?: string; model?: string };
@@ -239,6 +241,15 @@ export const DEFAULT_CONFIG: JarvisConfig = {
     openai: {
       api_key: '',
       model: 'gpt-5.4',
+    },
+    cerebras: {
+      api_key: '',
+      model: 'gpt-oss-120b',
+    },
+    litellm: {
+      api_key: '',
+      base_url: 'http://localhost:4000/v1',
+      model: 'openai/gpt-4o-mini',
     },
     groq: {
       api_key: '',

--- a/src/daemon/agent-service.ts
+++ b/src/daemon/agent-service.ts
@@ -16,6 +16,8 @@ import type { PersonalityModel } from '../personality/model.ts';
 import { LLMManager } from '../llm/manager.ts';
 import { AnthropicProvider } from '../llm/anthropic.ts';
 import { OpenAIProvider } from '../llm/openai.ts';
+import { CerebrasProvider } from '../llm/cerebras.ts';
+import { LiteLLMProvider } from '../llm/litellm.ts';
 import { GroqProvider } from '../llm/groq.ts';
 import { GeminiProvider } from '../llm/gemini.ts';
 import { OllamaProvider } from '../llm/ollama.ts';
@@ -350,6 +352,29 @@ export class AgentService implements Service, IAgentService {
       this.llmManager.registerProvider(provider);
       hasProvider = true;
       console.log('[AgentService] Registered OpenAI provider');
+    }
+
+    // Register Cerebras
+    if (llm.cerebras?.api_key) {
+      const provider = new CerebrasProvider(
+        llm.cerebras.api_key,
+        llm.cerebras.model
+      );
+      this.llmManager.registerProvider(provider);
+      hasProvider = true;
+      console.log('[AgentService] Registered Cerebras provider');
+    }
+
+    // Register LiteLLM
+    if (llm.litellm?.base_url) {
+      const provider = new LiteLLMProvider(
+        llm.litellm.base_url,
+        llm.litellm.model,
+        llm.litellm.api_key ?? ''
+      );
+      this.llmManager.registerProvider(provider);
+      hasProvider = true;
+      console.log('[AgentService] Registered LiteLLM provider');
     }
 
     // Register Groq

--- a/src/daemon/api-routes.ts
+++ b/src/daemon/api-routes.ts
@@ -770,6 +770,8 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
             fallback: config.llm.fallback,
             anthropic: config.llm.anthropic ? { model: config.llm.anthropic.model } : null,
             openai: config.llm.openai ? { model: config.llm.openai.model } : null,
+            cerebras: config.llm.cerebras ? { model: config.llm.cerebras.model } : null,
+            litellm: config.llm.litellm ? { model: config.llm.litellm.model, base_url: config.llm.litellm.base_url } : null,
             groq: config.llm.groq ? { model: config.llm.groq.model } : null,
             ollama: config.llm.ollama ?? null,
           },

--- a/src/daemon/llm-settings.ts
+++ b/src/daemon/llm-settings.ts
@@ -10,6 +10,8 @@ import { getSecret, setSecret, deleteSecret, hasSecret } from '../vault/keychain
 import type { JarvisConfig } from '../config/types.ts';
 import { AnthropicProvider } from '../llm/anthropic.ts';
 import { OpenAIProvider } from '../llm/openai.ts';
+import { CerebrasProvider } from '../llm/cerebras.ts';
+import { LiteLLMProvider } from '../llm/litellm.ts';
 import { GroqProvider } from '../llm/groq.ts';
 import { GeminiProvider } from '../llm/gemini.ts';
 import { OllamaProvider } from '../llm/ollama.ts';
@@ -20,6 +22,8 @@ import type { LLMManager } from '../llm/manager.ts';
 // Keychain key names
 const KEY_ANTHROPIC = 'llm.anthropic.api_key';
 const KEY_OPENAI = 'llm.openai.api_key';
+const KEY_CEREBRAS = 'llm.cerebras.api_key';
+const KEY_LITELLM = 'llm.litellm.api_key';
 const KEY_GROQ = 'llm.groq.api_key';
 const KEY_GEMINI = 'llm.gemini.api_key';
 const KEY_OPENROUTER = 'llm.openrouter.api_key';
@@ -29,6 +33,9 @@ const SETTING_PRIMARY = 'llm.primary';
 const SETTING_FALLBACK = 'llm.fallback';
 const SETTING_ANTHROPIC_MODEL = 'llm.anthropic.model';
 const SETTING_OPENAI_MODEL = 'llm.openai.model';
+const SETTING_CEREBRAS_MODEL = 'llm.cerebras.model';
+const SETTING_LITELLM_MODEL = 'llm.litellm.model';
+const SETTING_LITELLM_BASE_URL = 'llm.litellm.base_url';
 const SETTING_GROQ_MODEL = 'llm.groq.model';
 const SETTING_GEMINI_MODEL = 'llm.gemini.model';
 const SETTING_OLLAMA_MODEL = 'llm.ollama.model';
@@ -40,6 +47,8 @@ export type LLMSettingsResponse = {
   fallback: string[];
   anthropic: { model: string; has_api_key: boolean } | null;
   openai: { model: string; has_api_key: boolean } | null;
+  cerebras: { model: string; has_api_key: boolean } | null;
+  litellm: { base_url: string; model: string; has_api_key: boolean } | null;
   groq: { model: string; has_api_key: boolean } | null;
   gemini: { model: string; has_api_key: boolean } | null;
   ollama: { base_url: string; model: string } | null;
@@ -57,6 +66,9 @@ export function getLLMSettings(config: JarvisConfig): LLMSettingsResponse {
 
   const anthropicModel = getSetting(SETTING_ANTHROPIC_MODEL) ?? config.llm.anthropic?.model ?? 'claude-sonnet-4-6';
   const openaiModel = getSetting(SETTING_OPENAI_MODEL) ?? config.llm.openai?.model ?? 'gpt-5.4';
+  const cerebrasModel = getSetting(SETTING_CEREBRAS_MODEL) ?? config.llm.cerebras?.model ?? 'gpt-oss-120b';
+  const litellmModel = getSetting(SETTING_LITELLM_MODEL) ?? config.llm.litellm?.model ?? 'openai/gpt-4o-mini';
+  const litellmBaseUrl = getSetting(SETTING_LITELLM_BASE_URL) ?? config.llm.litellm?.base_url ?? 'http://localhost:4000/v1';
   const groqModel = getSetting(SETTING_GROQ_MODEL) ?? config.llm.groq?.model ?? 'llama-3.3-70b-versatile';
   const geminiModel = getSetting(SETTING_GEMINI_MODEL) ?? config.llm.gemini?.model ?? 'gemini-3-flash-preview';
   const ollamaModel = getSetting(SETTING_OLLAMA_MODEL) ?? config.llm.ollama?.model ?? 'llama3';
@@ -66,6 +78,8 @@ export function getLLMSettings(config: JarvisConfig): LLMSettingsResponse {
 
   const hasAnthropicKey = hasSecret(KEY_ANTHROPIC) || !!config.llm.anthropic?.api_key;
   const hasOpenaiKey = hasSecret(KEY_OPENAI) || !!config.llm.openai?.api_key;
+  const hasCerebrasKey = hasSecret(KEY_CEREBRAS) || !!config.llm.cerebras?.api_key;
+  const hasLiteLLMKey = hasSecret(KEY_LITELLM) || !!config.llm.litellm?.api_key;
   const hasGroqKey = hasSecret(KEY_GROQ) || !!config.llm.groq?.api_key;
   const hasGeminiKey = hasSecret(KEY_GEMINI) || !!config.llm.gemini?.api_key;
   const hasOpenrouterKey = hasSecret(KEY_OPENROUTER) || !!config.llm.openrouter?.api_key;
@@ -75,6 +89,8 @@ export function getLLMSettings(config: JarvisConfig): LLMSettingsResponse {
     fallback,
     anthropic: { model: anthropicModel, has_api_key: hasAnthropicKey },
     openai: { model: openaiModel, has_api_key: hasOpenaiKey },
+    cerebras: { model: cerebrasModel, has_api_key: hasCerebrasKey },
+    litellm: { base_url: litellmBaseUrl, model: litellmModel, has_api_key: hasLiteLLMKey },
     groq: { model: groqModel, has_api_key: hasGroqKey },
     gemini: { model: geminiModel, has_api_key: hasGeminiKey },
     ollama: { base_url: ollamaBaseUrl, model: ollamaModel },
@@ -92,6 +108,8 @@ export function saveLLMSettings(
     fallback?: string[];
     anthropic?: { api_key?: string; model?: string };
     openai?: { api_key?: string; model?: string };
+    cerebras?: { api_key?: string; model?: string };
+    litellm?: { api_key?: string; base_url?: string; model?: string };
     groq?: { api_key?: string; model?: string };
     gemini?: { api_key?: string; model?: string };
     ollama?: { base_url?: string; model?: string };
@@ -135,6 +153,40 @@ export function saveLLMSettings(
       ...config.llm.openai,
       model: body.openai.model ?? config.llm.openai?.model,
       api_key: body.openai.api_key ?? getOpenAIApiKey(config) ?? '',
+    };
+  }
+
+  // Cerebras
+  if (body.cerebras) {
+    if (body.cerebras.model) {
+      setSetting(SETTING_CEREBRAS_MODEL, body.cerebras.model);
+    }
+    if (body.cerebras.api_key) {
+      setSecret(KEY_CEREBRAS, body.cerebras.api_key);
+    }
+    config.llm.cerebras = {
+      ...config.llm.cerebras,
+      model: body.cerebras.model ?? config.llm.cerebras?.model,
+      api_key: body.cerebras.api_key ?? getCerebrasApiKey(config) ?? '',
+    };
+  }
+
+  // LiteLLM
+  if (body.litellm) {
+    if (body.litellm.model) {
+      setSetting(SETTING_LITELLM_MODEL, body.litellm.model);
+    }
+    if (body.litellm.base_url) {
+      setSetting(SETTING_LITELLM_BASE_URL, body.litellm.base_url);
+    }
+    if (body.litellm.api_key) {
+      setSecret(KEY_LITELLM, body.litellm.api_key);
+    }
+    config.llm.litellm = {
+      ...config.llm.litellm,
+      model: body.litellm.model ?? config.llm.litellm?.model,
+      base_url: body.litellm.base_url ?? config.llm.litellm?.base_url,
+      api_key: body.litellm.api_key ?? getLiteLLMApiKey(config) ?? '',
     };
   }
 
@@ -214,6 +266,20 @@ function getOpenAIApiKey(config: JarvisConfig): string | null {
 }
 
 /**
+ * Resolve the Cerebras API key: keychain > config.yaml > env var.
+ */
+function getCerebrasApiKey(config: JarvisConfig): string | null {
+  return getSecret(KEY_CEREBRAS) ?? config.llm.cerebras?.api_key ?? null;
+}
+
+/**
+ * Resolve the LiteLLM API key: keychain > config.yaml > env var.
+ */
+function getLiteLLMApiKey(config: JarvisConfig): string | null {
+  return getSecret(KEY_LITELLM) ?? config.llm.litellm?.api_key ?? null;
+}
+
+/**
  * Resolve the Groq API key: keychain > config.yaml > env var.
  */
 function getGroqApiKey(config: JarvisConfig): string | null {
@@ -269,6 +335,36 @@ export function mergeLLMSettingsIntoConfig(config: JarvisConfig): void {
         ? keychainOpenaiKey
         : (config.llm.openai?.api_key ?? ''),
       model: dbOpenaiModel ?? config.llm.openai?.model,
+    };
+  }
+
+  // Cerebras
+  const dbCerebrasModel = getSetting(SETTING_CEREBRAS_MODEL);
+  const keychainCerebrasKey = getSecret(KEY_CEREBRAS);
+  if (dbCerebrasModel || keychainCerebrasKey) {
+    config.llm.cerebras = {
+      ...config.llm.cerebras,
+      api_key: (!process.env.JARVIS_CEREBRAS_KEY && keychainCerebrasKey)
+        ? keychainCerebrasKey
+        : (config.llm.cerebras?.api_key ?? ''),
+      model: dbCerebrasModel ?? config.llm.cerebras?.model,
+    };
+  }
+
+  // LiteLLM
+  const dbLiteLLMModel = getSetting(SETTING_LITELLM_MODEL);
+  const dbLiteLLMUrl = getSetting(SETTING_LITELLM_BASE_URL);
+  const keychainLiteLLMKey = getSecret(KEY_LITELLM);
+  if (dbLiteLLMModel || dbLiteLLMUrl || keychainLiteLLMKey) {
+    config.llm.litellm = {
+      ...config.llm.litellm,
+      api_key: (!process.env.JARVIS_LITELLM_KEY && keychainLiteLLMKey)
+        ? keychainLiteLLMKey
+        : (config.llm.litellm?.api_key ?? ''),
+      model: dbLiteLLMModel ?? config.llm.litellm?.model,
+      base_url: (!process.env.JARVIS_LITELLM_URL && dbLiteLLMUrl)
+        ? dbLiteLLMUrl
+        : (config.llm.litellm?.base_url ?? 'http://localhost:4000/v1'),
     };
   }
 
@@ -341,6 +437,14 @@ export function hotReloadLLMProviders(config: JarvisConfig, llmManager: LLMManag
     providers.push(new OpenAIProvider(llm.openai.api_key, llm.openai.model));
     console.log('[LLM] Hot-reloaded OpenAI provider');
   }
+  if (llm.cerebras?.api_key) {
+    providers.push(new CerebrasProvider(llm.cerebras.api_key, llm.cerebras.model));
+    console.log('[LLM] Hot-reloaded Cerebras provider');
+  }
+  if (llm.litellm?.base_url) {
+    providers.push(new LiteLLMProvider(llm.litellm.base_url, llm.litellm.model, llm.litellm.api_key ?? ''));
+    console.log('[LLM] Hot-reloaded LiteLLM provider');
+  }
   if (llm.groq?.api_key) {
     providers.push(new GroqProvider(llm.groq.api_key, llm.groq.model));
     console.log('[LLM] Hot-reloaded Groq provider');
@@ -387,6 +491,16 @@ export async function testLLMProvider(
       const key = opts.api_key || getSecret(KEY_OPENAI) || config.llm.openai?.api_key;
       if (!key) return { ok: false, error: 'API key required' };
       instance = new OpenAIProvider(key, opts.model ?? config.llm.openai?.model);
+    } else if (opts.provider === 'cerebras') {
+      const key = opts.api_key || getSecret(KEY_CEREBRAS) || config.llm.cerebras?.api_key;
+      if (!key) return { ok: false, error: 'API key required' };
+      instance = new CerebrasProvider(key, opts.model ?? config.llm.cerebras?.model);
+    } else if (opts.provider === 'litellm') {
+      instance = new LiteLLMProvider(
+        opts.base_url ?? config.llm.litellm?.base_url,
+        opts.model ?? config.llm.litellm?.model,
+        opts.api_key || getSecret(KEY_LITELLM) || config.llm.litellm?.api_key || '',
+      );
     } else if (opts.provider === 'groq') {
       const key = opts.api_key || getSecret(KEY_GROQ) || config.llm.groq?.api_key;
       if (!key) return { ok: false, error: 'API key required' };

--- a/src/llm/cerebras.ts
+++ b/src/llm/cerebras.ts
@@ -1,0 +1,372 @@
+import type {
+  LLMProvider,
+  LLMMessage,
+  LLMOptions,
+  LLMResponse,
+  LLMStreamEvent,
+  LLMTool,
+  LLMToolCall,
+} from './provider.ts';
+import { compactHistory, calculateHistoryBudget } from './history.ts';
+
+type XAIMessage = {
+  role: 'system' | 'user' | 'assistant' | 'tool';
+  content: string;
+  tool_calls?: XAIToolCall[];
+  tool_call_id?: string;
+};
+
+type XAIToolDef = {
+  type: 'function';
+  function: {
+    name: string;
+    description: string;
+    parameters: Record<string, unknown>;
+  };
+};
+
+type XAIToolCall = {
+  id: string;
+  type: 'function';
+  function: {
+    name: string;
+    arguments: string;
+  };
+};
+
+type XAIResponse = {
+  id: string;
+  object: 'chat.completion';
+  created: number;
+  model: string;
+  choices: Array<{
+    index: number;
+    message: {
+      role: 'assistant';
+      content: string | null;
+      tool_calls?: XAIToolCall[];
+    };
+    finish_reason: 'stop' | 'length' | 'tool_calls' | 'content_filter' | null;
+  }>;
+  usage: {
+    prompt_tokens: number;
+    completion_tokens: number;
+    total_tokens: number;
+  };
+};
+
+type XAIStreamChunk = {
+  id: string;
+  object: 'chat.completion.chunk';
+  created: number;
+  model: string;
+  choices: Array<{
+    index: number;
+    delta: {
+      role?: 'assistant';
+      content?: string;
+      tool_calls?: Array<{
+        index: number;
+        id?: string;
+        type?: 'function';
+        function?: {
+          name?: string;
+          arguments?: string;
+        };
+      }>;
+    };
+    finish_reason: 'stop' | 'length' | 'tool_calls' | 'content_filter' | null;
+  }>;
+};
+
+export class CerebrasProvider implements LLMProvider {
+  name = 'cerebras';
+  private apiKey: string;
+  private defaultModel: string;
+  private apiUrl = 'https://api.cerebras.ai/v1/chat/completions';
+
+  constructor(apiKey: string, defaultModel = 'gpt-oss-120b') {
+    this.apiKey = apiKey;
+    this.defaultModel = defaultModel;
+  }
+
+  async chat(messages: LLMMessage[], options: LLMOptions = {}): Promise<LLMResponse> {
+    const { model = this.defaultModel, temperature, max_tokens, tools, tool_choice } = options;
+
+    const budget = calculateHistoryBudget(128000);
+    const compactedMessages = compactHistory(messages, budget);
+
+    const body: Record<string, unknown> = {
+      model,
+      messages: this.convertMessages(compactedMessages),
+    };
+
+    if (temperature !== undefined) body.temperature = temperature;
+    if (max_tokens !== undefined) body.max_tokens = max_tokens;
+    if (tools && tools.length > 0) {
+      body.tools = this.convertTools(tools);
+      body.tool_choice = tool_choice || 'auto';
+    }
+
+    const response = await fetch(this.apiUrl, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${this.apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Cerebras API error (${response.status}): ${errorText}`);
+    }
+
+    const data = await response.json() as XAIResponse;
+    return this.convertResponse(data);
+  }
+
+  async *stream(messages: LLMMessage[], options: LLMOptions = {}): AsyncIterable<LLMStreamEvent> {
+    const { model = this.defaultModel, temperature, max_tokens, tools, tool_choice } = options;
+
+    const budget = calculateHistoryBudget(128000);
+    const compactedMessages = compactHistory(messages, budget);
+
+    const body: Record<string, unknown> = {
+      model,
+      messages: this.convertMessages(compactedMessages),
+      stream: true,
+    };
+
+    if (temperature !== undefined) body.temperature = temperature;
+    if (max_tokens !== undefined) body.max_tokens = max_tokens;
+    if (tools && tools.length > 0) {
+      body.tools = this.convertTools(tools);
+      body.tool_choice = tool_choice || 'auto';
+    }
+
+    const response = await fetch(this.apiUrl, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${this.apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      yield { type: 'error', error: `Cerebras API error (${response.status}): ${errorText}` };
+      return;
+    }
+
+    if (!response.body) {
+      yield { type: 'error', error: 'No response body' };
+      return;
+    }
+
+    let accumulatedText = '';
+    const toolCalls: LLMToolCall[] = [];
+    const toolCallBuilders: Map<number, { id: string; name: string; arguments: string }> = new Map();
+    let finishReason: string | null = null;
+    let responseModel = model;
+
+    try {
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = '';
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split('\n');
+        buffer = lines.pop() || '';
+
+        for (const line of lines) {
+          if (!line.trim() || !line.startsWith('data: ')) continue;
+
+          const data = line.slice(6);
+          if (data === '[DONE]') continue;
+
+          try {
+            const chunk = JSON.parse(data) as XAIStreamChunk;
+            if (chunk.choices && chunk.choices.length > 0) {
+              const choice = chunk.choices[0];
+              responseModel = chunk.model;
+
+              if (choice!.delta.content) {
+                accumulatedText += choice!.delta.content;
+                yield { type: 'text', text: choice!.delta.content };
+              }
+
+              if (choice!.delta.tool_calls) {
+                for (const toolCallDelta of choice!.delta.tool_calls) {
+                  const index = toolCallDelta.index;
+                  let builder = toolCallBuilders.get(index);
+
+                  if (!builder) {
+                    builder = {
+                      id: toolCallDelta.id || '',
+                      name: toolCallDelta.function?.name || '',
+                      arguments: '',
+                    };
+                    toolCallBuilders.set(index, builder);
+                  }
+
+                  if (toolCallDelta.id) builder.id = toolCallDelta.id;
+                  if (toolCallDelta.function?.name) builder.name = toolCallDelta.function.name;
+                  if (toolCallDelta.function?.arguments) {
+                    builder.arguments += toolCallDelta.function.arguments;
+                  }
+                }
+              }
+
+              if (choice!.finish_reason) {
+                finishReason = choice!.finish_reason;
+              }
+            }
+          } catch (err) {
+            console.error('Failed to parse SSE chunk:', err);
+          }
+        }
+      }
+
+      for (const builder of toolCallBuilders.values()) {
+        try {
+          const toolCall: LLMToolCall = {
+            id: builder.id,
+            name: builder.name,
+            arguments: JSON.parse(builder.arguments),
+          };
+          toolCalls.push(toolCall);
+          yield { type: 'tool_call', tool_call: toolCall };
+        } catch (err) {
+          yield { type: 'error', error: `Failed to parse tool call arguments: ${err}` };
+        }
+      }
+
+      const mappedFinishReason = this.mapFinishReason(finishReason);
+      yield {
+        type: 'done',
+        response: {
+          content: accumulatedText,
+          tool_calls: toolCalls,
+          usage: { input_tokens: 0, output_tokens: 0 },
+          model: responseModel,
+          finish_reason: mappedFinishReason,
+        },
+      };
+    } catch (err) {
+      yield { type: 'error', error: `Stream error: ${err}` };
+    }
+  }
+
+  async listModels(): Promise<string[]> {
+    try {
+      const response = await fetch('https://api.cerebras.ai/v1/models', {
+        headers: {
+          'Authorization': `Bearer ${this.apiKey}`,
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error(`Failed to list models: ${response.status}`);
+      }
+
+      const data = await response.json() as { data: Array<{ id: string }> };
+      return data.data
+        .map((model) => model.id)
+        .sort();
+    } catch {
+      return [
+        'gpt-oss-120b',
+        'llama-3.3-70b',
+        'llama-4-scout-17b-16e-instruct',
+        'qwen-3-235b-a22b-instruct-2507',
+      ];
+    }
+  }
+
+  private convertMessages(messages: LLMMessage[]): XAIMessage[] {
+    return messages.map((message) => {
+      const text = typeof message.content === 'string'
+        ? message.content
+        : message.content.map((block) => block.type === 'text' ? block.text : '[image]').join('\n');
+      const converted: XAIMessage = {
+        role: message.role as 'system' | 'user' | 'assistant' | 'tool',
+        content: (message.tool_calls && message.tool_calls.length > 0) ? '' : text,
+      };
+      if (message.tool_calls && message.tool_calls.length > 0) {
+        converted.tool_calls = message.tool_calls.map((toolCall) => ({
+          id: toolCall.id,
+          type: 'function' as const,
+          function: { name: toolCall.name, arguments: JSON.stringify(toolCall.arguments) },
+        }));
+      }
+      if (message.tool_call_id) {
+        converted.tool_call_id = message.tool_call_id;
+      }
+      return converted;
+    });
+  }
+
+  private convertTools(tools: LLMTool[]): XAIToolDef[] {
+    return tools.map((tool) => ({
+      type: 'function',
+      function: {
+        name: tool.name,
+        description: tool.description,
+        parameters: tool.parameters,
+      },
+    }));
+  }
+
+  private convertResponse(response: XAIResponse): LLMResponse {
+    const choice = response.choices[0]!;
+    const message = choice.message;
+    const content = message.content || '';
+    const tool_calls: LLMToolCall[] = [];
+
+    if (message.tool_calls) {
+      for (const toolCall of message.tool_calls) {
+        try {
+          tool_calls.push({
+            id: toolCall.id,
+            name: toolCall.function.name,
+            arguments: JSON.parse(toolCall.function.arguments),
+          });
+        } catch (err) {
+          console.error('Failed to parse tool call arguments:', err);
+        }
+      }
+    }
+
+    return {
+      content,
+      tool_calls,
+      usage: {
+        input_tokens: response.usage.prompt_tokens,
+        output_tokens: response.usage.completion_tokens,
+      },
+      model: response.model,
+      finish_reason: this.mapFinishReason(choice!.finish_reason),
+    };
+  }
+
+  private mapFinishReason(finishReason: string | null): 'stop' | 'tool_use' | 'length' | 'error' {
+    switch (finishReason) {
+      case 'stop':
+        return 'stop';
+      case 'tool_calls':
+        return 'tool_use';
+      case 'length':
+        return 'length';
+      case 'content_filter':
+        return 'error';
+      default:
+        return 'stop';
+    }
+  }
+}

--- a/src/llm/index.ts
+++ b/src/llm/index.ts
@@ -12,6 +12,8 @@ export type {
 // Provider implementations
 export { AnthropicProvider } from './anthropic.ts';
 export { OpenAIProvider } from './openai.ts';
+export { CerebrasProvider } from './cerebras.ts';
+export { LiteLLMProvider } from './litellm.ts';
 export { GroqProvider } from './groq.ts';
 export { GeminiProvider } from './gemini.ts';
 export { OllamaProvider } from './ollama.ts';

--- a/src/llm/litellm.ts
+++ b/src/llm/litellm.ts
@@ -1,0 +1,376 @@
+import type {
+  LLMProvider,
+  LLMMessage,
+  LLMOptions,
+  LLMResponse,
+  LLMStreamEvent,
+  LLMTool,
+  LLMToolCall,
+} from './provider.ts';
+import { compactHistory, calculateHistoryBudget } from './history.ts';
+
+type XAIMessage = {
+  role: 'system' | 'user' | 'assistant' | 'tool';
+  content: string;
+  tool_calls?: XAIToolCall[];
+  tool_call_id?: string;
+};
+
+type XAIToolDef = {
+  type: 'function';
+  function: {
+    name: string;
+    description: string;
+    parameters: Record<string, unknown>;
+  };
+};
+
+type XAIToolCall = {
+  id: string;
+  type: 'function';
+  function: {
+    name: string;
+    arguments: string;
+  };
+};
+
+type XAIResponse = {
+  id: string;
+  object: 'chat.completion';
+  created: number;
+  model: string;
+  choices: Array<{
+    index: number;
+    message: {
+      role: 'assistant';
+      content: string | null;
+      tool_calls?: XAIToolCall[];
+    };
+    finish_reason: 'stop' | 'length' | 'tool_calls' | 'content_filter' | null;
+  }>;
+  usage: {
+    prompt_tokens: number;
+    completion_tokens: number;
+    total_tokens: number;
+  };
+};
+
+type XAIStreamChunk = {
+  id: string;
+  object: 'chat.completion.chunk';
+  created: number;
+  model: string;
+  choices: Array<{
+    index: number;
+    delta: {
+      role?: 'assistant';
+      content?: string;
+      tool_calls?: Array<{
+        index: number;
+        id?: string;
+        type?: 'function';
+        function?: {
+          name?: string;
+          arguments?: string;
+        };
+      }>;
+    };
+    finish_reason: 'stop' | 'length' | 'tool_calls' | 'content_filter' | null;
+  }>;
+};
+
+export class LiteLLMProvider implements LLMProvider {
+  name = 'litellm';
+  private apiKey: string;
+  private defaultModel: string;
+  private baseUrl: string;
+  private apiUrl: string;
+
+  constructor(baseUrl = 'http://localhost:4000/v1', defaultModel = 'openai/gpt-4o-mini', apiKey = '') {
+    this.baseUrl = baseUrl.replace(/\/$/, '');
+    this.apiUrl = `${this.baseUrl}/chat/completions`;
+    this.apiKey = apiKey;
+    this.defaultModel = defaultModel;
+  }
+
+  private getHeaders(): Record<string, string> {
+    return this.apiKey
+      ? {
+          'Authorization': `Bearer ${this.apiKey}`,
+          'Content-Type': 'application/json',
+        }
+      : {
+          'Content-Type': 'application/json',
+        };
+  }
+
+  async chat(messages: LLMMessage[], options: LLMOptions = {}): Promise<LLMResponse> {
+    const { model = this.defaultModel, temperature, max_tokens, tools, tool_choice } = options;
+
+    const budget = calculateHistoryBudget(128000);
+    const compactedMessages = compactHistory(messages, budget);
+
+    const body: Record<string, unknown> = {
+      model,
+      messages: this.convertMessages(compactedMessages),
+    };
+
+    if (temperature !== undefined) body.temperature = temperature;
+    if (max_tokens !== undefined) body.max_tokens = max_tokens;
+    if (tools && tools.length > 0) {
+      body.tools = this.convertTools(tools);
+      body.tool_choice = tool_choice || 'auto';
+    }
+
+    const response = await fetch(this.apiUrl, {
+      method: 'POST',
+      headers: this.getHeaders(),
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`LiteLLM API error (${response.status}): ${errorText}`);
+    }
+
+    const data = await response.json() as XAIResponse;
+    return this.convertResponse(data);
+  }
+
+  async *stream(messages: LLMMessage[], options: LLMOptions = {}): AsyncIterable<LLMStreamEvent> {
+    const { model = this.defaultModel, temperature, max_tokens, tools, tool_choice } = options;
+
+    const budget = calculateHistoryBudget(128000);
+    const compactedMessages = compactHistory(messages, budget);
+
+    const body: Record<string, unknown> = {
+      model,
+      messages: this.convertMessages(compactedMessages),
+      stream: true,
+    };
+
+    if (temperature !== undefined) body.temperature = temperature;
+    if (max_tokens !== undefined) body.max_tokens = max_tokens;
+    if (tools && tools.length > 0) {
+      body.tools = this.convertTools(tools);
+      body.tool_choice = tool_choice || 'auto';
+    }
+
+    const response = await fetch(this.apiUrl, {
+      method: 'POST',
+      headers: this.getHeaders(),
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      yield { type: 'error', error: `LiteLLM API error (${response.status}): ${errorText}` };
+      return;
+    }
+
+    if (!response.body) {
+      yield { type: 'error', error: 'No response body' };
+      return;
+    }
+
+    let accumulatedText = '';
+    const toolCalls: LLMToolCall[] = [];
+    const toolCallBuilders: Map<number, { id: string; name: string; arguments: string }> = new Map();
+    let finishReason: string | null = null;
+    let responseModel = model;
+
+    try {
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = '';
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split('\n');
+        buffer = lines.pop() || '';
+
+        for (const line of lines) {
+          if (!line.trim() || !line.startsWith('data: ')) continue;
+
+          const data = line.slice(6);
+          if (data === '[DONE]') continue;
+
+          try {
+            const chunk = JSON.parse(data) as XAIStreamChunk;
+            if (chunk.choices && chunk.choices.length > 0) {
+              const choice = chunk.choices[0];
+              responseModel = chunk.model;
+
+              if (choice!.delta.content) {
+                accumulatedText += choice!.delta.content;
+                yield { type: 'text', text: choice!.delta.content };
+              }
+
+              if (choice!.delta.tool_calls) {
+                for (const toolCallDelta of choice!.delta.tool_calls) {
+                  const index = toolCallDelta.index;
+                  let builder = toolCallBuilders.get(index);
+
+                  if (!builder) {
+                    builder = {
+                      id: toolCallDelta.id || '',
+                      name: toolCallDelta.function?.name || '',
+                      arguments: '',
+                    };
+                    toolCallBuilders.set(index, builder);
+                  }
+
+                  if (toolCallDelta.id) builder.id = toolCallDelta.id;
+                  if (toolCallDelta.function?.name) builder.name = toolCallDelta.function.name;
+                  if (toolCallDelta.function?.arguments) {
+                    builder.arguments += toolCallDelta.function.arguments;
+                  }
+                }
+              }
+
+              if (choice!.finish_reason) {
+                finishReason = choice!.finish_reason;
+              }
+            }
+          } catch (err) {
+            console.error('Failed to parse SSE chunk:', err);
+          }
+        }
+      }
+
+      for (const builder of toolCallBuilders.values()) {
+        try {
+          const toolCall: LLMToolCall = {
+            id: builder.id,
+            name: builder.name,
+            arguments: JSON.parse(builder.arguments),
+          };
+          toolCalls.push(toolCall);
+          yield { type: 'tool_call', tool_call: toolCall };
+        } catch (err) {
+          yield { type: 'error', error: `Failed to parse tool call arguments: ${err}` };
+        }
+      }
+
+      const mappedFinishReason = this.mapFinishReason(finishReason);
+      yield {
+        type: 'done',
+        response: {
+          content: accumulatedText,
+          tool_calls: toolCalls,
+          usage: { input_tokens: 0, output_tokens: 0 },
+          model: responseModel,
+          finish_reason: mappedFinishReason,
+        },
+      };
+    } catch (err) {
+      yield { type: 'error', error: `Stream error: ${err}` };
+    }
+  }
+
+  async listModels(): Promise<string[]> {
+    try {
+      const response = await fetch(`${this.baseUrl}/models`, { headers: this.getHeaders() });
+
+      if (!response.ok) {
+        throw new Error(`Failed to list models: ${response.status}`);
+      }
+
+      const data = await response.json() as { data: Array<{ id: string }> };
+      return data.data
+        .map((model) => model.id)
+        .sort();
+    } catch {
+      return [
+        'openai/gpt-4o-mini',
+        'anthropic/claude-3-5-sonnet-latest',
+        'groq/llama-3.3-70b-versatile',
+        'ollama/llama3.1',
+      ];
+    }
+  }
+
+  private convertMessages(messages: LLMMessage[]): XAIMessage[] {
+    return messages.map((message) => {
+      const text = typeof message.content === 'string'
+        ? message.content
+        : message.content.map((block) => block.type === 'text' ? block.text : '[image]').join('\n');
+      const converted: XAIMessage = {
+        role: message.role as 'system' | 'user' | 'assistant' | 'tool',
+        content: (message.tool_calls && message.tool_calls.length > 0) ? '' : text,
+      };
+      if (message.tool_calls && message.tool_calls.length > 0) {
+        converted.tool_calls = message.tool_calls.map((toolCall) => ({
+          id: toolCall.id,
+          type: 'function' as const,
+          function: { name: toolCall.name, arguments: JSON.stringify(toolCall.arguments) },
+        }));
+      }
+      if (message.tool_call_id) {
+        converted.tool_call_id = message.tool_call_id;
+      }
+      return converted;
+    });
+  }
+
+  private convertTools(tools: LLMTool[]): XAIToolDef[] {
+    return tools.map((tool) => ({
+      type: 'function',
+      function: {
+        name: tool.name,
+        description: tool.description,
+        parameters: tool.parameters,
+      },
+    }));
+  }
+
+  private convertResponse(response: XAIResponse): LLMResponse {
+    const choice = response.choices[0]!;
+    const message = choice.message;
+    const content = message.content || '';
+    const tool_calls: LLMToolCall[] = [];
+
+    if (message.tool_calls) {
+      for (const toolCall of message.tool_calls) {
+        try {
+          tool_calls.push({
+            id: toolCall.id,
+            name: toolCall.function.name,
+            arguments: JSON.parse(toolCall.function.arguments),
+          });
+        } catch (err) {
+          console.error('Failed to parse tool call arguments:', err);
+        }
+      }
+    }
+
+    return {
+      content,
+      tool_calls,
+      usage: {
+        input_tokens: response.usage.prompt_tokens,
+        output_tokens: response.usage.completion_tokens,
+      },
+      model: response.model,
+      finish_reason: this.mapFinishReason(choice!.finish_reason),
+    };
+  }
+
+  private mapFinishReason(finishReason: string | null): 'stop' | 'tool_use' | 'length' | 'error' {
+    switch (finishReason) {
+      case 'stop':
+        return 'stop';
+      case 'tool_calls':
+        return 'tool_use';
+      case 'length':
+        return 'length';
+      case 'content_filter':
+        return 'error';
+      default:
+        return 'stop';
+    }
+  }
+}

--- a/src/llm/provider.test.ts
+++ b/src/llm/provider.test.ts
@@ -1,6 +1,8 @@
 import { test, expect, describe, beforeEach, afterEach, mock } from 'bun:test';
 import { AnthropicProvider } from './anthropic.ts';
 import { OpenAIProvider } from './openai.ts';
+import { CerebrasProvider } from './cerebras.ts';
+import { LiteLLMProvider } from './litellm.ts';
 import { GroqProvider } from './groq.ts';
 import { OllamaProvider } from './ollama.ts';
 import { OpenRouterProvider } from './openrouter.ts';
@@ -18,6 +20,16 @@ describe('LLM Provider Types', () => {
   test('OpenAIProvider can be instantiated', () => {
     const provider = new OpenAIProvider('test-key', 'test-model');
     expect(provider.name).toBe('openai');
+  });
+
+  test('CerebrasProvider can be instantiated', () => {
+    const provider = new CerebrasProvider('test-key', 'gpt-oss-120b');
+    expect(provider.name).toBe('cerebras');
+  });
+
+  test('LiteLLMProvider can be instantiated', () => {
+    const provider = new LiteLLMProvider('http://localhost:4000/v1', 'openai/gpt-4o-mini');
+    expect(provider.name).toBe('litellm');
   });
 
   test('GroqProvider can be instantiated', () => {
@@ -243,6 +255,16 @@ describe('Provider URLs', () => {
     expect(provider.apiUrl).toBe('https://openrouter.ai/api/v1/chat/completions');
   });
 
+  test('CerebrasProvider uses correct API URL', () => {
+    const provider = new CerebrasProvider('test-key') as any;
+    expect(provider.apiUrl).toBe('https://api.cerebras.ai/v1/chat/completions');
+  });
+
+  test('LiteLLMProvider uses configured API URL', () => {
+    const provider = new LiteLLMProvider('http://localhost:4000/v1') as any;
+    expect(provider.apiUrl).toBe('http://localhost:4000/v1/chat/completions');
+  });
+
   test('GroqProvider uses correct API URL', () => {
     const provider = new GroqProvider('test-key') as any;
     expect(provider.apiUrl).toBe('https://api.groq.com/openai/v1/chat/completions');
@@ -288,6 +310,16 @@ describe('Default Models', () => {
   test('OpenRouterProvider has correct default model', () => {
     const provider = new OpenRouterProvider('test-key') as any;
     expect(provider.defaultModel).toBe('anthropic/claude-sonnet-4');
+  });
+
+  test('CerebrasProvider has correct default model', () => {
+    const provider = new CerebrasProvider('test-key') as any;
+    expect(provider.defaultModel).toBe('gpt-oss-120b');
+  });
+
+  test('LiteLLMProvider has correct default model', () => {
+    const provider = new LiteLLMProvider() as any;
+    expect(provider.defaultModel).toBe('openai/gpt-4o-mini');
   });
 
   test('NVIDIAProvider has correct default model', () => {

--- a/src/llm/test.ts
+++ b/src/llm/test.ts
@@ -4,7 +4,7 @@
  * Run with: bun run src/llm/test.ts
  */
 
-import { LLMManager, AnthropicProvider, OpenAIProvider, OllamaProvider } from './index.ts';
+import { LLMManager, AnthropicProvider, OpenAIProvider, CerebrasProvider, LiteLLMProvider, OllamaProvider } from './index.ts';
 import { loadConfig } from '../config/index.ts';
 
 async function testProviders() {
@@ -30,6 +30,25 @@ async function testProviders() {
     );
     manager.registerProvider(openai);
     console.log('Registered OpenAI provider');
+  }
+
+  if (config.llm.cerebras?.api_key) {
+    const cerebras = new CerebrasProvider(
+      config.llm.cerebras.api_key,
+      config.llm.cerebras.model
+    );
+    manager.registerProvider(cerebras);
+    console.log('Registered Cerebras provider');
+  }
+
+  if (config.llm.litellm?.base_url) {
+    const litellm = new LiteLLMProvider(
+      config.llm.litellm.base_url,
+      config.llm.litellm.model,
+      config.llm.litellm.api_key ?? ''
+    );
+    manager.registerProvider(litellm);
+    console.log('Registered LiteLLM provider');
   }
 
   if (config.llm.ollama) {

--- a/src/sites/builder-tools.ts
+++ b/src/sites/builder-tools.ts
@@ -17,7 +17,8 @@ const BLOCKED_SERVER_PATTERNS = /\b(make\s+dev|bun\s+--hot|vite\s*$|next\s+dev|n
 const SECRET_ENV_PATTERNS = [
   /api[_-]?key/i, /secret/i, /token/i, /password/i, /credential/i,
   /^JARVIS_API_KEY$/, /^JARVIS_AUTH_TOKEN$/, /^JARVIS_OPENAI_KEY$/,
-  /^JARVIS_OPENROUTER_KEY$/, /^ANTHROPIC_API_KEY$/, /^OPENAI_API_KEY$/,
+  /^JARVIS_CEREBRAS_KEY$/, /^JARVIS_LITELLM_KEY$/, /^JARVIS_OPENROUTER_KEY$/,
+  /^ANTHROPIC_API_KEY$/, /^OPENAI_API_KEY$/,
 ];
 
 /** Build a sanitized env with secrets stripped */

--- a/ui/src/components/settings/LLMPanel.tsx
+++ b/ui/src/components/settings/LLMPanel.tsx
@@ -6,10 +6,13 @@ type LLMConfig = {
   fallback: string[];
   anthropic: { model: string; has_api_key: boolean } | null;
   openai: { model: string; has_api_key: boolean } | null;
+  cerebras: { model: string; has_api_key: boolean } | null;
+  litellm: { base_url: string; model: string; has_api_key: boolean } | null;
   groq: { model: string; has_api_key: boolean } | null;
   gemini: { model: string; has_api_key: boolean } | null;
   ollama: { base_url: string; model: string } | null;
   openrouter: { model: string; has_api_key: boolean } | null;
+  nvidia?: { model: string; has_api_key: boolean } | null;
 };
 
 type TestResult = { ok: boolean; model?: string; error?: string };
@@ -32,6 +35,20 @@ const OPENAI_MODELS = [
   "gpt-4.1",
   "o3",
   "o4-mini",
+];
+
+const CEREBRAS_MODELS = [
+  "gpt-oss-120b",
+  "llama-3.3-70b",
+  "llama-4-scout-17b-16e-instruct",
+  "qwen-3-235b-a22b-instruct-2507",
+];
+
+const LITELLM_MODELS = [
+  "openai/gpt-4o-mini",
+  "anthropic/claude-3-5-sonnet-latest",
+  "groq/llama-3.3-70b-versatile",
+  "ollama/llama3.1",
 ];
 
 const GROQ_MODELS = [
@@ -81,11 +98,13 @@ const OPENROUTER_MODELS = [
   "mistralai/mistral-large",
 ];
 
-const PROVIDERS = ["anthropic", "openai", "groq", "gemini", "ollama", "openrouter", "nvidia"] as const;
+const PROVIDERS = ["anthropic", "openai", "cerebras", "litellm", "groq", "gemini", "ollama", "openrouter", "nvidia"] as const;
 
 const PROVIDER_LABELS: Record<string, string> = {
   anthropic: "Anthropic",
   openai: "OpenAI",
+  cerebras: "Cerebras",
+  litellm: "LiteLLM",
   groq: "Groq",
   gemini: "Gemini",
   ollama: "Ollama",
@@ -109,6 +128,17 @@ export function LLMPanel() {
   const [openaiKey, setOpenaiKey] = useState("");
   const [openaiModel, setOpenaiModel] = useState("gpt-5.4");
   const [openaiCustomModel, setOpenaiCustomModel] = useState("");
+
+  // Cerebras
+  const [cerebrasKey, setCerebrasKey] = useState("");
+  const [cerebrasModel, setCerebrasModel] = useState("gpt-oss-120b");
+  const [cerebrasCustomModel, setCerebrasCustomModel] = useState("");
+
+  // LiteLLM
+  const [litellmKey, setLitellmKey] = useState("");
+  const [litellmBaseUrl, setLitellmBaseUrl] = useState("http://localhost:4000/v1");
+  const [litellmModel, setLitellmModel] = useState("openai/gpt-4o-mini");
+  const [litellmCustomModel, setLitellmCustomModel] = useState("");
 
   // Groq
   const [groqKey, setGroqKey] = useState("");
@@ -166,6 +196,27 @@ export function LLMPanel() {
       } else {
         setOpenaiModel("custom");
         setOpenaiCustomModel(m);
+      }
+    }
+    if (config.cerebras) {
+      const m = config.cerebras.model;
+      if (CEREBRAS_MODELS.includes(m)) {
+        setCerebrasModel(m);
+        setCerebrasCustomModel("");
+      } else {
+        setCerebrasModel("custom");
+        setCerebrasCustomModel(m);
+      }
+    }
+    if (config.litellm) {
+      setLitellmBaseUrl(config.litellm.base_url);
+      const m = config.litellm.model;
+      if (LITELLM_MODELS.includes(m)) {
+        setLitellmModel(m);
+        setLitellmCustomModel("");
+      } else {
+        setLitellmModel("custom");
+        setLitellmCustomModel(m);
       }
     }
     if (config.groq) {
@@ -241,6 +292,15 @@ export function LLMPanel() {
           model: resolveModel(openaiModel, openaiCustomModel),
           ...(openaiKey ? { api_key: openaiKey } : {}),
         },
+        cerebras: {
+          model: resolveModel(cerebrasModel, cerebrasCustomModel),
+          ...(cerebrasKey ? { api_key: cerebrasKey } : {}),
+        },
+        litellm: {
+          base_url: litellmBaseUrl,
+          model: resolveModel(litellmModel, litellmCustomModel),
+          ...(litellmKey ? { api_key: litellmKey } : {}),
+        },
         groq: {
           model: resolveModel(groqModel, groqCustomModel),
           ...(groqKey ? { api_key: groqKey } : {}),
@@ -269,6 +329,8 @@ export function LLMPanel() {
       setMessage({ text: resp.message, type: "ok" });
       setAnthropicKey("");
       setOpenaiKey("");
+      setCerebrasKey("");
+      setLitellmKey("");
       setGroqKey("");
       setGeminiKey("");
       setOpenrouterKey("");
@@ -293,6 +355,13 @@ export function LLMPanel() {
       } else if (provider === "openai") {
         body.api_key = openaiKey || undefined;
         body.model = resolveModel(openaiModel, openaiCustomModel);
+      } else if (provider === "cerebras") {
+        body.api_key = cerebrasKey || undefined;
+        body.model = resolveModel(cerebrasModel, cerebrasCustomModel);
+      } else if (provider === "litellm") {
+        body.api_key = litellmKey || undefined;
+        body.base_url = litellmBaseUrl;
+        body.model = resolveModel(litellmModel, litellmCustomModel);
       } else if (provider === "groq") {
         body.api_key = groqKey || undefined;
         body.model = resolveModel(groqModel, groqCustomModel);
@@ -413,6 +482,50 @@ export function LLMPanel() {
           onFallbackToggle={() => toggleFallback("openai")}
           expanded={!!expanded.openai}
           onToggleExpand={() => setExpanded((s) => ({ ...s, openai: !s.openai }))}
+        />
+
+        <ProviderSection
+          name="Cerebras"
+          provider="cerebras"
+          isPrimary={primary === "cerebras"}
+          hasKey={config.cerebras?.has_api_key ?? false}
+          apiKey={cerebrasKey}
+          onApiKeyChange={setCerebrasKey}
+          model={cerebrasModel}
+          customModel={cerebrasCustomModel}
+          onModelChange={setCerebrasModel}
+          onCustomModelChange={setCerebrasCustomModel}
+          models={CEREBRAS_MODELS}
+          testing={testing === "cerebras"}
+          testResult={testResult.cerebras}
+          onTest={() => handleTest("cerebras")}
+          isFallback={fallback.includes("cerebras")}
+          onFallbackToggle={() => toggleFallback("cerebras")}
+          expanded={!!expanded.cerebras}
+          onToggleExpand={() => setExpanded((s) => ({ ...s, cerebras: !s.cerebras }))}
+        />
+
+        <ProviderSection
+          name="LiteLLM"
+          provider="litellm"
+          isPrimary={primary === "litellm"}
+          hasKey={!!config.litellm?.base_url}
+          apiKey={litellmKey}
+          onApiKeyChange={setLitellmKey}
+          model={litellmModel}
+          customModel={litellmCustomModel}
+          onModelChange={setLitellmModel}
+          onCustomModelChange={setLitellmCustomModel}
+          models={LITELLM_MODELS}
+          testing={testing === "litellm"}
+          testResult={testResult.litellm}
+          onTest={() => handleTest("litellm")}
+          isFallback={fallback.includes("litellm")}
+          onFallbackToggle={() => toggleFallback("litellm")}
+          expanded={!!expanded.litellm}
+          onToggleExpand={() => setExpanded((s) => ({ ...s, litellm: !s.litellm }))}
+          baseUrl={litellmBaseUrl}
+          onBaseUrlChange={setLitellmBaseUrl}
         />
 
         <ProviderSection


### PR DESCRIPTION
## Summary
- add first-class Cerebras and LiteLLM provider support
- wire both providers through config, settings persistence, runtime registration, onboarding, testing, and dashboard UI
- preserve the standard Jarvis daemon-side tool-calling and memory/knowledge integration path
