### PR TITLE
Better provider error handling

### DIFF
--- a/src/comms/streaming.ts
+++ b/src/comms/streaming.ts
@@ -1,4 +1,5 @@
 import type { LLMStreamEvent } from '../llm/provider.ts';
+import { classifyErrorString } from '../llm/provider.ts';
 import type { WebSocketServer, WSMessage } from './websocket.ts';
 
 export type RelayOptions = {
@@ -88,6 +89,7 @@ export class StreamRelay {
             type: 'error',
             payload: {
               message: event.error,
+              code: event.code ?? classifyErrorString(event.error),
               requestId,
             },
             id: requestId,
@@ -129,10 +131,12 @@ export class StreamRelay {
     } catch (error) {
       console.error('[StreamRelay] Error relaying stream:', error);
 
+      const message = error instanceof Error ? error.message : 'Stream relay error';
       const errorMessage: WSMessage = {
         type: 'error',
         payload: {
-          message: error instanceof Error ? error.message : 'Stream relay error',
+          message,
+          code: classifyErrorString(message),
           requestId,
         },
         id: requestId,

--- a/src/daemon/ws-service.ts
+++ b/src/daemon/ws-service.ts
@@ -19,6 +19,7 @@ import type { EmergencyState } from '../authority/emergency.ts';
 import { createCommitment, updateCommitmentStatus, updateCommitmentAssignee } from '../vault/commitments.ts';
 import { WebSocketServer, type WSMessage } from '../comms/websocket.ts';
 import { StreamRelay } from '../comms/streaming.ts';
+import { classifyErrorString } from '../llm/provider.ts';
 import { getOrCreateConversation, addMessage } from '../vault/conversations.ts';
 import { maybeCreateUserProfileFollowupPrompt, recordUserProfileTurn } from '../user/profile-followup.ts';
 
@@ -775,10 +776,12 @@ If the user wants to create a new project, tell them to use the Site Builder pag
         }
       }
 
+      const message = error instanceof Error ? error.message : 'Chat processing failed';
       return {
         type: 'error',
         payload: {
-          message: error instanceof Error ? error.message : 'Chat processing failed',
+          message,
+          code: classifyErrorString(message),
         },
         id: requestId,
         timestamp: Date.now(),

--- a/src/llm/anthropic.ts
+++ b/src/llm/anthropic.ts
@@ -6,8 +6,30 @@ import type {
   LLMStreamEvent,
   LLMTool,
   LLMToolCall,
+  LLMErrorCode,
 } from './provider.ts';
+import { classifyErrorString } from './provider.ts';
 import { compactHistory, calculateHistoryBudget } from './history.ts';
+
+/** Map Anthropic's SSE-level error.type to our canonical code. */
+function classifyAnthropicErrorType(type: string): LLMErrorCode {
+  switch (type) {
+    case 'authentication_error':
+    case 'permission_error':
+      return 'auth';
+    case 'rate_limit_error':
+      return 'rate_limit';
+    case 'overloaded_error':
+    case 'api_error':
+      return 'server';
+    case 'invalid_request_error':
+      return 'bad_request';
+    case 'not_found_error':
+      return 'not_found';
+    default:
+      return 'unknown';
+  }
+}
 
 type AnthropicMessage = {
   role: 'user' | 'assistant';
@@ -160,12 +182,13 @@ export class AnthropicProvider implements LLMProvider {
     try {
       response = await this.fetchWithRetry(JSON.stringify(body), true);
     } catch (err) {
-      yield { type: 'error', error: err instanceof Error ? err.message : String(err) };
+      const message = err instanceof Error ? err.message : String(err);
+      yield { type: 'error', error: message, code: classifyErrorString(message) };
       return;
     }
 
     if (!response.body) {
-      yield { type: 'error', error: 'No response body' };
+      yield { type: 'error', error: 'No response body', code: 'network' };
       return;
     }
 
@@ -242,7 +265,11 @@ export class AnthropicProvider implements LLMProvider {
                 usage.output_tokens = event.delta.usage.output_tokens;
               }
             } else if (event.type === 'error') {
-              yield { type: 'error', error: `${event.error.type}: ${event.error.message}` };
+              yield {
+                type: 'error',
+                error: `${event.error.type}: ${event.error.message}`,
+                code: classifyAnthropicErrorType(event.error.type),
+              };
               return;
             }
           } catch (err) {
@@ -264,7 +291,7 @@ export class AnthropicProvider implements LLMProvider {
         },
       };
     } catch (err) {
-      yield { type: 'error', error: `Stream error: ${err}` };
+      yield { type: 'error', error: `Stream error: ${err}`, code: 'network' };
     }
   }
 

--- a/src/llm/gemini.ts
+++ b/src/llm/gemini.ts
@@ -7,6 +7,7 @@ import type {
   LLMTool,
   LLMToolCall,
 } from './provider.ts';
+import { classifyErrorString } from './provider.ts';
 import { compactHistory, calculateHistoryBudget } from './history.ts';
 
 type GeminiPart =
@@ -141,12 +142,13 @@ export class GeminiProvider implements LLMProvider {
     try {
       response = await this.fetchWithRetry(url, JSON.stringify(body));
     } catch (err) {
-      yield { type: 'error', error: err instanceof Error ? err.message : String(err) };
+      const message = err instanceof Error ? err.message : String(err);
+      yield { type: 'error', error: message, code: classifyErrorString(message) };
       return;
     }
 
     if (!response.body) {
-      yield { type: 'error', error: 'No response body' };
+      yield { type: 'error', error: 'No response body', code: 'network' };
       return;
     }
 
@@ -223,7 +225,7 @@ export class GeminiProvider implements LLMProvider {
         },
       };
     } catch (err) {
-      yield { type: 'error', error: `Stream error: ${err}` };
+      yield { type: 'error', error: `Stream error: ${err}`, code: 'network' };
     }
   }
 

