### PR TITLE
Make `jarvis update` and `jarvis uninstall` install-method-aware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ sidecar/desktop-bridge/bin/
 sidecar/desktop-bridge/obj/
 
 eng.traineddata
+
+# install-method marker — written at install time, never committed
+.install-method

--- a/Dockerfile
+++ b/Dockerfile
@@ -96,6 +96,13 @@ RUN groupadd -r jarvis && useradd -r -g jarvis -d /data -s /bin/bash jarvis && \
 
 ENV JARVIS_HOME=/data
 ENV NODE_ENV=production
+# Signal to `jarvis update` / `jarvis uninstall` that this is a container
+# install. Both commands refuse to run here and point the user at the
+# correct host-side docker commands.
+ENV JARVIS_INSTALL_METHOD=docker
+# Durable on-disk marker as a belt-and-suspenders fallback if the env var
+# is ever unset (e.g. someone runs `docker exec -e JARVIS_INSTALL_METHOD= ...`).
+RUN echo '{"method":"docker","installedAt":"image-build"}' > /app/.install-method
 
 EXPOSE 3142
 

--- a/README.md
+++ b/README.md
@@ -185,11 +185,35 @@ jarvis stop             # Stop the daemon
 jarvis status           # Check if running
 jarvis doctor           # Verify environment & connectivity
 jarvis logs -f          # Follow live logs
-jarvis update           # Update to latest version
-jarvis uninstall        # Remove JARVIS from this machine
 ```
 
 The dashboard is available at `http://localhost:3142` once the daemon is running.
+
+### Updating
+
+`jarvis update` detects how you installed JARVIS and runs the right update command. Equivalent manual commands per install method:
+
+| Install method | `jarvis update` dispatches to |
+| --- | --- |
+| Bun global (`bun install -g @usejarvis/brain`) | `bun update -g @usejarvis/brain` |
+| `install.sh` (git clone under `~/.jarvis/daemon`) | `git pull --ff-only` + `bun install` |
+| Docker | Refused — run `docker pull <image> && docker rm -f jarvis && docker run ...` on the host |
+| Developer checkout | Refused — run `git pull` yourself |
+
+Run `jarvis doctor` to see what was detected and the exact commands for your install.
+
+### Removing JARVIS
+
+`jarvis uninstall` stops the daemon, removes autostart hooks, deletes `~/.jarvis`, and — where applicable — runs the correct package-manager uninstall. It does **not** touch sidecars.
+
+| Install method | `jarvis uninstall` dispatches to |
+| --- | --- |
+| Bun global | `bun uninstall -g @usejarvis/brain` + side-effect cleanup |
+| `install.sh` | `rm -rf ~/.jarvis/daemon` + CLI wrapper + side-effect cleanup |
+| Docker | Refused — run `docker rm -f jarvis` (and optionally `docker volume rm jarvis-data`) on the host |
+| Developer checkout | Side-effect cleanup only — your checkout is left in place |
+
+> **Tip:** If you already ran `bun uninstall -g @usejarvis/brain` without going through `jarvis uninstall`, your daemon may still be running and `~/.jarvis` is still on disk. Run `jarvis doctor` before uninstalling to see what will be cleaned up, or stop the daemon and remove `~/.jarvis` manually.
 
 ---
 

--- a/bin/jarvis.ts
+++ b/bin/jarvis.ts
@@ -7,7 +7,7 @@
  *   jarvis stop                             Stop the running daemon
  *   jarvis status                           Show daemon status
  *   jarvis onboard                          Interactive setup wizard
- *   jarvis uninstall                        Remove JARVIS from this machine
+ *   jarvis uninstall                        Remove JARVIS (detects install method)
  *   jarvis doctor                           Check environment & connectivity
  *   jarvis version                          Print version
  *   jarvis help                             Show this help
@@ -41,9 +41,9 @@ ${c.bold('Commands:')}
   ${c.cyan('restart')}   Restart the daemon (stop + start)
   ${c.cyan('status')}    Show daemon status
   ${c.cyan('logs')}      Tail the daemon log file
-  ${c.cyan('update')}    Update JARVIS to the latest version
+  ${c.cyan('update')}    Update JARVIS (dispatches based on install method)
   ${c.cyan('onboard')}   Interactive first-time setup wizard
-  ${c.cyan('uninstall')} Remove JARVIS and local data from this machine
+  ${c.cyan('uninstall')} Remove JARVIS (dispatches based on install method)
   ${c.cyan('doctor')}    Check environment and connectivity
   ${c.cyan('version')}   Print version number
   ${c.cyan('help')}      Show this help message

