### PR TITLE
Follow-ups to #67: harden keepalive install, non-blocking restart, tests

### DIFF
--- a/src/cli/autostart.test.ts
+++ b/src/cli/autostart.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  canUseSystemdUserService,
+  decodeLaunchctlOutput,
+  isLaunchdAlreadyLoaded,
+  type SpawnResultLike,
+  type SpawnSyncFn,
+} from './autostart.ts';
+
+function makeSpawn(responses: Record<string, SpawnResultLike>): SpawnSyncFn {
+  return (cmd) => {
+    const key = cmd.join(' ');
+    const res = responses[key];
+    if (!res) throw new Error(`Unexpected spawn call: ${key}`);
+    return res;
+  };
+}
+
+const ok: SpawnResultLike = { exitCode: 0 };
+const fail: SpawnResultLike = { exitCode: 1 };
+
+describe('canUseSystemdUserService', () => {
+  test('returns false when systemctl --version fails (not installed)', () => {
+    const spawn = makeSpawn({
+      'systemctl --user --version': fail,
+    });
+    expect(canUseSystemdUserService(spawn)).toBe(false);
+  });
+
+  test('returns true when is-system-running exits 0 (healthy)', () => {
+    const spawn = makeSpawn({
+      'systemctl --user --version': ok,
+      'systemctl --user is-system-running': ok,
+    });
+    expect(canUseSystemdUserService(spawn)).toBe(true);
+  });
+
+  test('falls back to show-environment when is-system-running fails but bus is reachable', () => {
+    const spawn = makeSpawn({
+      'systemctl --user --version': ok,
+      'systemctl --user is-system-running': fail,
+      'systemctl --user show-environment': ok,
+    });
+    expect(canUseSystemdUserService(spawn)).toBe(true);
+  });
+
+  test('returns false when both is-system-running and show-environment fail (WSL2 without systemd)', () => {
+    const spawn = makeSpawn({
+      'systemctl --user --version': ok,
+      'systemctl --user is-system-running': fail,
+      'systemctl --user show-environment': fail,
+    });
+    expect(canUseSystemdUserService(spawn)).toBe(false);
+  });
+
+  test('returns false when spawn throws', () => {
+    const spawn: SpawnSyncFn = () => {
+      throw new Error('ENOENT');
+    };
+    expect(canUseSystemdUserService(spawn)).toBe(false);
+  });
+});
+
+describe('isLaunchdAlreadyLoaded', () => {
+  test('returns false when exit code is 0 (genuine success)', () => {
+    expect(isLaunchdAlreadyLoaded({ exitCode: 0 })).toBe(false);
+  });
+
+  test('returns false when output is empty on failure', () => {
+    expect(isLaunchdAlreadyLoaded({ exitCode: 1 })).toBe(false);
+  });
+
+  test('detects "already loaded" phrasing', () => {
+    const stderr = new TextEncoder().encode('Load failed: service already loaded');
+    expect(isLaunchdAlreadyLoaded({ exitCode: 1, stderr })).toBe(true);
+  });
+
+  test('detects "already bootstrapped" phrasing', () => {
+    const stderr = new TextEncoder().encode('Bootstrap failed: 5: Input/output error\nservice already bootstrapped');
+    expect(isLaunchdAlreadyLoaded({ exitCode: 1, stderr })).toBe(true);
+  });
+
+  test('detects "service already exists" phrasing', () => {
+    const stdout = new TextEncoder().encode('launchctl: service already exists');
+    expect(isLaunchdAlreadyLoaded({ exitCode: 1, stdout })).toBe(true);
+  });
+
+  test('detects "Service already loaded" with mixed case', () => {
+    const stderr = new TextEncoder().encode('Launchctl Error: Service Already Loaded');
+    expect(isLaunchdAlreadyLoaded({ exitCode: 1, stderr })).toBe(true);
+  });
+
+  test('returns false for unrelated failure messages', () => {
+    const stderr = new TextEncoder().encode('Load failed: 5: Input/output error');
+    expect(isLaunchdAlreadyLoaded({ exitCode: 1, stderr })).toBe(false);
+  });
+});
+
+describe('decodeLaunchctlOutput', () => {
+  test('decodes Uint8Array', () => {
+    const buf = new TextEncoder().encode('hello');
+    expect(decodeLaunchctlOutput(buf)).toBe('hello');
+  });
+
+  test('decodes ArrayBuffer', () => {
+    const buf = new TextEncoder().encode('world').buffer as ArrayBuffer;
+    expect(decodeLaunchctlOutput(buf)).toBe('world');
+  });
+
+  test('returns empty string for null', () => {
+    expect(decodeLaunchctlOutput(null)).toBe('');
+  });
+
+  test('returns empty string for undefined', () => {
+    expect(decodeLaunchctlOutput(undefined)).toBe('');
+  });
+});