--- a/src/llm/groq.ts
+++ b/src/llm/groq.ts
@@ -7,6 +7,7 @@ import type {
   LLMTool,
   LLMToolCall,
 } from './provider.ts';
+import { classifyHttpStatus } from './provider.ts';
 type GroqMessage = {
   role: 'system' | 'user' | 'assistant' | 'tool';
   content: string | null;
@@ -133,7 +134,11 @@ export class GroqProvider implements LLMProvider {
     if (!response.ok) {
       const errorText = await response.text();
       if (!this.isRequestTooLargeError(response.status, errorText)) {
-        yield { type: 'error', error: `Groq API error (${response.status}): ${errorText}` };
+        yield {
+          type: 'error',
+          error: `Groq API error (${response.status}): ${errorText}`,
+          code: classifyHttpStatus(response.status),
+        };
         return;
       }
       response = await this.sendRequest(
@@ -146,13 +151,17 @@ export class GroqProvider implements LLMProvider {
       );
       if (!response.ok) {
         const retryError = await response.text();
-        yield { type: 'error', error: `Groq API error after retry (${response.status}): ${retryError}` };
+        yield {
+          type: 'error',
+          error: `Groq API error after retry (${response.status}): ${retryError}`,
+          code: classifyHttpStatus(response.status),
+        };
         return;
       }
     }
 
     if (!response.body) {
-      yield { type: 'error', error: 'No response body' };
+      yield { type: 'error', error: 'No response body', code: 'network' };
       return;
     }
 
@@ -236,7 +245,7 @@ export class GroqProvider implements LLMProvider {
           toolCalls.push(toolCall);
           yield { type: 'tool_call', tool_call: toolCall };
         } catch (err) {
-          yield { type: 'error', error: `Failed to parse tool call arguments: ${err}` };
+          yield { type: 'error', error: `Failed to parse tool call arguments: ${err}`, code: 'bad_request' };
         }
       }
 
@@ -252,7 +261,7 @@ export class GroqProvider implements LLMProvider {
         },
       };
     } catch (err) {
-      yield { type: 'error', error: `Stream error: ${err}` };
+      yield { type: 'error', error: `Stream error: ${err}`, code: 'network' };
     }
   }
 

--- a/src/llm/manager.ts
+++ b/src/llm/manager.ts
@@ -4,7 +4,9 @@ import type {
   LLMOptions,
   LLMResponse,
   LLMStreamEvent,
+  LLMErrorCode,
 } from './provider.ts';
