### PR TITLE
Follow-ups for PR #113 (core dependency onboarding)

### DIFF
--- a/src/cli/deps.test.ts
+++ b/src/cli/deps.test.ts
@@ -45,4 +45,18 @@ describe('CLI dependency helpers', () => {
       unresolved: ['xdg-open'],
     });
   });
+
+  test('maps wslview to wslu on WSL with apt', () => {
+    expect(resolveCoreInstallPlan('apt', 'wsl', ['git', 'wslview'])).toEqual({
+      packages: ['git', 'wslu'],
+      unresolved: [],
+    });
+  });
+
+  test('reports wslview unresolved on brew (no mapping)', () => {
+    expect(resolveCoreInstallPlan('brew', 'wsl', ['wslview'])).toEqual({
+      packages: [],
+      unresolved: ['wslview'],
+    });
+  });
 });

--- a/src/cli/deps.test.ts
+++ b/src/cli/deps.test.ts
@@ -38,4 +38,11 @@ describe('CLI dependency helpers', () => {
       unresolved: ['xdg-open'],
     });
   });
+
+  test('dedupes unresolved entries when missing has duplicates', () => {
+    expect(resolveCoreInstallPlan('brew', 'linux', ['xdg-open', 'xdg-open'])).toEqual({
+      packages: [],
+      unresolved: ['xdg-open'],
+    });
+  });
 });

--- a/src/cli/deps.ts
+++ b/src/cli/deps.ts
@@ -287,34 +287,12 @@ export async function installBrowser(): Promise<boolean> {
   // Linux / WSL — install a Linux browser (preferred for CDP)
   if (pm === 'apt') {
     // Try chromium-browser first (most common on Ubuntu/Debian), then chromium
-    console.log(c.dim('  Running: sudo apt install -y chromium-browser'));
-    let result = spawnSync(['sudo', 'apt', 'install', '-y', 'chromium-browser'], {
-      stdout: 'inherit', stderr: 'inherit',
-    });
-    if (result.exitCode === 0) return true;
-
-    console.log(c.dim('  Trying: sudo apt install -y chromium'));
-    result = spawnSync(['sudo', 'apt', 'install', '-y', 'chromium'], {
-      stdout: 'inherit', stderr: 'inherit',
-    });
-    return result.exitCode === 0;
+    if (runPackageInstall('apt', ['chromium-browser'])) return true;
+    return runPackageInstall('apt', ['chromium']);
   }
 
-  if (pm === 'dnf') {
-    console.log(c.dim('  Running: sudo dnf install -y chromium'));
-    const result = spawnSync(['sudo', 'dnf', 'install', '-y', 'chromium'], {
-      stdout: 'inherit', stderr: 'inherit',
-    });
-    return result.exitCode === 0;
-  }
-
-  if (pm === 'pacman') {
-    console.log(c.dim('  Running: sudo pacman -S --noconfirm chromium'));
-    const result = spawnSync(['sudo', 'pacman', '-S', '--noconfirm', 'chromium'], {
-      stdout: 'inherit', stderr: 'inherit',
-    });
-    return result.exitCode === 0;
-  }
+  if (pm === 'dnf') return runPackageInstall('dnf', ['chromium']);
+  if (pm === 'pacman') return runPackageInstall('pacman', ['chromium']);
 
   printInfo('Install Chromium manually for your distribution.');
   return false;

--- a/src/cli/deps.ts
+++ b/src/cli/deps.ts
@@ -159,15 +159,12 @@ export function checkLinuxTools(): DepStatus[] {
 
   return tools.map(tool => {
     const cmd = tool.cmd ?? tool.name;
-    const result = spawnSync(['which', cmd], { stdout: 'pipe', stderr: 'pipe' });
-    const found = result.exitCode === 0;
-    const path = found ? result.stdout.toString().trim() : undefined;
-
+    const result = commandExists(cmd);
     return {
       name: tool.name,
-      found,
-      path,
-      message: found ? path! : `Not installed (${tool.desc})`,
+      found: result.found,
+      path: result.path,
+      message: result.found ? result.path! : `Not installed (${tool.desc})`,
       installable: true,
     };
   });

--- a/src/cli/deps.ts
+++ b/src/cli/deps.ts
@@ -229,7 +229,7 @@ export function resolveCoreInstallPlan(
       .filter(Boolean) as string[],
   )];
 
-  const unresolved = missing.filter((name) => !packageMap.get(name));
+  const unresolved = [...new Set(missing.filter((name) => !packageMap.get(name)))];
 
   return { packages, unresolved };
 }