--- a/src/cli/autostart.test.ts
+++ b/src/cli/autostart.test.ts
@@ -4,6 +4,7 @@ import {
   decodeLaunchctlOutput,
   isLaunchdAlreadyLoaded,
   probeSystemdUserService,
+  scheduleSystemdRestart,
   type SpawnResultLike,
   type SpawnSyncFn,
 } from './autostart.ts';
@@ -153,6 +154,30 @@ describe('isLaunchdAlreadyLoaded', () => {
   test('returns false for unrelated failure messages', () => {
     const stderr = new TextEncoder().encode('Load failed: 5: Input/output error');
     expect(isLaunchdAlreadyLoaded({ exitCode: 1, stderr })).toBe(false);
+  });
+});
+
+describe('scheduleSystemdRestart', () => {
+  test('uses --no-block so caller returns before systemd cycles the unit', () => {
+    const calls: string[][] = [];
+    const spawn: SpawnSyncFn = (cmd) => {
+      calls.push(cmd);
+      return ok;
+    };
+    expect(scheduleSystemdRestart(spawn)).toBe(true);
+    expect(calls[0]).toEqual(['systemctl', '--user', '--no-block', 'restart', 'jarvis.service']);
+  });
+
+  test('returns false when systemctl exits non-zero', () => {
+    const spawn: SpawnSyncFn = () => ({ exitCode: 5 });
+    expect(scheduleSystemdRestart(spawn)).toBe(false);
+  });
+
+  test('returns false when spawn throws', () => {
+    const spawn: SpawnSyncFn = () => {
+      throw new Error('boom');
+    };
+    expect(scheduleSystemdRestart(spawn)).toBe(false);
   });
 });
 

--- a/src/cli/autostart.test.ts
+++ b/src/cli/autostart.test.ts
@@ -3,6 +3,7 @@ import {
   canUseSystemdUserService,
   decodeLaunchctlOutput,
   isLaunchdAlreadyLoaded,
+  probeSystemdUserService,
   type SpawnResultLike,
   type SpawnSyncFn,
 } from './autostart.ts';