+import { classifyErrorString } from './provider.ts';
 
 export class LLMManager {
   private providers: Map<string, LLMProvider> = new Map();
@@ -163,6 +165,7 @@ export class LLMManager {
 
   async *stream(messages: LLMMessage[], options?: LLMOptions): AsyncIterable<LLMStreamEvent> {
     const failures: string[] = [];
+    let lastErrorCode: LLMErrorCode | undefined;
 
     for (const providerName of this.getProviderSequence()) {
       const provider = this.providers.get(providerName);
@@ -180,11 +183,16 @@ export class LLMManager {
             if (event.type === 'error') {
               hasError = true;
               errors.push(`attempt ${attempt}: ${event.error}`);
+              lastErrorCode = event.code ?? classifyErrorString(event.error);
               console.error(
                 `[LLM] Provider ${providerName} stream error (attempt ${attempt}/${LLMManager.MAX_RETRIES_PER_PROVIDER}): ${event.error}`
               );
               if (emittedContent) {
-                yield { type: 'error', error: this.formatFailure(providerName, errors) };
+                yield {
+                  type: 'error',
+                  error: this.formatFailure(providerName, errors),
+                  code: lastErrorCode,
+                };
                 return;
               }
               break;
@@ -201,6 +209,7 @@ export class LLMManager {
         } catch (err) {
           const errorMsg = err instanceof Error ? err.message : String(err);
           errors.push(`attempt ${attempt}: ${errorMsg}`);
+          lastErrorCode = classifyErrorString(errorMsg);
 
           const shouldRetry = this.shouldRetry(err);
           console.error(
@@ -208,7 +217,11 @@ export class LLMManager {
           );
 
           if (emittedContent) {
-            yield { type: 'error', error: this.formatFailure(providerName, errors) };
+            yield {
+              type: 'error',
+              error: this.formatFailure(providerName, errors),
+              code: lastErrorCode,
+            };
             return;
           }
 
@@ -219,9 +232,11 @@ export class LLMManager {
       failures.push(this.formatFailure(providerName, errors));
     }
 
+    const aggregated = failures.join('\n\n');
     yield {
       type: 'error',
-      error: failures.join('\n\n'),
+      error: aggregated,
+      code: lastErrorCode ?? classifyErrorString(aggregated),
     };
   }
 }

--- a/src/llm/nvidia.ts
+++ b/src/llm/nvidia.ts
@@ -7,6 +7,7 @@ import type {
   LLMTool,
   LLMToolCall,
 } from './provider.ts';
+import { classifyHttpStatus } from './provider.ts';
 import { compactHistory, calculateHistoryBudget } from './history.ts';
 
 type OpenAIMessage = {
@@ -158,12 +159,16 @@ export class NVIDIAProvider implements LLMProvider {
 
     if (!response.ok) {
       const errorText = await response.text();
-      yield { type: 'error', error: `NVIDIA API error (${response.status}): ${errorText}` };
+      yield {
+        type: 'error',
+        error: `NVIDIA API error (${response.status}): ${errorText}`,
+        code: classifyHttpStatus(response.status),
+      };
       return;
     }
 
     if (!response.body) {
-      yield { type: 'error', error: 'No response body' };
+      yield { type: 'error', error: 'No response body', code: 'network' };
       return;
     }
 
@@ -246,7 +251,7 @@ export class NVIDIAProvider implements LLMProvider {
           toolCalls.push(toolCall);
           yield { type: 'tool_call', tool_call: toolCall };
         } catch (err) {
-          yield { type: 'error', error: `Failed to parse tool call arguments: ${err}` };
+          yield { type: 'error', error: `Failed to parse tool call arguments: ${err}`, code: 'bad_request' };
         }
       }
 
@@ -262,7 +267,7 @@ export class NVIDIAProvider implements LLMProvider {
         },
       };
     } catch (err) {
-      yield { type: 'error', error: `Stream error: ${err}` };
+      yield { type: 'error', error: `Stream error: ${err}`, code: 'network' };
     }
   }
 

--- a/src/llm/ollama.ts
+++ b/src/llm/ollama.ts
@@ -7,6 +7,7 @@ import type {
   LLMTool,
   LLMToolCall,
 } from './provider.ts';
+import { classifyHttpStatus } from './provider.ts';
 import { compactHistory, calculateHistoryBudget } from './history.ts';
 
 type OllamaMessage = {
@@ -150,12 +151,16 @@ export class OllamaProvider implements LLMProvider {
 
     if (!response.ok) {
       const errorText = await response.text();
-      yield { type: 'error', error: `Ollama API error (${response.status}): ${errorText}` };
+      yield {
+        type: 'error',
+        error: `Ollama API error (${response.status}): ${errorText}`,
+        code: classifyHttpStatus(response.status),
+      };
       return;
     }
 
     if (!response.body) {
-      yield { type: 'error', error: 'No response body' };
+      yield { type: 'error', error: 'No response body', code: 'network' };
       return;
     }
 
@@ -224,7 +229,7 @@ export class OllamaProvider implements LLMProvider {
         }
       }
     } catch (err) {
-      yield { type: 'error', error: `Stream error: ${err}` };
+      yield { type: 'error', error: `Stream error: ${err}`, code: 'network' };
     }
   }
 

--- a/src/llm/openai.ts
+++ b/src/llm/openai.ts
@@ -7,6 +7,7 @@ import type {
   LLMTool,
   LLMToolCall,
 } from './provider.ts';
+import { classifyHttpStatus } from './provider.ts';
 import { compactHistory, calculateHistoryBudget } from './history.ts';
 
 type OpenAIMessage = {
@@ -158,12 +159,16 @@ export class OpenAIProvider implements LLMProvider {
 
     if (!response.ok) {
       const errorText = await response.text();
-      yield { type: 'error', error: `OpenAI API error (${response.status}): ${errorText}` };
+      yield {
+        type: 'error',
+        error: `OpenAI API error (${response.status}): ${errorText}`,
+        code: classifyHttpStatus(response.status),
+      };
       return;
     }
 
     if (!response.body) {
-      yield { type: 'error', error: 'No response body' };
+      yield { type: 'error', error: 'No response body', code: 'network' };
       return;
     }
 
@@ -247,7 +252,7 @@ export class OpenAIProvider implements LLMProvider {
           toolCalls.push(toolCall);
           yield { type: 'tool_call', tool_call: toolCall };
         } catch (err) {
-          yield { type: 'error', error: `Failed to parse tool call arguments: ${err}` };
+          yield { type: 'error', error: `Failed to parse tool call arguments: ${err}`, code: 'bad_request' };
         }
       }
 
@@ -263,7 +268,7 @@ export class OpenAIProvider implements LLMProvider {
         },
       };
     } catch (err) {
-      yield { type: 'error', error: `Stream error: ${err}` };
+      yield { type: 'error', error: `Stream error: ${err}`, code: 'network' };
     }
   }
 

--- a/src/llm/openrouter.ts
+++ b/src/llm/openrouter.ts
@@ -7,6 +7,7 @@ import type {
   LLMTool,
   LLMToolCall,
 } from './provider.ts';
+import { classifyHttpStatus } from './provider.ts';
 import { compactHistory, calculateHistoryBudget } from './history.ts';
 
 type OpenRouterMessage = {
@@ -162,12 +163,16 @@ export class OpenRouterProvider implements LLMProvider {
 
     if (!response.ok) {
       const errorText = await response.text();
-      yield { type: 'error', error: `OpenRouter API error (${response.status}): ${errorText}` };
+      yield {
+        type: 'error',
+        error: `OpenRouter API error (${response.status}): ${errorText}`,
+        code: classifyHttpStatus(response.status),
+      };
       return;
     }
 
     if (!response.body) {
-      yield { type: 'error', error: 'No response body' };
+      yield { type: 'error', error: 'No response body', code: 'network' };
       return;
     }
 
@@ -251,7 +256,7 @@ export class OpenRouterProvider implements LLMProvider {
           toolCalls.push(toolCall);
           yield { type: 'tool_call', tool_call: toolCall };
         } catch (err) {
-          yield { type: 'error', error: `Failed to parse tool call arguments: ${err}` };
+          yield { type: 'error', error: `Failed to parse tool call arguments: ${err}`, code: 'bad_request' };
         }
       }
 
@@ -267,7 +272,7 @@ export class OpenRouterProvider implements LLMProvider {
         },
       };
     } catch (err) {
-      yield { type: 'error', error: `Stream error: ${err}` };
+      yield { type: 'error', error: `Stream error: ${err}`, code: 'network' };
     }
   }
 

--- a/src/llm/provider.test.ts
+++ b/src/llm/provider.test.ts
@@ -6,7 +6,7 @@ import { OllamaProvider } from './ollama.ts';
 import { OpenRouterProvider } from './openrouter.ts';
 import { NVIDIAProvider } from './nvidia.ts';
 import { LLMManager } from './manager.ts';