@@ -370,13 +370,13 @@ export async function installCoreTools(missing: string[]): Promise<boolean> {
   }
 
   if (unresolved.length > 0) {
-    printInfo(`No ${pm} package mapping for: ${[...new Set(unresolved)].join(', ')}`);
+    printInfo(`No ${pm} package mapping for: ${unresolved.join(', ')}`);
   }
 
   const installed = runPackageInstall(pm, packages);
 
   if (unresolved.length > 0) {
-    printInfo(`Install manually: ${[...new Set(unresolved)].join(', ')}`);
+    printInfo(`Install manually: ${unresolved.join(', ')}`);
   }
 
   return installed && unresolved.length === 0;

--- a/src/cli/deps.ts
+++ b/src/cli/deps.ts
@@ -14,8 +14,11 @@ import { spawnSync } from 'bun';
 import { c, printOk, printWarn, printErr, printInfo, askYesNo, ask, askSecret, startSpinner, detectPlatform } from './helpers.ts';
 import { LINUX_BROWSER_PATHS, MACOS_BROWSER_PATHS, type BrowserExecutable } from '../actions/browser/chrome-launcher.ts';
 
+export type DepKind = 'core' | 'browser' | 'linux' | 'google';
+
 export type DepStatus = {
   name: string;
+  kind: DepKind;
   found: boolean;
   path?: string;
   message: string;
@@ -46,6 +49,7 @@ export function checkBrowser(): DepStatus {
     if (existsSync(c.path)) {
       return {
         name: 'Browser (Chrome/Chromium)',
+        kind: 'browser',
         found: true,
         path: c.path,
         message: `${c.kind} at ${c.path}`,
@@ -66,6 +70,7 @@ export function checkBrowser(): DepStatus {
       if (existsSync(p)) {
         return {
           name: 'Browser (Chrome/Chromium)',
+          kind: 'browser',
           found: true,
           path: p,
           message: `Windows browser at ${p}`,
@@ -77,6 +82,7 @@ export function checkBrowser(): DepStatus {
 
   return {
     name: 'Browser (Chrome/Chromium)',
+    kind: 'browser',
     found: false,
     message: 'Not found',
     installable: true,
@@ -136,6 +142,7 @@ export function checkCoreTools(): DepStatus[] {
     const result = commandExists(tool.command);
     return {
       name: tool.name,
+      kind: 'core',
       found: result.found,
       path: result.path,
       message: result.found ? result.path! : `Not installed (${tool.description})`,
@@ -162,6 +169,7 @@ export function checkLinuxTools(): DepStatus[] {
     const result = commandExists(cmd);
     return {
       name: tool.name,
+      kind: 'linux',
       found: result.found,
       path: result.path,
       message: result.found ? result.path! : `Not installed (${tool.desc})`,
@@ -179,6 +187,7 @@ export function checkGoogleAuth(): DepStatus {
 
   return {
     name: 'Google OAuth',
+    kind: 'google',
     found,
     path: found ? tokensPath : undefined,
     message: found ? 'Tokens exist' : 'Not configured (optional, for Gmail/Calendar)',
@@ -526,7 +535,7 @@ export async function runDependencyCheck(config: any): Promise<void> {
   printInfo(`${missing.length} ${missing.length === 1 ? 'dependency' : 'dependencies'} not found.`);
   console.log('');
 
-  const missingCore = missing.filter(d => coreTools.some(core => core.name === d.name));
+  const missingCore = missing.filter(d => d.kind === 'core');
   if (missingCore.length > 0) {
     const names = missingCore.map(d => d.name).join(', ');
     const install = await askYesNo(`Install core system tools (${names})?`, true);
@@ -541,7 +550,7 @@ export async function runDependencyCheck(config: any): Promise<void> {
 
   // Offer to install each missing dependency
   // Group: browser
-  const missingBrowser = missing.find(d => d.name.includes('Browser'));
+  const missingBrowser = missing.find(d => d.kind === 'browser');
   if (missingBrowser) {
     const install = await askYesNo('Install a Chromium-based browser?', true);
     if (install) {
@@ -554,9 +563,7 @@ export async function runDependencyCheck(config: any): Promise<void> {
   }
 
   // Group: Linux tools (batch install)
-  const missingLinux = missing.filter(d =>
-    d.name === 'xdotool' || d.name === 'xprop' || d.name === 'import (ImageMagick)'
-  );
+  const missingLinux = missing.filter(d => d.kind === 'linux');
   if (missingLinux.length > 0) {
     const names = missingLinux.map(d => d.name).join(', ');
     const install = await askYesNo(`Install Linux tools (${names})?`, true);
@@ -570,7 +577,7 @@ export async function runDependencyCheck(config: any): Promise<void> {
   }
 
   // Group: Google OAuth (special — only if user has google config or wants to set up)
-  const missingGoogle = missing.find(d => d.name === 'Google OAuth');
+  const missingGoogle = missing.find(d => d.kind === 'google');
   if (missingGoogle) {
     const install = await askYesNo('Set up Google OAuth for Gmail/Calendar? (optional)', false);
     if (install) {

--- a/src/cli/deps.ts
+++ b/src/cli/deps.ts
@@ -342,14 +342,14 @@ export async function installCoreTools(missing: string[]): Promise<boolean> {
   const platform = detectPlatform();
   const pm = detectPackageManager();
   if (!pm) {
-    printInfo('Install manually: ' + missing.join(', '));
+    printInfo('Install manually: ' + [...new Set(missing)].join(', '));
     return false;
   }
 
   const { packages, unresolved } = resolveCoreInstallPlan(pm, platform, missing);
 
   if (packages.length === 0) {
-    printInfo('Install manually: ' + missing.join(', '));
+    printInfo('Install manually: ' + [...new Set(missing)].join(', '));
     return false;
   }
 


### PR DESCRIPTION
PR #113 added detection + installation for `git`, `curl`, and platform-specific
browser openers (`xdg-open`/`wslview`) during the onboarding wizard. The shape
was solid - pure resolver + tested matrix - but six small things were left on
the table:

1. The resolver's output contract was asymmetric: `packages` was deduped via
   `new Set`, `unresolved` was a raw `.filter()`. Callers papered over it with
   `[...new Set(unresolved)]` at print sites.
2. Test coverage skipped the WSL × `apt` × `wslview` -> `wslu` branch - the only
   non-trivial spec branch other than Linux × `apt` × `xdg-open`.
3. `checkLinuxTools` still hand-rolled `which` despite the new `commandExists`
   helper doing exactly that.
4. `installBrowser` still had four near-identical Linux branches that the new
   `runPackageInstall` helper was designed to replace - the PR wired it into
   `installLinuxTools` and `installCoreTools` but missed `installBrowser`.
5. Three sites in `runDependencyCheck` grouped missing deps via fragile
   string-name matching: `name.includes('Browser')`, name-equality lists for
   the Linux-tool group, and `name === 'Google OAuth'`. Adding any new dep
   whose display name overlapped would silently break grouping.
6. `installCoreTools`'s early-return paths printed the input `missing` list
   without dedup, leaving the function's output contract dependent on caller
   hygiene.

## What changed

### 1 - Resolver dedupes `unresolved`

`resolveCoreInstallPlan` now returns deduped `unresolved`, matching the shape
of `packages`. Print-site `[...new Set(...)]` wrappers in `installCoreTools`
removed (function output is the contract). New regression test:
`resolveCoreInstallPlan('brew', 'linux', ['xdg-open', 'xdg-open']).unresolved`
returns `['xdg-open']`, not duplicates.

### 2 - WSL resolver coverage

Two new tests for the wslview branch:
- `apt` × `wsl` × `['git', 'wslview']` -> packages `['git', 'wslu']`,
  unresolved `[]`
- `brew` × `wsl` × `['wslview']` -> packages `[]`, unresolved `['wslview']`
  (since `wslview`'s spec has no `brew` entry)

Lock the only spec branch the original test suite never exercised.

### 3 - `checkLinuxTools` uses `commandExists`

Pure dedup. Drops a hand-rolled `spawnSync(['which', cmd], ...)` block in favour
of the helper introduced by PR #113 itself. Behaviour identical.

### 4 - `installBrowser` Linux branches use `runPackageInstall`

26 lines collapsed to 4. macOS `brew install --cask google-chrome` stays
special-cased because `runPackageInstall` doesn't model `--cask`. apt's
chromium-browser -> chromium fallback chain preserved.

### 5 - `DepStatus.kind` discriminator

New `DepKind = 'core' | 'browser' | 'linux' | 'google'` field on every
`DepStatus`. Each `check*` function stamps it. `runDependencyCheck` switches
the four grouping sites from name-string match to `d.kind === '...'`. Any
future dep with an overlapping display name can no longer collide.

### 6 - Dedupe `missing` in `installCoreTools` early-return prints

Two `printInfo('Install manually: ' + missing.join(', '))` sites now wrap with
`[...new Set(...)]`. Closes the only remaining caller-hygiene dependency in
the public function.
