### PR TITLE
Port-aware jarvis stop

### DIFF
--- a/bin/jarvis.ts
+++ b/bin/jarvis.ts
@@ -4,7 +4,7 @@
  *
  * Usage:
  *   jarvis start [--port N] [-d|--detach]   Start the daemon
- *   jarvis stop                             Stop the running daemon
+ *   jarvis stop [--port N]                  Stop the running daemon
  *   jarvis status                           Show daemon status
  *   jarvis onboard                          Interactive setup wizard
  *   jarvis uninstall                        Remove JARVIS (detects install method)
@@ -18,7 +18,7 @@ import { openSync } from 'node:fs';
 import { spawn } from 'node:child_process';
 import { acquireLock, releaseLock, isLocked, getLogPath } from '../src/daemon/pid.ts';
 import { c } from '../src/cli/helpers.ts';
-import { ensurePortReleased, getConfiguredPort } from '../src/cli/lifecycle.ts';
+import { ensurePortReleased, getConfiguredPort, resolveStopPort } from '../src/cli/lifecycle.ts';
 import { getInstalledVersion } from '../src/cli/version.ts';
 
 const PACKAGE_ROOT = join(import.meta.dir, '..');
@@ -171,9 +171,28 @@ async function cmdStart(args: string[]): Promise<void> {
   }
 }
 