-import { guardImageSize, type LLMMessage, type ContentBlock } from './provider.ts';
+import { guardImageSize, classifyHttpStatus, classifyErrorString, type LLMMessage, type ContentBlock } from './provider.ts';
 import { isToolResult, type ToolResult } from '../actions/tools/registry.ts';
 
 describe('LLM Provider Types', () => {
@@ -712,5 +712,75 @@ describe('Groq request shaping', () => {
     expect(events.join('')).toBe('retry-stream ok');
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(JSON.stringify(secondBody).length).toBeLessThan(JSON.stringify(firstBody).length);
+  });
+});
+
+describe('classifyHttpStatus', () => {
+  test('401/403 → auth', () => {
+    expect(classifyHttpStatus(401)).toBe('auth');
+    expect(classifyHttpStatus(403)).toBe('auth');
+  });
+
+  test('429 → rate_limit', () => {
+    expect(classifyHttpStatus(429)).toBe('rate_limit');
+  });
+
+  test('404 → not_found', () => {
+    expect(classifyHttpStatus(404)).toBe('not_found');
+  });
+
+  test('400/422 → bad_request', () => {
+    expect(classifyHttpStatus(400)).toBe('bad_request');
+    expect(classifyHttpStatus(422)).toBe('bad_request');
+  });
+
+  test('502/503/504 → network (transient)', () => {
+    expect(classifyHttpStatus(502)).toBe('network');
+    expect(classifyHttpStatus(503)).toBe('network');
+    expect(classifyHttpStatus(504)).toBe('network');
+  });
+
+  test('other 5xx → server', () => {
+    expect(classifyHttpStatus(500)).toBe('server');
+    expect(classifyHttpStatus(501)).toBe('server');
+  });
+
+  test('200 and unknowns → unknown', () => {
+    expect(classifyHttpStatus(200)).toBe('unknown');
+    expect(classifyHttpStatus(418)).toBe('unknown');
+  });
+});
+
+describe('classifyErrorString', () => {
+  test('auth via 401 / unauthorized / api key', () => {
+    expect(classifyErrorString('HTTP 401 Unauthorized')).toBe('auth');
+    expect(classifyErrorString('invalid x-api-key')).toBe('auth');
+    expect(classifyErrorString('Incorrect API key provided')).toBe('auth');
+  });
+
+  test('rate_limit via 429 / quota / rate limit', () => {
+    expect(classifyErrorString('OpenAI API error (429): rate_limit_exceeded')).toBe('rate_limit');
+    expect(classifyErrorString('You exceeded your current quota')).toBe('rate_limit');
+    expect(classifyErrorString('Too Many Requests')).toBe('rate_limit');
+  });
+
+  test('network via 503 / timeout / econnrefused', () => {
+    expect(classifyErrorString('Service temporarily unavailable (503)')).toBe('network');
+    expect(classifyErrorString('fetch failed: ECONNREFUSED')).toBe('network');
+    expect(classifyErrorString('Request timeout')).toBe('network');
+  });
+
+  test('word-boundary: 4295 does not collide with 429', () => {
+    expect(classifyErrorString('prompt has 4295 tokens')).not.toBe('rate_limit');
+  });
+
+  test('word-boundary: 14018 does not collide with 401', () => {
+    expect(classifyErrorString('context at 14018 tokens')).not.toBe('auth');
+  });
+
+  test('unknown when nothing matches', () => {
+    expect(classifyErrorString('something unexpected happened')).toBe('unknown');
+    expect(classifyErrorString(undefined)).toBe('unknown');
+    expect(classifyErrorString('')).toBe('unknown');
   });
 });

--- a/src/llm/provider.ts
+++ b/src/llm/provider.ts
@@ -29,11 +29,70 @@ export type LLMResponse = {
   finish_reason: 'stop' | 'tool_use' | 'length' | 'error';
 };
 
+/**
+ * Structured classification for provider/stream errors. Lets the UI render
+ * user-facing copy without string-matching the upstream error message.
+ */
+export type LLMErrorCode =
+  | 'auth'         // invalid API key, unauthorized
+  | 'rate_limit'   // 429, quota exhausted
+  | 'network'      // timeout, connection refused, 502/503/504
+  | 'bad_request'  // 400/422, invalid parameters
+  | 'not_found'    // 404, model/resource missing
+  | 'server'       // generic 5xx
+  | 'unknown';
+
 export type LLMStreamEvent =
   | { type: 'text'; text: string }
   | { type: 'tool_call'; tool_call: LLMToolCall }
   | { type: 'done'; response: LLMResponse }
