### PR TITLE
Harden the release-aware `jarvis version` command

### DIFF
--- a/bin/jarvis.ts
+++ b/bin/jarvis.ts
@@ -400,7 +400,7 @@ switch (command) {
   case 'version':
   case '-v':
   case '--version':
-    console.log(getVersion());
+    console.log(`v${getVersion()}`);
     break;
   case 'help':
   case '-h':

--- a/src/cli/version.test.ts
+++ b/src/cli/version.test.ts
@@ -104,6 +104,27 @@ exit 1
     expect(selectInstalledVersion('0.0.0', '1.0.0', null)).toBe('1.0.0');
   });
 
+  test('rejects bare-SHA describe output and falls back to package.json', async () => {
+    await withFakeGit(
+      'tagless-repo',
+      `#!/usr/bin/env bash
+if [ "$1" = "-C" ] && [ "$3" = "describe" ] && [ "$4" = "--tags" ] && [ "$5" = "--exact-match" ]; then
+  exit 1
+fi
+if [ "$1" = "-C" ] && [ "$3" = "describe" ] && [ "$4" = "--tags" ] && [ "$5" = "--always" ]; then
+  printf 'abc1234\\n'
+  exit 0
+fi
+exit 1
+`,
+      async (dir) => {
+        // Package.json was seeded with 0.4.0 by the harness; the bare SHA
+        // must be rejected as not-a-version.
+        expect(getInstalledVersion(dir)).toBe('0.4.0');
+      },
+    );
+  });
+
   test('falls back to package.json version when git metadata is unavailable', async () => {
     const dir = makeTempDir('package-only');
     await writePackageJson(dir, '3.2.1');

--- a/src/cli/version.test.ts
+++ b/src/cli/version.test.ts
@@ -57,7 +57,7 @@ afterEach(async () => {
 });
 
 describe('CLI version resolver', () => {
-  test('reads an exact release tag through the git resolver path', async () => {
+  test('reads an exact release tag and strips the leading v', async () => {
     await withFakeGit(
       'exact-tag',
       `#!/usr/bin/env bash
@@ -68,7 +68,7 @@ fi
 exit 1
 `,
       async (dir) => {
-        expect(getInstalledVersion(dir)).toBe('v9.9.9');
+        expect(getInstalledVersion(dir)).toBe('9.9.9');
       },
     );
   });
@@ -87,17 +87,21 @@ fi
 exit 1
 `,
       async (dir) => {
-        expect(getInstalledVersion(dir)).toBe('v1.2.3-1-gabc123');
+        expect(getInstalledVersion(dir)).toBe('1.2.3-1-gabc123');
       },
     );
   });
 
-  test('prefers the exact release tag over other version sources', () => {
-    expect(selectInstalledVersion('0.4.0', 'v9.9.9', 'v9.9.9-1-gabc123')).toBe('v9.9.9');
+  test('prefers the exact release tag over other version sources (v stripped)', () => {
+    expect(selectInstalledVersion('0.4.0', 'v9.9.9', 'v9.9.9-1-gabc123')).toBe('9.9.9');
   });
 
-  test('uses git describe output when the checkout is ahead of the last release tag', () => {
-    expect(selectInstalledVersion('0.4.0', null, 'v1.2.3-1-gabc123')).toBe('v1.2.3-1-gabc123');
+  test('uses git describe output when ahead of the last release tag (v stripped)', () => {
+    expect(selectInstalledVersion('0.4.0', null, 'v1.2.3-1-gabc123')).toBe('1.2.3-1-gabc123');
+  });
+
+  test('leaves tags without a v prefix unchanged', () => {
+    expect(selectInstalledVersion('0.0.0', '1.0.0', null)).toBe('1.0.0');
   });
 
   test('falls back to package.json version when git metadata is unavailable', async () => {

--- a/src/cli/version.test.ts
+++ b/src/cli/version.test.ts
@@ -29,11 +29,29 @@ async function writeFakeGit(dir: string, script: string): Promise<void> {
   chmodSync(gitPath, 0o755);
 }
 
-async function withFakeGit<T>(name: string, script: string, run: (packageRoot: string) => Promise<T>): Promise<T> {
+// Builds a fake-git script that always succeeds for `rev-parse --git-dir`
+// (so isGitCheckout returns true) and lets the caller specify how the
+// `describe` invocations should behave. Note: $1=-C, $2=cwd, $3=subcommand,
+// $4..=flags.
+function fakeGitScript(describeBranch: string): string {
+  return `#!/usr/bin/env bash
+if [ "$3" = "rev-parse" ] && [ "$4" = "--git-dir" ]; then
+  printf '.git\\n'
+  exit 0
+fi
+${describeBranch}
+exit 1
+`;
+}
+
+async function withFakeGit<T>(
+  name: string,
+  describeBranch: string,
+  run: (packageRoot: string) => Promise<T>,
+): Promise<T> {
   const dir = makeTempDir(name);
   await writePackageJson(dir, '0.4.0');
-  mkdirSync(join(dir, '.git'));
-  await writeFakeGit(dir, script);
+  await writeFakeGit(dir, fakeGitScript(describeBranch));
 
   const previousGitBin = process.env.JARVIS_GIT_BIN;
   process.env.JARVIS_GIT_BIN = join(dir, 'bin', 'git');
@@ -60,13 +78,10 @@ describe('CLI version resolver', () => {
   test('reads an exact release tag and strips the leading v', async () => {
     await withFakeGit(
       'exact-tag',
-      `#!/usr/bin/env bash
-if [ "$1" = "-C" ] && [ "$3" = "describe" ] && [ "$4" = "--tags" ] && [ "$5" = "--exact-match" ]; then
+      `if [ "$3" = "describe" ] && [ "$4" = "--tags" ] && [ "$5" = "--exact-match" ]; then
   printf 'v9.9.9\\n'
   exit 0
-fi
-exit 1
-`,
+fi`,
       async (dir) => {
         expect(getInstalledVersion(dir)).toBe('9.9.9');
       },
@@ -76,51 +91,31 @@ exit 1
   test('falls back to git describe when HEAD is ahead of the last tag', async () => {
     await withFakeGit(
       'described-version',
-      `#!/usr/bin/env bash
-if [ "$1" = "-C" ] && [ "$3" = "describe" ] && [ "$4" = "--tags" ] && [ "$5" = "--exact-match" ]; then
+      `if [ "$3" = "describe" ] && [ "$4" = "--tags" ] && [ "$5" = "--exact-match" ]; then
   exit 1
 fi
-if [ "$1" = "-C" ] && [ "$3" = "describe" ] && [ "$4" = "--tags" ] && [ "$5" = "--always" ]; then
+if [ "$3" = "describe" ] && [ "$4" = "--tags" ] && [ "$5" = "--always" ]; then
   printf 'v1.2.3-1-gabc123\\n'
   exit 0
-fi
-exit 1
-`,
+fi`,
       async (dir) => {
         expect(getInstalledVersion(dir)).toBe('1.2.3-1-gabc123');
       },
     );
   });
 
-  test('prefers the exact release tag over other version sources (v stripped)', () => {
-    expect(selectInstalledVersion('0.4.0', 'v9.9.9', 'v9.9.9-1-gabc123')).toBe('9.9.9');
-  });
-
-  test('uses git describe output when ahead of the last release tag (v stripped)', () => {
-    expect(selectInstalledVersion('0.4.0', null, 'v1.2.3-1-gabc123')).toBe('1.2.3-1-gabc123');
-  });
-
-  test('leaves tags without a v prefix unchanged', () => {
-    expect(selectInstalledVersion('0.0.0', '1.0.0', null)).toBe('1.0.0');
-  });
-
   test('does not run --always when --exact-match resolves a tag', async () => {
     // The fake git exits 99 if --always is invoked; the resolver must
-    // never reach it on a tagged commit. If the short-circuit regresses
-    // this test fails because runGit returns null for non-zero exits and
-    // any other failure mode would surface as an unexpected version.
+    // never reach it on a tagged commit.
     await withFakeGit(
       'short-circuit',
-      `#!/usr/bin/env bash
-if [ "$1" = "-C" ] && [ "$3" = "describe" ] && [ "$4" = "--tags" ] && [ "$5" = "--exact-match" ]; then
+      `if [ "$3" = "describe" ] && [ "$4" = "--tags" ] && [ "$5" = "--exact-match" ]; then
   printf 'v0.5.0\\n'
   exit 0
 fi
-if [ "$1" = "-C" ] && [ "$3" = "describe" ] && [ "$4" = "--tags" ] && [ "$5" = "--always" ]; then
+if [ "$3" = "describe" ] && [ "$4" = "--tags" ] && [ "$5" = "--always" ]; then
   exit 99
-fi
-exit 1
-`,
+fi`,
       async (dir) => {
         expect(getInstalledVersion(dir)).toBe('0.5.0');
       },
@@ -130,16 +125,13 @@ exit 1
   test('rejects bare-SHA describe output and falls back to package.json', async () => {
     await withFakeGit(
       'tagless-repo',
-      `#!/usr/bin/env bash
-if [ "$1" = "-C" ] && [ "$3" = "describe" ] && [ "$4" = "--tags" ] && [ "$5" = "--exact-match" ]; then
+      `if [ "$3" = "describe" ] && [ "$4" = "--tags" ] && [ "$5" = "--exact-match" ]; then
   exit 1
 fi
-if [ "$1" = "-C" ] && [ "$3" = "describe" ] && [ "$4" = "--tags" ] && [ "$5" = "--always" ]; then
+if [ "$3" = "describe" ] && [ "$4" = "--tags" ] && [ "$5" = "--always" ]; then
   printf 'abc1234\\n'
   exit 0
-fi
-exit 1
-`,
+fi`,
       async (dir) => {
         // Package.json was seeded with 0.4.0 by the harness; the bare SHA
         // must be rejected as not-a-version.
@@ -148,10 +140,36 @@ exit 1
     );
   });
 
-  test('falls back to package.json version when git metadata is unavailable', async () => {
-    const dir = makeTempDir('package-only');
+  test('falls back to package.json when not a git checkout', async () => {
+    const dir = makeTempDir('non-git');
     await writePackageJson(dir, '3.2.1');
-    expect(selectInstalledVersion('3.2.1', null, null)).toBe('3.2.1');
-    expect(getInstalledVersion(dir)).toBe('3.2.1');
+    // Point JARVIS_GIT_BIN at a non-existent file so rev-parse fails →
+    // isGitCheckout returns false and we never call describe.
+    const previousGitBin = process.env.JARVIS_GIT_BIN;
+    process.env.JARVIS_GIT_BIN = join(dir, 'no-such-git-binary');
+    try {
+      expect(getInstalledVersion(dir)).toBe('3.2.1');
+    } finally {
+      if (previousGitBin === undefined) delete process.env.JARVIS_GIT_BIN;
+      else process.env.JARVIS_GIT_BIN = previousGitBin;
+    }
+  });
+
+  // ── pure selector ─────────────────────────────────────────────────
+
+  test('selectInstalledVersion: exact tag wins (v stripped)', () => {
+    expect(selectInstalledVersion('v9.9.9', 'v9.9.9-1-gabc123', '0.4.0')).toBe('9.9.9');
+  });
+
+  test('selectInstalledVersion: described wins when no exact tag (v stripped)', () => {
+    expect(selectInstalledVersion(null, 'v1.2.3-1-gabc123', '0.4.0')).toBe('1.2.3-1-gabc123');
+  });
+
+  test('selectInstalledVersion: package.json wins when neither git source resolves', () => {
+    expect(selectInstalledVersion(null, null, '3.2.1')).toBe('3.2.1');
+  });
+
+  test('selectInstalledVersion: leaves tags without a v prefix unchanged', () => {
+    expect(selectInstalledVersion('1.0.0', null, '0.0.0')).toBe('1.0.0');
   });
 });

--- a/src/cli/version.test.ts
+++ b/src/cli/version.test.ts
@@ -173,3 +173,54 @@ fi`,
     expect(selectInstalledVersion('1.0.0', null, '0.0.0')).toBe('1.0.0');
   });
 });
+
+// ── End-to-end CLI smoke tests ──────────────────────────────────────
+// Run the real `bin/jarvis.ts --version` / `version` paths so the banner
+// `v`-prefixing contract is locked. The matcher unit tests above verify
+// the resolver's shape; these prove the call sites add `v` consistently.
+
+describe('CLI --version output', () => {
+  const REPO_ROOT = resolve(import.meta.dir, '..', '..');
+  const JARVIS_BIN = join(REPO_ROOT, 'bin', 'jarvis.ts');
+
+  async function runCli(args: string[]): Promise<{ exitCode: number; stdout: string }> {
+    const proc = Bun.spawn(['bun', JARVIS_BIN, ...args], {
+      stdout: 'pipe',
+      stderr: 'pipe',
+      cwd: REPO_ROOT,
+    });
+    const exitCode = await proc.exited;
+    const stdout = (await new Response(proc.stdout).text()).trim();
+    return { exitCode, stdout };
+  }
+
+  test('`jarvis --version` prints v-prefixed version with no doubling', async () => {
+    const { exitCode, stdout } = await runCli(['--version']);
+    expect(exitCode).toBe(0);
+    expect(stdout).toMatch(/^v\d+\.\d+/);
+    expect(stdout.startsWith('vv')).toBe(false);
+  }, { timeout: 15000 });
+
+  test('`jarvis version` matches `--version` output', async () => {
+    const a = await runCli(['version']);
+    const b = await runCli(['--version']);
+    expect(a.exitCode).toBe(0);
+    expect(b.exitCode).toBe(0);
+    expect(a.stdout).toBe(b.stdout);
+  }, { timeout: 15000 });
+
+  test('`jarvis -v` matches `--version` output', async () => {
+    const a = await runCli(['-v']);
+    const b = await runCli(['--version']);
+    expect(a.exitCode).toBe(0);
+    expect(b.exitCode).toBe(0);
+    expect(a.stdout).toBe(b.stdout);
+  }, { timeout: 15000 });
+
+  test('`jarvis help` banner contains exactly one v-prefixed version (no vv)', async () => {
+    const { exitCode, stdout } = await runCli(['help']);
+    expect(exitCode).toBe(0);
+    expect(stdout).not.toMatch(/vv\d+\.\d+/);
+    expect(stdout).toMatch(/v\d+\.\d+/);
+  }, { timeout: 15000 });
+});

--- a/src/cli/version.test.ts
+++ b/src/cli/version.test.ts
@@ -104,6 +104,29 @@ exit 1
     expect(selectInstalledVersion('0.0.0', '1.0.0', null)).toBe('1.0.0');
   });
 