@@ -58,6 +59,65 @@ describe('canUseSystemdUserService', () => {
       throw new Error('ENOENT');
     };
     expect(canUseSystemdUserService(spawn)).toBe(false);
+  });
+});
+
+describe('probeSystemdUserService', () => {
+  test('captures stderr from systemctl --version failure', () => {
+    const stderr = new TextEncoder().encode('bash: systemctl: command not found');
+    const spawn = makeSpawn({
+      'systemctl --user --version': { exitCode: 127, stderr },
+    });
+    const result = probeSystemdUserService(spawn);
+    expect(result.supported).toBe(false);
+    expect(result.reason).toContain('systemctl: command not found');
+  });
+
+  test('captures stderr when bus is unreachable (WSL2 without systemd)', () => {
+    const stderr = new TextEncoder().encode('Failed to connect to bus: No such file or directory');
+    const spawn = makeSpawn({
+      'systemctl --user --version': ok,
+      'systemctl --user is-system-running': { exitCode: 1, stderr },
+      'systemctl --user show-environment': { exitCode: 1, stderr },
+    });
+    const result = probeSystemdUserService(spawn);
+    expect(result.supported).toBe(false);
+    expect(result.reason).toContain('Failed to connect to bus');
+  });
+
+  test('returns supported=true with no reason when bus is reachable', () => {
+    const spawn = makeSpawn({
+      'systemctl --user --version': ok,
+      'systemctl --user is-system-running': ok,
+    });
+    expect(probeSystemdUserService(spawn)).toEqual({ supported: true });
+  });
+
+  test('returns supported=true when show-environment fallback succeeds', () => {
+    const spawn = makeSpawn({
+      'systemctl --user --version': ok,
+      'systemctl --user is-system-running': fail,
+      'systemctl --user show-environment': ok,
+    });
+    expect(probeSystemdUserService(spawn)).toEqual({ supported: true });
+  });
+
+  test('reports spawn exception message', () => {
+    const spawn: SpawnSyncFn = () => {
+      throw new Error('ENOENT: systemctl missing');
+    };
+    const result = probeSystemdUserService(spawn);
+    expect(result.supported).toBe(false);
+    expect(result.reason).toContain('ENOENT');
+  });
+
+  test('first line only when stderr has multiple lines', () => {
+    const stderr = new TextEncoder().encode('line one\nline two\nline three');
+    const spawn = makeSpawn({
+      'systemctl --user --version': { exitCode: 1, stderr },
+    });
+    const result = probeSystemdUserService(spawn);
+    expect(result.reason).toBe('line one');
   });
 });
 

--- a/src/cli/autostart.ts
+++ b/src/cli/autostart.ts
@@ -181,11 +181,15 @@ async function startSystemdService(): Promise<boolean> {
   }
 }
 
