### PR TITLE
Block native Windows daemon installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,8 @@ Visit [opencove.host](https://opencove.host) to get started.
 ## 📋 Requirements
 
 - **Bun** >= 1.0 (installed automatically if missing)
-- **OS**: Windows, macOS, or Linux
+- **OS (native daemon install)**: macOS, Linux, or WSL
+- **Windows**: use WSL2 for the Bun install, or Docker for the daemon
 - **LLM API key** — at least one of: Anthropic, OpenAI, Google Gemini, or a local Ollama instance
 - Google OAuth credentials (optional — Calendar and Gmail integration)
 - Telegram bot token (optional — notification channel)
@@ -132,6 +133,8 @@ Visit [opencove.host](https://opencove.host) to get started.
 bun install -g @usejarvis/brain
 jarvis onboard
 ```
+
+> **Note:** Native Windows installs are blocked for the JARVIS daemon. On Windows, use WSL2 for the Bun install above, or use the Docker install instead.
 
 ### Docker
 
@@ -157,6 +160,8 @@ jarvis onboard
 ```
 
 The install script sets up Bun, clones the repo, and links the `jarvis` CLI. Then run `jarvis onboard` to configure your assistant interactively.
+
+> **Note:** The one-liner only supports macOS, Linux, and WSL. Native Windows shells such as PowerShell, Git Bash, and CMD should use WSL2 or the Docker install instead.
 
 ### Manual
 

--- a/bin/jarvis.ts
+++ b/bin/jarvis.ts
@@ -75,6 +75,14 @@ ${c.bold('Examples:')}
 `);
 }
 
+function assertSupportedPlatform(): void {
+  if (process.platform !== 'win32') return;
+  console.error(c.red('Native Windows installs are not supported for the JARVIS daemon.'));
+  console.error(c.dim('Use WSL2 for the Bun install, or run JARVIS with Docker on Windows.'));
+  console.error(c.dim('The Windows sidecar is still supported separately.'));
+  process.exit(1);
+}
+
 async function cmdStart(args: string[]): Promise<void> {
   const detach = args.includes('--detach') || args.includes('-d');
   const noOpen = args.includes('--no-open');
@@ -386,6 +394,8 @@ function openDashboard(port: number): void {
 }
 
 // ── Main ─────────────────────────────────────────────────────────────
+
+assertSupportedPlatform();
 
 const args = process.argv.slice(2);
 const command = args[0] || 'help';

--- a/install.sh
+++ b/install.sh
@@ -56,6 +56,7 @@ detect_os() {
         echo "linux"
       fi
       ;;
+    MINGW*|MSYS*|CYGWIN*) echo "windows-native" ;;
     *) echo "unknown" ;;
   esac
 }
@@ -145,6 +146,13 @@ main() {
 
   if [ "$OS" = "unknown" ]; then
     err "Unsupported operating system. JARVIS supports macOS, Linux, and WSL."
+    exit 1
+  fi
+
+  if [ "$OS" = "windows-native" ]; then
+    err "Native Windows installs are not supported for the JARVIS daemon."
+    err "Use WSL2 for the Bun install, or run JARVIS with Docker on Windows."
+    err "The Windows sidecar is still supported separately."
     exit 1
   fi
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "test:llm": "bun run src/llm/test.ts",
     "examples": "bun run examples/llm-integration.ts",
     "setup:google": "bun run src/scripts/google-setup.ts",
-    "postinstall": "node scripts/ensure-bun.cjs && bun run copy:models 2>/dev/null || true",
+    "postinstall": "node scripts/ensure-bun.cjs && (bun run copy:models 2>/dev/null || true)",
     "prepare": "git config core.hooksPath .githooks 2>/dev/null || true",
     "prepublishOnly": "bun run copy:models && bun run build:ui"
   },

--- a/scripts/ensure-bun.cjs
+++ b/scripts/ensure-bun.cjs
@@ -1,5 +1,13 @@
 #!/usr/bin/env node
 const { execSync } = require('child_process');
+
+if (process.platform === 'win32') {
+  console.error('Native Windows installs are not supported for the JARVIS daemon.');
+  console.error('Use WSL2 for the Bun install, or run JARVIS with Docker on Windows.');
+  console.error('The Windows sidecar is still supported separately.');
+  process.exit(1);
+}
+
 try {
   execSync('bun --version', { stdio: 'ignore' });
 } catch {


### PR DESCRIPTION
## Summary
- fail fast when the CLI is launched on unsupported native Windows installs
- guide users toward WSL or Docker paths instead of a broken daemon setup
- update install/bootstrap entrypoints and docs to match the supported flow