+  test('does not run --always when --exact-match resolves a tag', async () => {
+    // The fake git exits 99 if --always is invoked; the resolver must
+    // never reach it on a tagged commit. If the short-circuit regresses
+    // this test fails because runGit returns null for non-zero exits and
+    // any other failure mode would surface as an unexpected version.
+    await withFakeGit(
+      'short-circuit',
+      `#!/usr/bin/env bash
+if [ "$1" = "-C" ] && [ "$3" = "describe" ] && [ "$4" = "--tags" ] && [ "$5" = "--exact-match" ]; then
+  printf 'v0.5.0\\n'
+  exit 0
+fi
+if [ "$1" = "-C" ] && [ "$3" = "describe" ] && [ "$4" = "--tags" ] && [ "$5" = "--always" ]; then
+  exit 99
+fi
+exit 1
+`,
+      async (dir) => {
+        expect(getInstalledVersion(dir)).toBe('0.5.0');
+      },
+    );
+  });
+
   test('rejects bare-SHA describe output and falls back to package.json', async () => {
     await withFakeGit(
       'tagless-repo',

--- a/src/cli/version.ts
+++ b/src/cli/version.ts
@@ -30,6 +30,13 @@ function stripLeadingV(s: string): string {
   return s.startsWith('v') ? s.slice(1) : s;
 }
 
+// `git describe --tags --always` falls back to a bare commit SHA in repos
+// with no tags reachable from HEAD. Reject anything that doesn't look like
+// a version so the package.json fallback wins instead of printing `abc1234`.
+function looksLikeVersion(s: string): boolean {
+  return /^v?\d+\.\d+/.test(s);
+}
+
 export function selectInstalledVersion(
   packageVersion: string,
   exactTag: string | null,
@@ -54,6 +61,7 @@ export function getInstalledVersion(packageRoot: string): string {
   }
 
   const exactTag = runGit(['describe', '--tags', '--exact-match'], packageRoot);
-  const described = runGit(['describe', '--tags', '--always'], packageRoot);
+  const describedRaw = runGit(['describe', '--tags', '--always'], packageRoot);
+  const described = describedRaw && looksLikeVersion(describedRaw) ? describedRaw : null;
   return selectInstalledVersion(pkgVersion, exactTag, described);
 }

--- a/src/cli/version.ts
+++ b/src/cli/version.ts
@@ -61,7 +61,11 @@ export function getInstalledVersion(packageRoot: string): string {
   }
 
   const exactTag = runGit(['describe', '--tags', '--exact-match'], packageRoot);
+  if (exactTag) {
+    return selectInstalledVersion(pkgVersion, exactTag, null);
+  }
+
   const describedRaw = runGit(['describe', '--tags', '--always'], packageRoot);
   const described = describedRaw && looksLikeVersion(describedRaw) ? describedRaw : null;
-  return selectInstalledVersion(pkgVersion, exactTag, described);
+  return selectInstalledVersion(pkgVersion, null, described);
 }

--- a/src/cli/version.ts
+++ b/src/cli/version.ts
@@ -1,29 +1,45 @@
-import { existsSync, readFileSync } from 'node:fs';
+import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { spawnSync } from 'bun';
 
 function readPackageVersion(packageRoot: string): string {
   try {
-    const pkg = JSON.parse(readFileSync(join(packageRoot, 'package.json'), 'utf-8')) as { version?: string };
-    return pkg.version || '0.0.0';
+    const pkg = JSON.parse(readFileSync(join(packageRoot, 'package.json'), 'utf-8')) as { version?: unknown };
+    if (typeof pkg.version !== 'string' || pkg.version.length === 0) return '0.0.0';
+    return pkg.version;
   } catch {
     return '0.0.0';
   }
 }
 
+// JARVIS_GIT_BIN is a test-only seam: lets unit tests substitute a fake
+// git binary so we don't depend on the host's real git installation.
 function runGit(args: string[], cwd: string): string | null {
   const gitBin = process.env.JARVIS_GIT_BIN || 'git';
-  const result = spawnSync([gitBin, '-C', cwd, ...args], {
-    stdout: 'pipe',
-    stderr: 'pipe',
-  });
+  let result: ReturnType<typeof spawnSync>;
+  try {
+    result = spawnSync([gitBin, '-C', cwd, ...args], {
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+  } catch {
+    // git binary missing or unspawnable — treat as "no git here".
+    return null;
+  }
 
-  if (result.exitCode !== 0) {
+  if (result.exitCode !== 0 || !result.stdout) {
     return null;
   }
 
   const text = result.stdout.toString().trim();
   return text || null;
+}
+
+// Use git's own probe instead of `existsSync('.git')` so linked worktrees
+// (where `.git` is a file pointing into the main repo) and submodules
+// resolve correctly. Falls through to package.json when git can't answer.
+function isGitCheckout(packageRoot: string): boolean {
+  return runGit(['rev-parse', '--git-dir'], packageRoot) !== null;
 }
 
 function stripLeadingV(s: string): string {
@@ -38,34 +54,28 @@ function looksLikeVersion(s: string): boolean {
 }
 
 export function selectInstalledVersion(
-  packageVersion: string,
   exactTag: string | null,
   describedVersion: string | null,
+  packageVersion: string,
 ): string {
-  if (exactTag) {
-    return stripLeadingV(exactTag);
-  }
-
-  if (describedVersion) {
-    return stripLeadingV(describedVersion);
-  }
-
+  if (exactTag) return stripLeadingV(exactTag);
+  if (describedVersion) return stripLeadingV(describedVersion);
   return packageVersion;
 }
 
 export function getInstalledVersion(packageRoot: string): string {
   const pkgVersion = readPackageVersion(packageRoot);
 
-  if (!existsSync(join(packageRoot, '.git'))) {
+  if (!isGitCheckout(packageRoot)) {
     return pkgVersion;
   }
 
   const exactTag = runGit(['describe', '--tags', '--exact-match'], packageRoot);
   if (exactTag) {
-    return selectInstalledVersion(pkgVersion, exactTag, null);
+    return selectInstalledVersion(exactTag, null, pkgVersion);
   }
 
   const describedRaw = runGit(['describe', '--tags', '--always'], packageRoot);
   const described = describedRaw && looksLikeVersion(describedRaw) ? describedRaw : null;
-  return selectInstalledVersion(pkgVersion, null, described);
+  return selectInstalledVersion(null, described, pkgVersion);
 }

--- a/src/cli/version.ts
+++ b/src/cli/version.ts
@@ -26,17 +26,21 @@ function runGit(args: string[], cwd: string): string | null {
   return text || null;
 }
 
+function stripLeadingV(s: string): string {
+  return s.startsWith('v') ? s.slice(1) : s;
+}
+
 export function selectInstalledVersion(
   packageVersion: string,
   exactTag: string | null,
   describedVersion: string | null,
 ): string {
   if (exactTag) {
-    return exactTag;
+    return stripLeadingV(exactTag);
   }
 
   if (describedVersion) {
-    return describedVersion;
+    return stripLeadingV(describedVersion);
   }
 
   return packageVersion;


### PR DESCRIPTION
Follow-ups to #114. The original PR introduced `getInstalledVersion` with priority `exact tag > git describe > package.json`, but the resolver and the CLI call sites disagreed on who owns the leading `v`, the SHA fallback could leak past the intended-as-version semantics, and the git probe didn't handle a few real-world checkout shapes.

## What was broken

1. **`vv` on tagged checkouts.** `getInstalledVersion` returned `v9.9.9` (with `v`) and the banner already prefixed with `v`, so the help banner displayed `vv9.9.9`. `jarvis --version` had the inverse problem - printed `0.4.4-12-gabc` while the banner showed `v0.4.4-12-gabc`. The two outputs disagreed.
2. **Bare-SHA leaks.** `git describe --tags --always` falls back to a 7-char commit SHA in tagless histories (fresh forks, shallow clones). The resolver accepted that as a valid version, so `jarvis --version` could print `abc1234` while a perfectly valid `0.4.0` sat unused in `package.json`.
3. **Wasted spawn on every tagged release.** `--exact-match` and `--always` were always invoked back-to-back; the second is wasted work (~10–30ms) when the first hits.
4. **Crashed on systems without git.** `spawnSync` threw `ENOENT` when the binary was missing instead of returning a non-zero status; users on a stripped image or a CI without git would see a stack trace from `jarvis --version`.
5. **`existsSync('.git')`** worked for the common case but was a poor probe for linked worktrees (`.git` is a *file* there, not a directory) and submodules.
6. **No CLI-output coverage.** The unit tests exercised the resolver in isolation; nothing locked the user-visible contract that `jarvis --version` and the banner must show exactly one `v`.

## What changed

### `src/cli/version.ts` - resolver hardening

- `selectInstalledVersion` now strips a leading `v` from any git-derived value and the call sites own the `v` prefix. Argument order reordered to `(exactTag, describedVersion, packageVersion)` so it matches the priority order it implements.
- `looksLikeVersion(/^v?\d+\.\d+/)` filters `--always` output before it can win — bare SHAs fall through to `package.json`.
- `getInstalledVersion` short-circuits the second `git describe` when the first resolves an exact tag.
- `isGitCheckout` uses `git rev-parse --git-dir` instead of `existsSync('.git')`, picking up worktrees and submodules.
- `runGit` wraps `spawnSync` in `try/catch` so a missing `git` binary returns `null` cleanly. Documented `JARVIS_GIT_BIN` as a test-only seam.
- `readPackageVersion` strict-checks for a non-empty string; empty `version` no longer silently coerces to `0.0.0` via the `||` shortcut.

### `bin/jarvis.ts` - single-line call-site fix

`console.log(getVersion())` → `console.log(\`v${getVersion()}\`)` so the standalone `--version` output matches the banner format.

### `src/cli/version.test.ts` - coverage

- Existing five tests updated to the stripped-`v`, reordered-arg contract.
- New regression tests:
  - **Tagless repo / bare-SHA rejection** - fake git returns `abc1234`; resolver must fall through to package.json.
  - **`--exact-match` short-circuit** - fake git exits 99 on `--always`; resolver must never invoke it on a tagged commit.
  - **Non-git checkout** - `JARVIS_GIT_BIN` points at a missing binary; resolver must fall through to package.json without crashing.
  - **Tags without `v`** - verifies the strip logic is a no-op on already-bare versions.
- Test harness updated: the fake-git helper now responds to `rev-parse --git-dir` (paired with the `existsSync` -> `rev-parse` switch in the resolver), and the per-test scripts no longer need their own shebang or trailing `exit 1`.
- New CLI smoke-test block: spawns `bun bin/jarvis.ts {--version,version,-v,help}` and asserts a single `v` prefix in every output. The `vv` regression that motivated this PR would now fail at the test boundary.

## Behaviour matrix

| Checkout state | `jarvis --version` (before) | `jarvis --version` (after) |
|---|---|---|
| On a tag (`v0.4.4`) | `0.4.4` (banner showed `vv0.4.4`) | `v0.4.4` |
| Between tags | `0.4.4-12-gabc` (banner showed `v0.4.4-12-gabc`) | `v0.4.4-12-gabc` |
| Tagless history | `abc1234` (raw SHA) | `v<package.json version>` |
| No git binary | `ENOENT` crash | `v<package.json version>` |
| Linked worktree | mostly worked but probe was brittle | works via `rev-parse --git-dir` |
| `npm install`-ed copy | `v<package.json version>` | unchanged |
