### PR TITLE
Harden Groq oversized-request handling

### DIFF
--- a/src/llm/groq.ts
+++ b/src/llm/groq.ts
@@ -347,6 +347,14 @@ export class GroqProvider implements LLMProvider {
       )
       : 0;
     const budget = Math.max(6_000, promptBudget - toolOverhead);
+
+    // Fast path: if the conversation already fits under budget at full size,
+    // return it untouched. This avoids unconditionally truncating individual
+    // messages with the visible "...[truncated for Groq]..." marker on every
+    // request — the per-role caps only apply when we actually have to shrink.
+    const rawTotal = messages.reduce((sum, m) => sum + this.measureMessage(m), 0);
+    if (rawTotal <= budget) return messages;
+
     const normalized = messages.map((message) => this.normalizeMessage(message));
     const systemMessages = normalized.filter((message) => message.role === 'system');
     const nonSystemMessages = normalized.filter((message) => message.role !== 'system');

--- a/src/llm/groq.ts
+++ b/src/llm/groq.ts
@@ -365,34 +365,67 @@ export class GroqProvider implements LLMProvider {
       return systemMessages;
     }
 
-    const recentCount = Math.min(nonSystemMessages.length, GroqProvider.MIN_RECENT_MESSAGES);
-    const olderMessages = nonSystemMessages.slice(0, nonSystemMessages.length - recentCount);
-    const recentMessages = nonSystemMessages.slice(-recentCount);
+    // Group an assistant-with-tool_calls together with its immediately-following
+    // tool responses (matched by tool_call_id) so we can drop/keep tool pairs
+    // atomically. Groq rejects requests where a tool_call_id has no matching
+    // assistant tool_call (or vice versa) as malformed.
+    const groups = this.groupForAtomicCompaction(nonSystemMessages);
+
+    const recentGroupCount = Math.min(groups.length, GroqProvider.MIN_RECENT_MESSAGES);
+    const olderGroups = groups.slice(0, groups.length - recentGroupCount);
+    const recentGroups = groups.slice(-recentGroupCount);
     // 64 = per-message framing overhead reserved for role/JSON keys; 240 = floor
     // so the recent budget never collapses to nothing on a very tight payload.
-    const recentBudget = Math.max(Math.floor(remainingBudget / Math.max(recentCount, 1)) - 64, 240);
+    const recentBudget = Math.max(Math.floor(remainingBudget / Math.max(recentGroupCount, 1)) - 64, 240);
     const selectedOlder: LLMMessage[] = [];
     const selectedRecent: LLMMessage[] = [];
 