-  | { type: 'error'; error: string };
+  | { type: 'error'; error: string; code?: LLMErrorCode };
+
+/**
+ * Map an HTTP status code returned by a provider to a canonical error code.
+ * Use this at the emission site (where the status is still available) so the
+ * UI doesn't have to guess from the error string.
+ */
+export function classifyHttpStatus(status: number): LLMErrorCode {
+  if (status === 401 || status === 403) return 'auth';
+  if (status === 429) return 'rate_limit';
+  if (status === 404) return 'not_found';
+  if (status === 400 || status === 422) return 'bad_request';
+  if (status === 502 || status === 503 || status === 504) return 'network';
+  if (status >= 500) return 'server';
+  return 'unknown';
+}
+
+/**
+ * Fallback classifier when the HTTP status is not available (e.g., error came
+ * from a thrown Error or an aggregated failure message). Uses word-boundary
+ * regexes so stray digits inside a message don't misclassify the bucket.
+ */
+export function classifyErrorString(raw: string | undefined | null): LLMErrorCode {
+  if (!raw) return 'unknown';
+  const s = raw.toLowerCase();
+  if (
+    /\b401\b/.test(s) || /\b403\b/.test(s) ||
+    s.includes('unauthorized') || s.includes('api key') ||
+    s.includes('invalid_api_key') || s.includes('invalid x-api-key') ||
+    s.includes('authentication')
+  ) return 'auth';
+  if (
+    /\b429\b/.test(s) ||
+    s.includes('rate limit') || s.includes('too many requests') ||
+    s.includes('insufficient_quota') || s.includes('quota')
+  ) return 'rate_limit';
+  if (
+    /\b(502|503|504)\b/.test(s) ||
+    s.includes('timeout') || s.includes('temporarily unavailable') ||
+    s.includes('econnrefused') || s.includes('enotfound') ||
+    s.includes('network')
+  ) return 'network';
+  if (/\b404\b/.test(s) || s.includes('not found') || s.includes('model_not_found')) return 'not_found';
+  if (/\b(400|422)\b/.test(s) || s.includes('bad request') || s.includes('invalid_request')) return 'bad_request';
+  if (/\b5\d\d\b/.test(s) || s.includes('internal server error')) return 'server';
+  return 'unknown';
+}
 
 export type LLMOptions = {
   model?: string;

--- a/ui/src/components/chat/MessageBubble.tsx
+++ b/ui/src/components/chat/MessageBubble.tsx
@@ -55,6 +55,12 @@ export function MessageBubble({ message }: Props) {
             <div className={`chat-system-text ${type === "error" ? "chat-system-text-error" : ""}`}>
               <MarkdownContent content={message.content} />
             </div>
+            {message.detail ? (
+              <details className="chat-system-detail">
+                <summary>Show details</summary>
+                <pre className="chat-system-detail-pre">{message.detail}</pre>
+              </details>
+            ) : null}
             <div className="chat-system-ts">{timestamp}</div>
           </div>
         </div>

--- a/ui/src/hooks/useWebSocket.test.ts
+++ b/ui/src/hooks/useWebSocket.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, test } from "bun:test";
+import { extractNestedMessage, formatProviderErrorMessage } from "./useWebSocket.ts";
+
+describe("extractNestedMessage", () => {
+  test("returns null for non-objects and empty values", () => {
+    expect(extractNestedMessage(null)).toBeNull();
+    expect(extractNestedMessage("string")).toBeNull();
+    expect(extractNestedMessage(42)).toBeNull();
+  });
+
+  test("pulls .message from a flat object", () => {
+    expect(extractNestedMessage({ message: "boom" })).toBe("boom");
+  });
+
+  test("pulls string .error", () => {
+    expect(extractNestedMessage({ error: "nope" })).toBe("nope");
+  });
+
+  test("recurses into nested .error.message (Anthropic shape)", () => {
+    const payload = { error: { type: "invalid_request_error", message: "bad input" } };
+    expect(extractNestedMessage(payload)).toBe("bad input");
+  });
+
+  test("trims whitespace", () => {
+    expect(extractNestedMessage({ message: "  hi  " })).toBe("hi");
+  });
+});
+
+describe("formatProviderErrorMessage — buckets", () => {
+  test("auth: 401 status code", () => {
+    const r = formatProviderErrorMessage("OpenAI API error (401): invalid_api_key");
+    expect(r.summary).toContain("API key");
+  });
+
+  test("auth: invalid x-api-key", () => {
+    const r = formatProviderErrorMessage("authentication_error: invalid x-api-key");
+    expect(r.summary).toContain("API key");
+  });
+
+  test("rate limit: 429 status code — split from network bucket", () => {
+    const r = formatProviderErrorMessage("OpenAI API error (429): rate_limit_exceeded");
+    expect(r.summary).toContain("rate-limit");
+    expect(r.summary).not.toContain("connection");
+  });
+
+  test("rate limit: insufficient_quota", () => {
+    const r = formatProviderErrorMessage("You exceeded your current quota: insufficient_quota");
+    expect(r.summary).toContain("rate-limit");
+  });
+
+  test("network: 503", () => {
+    const r = formatProviderErrorMessage("Service temporarily unavailable (503)");
+    expect(r.summary).toContain("connection");
+    expect(r.summary).not.toContain("rate-limit");
+  });
+
+  test("network: econnrefused", () => {
+    const r = formatProviderErrorMessage("fetch failed: ECONNREFUSED 127.0.0.1:11434");
+    expect(r.summary).toContain("connection");
+  });
+
+  test("fallback: unknown errors still preserve detail", () => {
+    const r = formatProviderErrorMessage("weird: model_not_found");
+    expect(r.summary).toContain("Couldn't reach");
+    expect(r.detail).toBe("weird: model_not_found");
+  });
+});
+
+describe("formatProviderErrorMessage — detail extraction", () => {
+  test("parses full-JSON payload and extracts nested message as detail", () => {
+    const raw = JSON.stringify({ error: { type: "invalid_request_error", message: "context_length_exceeded" } });
+    const r = formatProviderErrorMessage(raw);
+    expect(r.detail).toBe("context_length_exceeded");
+  });
+
+  test("parses embedded-JSON payload", () => {
+    const raw = 'Anthropic API error (400): {"error":{"type":"overloaded_error","message":"try again later"}}';
+    const r = formatProviderErrorMessage(raw);
+    expect(r.detail).toBe("try again later");
+  });
+
+  test("returns empty detail when raw is missing", () => {
+    const r = formatProviderErrorMessage(undefined);
+    expect(r.detail).toBe("");
+  });
+
+  test("gracefully handles malformed embedded JSON", () => {
+    const raw = "Broken: {not valid json}";
+    const r = formatProviderErrorMessage(raw);
+    expect(r.detail).toBe(raw);
+  });
+});
+
+describe("formatProviderErrorMessage — status-code brittleness fix", () => {
+  test("does NOT match '401' embedded in unrelated digits", () => {
+    const r = formatProviderErrorMessage("context window exceeded at token 14018");
+    // falls through to the generic fallback, not the auth-specific copy
+    expect(r.summary).not.toContain("Check your API key and model settings");
+  });
+
+  test("does NOT match '429' embedded in unrelated digits", () => {
+    const r = formatProviderErrorMessage("prompt length was 4295 tokens");
+    expect(r.summary).not.toContain("rate-limit");
+  });
+
+  test("DOES match '\\b401\\b' when it is a real status code", () => {
+    const r = formatProviderErrorMessage("HTTP 401 Unauthorized");
+    expect(r.summary).toContain("Check your API key and model settings");
+  });
+});

--- a/ui/src/hooks/useWebSocket.test.ts
+++ b/ui/src/hooks/useWebSocket.test.ts
@@ -91,6 +91,46 @@ describe("formatProviderErrorMessage — detail extraction", () => {
   });
 });
 
