### PR TITLE
Follow-ups to #85 and #117: harden the voice wake recognizer

### DIFF
--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -203,6 +203,47 @@ daemon:
   });
 });
 
+describe('Voice Config', () => {
+  afterEach(async () => {
+    delete process.env.JARVIS_WAKE_ENGINE;
+    if (existsSync(TEST_CONFIG_PATH)) {
+      await unlink(TEST_CONFIG_PATH);
+    }
+  });
+
+  test('defaults wake_engine to openwakeword (privacy-preserving local path)', async () => {
+    const config = await loadConfig('/tmp/jarvis-voice-defaults.yaml');
+    expect(config.voice?.wake_engine).toBe('openwakeword');
+  });
+
+  test('round-trips user-supplied wake_engine', async () => {
+    const yaml = `
+voice:
+  wake_engine: webspeech
+`;
+    await Bun.write(TEST_CONFIG_PATH, yaml);
+    const config = await loadConfig(TEST_CONFIG_PATH);
+    expect(config.voice?.wake_engine).toBe('webspeech');
+  });
+
+  test('JARVIS_WAKE_ENGINE env override wins over YAML', async () => {
+    const yaml = `
+voice:
+  wake_engine: openwakeword
+`;
+    await Bun.write(TEST_CONFIG_PATH, yaml);
+    process.env.JARVIS_WAKE_ENGINE = 'auto';
+    const config = await loadConfig(TEST_CONFIG_PATH);
+    expect(config.voice?.wake_engine).toBe('auto');
+  });
+
+  test('invalid JARVIS_WAKE_ENGINE is ignored, default is preserved', async () => {
+    process.env.JARVIS_WAKE_ENGINE = 'siri';
+    const config = await loadConfig('/tmp/jarvis-voice-invalid-env.yaml');
+    expect(config.voice?.wake_engine).toBe('openwakeword');
+  });
+});
+
 describe('Path Expansion', () => {
   test('expands tilde in paths', async () => {
     const config = await loadConfig();

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -98,6 +98,16 @@ function applyEnvOverrides(config: JarvisConfig): void {
     if (!config.auth) config.auth = {};
     config.auth.token = env.JARVIS_AUTH_TOKEN;
   }
+
+  if (env.JARVIS_WAKE_ENGINE) {
+    const engine = env.JARVIS_WAKE_ENGINE;
+    if (engine === 'openwakeword' || engine === 'webspeech' || engine === 'auto') {
+      if (!config.voice) config.voice = { wake_engine: 'openwakeword' };
+      config.voice.wake_engine = engine;
+    } else {
+      console.warn(`[Config] Invalid JARVIS_WAKE_ENGINE="${engine}" — must be openwakeword|webspeech|auto; ignoring.`);
+    }
+  }
 }
 
 export async function loadConfig(configPath?: string): Promise<JarvisConfig> {

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -23,6 +23,20 @@ export type ChannelConfig = {
   };
 };
 
+export type WakeEngine = 'openwakeword' | 'webspeech' | 'auto';
+
+export type VoiceConfig = {
+  /**
+   * Wake-word engine used by the browser UI.
+   *  - "openwakeword": local on-device model (default, private).
+   *  - "webspeech":    browser SpeechRecognition (Chromium only; streams audio
+   *                    to the browser vendor's cloud for transcription).
+   *  - "auto":         prefer webspeech when available, fall back to openwakeword.
+   * Env: JARVIS_WAKE_ENGINE
+   */
+  wake_engine: WakeEngine;
+};
+
 export type STTConfig = {
   provider: 'openai' | 'groq' | 'local' | 'sarvam';
   openai?: { api_key: string; model?: string };
@@ -150,6 +164,7 @@ export type JarvisConfig = {
   channels?: ChannelConfig;
   stt?: STTConfig;
   tts?: TTSConfig;
+  voice?: VoiceConfig;
   desktop?: DesktopConfig;
   awareness?: AwarenessConfig;
   llm: {
@@ -204,6 +219,9 @@ export const DEFAULT_CONFIG: JarvisConfig = {
     voice: 'en-US-AriaNeural',
     rate: '+0%',
     volume: '+0%',
+  },
+  voice: {
+    wake_engine: 'openwakeword',
   },
   desktop: {
     enabled: true,

--- a/src/daemon/api-routes.ts
+++ b/src/daemon/api-routes.ts
@@ -777,6 +777,7 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
           authority: config.authority,
           heartbeat: config.heartbeat,
           active_role: config.active_role,
+          voice: config.voice ?? { wake_engine: 'openwakeword' },
         });
       },
     },

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,7 +1,12 @@
 import React, { useState, useEffect } from "react";
 import { useWebSocket } from "./hooks/useWebSocket";
-import { useVoice } from "./hooks/useVoice";
+import { useVoice, type WakeEngineChoice } from "./hooks/useVoice";
+import { useApiData } from "./hooks/useApi";
 import "./styles/sidebar.css";
+
+type PublicConfig = {
+  voice?: { wake_engine?: WakeEngineChoice };
+};
 
 import ChatPage from "./pages/ChatPage";
 
@@ -106,7 +111,9 @@ export function App() {
   const [route, setRoute] = useState<Route>(getRoute);
   const [settingsSection, setSettingsSection] = useState<SettingsSection>(getSettingsSection);
   const ws = useWebSocket();
-  const voice = useVoice({ wsRef: ws.wsRef });
+  const { data: publicConfig } = useApiData<PublicConfig>("/api/config", []);
+  const wakeEngine = publicConfig?.voice?.wake_engine ?? "openwakeword";
+  const voice = useVoice({ wsRef: ws.wsRef, wakeEngine });
 
   // Wire voice callbacks into WS hook
   useEffect(() => {

--- a/ui/src/components/chat/ChatInput.tsx
+++ b/ui/src/components/chat/ChatInput.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useEffect } from "react";
-import type { VoiceState } from "../../hooks/useVoice";
+import type { VoiceState, ActiveWakeEngine } from "../../hooks/useVoice";
 
 type VoiceProps = {
   voiceState: VoiceState;
@@ -9,7 +9,14 @@ type VoiceProps = {
   isWakeWordReady: boolean;
   ttsAudioPlaying: boolean;
   cancelTTS: () => void;
+  activeWakeEngine: ActiveWakeEngine;
 };
+
+function engineLabel(engine: ActiveWakeEngine): string {
+  if (engine === "openwakeword") return "local wake";
+  if (engine === "webspeech") return "cloud wake (browser)";
+  return "wake off";
+}
 
 type Props = {
   onSend: (text: string) => void;
@@ -54,8 +61,9 @@ export function ChatInput({ onSend, disabled, voice }: Props) {
     if (!voice) return "";
     if (voice.ttsAudioPlaying) return "Stop speaking";
     if (voice.voiceState === "recording") return "Click to send";
-    if (voice.isWakeWordReady) return 'Say "Hey JARVIS" or click to speak';
-    return "Click to speak";
+    const engineSuffix = ` · ${engineLabel(voice.activeWakeEngine)}`;
+    if (voice.isWakeWordReady) return `Say "Hey JARVIS" or click to speak${engineSuffix}`;
+    return `Click to speak${engineSuffix}`;
   };
 
   const getMicIcon = () => {

--- a/ui/src/declarations.d.ts
+++ b/ui/src/declarations.d.ts
@@ -1,1 +1,69 @@
 declare module 'openwakeword-wasm-browser';
+
+// ── Web Speech API ──────────────────────────────────────────────────
+// Ambient types for SpeechRecognition. lib.dom covers some of this in
+// newer TS versions but coverage is inconsistent across lib variants,
+// and webkitSpeechRecognition is never declared. Declaring the surface
+// we actually use keeps the hook strictly typed without a runtime dep.
+
+type SpeechRecognitionErrorCode =
+  | 'no-speech'
+  | 'aborted'
+  | 'audio-capture'
+  | 'network'
+  | 'not-allowed'
+  | 'service-not-allowed'
+  | 'bad-grammar'
+  | 'language-not-supported';
+
+interface SpeechRecognitionAlternative {
+  readonly transcript: string;
+  readonly confidence: number;
+}
+
+interface SpeechRecognitionResult {
+  readonly length: number;
+  readonly isFinal: boolean;
+  item(index: number): SpeechRecognitionAlternative;
+  [index: number]: SpeechRecognitionAlternative;
+}
+
+interface SpeechRecognitionResultList {
+  readonly length: number;
+  item(index: number): SpeechRecognitionResult;
+  [index: number]: SpeechRecognitionResult;
+}
+
+interface SpeechRecognitionEvent extends Event {
+  readonly resultIndex: number;
+  readonly results: SpeechRecognitionResultList;
+}
+
+interface SpeechRecognitionErrorEvent extends Event {
+  readonly error: SpeechRecognitionErrorCode;
+  readonly message: string;
+}
+
+interface SpeechRecognition extends EventTarget {
+  continuous: boolean;
+  interimResults: boolean;
+  lang: string;
+  maxAlternatives: number;
+  onstart: ((this: SpeechRecognition, ev: Event) => void) | null;
+  onend: ((this: SpeechRecognition, ev: Event) => void) | null;
+  onerror: ((this: SpeechRecognition, ev: SpeechRecognitionErrorEvent) => void) | null;
+  onresult: ((this: SpeechRecognition, ev: SpeechRecognitionEvent) => void) | null;
+  start(): void;
+  stop(): void;
+  abort(): void;
+}
+
+interface SpeechRecognitionConstructor {
+  new (): SpeechRecognition;
+  prototype: SpeechRecognition;
+}
+
+interface Window {
+  SpeechRecognition?: SpeechRecognitionConstructor;
+  webkitSpeechRecognition?: SpeechRecognitionConstructor;
+}

--- a/ui/src/hooks/useVoice.test.ts
+++ b/ui/src/hooks/useVoice.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { matchesSpeechWakePhrase, shouldSpeechWakeBeRunning } from "./useVoice.ts";
+import { matchesSpeechWakePhrase, shouldSpeechWakeBeRunning, classifySpeechWakeError } from "./useVoice.ts";
 
 describe("matchesSpeechWakePhrase", () => {
   test("accepts direct wake phrases", () => {
@@ -55,5 +55,33 @@ describe("shouldSpeechWakeBeRunning", () => {
 
   test("webspeech requires SpeechRecognition to be available", () => {
     expect(shouldSpeechWakeBeRunning({ ...base, speechRecognitionAvailable: false })).toBe(false);
+  });
+
+  test("stops running once speechWakeFatal is set, even if everything else is fine", () => {
+    expect(shouldSpeechWakeBeRunning({ ...base, speechWakeFatal: true })).toBe(false);
+    expect(shouldSpeechWakeBeRunning({ ...base, speechWakeFatal: true, voiceState: "speaking" })).toBe(false);
+    expect(shouldSpeechWakeBeRunning({ ...base, speechWakeFatal: true, wakeEngine: "auto" })).toBe(false);
+  });
+});
+
+describe("classifySpeechWakeError", () => {
+  test("aborted and no-speech are expected lifecycle events", () => {
+    expect(classifySpeechWakeError("aborted")).toBe("expected");
+    expect(classifySpeechWakeError("no-speech")).toBe("expected");
+  });
+
+  test("audio-capture and network are transient", () => {
+    expect(classifySpeechWakeError("audio-capture")).toBe("transient");
+    expect(classifySpeechWakeError("network")).toBe("transient");
+  });
+
+  test("not-allowed and service-not-allowed are fatal (user/env action required)", () => {
+    expect(classifySpeechWakeError("not-allowed")).toBe("fatal");
+    expect(classifySpeechWakeError("service-not-allowed")).toBe("fatal");
+  });
+
+  test("bad-grammar and language-not-supported are fatal (config problems)", () => {
+    expect(classifySpeechWakeError("bad-grammar")).toBe("fatal");
+    expect(classifySpeechWakeError("language-not-supported")).toBe("fatal");
   });
 });

--- a/ui/src/hooks/useVoice.test.ts
+++ b/ui/src/hooks/useVoice.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import { matchesSpeechWakePhrase, shouldSpeechWakeBeRunning, classifySpeechWakeError } from "./useVoice.ts";
+import { matchesSpeechWakePhrase, matchesSpeechWakePrefix, shouldSpeechWakeBeRunning, classifySpeechWakeError } from "./useVoice.ts";
 
-describe("matchesSpeechWakePhrase", () => {
+describe("matchesSpeechWakePhrase (strict; used during TTS playback)", () => {
   test("accepts direct wake phrases", () => {
     expect(matchesSpeechWakePhrase("Jarvis")).toBe(true);
     expect(matchesSpeechWakePhrase("hey jarvis")).toBe(true);
@@ -9,11 +9,36 @@ describe("matchesSpeechWakePhrase", () => {
     expect(matchesSpeechWakePhrase("Hey Jarvis, hold on")).toBe(true);
   });
 
-  test("rejects longer sentences that merely mention jarvis", () => {
+  test("rejects longer sentences that merely mention jarvis (echo protection)", () => {
     expect(matchesSpeechWakePhrase("Jarvis is already working on that")).toBe(false);
     expect(matchesSpeechWakePhrase("Can you tell Jarvis to send that")).toBe(false);
     expect(matchesSpeechWakePhrase("I said Jarvis in the middle of a sentence")).toBe(false);
     expect(matchesSpeechWakePhrase("Hey Jarvis can you help")).toBe(false);
+  });
+});
+
+describe("matchesSpeechWakePrefix (loose; used when idle)", () => {
+  test("accepts bare wake phrases", () => {
+    expect(matchesSpeechWakePrefix("Jarvis")).toBe(true);
+    expect(matchesSpeechWakePrefix("hey jarvis")).toBe(true);
+  });
+
+  test("accepts wake phrase followed by any command in one utterance", () => {
+    expect(matchesSpeechWakePrefix("hey jarvis turn off the lights")).toBe(true);
+    expect(matchesSpeechWakePrefix("jarvis what's the weather")).toBe(true);
+    expect(matchesSpeechWakePrefix("Hey Jarvis, play some music")).toBe(true);
+    expect(matchesSpeechWakePrefix("jarvis can you help me")).toBe(true);
+  });
+
+  test("rejects utterances that merely contain jarvis mid-sentence", () => {
+    expect(matchesSpeechWakePrefix("Can you tell Jarvis to send that")).toBe(false);
+    expect(matchesSpeechWakePrefix("I said Jarvis in the middle of a sentence")).toBe(false);
+    expect(matchesSpeechWakePrefix("that was Jarvis talking")).toBe(false);
+  });
+
+  test("rejects empty or whitespace-only transcripts", () => {
+    expect(matchesSpeechWakePrefix("")).toBe(false);
+    expect(matchesSpeechWakePrefix("   ")).toBe(false);
   });
 });
 

--- a/ui/src/hooks/useVoice.test.ts
+++ b/ui/src/hooks/useVoice.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { matchesSpeechWakePhrase } from "./useVoice.ts";
+import { matchesSpeechWakePhrase, shouldSpeechWakeBeRunning } from "./useVoice.ts";
 
 describe("matchesSpeechWakePhrase", () => {
   test("accepts direct wake phrases", () => {
@@ -14,5 +14,46 @@ describe("matchesSpeechWakePhrase", () => {
     expect(matchesSpeechWakePhrase("Can you tell Jarvis to send that")).toBe(false);
     expect(matchesSpeechWakePhrase("I said Jarvis in the middle of a sentence")).toBe(false);
     expect(matchesSpeechWakePhrase("Hey Jarvis can you help")).toBe(false);
+  });
+});
+
+describe("shouldSpeechWakeBeRunning", () => {
+  const base = {
+    isMicAvailable: true,
+    wakeWordEnabled: true,
+    voiceState: "idle" as const,
+    wakeEngine: "webspeech" as const,
+    speechRecognitionAvailable: true,
+  };
+
+  test("runs in idle and speaking (for barge-in)", () => {
+    expect(shouldSpeechWakeBeRunning(base)).toBe(true);
+    expect(shouldSpeechWakeBeRunning({ ...base, voiceState: "speaking" })).toBe(true);
+  });
+
+  test("does not run during recording, processing, wake_detected, or error", () => {
+    expect(shouldSpeechWakeBeRunning({ ...base, voiceState: "recording" })).toBe(false);
+    expect(shouldSpeechWakeBeRunning({ ...base, voiceState: "processing" })).toBe(false);
+    expect(shouldSpeechWakeBeRunning({ ...base, voiceState: "wake_detected" })).toBe(false);
+    expect(shouldSpeechWakeBeRunning({ ...base, voiceState: "error" })).toBe(false);
+  });
+
+  test("does not run when mic is unavailable or wake word is disabled", () => {
+    expect(shouldSpeechWakeBeRunning({ ...base, isMicAvailable: false })).toBe(false);
+    expect(shouldSpeechWakeBeRunning({ ...base, wakeWordEnabled: false })).toBe(false);
+  });
+
+  test("never runs when the configured engine is openwakeword", () => {
+    expect(shouldSpeechWakeBeRunning({ ...base, wakeEngine: "openwakeword" })).toBe(false);
+    expect(shouldSpeechWakeBeRunning({ ...base, wakeEngine: "openwakeword", voiceState: "speaking" })).toBe(false);
+  });
+
+  test("auto only runs speech wake when SpeechRecognition is present", () => {
+    expect(shouldSpeechWakeBeRunning({ ...base, wakeEngine: "auto" })).toBe(true);
+    expect(shouldSpeechWakeBeRunning({ ...base, wakeEngine: "auto", speechRecognitionAvailable: false })).toBe(false);
+  });
+
+  test("webspeech requires SpeechRecognition to be available", () => {
+    expect(shouldSpeechWakeBeRunning({ ...base, speechRecognitionAvailable: false })).toBe(false);
   });
 });

--- a/ui/src/hooks/useVoice.test.ts
+++ b/ui/src/hooks/useVoice.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from "bun:test";
-import { matchesSpeechWakePhrase, matchesSpeechWakePrefix, shouldSpeechWakeBeRunning, classifySpeechWakeError } from "./useVoice.ts";
+import {
+  matchesSpeechWakePhrase,
+  matchesSpeechWakePrefix,
+  shouldSpeechWakeBeRunning,
+  classifySpeechWakeError,
+  selectActiveWakeEngine,
+} from "./useVoice.ts";
 
 describe("matchesSpeechWakePhrase (strict; used during TTS playback)", () => {
   test("accepts direct wake phrases", () => {
@@ -39,6 +45,24 @@ describe("matchesSpeechWakePrefix (loose; used when idle)", () => {
   test("rejects empty or whitespace-only transcripts", () => {
     expect(matchesSpeechWakePrefix("")).toBe(false);
     expect(matchesSpeechWakePrefix("   ")).toBe(false);
+  });
+});
+
+describe("matcher normalization (shared by both matchers)", () => {
+  test("handles mixed case and surrounding whitespace", () => {
+    expect(matchesSpeechWakePrefix("   HEY JARVIS   ")).toBe(true);
+    expect(matchesSpeechWakePhrase("   JARVIS, STOP!   ")).toBe(true);
+  });
+
+  test("collapses stacked punctuation and multiple spaces", () => {
+    expect(matchesSpeechWakePhrase("Jarvis... stop!!")).toBe(true);
+    expect(matchesSpeechWakePrefix("hey   jarvis    play   music")).toBe(true);
+  });
+
+  test("is not fooled by mid-word 'jarvis' substrings", () => {
+    // "starjarvis" is one token; without a word boundary it must not match.
+    expect(matchesSpeechWakePrefix("starjarvis")).toBe(false);
+    expect(matchesSpeechWakePhrase("starjarvis stop")).toBe(false);
   });
 });
 
@@ -86,6 +110,48 @@ describe("shouldSpeechWakeBeRunning", () => {
     expect(shouldSpeechWakeBeRunning({ ...base, speechWakeFatal: true })).toBe(false);
     expect(shouldSpeechWakeBeRunning({ ...base, speechWakeFatal: true, voiceState: "speaking" })).toBe(false);
     expect(shouldSpeechWakeBeRunning({ ...base, speechWakeFatal: true, wakeEngine: "auto" })).toBe(false);
+  });
+});
+
+describe("selectActiveWakeEngine", () => {
+  const base = {
+    isMicAvailable: true,
+    wakeWordEnabled: true,
+    wakeEngine: "openwakeword" as const,
+    speechRecognitionAvailable: true,
+    speechWakeFatal: false,
+  };
+
+  test("returns 'none' when mic is unavailable or wake word is disabled", () => {
+    expect(selectActiveWakeEngine({ ...base, isMicAvailable: false })).toBe("none");
+    expect(selectActiveWakeEngine({ ...base, wakeWordEnabled: false })).toBe("none");
+  });
+
+  test("'openwakeword' always resolves to openwakeword (privacy-preserving path)", () => {
+    expect(selectActiveWakeEngine({ ...base, wakeEngine: "openwakeword" })).toBe("openwakeword");
+    // Even with speech available, config wins:
+    expect(selectActiveWakeEngine({ ...base, wakeEngine: "openwakeword", speechRecognitionAvailable: true })).toBe("openwakeword");
+    // Fatal speech-wake state is irrelevant when config doesn't want it.
+    expect(selectActiveWakeEngine({ ...base, wakeEngine: "openwakeword", speechWakeFatal: true })).toBe("openwakeword");
+  });
+
+  test("'webspeech' resolves to webspeech when available, else 'none' (hard mode)", () => {
+    expect(selectActiveWakeEngine({ ...base, wakeEngine: "webspeech" })).toBe("webspeech");
+    expect(selectActiveWakeEngine({ ...base, wakeEngine: "webspeech", speechRecognitionAvailable: false })).toBe("none");
+    expect(selectActiveWakeEngine({ ...base, wakeEngine: "webspeech", speechWakeFatal: true })).toBe("none");
+  });
+
+  test("'auto' prefers webspeech but gracefully falls back to openwakeword", () => {
+    expect(selectActiveWakeEngine({ ...base, wakeEngine: "auto" })).toBe("webspeech");
+    expect(selectActiveWakeEngine({ ...base, wakeEngine: "auto", speechRecognitionAvailable: false })).toBe("openwakeword");
+    expect(selectActiveWakeEngine({ ...base, wakeEngine: "auto", speechWakeFatal: true })).toBe("openwakeword");
+    // Both unavailable → still falls back to openwakeword rather than silently no-op.
+    expect(selectActiveWakeEngine({ ...base, wakeEngine: "auto", speechRecognitionAvailable: false, speechWakeFatal: true })).toBe("openwakeword");
+  });
+
+  test("mic/toggle gates override everything else", () => {
+    expect(selectActiveWakeEngine({ ...base, wakeEngine: "auto", isMicAvailable: false })).toBe("none");
+    expect(selectActiveWakeEngine({ ...base, wakeEngine: "openwakeword", wakeWordEnabled: false })).toBe("none");
   });
 });
 

--- a/ui/src/hooks/useVoice.ts
+++ b/ui/src/hooks/useVoice.ts
@@ -56,6 +56,32 @@ type SpeechWakeState = "stopped" | "starting" | "running" | "stopping";
 /** Minimum ms between two accepted wake matches. Prevents interim-result bursts. */
 const WAKE_COOLDOWN_MS = 500;
 
+/** After this many consecutive transient errors without a successful start, stop retrying. */
+const SPEECH_WAKE_MAX_CONSECUTIVE_ERRORS = 3;
+
+/**
+ * Classify a SpeechRecognition error so the caller can decide what to do:
+ *  - "expected":  normal part of the API lifecycle; ignore.
+ *  - "transient": may recover; retry with existing restart logic.
+ *  - "fatal":     user or environment requires manual intervention; stop.
+ * Exported for unit testing.
+ */
+export function classifySpeechWakeError(code: SpeechRecognitionErrorCode): "expected" | "transient" | "fatal" {
+  switch (code) {
+    case "aborted":
+    case "no-speech":
+      return "expected";
+    case "not-allowed":
+    case "service-not-allowed":
+    case "bad-grammar":
+    case "language-not-supported":
+      return "fatal";
+    case "audio-capture":
+    case "network":
+      return "transient";
+  }
+}
+
 /**
  * Pure decision function: given current inputs, should the Web Speech wake
  * recognizer be running right now? Exported for unit testing.
@@ -66,8 +92,11 @@ export function shouldSpeechWakeBeRunning(inputs: {
   voiceState: VoiceState;
   wakeEngine: WakeEngineChoice;
   speechRecognitionAvailable: boolean;
+  /** True once the recognizer has hit a non-recoverable error. */
+  speechWakeFatal?: boolean;
 }): boolean {
-  const { isMicAvailable, wakeWordEnabled, voiceState, wakeEngine, speechRecognitionAvailable } = inputs;
+  const { isMicAvailable, wakeWordEnabled, voiceState, wakeEngine, speechRecognitionAvailable, speechWakeFatal } = inputs;
+  if (speechWakeFatal) return false;
   if (!isMicAvailable || !wakeWordEnabled || !speechRecognitionAvailable) return false;
   if (voiceState !== "idle" && voiceState !== "speaking") return false;
   if (wakeEngine === "openwakeword") return false;
@@ -103,6 +132,7 @@ export function useVoice({ wsRef, wakeWordEnabled = true, wakeEngine = "openwake
   const [isWakeWordReady, setIsWakeWordReady] = useState(false);
   const [ttsAudioPlaying, setTtsAudioPlaying] = useState(false);
   const [activeWakeEngine, setActiveWakeEngine] = useState<ActiveWakeEngine>("none");
+  const [speechWakeFatal, setSpeechWakeFatal] = useState(false);
 
   const recordingContextRef = useRef<AudioContext | null>(null);
   const recordingSourceRef = useRef<MediaStreamAudioSourceNode | null>(null);
@@ -125,6 +155,8 @@ export function useVoice({ wsRef, wakeWordEnabled = true, wakeEngine = "openwake
   const speechWakeRef = useRef<SpeechRecognition | null>(null);
   const speechWakeStateRef = useRef<SpeechWakeState>("stopped");
   const speechWakeRestartTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const speechWakeFatalRef = useRef(false);
+  const speechWakeConsecutiveErrorsRef = useRef(0);
   const lastWakeAtRef = useRef(0);
   const isMicAvailableRef = useRef(false);
   const configuredWakeEngineRef = useRef<WakeEngineChoice>(wakeEngine);
@@ -137,6 +169,14 @@ export function useVoice({ wsRef, wakeWordEnabled = true, wakeEngine = "openwake
   useEffect(() => { wakeWordEnabledRef.current = wakeWordEnabled; }, [wakeWordEnabled]);
   useEffect(() => { isMicAvailableRef.current = isMicAvailable; }, [isMicAvailable]);
   useEffect(() => { configuredWakeEngineRef.current = wakeEngine; }, [wakeEngine]);
+  useEffect(() => { speechWakeFatalRef.current = speechWakeFatal; }, [speechWakeFatal]);
+
+  // Reset fatal state when the user changes engine choice or toggles wake word.
+  // A config change is a clear signal that the user wants us to retry.
+  useEffect(() => {
+    setSpeechWakeFatal(false);
+    speechWakeConsecutiveErrorsRef.current = 0;
+  }, [wakeEngine, wakeWordEnabled]);
 
   // --- AudioContext helper ---
   const getAudioContext = useCallback((): AudioContext => {
@@ -271,6 +311,20 @@ export function useVoice({ wsRef, wakeWordEnabled = true, wakeEngine = "openwake
   // The public API is startSpeechWakeIfNeeded / stopSpeechWakeIfNeeded — both
   // idempotent and safe to call from any code path.
 
+  // Promote the speech-wake recognizer to "permanently failed" until the user
+  // changes config (which resets the flag). For "auto", fall back to local OWW.
+  const markSpeechWakeFatal = useCallback((): void => {
+    speechWakeFatalRef.current = true;
+    setSpeechWakeFatal(true);
+    setIsWakeWordReady(false);
+    if (configuredWakeEngineRef.current === "auto") {
+      startWakeWordEngine();
+      setActiveWakeEngine("openwakeword");
+    } else {
+      setActiveWakeEngine("none");
+    }
+  }, [startWakeWordEngine]);
+
   const shouldSpeechWakeRun = useCallback((): boolean => {
     return shouldSpeechWakeBeRunning({
       isMicAvailable: isMicAvailableRef.current,
@@ -278,6 +332,7 @@ export function useVoice({ wsRef, wakeWordEnabled = true, wakeEngine = "openwake
       voiceState: voiceStateRef.current,
       wakeEngine: configuredWakeEngineRef.current,
       speechRecognitionAvailable: isSpeechRecognitionAvailable(),
+      speechWakeFatal: speechWakeFatalRef.current,
     });
   }, [isSpeechRecognitionAvailable]);
 
@@ -298,6 +353,9 @@ export function useVoice({ wsRef, wakeWordEnabled = true, wakeEngine = "openwake
 
       recognition.onstart = () => {
         speechWakeStateRef.current = "running";
+        // A successful start means any prior transient error streak is resolved.
+        speechWakeConsecutiveErrorsRef.current = 0;
+        setIsWakeWordReady(true);
       };
 
       recognition.onresult = (event: SpeechRecognitionEvent) => {
@@ -347,7 +405,22 @@ export function useVoice({ wsRef, wakeWordEnabled = true, wakeEngine = "openwake
       };
 
       recognition.onerror = (event: SpeechRecognitionErrorEvent) => {
-        console.warn(`[Voice] Speech wake recognizer error: ${event.error}`, event.message);
+        const kind = classifySpeechWakeError(event.error);
+        if (kind === "expected") return; // aborted / no-speech are part of normal lifecycle
+
+        if (kind === "transient") {
+          speechWakeConsecutiveErrorsRef.current += 1;
+          console.warn(`[Voice] Speech wake transient error (${speechWakeConsecutiveErrorsRef.current}/${SPEECH_WAKE_MAX_CONSECUTIVE_ERRORS}): ${event.error}`, event.message);
+          if (speechWakeConsecutiveErrorsRef.current >= SPEECH_WAKE_MAX_CONSECUTIVE_ERRORS) {
+            console.error(`[Voice] Speech wake disabled after ${SPEECH_WAKE_MAX_CONSECUTIVE_ERRORS} consecutive "${event.error}" errors`);
+            markSpeechWakeFatal();
+          }
+          return; // otherwise let the existing onend-driven restart handle it
+        }
+
+        // kind === "fatal"
+        console.error(`[Voice] Speech wake recognizer fatal error: ${event.error}`, event.message);
+        markSpeechWakeFatal();
       };
 
       recognition.onend = () => {
@@ -444,10 +517,11 @@ export function useVoice({ wsRef, wakeWordEnabled = true, wakeEngine = "openwake
       voiceState,
       wakeEngine,
       speechRecognitionAvailable: isSpeechRecognitionAvailable(),
+      speechWakeFatal,
     });
     if (shouldRun) startSpeechWakeIfNeeded();
     else stopSpeechWakeIfNeeded();
-  }, [isMicAvailable, wakeWordEnabled, voiceState, wakeEngine, startSpeechWakeIfNeeded, stopSpeechWakeIfNeeded, isSpeechRecognitionAvailable]);
+  }, [isMicAvailable, wakeWordEnabled, voiceState, wakeEngine, speechWakeFatal, startSpeechWakeIfNeeded, stopSpeechWakeIfNeeded, isSpeechRecognitionAvailable]);
 
   // Restart wake word listening when returning to idle (with delay for mic release)
   useEffect(() => {

--- a/ui/src/hooks/useVoice.ts
+++ b/ui/src/hooks/useVoice.ts
@@ -40,9 +40,17 @@ export type VoiceState =
   | "speaking"       // receiving and playing TTS audio
   | "error";         // recoverable — returns to idle after timeout
 
+/** User-facing engine choice (see server config `voice.wake_engine`). */
+export type WakeEngineChoice = "openwakeword" | "webspeech" | "auto";
+
+/** Which engine is actually running right now (reported back to UI). */
+export type ActiveWakeEngine = "openwakeword" | "webspeech" | "none";
+
 export type UseVoiceOptions = {
   wsRef: React.MutableRefObject<WebSocket | null>;
   wakeWordEnabled?: boolean;
+  /** Default "openwakeword" (local). "webspeech" uses Chromium's cloud STT. */
+  wakeEngine?: WakeEngineChoice;
 };
 
 export type UseVoiceReturn = {
@@ -53,6 +61,7 @@ export type UseVoiceReturn = {
   isWakeWordReady: boolean;
   ttsAudioPlaying: boolean;
   cancelTTS: () => void;
+  activeWakeEngine: ActiveWakeEngine;
   // Called by useWebSocket for TTS events
   handleTTSBinary: (data: ArrayBuffer) => void;
   handleTTSStart: (requestId: string) => void;
@@ -60,11 +69,12 @@ export type UseVoiceReturn = {
   handleError: (message?: string) => void;
 };
 
-export function useVoice({ wsRef, wakeWordEnabled = true }: UseVoiceOptions): UseVoiceReturn {
+export function useVoice({ wsRef, wakeWordEnabled = true, wakeEngine = "openwakeword" }: UseVoiceOptions): UseVoiceReturn {
   const [voiceState, setVoiceState] = useState<VoiceState>("idle");
   const [isMicAvailable, setIsMicAvailable] = useState(false);
   const [isWakeWordReady, setIsWakeWordReady] = useState(false);
   const [ttsAudioPlaying, setTtsAudioPlaying] = useState(false);
+  const [activeWakeEngine, setActiveWakeEngine] = useState<ActiveWakeEngine>("none");
 
   const recordingContextRef = useRef<AudioContext | null>(null);
   const recordingSourceRef = useRef<MediaStreamAudioSourceNode | null>(null);
@@ -306,22 +316,39 @@ export function useVoice({ wsRef, wakeWordEnabled = true }: UseVoiceOptions): Us
     return speechWakeActiveRef.current;
   }, []);
 
-  // Initialize wake word engine when mic available and enabled
+  // Initialize wake word engine when mic available and enabled.
+  // Engine choice is driven by config (voice.wake_engine) — defaulting to the
+  // local OpenWakeWord path to avoid streaming ambient audio to cloud STT.
   useEffect(() => {
-    if (isMicAvailable && wakeWordEnabled) {
-      const speechWakeStarted = startSpeechWakeRecognizer();
-      // Use OpenWakeWord only if browser speech wake phrase recognition isn't available.
-      if (!speechWakeStarted) {
-        startWakeWordEngine();
-      } else {
+    if (!(isMicAvailable && wakeWordEnabled)) {
+      setActiveWakeEngine("none");
+      return;
+    }
+
+    if (wakeEngine === "openwakeword") {
+      startWakeWordEngine();
+      setActiveWakeEngine("openwakeword");
+    } else if (wakeEngine === "webspeech") {
+      const started = startSpeechWakeRecognizer();
+      setActiveWakeEngine(started ? "webspeech" : "none");
+    } else {
+      // "auto": prefer the browser recognizer when present, fall back to local.
+      const started = startSpeechWakeRecognizer();
+      if (started) {
         stopWakeWordEngine();
+        setActiveWakeEngine("webspeech");
+      } else {
+        startWakeWordEngine();
+        setActiveWakeEngine("openwakeword");
       }
     }
+
     return () => {
       stopWakeWordEngine();
       stopSpeechWakeRecognizer();
+      setActiveWakeEngine("none");
     };
-  }, [isMicAvailable, wakeWordEnabled, startWakeWordEngine, stopWakeWordEngine, startSpeechWakeRecognizer, stopSpeechWakeRecognizer]);
+  }, [isMicAvailable, wakeWordEnabled, wakeEngine, startWakeWordEngine, stopWakeWordEngine, startSpeechWakeRecognizer, stopSpeechWakeRecognizer]);
 
   // Restart wake word listening when returning to idle (with delay for mic release)
   useEffect(() => {
@@ -346,12 +373,18 @@ export function useVoice({ wsRef, wakeWordEnabled = true }: UseVoiceOptions): Us
     }
   }, [voiceState]);
 
-  // Ensure speech fallback is active when idle or speaking so Jarvis can be interrupted while speaking.
+  // Keep the configured wake engine armed when idle or speaking (enables barge-in).
   useEffect(() => {
     if (voiceState === "idle" || voiceState === "speaking") {
-      const speechWakeStarted = startSpeechWakeRecognizer();
-      if (!speechWakeStarted && wakeEngineRef.current) {
-        wakeEngineRef.current.start().catch(() => {});
+      if (wakeEngine === "openwakeword") {
+        wakeEngineRef.current?.start().catch(() => {});
+      } else if (wakeEngine === "webspeech") {
+        startSpeechWakeRecognizer();
+      } else {
+        const started = startSpeechWakeRecognizer();
+        if (!started && wakeEngineRef.current) {
+          wakeEngineRef.current.start().catch(() => {});
+        }
       }
     } else if (voiceState === "recording" || voiceState === "processing") {
       stopSpeechWakeRecognizer();
@@ -359,7 +392,7 @@ export function useVoice({ wsRef, wakeWordEnabled = true }: UseVoiceOptions): Us
     return () => {
       stopSpeechWakeRecognizer();
     };
-  }, [voiceState, startSpeechWakeRecognizer, stopSpeechWakeRecognizer]);
+  }, [voiceState, wakeEngine, startSpeechWakeRecognizer, stopSpeechWakeRecognizer]);
 
   // --- TTS Playback ---
   const playNextTTSChunk = useCallback(() => {
@@ -650,6 +683,7 @@ export function useVoice({ wsRef, wakeWordEnabled = true }: UseVoiceOptions): Us
     isWakeWordReady,
     ttsAudioPlaying,
     cancelTTS,
+    activeWakeEngine,
     handleTTSBinary,
     handleTTSStart,
     handleTTSEnd,

--- a/ui/src/hooks/useVoice.ts
+++ b/ui/src/hooks/useVoice.ts
@@ -111,6 +111,29 @@ export function classifySpeechWakeError(code: SpeechRecognitionErrorCode): "expe
 }
 
 /**
+ * Pure decision function: which wake engine should own the mic right now?
+ * Consolidates the engine-selection rules (config + SpeechRecognition
+ * availability + fatal state) so the effect that drives OpenWakeWord /
+ * the active-engine indicator can't drift from the test expectations.
+ * Exported for unit testing.
+ */
+export function selectActiveWakeEngine(inputs: {
+  isMicAvailable: boolean;
+  wakeWordEnabled: boolean;
+  wakeEngine: WakeEngineChoice;
+  speechRecognitionAvailable: boolean;
+  speechWakeFatal: boolean;
+}): ActiveWakeEngine {
+  const { isMicAvailable, wakeWordEnabled, wakeEngine, speechRecognitionAvailable, speechWakeFatal } = inputs;
+  if (!isMicAvailable || !wakeWordEnabled) return "none";
+  if (wakeEngine === "openwakeword") return "openwakeword";
+  const speechUsable = speechRecognitionAvailable && !speechWakeFatal;
+  if (wakeEngine === "webspeech") return speechUsable ? "webspeech" : "none";
+  // "auto": prefer the browser recognizer when usable, fall back to local.
+  return speechUsable ? "webspeech" : "openwakeword";
+}
+
+/**
  * Pure decision function: given current inputs, should the Web Speech wake
  * recognizer be running right now? Exported for unit testing.
  */
@@ -340,18 +363,13 @@ export function useVoice({ wsRef, wakeWordEnabled = true, wakeEngine = "openwake
   // idempotent and safe to call from any code path.
 
   // Promote the speech-wake recognizer to "permanently failed" until the user
-  // changes config (which resets the flag). For "auto", fall back to local OWW.
+  // changes config (which resets the flag). The engine-selection effect picks
+  // up the new state and handles the OWW fallback for "auto".
   const markSpeechWakeFatal = useCallback((): void => {
     speechWakeFatalRef.current = true;
     setSpeechWakeFatal(true);
     setIsWakeWordReady(false);
-    if (configuredWakeEngineRef.current === "auto") {
-      startWakeWordEngine();
-      setActiveWakeEngine("openwakeword");
-    } else {
-      setActiveWakeEngine("none");
-    }
-  }, [startWakeWordEngine]);
+  }, []);
 
   const shouldSpeechWakeRun = useCallback((): boolean => {
     return shouldSpeechWakeBeRunning({
@@ -507,38 +525,21 @@ export function useVoice({ wsRef, wakeWordEnabled = true, wakeEngine = "openwake
   }, []);
 
   // Engine selection effect. Picks which wake engine should own the mic based
-  // on config + SpeechRecognition availability, and drives the OpenWakeWord
-  // side. The speech-wake recognizer itself is driven by the reconcile effect
-  // below so we avoid two code paths fighting over a single recognizer.
+  // on config + SpeechRecognition availability + fatal state via the pure
+  // selector. Imperatively drives the OpenWakeWord side here; the speech-wake
+  // recognizer is driven by the reconcile effect below.
   useEffect(() => {
-    if (!(isMicAvailable && wakeWordEnabled)) {
-      stopWakeWordEngine();
-      setActiveWakeEngine("none");
-      return;
-    }
-
-    const speechAvailable = isSpeechRecognitionAvailable();
-
-    switch (wakeEngine) {
-      case "openwakeword":
-        startWakeWordEngine();
-        setActiveWakeEngine("openwakeword");
-        break;
-      case "webspeech":
-        stopWakeWordEngine();
-        setActiveWakeEngine(speechAvailable ? "webspeech" : "none");
-        break;
-      case "auto":
-        if (speechAvailable) {
-          stopWakeWordEngine();
-          setActiveWakeEngine("webspeech");
-        } else {
-          startWakeWordEngine();
-          setActiveWakeEngine("openwakeword");
-        }
-        break;
-    }
-  }, [isMicAvailable, wakeWordEnabled, wakeEngine, startWakeWordEngine, stopWakeWordEngine, isSpeechRecognitionAvailable]);
+    const active = selectActiveWakeEngine({
+      isMicAvailable,
+      wakeWordEnabled,
+      wakeEngine,
+      speechRecognitionAvailable: isSpeechRecognitionAvailable(),
+      speechWakeFatal,
+    });
+    setActiveWakeEngine(active);
+    if (active === "openwakeword") startWakeWordEngine();
+    else stopWakeWordEngine();
+  }, [isMicAvailable, wakeWordEnabled, wakeEngine, speechWakeFatal, startWakeWordEngine, stopWakeWordEngine, isSpeechRecognitionAvailable]);
 
   // Single reconcile effect for the Web Speech recognizer. Computes desired
   // running state from inputs and nudges the state machine toward it. Has no

--- a/ui/src/hooks/useVoice.ts
+++ b/ui/src/hooks/useVoice.ts
@@ -46,6 +46,34 @@ export type WakeEngineChoice = "openwakeword" | "webspeech" | "auto";
 /** Which engine is actually running right now (reported back to UI). */
 export type ActiveWakeEngine = "openwakeword" | "webspeech" | "none";
 
+/**
+ * Internal state machine for the Web Speech recognizer. Transitions are only
+ * driven by real browser events (`onstart`, `onend`) — never optimistically
+ * flipped on `.start()` / `.stop()` calls, which used to race on Chromium.
+ */
+type SpeechWakeState = "stopped" | "starting" | "running" | "stopping";
+
+/** Minimum ms between two accepted wake matches. Prevents interim-result bursts. */
+const WAKE_COOLDOWN_MS = 500;
+
+/**
+ * Pure decision function: given current inputs, should the Web Speech wake
+ * recognizer be running right now? Exported for unit testing.
+ */
+export function shouldSpeechWakeBeRunning(inputs: {
+  isMicAvailable: boolean;
+  wakeWordEnabled: boolean;
+  voiceState: VoiceState;
+  wakeEngine: WakeEngineChoice;
+  speechRecognitionAvailable: boolean;
+}): boolean {
+  const { isMicAvailable, wakeWordEnabled, voiceState, wakeEngine, speechRecognitionAvailable } = inputs;
+  if (!isMicAvailable || !wakeWordEnabled || !speechRecognitionAvailable) return false;
+  if (voiceState !== "idle" && voiceState !== "speaking") return false;
+  if (wakeEngine === "openwakeword") return false;
+  return true; // "webspeech" or "auto" with the API available
+}
+
 export type UseVoiceOptions = {
   wsRef: React.MutableRefObject<WebSocket | null>;
   wakeWordEnabled?: boolean;
@@ -95,8 +123,11 @@ export function useVoice({ wsRef, wakeWordEnabled = true, wakeEngine = "openwake
   const wakeEngineRef = useRef<any>(null);
   const wakeWordEnabledRef = useRef(wakeWordEnabled);
   const speechWakeRef = useRef<SpeechRecognition | null>(null);
-  const speechWakeActiveRef = useRef(false);
+  const speechWakeStateRef = useRef<SpeechWakeState>("stopped");
   const speechWakeRestartTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const lastWakeAtRef = useRef(0);
+  const isMicAvailableRef = useRef(false);
+  const configuredWakeEngineRef = useRef<WakeEngineChoice>(wakeEngine);
   const startRecordingRef = useRef<(autoStop?: boolean) => void>(() => {});
   const autoStopRef = useRef(false);
   const cancelTTSRef = useRef<() => void>(() => {});
@@ -104,6 +135,8 @@ export function useVoice({ wsRef, wakeWordEnabled = true, wakeEngine = "openwake
   // Keep refs in sync with state for use inside callbacks
   useEffect(() => { voiceStateRef.current = voiceState; }, [voiceState]);
   useEffect(() => { wakeWordEnabledRef.current = wakeWordEnabled; }, [wakeWordEnabled]);
+  useEffect(() => { isMicAvailableRef.current = isMicAvailable; }, [isMicAvailable]);
+  useEffect(() => { configuredWakeEngineRef.current = wakeEngine; }, [wakeEngine]);
 
   // --- AudioContext helper ---
   const getAudioContext = useCallback((): AudioContext => {
@@ -229,30 +262,43 @@ export function useVoice({ wsRef, wakeWordEnabled = true, wakeEngine = "openwake
     }
   }, []);
 
-  const stopSpeechWakeRecognizer = useCallback(() => {
-    if (speechWakeRestartTimerRef.current) {
-      clearTimeout(speechWakeRestartTimerRef.current);
-      speechWakeRestartTimerRef.current = null;
-    }
-    speechWakeActiveRef.current = false;
-    if (speechWakeRef.current) {
-      // Keep handlers attached so the recognizer can be restarted reliably.
-      try { speechWakeRef.current.stop(); } catch {}
-    }
+  const isSpeechRecognitionAvailable = useCallback((): boolean => {
+    return (window.SpeechRecognition ?? window.webkitSpeechRecognition) != null;
   }, []);
 
-  const startSpeechWakeRecognizer = useCallback((): boolean => {
-    const SpeechRecognitionCtor = window.SpeechRecognition ?? window.webkitSpeechRecognition;
-    if (!SpeechRecognitionCtor) {
-      console.warn("[Voice] SpeechRecognition fallback unavailable in this browser");
-      return false;
-    }
+  // ── Speech wake recognizer: state machine + reconcile ─────────────────
+  // Transitions are only flipped on real browser events (`onstart`, `onend`).
+  // The public API is startSpeechWakeIfNeeded / stopSpeechWakeIfNeeded — both
+  // idempotent and safe to call from any code path.
+
+  const shouldSpeechWakeRun = useCallback((): boolean => {
+    return shouldSpeechWakeBeRunning({
+      isMicAvailable: isMicAvailableRef.current,
+      wakeWordEnabled: wakeWordEnabledRef.current,
+      voiceState: voiceStateRef.current,
+      wakeEngine: configuredWakeEngineRef.current,
+      speechRecognitionAvailable: isSpeechRecognitionAvailable(),
+    });
+  }, [isSpeechRecognitionAvailable]);
+
+  const startSpeechWakeIfNeeded = useCallback((): void => {
+    if (speechWakeStateRef.current !== "stopped") return;
 
     if (!speechWakeRef.current) {
+      const SpeechRecognitionCtor = window.SpeechRecognition ?? window.webkitSpeechRecognition;
+      if (!SpeechRecognitionCtor) {
+        console.warn("[Voice] SpeechRecognition fallback unavailable in this browser");
+        return;
+      }
+
       const recognition = new SpeechRecognitionCtor();
       recognition.continuous = true;
       recognition.interimResults = true;
       recognition.lang = "en-US";
+
+      recognition.onstart = () => {
+        speechWakeStateRef.current = "running";
+      };
 
       recognition.onresult = (event: SpeechRecognitionEvent) => {
         if (voiceStateRef.current === "recording" || voiceStateRef.current === "processing") return;
@@ -260,23 +306,43 @@ export function useVoice({ wsRef, wakeWordEnabled = true, wakeEngine = "openwake
         for (let i = event.resultIndex; i < event.results.length; i++) {
           const transcript = String(event.results[i]?.[0]?.transcript ?? "").toLowerCase().trim();
           if (!transcript) continue;
-          if (matchesSpeechWakePhrase(transcript)) {
-            console.log(`[Voice] Speech wake phrase detected: "${transcript}"`);
-            if (voiceStateRef.current === "speaking") {
-              cancelTTSRef.current();
-              setTimeout(() => {
+          if (!matchesSpeechWakePhrase(transcript)) continue;
+
+          const now = Date.now();
+          if (now - lastWakeAtRef.current < WAKE_COOLDOWN_MS) return;
+          lastWakeAtRef.current = now;
+
+          console.log(`[Voice] Speech wake phrase detected: "${transcript}"`);
+          if (voiceStateRef.current === "speaking") cancelTTSRef.current();
+          setVoiceState("wake_detected");
+
+          // Hand the mic off cleanly: wait for the recognizer's own end event
+          // before calling getUserMedia so Chrome can fully release its mic stream.
+          const rec = speechWakeRef.current;
+          if (rec) {
+            const onEnd = () => {
+              rec.removeEventListener("end", onEnd);
+              if (voiceStateRef.current === "wake_detected") {
                 startRecordingRef.current(true);
-              }, 200);
-            } else {
-              setVoiceState("wake_detected");
-              setTimeout(() => {
-                if (voiceStateRef.current === "wake_detected") {
-                  startRecordingRef.current(true);
-                }
-              }, 200);
+              }
+            };
+            rec.addEventListener("end", onEnd);
+            try {
+              if (speechWakeStateRef.current !== "stopping") {
+                rec.stop();
+                speechWakeStateRef.current = "stopping";
+              }
+            } catch {
+              rec.removeEventListener("end", onEnd);
+              speechWakeStateRef.current = "stopped";
+              if (voiceStateRef.current === "wake_detected") {
+                startRecordingRef.current(true);
+              }
             }
-            break;
+          } else {
+            startRecordingRef.current(true);
           }
+          return;
         }
       };
 
@@ -285,70 +351,103 @@ export function useVoice({ wsRef, wakeWordEnabled = true, wakeEngine = "openwake
       };
 
       recognition.onend = () => {
-        speechWakeActiveRef.current = false;
-        if (!wakeWordEnabledRef.current || voiceStateRef.current === "recording" || voiceStateRef.current === "processing") return;
+        const wasStopping = speechWakeStateRef.current === "stopping";
+        speechWakeStateRef.current = "stopped";
+        if (speechWakeRestartTimerRef.current) {
+          clearTimeout(speechWakeRestartTimerRef.current);
+          speechWakeRestartTimerRef.current = null;
+        }
+        if (wasStopping) return;
+        // Chrome ends continuous sessions ~every 30s; retry if we still need to run.
+        if (!shouldSpeechWakeRun()) return;
         speechWakeRestartTimerRef.current = setTimeout(() => {
-          try {
-            speechWakeRef.current?.start();
-            speechWakeActiveRef.current = true;
-            console.log("[Voice] Speech wake recognizer restarted");
-          } catch {
-            // ignore repeated start races
-          }
+          speechWakeRestartTimerRef.current = null;
+          startSpeechWakeIfNeeded();
         }, 300);
       };
 
       speechWakeRef.current = recognition;
     }
 
-    if (!speechWakeActiveRef.current && (voiceStateRef.current === "idle" || voiceStateRef.current === "speaking")) {
-      try {
-        speechWakeRef.current.start();
-        speechWakeActiveRef.current = true;
-        console.log("[Voice] Speech wake recognizer started — say 'Jarvis' or 'Hey Jarvis'");
-        return true;
-      } catch {
-        // ignore repeated start races
-        return false;
-      }
+    try {
+      speechWakeRef.current.start();
+      speechWakeStateRef.current = "starting";
+      console.log("[Voice] Speech wake recognizer starting — say 'Jarvis' or 'Hey Jarvis'");
+    } catch {
+      // The browser throws if start() is called in an invalid state; the
+      // reconcile effect will retry on the next relevant change.
     }
+  }, [shouldSpeechWakeRun]);
 
-    return speechWakeActiveRef.current;
+  const stopSpeechWakeIfNeeded = useCallback((): void => {
+    if (speechWakeRestartTimerRef.current) {
+      clearTimeout(speechWakeRestartTimerRef.current);
+      speechWakeRestartTimerRef.current = null;
+    }
+    const s = speechWakeStateRef.current;
+    if (s === "stopped" || s === "stopping") return;
+    const rec = speechWakeRef.current;
+    if (!rec) {
+      speechWakeStateRef.current = "stopped";
+      return;
+    }
+    try {
+      rec.stop();
+      speechWakeStateRef.current = "stopping";
+    } catch {
+      speechWakeStateRef.current = "stopped";
+    }
   }, []);
 
-  // Initialize wake word engine when mic available and enabled.
-  // Engine choice is driven by config (voice.wake_engine) — defaulting to the
-  // local OpenWakeWord path to avoid streaming ambient audio to cloud STT.
+  // Engine selection effect. Picks which wake engine should own the mic based
+  // on config + SpeechRecognition availability, and drives the OpenWakeWord
+  // side. The speech-wake recognizer itself is driven by the reconcile effect
+  // below so we avoid two code paths fighting over a single recognizer.
   useEffect(() => {
     if (!(isMicAvailable && wakeWordEnabled)) {
+      stopWakeWordEngine();
       setActiveWakeEngine("none");
       return;
     }
 
-    if (wakeEngine === "openwakeword") {
-      startWakeWordEngine();
-      setActiveWakeEngine("openwakeword");
-    } else if (wakeEngine === "webspeech") {
-      const started = startSpeechWakeRecognizer();
-      setActiveWakeEngine(started ? "webspeech" : "none");
-    } else {
-      // "auto": prefer the browser recognizer when present, fall back to local.
-      const started = startSpeechWakeRecognizer();
-      if (started) {
-        stopWakeWordEngine();
-        setActiveWakeEngine("webspeech");
-      } else {
+    const speechAvailable = isSpeechRecognitionAvailable();
+
+    switch (wakeEngine) {
+      case "openwakeword":
         startWakeWordEngine();
         setActiveWakeEngine("openwakeword");
-      }
+        break;
+      case "webspeech":
+        stopWakeWordEngine();
+        setActiveWakeEngine(speechAvailable ? "webspeech" : "none");
+        break;
+      case "auto":
+        if (speechAvailable) {
+          stopWakeWordEngine();
+          setActiveWakeEngine("webspeech");
+        } else {
+          startWakeWordEngine();
+          setActiveWakeEngine("openwakeword");
+        }
+        break;
     }
+  }, [isMicAvailable, wakeWordEnabled, wakeEngine, startWakeWordEngine, stopWakeWordEngine, isSpeechRecognitionAvailable]);
 
-    return () => {
-      stopWakeWordEngine();
-      stopSpeechWakeRecognizer();
-      setActiveWakeEngine("none");
-    };
-  }, [isMicAvailable, wakeWordEnabled, wakeEngine, startWakeWordEngine, stopWakeWordEngine, startSpeechWakeRecognizer, stopSpeechWakeRecognizer]);
+  // Single reconcile effect for the Web Speech recognizer. Computes desired
+  // running state from inputs and nudges the state machine toward it. Has no
+  // cleanup function — transitions are idempotent and the dedicated unmount
+  // effect tears the recognizer down.
+  useEffect(() => {
+    const shouldRun = shouldSpeechWakeBeRunning({
+      isMicAvailable,
+      wakeWordEnabled,
+      voiceState,
+      wakeEngine,
+      speechRecognitionAvailable: isSpeechRecognitionAvailable(),
+    });
+    if (shouldRun) startSpeechWakeIfNeeded();
+    else stopSpeechWakeIfNeeded();
+  }, [isMicAvailable, wakeWordEnabled, voiceState, wakeEngine, startSpeechWakeIfNeeded, stopSpeechWakeIfNeeded, isSpeechRecognitionAvailable]);
 
   // Restart wake word listening when returning to idle (with delay for mic release)
   useEffect(() => {
@@ -372,27 +471,6 @@ export function useVoice({ wsRef, wakeWordEnabled = true, wakeEngine = "openwake
       return () => clearTimeout(timer);
     }
   }, [voiceState]);
-
-  // Keep the configured wake engine armed when idle or speaking (enables barge-in).
-  useEffect(() => {
-    if (voiceState === "idle" || voiceState === "speaking") {
-      if (wakeEngine === "openwakeword") {
-        wakeEngineRef.current?.start().catch(() => {});
-      } else if (wakeEngine === "webspeech") {
-        startSpeechWakeRecognizer();
-      } else {
-        const started = startSpeechWakeRecognizer();
-        if (!started && wakeEngineRef.current) {
-          wakeEngineRef.current.start().catch(() => {});
-        }
-      }
-    } else if (voiceState === "recording" || voiceState === "processing") {
-      stopSpeechWakeRecognizer();
-    }
-    return () => {
-      stopSpeechWakeRecognizer();
-    };
-  }, [voiceState, wakeEngine, startSpeechWakeRecognizer, stopSpeechWakeRecognizer]);
 
   // --- TTS Playback ---
   const playNextTTSChunk = useCallback(() => {
@@ -671,9 +749,9 @@ export function useVoice({ wsRef, wakeWordEnabled = true, wakeEngine = "openwake
         wakeEngineRef.current.stop().catch(() => {});
         wakeEngineRef.current = null;
       }
-      stopSpeechWakeRecognizer();
+      stopSpeechWakeIfNeeded();
     };
-  }, [stopSpeechWakeRecognizer]);
+  }, [stopSpeechWakeIfNeeded]);
 
   return {
     voiceState,

--- a/ui/src/hooks/useVoice.ts
+++ b/ui/src/hooks/useVoice.ts
@@ -84,7 +84,7 @@ export function useVoice({ wsRef, wakeWordEnabled = true }: UseVoiceOptions): Us
   const voiceStateRef = useRef<VoiceState>("idle");
   const wakeEngineRef = useRef<any>(null);
   const wakeWordEnabledRef = useRef(wakeWordEnabled);
-  const speechWakeRef = useRef<any>(null);
+  const speechWakeRef = useRef<SpeechRecognition | null>(null);
   const speechWakeActiveRef = useRef(false);
   const speechWakeRestartTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const startRecordingRef = useRef<(autoStop?: boolean) => void>(() => {});
@@ -232,7 +232,7 @@ export function useVoice({ wsRef, wakeWordEnabled = true }: UseVoiceOptions): Us
   }, []);
 
   const startSpeechWakeRecognizer = useCallback((): boolean => {
-    const SpeechRecognitionCtor = (window as any).SpeechRecognition || (window as any).webkitSpeechRecognition;
+    const SpeechRecognitionCtor = window.SpeechRecognition ?? window.webkitSpeechRecognition;
     if (!SpeechRecognitionCtor) {
       console.warn("[Voice] SpeechRecognition fallback unavailable in this browser");
       return false;
@@ -244,11 +244,11 @@ export function useVoice({ wsRef, wakeWordEnabled = true }: UseVoiceOptions): Us
       recognition.interimResults = true;
       recognition.lang = "en-US";
 
-      recognition.onresult = (event: any) => {
+      recognition.onresult = (event: SpeechRecognitionEvent) => {
         if (voiceStateRef.current === "recording" || voiceStateRef.current === "processing") return;
 
         for (let i = event.resultIndex; i < event.results.length; i++) {
-          const transcript = String(event.results[i]?.[0]?.transcript || "").toLowerCase().trim();
+          const transcript = String(event.results[i]?.[0]?.transcript ?? "").toLowerCase().trim();
           if (!transcript) continue;
           if (matchesSpeechWakePhrase(transcript)) {
             console.log(`[Voice] Speech wake phrase detected: "${transcript}"`);
@@ -270,8 +270,8 @@ export function useVoice({ wsRef, wakeWordEnabled = true }: UseVoiceOptions): Us
         }
       };
 
-      recognition.onerror = (err: any) => {
-        console.warn("[Voice] Speech wake recognizer error:", err);
+      recognition.onerror = (event: SpeechRecognitionErrorEvent) => {
+        console.warn(`[Voice] Speech wake recognizer error: ${event.error}`, event.message);
       };
 
       recognition.onend = () => {

--- a/ui/src/hooks/useVoice.ts
+++ b/ui/src/hooks/useVoice.ts
@@ -13,23 +13,51 @@ const SPEECH_WAKE_INTERRUPT_COMMANDS = new Set([
   "one second",
 ]);
 
-export function matchesSpeechWakePhrase(transcript: string): boolean {
-  const normalized = transcript
+function normalizeTranscript(transcript: string): string {
+  return transcript
     .toLowerCase()
     .replace(/[.,!?;:]+/g, " ")
     .replace(/\s+/g, " ")
     .trim();
+}
 
+function getWakePrefix(normalized: string): "hey jarvis " | "jarvis " | null {
+  if (normalized.startsWith("hey jarvis ")) return "hey jarvis ";
+  if (normalized.startsWith("jarvis ")) return "jarvis ";
+  return null;
+}
+
+/**
+ * Strict matcher used during TTS playback (voiceState === "speaking").
+ * Accepts bare wake phrases ("jarvis", "hey jarvis") or wake + a short
+ * whitelisted interrupt command. Prevents Jarvis's own TTS from self-triggering
+ * when the reply contains the word "jarvis" inside a sentence.
+ */
+export function matchesSpeechWakePhrase(transcript: string): boolean {
+  const normalized = normalizeTranscript(transcript);
   if (!normalized) return false;
   if (normalized === "jarvis" || normalized === "hey jarvis") return true;
 
-  const prefix = normalized.startsWith("hey jarvis ") ? "hey jarvis " : normalized.startsWith("jarvis ") ? "jarvis " : null;
+  const prefix = getWakePrefix(normalized);
   if (!prefix) return false;
 
   const remainder = normalized.slice(prefix.length).trim();
   if (!remainder) return true;
 
   return SPEECH_WAKE_INTERRUPT_COMMANDS.has(remainder);
+}
+
+/**
+ * Loose matcher used when idle. Accepts any utterance that starts with the
+ * wake phrase, so natural "hey jarvis turn off the lights" wakes in one breath
+ * without waiting for Chrome to emit a bare-wake interim first.
+ * NOT safe to use while Jarvis is speaking — use matchesSpeechWakePhrase there.
+ */
+export function matchesSpeechWakePrefix(transcript: string): boolean {
+  const normalized = normalizeTranscript(transcript);
+  if (!normalized) return false;
+  if (normalized === "jarvis" || normalized === "hey jarvis") return true;
+  return getWakePrefix(normalized) != null;
 }
 
 export type VoiceState =
@@ -361,10 +389,16 @@ export function useVoice({ wsRef, wakeWordEnabled = true, wakeEngine = "openwake
       recognition.onresult = (event: SpeechRecognitionEvent) => {
         if (voiceStateRef.current === "recording" || voiceStateRef.current === "processing") return;
 
+        // Strict matcher during speaking to keep TTS echo from self-triggering;
+        // loose prefix matcher when idle so "hey jarvis <command>" wakes in one breath.
+        const matcher = voiceStateRef.current === "speaking"
+          ? matchesSpeechWakePhrase
+          : matchesSpeechWakePrefix;
+
         for (let i = event.resultIndex; i < event.results.length; i++) {
           const transcript = String(event.results[i]?.[0]?.transcript ?? "").toLowerCase().trim();
           if (!transcript) continue;
-          if (!matchesSpeechWakePhrase(transcript)) continue;
+          if (!matcher(transcript)) continue;
 
           const now = Date.now();
           if (now - lastWakeAtRef.current < WAKE_COOLDOWN_MS) return;

--- a/ui/src/pages/ChatPage.tsx
+++ b/ui/src/pages/ChatPage.tsx
@@ -89,6 +89,7 @@ export default function ChatPage({ messages, isConnected, sendMessage, voice }: 
           isWakeWordReady: voice.isWakeWordReady,
           ttsAudioPlaying: voice.ttsAudioPlaying,
           cancelTTS: voice.cancelTTS,
+          activeWakeEngine: voice.activeWakeEngine,
         } : undefined}
       />
     </div>


### PR DESCRIPTION
## Summary
Follow-ups to the Web Speech wake recognizer added in #85 and repaired in #117.
Addresses every concern from the post-review audit: `any` typing, undisclosed
cloud-STT default, dual-effect races, unhandled errors, timed mic handoffs, and
the "wake + command in one breath" UX regression. Six focused commits, each
independently reviewable; no behavioral changes to the OpenWakeWord path or to
recording/TTS/WebSocket wiring.

## Changes
- **Types** (`50dab1d`) — Ambient Web Speech API declarations in
  `ui/src/declarations.d.ts`; every `any` cast in the speech-wake path removed.
  Strict `tsc --noEmit` now catches mistakes in this code at compile time.
- **Config** (`43f8bc2`) — New `voice.wake_engine` config
  (`openwakeword | webspeech | auto`) with YAML, `JARVIS_WAKE_ENGINE` env
  override, and validation. Default is `openwakeword` (local, private).
  `/api/config` exposes the field; mic tooltip shows `local wake` /
  `cloud wake (browser)` / `wake off` so users know which path is active.
  Fixes the silent privacy regression.
- **Lifecycle** (`279ae1a`) — Collapsed the two fighting effects into a single
  reconcile effect keyed on `(isMicAvailable, wakeWordEnabled, voiceState,
  wakeEngine)`, driven by a proper state machine
  (`stopped | starting | running | stopping`) that only transitions on real
  `onstart` / `onend` events. Replaced the 200 ms `setTimeout` mic-handoff with
  an awaited `end` event; added a 500 ms wake cooldown for interim-result bursts.
- **Error handling** (`78863df`) — Exported `classifySpeechWakeError()` splits
  errors into expected / transient / fatal. Fatal errors (`not-allowed`,
  `service-not-allowed`, …) stop retries; transient errors escalate to fatal
  after 3 consecutive failures. For `wakeEngine: auto`, a fatal error triggers
  an automatic fallback to OpenWakeWord. The fatal flag resets on config change.
- **Matcher UX** (`973924c`) — Introduced loose `matchesSpeechWakePrefix()`
  used when idle so `"hey jarvis turn off the lights"` wakes in one breath.
  Kept #117's strict `matchesSpeechWakePhrase()` for the `speaking` state so
  TTS echo mentioning "jarvis" still cannot self-trigger.
- **Coverage** (`2909462`) — Extracted `selectActiveWakeEngine()` as the pure
  source of truth for engine selection; the effect is now a 4-line adapter.
  25 unit tests across five pure functions cover every decision branch and
  matcher edge case.
- [x] `bun test` — full suite 512/512 passing (+27 over main).
- [x] `bunx tsc --noEmit` — clean in strict mode.
- [x] `curl /api/config` — new `voice` field appears with the right default.
- [x] `JARVIS_WAKE_ENGINE` env override verified for `auto`, `webspeech`, and
      invalid values (logs warning, preserves default).
- [x] **Manual browser pass** (Chrome, mic granted):
  - [x] Default: OpenWakeWord wakes on "Hey JARVIS"; tooltip `local wake`.
  - [x] `webspeech`: `"hey jarvis turn off the lights"` in one breath triggers
        recording; TTS saying "jarvis" mid-sentence does NOT self-trigger;
        `"jarvis, stop"` during TTS cancels it.
  - [x] `auto` + revoke mic: `activeWakeEngine` flips `webspeech → openwakeword`;
        no start/stop loop in the console.
  - [x] Firefox + `auto`: falls back to OpenWakeWord automatically.
  - [x] Idle `webspeech` tab ~45 s: one `[Voice] Speech wake recognizer restarted`
        line, not a loop.