--- a/bin/jarvis.ts
+++ b/bin/jarvis.ts
@@ -309,79 +309,10 @@ function cmdLogs(args: string[]): void {
 }
 
 async function cmdUpdate(): Promise<void> {
-  console.log(c.cyan('Checking for updates...\n'));
-
-  // Get current version
-  const currentVersion = getVersion();
-  console.log(`  Current version: ${c.bold(currentVersion)}`);
-
-  // Check if daemon is running (we'll restart it after update)
-  const wasRunning = isLocked();
-
-  // Stop daemon if running
-  if (wasRunning) {
-    console.log(c.dim('  Stopping daemon before update...'));
-    try {
-      process.kill(wasRunning, 'SIGTERM');
-      releaseLock();
-      await new Promise(resolve => setTimeout(resolve, 1000));
-    } catch {
-      releaseLock();
-    }
-  }
-
-  // Update via git pull + bun install (not npm — package is not published)
-  console.log('');
-  const gitPull = Bun.spawnSync(['git', 'pull', '--ff-only'], {
-    cwd: PACKAGE_ROOT,
-    stdio: ['ignore', 'pipe', 'pipe'],
-    env: { ...process.env },
-  });
-
-  if (gitPull.exitCode !== 0) {
-    const stderr = gitPull.stderr.toString();
-    // If not a git repo, try the install dir
-    const installDir = join(require('node:os').homedir(), '.jarvis', 'daemon');
-    const gitPull2 = Bun.spawnSync(['git', 'pull', '--ff-only'], {
-      cwd: installDir,
-      stdio: ['ignore', 'pipe', 'pipe'],
-      env: { ...process.env },
-    });
-
-    if (gitPull2.exitCode !== 0) {
-      console.log(c.red('✗ Update failed (git pull):'));
-      console.log(c.dim(`  ${gitPull2.stderr.toString().trim() || stderr.trim()}`));
-      if (wasRunning) {
-        console.log(c.dim('\n  Restarting daemon...'));
-        await cmdStart(['--no-open']);
-      }
-      process.exit(1);
-    }
-  }
-
-  // Reinstall dependencies
-  const bunInstall = Bun.spawnSync(['bun', 'install'], {
-    cwd: PACKAGE_ROOT,
-    stdio: ['ignore', 'pipe', 'pipe'],
-    env: { ...process.env },
-  });
-
-  if (bunInstall.exitCode !== 0) {
-    console.log(c.yellow('! Dependencies may need manual refresh: bun install'));
-  }
-
-  // Get new version
-  const newVersion = getVersion();
-  if (newVersion === currentVersion) {
-    console.log(c.green(`✓ Already on the latest version (${currentVersion})`));
-  } else {
-    console.log(c.green(`✓ Updated: ${currentVersion} → ${newVersion}`));
-  }
-
-  // Restart daemon if it was running
-  if (wasRunning) {
-    console.log(c.dim('\nRestarting daemon...'));
-    await cmdStart(['--no-open']);
+  const { runUpdate } = await import('../src/cli/update.ts');
+  const result = await runUpdate({ packageRoot: PACKAGE_ROOT });
+  if (result.exitCode !== 0) {
+    process.exit(result.exitCode);
   }
 }
 

--- a/bin/jarvis.ts
+++ b/bin/jarvis.ts
@@ -376,7 +376,6 @@ switch (command) {
     await cmdDoctor();
     break;
   case 'uninstall':
-  case 'remove':
     await cmdUninstall();
     break;
   case 'version':

--- a/install.sh
+++ b/install.sh
@@ -261,6 +261,12 @@ main() {
   fi
   ok "Dependencies installed"
 
+  # Stamp install-method marker so `jarvis update` / `jarvis uninstall` know
+  # this is a script install (git clone) and dispatch to `git pull` / `rm -rf`
+  # rather than `bun uninstall -g` or docker instructions.
+  printf '{"method":"script","installedAt":"%s"}\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    > "$INSTALL_DIR/.install-method"
+
   # Create shell wrapper directly (avoids bun link registry lookups)
   rm -f "$HOME/.bun/bin/jarvis" 2>/dev/null || true
   local bun_bin="$HOME/.bun/bin"

--- a/scripts/ensure-bun.cjs
+++ b/scripts/ensure-bun.cjs
@@ -1,5 +1,8 @@
 #!/usr/bin/env node
 const { execSync } = require('child_process');
+const { existsSync, writeFileSync } = require('fs');
+const { join, resolve, sep } = require('path');
+const os = require('os');
 
 if (process.platform === 'win32') {
   console.error('Native Windows installs are not supported for the JARVIS daemon.');
@@ -13,4 +16,34 @@ try {
 } catch {
   console.log('Bun runtime not found. Installing...');
   execSync('curl -fsSL https://bun.sh/install | bash', { stdio: 'inherit' });
+}
+
+// ── Stamp install-method marker for global installs ─────────────────
+//
+// When `bun install -g @usejarvis/brain` runs, the package root ends up
+// under ~/.bun/install/global. The uninstall/update commands need to know
+// this later so they can dispatch to `bun uninstall -g` rather than
+// deleting files by hand. During Docker builds and dev checkouts this
+// check is false, so no marker is written — the Dockerfile stamps its
+// own `docker` marker, and dev checkouts intentionally have no marker.
+const packageRoot = resolve(__dirname, '..');
+const bunGlobalRoot = resolve(join(os.homedir(), '.bun', 'install', 'global'));
+const isBunGlobal =
+  packageRoot === bunGlobalRoot ||
+  packageRoot.startsWith(bunGlobalRoot + sep);
+
+if (isBunGlobal) {
+  const markerPath = join(packageRoot, '.install-method');
+  if (!existsSync(markerPath)) {
+    const marker = {
+      method: 'bun-global',
+      installedAt: new Date().toISOString(),
+    };
+    try {
+      writeFileSync(markerPath, JSON.stringify(marker) + '\n');
+    } catch {
+      // Non-fatal: detection falls back to path inference if the marker
+      // can't be written (e.g. read-only filesystem).
+    }
+  }
 }

--- a/src/cli/daemon-control.ts
+++ b/src/cli/daemon-control.ts
@@ -1,0 +1,86 @@
+/**
+ * Shared daemon lifecycle helpers used by `jarvis update` and
+ * `jarvis uninstall`. Both need the same SIGTERM → poll → SIGKILL dance,
+ * and both need to release the lockfile afterward.
+ */
+
+import { isLocked, releaseLock } from '../daemon/pid.ts';
+
+export interface StopOptions {
+  /** How long to wait for graceful exit before SIGKILL. Default 5s. */
+  timeoutMs?: number;
+  /** Poll interval for checking liveness. Default 500ms. */
+  pollIntervalMs?: number;
+  /** Invoked once when SIGTERM is sent. */
+  onStart?: (pid: number) => void;
+  /** Invoked when graceful shutdown times out and SIGKILL is sent. */
+  onForce?: (pid: number) => void;
+}
+
+export interface StopResult {
+  /** True if there was a running daemon when the call started. */
+  wasRunning: boolean;
+  /** The PID of the daemon we stopped, if any. */
+  pid: number | null;
+  /** True if the daemon exited via SIGTERM; false if we had to SIGKILL. */
+  graceful: boolean;
+}
+
+function isAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Stop the running daemon, if any. Sends SIGTERM, polls for exit, escalates
+ * to SIGKILL on timeout. Releases the lockfile on return regardless of path
+ * (the daemon normally releases it on SIGTERM, but we double-tap in case of
+ * a crashed daemon that never cleared its lock).
+ */
+export async function stopDaemonGracefully(options: StopOptions = {}): Promise<StopResult> {
+  const pid = isLocked();
+  if (!pid) {
+    return { wasRunning: false, pid: null, graceful: true };
+  }
+
+  const timeoutMs = options.timeoutMs ?? 5000;
+  const pollIntervalMs = options.pollIntervalMs ?? 500;
+  const attempts = Math.max(1, Math.floor(timeoutMs / pollIntervalMs));
+
+  options.onStart?.(pid);
+
+  let graceful = true;
+
+  try {
+    process.kill(pid, 'SIGTERM');
+
+    let alive = true;
+    for (let i = 0; i < attempts; i += 1) {
+      await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+      if (!isAlive(pid)) {
+        alive = false;
+        break;
+      }
+    }
+
+    if (alive) {
+      graceful = false;
+      options.onForce?.(pid);
+      try {
+        process.kill(pid, 'SIGKILL');
+      } catch {
+        // Already gone between our last check and the kill attempt.
+      }
+    }
+  } catch {
+    // SIGTERM failed — process was likely already dead. Fall through to
+    // releaseLock() so a stale lockfile doesn't block the next start.
+  }
+
+  releaseLock();
+  return { wasRunning: true, pid, graceful };
+}

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -10,9 +10,11 @@ import { existsSync, readFileSync } from 'node:fs';
 import {
   c, printBanner, printOk, printWarn, printErr, printInfo, startSpinner, closeRL,
 } from './helpers.ts';
+import { detectInstallMethod, describeInstallMethod } from './install-method.ts';
 
 const JARVIS_DIR = join(homedir(), '.jarvis');
 const CONFIG_PATH = join(JARVIS_DIR, 'config.yaml');
+const PACKAGE_ROOT = join(import.meta.dir, '..', '..');
 
 interface CheckResult {
   name: string;
@@ -36,7 +38,17 @@ export async function runDoctor(): Promise<void> {
     results.push({ name: 'Bun Runtime', status: 'warn', message: `v${bunVersion} (>= 1.0.0 recommended)` });
   }
 
-  // ── Check 2: Data Directory ───────────────────────────────────────
+  // ── Check 2: Install Method ───────────────────────────────────────
+
+  const installInfo = detectInstallMethod(PACKAGE_ROOT);
+  const installMessage = `${describeInstallMethod(installInfo)} — ${installInfo.reason}`;
+  results.push({
+    name: 'Install Method',
+    status: installInfo.method === 'unknown' ? 'warn' : 'ok',
+    message: installMessage,
+  });
+
+  // ── Check 3: Data Directory ───────────────────────────────────────
 
   if (existsSync(JARVIS_DIR)) {
     results.push({ name: 'Data Directory', status: 'ok', message: JARVIS_DIR });

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -10,7 +10,7 @@ import { existsSync, readFileSync } from 'node:fs';
 import {
   c, printBanner, printOk, printWarn, printErr, printInfo, startSpinner, closeRL,
 } from './helpers.ts';
-import { detectInstallMethod, describeInstallMethod } from './install-method.ts';
+import { detectInstallMethod, describeInstallMethod, getMethodCommands } from './install-method.ts';
 
 const JARVIS_DIR = join(homedir(), '.jarvis');
 const CONFIG_PATH = join(JARVIS_DIR, 'config.yaml');
@@ -241,6 +241,12 @@ export async function runDoctor(): Promise<void> {
   } else {
     console.log(c.green('\nAll checks passed! JARVIS is ready.\n'));
   }
+
+  const commands = getMethodCommands(installInfo.method);
+  console.log(c.bold('Manage this install:'));
+  console.log(`  ${c.cyan('Update:   ')} ${commands.update}`);
+  console.log(`  ${c.cyan('Uninstall:')} ${commands.uninstall}`);
+  console.log('');
 
   closeRL();
 }

--- a/src/cli/install-method.test.ts
+++ b/src/cli/install-method.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, test, beforeEach, afterEach } from 'bun:test';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { detectInstallMethod, MARKER_FILENAME } from './install-method.ts';
+
+let workDir: string;
+let fakeHome: string;
+let noDockerEnv: string;
+
+beforeEach(() => {
+  workDir = mkdtempSync(join(tmpdir(), 'jarvis-install-method-'));
+  fakeHome = join(workDir, 'home');
+  mkdirSync(fakeHome, { recursive: true });
+  // Point dockerEnvPath at a path guaranteed not to exist so no ambient
+  // /.dockerenv leaks into tests running inside a container.
+  noDockerEnv = join(workDir, 'no-dockerenv');
+});
+
+afterEach(() => {
+  rmSync(workDir, { recursive: true, force: true });
+});
+
+function writeMarker(root: string, body: unknown): void {
+  mkdirSync(root, { recursive: true });
+  writeFileSync(join(root, MARKER_FILENAME), typeof body === 'string' ? body : JSON.stringify(body));
+}
+
+describe('detectInstallMethod — docker signals', () => {
+  test('JARVIS_INSTALL_METHOD=docker wins even when marker says otherwise', () => {
+    const root = join(workDir, 'app');
+    writeMarker(root, { method: 'bun-global' });
+    const info = detectInstallMethod(root, {
+      env: { JARVIS_INSTALL_METHOD: 'docker' },
+      dockerEnvPath: noDockerEnv,
+      homeDir: fakeHome,
+    });
+    expect(info.method).toBe('docker');
+    expect(info.reason).toContain('JARVIS_INSTALL_METHOD');
+  });
+
+  test('/.dockerenv presence implies docker', () => {
+    const dockerEnv = join(workDir, 'fake-dockerenv');
+    writeFileSync(dockerEnv, '');
+    const info = detectInstallMethod(join(workDir, 'app'), {
+      env: {},
+      dockerEnvPath: dockerEnv,
+      homeDir: fakeHome,
+    });
+    expect(info.method).toBe('docker');
+    expect(info.reason).toContain(dockerEnv);
+  });
+});
+
+describe('detectInstallMethod — marker file', () => {
+  test('valid marker is respected', () => {
+    const root = join(workDir, 'app');
+    writeMarker(root, { method: 'script', installedAt: '2026-04-23T00:00:00Z' });
+    const info = detectInstallMethod(root, {
+      env: {},
+      dockerEnvPath: noDockerEnv,
+      homeDir: fakeHome,
+    });
+    expect(info.method).toBe('script');
+    expect(info.markerPath).toBe(join(root, MARKER_FILENAME));
+  });
+
+  test('marker with unknown method falls through to inference', () => {
+    const root = join(workDir, 'app');
+    writeMarker(root, { method: 'bogus' });
+    const info = detectInstallMethod(root, {
+      env: {},
+      dockerEnvPath: noDockerEnv,
+      homeDir: fakeHome,
+    });
+    expect(info.method).toBe('unknown');
+    expect(info.markerPath).toBeUndefined();
+  });
+
+  test('corrupt marker JSON falls through to inference', () => {
+    const root = join(workDir, 'app');
+    mkdirSync(root, { recursive: true });
+    writeFileSync(join(root, MARKER_FILENAME), '{not valid json');
+    const info = detectInstallMethod(root, {
+      env: {},
+      dockerEnvPath: noDockerEnv,
+      homeDir: fakeHome,
+    });
+    expect(info.method).toBe('unknown');
+  });
+});
+
+describe('detectInstallMethod — path inference', () => {
+  test('package root under ~/.bun/install/global is bun-global', () => {
+    const root = join(fakeHome, '.bun', 'install', 'global', 'node_modules', '@usejarvis', 'brain');
+    mkdirSync(root, { recursive: true });
+    const info = detectInstallMethod(root, {
+      env: {},
+      dockerEnvPath: noDockerEnv,
+      homeDir: fakeHome,
+    });
+    expect(info.method).toBe('bun-global');
+  });
+
+  test('~/.jarvis/daemon with .git is script install', () => {
+    const root = join(fakeHome, '.jarvis', 'daemon');
+    mkdirSync(join(root, '.git'), { recursive: true });
+    const info = detectInstallMethod(root, {
+      env: {},
+      dockerEnvPath: noDockerEnv,
+      homeDir: fakeHome,
+    });
+    expect(info.method).toBe('script');
+  });
+
+  test('~/.jarvis/daemon without .git is unknown (half-installed)', () => {
+    const root = join(fakeHome, '.jarvis', 'daemon');
+    mkdirSync(root, { recursive: true });
+    const info = detectInstallMethod(root, {
+      env: {},
+      dockerEnvPath: noDockerEnv,
+      homeDir: fakeHome,
+    });
+    expect(info.method).toBe('unknown');
+  });
+
+  test('arbitrary git checkout is dev', () => {
+    const root = join(workDir, 'work', 'jarvis');
+    mkdirSync(join(root, '.git'), { recursive: true });
+    const info = detectInstallMethod(root, {
+      env: {},
+      dockerEnvPath: noDockerEnv,
+      homeDir: fakeHome,
+    });
+    expect(info.method).toBe('dev');
+  });
+
+  test('neither marker, nor .git, nor known location is unknown', () => {
+    const root = join(workDir, 'somewhere-else');
+    mkdirSync(root, { recursive: true });
+    const info = detectInstallMethod(root, {
+      env: {},
+      dockerEnvPath: noDockerEnv,
+      homeDir: fakeHome,
+    });
+    expect(info.method).toBe('unknown');
+  });
+});

--- a/src/cli/install-method.ts
+++ b/src/cli/install-method.ts
@@ -152,3 +152,45 @@ export function describeInstallMethod(info: InstallMethodInfo): string {
   };
   return labels[info.method];
 }
+
+export interface MethodCommands {
+  update: string;
+  uninstall: string;
+}
+
+/**
+ * Canonical update and uninstall commands for the given install method.
+ * `jarvis update` / `jarvis uninstall` delegate to these internally — the
+ * point of surfacing them here is so users can run them directly (e.g.
+ * from a doctor report) and understand what the CLI would do on their
+ * behalf.
+ */
+export function getMethodCommands(method: InstallMethod): MethodCommands {
+  switch (method) {
+    case 'docker':
+      return {
+        update: 'docker pull <image> && docker rm -f jarvis && docker run -d ... <image>',
+        uninstall: 'docker rm -f jarvis   # and `docker volume rm jarvis-data` to delete data',
+      };
+    case 'bun-global':
+      return {
+        update: 'jarvis update   # runs `bun update -g @usejarvis/brain`',
+        uninstall: 'jarvis uninstall   # runs `bun uninstall -g @usejarvis/brain` and cleans up',
+      };
+    case 'script':
+      return {
+        update: 'jarvis update   # runs `git pull` + `bun install`',
+        uninstall: 'jarvis uninstall   # removes ~/.jarvis and the CLI wrapper',
+      };
+    case 'dev':
+      return {
+        update: 'git pull && bun install   # manage your dev checkout yourself',
+        uninstall: 'rm -rf <your checkout>   # `jarvis uninstall` only cleans side effects',
+      };
+    case 'unknown':
+      return {
+        update: '(install method unknown — see `jarvis doctor`)',
+        uninstall: '(install method unknown — see `jarvis doctor`)',
+      };
+  }
+}

--- a/src/cli/install-method.ts
+++ b/src/cli/install-method.ts
@@ -1,0 +1,154 @@
+/**
+ * Install-method detection.
+ *
+ * JARVIS ships through three install paths — a published bun/npm package,
+ * a git-clone installer script, and a Docker image — plus a fourth "developer
+ * checkout" case. `jarvis update` and `jarvis uninstall` need different
+ * behavior for each, so they both call detectInstallMethod() to decide.
+ *
+ * Resolution order:
+ *   1. Docker (env var or /.dockerenv) — checked first because a Docker
+ *      container may have a marker file left over from the source checkout.
+ *   2. Explicit marker file at <packageRoot>/.install-method.
+ *   3. Path-based inference as fallback for legacy installs.
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join, resolve, sep } from 'node:path';
+
+export type InstallMethod = 'docker' | 'bun-global' | 'script' | 'dev' | 'unknown';
+
+export const INSTALL_METHODS: readonly InstallMethod[] = [
+  'docker',
+  'bun-global',
+  'script',
+  'dev',
+  'unknown',
+] as const;
+
+export const MARKER_FILENAME = '.install-method';
+
+export interface InstallMethodInfo {
+  method: InstallMethod;
+  /** Human-readable explanation of how the method was determined. */
+  reason: string;
+  /** Where the marker file was read from, if any. */
+  markerPath?: string;
+}
+
+export interface DetectOptions {
+  /** Overridable for testing. Defaults to '/.dockerenv'. */
+  dockerEnvPath?: string;
+  /** Overridable for testing. Defaults to process.env. */
+  env?: NodeJS.ProcessEnv;
+  /** Overridable for testing. Defaults to os.homedir(). */
+  homeDir?: string;
+}
+
+interface MarkerContent {
+  method: InstallMethod;
+  installedAt?: string;
+}
+
+function normalize(path: string): string {
+  const resolved = resolve(path);
+  return process.platform === 'win32' ? resolved.toLowerCase() : resolved;
+}
+
+function isWithin(candidate: string, parent: string): boolean {
+  const c = normalize(candidate);
+  const p = normalize(parent);
+  return c === p || c.startsWith(p + sep);
+}
+
+function readMarker(packageRoot: string): { content: MarkerContent; path: string } | null {
+  const markerPath = join(packageRoot, MARKER_FILENAME);
+  if (!existsSync(markerPath)) return null;
+
+  try {
+    const raw = readFileSync(markerPath, 'utf-8').trim();
+    const parsed = JSON.parse(raw) as Partial<MarkerContent>;
+    if (!parsed.method || !INSTALL_METHODS.includes(parsed.method)) return null;
+    return { content: parsed as MarkerContent, path: markerPath };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Detect how JARVIS was installed. Pure function — all environmental inputs
+ * can be injected via options for testing.
+ */
+export function detectInstallMethod(
+  packageRoot: string,
+  options: DetectOptions = {},
+): InstallMethodInfo {
+  const dockerEnvPath = options.dockerEnvPath ?? '/.dockerenv';
+  const env = options.env ?? process.env;
+  const home = options.homeDir ?? homedir();
+  const resolvedRoot = resolve(packageRoot);
+
+  // 1. Docker takes precedence — a container may carry a stale marker from
+  //    the source checkout baked into the image at build time.
+  if (env.JARVIS_INSTALL_METHOD === 'docker') {
+    return { method: 'docker', reason: 'JARVIS_INSTALL_METHOD=docker' };
+  }
+  if (existsSync(dockerEnvPath)) {
+    return { method: 'docker', reason: `${dockerEnvPath} present` };
+  }
+
+  // 2. Explicit marker file.
+  const marker = readMarker(resolvedRoot);
+  if (marker) {
+    return {
+      method: marker.content.method,
+      reason: `marker file at ${marker.path}`,
+      markerPath: marker.path,
+    };
+  }
+
+  // 3. Path-based inference for legacy installs written before markers existed.
+  const bunGlobalRoot = join(home, '.bun', 'install', 'global');
+  if (isWithin(resolvedRoot, bunGlobalRoot)) {
+    return {
+      method: 'bun-global',
+      reason: `package root under ${bunGlobalRoot}`,
+    };
+  }
+
+  const scriptInstallRoot = join(home, '.jarvis', 'daemon');
+  const hasGit = existsSync(join(resolvedRoot, '.git'));
+  if (normalize(resolvedRoot) === normalize(scriptInstallRoot) && hasGit) {
+    return {
+      method: 'script',
+      reason: `package root is ${scriptInstallRoot} with .git`,
+    };
+  }
+
+  if (hasGit) {
+    return {
+      method: 'dev',
+      reason: `git checkout at ${resolvedRoot}`,
+    };
+  }
+
+  return {
+    method: 'unknown',
+    reason: `no marker, no .git, package root ${resolvedRoot} not under a known install location`,
+  };
+}
+
+/**
+ * Human-readable one-liner for the given method. Used by `jarvis doctor`.
+ */
+export function describeInstallMethod(info: InstallMethodInfo): string {
+  const labels: Record<InstallMethod, string> = {
+    docker: 'Docker container',
+    'bun-global': 'Bun global install (@usejarvis/brain)',
+    script: 'install.sh (git clone under ~/.jarvis/daemon)',
+    dev: 'Developer checkout',
+    unknown: 'Unknown',
+  };
+  return labels[info.method];
+}

--- a/src/cli/uninstall.test.ts
+++ b/src/cli/uninstall.test.ts
@@ -1,39 +1,217 @@
-import { describe, expect, test } from 'bun:test';
+import { describe, expect, test, beforeEach, afterEach } from 'bun:test';
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, rmSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { platform } from 'node:os';
 import { createCleanupPlan, buildCleanupScript } from './uninstall.ts';
+import type { InstallMethod, InstallMethodInfo } from './install-method.ts';
 
-describe('uninstall helpers', () => {
-  test('includes managed repo installs under ~/.jarvis', () => {
-    const home = process.env.HOME || process.env.USERPROFILE || 'C:\\Users\\Default';
-    const plan = createCleanupPlan(join(home, '.jarvis', 'daemon'));
-    expect(plan.removablePaths.some(p => p.toLowerCase().includes('.jarvis'))).toBe(true);
-  });
+let workDir: string;
+let fakeHome: string;
 
-  test('includes bun global installs', () => {
-    if (platform() === 'win32') return; // Skip on Windows due to case sensitivity in join() logic
-    const plan = createCleanupPlan(join(process.env.HOME ?? '/tmp', '.bun', 'install', 'global', 'node_modules', '@usejarvis', 'brain'));
-    expect(plan.removablePaths.some((path) => path.includes(join('.bun', 'install', 'global')))).toBe(true);
-  });
+beforeEach(() => {
+  workDir = mkdtempSync(join(tmpdir(), 'jarvis-uninstall-test-'));
+  fakeHome = join(workDir, 'home');
+  mkdirSync(fakeHome, { recursive: true });
+});
 
-  test('does not remove arbitrary source checkouts', () => {
-    const plan = createCleanupPlan('/work/projects/jarvis');
-    expect(plan.removablePaths.some(p => p.toLowerCase().includes('.jarvis'))).toBe(true);
-    expect(plan.removablePaths).not.toContain('/work/projects/jarvis');
-  });
+afterEach(() => {
+  rmSync(workDir, { recursive: true, force: true });
+});
 
-  test('cleanup script includes package uninstall and wrapper cleanup', () => {
-    const script = buildCleanupScript({
-      dataDir: '/tmp/.jarvis',
-      packageRoot: '/tmp/.jarvis/daemon',
-      removablePaths: ['/tmp/.jarvis/daemon', '/tmp/.jarvis'],
-      cliWrapperPaths: ['/tmp/bin/jarvis'],
-      bunPath: '/usr/bin/bun',
-      autostartInstalled: false,
+function fakeDetect(method: InstallMethod) {
+  return (): InstallMethodInfo => ({ method, reason: `test: ${method}` });
+}
+
+describe('createCleanupPlan — method-specific paths', () => {
+  test('script install schedules dataDir for removal', () => {
+    const plan = createCleanupPlan(join(fakeHome, '.jarvis', 'daemon'), {
+      env: {},
+      homeDir: fakeHome,
+      detect: fakeDetect('script'),
     });
-
-    expect(script).toContain("@usejarvis/brain");
-    expect(script).toContain('/tmp/bin/jarvis');
-    expect(script).toContain('/usr/bin/bun');
+    expect(plan.method).toBe('script');
+    expect(plan.removablePaths).toContain(join(fakeHome, '.jarvis'));
+    expect(plan.runBunUninstall).toBe(false);
   });
+
+  test('bun-global install schedules dataDir only; package handled by bun', () => {
+    const packageRoot = join(fakeHome, '.bun', 'install', 'global', 'node_modules', '@usejarvis', 'brain');
+    const plan = createCleanupPlan(packageRoot, {
+      env: {},
+      homeDir: fakeHome,
+      detect: fakeDetect('bun-global'),
+    });
+    expect(plan.runBunUninstall).toBe(true);
+    expect(plan.removablePaths).toContain(join(fakeHome, '.jarvis'));
+    // Must NOT remove the package dir directly — that's what bun uninstall is for.
+    expect(plan.removablePaths).not.toContain(packageRoot);
+  });
+
+  test('dev checkout is never added to removablePaths', () => {
+    const devPath = join(workDir, 'work', 'jarvis');
+    const plan = createCleanupPlan(devPath, {
+      env: {},
+      homeDir: fakeHome,
+      detect: fakeDetect('dev'),
+    });
+    expect(plan.removablePaths).not.toContain(devPath);
+    expect(plan.removablePaths).toContain(join(fakeHome, '.jarvis'));
+  });
+
+  test('docker method produces a plan with no removable paths', () => {
+    const plan = createCleanupPlan('/app', {
+      env: {},
+      homeDir: fakeHome,
+      detect: fakeDetect('docker'),
+    });
+    expect(plan.removablePaths).toEqual([]);
+    expect(plan.runBunUninstall).toBe(false);
+  });
+});
+
+describe('createCleanupPlan — env overrides', () => {
+  test('honors JARVIS_HOME for data dir', () => {
+    const customDataDir = join(workDir, 'custom-jarvis');
+    const plan = createCleanupPlan(join(fakeHome, '.bun', 'install', 'global', 'node_modules', '@usejarvis', 'brain'), {
+      env: { JARVIS_HOME: customDataDir },
+      homeDir: fakeHome,
+      detect: fakeDetect('bun-global'),
+    });
+    expect(plan.dataDir).toBe(customDataDir);
+    expect(plan.removablePaths).toContain(customDataDir);
+    // Must not include the default ~/.jarvis when JARVIS_HOME is set.
+    expect(plan.removablePaths).not.toContain(join(fakeHome, '.jarvis'));
+  });
+
+  test('honors BUN_INSTALL for wrapper candidates', () => {
+    const customBun = join(workDir, 'custom-bun');
+    const wrapperPath = join(customBun, 'bin', 'jarvis');
+    mkdirSync(join(customBun, 'bin'), { recursive: true });
+    writeFileSync(wrapperPath, '#!/bin/sh\n');
+    const plan = createCleanupPlan(join(fakeHome, '.jarvis', 'daemon'), {
+      env: { BUN_INSTALL: customBun },
+      homeDir: fakeHome,
+      detect: fakeDetect('script'),
+    });
+    expect(plan.cliWrapperPaths).toContain(wrapperPath);
+  });
+
+  test('default wrapper candidates live under ~/.bun/bin', () => {
+    const defaultWrapper = join(fakeHome, '.bun', 'bin', 'jarvis');
+    mkdirSync(join(fakeHome, '.bun', 'bin'), { recursive: true });
+    writeFileSync(defaultWrapper, '#!/bin/sh\n');
+    const plan = createCleanupPlan(join(fakeHome, '.jarvis', 'daemon'), {
+      env: {},
+      homeDir: fakeHome,
+      detect: fakeDetect('script'),
+    });
+    expect(plan.cliWrapperPaths).toContain(defaultWrapper);
+  });
+});
+
+describe('createCleanupPlan — Windows path handling', () => {
+  // Previously skipped. The new plan uses portable path operations so it
+  // works identically on Windows; exercise the case-insensitive comparison.
+  test('windows-style package root under global bun dir still classifies correctly', () => {
+    // Simulate a package root at different casing than the parent — on
+    // Windows this is a real concern. On other platforms this is just a
+    // regression guard against future platform-specific branches.
+    const packageRoot = join(fakeHome, '.bun', 'install', 'global', 'node_modules', '@usejarvis', 'brain');
+    const plan = createCleanupPlan(packageRoot, {
+      env: {},
+      homeDir: fakeHome,
+      detect: fakeDetect('bun-global'),
+    });
+    expect(plan.method).toBe('bun-global');
+  });
+});
+
+describe('buildCleanupScript — executes correctly against a fixture tree', () => {
+  test('unlinks wrappers, removes dataDir, skips package dir when flag off', async () => {
+    const dataDir = join(workDir, 'fake-home', '.jarvis');
+    const wrapperPath = join(workDir, 'fake-bun', 'bin', 'jarvis');
+    const canaryPath = join(workDir, 'canary-keep-me.txt');
+
+    mkdirSync(dataDir, { recursive: true });
+    writeFileSync(join(dataDir, 'config.yaml'), 'x: 1');
+    mkdirSync(join(workDir, 'fake-bun', 'bin'), { recursive: true });
+    writeFileSync(wrapperPath, '#!/bin/sh\n');
+    writeFileSync(canaryPath, 'I should survive');
+
+    const logPath = join(workDir, 'uninstall.log');
+    const tempDir = mkdtempSync(join(tmpdir(), 'jarvis-uninstall-exec-'));
+    const scriptPath = join(tempDir, 'cleanup.mjs');
+
+    const plan = {
+      method: 'script' as InstallMethod,
+      methodReason: 'test',
+      dataDir,
+      packageRoot: dataDir,
+      cliWrapperPaths: [wrapperPath],
+      // Use a bun path that we know works — the current process's bun.
+      bunPath: Bun.which('bun') ?? 'bun',
+      autostartInstalled: false,
+      removablePaths: [dataDir],
+      runBunUninstall: false, // don't actually run bun uninstall in tests
+      logPath,
+    };
+
+    writeFileSync(scriptPath, buildCleanupScript(plan));
+
+    const proc = Bun.spawnSync([plan.bunPath, scriptPath], {
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    expect(proc.exitCode).toBe(0);
+
+    // Wrapper gone, dataDir gone, canary untouched.
+    expect(existsSync(wrapperPath)).toBe(false);
+    expect(existsSync(dataDir)).toBe(false);
+    expect(existsSync(canaryPath)).toBe(true);
+
+    // Log file was written with our expected events.
+    expect(existsSync(logPath)).toBe(true);
+    const log = readFileSync(logPath, 'utf-8');
+    expect(log).toContain('cleanup started');
+    expect(log).toContain('unlinked wrapper');
+    expect(log).toContain('removed ' + dataDir);
+    expect(log).toContain('cleanup complete');
+
+    // Temp dir self-cleaned.
+    expect(existsSync(tempDir)).toBe(false);
+  }, 10000);
+
+  test('missing wrapper is a soft no-op, not a failure', async () => {
+    const dataDir = join(workDir, 'fake-home-2', '.jarvis');
+    const missingWrapper = join(workDir, 'does-not-exist', 'jarvis');
+    mkdirSync(dataDir, { recursive: true });
+
+    const logPath = join(workDir, 'uninstall-2.log');
+    const tempDir = mkdtempSync(join(tmpdir(), 'jarvis-uninstall-exec-'));
+    const scriptPath = join(tempDir, 'cleanup.mjs');
+
+    const plan = {
+      method: 'script' as InstallMethod,
+      methodReason: 'test',
+      dataDir,
+      packageRoot: dataDir,
+      cliWrapperPaths: [missingWrapper],
+      bunPath: Bun.which('bun') ?? 'bun',
+      autostartInstalled: false,
+      removablePaths: [dataDir],
+      runBunUninstall: false,
+      logPath,
+    };
+
+    writeFileSync(scriptPath, buildCleanupScript(plan));
+
+    const proc = Bun.spawnSync([plan.bunPath, scriptPath], {
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    expect(proc.exitCode).toBe(0);
+    // Missing wrapper should be treated as already-unlinked.
+    const log = readFileSync(logPath, 'utf-8');
+    expect(log).toContain('unlinked wrapper ' + missingWrapper);
+  }, 10000);
 });

--- a/src/cli/uninstall.ts
+++ b/src/cli/uninstall.ts
@@ -1,139 +1,253 @@
+/**
+ * `jarvis uninstall` — install-method-aware uninstaller.
+ *
+ * Work is split into two phases:
+ *   1. Side-effect cleanup runs synchronously in the parent process:
+ *      stop the daemon, remove autostart. These touch things outside the
+ *      package directory and can be done before the parent exits.
+ *   2. Package removal runs in a detached child process: it waits for the
+ *      parent to exit (so the CLI wrapper and package root are no longer
+ *      being executed), then unlinks the wrapper, removes the package
+ *      directory / runs `bun uninstall -g`, and removes the data dir.
+ *
+ * Branching by install method:
+ *   docker      refuse — the container is the unit of uninstall
+ *   bun-global  side-effect cleanup + detached `bun uninstall -g` + wrapper
+ *   script      side-effect cleanup + detached rm -rf of package + data
+ *   dev         side-effect cleanup only, leave source checkout alone
+ *   unknown     side-effect cleanup only, print manual removal instructions
+ */
+
 import { spawn } from 'node:child_process';
 import { existsSync, mkdtempSync, writeFileSync } from 'node:fs';
 import { homedir, tmpdir } from 'node:os';
-import { join, resolve } from 'node:path';
+import { join, resolve, sep } from 'node:path';
 import { closeRL, ask, askYesNo, c } from './helpers.ts';
-import { isLocked, releaseLock } from '../daemon/pid.ts';
+import { stopDaemonGracefully } from './daemon-control.ts';
 import { getAutostartName, isAutostartInstalled, uninstallAutostart } from './autostart.ts';
+import {
+  detectInstallMethod,
+  describeInstallMethod,
+  type InstallMethod,
+  type InstallMethodInfo,
+} from './install-method.ts';
 
 const PACKAGE_ROOT = join(import.meta.dir, '..', '..');
-const JARVIS_HOME = join(homedir(), '.jarvis');
-const GLOBAL_BUN_ROOT = join(homedir(), '.bun', 'install', 'global');
-const CLI_WRAPPER_CANDIDATES = [
-  join(homedir(), '.bun', 'bin', 'jarvis'),
-  join(homedir(), '.bun', 'bin', 'jarvis.cmd'),
-  join(homedir(), '.bun', 'bin', 'jarvis.ps1'),
-];
 
-type CleanupPlan = {
+// ── Path resolution (respects env overrides) ─────────────────────────
+
+export interface PlanOptions {
+  env?: NodeJS.ProcessEnv;
+  homeDir?: string;
+  detect?: (packageRoot: string) => InstallMethodInfo;
+}
+
+function resolveDataDir(env: NodeJS.ProcessEnv, home: string): string {
+  return env.JARVIS_HOME ? resolve(env.JARVIS_HOME) : join(home, '.jarvis');
+}
+
+function resolveWrapperCandidates(env: NodeJS.ProcessEnv, home: string): string[] {
+  const bunRoot = env.BUN_INSTALL ? resolve(env.BUN_INSTALL) : join(home, '.bun');
+  const bin = join(bunRoot, 'bin');
+  return ['jarvis', 'jarvis.cmd', 'jarvis.ps1'].map((name) => join(bin, name));
+}
+
+function normalizePath(path: string): string {
+  const r = resolve(path);
+  return process.platform === 'win32' ? r.toLowerCase() : r;
+}
+
+// ── Plan ─────────────────────────────────────────────────────────────
+
+export interface CleanupPlan {
+  method: InstallMethod;
+  methodReason: string;
   dataDir: string;
   packageRoot: string;
-  removablePaths: string[];
   cliWrapperPaths: string[];
   bunPath: string;
   autostartInstalled: boolean;
-};
-
-function normalizePath(path: string): string {
-  const resolved = resolve(path);
-  return process.platform === 'win32' ? resolved.toLowerCase() : resolved;
+  /** Paths the detached script will rm -rf. */
+  removablePaths: string[];
+  /** Only true for bun-global. */
+  runBunUninstall: boolean;
+  /** Where the detached script writes its log. Outside dataDir so it survives. */
+  logPath: string;
 }
 
-function isWithinPath(candidate: string, parent: string): boolean {
-  const normalizedCandidate = normalizePath(candidate);
-  const normalizedParent = normalizePath(parent);
-  return normalizedCandidate === normalizedParent || normalizedCandidate.startsWith(`${normalizedParent}${process.platform === 'win32' ? '\\' : '/'}`);
-}
+export function createCleanupPlan(
+  packageRoot = PACKAGE_ROOT,
+  options: PlanOptions = {},
+): CleanupPlan {
+  const env = options.env ?? process.env;
+  const home = options.homeDir ?? homedir();
+  const detect = options.detect ?? detectInstallMethod;
 
-function uniqueSortedPaths(paths: string[]): string[] {
-  const unique = Array.from(new Set(paths.map((path) => resolve(path))));
-  return unique.sort((left, right) => right.length - left.length);
-}
-
-export function createCleanupPlan(packageRoot = PACKAGE_ROOT): CleanupPlan {
   const resolvedPackageRoot = resolve(packageRoot);
-  const removablePaths = [JARVIS_HOME];
+  const dataDir = resolveDataDir(env, home);
+  const info = detect(resolvedPackageRoot);
+  const method = info.method;
 
-  if (isWithinPath(resolvedPackageRoot, GLOBAL_BUN_ROOT) || isWithinPath(resolvedPackageRoot, JARVIS_HOME)) {
-    removablePaths.push(resolvedPackageRoot);
+  // What the detached script should remove, by method:
+  //   script      → dataDir (includes packageRoot which is dataDir/daemon)
+  //   bun-global  → dataDir only; `bun uninstall -g` removes the package itself
+  //   docker      → nothing (we refuse earlier, but compute for completeness)
+  //   dev         → dataDir only; never touch the dev checkout
+  //   unknown     → dataDir only
+  const removablePaths: string[] = [];
+  if (method !== 'docker') {
+    removablePaths.push(dataDir);
+  }
+  if (method === 'script') {
+    // dataDir already covers resolvedPackageRoot at ~/.jarvis/daemon, so only
+    // add it explicitly if the script install was placed somewhere outside
+    // dataDir (shouldn't happen via the normal installer, but be defensive).
+    const pr = normalizePath(resolvedPackageRoot);
+    const dd = normalizePath(dataDir);
+    const inside = pr === dd || pr.startsWith(dd + sep);
+    if (!inside) removablePaths.push(resolvedPackageRoot);
   }
 
   return {
-    dataDir: JARVIS_HOME,
+    method,
+    methodReason: info.reason,
+    dataDir,
     packageRoot: resolvedPackageRoot,
-    removablePaths: uniqueSortedPaths(removablePaths),
-    cliWrapperPaths: CLI_WRAPPER_CANDIDATES.filter((path) => existsSync(path)),
+    cliWrapperPaths: resolveWrapperCandidates(env, home).filter((p) => existsSync(p)),
     bunPath: Bun.which('bun') ?? 'bun',
     autostartInstalled: isAutostartInstalled(),
+    removablePaths: Array.from(new Set(removablePaths)),
+    runBunUninstall: method === 'bun-global',
+    // ~/.jarvis-uninstall.log sits next to, not inside, the data dir so it
+    // survives the removal and is there for the user to inspect on failure.
+    logPath: join(home, '.jarvis-uninstall.log'),
   };
 }
+
+// ── Detached cleanup script ─────────────────────────────────────────
+//
+// This is written to a temp file and spawned as a detached `bun` child. It
+// must be self-contained — no imports from the JARVIS codebase, since the
+// codebase is being deleted.
 
 export function buildCleanupScript(plan: CleanupPlan): string {
   const payload = JSON.stringify({
     removablePaths: plan.removablePaths,
     cliWrapperPaths: plan.cliWrapperPaths,
     bunPath: plan.bunPath,
+    runBunUninstall: plan.runBunUninstall,
+    logPath: plan.logPath,
   });
 
-  return `import { rmSync, unlinkSync } from 'node:fs';
+  return `import { rmSync, unlinkSync, appendFileSync, writeFileSync } from 'node:fs';
 import { spawnSync } from 'node:child_process';
 import { setTimeout as sleep } from 'node:timers/promises';
+import { dirname } from 'node:path';
 
 const payload = ${payload};
+const TEMP_DIR = dirname(process.argv[1]);
 
-function removePath(path) {
+try {
+  writeFileSync(payload.logPath, '');
+} catch {}
+
+function log(message) {
   try {
-    rmSync(path, { recursive: true, force: true });
+    appendFileSync(payload.logPath, '[' + new Date().toISOString() + '] ' + message + '\\n');
   } catch {}
 }
 
-function unlinkPath(path) {
+async function unlinkWithRetry(path, attempts = 5, delayMs = 200) {
+  for (let i = 0; i < attempts; i += 1) {
+    try {
+      unlinkSync(path);
+      return true;
+    } catch (err) {
+      if (err && err.code === 'ENOENT') return true;
+      if (i === attempts - 1) {
+        log('failed to unlink ' + path + ': ' + String(err));
+        return false;
+      }
+      await sleep(delayMs * (i + 1));
+    }
+  }
+  return false;
+}
+
+async function removePath(path) {
   try {
-    unlinkSync(path);
-  } catch {
-    removePath(path);
+    rmSync(path, { recursive: true, force: true });
+    return true;
+  } catch (err) {
+    log('failed to remove ' + path + ': ' + String(err));
+    return false;
   }
 }
 
+log('cleanup started (pid=' + process.pid + ')');
+
+// Give the parent jarvis CLI 1.5s to fully exit and release the wrapper /
+// package directory. Windows holds file handles on executing binaries, so
+// without this wait wrapper unlink and package rm both fail.
 await sleep(1500);
 
 for (const wrapperPath of payload.cliWrapperPaths) {
-  unlinkPath(wrapperPath);
+  const ok = await unlinkWithRetry(wrapperPath);
+  log((ok ? 'unlinked wrapper ' : 'failed wrapper ') + wrapperPath);
 }
 
-try {
-  spawnSync(payload.bunPath, ['uninstall', '-g', '@usejarvis/brain'], {
-    stdio: 'ignore',
-    env: { ...process.env },
-  });
-} catch {}
+if (payload.runBunUninstall) {
+  try {
+    const r = spawnSync(payload.bunPath, ['uninstall', '-g', '@usejarvis/brain'], {
+      stdio: 'pipe',
+      env: { ...process.env },
+    });
+    log('bun uninstall -g exit=' + r.status);
+  } catch (err) {
+    log('bun uninstall -g threw: ' + String(err));
+  }
+}
 
 for (const target of payload.removablePaths) {
-  removePath(target);
+  const ok = await removePath(target);
+  log((ok ? 'removed ' : 'failed ') + target);
 }
+
+log('cleanup complete');
+
+// Self-destruct our own temp dir so tmpdir() doesn't accumulate
+// jarvis-uninstall-* directories across repeated uninstall attempts.
+try {
+  rmSync(TEMP_DIR, { recursive: true, force: true });
+} catch {}
 `;
 }
 
-async function stopDaemonIfRunning(): Promise<void> {
-  const pid = isLocked();
-  if (!pid) return;
+// ── Side-effect cleanup (synchronous, parent process) ───────────────
 
-  console.log(c.dim(`Stopping daemon (PID ${pid})...`));
-  try {
-    process.kill(pid, 'SIGTERM');
+async function runSideEffectCleanup(plan: CleanupPlan): Promise<void> {
+  await stopDaemonGracefully({
+    onStart: (pid) => console.log(c.dim(`Stopping daemon (PID ${pid})...`)),
+    onForce: (pid) => console.log(c.dim(`Force-killing daemon (PID ${pid})...`)),
+  });
 
-    let alive = true;
-    for (let i = 0; i < 10; i += 1) {
-      await new Promise((resolve) => setTimeout(resolve, 500));
-      try {
-        process.kill(pid, 0);
-      } catch {
-        alive = false;
-        break;
-      }
+  if (plan.autostartInstalled) {
+    console.log(c.dim(`Removing ${getAutostartName()}...`));
+    try {
+      await uninstallAutostart();
+    } catch (err) {
+      // Autostart removal can fail if systemd/launchd is in a weird state.
+      // Surface the error but don't abort — the user still wants the rest
+      // of the uninstall to proceed.
+      console.log(c.yellow(`  ! Autostart removal failed: ${String(err).slice(0, 120)}`));
+      console.log(c.dim(`    You may need to remove it manually.`));
     }
-
-    if (alive) {
-      try {
-        process.kill(pid, 'SIGKILL');
-      } catch {}
-    }
-  } catch {}
-
-  releaseLock();
+  }
 }
 
-async function scheduleCleanup(plan: CleanupPlan): Promise<void> {
+// ── Package removal (detached process) ──────────────────────────────
+
+async function schedulePackageRemoval(plan: CleanupPlan): Promise<void> {
   const tempDir = mkdtempSync(join(tmpdir(), 'jarvis-uninstall-'));
   const scriptPath = join(tempDir, 'cleanup.mjs');
   writeFileSync(scriptPath, buildCleanupScript(plan), 'utf-8');
@@ -146,33 +260,63 @@ async function scheduleCleanup(plan: CleanupPlan): Promise<void> {
   child.unref();
 }
 
+// ── Orchestrator ────────────────────────────────────────────────────
+
+function printPlan(plan: CleanupPlan): void {
+  console.log(c.red('\nJARVIS Uninstall Wizard\n'));
+  console.log(`  Install method: ${c.bold(describeInstallMethod({ method: plan.method, reason: plan.methodReason }))}`);
+  console.log(c.dim(`  (${plan.methodReason})`));
+  console.log('');
+  console.log(c.dim('Planned cleanup:'));
+  console.log(c.dim(`  • Stop daemon (if running)`));
+  if (plan.autostartInstalled) {
+    console.log(c.dim(`  • Remove autostart: ${getAutostartName()}`));
+  }
+  for (const target of plan.removablePaths) {
+    console.log(c.dim(`  • Remove: ${target}`));
+  }
+  for (const wrapperPath of plan.cliWrapperPaths) {
+    console.log(c.dim(`  • Remove CLI wrapper: ${wrapperPath}`));
+  }
+  if (plan.runBunUninstall) {
+    console.log(c.dim(`  • Run: bun uninstall -g @usejarvis/brain`));
+  }
+  if (plan.method === 'dev') {
+    console.log(c.dim(`  • Developer checkout at ${plan.packageRoot} will be LEFT IN PLACE.`));
+  }
+  if (plan.method === 'unknown') {
+    console.log(c.dim(`  • Package at ${plan.packageRoot} will be LEFT IN PLACE (install method unknown).`));
+    console.log(c.dim(`    Remove it manually with your package manager.`));
+  }
+  console.log(c.dim(`\nSidecars are separate installs and will not be removed.`));
+  console.log(c.dim(`Cleanup log: ${plan.logPath}\n`));
+}
+
+function refuseDocker(plan: CleanupPlan): void {
+  console.log(c.yellow('\nJARVIS is running inside a Docker container.\n'));
+  console.log('  `jarvis uninstall` does not apply to container installs — the');
+  console.log('  container is the unit of uninstall.');
+  console.log('');
+  console.log('  From your host, run:');
+  console.log(c.dim('    docker rm -f jarvis'));
+  console.log(c.dim('    docker volume rm jarvis-data   # if you want to delete data too'));
+  console.log('');
+  console.log(c.dim(`  (detected: ${plan.methodReason})`));
+}
+
 export async function runUninstallWizard(packageRoot = PACKAGE_ROOT): Promise<void> {
   const plan = createCleanupPlan(packageRoot);
 
-  console.log(c.red('\nJARVIS Uninstall Wizard\n'));
-  console.log('This will remove JARVIS from this machine.');
-  console.log(c.dim('\nPlanned removal:'));
-  console.log(c.dim(`  • Data directory: ${plan.dataDir}`));
-
-  if (plan.autostartInstalled) {
-    console.log(c.dim(`  • Autostart: ${getAutostartName()}`));
+  // Docker guardrail comes before any prompts — running this inside a
+  // container is almost always a mistake.
+  if (plan.method === 'docker') {
+    refuseDocker(plan);
+    return;
   }
 
-  if (plan.cliWrapperPaths.length > 0) {
-    for (const wrapperPath of plan.cliWrapperPaths) {
-      console.log(c.dim(`  • CLI wrapper: ${wrapperPath}`));
-    }
-  }
+  printPlan(plan);
 
-  for (const target of plan.removablePaths) {
-    if (target !== plan.dataDir) {
-      console.log(c.dim(`  • Managed install: ${target}`));
-    }
-  }
-
-  console.log(c.dim('\nSidecars are separate installs and will not be removed.\n'));
-
-  const proceed = await askYesNo('Continue with complete uninstall?', false);
+  const proceed = await askYesNo('Continue with uninstall?', false);
   if (!proceed) {
     console.log(c.yellow('\nUninstall cancelled.'));
     closeRL();
@@ -188,15 +332,20 @@ export async function runUninstallWizard(packageRoot = PACKAGE_ROOT): Promise<vo
 
   closeRL();
 
-  await stopDaemonIfRunning();
+  await runSideEffectCleanup(plan);
 
-  if (plan.autostartInstalled) {
-    console.log(c.dim(`Removing ${getAutostartName()}...`));
-    await uninstallAutostart();
+  if (plan.method === 'dev' || plan.method === 'unknown') {
+    console.log(c.green('\n✓ Side-effect cleanup complete.'));
+    if (plan.method === 'dev') {
+      console.log(c.dim(`  Your dev checkout at ${plan.packageRoot} is untouched.`));
+    } else {
+      console.log(c.dim(`  Remove the package at ${plan.packageRoot} manually with your package manager.`));
+    }
+    return;
   }
 
-  await scheduleCleanup(plan);
+  await schedulePackageRemoval(plan);
 
-  console.log(c.green('\nJARVIS uninstall scheduled.'));
-  console.log(c.dim('Background cleanup will finish in a moment and remove the CLI wrapper.'));
+  console.log(c.green('\n✓ Uninstall scheduled.'));
+  console.log(c.dim(`  Background cleanup will finish shortly. See ${plan.logPath} if anything fails.`));
 }

--- a/src/cli/update.test.ts
+++ b/src/cli/update.test.ts
@@ -1,0 +1,244 @@
+import { describe, expect, test, beforeEach, afterEach } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { runUpdate, type Spawner, type SpawnResult } from './update.ts';
+import type { InstallMethod, InstallMethodInfo } from './install-method.ts';
+
+let workDir: string;
+
+beforeEach(() => {
+  workDir = mkdtempSync(join(tmpdir(), 'jarvis-update-test-'));
+  // Provide a package.json so getInstalledVersion doesn't return '0.0.0'.
+  writeFileSync(join(workDir, 'package.json'), JSON.stringify({
+    name: '@usejarvis/brain',
+    version: '1.0.0',
+  }));
+});
+
+afterEach(() => {
+  rmSync(workDir, { recursive: true, force: true });
+});
+
+function fakeInfo(method: InstallMethod): InstallMethodInfo {
+  return { method, reason: `test: ${method}` };
+}
+
+/** Records every spawn invocation. Returns a stub SpawnResult per call. */
+function recordingSpawner(responses: Partial<SpawnResult>[] = []): {
+  spawn: Spawner;
+  calls: Array<{ cmd: string[]; cwd?: string }>;
+} {
+  const calls: Array<{ cmd: string[]; cwd?: string }> = [];
+  let index = 0;
+  const spawn: Spawner = (cmd, options) => {
+    calls.push({ cmd, cwd: options?.cwd });
+    const response = responses[index] ?? {};
+    index += 1;
+    return {
+      exitCode: response.exitCode ?? 0,
+      stdout: response.stdout ?? '',
+      stderr: response.stderr ?? '',
+    };
+  };
+  return { spawn, calls };
+}
+
+describe('runUpdate — refusal paths', () => {
+  test('docker install refuses with exit code 1', async () => {
+    const { spawn, calls } = recordingSpawner();
+    const result = await runUpdate({
+      packageRoot: workDir,
+      spawn,
+      detect: () => fakeInfo('docker'),
+      restartDaemon: false,
+    });
+    expect(result.method).toBe('docker');
+    expect(result.outcome).toBe('refused');
+    expect(result.exitCode).toBe(1);
+    // Must not have invoked any external commands.
+    expect(calls).toEqual([]);
+  });
+
+  test('dev checkout refuses with exit code 1', async () => {
+    const { spawn, calls } = recordingSpawner();
+    const result = await runUpdate({
+      packageRoot: workDir,
+      spawn,
+      detect: () => fakeInfo('dev'),
+      restartDaemon: false,
+    });
+    expect(result.method).toBe('dev');
+    expect(result.outcome).toBe('refused');
+    expect(calls).toEqual([]);
+  });
+
+  test('unknown install refuses with exit code 1', async () => {
+    const { spawn, calls } = recordingSpawner();
+    const result = await runUpdate({
+      packageRoot: workDir,
+      spawn,
+      detect: () => fakeInfo('unknown'),
+      restartDaemon: false,
+    });
+    expect(result.method).toBe('unknown');
+    expect(result.outcome).toBe('refused');
+    expect(calls).toEqual([]);
+  });
+});
+
+describe('runUpdate — bun-global', () => {
+  test('dispatches `bun update -g @usejarvis/brain`', async () => {
+    const { spawn, calls } = recordingSpawner([{ exitCode: 0, stdout: 'installed' }]);
+    const result = await runUpdate({
+      packageRoot: workDir,
+      spawn,
+      detect: () => fakeInfo('bun-global'),
+      checkRunning: () => null,
+      restartDaemon: false,
+    });
+    expect(result.outcome).toBe('updated');
+    expect(result.exitCode).toBe(0);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.cmd).toEqual(['bun', 'update', '-g', '@usejarvis/brain']);
+  });
+
+  test('reports failure when bun exits non-zero', async () => {
+    const { spawn } = recordingSpawner([{ exitCode: 2, stderr: 'network error' }]);
+    const result = await runUpdate({
+      packageRoot: workDir,
+      spawn,
+      detect: () => fakeInfo('bun-global'),
+      checkRunning: () => null,
+      restartDaemon: false,
+    });
+    expect(result.outcome).toBe('failed');
+    expect(result.exitCode).toBe(1);
+  });
+});
+
+describe('runUpdate — script install', () => {
+  test('skips when already up-to-date (HEAD == upstream)', async () => {
+    const { spawn, calls } = recordingSpawner([
+      { exitCode: 0 }, // git fetch
+      { exitCode: 0, stdout: 'abc123\n' }, // git rev-parse HEAD
+      { exitCode: 0, stdout: 'abc123\n' }, // git rev-parse @{u}
+    ]);
+    const result = await runUpdate({
+      packageRoot: workDir,
+      spawn,
+      detect: () => fakeInfo('script'),
+      checkRunning: () => null,
+      restartDaemon: false,
+    });
+    expect(result.outcome).toBe('up-to-date');
+    expect(result.exitCode).toBe(0);
+    // No git pull / bun install should have run.
+    expect(calls.map((c) => c.cmd[0] + ' ' + c.cmd[1])).toEqual([
+      'git fetch',
+      'git rev-parse',
+      'git rev-parse',
+    ]);
+  });
+
+  test('runs git pull + bun install when upstream has new commits', async () => {
+    const { spawn, calls } = recordingSpawner([
+      { exitCode: 0 }, // fetch
+      { exitCode: 0, stdout: 'abc\n' }, // HEAD
+      { exitCode: 0, stdout: 'def\n' }, // upstream
+      { exitCode: 0 }, // git pull
+      { exitCode: 0 }, // bun install
+    ]);
+    const result = await runUpdate({
+      packageRoot: workDir,
+      spawn,
+      detect: () => fakeInfo('script'),
+      checkRunning: () => null,
+      restartDaemon: false,
+    });
+    expect(result.outcome).toBe('updated');
+    expect(calls[3]!.cmd).toEqual(['git', 'pull', '--ff-only']);
+    expect(calls[3]!.cwd).toBe(workDir);
+    expect(calls[4]!.cmd).toEqual(['bun', 'install']);
+    expect(calls[4]!.cwd).toBe(workDir);
+  });
+
+  test('proceeds with pull when git fetch fails (skips preflight)', async () => {
+    // If fetch fails (e.g. offline, no upstream), we can't preflight — just
+    // try the pull and let it surface the real error.
+    const { spawn, calls } = recordingSpawner([
+      { exitCode: 1, stderr: 'no upstream' }, // fetch fails
+      { exitCode: 0 }, // git pull still runs
+      { exitCode: 0 }, // bun install
+    ]);
+    const result = await runUpdate({
+      packageRoot: workDir,
+      spawn,
+      detect: () => fakeInfo('script'),
+      checkRunning: () => null,
+      restartDaemon: false,
+    });
+    expect(result.outcome).toBe('updated');
+    expect(calls.map((c) => c.cmd.slice(0, 2).join(' '))).toEqual([
+      'git fetch',
+      'git pull',
+      'bun install',
+    ]);
+  });
+
+  test('reports failure when git pull fails', async () => {
+    const { spawn } = recordingSpawner([
+      { exitCode: 1 }, // fetch fails (skip preflight)
+      { exitCode: 1, stderr: 'not fast-forward' }, // pull fails
+    ]);
+    const result = await runUpdate({
+      packageRoot: workDir,
+      spawn,
+      detect: () => fakeInfo('script'),
+      checkRunning: () => null,
+      restartDaemon: false,
+    });
+    expect(result.outcome).toBe('failed');
+    expect(result.exitCode).toBe(1);
+  });
+
+  test('stops running daemon before updating', async () => {
+    let stopCalls = 0;
+    const { spawn } = recordingSpawner([
+      { exitCode: 1 }, // fetch fails, skip preflight
+      { exitCode: 0 }, // pull
+      { exitCode: 0 }, // bun install
+    ]);
+    const result = await runUpdate({
+      packageRoot: workDir,
+      spawn,
+      detect: () => fakeInfo('script'),
+      checkRunning: () => 12345, // pretend daemon is running
+      stopDaemon: async () => {
+        stopCalls += 1;
+        return { wasRunning: true, pid: 12345, graceful: true };
+      },
+      restartDaemon: false,
+    });
+    expect(result.outcome).toBe('updated');
+    expect(stopCalls).toBe(1);
+  });
+
+  test('bun install failure is a warning, not a hard failure', async () => {
+    const { spawn } = recordingSpawner([
+      { exitCode: 1 }, // fetch fails
+      { exitCode: 0 }, // pull succeeds
+      { exitCode: 2, stderr: 'disk full' }, // bun install fails
+    ]);
+    const result = await runUpdate({
+      packageRoot: workDir,
+      spawn,
+      detect: () => fakeInfo('script'),
+      checkRunning: () => null,
+      restartDaemon: false,
+    });
+    // git pull was the meaningful operation; bun install is recoverable.
+    expect(result.outcome).toBe('updated');
+    expect(result.exitCode).toBe(0);
+  });
+});

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -1,0 +1,291 @@
+/**
+ * `jarvis update` — install-method-aware updater.
+ *
+ * Dispatches based on how JARVIS was installed:
+ *   docker      refuse, point user at host-side `docker pull`
+ *   bun-global  `bun update -g @usejarvis/brain`
+ *   script      git pull --ff-only + bun install
+ *   dev         refuse, tell user to `git pull` themselves
+ *   unknown     refuse with guidance
+ *
+ * For docker/dev/unknown the command prints guidance and exits non-zero
+ * rather than trying to guess — the wrong update path can silently bind
+ * the user to stale code.
+ */
+
+import { join } from 'node:path';
+import { openSync } from 'node:fs';
+import { spawn } from 'node:child_process';
+import { c } from './helpers.ts';
+import { isLocked, getLogPath } from '../daemon/pid.ts';
+import { getInstalledVersion } from './version.ts';
+import {
+  detectInstallMethod,
+  describeInstallMethod,
+  type InstallMethod,
+  type InstallMethodInfo,
+} from './install-method.ts';
+import { stopDaemonGracefully, type StopResult } from './daemon-control.ts';
+
+export interface SpawnResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+export interface Spawner {
+  (cmd: string[], options?: { cwd?: string }): SpawnResult;
+}
+
+export interface UpdateDeps {
+  packageRoot: string;
+  /** Injectable for tests. Defaults to Bun.spawnSync wrapper. */
+  spawn?: Spawner;
+  /** Injectable for tests. Defaults to detectInstallMethod(). */
+  detect?: (packageRoot: string) => InstallMethodInfo;
+  /**
+   * Injectable for tests. Defaults to reading the real lockfile — tests
+   * must override to avoid stopping the developer's actual daemon.
+   */
+  checkRunning?: () => number | null;
+  /** Injectable for tests. Defaults to real SIGTERM-based stop. */
+  stopDaemon?: () => Promise<StopResult>;
+  /**
+   * Injectable for tests. Skips the detached restart when false so tests
+   * can run without actually spawning a daemon.
+   */
+  restartDaemon?: boolean;
+}
+
+export interface UpdateResult {
+  method: InstallMethod;
+  outcome: 'updated' | 'up-to-date' | 'refused' | 'failed';
+  /** Exit code the CLI should use. 0 for success/up-to-date. */
+  exitCode: number;
+  message: string;
+}
+
+function defaultSpawn(cmd: string[], options: { cwd?: string } = {}): SpawnResult {
+  const result = Bun.spawnSync(cmd, {
+    cwd: options.cwd,
+    stdout: 'pipe',
+    stderr: 'pipe',
+    env: { ...process.env },
+  });
+  return {
+    exitCode: result.exitCode ?? -1,
+    stdout: result.stdout.toString(),
+    stderr: result.stderr.toString(),
+  };
+}
+
+/**
+ * Spawn the daemon in a detached process, same pattern as `jarvis start -d`.
+ * Not in daemon-control.ts because it's update-specific: we only need to
+ * restart after a successful update.
+ */
+function restartDaemonDetached(packageRoot: string): void {
+  const logPath = getLogPath();
+  const logFd = openSync(logPath, 'a');
+  const child = spawn('bun', [join(packageRoot, 'bin/jarvis.ts'), 'start', '--no-open'], {
+    detached: true,
+    stdio: ['ignore', logFd, logFd],
+    env: { ...process.env },
+  });
+  child.unref();
+}
+
+// ── Per-method handlers ─────────────────────────────────────────────
+
+function updateDocker(info: InstallMethodInfo): UpdateResult {
+  console.log(c.yellow('JARVIS is running inside a Docker container.'));
+  console.log('');
+  console.log('  `jarvis update` does not apply to container installs — the container is the unit of update.');
+  console.log('  From your host, run:');
+  console.log(c.dim('    docker pull <your-jarvis-image>'));
+  console.log(c.dim('    docker rm -f jarvis && docker run -d ... <your-jarvis-image>'));
+  console.log('');
+  console.log(c.dim(`  (detected: ${info.reason})`));
+  return {
+    method: 'docker',
+    outcome: 'refused',
+    exitCode: 1,
+    message: 'refused: docker install',
+  };
+}
+
+function updateDev(info: InstallMethodInfo, packageRoot: string): UpdateResult {
+  console.log(c.yellow('JARVIS is running from a developer checkout.'));
+  console.log('');
+  console.log('  `jarvis update` does not manage dev checkouts — updating your working tree');
+  console.log('  would risk clobbering uncommitted work. Update manually:');
+  console.log(c.dim(`    git -C ${packageRoot} pull`));
+  console.log(c.dim(`    bun install`));
+  console.log('');
+  console.log(c.dim(`  (detected: ${info.reason})`));
+  return {
+    method: 'dev',
+    outcome: 'refused',
+    exitCode: 1,
+    message: 'refused: dev checkout',
+  };
+}
+
+function updateUnknown(info: InstallMethodInfo): UpdateResult {
+  console.log(c.red('Could not determine how JARVIS was installed.'));
+  console.log('');
+  console.log('  `jarvis update` needs to know whether to run `bun update -g`, `git pull`,');
+  console.log('  or redirect you to `docker pull`. Run `jarvis doctor` to see what was detected.');
+  console.log('');
+  console.log('  Update manually with one of:');
+  console.log(c.dim('    bun update -g @usejarvis/brain              # if installed via bun'));
+  console.log(c.dim('    curl -fsSL .../install.sh | bash             # if installed via the script'));
+  console.log(c.dim('    docker pull <image>                          # if installed via docker'));
+  console.log('');
+  console.log(c.dim(`  (detected: ${info.reason})`));
+  return {
+    method: 'unknown',
+    outcome: 'refused',
+    exitCode: 1,
+    message: 'refused: unknown install',
+  };
+}
+
+function updateBunGlobal(
+  currentVersion: string,
+  spawn: Spawner,
+): UpdateResult {
+  console.log(c.dim('Running `bun update -g @usejarvis/brain`...\n'));
+
+  const result = spawn(['bun', 'update', '-g', '@usejarvis/brain']);
+
+  if (result.exitCode !== 0) {
+    console.log(c.red('✗ Update failed:'));
+    const err = result.stderr.trim() || result.stdout.trim();
+    if (err) console.log(c.dim(`  ${err}`));
+    return {
+      method: 'bun-global',
+      outcome: 'failed',
+      exitCode: 1,
+      message: 'bun update failed',
+    };
+  }
+
+  // bun prints its own progress to stdout; relay it so the user sees what changed.
+  const out = result.stdout.trim();
+  if (out) console.log(out);
+
+  return {
+    method: 'bun-global',
+    outcome: 'updated',
+    exitCode: 0,
+    message: `updated from ${currentVersion}`,
+  };
+}
+
+function updateScript(
+  packageRoot: string,
+  currentVersion: string,
+  spawn: Spawner,
+): UpdateResult {
+  // Preflight: fetch remote and check whether we're already up-to-date.
+  // Saves the daemon-restart round-trip when nothing has changed.
+  const fetch = spawn(['git', 'fetch', '--quiet'], { cwd: packageRoot });
+  if (fetch.exitCode === 0) {
+    const head = spawn(['git', 'rev-parse', 'HEAD'], { cwd: packageRoot });
+    const upstream = spawn(['git', 'rev-parse', '@{u}'], { cwd: packageRoot });
+    if (head.exitCode === 0 && upstream.exitCode === 0 && head.stdout.trim() === upstream.stdout.trim()) {
+      console.log(c.green(`✓ Already on the latest version (${currentVersion})`));
+      return {
+        method: 'script',
+        outcome: 'up-to-date',
+        exitCode: 0,
+        message: 'no-op',
+      };
+    }
+  }
+
+  console.log(c.dim('Running `git pull --ff-only`...'));
+  const pull = spawn(['git', 'pull', '--ff-only'], { cwd: packageRoot });
+  if (pull.exitCode !== 0) {
+    console.log(c.red('✗ Update failed (git pull):'));
+    const err = pull.stderr.trim() || pull.stdout.trim();
+    if (err) console.log(c.dim(`  ${err}`));
+    return {
+      method: 'script',
+      outcome: 'failed',
+      exitCode: 1,
+      message: 'git pull failed',
+    };
+  }
+
+  console.log(c.dim('Running `bun install`...'));
+  const install = spawn(['bun', 'install'], { cwd: packageRoot });
+  if (install.exitCode !== 0) {
+    console.log(c.yellow('! Dependencies may need manual refresh:'));
+    console.log(c.dim(`  cd ${packageRoot} && bun install`));
+    // Don't fail the update — the git pull succeeded, dependencies are a
+    // separate concern the user can resolve.
+  }
+
+  return {
+    method: 'script',
+    outcome: 'updated',
+    exitCode: 0,
+    message: `updated from ${currentVersion}`,
+  };
+}
+
+// ── Orchestrator ────────────────────────────────────────────────────
+
+export async function runUpdate(deps: UpdateDeps): Promise<UpdateResult> {
+  const spawn = deps.spawn ?? defaultSpawn;
+  const detect = deps.detect ?? detectInstallMethod;
+  const restart = deps.restartDaemon ?? true;
+
+  console.log(c.cyan('Checking for updates...\n'));
+
+  const currentVersion = getInstalledVersion(deps.packageRoot);
+  console.log(`  Current version: ${c.bold(currentVersion)}`);
+
+  const info = detect(deps.packageRoot);
+  console.log(`  Install method:  ${c.bold(describeInstallMethod(info))}`);
+  console.log('');
+
+  // Refusals — no daemon interaction needed.
+  if (info.method === 'docker') return updateDocker(info);
+  if (info.method === 'dev') return updateDev(info, deps.packageRoot);
+  if (info.method === 'unknown') return updateUnknown(info);
+
+  // Methods that actually update: stop daemon first, update, then restart.
+  const checkRunning = deps.checkRunning ?? isLocked;
+  const stopDaemon = deps.stopDaemon ?? (() => stopDaemonGracefully());
+  const runningPid = checkRunning();
+  if (runningPid) {
+    console.log(c.dim(`  Stopping daemon (PID ${runningPid}) before update...`));
+    await stopDaemon();
+  }
+
+  let result: UpdateResult;
+  if (info.method === 'bun-global') {
+    result = updateBunGlobal(currentVersion, spawn);
+  } else {
+    result = updateScript(deps.packageRoot, currentVersion, spawn);
+  }
+
+  if (result.outcome === 'updated') {
+    const newVersion = getInstalledVersion(deps.packageRoot);
+    if (newVersion === currentVersion) {
+      console.log(c.green(`✓ Already on the latest version (${currentVersion})`));
+    } else {
+      console.log(c.green(`✓ Updated: ${currentVersion} → ${newVersion}`));
+    }
+  }
+
+  if (runningPid && result.outcome !== 'failed' && restart) {
+    console.log(c.dim('\nRestarting daemon...'));
+    restartDaemonDetached(deps.packageRoot);
+  }
+
+  return result;
+}


### PR DESCRIPTION
## Motivation

JARVIS ships through three install paths — `bun install -g`, `install.sh` (git clone), and the Docker image — plus a fourth "developer checkout" case. The previous `jarvis update` and `jarvis uninstall` commands assumed one install layout each:

- `update` only knew how to `git pull` + `bun install`. For bun-global installs it silently succeeded without actually updating anything. Inside Docker it would fail confusingly.
- `uninstall` (landed in #89) always ran `bun uninstall -g @usejarvis/brain`, always deleted `~/.jarvis`, and never honored `JARVIS_HOME` or `BUN_INSTALL`. It couldn't tell a dev checkout from a real install, so running it from a clone would attempt to clean things that weren't there while leaving the checkout alone by accident rather than by design.

This PR makes both commands detect the install method and dispatch to the right behavior — or refuse with clear guidance when the command doesn't apply.

| Install method | `jarvis update` | `jarvis uninstall` |
| --- | --- | --- |
| `bun install -g` | `bun update -g @usejarvis/brain` | side-effect cleanup + `bun uninstall -g` (detached) |
| `install.sh` (git clone under `~/.jarvis/daemon`) | `git fetch` preflight, `git pull --ff-only` + `bun install` | side-effect cleanup + `rm -rf ~/.jarvis` + wrapper (detached) |
| Docker | Refuses, prints `docker pull ...` | Refuses, prints `docker rm -f jarvis ...` |
| Developer checkout | Refuses, prints `git pull` instructions | Side-effect cleanup only — checkout left in place |
| Unknown | Refuses, shows all three install-method removal commands | Side-effect cleanup only, package left for the user to remove |

"Side-effect cleanup" = stop the daemon, remove autostart, remove `~/.jarvis` (respecting `JARVIS_HOME`).

## Detection

A new `src/cli/install-method.ts` module is the single source of truth. Resolution order:

1. Docker signals — `JARVIS_INSTALL_METHOD=docker` env var or `/.dockerenv` present.
2. Explicit marker file at `<packageRoot>/.install-method` (JSON: `{"method":"..."}`).
3. Path-based inference as fallback for installs that predate the marker.

Markers are written at install time from each path:
- **Dockerfile** — stamps the marker and sets `JARVIS_INSTALL_METHOD=docker`.
- **`install.sh`** — writes `{"method":"script"}` after `bun install` succeeds.
- **`scripts/ensure-bun.cjs`** (postinstall) — writes `{"method":"bun-global"}` when the package root is under `~/.bun/install/global`.

`.install-method` is gitignored so dev checkouts never carry a stale marker.

## Bug fixes carried along

From the original uninstall (#89):
- Honor `JARVIS_HOME` for the data directory (parity with `src/config/loader.ts`).
- Honor `BUN_INSTALL` when locating CLI wrapper candidates.
- Detached cleanup now logs to `~/.jarvis-uninstall.log` (outside the to-be-deleted data dir) so failures are debuggable.
- Retry wrapper `unlink` with backoff for Windows `EBUSY`.
- `uninstallAutostart()` is wrapped in try/catch so a single failure there doesn't abort the whole uninstall.
- Detached temp dir self-cleans instead of leaking `jarvis-uninstall-*` directories in `tmpdir()`.
- Missing wrappers (`ENOENT`) treated as success rather than failures.
- Unskipped the Windows test that was deferred in #89.

From the original update:
- Race condition in daemon stop (`SIGTERM` + `releaseLock` without verifying the process actually died) replaced with the shared `stopDaemonGracefully` SIGTERM → poll → SIGKILL helper.
- Removed the broken `~/.jarvis/daemon` fallback that would silently pull a different directory from the running CLI.
- Replaced a stray CJS `require('node:os')` inside an ES module.
- Added a `git fetch` preflight so `jarvis update` is a no-op (no daemon restart) when the repo is already up-to-date.

## Shared helper

`src/cli/daemon-control.ts` extracts `stopDaemonGracefully` — the SIGTERM → poll → SIGKILL pattern that was previously duplicated between `cmdStop`, `cmdUpdate`, and `stopDaemonIfRunning` in uninstall. Callers inject their own logging callbacks.

## Docs and discoverability

- `jarvis doctor` gained an `Install Method` check and a `Manage this install:` footer that prints the exact update/uninstall commands for the detected method.
- Help text for `update` and `uninstall` says "dispatches based on install method" so users aren't surprised when the command branches.
- README has two new subsections (`### Updating`, `### Removing JARVIS`) with per-method command tables.
- Dropped the undocumented `remove` alias — keep one canonical name.

## Commits

1. `Add install-method detector and write markers from docker, install.sh, and bun postinstall`
2. `Refactor jarvis update to dispatch on install method with shared daemon-control helper`
3. `Rewrite jarvis uninstall with per-method dispatch, split phases, and detached-cleanup logging`
4. `Document per-method update and uninstall in README, help text, and doctor footer`