-    for (const message of recentMessages) {
-      const candidate = this.normalizeMessage(message, recentBudget);
-      const candidateSize = this.measureMessage(candidate);
-      if (candidateSize <= remainingBudget) {
-        selectedRecent.push(candidate);
-        remainingBudget -= candidateSize;
+    for (const group of recentGroups) {
+      const candidates = group.map((m) => this.normalizeMessage(m, recentBudget));
+      const groupSize = candidates.reduce((sum, m) => sum + this.measureMessage(m), 0);
+      if (groupSize <= remainingBudget) {
+        selectedRecent.push(...candidates);
+        remainingBudget -= groupSize;
       }
     }
 
-    for (let i = olderMessages.length - 1; i >= 0; i--) {
-      const candidate = olderMessages[i]!;
-      const candidateSize = this.measureMessage(candidate);
-      if (candidateSize <= remainingBudget) {
-        selectedOlder.unshift(candidate);
-        remainingBudget -= candidateSize;
+    for (let i = olderGroups.length - 1; i >= 0; i--) {
+      const group = olderGroups[i]!;
+      const groupSize = group.reduce((sum, m) => sum + this.measureMessage(m), 0);
+      if (groupSize <= remainingBudget) {
+        selectedOlder.unshift(...group);
+        remainingBudget -= groupSize;
       }
     }
 
     return [...systemMessages, ...selectedOlder, ...selectedRecent];
+  }
+
+  private groupForAtomicCompaction(messages: LLMMessage[]): LLMMessage[][] {
+    const groups: LLMMessage[][] = [];
+    let i = 0;
+    while (i < messages.length) {
+      const current = messages[i]!;
+      if (current.role === 'assistant' && current.tool_calls && current.tool_calls.length > 0) {
+        const toolCallIds = new Set(current.tool_calls.map((tc) => tc.id));
+        const grouped: LLMMessage[] = [current];
+        i++;
+        while (
+          i < messages.length
+          && messages[i]!.role === 'tool'
+          && messages[i]!.tool_call_id !== undefined
+          && toolCallIds.has(messages[i]!.tool_call_id!)
+        ) {
+          grouped.push(messages[i]!);
+          i++;
+        }
+        groups.push(grouped);
+      } else {
+        groups.push([current]);
+        i++;
+      }
+    }
+    return groups;
   }
 
   private normalizeMessage(message: LLMMessage, overrideBudget?: number): LLMMessage {

--- a/src/llm/groq.ts
+++ b/src/llm/groq.ts
@@ -364,6 +364,8 @@ export class GroqProvider implements LLMProvider {
     const recentCount = Math.min(nonSystemMessages.length, GroqProvider.MIN_RECENT_MESSAGES);
     const olderMessages = nonSystemMessages.slice(0, nonSystemMessages.length - recentCount);
     const recentMessages = nonSystemMessages.slice(-recentCount);
+    // 64 = per-message framing overhead reserved for role/JSON keys; 240 = floor
+    // so the recent budget never collapses to nothing on a very tight payload.
     const recentBudget = Math.max(Math.floor(remainingBudget / Math.max(recentCount, 1)) - 64, 240);
     const selectedOlder: LLMMessage[] = [];
     const selectedRecent: LLMMessage[] = [];
@@ -414,13 +416,15 @@ export class GroqProvider implements LLMProvider {
     }
   }
 
+  private static readonly TRUNCATION_MARKER = '\n...[truncated for Groq]...\n';
+
   private truncateText(text: string, maxChars: number): string {
     if (text.length <= maxChars) return text;
     if (maxChars <= 80) return text.slice(0, maxChars);
     const head = Math.floor(maxChars * 0.65);
-    const tail = Math.max(maxChars - head - 29, 0);
+    const tail = Math.max(maxChars - head - GroqProvider.TRUNCATION_MARKER.length, 0);
     const suffix = tail > 0 ? text.slice(-tail) : '';
-    return `${text.slice(0, head)}\n...[truncated for Groq]...\n${suffix}`;
+    return `${text.slice(0, head)}${GroqProvider.TRUNCATION_MARKER}${suffix}`;
   }
 
   private measureMessage(message: LLMMessage): number {

--- a/src/llm/groq.ts
+++ b/src/llm/groq.ts
@@ -435,8 +435,14 @@ export class GroqProvider implements LLMProvider {
     return content.length + toolCallsSize + 128;
   }
 
+  // Treat 413 Payload Too Large as authoritative. For 400 Bad Request we
+  // also accept a narrow set of size-related phrases Groq uses in practice;
+  // a smaller retry budget can recover from those. Everything else
+  // (auth, rate limit, generic 400/500) is not retryable here.
   private isRequestTooLargeError(status: number, errorText: string): boolean {
-    return status === 413 || /message is too large|request too large|context length|too many tokens|payload too large/i.test(errorText);
+    if (status === 413) return true;
+    if (status !== 400) return false;
+    return /\b(message is too large|request too large|payload too large|too many tokens|maximum context length|context window)\b/i.test(errorText);
   }
 
   private convertTools(tools: LLMTool[]): GroqToolDef[] {

--- a/src/llm/groq.ts
+++ b/src/llm/groq.ts
@@ -103,18 +103,16 @@ export class GroqProvider implements LLMProvider {
 
     if (!response.ok) {
       const errorText = await response.text();
-      if (this.isRequestTooLargeError(response.status, errorText)) {
-        response = await this.sendRequest(
-          this.buildRequestBody(messages, options, false, GroqProvider.RETRY_PROMPT_CHAR_BUDGET)
-        );
-      } else {
+      if (!this.isRequestTooLargeError(response.status, errorText)) {
         throw new Error(`Groq API error (${response.status}): ${errorText}`);
       }
-    }
-
-    if (!response.ok) {
-      const errorText = await response.text();
-      throw new Error(`Groq API error (${response.status}): ${errorText}`);
+      response = await this.sendRequest(
+        this.buildRequestBody(messages, options, false, GroqProvider.RETRY_PROMPT_CHAR_BUDGET)
+      );
+      if (!response.ok) {
+        const retryError = await response.text();
+        throw new Error(`Groq API error after retry (${response.status}): ${retryError}`);
+      }
     }
 
     const data = await response.json() as GroqResponse;
@@ -134,25 +132,23 @@ export class GroqProvider implements LLMProvider {
 
     if (!response.ok) {
       const errorText = await response.text();
-      if (this.isRequestTooLargeError(response.status, errorText)) {
-        response = await this.sendRequest(
-          this.buildRequestBody(
-            messages,
-            options,
-            true,
-            GroqProvider.RETRY_PROMPT_CHAR_BUDGET,
-          )
-        );
-      } else {
+      if (!this.isRequestTooLargeError(response.status, errorText)) {
         yield { type: 'error', error: `Groq API error (${response.status}): ${errorText}` };
         return;
       }
-    }
-
-    if (!response.ok) {
-      const errorText = await response.text();
-      yield { type: 'error', error: `Groq API error (${response.status}): ${errorText}` };
-      return;
+      response = await this.sendRequest(
+        this.buildRequestBody(
+          messages,
+          options,
+          true,
+          GroqProvider.RETRY_PROMPT_CHAR_BUDGET,
+        )
+      );
+      if (!response.ok) {
+        const retryError = await response.text();
+        yield { type: 'error', error: `Groq API error after retry (${response.status}): ${retryError}` };
+        return;
+      }
     }
 
     if (!response.body) {

--- a/src/llm/provider.test.ts
+++ b/src/llm/provider.test.ts
@@ -597,7 +597,7 @@ describe('Groq request shaping', () => {
       });
     }) as unknown as typeof fetch;
 
-    const provider = new GroqProvider('test-key') as any;
+    const provider = new GroqProvider('test-key');
     const messages: LLMMessage[] = [
       { role: 'system', content: 'S'.repeat(14_000) },
       { role: 'user', content: 'U'.repeat(10_000) },

--- a/src/llm/provider.test.ts
+++ b/src/llm/provider.test.ts
@@ -614,4 +614,61 @@ describe('Groq request shaping', () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(JSON.stringify(secondBody).length).toBeLessThan(JSON.stringify(firstBody).length);
   });
+
+  test('GroqProvider streams successfully after retrying an oversized request', async () => {
+    function makeSseStream(): ReadableStream<Uint8Array> {
+      const enc = new TextEncoder();
+      const chunks = [
+        `data: ${JSON.stringify({
+          id: 'c', object: 'chat.completion.chunk', created: 0, model: 'llama-test',
+          choices: [{ index: 0, delta: { content: 'retry-stream ok' }, finish_reason: null }],
+        })}\n\n`,
+        `data: ${JSON.stringify({
+          id: 'c', object: 'chat.completion.chunk', created: 0, model: 'llama-test',
+          choices: [{ index: 0, delta: {}, finish_reason: 'stop' }],
+        })}\n\n`,
+        'data: [DONE]\n\n',
+      ];
+      return new ReadableStream({
+        start(controller) {
+          for (const c of chunks) controller.enqueue(enc.encode(c));
+          controller.close();
+        },
+      });
+    }
+
+    globalThis.fetch = mock(async () => {
+      const callCount = (globalThis.fetch as unknown as ReturnType<typeof mock>).mock.calls.length;
+      if (callCount === 1) {
+        return new Response('message is too large', { status: 413 });
+      }
+      return new Response(makeSseStream(), {
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream' },
+      });
+    }) as unknown as typeof fetch;
+
+    const provider = new GroqProvider('test-key');
+    const messages: LLMMessage[] = [
+      { role: 'system', content: 'S'.repeat(14_000) },
+      { role: 'user', content: 'U'.repeat(10_000) },
+      { role: 'user', content: 'Can you still stream?' },
+    ];
+
+    const events: string[] = [];
+    let sawError = false;
+    for await (const ev of provider.stream(messages)) {
+      if (ev.type === 'text') events.push(ev.text);
+      if (ev.type === 'error') sawError = true;
+    }
+
+    const fetchMock = globalThis.fetch as unknown as ReturnType<typeof mock>;
+    const firstBody = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body));
+    const secondBody = JSON.parse(String(fetchMock.mock.calls[1]?.[1]?.body));
+
+    expect(sawError).toBe(false);
+    expect(events.join('')).toBe('retry-stream ok');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(JSON.stringify(secondBody).length).toBeLessThan(JSON.stringify(firstBody).length);
+  });
 });

--- a/src/llm/provider.test.ts
+++ b/src/llm/provider.test.ts
@@ -615,6 +615,48 @@ describe('Groq request shaping', () => {
     expect(JSON.stringify(secondBody).length).toBeLessThan(JSON.stringify(firstBody).length);
   });
 
+  test('GroqProvider compaction never orphans a tool message from its assistant tool_call', async () => {
+    let captured: any = null;
+    globalThis.fetch = mock(async (_url: string, init?: RequestInit) => {
+      captured = JSON.parse(String(init?.body));
+      return new Response(JSON.stringify({
+        id: 'cmpl', object: 'chat.completion', created: 0, model: 'm',
+        choices: [{ index: 0, message: { role: 'assistant', content: 'ok' }, finish_reason: 'stop' }],
+        usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+    }) as unknown as typeof fetch;
+
+    // Pad the assistant content so the assistant+tool group is large enough
+    // that a per-message budget would tempt the compactor to keep one and
+    // drop the other if pairing weren't enforced.
+    const provider = new GroqProvider('test-key');
+    const messages: LLMMessage[] = [
+      { role: 'system', content: 'sys' },
+      { role: 'user', content: 'U'.repeat(20_000) },
+      { role: 'user', content: 'U'.repeat(20_000) },
+      {
+        role: 'assistant',
+        content: 'A'.repeat(2_000),
+        tool_calls: [{ id: 'tc_1', name: 'lookup', arguments: { q: 'x' } }],
+      },
+      { role: 'tool', tool_call_id: 'tc_1', content: 'T'.repeat(2_000) },
+      { role: 'user', content: 'follow up' },
+    ];
+
+    await provider.chat(messages);
+
+    const assistants = (captured.messages as Array<{ role: string; tool_calls?: unknown[] }>)
+      .filter((m) => m.role === 'assistant' && Array.isArray(m.tool_calls) && m.tool_calls.length > 0);
+    const tools = (captured.messages as Array<{ role: string; tool_call_id?: string }>)
+      .filter((m) => m.role === 'tool');
+
+    // Either both survive together, or neither does — but a tool message
+    // must never appear without its originating assistant tool_call.
+    if (tools.length > 0) {
+      expect(assistants.length).toBeGreaterThan(0);
+    }
+  });
+
   test('GroqProvider streams successfully after retrying an oversized request', async () => {
     function makeSseStream(): ReadableStream<Uint8Array> {
       const enc = new TextEncoder();


### PR DESCRIPTION
Follow-ups to #115. The original PR introduced a tighter retry budget when Groq rejects a payload as oversized, plus per-role character caps. The retry path is the right shape, but several rough edges around tool-call pairing, error observability, and unconditional truncation needed cleanup.

## What was rough

1. **Tool-call ↔ tool-result pairing was not protected during compaction.** Each message was dropped/kept independently of its neighbors. If an `assistant` message carrying `tool_calls` got dropped while its corresponding `tool` reply (matching `tool_call_id`) survived (or the inverse), Groq would reject the whole request as malformed.
2. **Stream-path retry was uncovered.** The retry test only exercised `chat`. The streaming code had identical retry logic with different control flow (`yield { type: 'error' }` instead of `throw`) and no test pinned it.
3. **Errors after a failed retry looked like first-attempt errors.** When both the initial 24k-budget request and the 12k retry failed, the user saw `Groq API error (413): message is too large` with no indication that a retry had already happened. Operators couldn't distinguish "first attempt was big" from "even our retry budget is too big - model can't fit this conversation."
4. **Per-role hard caps fired on every request, not just oversized ones.** A user pasting a 5k-char log silently lost ~1.5k of it on every Groq call - even when total payload was well under budget - and the visible `...[truncated for Groq]...` marker leaked into the conversation history.
5. **`isRequestTooLargeError` regex was overly broad.** `/context length/i` would also match hard-limit errors that a smaller retry budget can't solve, burning a wasted round-trip.
6. **Cosmetic gaps.** Gratuitous `as any` cast on a public-API call in the new test, magic numbers (`64`, `240`, `29`) without comments, and a one-char off-by-one in the truncation marker arithmetic (`...[truncated for Groq]...\n` is 28 chars, not 29).

## What changed

### `src/llm/groq.ts`

- **Atomic tool pairing.** New private `groupForAtomicCompaction` walks the non-system messages and bundles each `assistant.tool_calls` message with its immediately-following `tool` messages whose `tool_call_id` matches one of the calls. The compactor then drops/keeps whole groups, never half-pairs. (Standalone `tool` messages whose `tool_call_id` doesn't match the prior assistant - malformed input - are kept as singletons; Groq still rejects those, but that's the caller's problem, not the compactor's.)
- **Fast path for already-fitting conversations.** Before normalizing or grouping, sum raw message sizes; if the total is under the budget, return the original messages untouched. The per-role caps and the `...[truncated for Groq]...` marker only appear when we actually need to shrink.
- **Tightened `isRequestTooLargeError`.** Authoritative on `status === 413`; for `status === 400`, only matches a curated list of size-related phrases (`message is too large`, `request too large`, `payload too large`, `too many tokens`, `maximum context length`, `context window`) with `\b` word boundaries. Auth/rate-limit/generic errors no longer trigger pointless retries.
- **Distinct error after retry.** `chat` now throws `Groq API error after retry (...)` on the second-failure path; `stream` yields the same. The single-failure path is unchanged: `Groq API error (...)`. The duplicated `if (!response.ok)` blocks collapse into one nested form.
- **`TRUNCATION_MARKER` constant.** Replaces the literal string and the off-by-one `29` with a single source of truth for both the marker text and its length.
- **Magic numbers commented.** `64` (per-message framing overhead) and `240` (recent-budget floor) now have a one-line explanation.

### `src/llm/provider.test.ts`

- **Stream retry test.** Builds a fake SSE stream that returns 413 on the first call and a valid `text` + `stop` event sequence on the second. Iterates the async generator and asserts no `error` event fired, the text concatenation matches, and the second body is smaller than the first.
- **Atomicity regression test.** Constructs an oversized conversation that includes an `assistant.tool_calls` paired with a `tool` reply by `tool_call_id`. Asserts that whenever the compacted output contains any `tool` message, it also contains an `assistant` with `tool_calls` - the pairing invariant.
- **Dropped `as any`** on the `GroqProvider` instantiation in the original retry test (the test only calls public `chat`, no private access needed).