-async function cmdStop(): Promise<void> {
+async function cmdStop(args: string[] = []): Promise<void> {
   const pid = isLocked();
-  const port = getConfiguredPort();
+
+  // Parse `--port N` for the no-lockfile recovery path. Ignored when the
+  // lockfile recorded the daemon's actual port (authoritative).
+  let cliPort: number | undefined;
+  const portIdx = args.indexOf('--port');
+  if (portIdx !== -1 && args[portIdx + 1]) {
+    const parsed = parseInt(args[portIdx + 1]!, 10);
+    if (isNaN(parsed) || parsed < 1 || parsed > 65535) {
+      console.error(c.red('Error: --port requires a number between 1 and 65535'));
+      process.exit(1);
+    }
+    cliPort = parsed;
+  }
+
+  const resolution = resolveStopPort({ cliPort });
+  const port = resolution.port;
+  if (resolution.source !== 'lockfile' && resolution.source !== 'default') {
+    console.log(c.dim(`  Using port ${port} (from ${resolution.source})`));
+  }
+
   if (!pid) {
     const cleanup = await ensurePortReleased(port);
     if (cleanup.terminated.length > 0 || cleanup.forced.length > 0) {
@@ -353,7 +372,7 @@ switch (command) {
     await cmdStart(commandArgs);
     break;
   case 'stop':
-    await cmdStop();
+    await cmdStop(commandArgs);
     break;
   case 'restart':
     await cmdRestart(commandArgs);

--- a/src/cli/lifecycle.test.ts
+++ b/src/cli/lifecycle.test.ts
@@ -1,20 +1,115 @@
-import { describe, expect, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { unlink } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
-import { getConfiguredPort } from './lifecycle.ts';
+import {
+  DEFAULT_DAEMON_PORT,
+  getConfiguredPort,
+  readConfiguredPort,
+  resolveStopPort,
+} from './lifecycle.ts';
+import { acquireLock, releaseLock, writeLockedPort } from '../daemon/pid.ts';
 
 const TEST_CONFIG_PATH = '/tmp/jarvis-cli-lifecycle-config.yaml';
+const MISSING_CONFIG_PATH = '/tmp/jarvis-cli-lifecycle-missing.yaml';
 
-describe('CLI lifecycle helpers', () => {
+async function cleanupConfig(): Promise<void> {
+  if (existsSync(TEST_CONFIG_PATH)) await unlink(TEST_CONFIG_PATH);
+}
+
+describe('getConfiguredPort / readConfiguredPort', () => {
+  afterEach(cleanupConfig);
+
   test('reads configured port from YAML', async () => {
     await Bun.write(TEST_CONFIG_PATH, 'daemon:\n  port: 4242\n');
     expect(getConfiguredPort(TEST_CONFIG_PATH)).toBe(4242);
-    if (existsSync(TEST_CONFIG_PATH)) await unlink(TEST_CONFIG_PATH);
+    expect(readConfiguredPort(TEST_CONFIG_PATH)).toBe(4242);
   });
 
   test('falls back to default port for invalid config', async () => {
     await Bun.write(TEST_CONFIG_PATH, 'daemon:\n  port:\n    nope: true\n');
-    expect(getConfiguredPort(TEST_CONFIG_PATH)).toBe(3142);
-    if (existsSync(TEST_CONFIG_PATH)) await unlink(TEST_CONFIG_PATH);
+    expect(getConfiguredPort(TEST_CONFIG_PATH)).toBe(DEFAULT_DAEMON_PORT);
+    expect(readConfiguredPort(TEST_CONFIG_PATH)).toBeNull();
+  });
+
+  test('readConfiguredPort returns null for missing file', () => {
+    expect(readConfiguredPort(MISSING_CONFIG_PATH)).toBeNull();
+    expect(getConfiguredPort(MISSING_CONFIG_PATH)).toBe(DEFAULT_DAEMON_PORT);
+  });
+});
+
+describe('resolveStopPort precedence', () => {
+  beforeEach(() => releaseLock());
+  afterEach(async () => {
+    releaseLock();
+    await cleanupConfig();
+  });
+
+  test('lockfile beats env, CLI, config', async () => {
+    await Bun.write(TEST_CONFIG_PATH, 'daemon:\n  port: 5000\n');
+    acquireLock(process.pid);
+    writeLockedPort(9000);
+
+    const result = resolveStopPort({
+      cliPort: 8000,
+      configPath: TEST_CONFIG_PATH,
+      env: { JARVIS_PORT: '7000' },
+    });
+    expect(result).toEqual({ port: 9000, source: 'lockfile' });
+  });
+
+  test('env beats CLI and config when no lockfile port', async () => {
+    await Bun.write(TEST_CONFIG_PATH, 'daemon:\n  port: 5000\n');
+    const result = resolveStopPort({
+      cliPort: 8000,
+      configPath: TEST_CONFIG_PATH,
+      env: { JARVIS_PORT: '7000' },
+    });
+    expect(result).toEqual({ port: 7000, source: 'env' });
+  });
+
+  test('CLI beats config when no lockfile and no env', async () => {
+    await Bun.write(TEST_CONFIG_PATH, 'daemon:\n  port: 5000\n');
+    const result = resolveStopPort({
+      cliPort: 8000,
+      configPath: TEST_CONFIG_PATH,
+      env: {},
+    });
+    expect(result).toEqual({ port: 8000, source: 'cli' });
+  });
+
+  test('config used when no lockfile, env, or CLI', async () => {
+    await Bun.write(TEST_CONFIG_PATH, 'daemon:\n  port: 5000\n');
+    const result = resolveStopPort({ configPath: TEST_CONFIG_PATH, env: {} });
+    expect(result).toEqual({ port: 5000, source: 'config' });
+  });
+
+  test('default used when nothing else is available', () => {
+    const result = resolveStopPort({ configPath: MISSING_CONFIG_PATH, env: {} });
+    expect(result).toEqual({ port: DEFAULT_DAEMON_PORT, source: 'default' });
+  });
+
+  test('invalid env var is ignored, next source wins', async () => {
+    await Bun.write(TEST_CONFIG_PATH, 'daemon:\n  port: 5000\n');
+    const result = resolveStopPort({
+      configPath: TEST_CONFIG_PATH,
+      env: { JARVIS_PORT: 'not-a-port' },
+    });
+    expect(result).toEqual({ port: 5000, source: 'config' });
+  });
+
+  test('invalid CLI port is ignored, next source wins', async () => {
+    await Bun.write(TEST_CONFIG_PATH, 'daemon:\n  port: 5000\n');
+    const result = resolveStopPort({
+      cliPort: 99999,
+      configPath: TEST_CONFIG_PATH,
+      env: {},
+    });
+    expect(result).toEqual({ port: 5000, source: 'config' });
+  });
+
+  test('explicitly-set port 3142 in config reports source "config", not "default"', async () => {
+    await Bun.write(TEST_CONFIG_PATH, `daemon:\n  port: ${DEFAULT_DAEMON_PORT}\n`);
+    const result = resolveStopPort({ configPath: TEST_CONFIG_PATH, env: {} });
+    expect(result).toEqual({ port: DEFAULT_DAEMON_PORT, source: 'config' });
   });
 });

--- a/src/cli/lifecycle.ts
+++ b/src/cli/lifecycle.ts
@@ -3,6 +3,9 @@ import { homedir } from 'node:os';
 import os from 'node:os';
 import { join } from 'node:path';
 import YAML from 'yaml';
+import { readLockedPort } from '../daemon/pid.ts';
+
+export const DEFAULT_DAEMON_PORT = 3142;
 
 function parsePidList(output: string, currentPid: number): number[] {
   return [...new Set(
@@ -120,16 +123,79 @@ export async function ensurePortReleased(
   };
 }
 
-export function getConfiguredPort(configPath = join(homedir(), '.jarvis', 'config.yaml')): number {
+/**
+ * Read `daemon.port` from the YAML config.
+ * Returns null when the file is absent, invalid, or the field is missing
+ * — callers decide what default to apply.
+ */
+export function readConfiguredPort(configPath = join(homedir(), '.jarvis', 'config.yaml')): number | null {
   try {
-    if (!existsSync(configPath)) return 3142;
+    if (!existsSync(configPath)) return null;
     const text = readFileSync(configPath, 'utf-8');
     const doc = YAML.parseDocument(text, { merge: true });
-    if (doc.errors.length > 0) return 3142;
+    if (doc.errors.length > 0) return null;
     const parsed = doc.toJS() as { daemon?: { port?: unknown } } | null;
     const port = parsed?.daemon?.port;
-    return typeof port === 'number' && port >= 1 && port <= 65535 ? port : 3142;
+    return typeof port === 'number' && port >= 1 && port <= 65535 ? port : null;
   } catch {
-    return 3142;
+    return null;
   }
+}
+
+/**
+ * Backwards-compatible: returns the configured port or the hardcoded default.
+ * Prefer `readConfiguredPort` + explicit fallback where the caller needs to
+ * distinguish "config said X" from "nothing was configured".
+ */
+export function getConfiguredPort(configPath?: string): number {
+  return readConfiguredPort(configPath) ?? DEFAULT_DAEMON_PORT;
+}
+
+function validPort(value: unknown): number | null {
+  const n = typeof value === 'string' ? Number.parseInt(value, 10) : typeof value === 'number' ? value : NaN;
+  return Number.isInteger(n) && n >= 1 && n <= 65535 ? n : null;
+}
+
+export type StopPortSource = 'lockfile' | 'env' | 'cli' | 'config' | 'default';
+
+export type StopPortResolution = {
+  port: number;
+  source: StopPortSource;
+};
+
+/**
+ * Resolve which port `jarvis stop` should verify.
+ *
+ * Precedence (highest first):
+ *   1. The port the running daemon recorded in its lockfile (authoritative).
+ *   2. `JARVIS_PORT` env var (matches `applyEnvOverrides` in the config loader).
+ *   3. An explicit `--port N` passed on the stop command line.
+ *   4. `daemon.port` from `~/.jarvis/config.yaml`.
+ *   5. The hardcoded default (3142).
+ *
+ * The lockfile wins over everything because it reflects the port the daemon
+ * actually bound to, not what config/env said at some point in the past. The
+ * env var beats `--port` so a user with a persistent `JARVIS_PORT` in their
+ * shell doesn't get caught out by forgetting to pass the flag.
+ */
+export function resolveStopPort(options?: {
+  cliPort?: unknown;
+  configPath?: string;
+  env?: Record<string, string | undefined>;
+}): StopPortResolution {
+  const env = options?.env ?? process.env;
+
+  const locked = validPort(readLockedPort());
+  if (locked !== null) return { port: locked, source: 'lockfile' };
+
+  const fromEnv = validPort(env.JARVIS_PORT);
+  if (fromEnv !== null) return { port: fromEnv, source: 'env' };
+
+  const fromCli = validPort(options?.cliPort);
+  if (fromCli !== null) return { port: fromCli, source: 'cli' };
+
+  const fromConfig = readConfiguredPort(options?.configPath);
+  if (fromConfig !== null) return { port: fromConfig, source: 'config' };
+
+  return { port: DEFAULT_DAEMON_PORT, source: 'default' };
 }

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -13,6 +13,7 @@ import { initDatabase, closeDb } from "../vault/schema.ts";
 import { ServiceRegistry } from "./services.ts";
 import { HealthMonitor } from "./health.ts";
 import { loadConfig } from "../config/loader.ts";
+import { writeLockedPort } from "./pid.ts";
 import { AgentService } from "./agent-service.ts";
 import { ObserverService } from "./observer-service.ts";
 import { WebSocketService } from "./ws-service.ts";
@@ -243,6 +244,11 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
     healthCheckInterval: userConfig?.healthCheckInterval ?? 30000,
     noLocalTools: userConfig?.noLocalTools ?? false,
   };
+
+  // Record the actual bound port in the lockfile so `jarvis stop` knows which
+  // port to verify even when the daemon was started with --port, JARVIS_PORT,
+  // or a mid-run config change. No-op if we don't hold the lock (e.g. tests).
+  writeLockedPort(port);
 
   // If dbPath is relative, make it absolute within dataDir
   if (!path.isAbsolute(config.dbPath)) {

--- a/src/daemon/pid.test.ts
+++ b/src/daemon/pid.test.ts
@@ -7,6 +7,8 @@ import {
   isLocked,
   releaseLock,
   readPid,
+  readLockedPort,
+  writeLockedPort,
   getPidPath,
   getLogPath,
   getLogDir,
@@ -187,6 +189,77 @@ describe('Process Lock Manager', () => {
       mkdirSync(JARVIS_DIR, { recursive: true });
       writeFileSync(LOCK_PATH, '-1');
       expect(readPid()).toBeNull();
+    });
+  });
+
+  // ── readLockedPort / writeLockedPort ─────────────────────────────
+
+  describe('readLockedPort', () => {
+    test('returns null when no lock file exists', () => {
+      expect(readLockedPort()).toBeNull();
+    });
+
+    test('returns null for legacy PID-only lock file', () => {
+      mkdirSync(JARVIS_DIR, { recursive: true });
+      writeFileSync(LOCK_PATH, '12345');
+      expect(readLockedPort()).toBeNull();
+    });
+
+    test('returns the port from a two-line lock file', () => {
+      mkdirSync(JARVIS_DIR, { recursive: true });
+      writeFileSync(LOCK_PATH, '12345\n9000\n');
+      expect(readLockedPort()).toBe(9000);
+    });
+
+    test('returns null for out-of-range port', () => {
+      mkdirSync(JARVIS_DIR, { recursive: true });
+      writeFileSync(LOCK_PATH, '12345\n99999\n');
+      expect(readLockedPort()).toBeNull();
+    });
+
+    test('returns null for non-numeric port line', () => {
+      mkdirSync(JARVIS_DIR, { recursive: true });
+      writeFileSync(LOCK_PATH, '12345\nabc\n');
+      expect(readLockedPort()).toBeNull();
+    });
+
+    test('readPid still works for two-line format', () => {
+      mkdirSync(JARVIS_DIR, { recursive: true });
+      writeFileSync(LOCK_PATH, '12345\n9000\n');
+      expect(readPid()).toBe(12345);
+    });
+  });
+
+  describe('writeLockedPort', () => {
+    test('is a no-op when no lock is held by this process', () => {
+      // No acquireLock — lockFd is null.
+      writeLockedPort(9000);
+      expect(existsSync(LOCK_PATH)).toBe(false);
+    });
+
+    test('records port alongside PID when lock is held', () => {
+      acquireLock(process.pid);
+      writeLockedPort(9000);
+      const content = readFileSync(LOCK_PATH, 'utf-8');
+      expect(content.split(/\r?\n/)[0]).toBe(String(process.pid));
+      expect(readLockedPort()).toBe(9000);
+      expect(readPid()).toBe(process.pid);
+    });
+
+    test('ignores invalid ports', () => {
+      acquireLock(process.pid);
+      writeLockedPort(0);
+      writeLockedPort(70000);
+      writeLockedPort(Number.NaN);
+      expect(readLockedPort()).toBeNull();
+      expect(readPid()).toBe(process.pid);
+    });
+
+    test('overwrites an earlier recorded port', () => {
+      acquireLock(process.pid);
+      writeLockedPort(9000);
+      writeLockedPort(3142);
+      expect(readLockedPort()).toBe(3142);
     });
   });
 

--- a/src/daemon/pid.ts
+++ b/src/daemon/pid.ts
@@ -144,16 +144,60 @@ export function releaseLock(): void {
 
 /**
  * Read the PID from the lock file. Returns null if no file or invalid content.
+ *
+ * Lock file format (either form is accepted):
+ *   PID            (legacy — single line)
+ *   PID\nPORT      (current — PID on line 1, bound port on line 2)
  */
 export function readPid(): number | null {
   if (!existsSync(LOCK_PATH)) return null;
   try {
-    const content = readFileSync(LOCK_PATH, 'utf-8').trim();
-    const pid = parseInt(content, 10);
+    const content = readFileSync(LOCK_PATH, 'utf-8');
+    const firstLine = content.split(/\r?\n/, 1)[0]?.trim() ?? '';
+    const pid = parseInt(firstLine, 10);
     if (isNaN(pid) || pid <= 0) return null;
     return pid;
   } catch {
     return null;
+  }
+}
+
+/**
+ * Read the port the locked daemon bound to, if it recorded one.
+ * Returns null for legacy lock files that contain only a PID.
+ */
+export function readLockedPort(): number | null {
+  if (!existsSync(LOCK_PATH)) return null;
+  try {
+    const content = readFileSync(LOCK_PATH, 'utf-8');
+    const lines = content.split(/\r?\n/);
+    const raw = lines[1]?.trim();
+    if (!raw) return null;
+    const port = parseInt(raw, 10);
+    if (isNaN(port) || port < 1 || port > 65535) return null;
+    return port;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Record the port the daemon has successfully bound to. Called from the
+ * daemon itself after port resolution so `jarvis stop` knows exactly which
+ * port to verify, regardless of how the daemon was launched (CLI flag, env
+ * var, config file, or default).
+ *
+ * No-op if the lock isn't held by this process.
+ */
+export function writeLockedPort(port: number): void {
+  if (lockFd === null) return;
+  if (!Number.isInteger(port) || port < 1 || port > 65535) return;
+  try {
+    const pid = process.pid;
+    ftruncateSync(lockFd, 0);
+    writeSync(lockFd, `${pid}\n${port}\n`, 0);
+  } catch (err) {
+    console.error(`[PID] Failed to record port ${port} in lock file: ${err}`);
   }
 }
 


### PR DESCRIPTION
Follow-up to #105. The original PR taught `jarvis stop` to verify that the daemon's port is actually free after the kill — a real fix for the zombie-port problem - but it assumed the port was always whatever sat in `~/.jarvis/config.yaml` at read-time. In practice the daemon can be on a different port for three reasons:

1. **`jarvis start --port N`** - the CLI parses the flag and threads it into `startDaemon`, but nothing persists the chosen port anywhere `jarvis stop` can find it later.
2. **`JARVIS_PORT` env var** - honored by `applyEnvOverrides` during config load, but `getConfiguredPort` in the CLI does its own YAML read that deliberately skips env overrides.
3. **Mid-run config edits** - the user changes `daemon.port` in `config.yaml` intending it for the next restart; meanwhile the live daemon is still on the old port.

In all three cases, `jarvis stop` was scanning the wrong port: it would either leave the real daemon's port held, or kill some unrelated process on `3142`. This PR makes stop authoritative.

## What changes

### Daemon records its port in the lockfile

`src/daemon/pid.ts` - the PID lockfile now carries the bound port on line 2:

```
<pid>
<port>
```

- `writeLockedPort(port)` (new) appends the port to the file using the already-held flock FD. No-op when the caller doesn't hold the lock, so offline callers can't corrupt it.
- `readLockedPort()` (new) returns the port or `null` for legacy one-line files. Fully backwards-compatible - nothing crashes on a pre-PR lockfile; it just falls through to the config.
- `readPid()` was tweaked to parse only the first line, so legacy callers see no behavior change.

`src/daemon/index.ts` - `startDaemon` calls `writeLockedPort(port)` immediately after resolving `port = userConfig?.port ?? jarvisConfig.daemon.port ?? DEFAULT_PORT`. That's the authoritative moment: the daemon has committed to the port but hasn't bound anything yet.

### Stop resolves the port by precedence, not guesswork

`src/cli/lifecycle.ts` - new `resolveStopPort({cliPort?, configPath?, env?})` returning `{port, source}`:

| Priority | Source | Rationale |
|---|---|---|
| 1 | `lockfile` | The daemon recorded the port it actually bound. Authoritative - always wins. |
| 2 | `env` (`JARVIS_PORT`) | Matches `applyEnvOverrides` in the config loader, so a user with `JARVIS_PORT` set in their shell doesn't have to remember `--port`. |
| 3 | `cli` (`--port N` on stop) | Explicit opt-in for scripts/CI that know the target port. |
| 4 | `config` (`daemon.port` from YAML) | What the config file says. |
| 5 | `default` (`3142`) | Hardcoded fallback. |

The `source` field is reported back so the CLI can show a dim `Using port X (from env|cli|config)` hint when the port didn't come from the lockfile or the default - useful for debugging "why did stop touch the wrong port?"

Side cleanups:
- `DEFAULT_DAEMON_PORT = 3142` extracted as a shared constant. Previously hardcoded in three places.
- `getConfiguredPort` refactored to delegate to a new `readConfiguredPort` that returns `number | null`, letting callers distinguish "config said 3142" from "nothing was configured."

### `jarvis stop` accepts `--port N`

`bin/jarvis.ts` - `cmdStop` now takes `args`, parses `--port N`, validates the range, and passes it to `resolveStopPort`. Help comment updated to `jarvis stop [--port N]`. Invalid ports exit 1 with a clear error. `cmdRestart` continues to call `cmdStop()` with no args - fine because the lockfile wins when the daemon is running.

## Behavioral consequence

After `jarvis start --port 9000` (or `JARVIS_PORT=9000 jarvis start`), a bare `jarvis stop` now scans port 9000 - not 3142. For the no-lockfile recovery path (stale lockfile, crashed daemon), users can drive the stop with either `JARVIS_PORT=9000 jarvis stop` or `jarvis stop --port 9000`, and the CLI will print which source it picked.

## Backwards compatibility

- Lockfiles from a pre-PR daemon are one line (`<pid>`). `readLockedPort` returns `null` on them, `readPid` still returns the PID. `resolveStopPort` falls through to env → CLI → config → default. No migration needed.
- `getConfiguredPort` signature is unchanged; its behavior ("configured-or-default") is unchanged.
- The CLI's `jarvis stop` still works without any arguments; the `--port` flag is purely additive.
- No change to how the daemon binds the port - only to what it writes into `~/.jarvis/jarvis.pid`.