+describe("formatProviderErrorMessage — structured code branching (Phase B)", () => {
+  test("auth code routes to auth summary regardless of raw text", () => {
+    const r = formatProviderErrorMessage("anything at all", "auth");
+    expect(r.summary).toContain("Check your API key and model settings");
+  });
+
+  test("rate_limit code overrides keyword heuristic (e.g. raw mentions 'timeout')", () => {
+    // raw string contains "timeout" which would otherwise trip the network bucket,
+    // but the structured code wins.
+    const r = formatProviderErrorMessage("request timeout after 30s (but really rate-limited)", "rate_limit");
+    expect(r.summary).toContain("rate-limit");
+    expect(r.summary).not.toContain("connection");
+  });
+
+  test("not_found has its own copy", () => {
+    const r = formatProviderErrorMessage("model xyz does not exist", "not_found");
+    expect(r.summary).toContain("couldn't find");
+  });
+
+  test("bad_request has its own copy", () => {
+    const r = formatProviderErrorMessage("missing required field", "bad_request");
+    expect(r.summary).toContain("rejected the request");
+  });
+
+  test("server has its own copy", () => {
+    const r = formatProviderErrorMessage("500 internal server error", "server");
+    expect(r.summary).toContain("server error");
+  });
+
+  test("unknown code falls back to keyword heuristic", () => {
+    const r = formatProviderErrorMessage("OpenAI API error (401): invalid_api_key", "unknown");
+    expect(r.summary).toContain("API key");
+  });
+
+  test("code present but no raw still returns a summary", () => {
+    const r = formatProviderErrorMessage(undefined, "rate_limit");
+    expect(r.summary).toContain("rate-limit");
+  });
+});
+
 describe("formatProviderErrorMessage — status-code brittleness fix", () => {
   test("does NOT match '401' embedded in unrelated digits", () => {
     const r = formatProviderErrorMessage("context window exceeded at token 14018");

--- a/ui/src/hooks/useWebSocket.ts
+++ b/ui/src/hooks/useWebSocket.ts
@@ -24,6 +24,7 @@ export type ChatMessage = {
   source?: string; // 'heartbeat', 'proactive', 'sub-agent'
   priority?: string;
   isStreaming?: boolean;
+  detail?: string; // raw error/debug payload, rendered collapsed in the chat
 };
 
 export type TaskEvent = {
@@ -148,7 +149,7 @@ function createSidecarNotice(payload: SidecarEventPayload, timestamp?: number): 
   };
 }
 
-function extractNestedMessage(value: unknown): string | null {
+export function extractNestedMessage(value: unknown): string | null {
   if (!value || typeof value !== "object") return null;
   const record = value as Record<string, unknown>;
   if (typeof record.message === "string" && record.message.trim()) return record.message.trim();
@@ -159,11 +160,17 @@ function extractNestedMessage(value: unknown): string | null {
   return null;
 }
 
-function formatProviderErrorMessage(raw: string | undefined): string {
-  const fallback = "Couldn't reach your AI provider. Check your API key, network connection, or fallback settings.";
-  if (!raw) return fallback;
+export type ProviderErrorFormatted = {
+  summary: string;
+  detail: string;
+};
 
-  let normalized = raw.trim();
+export function formatProviderErrorMessage(raw: string | undefined): ProviderErrorFormatted {
+  const fallbackSummary = "Couldn't reach your AI provider. Check your API key, network connection, or fallback settings.";
+  if (!raw) return { summary: fallbackSummary, detail: "" };
+
+  const original = raw.trim();
+  let normalized = original;
   try {
     const parsed = JSON.parse(normalized) as unknown;
     normalized = extractNestedMessage(parsed) ?? normalized;
@@ -180,6 +187,7 @@ function formatProviderErrorMessage(raw: string | undefined): string {
   }
 
   const lowered = normalized.toLowerCase();
+
   if (
     lowered.includes("api key") ||
     lowered.includes("authentication") ||
@@ -187,24 +195,42 @@ function formatProviderErrorMessage(raw: string | undefined): string {
     lowered.includes("invalid_api_key") ||
     lowered.includes("invalid x-api-key") ||
     lowered.includes("incorrect api key") ||
-    lowered.includes("401")
+    /\b401\b/.test(lowered)
   ) {
-    return "Couldn't reach your AI provider. Check your API key and model settings.";
+    return {
+      summary: "Couldn't reach your AI provider. Check your API key and model settings.",
+      detail: normalized,
+    };
+  }
+
+  if (
+    lowered.includes("rate limit") ||
+    lowered.includes("too many requests") ||
+    lowered.includes("insufficient_quota") ||
+    lowered.includes("quota") ||
+    /\b429\b/.test(lowered)
+  ) {
+    return {
+      summary: "Your AI provider is rate-limiting requests. Wait a moment, or check your usage and billing.",
+      detail: normalized,
+    };
   }
 
   if (
     lowered.includes("timeout") ||
     lowered.includes("temporarily unavailable") ||
-    lowered.includes("503") ||
-    lowered.includes("429") ||
     lowered.includes("econnrefused") ||
     lowered.includes("enotfound") ||
-    lowered.includes("network")
+    lowered.includes("network") ||
+    /\b503\b/.test(lowered)
   ) {
-    return "Couldn't reach your AI provider right now. Check your connection, provider status, or fallback settings.";
+    return {
+      summary: "Couldn't reach your AI provider right now. Check your connection, provider status, or fallback settings.",
+      detail: normalized,
+    };
   }
 
-  return fallback;
+  return { summary: fallbackSummary, detail: normalized };
 }
 
 export function useWebSocket() {
@@ -223,6 +249,7 @@ export function useWebSocket() {
   const toolCallsRef = useRef<ToolCall[]>([]);
   const subAgentEventsRef = useRef<SubAgentEvent[]>([]);
   const voiceCallbacksRef = useRef<VoiceCallbacks | null>(null);
+  const pendingChatIdsRef = useRef<Set<string>>(new Set());
 
   const connect = useCallback(() => {
     const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
@@ -428,6 +455,8 @@ export function useWebSocket() {
       streamIdRef.current = null;
       toolCallsRef.current = [];
       subAgentEventsRef.current = [];
+      // A successful completion ends any in-flight chat request correlation.
+      pendingChatIdsRef.current.clear();
     } else if (msg.type === "goal_event") {
       const goalEvent = msg.payload as GoalEvent;
       setGoalEvents((prev) => [...prev.slice(-100), goalEvent]);
@@ -500,14 +529,37 @@ export function useWebSocket() {
         ]);
       }
     } else if (msg.type === "error") {
-      voiceCallbacksRef.current?.onError(msg.payload?.message);
-      const friendlyMessage = formatProviderErrorMessage(msg.payload?.message);
+      const rawMessage = msg.payload?.message;
+      voiceCallbacksRef.current?.onError(rawMessage);
+
+      // Always preserve the raw payload in the console for debugging.
+      console.error("[WS] Error frame:", msg.payload);
+
+      // Only apply the provider-friendly formatter when the error correlates
+      // with a chat request we sent. Other errors (protocol, config, STT) are
+      // already human-readable and shouldn't be reshaped.
+      const isChatCorrelated = msg.id != null && pendingChatIdsRef.current.has(msg.id);
+      if (msg.id != null) pendingChatIdsRef.current.delete(msg.id);
+
+      let content: string;
+      let detail: string | undefined;
+      if (isChatCorrelated) {
+        const formatted = formatProviderErrorMessage(rawMessage);
+        content = formatted.summary;
+        detail = formatted.detail && formatted.detail !== formatted.summary ? formatted.detail : undefined;
+      } else {
+        content = typeof rawMessage === "string" && rawMessage.trim()
+          ? rawMessage
+          : "An unexpected error occurred.";
+      }
+
       setMessages((prev) => [
         ...prev,
         {
           id: crypto.randomUUID(),
           role: "system",
-          content: friendlyMessage,
+          content,
+          detail,
           timestamp: msg.timestamp,
           source: "error",
         },
@@ -544,6 +596,10 @@ export function useWebSocket() {
           source: options?.projectId ? `site:${options.projectId}` : undefined,
         },
       ]);
+
+      // Track this request ID so we can correlate any incoming error frame
+      // with the chat request that provoked it.
+      pendingChatIdsRef.current.add(id);
 
       // Send to server
       const msg: WSMessage = {

--- a/ui/src/hooks/useWebSocket.ts
+++ b/ui/src/hooks/useWebSocket.ts
@@ -165,11 +165,46 @@ export type ProviderErrorFormatted = {
   detail: string;
 };
 
-export function formatProviderErrorMessage(raw: string | undefined): ProviderErrorFormatted {
-  const fallbackSummary = "Couldn't reach your AI provider. Check your API key, network connection, or fallback settings.";
-  if (!raw) return { summary: fallbackSummary, detail: "" };
+/**
+ * Canonical error codes emitted by the server. Keep in sync with
+ * `LLMErrorCode` in src/llm/provider.ts.
+ */
+export type ProviderErrorCode =
+  | "auth"
+  | "rate_limit"
+  | "network"
+  | "bad_request"
+  | "not_found"
+  | "server"
+  | "unknown";
 
-  const original = raw.trim();
+function summaryForCode(code: ProviderErrorCode | undefined): string | null {
+  switch (code) {
+    case "auth":
+      return "Couldn't reach your AI provider. Check your API key and model settings.";
+    case "rate_limit":
+      return "Your AI provider is rate-limiting requests. Wait a moment, or check your usage and billing.";
+    case "network":
+      return "Couldn't reach your AI provider right now. Check your connection, provider status, or fallback settings.";
+    case "bad_request":
+      return "The AI provider rejected the request. The model or parameters may be invalid.";
+    case "not_found":
+      return "The AI provider couldn't find the requested resource. Check your model settings.";
+    case "server":
+      return "The AI provider had a server error. Try again in a moment.";
+    default:
+      return null;
+  }
+}
+
+export function formatProviderErrorMessage(
+  raw: string | undefined,
+  code?: ProviderErrorCode,
+): ProviderErrorFormatted {
+  const fallbackSummary = "Couldn't reach your AI provider. Check your API key, network connection, or fallback settings.";
+  if (!raw && !code) return { summary: fallbackSummary, detail: "" };
+
+  const original = (raw ?? "").trim();
   let normalized = original;
   try {
     const parsed = JSON.parse(normalized) as unknown;
@@ -184,6 +219,14 @@ export function formatProviderErrorMessage(raw: string | undefined): ProviderErr
         // Keep the original string when embedded JSON is malformed.
       }
     }
+  }
+
+  // Prefer the server-supplied structured code when available — the emission
+  // site knows the HTTP status and error type, and doesn't need us to guess
+  // from string contents.
+  const codeSummary = summaryForCode(code);
+  if (codeSummary) {
+    return { summary: codeSummary, detail: normalized };
   }
 
   const lowered = normalized.toLowerCase();
@@ -530,6 +573,7 @@ export function useWebSocket() {
       }
     } else if (msg.type === "error") {
       const rawMessage = msg.payload?.message;
+      const rawCode = typeof msg.payload?.code === "string" ? (msg.payload.code as ProviderErrorCode) : undefined;
       voiceCallbacksRef.current?.onError(rawMessage);
 
       // Always preserve the raw payload in the console for debugging.
@@ -544,7 +588,7 @@ export function useWebSocket() {
       let content: string;
       let detail: string | undefined;
       if (isChatCorrelated) {
-        const formatted = formatProviderErrorMessage(rawMessage);
+        const formatted = formatProviderErrorMessage(rawMessage, rawCode);
         content = formatted.summary;
         detail = formatted.detail && formatted.detail !== formatted.summary ? formatted.detail : undefined;
       } else {

--- a/ui/src/styles/chat.css
+++ b/ui/src/styles/chat.css
@@ -446,6 +446,33 @@
 .chat-system-text { font-size: 12px; color: var(--text-2); line-height: 1.55; }
 .chat-system-text-error { color: rgba(251,113,133,0.7); }
 
+.chat-system-detail {
+  margin-top: 6px;
+  font-size: 11px;
+  color: var(--text-3);
+}
+.chat-system-detail > summary {
+  cursor: pointer;
+  user-select: none;
+  opacity: 0.75;
+}
+.chat-system-detail > summary:hover { opacity: 1; }
+.chat-system-detail-pre {
+  margin: 6px 0 0;
+  padding: 8px 10px;
+  border-radius: 6px;
+  background: rgba(255,255,255,0.04);
+  border: 1px solid rgba(255,255,255,0.06);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  line-height: 1.5;
+  color: var(--text-2);
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 240px;
+  overflow: auto;
+}
+
 .chat-system-ts {
   font-family: 'JetBrains Mono', monospace;
   font-size: 9px;


### PR DESCRIPTION
Follow-ups to #98. The chat error bubble used to funnel every WebSocket `error` frame through a keyword-matching "provider error" formatter, which had three problems:

1. **Information loss.** Any novel failure (context length exceeded, model not found, content policy, quota exhausted, etc.) collapsed into one of two canned messages, so users could no longer see *what* actually went wrong.
2. **Rate-limiting was miscategorized.** 429s were bucketed with connection errors, telling users to "check your connection" when they actually needed to check their billing/usage.
3. **Wrong scope.** The formatter ran against *every* server-emitted error — not just provider failures. Client protocol errors ("Missing text in chat payload"), STT config errors, and unknown-command errors were all being rewritten into "Couldn't reach your AI provider", which is actively misleading.

## First commit - UI-only fixes (`94d37b0`)

- **Preserve the original error.** `console.error("[WS] Error frame:", …)` unconditionally, plus a new `detail?: string` on `ChatMessage` that renders as a `<details>` disclosure under the friendly summary. Click "Show details" to see the raw provider payload — the extracted nested message from JSON shapes like `{ error: { type, message } }` when available, otherwise the raw string.
- **Split the rate-limit bucket.** 429 / `rate limit` / `too many requests` / `insufficient_quota` / `quota` now get their own summary: *"Your AI provider is rate-limiting requests. Wait a moment, or check your usage and billing."* The network bucket keeps `timeout` / `502` / `503` / `504` / `econnrefused` / `enotfound` / `network`.
- **Word-boundary status matching.** Replaced `.includes("401")` / `.includes("429")` / `.includes("503")` with `\b401\b` / `\b429\b` / `\b503\b` regexes so stray digits inside unrelated messages (e.g. `"prompt has 4295 tokens"`) don't misclassify.
- **Scope the formatter to chat requests.** A new `pendingChatIdsRef` tracks outgoing chat request IDs; only error frames whose `msg.id` matches a tracked ID run through `formatProviderErrorMessage`. All other errors (protocol, config, STT) render their raw `payload.message` as-is. Stream-done clears the set.

## Second commit - Server-side structured error codes (`b26db82`)

- **New taxonomy in `src/llm/provider.ts`:** `LLMErrorCode = 'auth' | 'rate_limit' | 'network' | 'bad_request' | 'not_found' | 'server' | 'unknown'`. `LLMStreamEvent.error` now carries an optional `code`.
- **Two helpers:**
  - `classifyHttpStatus(status)` — authoritative mapping from HTTP status (401/403 → auth, 429 → rate_limit, 502/503/504 → network, etc.). Used at provider emission sites where the status is still available.
  - `classifyErrorString(raw)` — word-boundary fallback for cases where only a thrown string is available (aggregated failures, `fetchWithRetry` throws, caught errors).
- **Every provider updated** to attach a code at error sites: `openai`, `anthropic`, `groq`, `openrouter`, `ollama`, `nvidia`, `gemini`. Anthropic additionally maps its SSE `error.type` (`authentication_error`, `rate_limit_error`, `overloaded_error`, `invalid_request_error`, `not_found_error`, etc.) via a dedicated `classifyAnthropicErrorType`.
- **`LLMManager.stream` preserves the code** through retries, fallback chain transitions, and aggregated `formatFailure` output. When no code is present (older event), it derives one from the string.
- **`StreamRelay` and `ws-service.ts` forward the code** into the WS error payload: `{ type: 'error', payload: { message, code, requestId }, id, timestamp }`.
- **UI branches on `code` first.** `formatProviderErrorMessage(raw, code?)` now consults a `summaryForCode()` map before touching the keyword heuristic. Added two new summaries that the old code couldn't express: `bad_request` ("The AI provider rejected the request. The model or parameters may be invalid.") and `not_found` ("The AI provider couldn't find the requested resource. Check your model settings."), plus a distinct `server` summary.