-function scheduleSystemdRestart(): boolean {
-  return spawnDetachedShell(
-    'sleep 1; systemctl --user restart jarvis.service >/dev/null 2>&1',
-    ['bash', 'systemctl'],
-  );
+export function scheduleSystemdRestart(spawnSync: SpawnSyncFn = defaultSpawnSync): boolean {
+  // --no-block returns immediately; systemd queues the restart through its own
+  // lifecycle, so the calling HTTP handler can return before the unit cycles.
+  try {
+    const res = spawnSync(['systemctl', '--user', '--no-block', 'restart', 'jarvis.service']);
+    return res.exitCode === 0;
+  } catch {
+    return false;
+  }
 }
 
 async function uninstallSystemd(): Promise<boolean> {

--- a/src/cli/autostart.ts
+++ b/src/cli/autostart.ts
@@ -8,7 +8,6 @@
 
 import { join } from 'node:path';
 import { homedir } from 'node:os';
-import { Buffer } from 'node:buffer';
 import { spawn } from 'node:child_process';
 import { existsSync, mkdirSync, writeFileSync, unlinkSync } from 'node:fs';
 import { c, printOk, printErr, printWarn } from './helpers.ts';
@@ -280,16 +279,15 @@ async function installLaunchd(): Promise<boolean> {
   }
 }
 
+const utf8Decoder = new TextDecoder('utf-8');
+
 export function decodeLaunchctlOutput(output: Uint8Array | ArrayBuffer | null | undefined): string {
   if (!output) {
     return '';
   }
 
   try {
-    if (output instanceof Uint8Array) {
-      return Buffer.from(output).toString('utf8');
-    }
-    return Buffer.from(new Uint8Array(output)).toString('utf8');
+    return utf8Decoder.decode(output);
   } catch {
     return '';
   }
@@ -309,24 +307,37 @@ export function isLaunchdAlreadyLoaded(result: SpawnResultLike): boolean {
   );
 }
 
+function launchctlReason(result: SpawnResultLike): string {
+  const combined = `${decodeLaunchctlOutput(result.stderr)}\n${decodeLaunchctlOutput(result.stdout)}`.trim();
+  const first = combined.split('\n').find((line) => line.trim().length > 0);
+  return (first ?? `exit ${result.exitCode}`).slice(0, 200);
+}
+
 async function startLaunchdService(): Promise<boolean> {
   try {
     const getuid = process.getuid;
     const uid = typeof getuid === 'function' ? getuid.call(process) : undefined;
 
+    let bootstrapReason: string | null = null;
     if (typeof uid === 'number') {
       const bootstrap = Bun.spawnSync(['launchctl', 'bootstrap', `gui/${uid}`, LAUNCHD_PLIST]);
       if (bootstrap.exitCode === 0 || isLaunchdAlreadyLoaded(bootstrap)) {
         printOk('JARVIS launch agent is running.');
         return true;
       }
+      bootstrapReason = launchctlReason(bootstrap);
     } else {
-      printWarn('Could not determine the current user UID; skipping launchctl bootstrap and falling back to launchctl load.');
+      bootstrapReason = 'could not determine current user UID';
+      printWarn('Skipping launchctl bootstrap — no UID; falling back to launchctl load.');
     }
 
     const load = Bun.spawnSync(['launchctl', 'load', LAUNCHD_PLIST]);
     if (load.exitCode !== 0 && !isLaunchdAlreadyLoaded(load)) {
-      printWarn('Installed launchd plist, but could not start it immediately. It should start on next login.');
+      const loadReason = launchctlReason(load);
+      printWarn(
+        `Installed launchd plist, but could not start it immediately. It should start on next login. ` +
+          `(bootstrap: ${bootstrapReason}; load: ${loadReason})`,
+      );
       return false;
     }
 

--- a/src/cli/autostart.ts
+++ b/src/cli/autostart.ts
@@ -56,12 +56,22 @@ function getJarvisPath(): string {
   return join(import.meta.dir, '../../bin/jarvis.ts');
 }
 
-function canUseSystemdUserService(): boolean {
+export type SpawnResultLike = {
+  exitCode: number;
+  stdout?: Uint8Array | ArrayBuffer | null;
+  stderr?: Uint8Array | ArrayBuffer | null;
+};
+
+export type SpawnSyncFn = (cmd: string[], opts?: { stdout?: 'ignore'; stderr?: 'ignore' }) => SpawnResultLike;
+
+const defaultSpawnSync: SpawnSyncFn = (cmd, opts) => Bun.spawnSync(cmd, opts as never) as unknown as SpawnResultLike;
+
+export function canUseSystemdUserService(spawnSync: SpawnSyncFn = defaultSpawnSync): boolean {
   try {
-    const version = Bun.spawnSync(['systemctl', '--user', '--version']);
+    const version = spawnSync(['systemctl', '--user', '--version']);
     if (version.exitCode !== 0) return false;
 
-    const state = Bun.spawnSync(['systemctl', '--user', 'is-system-running'], {
+    const state = spawnSync(['systemctl', '--user', 'is-system-running'], {
       stdout: 'ignore',
       stderr: 'ignore',
     });
@@ -70,7 +80,7 @@ function canUseSystemdUserService(): boolean {
     // We only need the user manager to be reachable, not fully healthy.
     if (state.exitCode === 0) return true;
 
-    const env = Bun.spawnSync(['systemctl', '--user', 'show-environment'], {
+    const env = spawnSync(['systemctl', '--user', 'show-environment'], {
       stdout: 'ignore',
       stderr: 'ignore',
     });
@@ -252,7 +262,7 @@ async function installLaunchd(): Promise<boolean> {
   }
 }
 
-function decodeLaunchctlOutput(output: Uint8Array | ArrayBuffer | null | undefined): string {
+export function decodeLaunchctlOutput(output: Uint8Array | ArrayBuffer | null | undefined): string {
   if (!output) {
     return '';
   }
@@ -267,9 +277,7 @@ function decodeLaunchctlOutput(output: Uint8Array | ArrayBuffer | null | undefin
   }
 }
 
-function isLaunchdAlreadyLoaded(
-  result: { exitCode: number; stdout?: Uint8Array | ArrayBuffer | null; stderr?: Uint8Array | ArrayBuffer | null },
-): boolean {
+export function isLaunchdAlreadyLoaded(result: SpawnResultLike): boolean {
   if (result.exitCode === 0) {
     return false;
   }

--- a/src/cli/autostart.ts
+++ b/src/cli/autostart.ts
@@ -66,28 +66,42 @@ export type SpawnSyncFn = (cmd: string[], opts?: { stdout?: 'ignore'; stderr?: '
 
 const defaultSpawnSync: SpawnSyncFn = (cmd, opts) => Bun.spawnSync(cmd, opts as never) as unknown as SpawnResultLike;
 
-export function canUseSystemdUserService(spawnSync: SpawnSyncFn = defaultSpawnSync): boolean {
+export type SystemdProbeResult = { supported: boolean; reason?: string };
+
+function firstNonEmpty(...outputs: (Uint8Array | ArrayBuffer | null | undefined)[]): string {
+  for (const o of outputs) {
+    const text = decodeLaunchctlOutput(o).trim();
+    if (text) return text.split('\n')[0]!.slice(0, 200);
+  }
+  return '';
+}
+
+export function probeSystemdUserService(spawnSync: SpawnSyncFn = defaultSpawnSync): SystemdProbeResult {
   try {
     const version = spawnSync(['systemctl', '--user', '--version']);
-    if (version.exitCode !== 0) return false;
+    if (version.exitCode !== 0) {
+      return { supported: false, reason: firstNonEmpty(version.stderr, version.stdout) || 'systemctl --user not available' };
+    }
 
-    const state = spawnSync(['systemctl', '--user', 'is-system-running'], {
-      stdout: 'ignore',
-      stderr: 'ignore',
-    });
-
+    const state = spawnSync(['systemctl', '--user', 'is-system-running']);
     // "running" exits 0, degraded/offline can still manage units and usually exits non-zero.
     // We only need the user manager to be reachable, not fully healthy.
-    if (state.exitCode === 0) return true;
+    if (state.exitCode === 0) return { supported: true };
 
-    const env = spawnSync(['systemctl', '--user', 'show-environment'], {
-      stdout: 'ignore',
-      stderr: 'ignore',
-    });
-    return env.exitCode === 0;
-  } catch {
-    return false;
+    const env = spawnSync(['systemctl', '--user', 'show-environment']);
+    if (env.exitCode === 0) return { supported: true };
+
+    return {
+      supported: false,
+      reason: firstNonEmpty(env.stderr, env.stdout, state.stderr, state.stdout) || 'user systemd manager unreachable',
+    };
+  } catch (err) {
+    return { supported: false, reason: err instanceof Error ? err.message : String(err) };
   }
+}
+
+export function canUseSystemdUserService(spawnSync: SpawnSyncFn = defaultSpawnSync): boolean {
+  return probeSystemdUserService(spawnSync).supported;
 }
 
 // ── systemd (Linux) ──────────────────────────────────────────────────
@@ -408,10 +422,18 @@ export function isAutostartInstalled(): boolean {
  * Linux and WSL2 require a reachable user systemd instance.
  */
 export function isAutostartSupported(): boolean {
+  return checkAutostartSupport().supported;
+}
+
+/**
+ * Like isAutostartSupported, but returns why it isn't when the answer is no —
+ * useful for surfacing real diagnostics (e.g., WSL2 bus unreachable) in onboarding.
+ */
+export function checkAutostartSupport(): SystemdProbeResult {
   if (process.platform === 'darwin') {
-    return true;
+    return { supported: true };
   }
-  return canUseSystemdUserService();
+  return probeSystemdUserService();
 }
 
 /**

--- a/src/cli/onboard.ts
+++ b/src/cli/onboard.ts
@@ -15,7 +15,7 @@ import {
 } from './helpers.ts';
 import { DEFAULT_CONFIG, type JarvisConfig } from '../config/types.ts';
 import { loadConfig, saveConfig } from '../config/loader.ts';
-import { installAutostart, startAutostartService, getAutostartName, isAutostartSupported } from './autostart.ts';
+import { installAutostart, startAutostartService, getAutostartName, checkAutostartSupport } from './autostart.ts';
 import { runDependencyCheck } from './deps.ts';
 import { initDatabase, closeDb } from '../vault/schema.ts';
 import { saveUserProfile } from '../vault/user-profile.ts';
@@ -627,14 +627,17 @@ export async function runOnboard(): Promise<void> {
   printStep(10, TOTAL_STEPS, 'Keepalive');
   const platform = detectPlatform();
   let enableKeepalive = false;
-  const keepaliveSupported = isAutostartSupported();
+  const support = checkAutostartSupport();
 
-  if (!keepaliveSupported) {
+  if (!support.supported) {
     if (platform === 'wsl') {
       printInfo('WSL2 detected, but the user systemd service manager is not available in this session.');
       printInfo('Enable systemd in WSL, then rerun onboard to use 24/7 keepalive mode.');
     } else {
       printInfo('Keepalive mode is not supported in this environment.');
+    }
+    if (support.reason) {
+      console.log(c.dim(`  (${support.reason})`));
     }
     printInfo('Start JARVIS manually with: jarvis start');
   } else {


### PR DESCRIPTION
## Issues

A review of #67 (commit `4052e2c`, "Add cross-platform keepalive onboarding") surfaced four actionable problems with the keepalive install flow. The core of that PR is solid — splitting install from start, probing `systemctl --user` before offering keepalive, modernizing `launchctl bootstrap` — but the rough edges are worth cleaning up before they bite.

**1. Restart race on Linux.** The helper that restarted the systemd service from the daemon's own HTTP handler worked by spawning a detached bash subprocess that slept for a second, then issued a plain restart. The sleep existed so the HTTP handler could return a response before systemd cycled the unit. The problem is that the detached bash lives inside the user service's own slice, which means the restart kills the sleeping bash mid-sleep. In practice the response usually flushed in time, but the flow was timing-dependent and also tied to bash being on PATH — fragile in a way that the user wouldn't see until it failed in production.

**2. Swallowed diagnostics in the systemd probe.** The probe that decides whether to offer keepalive during onboarding ran `systemctl` with both stdout and stderr set to `ignore` and returned only a boolean. On WSL2 distributions where systemd is installed but the user bus isn't reachable, users saw a bare "keepalive is not supported" message with no indication why. The failure was recoverable (enable systemd in WSL and rerun onboard) but undiagnosable from the message alone.

**3. Lost error context in the macOS launchd fallback.** The start-service path first tries modern `launchctl bootstrap`, then falls back to legacy `launchctl load` on failure. If the bootstrap failed for a real reason and the fallback load also failed, only the load-level warning reached the user — the bootstrap reason was dropped. Users debugging a launchd install would be missing half the story.

**4. Zero test coverage on the pure helpers.** The probe decision, the "already loaded" heuristic (which matches four different phrasings Apple has shipped across macOS versions), and the output decoder are all pure functions, easy to cover with unit tests. None had any. A regression in the heuristic — for example, Apple adding a fifth phrasing — would go unnoticed.

## Plan

Four commits, ordered so each one rests on the previous one. Commit 1 establishes the safety net; commits 2 through 4 are the behavioral changes.

- Commit 1 exports the pure helpers, refactors the systemd probe to accept an injected spawn function for testability, and adds a dedicated test file covering every branch of the probe, every phrasing of the "already loaded" heuristic, and the output decoder on all input shapes. No behavior change.
- Commit 2 replaces the boolean probe with a version that returns a reason when it returns false, then surfaces that reason in the onboarding step as a dimmed line under the existing "not supported" message. Keeps the old boolean function as a thin wrapper so existing API callers don't move.
- Commit 3 rewrites the restart helper to issue a single non-blocking systemctl call. The `--no-block` flag queues the restart through systemd's own lifecycle and returns immediately, removing the shell, the sleep, and the race.
- Commit 4 captures the bootstrap reason on macOS and aggregates it with the load reason in a single warning if both paths fail, so no diagnostic is lost. Folds in a small decode simplification that drops the `node:buffer` dependency in favor of a module-level `TextDecoder`.