### PR TITLE
Revert PR #116 host-header overrides and harden enrollment UX

### DIFF
--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -156,7 +156,26 @@ export type JarvisConfig = {
     port: number;
     data_dir: string;
     db_path: string;
-    /** External domain for the brain (used in sidecar JWT tokens). Env: JARVIS_BRAIN_DOMAIN */
+    /**
+     * URL that sidecars dial to reach this brain — signed into enrollment
+     * JWTs, so this is what the sidecar will use forever once enrolled.
+     *
+     * NOT the brain's bind address. If the brain is fronted by a reverse
+     * proxy or accessed across NAT, this must be the externally-reachable
+     * URL (e.g. `https://brain.example.com` or `wss://brain.example.com`),
+     * not the internal `localhost:PORT` the brain listens on.
+     *
+     * Accepts a full URL (`https://...`, `wss://...`) or a bare host[:port]
+     * (`brain.example.com`, `10.0.0.5:3142`). Bare local hosts default to
+     * ws/http; everything else defaults to wss/https.
+     *
+     * Precedence: `JARVIS_BRAIN_DOMAIN` env var > this field > internal
+     * `localhost:<port>` fallback (with a startup warning).
+     *
+     * If sidecars on different network segments need different URLs, set
+     * the canonical one here and override per-sidecar via the sidecar's
+     * own `brain:` config field.
+     */
     brain_domain?: string;
   };
   auth?: AuthConfig;

--- a/src/daemon/api-routes.ts
+++ b/src/daemon/api-routes.ts
@@ -2479,13 +2479,7 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
           if (!ctx.sidecarManager) return error('Sidecar manager not available', 503);
           const body = await req.json() as { name?: string };
           if (!body.name) return error('Missing "name" field');
-          const forwardedProto = req.headers.get('x-forwarded-proto')?.split(',')[0]?.trim();
-          const forwardedHost = req.headers.get('x-forwarded-host')?.split(',')[0]?.trim();
-          const requestUrl = new URL(req.url);
-          const host = forwardedHost || req.headers.get('host') || requestUrl.host;
-          const protocol = forwardedProto || requestUrl.protocol.replace(':', '');
-          const enrollmentOrigin = host ? `${protocol}://${host}` : undefined;
-          const result = await ctx.sidecarManager.enrollSidecar(body.name, enrollmentOrigin);
+          const result = await ctx.sidecarManager.enrollSidecar(body.name);
           return json(result, 201);
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -327,8 +327,17 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
 
     // 6c. Create sidecar manager
     const sidecarManager = new SidecarManager(jarvisConfig.daemon.data_dir.replace('~', os.homedir()));
+    // Brain URL precedence: env > config.yaml > default fallback. The loader
+    // already collapses env into config.daemon.brain_domain, so we re-check
+    // the env var here only to attribute the source in the startup log —
+    // the operator needs to see which knob is active when debugging.
+    const brainSource: 'env' | 'config' | 'default' = process.env.JARVIS_BRAIN_DOMAIN
+      ? 'env'
+      : jarvisConfig.daemon.brain_domain
+        ? 'config'
+        : 'default';
     const brainDomain = jarvisConfig.daemon.brain_domain ?? `localhost:${config.port}`;
-    sidecarManager.setBrainUrl(brainDomain);
+    sidecarManager.setBrainUrl(brainDomain, brainSource);
 
     // 6d. Wire sidecar manager to WebSocket server for WS routing
     wsService.getServer().setSidecarManager(sidecarManager);

--- a/src/sidecar/manager.test.ts
+++ b/src/sidecar/manager.test.ts
@@ -1,20 +1,90 @@
 import { describe, expect, test } from 'bun:test';
-import { SidecarManager } from './manager.ts';
+import { buildEnrollmentUrls, isLocalhostBrainUrl } from './manager.ts';
 
-describe('SidecarManager enrollment URLs', () => {
-  test('uses explicit request origin when provided', () => {
-    const manager = new SidecarManager('/tmp/jarvis-sidecar-manager-test') as any;
-    const urls = manager.buildEnrollmentUrls('https://brain.example.com');
-
-    expect(urls.brainWs).toBe('wss://brain.example.com/sidecar/connect');
-    expect(urls.jwksUrl).toBe('https://brain.example.com/api/sidecars/.well-known/jwks.json');
+describe('buildEnrollmentUrls', () => {
+  test('parses https URL into wss/https pair', () => {
+    expect(buildEnrollmentUrls('https://brain.example.com')).toEqual({
+      brainWs: 'wss://brain.example.com/sidecar/connect',
+      jwksUrl: 'https://brain.example.com/api/sidecars/.well-known/jwks.json',
+    });
   });
 
-  test('preserves ws/http style URLs for local hosts', () => {
-    const manager = new SidecarManager('/tmp/jarvis-sidecar-manager-test') as any;
-    const urls = manager.buildEnrollmentUrls('10.0.0.25:3142');
+  test('parses wss URL into wss/https pair (preserves explicit ws scheme)', () => {
+    expect(buildEnrollmentUrls('wss://brain.example.com:8443')).toEqual({
+      brainWs: 'wss://brain.example.com:8443/sidecar/connect',
+      jwksUrl: 'https://brain.example.com:8443/api/sidecars/.well-known/jwks.json',
+    });
+  });
 
-    expect(urls.brainWs).toBe('ws://10.0.0.25:3142/sidecar/connect');
-    expect(urls.jwksUrl).toBe('http://10.0.0.25:3142/api/sidecars/.well-known/jwks.json');
+  test('parses http URL into ws/http pair', () => {
+    expect(buildEnrollmentUrls('http://10.0.0.5:3142')).toEqual({
+      brainWs: 'ws://10.0.0.5:3142/sidecar/connect',
+      jwksUrl: 'http://10.0.0.5:3142/api/sidecars/.well-known/jwks.json',
+    });
+  });
+
+  test('bare localhost host gets ws/http (insecure)', () => {
+    expect(buildEnrollmentUrls('localhost:3142')).toEqual({
+      brainWs: 'ws://localhost:3142/sidecar/connect',
+      jwksUrl: 'http://localhost:3142/api/sidecars/.well-known/jwks.json',
+    });
+  });
+
+  test('bare 127.0.0.1 host gets ws/http (insecure)', () => {
+    expect(buildEnrollmentUrls('127.0.0.1:3142')).toEqual({
+      brainWs: 'ws://127.0.0.1:3142/sidecar/connect',
+      jwksUrl: 'http://127.0.0.1:3142/api/sidecars/.well-known/jwks.json',
+    });
+  });
+
+  // Regression: pre-fix the bare-host heuristic was `!normalized.match(/:\d+$/)`,
+  // which downgraded any remote host with an explicit port to ws/http. A
+  // production deployment configured as `brain.example.com:443` would emit
+  // ws://brain.example.com:443 — wrong. Now any non-localhost defaults to wss.
+  test('bare remote host with explicit port stays wss/https', () => {
+    expect(buildEnrollmentUrls('brain.example.com:443')).toEqual({
+      brainWs: 'wss://brain.example.com:443/sidecar/connect',
+      jwksUrl: 'https://brain.example.com:443/api/sidecars/.well-known/jwks.json',
+    });
+  });
+
+  test('bare remote host without port gets wss/https', () => {
+    expect(buildEnrollmentUrls('brain.example.com')).toEqual({
+      brainWs: 'wss://brain.example.com/sidecar/connect',
+      jwksUrl: 'https://brain.example.com/api/sidecars/.well-known/jwks.json',
+    });
+  });
+
+  // Regression: pre-fix `normalized.includes('localhost')` matched
+  // `notlocalhost.example.com` and downgraded it to ws/http.
+  test('bare host containing the substring "localhost" but not equal to it stays wss', () => {
+    expect(buildEnrollmentUrls('notlocalhost.example.com').brainWs)
+      .toBe('wss://notlocalhost.example.com/sidecar/connect');
+  });
+
+  test('trims whitespace', () => {
+    expect(buildEnrollmentUrls('  brain.example.com  ').brainWs)
+      .toBe('wss://brain.example.com/sidecar/connect');
+  });
+});
+
+describe('isLocalhostBrainUrl', () => {
+  test.each([
+    ['localhost', true],
+    ['localhost:3142', true],
+    ['127.0.0.1', true],
+    ['127.0.0.1:3142', true],
+    ['0.0.0.0', true],
+    ['0.0.0.0:3142', true],
+    ['[::1]', true],
+    ['[::1]:3142', true],
+    ['http://localhost:3142', true],
+    ['ws://127.0.0.1:3142', true],
+    ['https://brain.example.com', false],
+    ['brain.example.com', false],
+    ['brain.example.com:443', false],
+    ['notlocalhost.example.com', false],
+  ])('isLocalhostBrainUrl(%p) === %p', (input, expected) => {
+    expect(isLocalhostBrainUrl(input)).toBe(expected);
   });
 });

--- a/src/sidecar/manager.ts
+++ b/src/sidecar/manager.ts
@@ -30,6 +30,51 @@ const KEY_DIR_NAME = 'sidecar-keys';
 const PRIVATE_KEY_FILE = 'private.pem';
 const PUBLIC_KEY_FILE = 'public.pem';
 
+// Localhost host check anchored: matches `localhost`, `localhost:PORT`, but
+// not e.g. `notlocalhost.example.com`. Used both for enrollment URL scheme
+// inference and for startup warnings.
+const LOCALHOST_HOST_RE = /^(localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\])(:\d+)?$/;
+
+export function isLocalhostBrainUrl(brainBase: string): boolean {
+  const normalized = brainBase.trim();
+  if (/^(https?|wss?):\/\//.test(normalized)) {
+    try {
+      return LOCALHOST_HOST_RE.test(new URL(normalized).host);
+    } catch {
+      return false;
+    }
+  }
+  return LOCALHOST_HOST_RE.test(normalized);
+}
+
+// Build the JWT-bound enrollment URLs from a single canonical brain base —
+// either a full URL (`https://brain.example.com`, `wss://...`) or a bare
+// host[:port] (`brain.example.com`, `10.0.0.5:3142`). Pure function: no
+// request input, no env, no class state. The single source of truth is
+// whatever the brain operator configured at startup.
+export function buildEnrollmentUrls(brainBase: string): { brainWs: string; jwksUrl: string } {
+  const normalized = brainBase.trim();
+
+  if (/^(https?|wss?):\/\//.test(normalized)) {
+    const parsed = new URL(normalized);
+    const isSecure = parsed.protocol === 'https:' || parsed.protocol === 'wss:';
+    return {
+      brainWs: `${isSecure ? 'wss' : 'ws'}://${parsed.host}/sidecar/connect`,
+      jwksUrl: `${isSecure ? 'https' : 'http'}://${parsed.host}/api/sidecars/.well-known/jwks.json`,
+    };
+  }
+
+  // Bare host: assume insecure only for explicit local hosts. A remote
+  // host with an explicit port (`brain.example.com:443`) used to be
+  // misclassified as insecure by a `:\d+$` heuristic; require a known
+  // local host instead so production deployments default to wss/https.
+  const isSecure = !LOCALHOST_HOST_RE.test(normalized);
+  return {
+    brainWs: `${isSecure ? 'wss' : 'ws'}://${normalized}/sidecar/connect`,
+    jwksUrl: `${isSecure ? 'https' : 'http'}://${normalized}/api/sidecars/.well-known/jwks.json`,
+  };
+}
+
 export class SidecarManager implements Service {
   readonly name = 'sidecar-manager';
 
@@ -227,7 +272,7 @@ export class SidecarManager implements Service {
   /**
    * Enroll a new sidecar. Returns the signed JWT enrollment token.
    */
-  async enrollSidecar(name: string, enrollmentOrigin?: string): Promise<{ token: string; sidecar: SidecarRecord }> {
+  async enrollSidecar(name: string): Promise<{ token: string; sidecar: SidecarRecord }> {
     if (!this.privateKey) throw new Error('SidecarManager not started');
     if (!this.brainUrl) throw new Error('Brain URL not configured — call setBrainUrl() first');
 
@@ -250,7 +295,7 @@ export class SidecarManager implements Service {
     const id = generateId();
     const tokenId = generateId();
 
-    const { brainWs, jwksUrl } = this.buildEnrollmentUrls(enrollmentOrigin || this.brainUrl);
+    const { brainWs, jwksUrl } = buildEnrollmentUrls(this.brainUrl);
 
     // Sign JWT
     const token = await new SignJWT({
@@ -275,29 +320,6 @@ export class SidecarManager implements Service {
     console.log(`[SidecarManager] Enrolled sidecar "${trimmed}" (${id})`);
 
     return { token, sidecar };
-  }
-
-  private buildEnrollmentUrls(brainBase: string): { brainWs: string; jwksUrl: string } {
-    const normalized = brainBase.trim();
-
-    if (/^https?:\/\//.test(normalized) || /^wss?:\/\//.test(normalized)) {
-      const parsed = new URL(normalized);
-      const host = parsed.host;
-      const wsProtocol = parsed.protocol === 'https:' || parsed.protocol === 'wss:' ? 'wss' : 'ws';
-      const httpProtocol = parsed.protocol === 'wss:' ? 'https' : parsed.protocol === 'ws:' ? 'http' : parsed.protocol.replace(':', '');
-      return {
-        brainWs: `${wsProtocol}://${host}/sidecar/connect`,
-        jwksUrl: `${httpProtocol}://${host}/api/sidecars/.well-known/jwks.json`,
-      };
-    }
-
-    const isSecure = !normalized.includes('localhost') && !normalized.match(/:\d+$/);
-    const wsProtocol = isSecure ? 'wss' : 'ws';
-    const httpProtocol = isSecure ? 'https' : 'http';
-    return {
-      brainWs: `${wsProtocol}://${normalized}/sidecar/connect`,
-      jwksUrl: `${httpProtocol}://${normalized}/api/sidecars/.well-known/jwks.json`,
-    };
   }
 
   // --------------- Registry (DB queries) ---------------

--- a/src/sidecar/manager.ts
+++ b/src/sidecar/manager.ts
@@ -106,9 +106,25 @@ export class SidecarManager implements Service {
    * Set the brain's external URL (used in JWT claims).
    * Must be called before enrolling sidecars.
    * Example: "shiny-panda.domain.com" or "localhost:3142"
+   *
+   * `source` is rendered in the startup log so operators can see at a
+   * glance which knob is active when something looks wrong (env var vs
+   * config.yaml vs default-fallback). Pass undefined for silent setters.
    */
-  setBrainUrl(url: string): void {
+  setBrainUrl(url: string, source?: 'env' | 'config' | 'default'): void {
     this.brainUrl = url;
+    if (source) {
+      const { brainWs } = buildEnrollmentUrls(url);
+      const sourceLabel = source === 'env' ? 'JARVIS_BRAIN_DOMAIN env var'
+        : source === 'config' ? 'config.yaml daemon.brain_domain'
+        : `default fallback — set daemon.brain_domain in config.yaml or JARVIS_BRAIN_DOMAIN env to override`;
+      console.log(`[SidecarManager] Brain URL: ${brainWs} (source: ${sourceLabel})`);
+      if (isLocalhostBrainUrl(url)) {
+        console.warn(
+          `[SidecarManager] Brain URL points at a local host. Sidecars on other machines will NOT be able to reach this URL — only enroll local sidecars, or set daemon.brain_domain to a routable hostname before enrolling remote sidecars.`,
+        );
+      }
+    }
   }
 
   // --------------- Service Interface ---------------


### PR DESCRIPTION
## Why this PR exists

PR #116 was framed as "Fix sidecar brain host overrides," but there was no brain-side bug to fix. The pre-#116 design was already correct: a single operator-controlled URL (`daemon.brain_domain` in config.yaml, override via `JARVIS_BRAIN_DOMAIN` env) gets signed into every enrollment JWT. Sidecars must be able to reach that URL. That is the entire contract, and it is the contract a credential-binding field should have.

What #116 actually responded to was a recurring operator mistake: setting `brain_domain` to the brain's internal bind address (`localhost:3142`) rather than the externally-reachable URL the sidecars are supposed to dial. The right answer to that is documentation and observability. PR #116 took the wrong answer: it made the brain trust request headers to "auto-derive" the URL at enrollment time.

## The security regression that #116 introduced

In #116, `/api/sidecars/enroll` started reading `Host` and `X-Forwarded-Host` to construct the URL stamped into the issued JWT. That moves the trust boundary from "value the brain operator wrote in config" to "value the HTTP client sent in a header." Those are not the same thing.

`Host` and `X-Forwarded-Host` are forgeable input unless a sanitizing reverse proxy is in front of the brain rewriting them from a trusted source. The PR did not require such a proxy and did not document the requirement. The attack surface this opens is not theoretical:

- An attacker who can reach the enrollment endpoint directly (or who tricks an authenticated admin into POSTing via CSRF / a malicious form / an embedded image-as-POST) controls the `Host` header that the request carries. They choose the value that ends up in `claims.brain` of the signed JWT.
- The brain signs that JWT with its own key, so the resulting token is cryptographically valid. The sidecar that later loads the token has no way to know that the `brain` claim was attacker-chosen.
- When that sidecar boots, it dials the URL in the claim. It sends its identity, runtime info, and capability list to attacker-controlled infrastructure. Subsequent RPC traffic, observer events, and tool invocations follow the same path.

The pre-#116 design made this attack impossible by construction: no request input ever touched the JWT. PR #116 made it possible by giving request input a path into a credential.

This is the part that needed reverting, urgently. It is not a "found a sharp edge in a feature" issue. It is "the feature itself is the issue, because the feature is misuse of the trust boundary the original code respected."

## What the original feature was, correctly understood

`JARVIS_BRAIN_DOMAIN` / `daemon.brain_domain` was always supposed to be "the URL sidecars dial to reach this brain." Single value, set once by the operator, signed into every token from that point on. A brain operator serving one user population on one network has one such URL. Topology problems (split-horizon DNS, NAT, multiple ingress hostnames) are operator concerns to be solved at the topology layer (DNS, anycast, picking one canonical hostname), not at the JWT-minting layer.

The "rigidity" #116 tried to soften was the design working as intended. The fact that operators sometimes set the field to the wrong value (their bind address rather than their external URL) is a UX gap, not a brain bug.

## What this PR does

Restores the original trust boundary, then closes the UX gap that motivated #116 in the first place.

### 1. Revert request-derived enrollmentOrigin (`416b310`)

`/api/sidecars/enroll` no longer reads any request headers when minting the JWT. The handler goes back to calling `enrollSidecar(name)` with no origin argument; the URL stamped into the token is, once again, exclusively the operator-configured `daemon.brain_domain` (or its env override).

This removes the host-header credential-binding path entirely. There is no "safe behind a proxy" mode to gate, no allowlist to maintain. The request simply does not get to influence the JWT, which is the correct posture for a signed credential.

### 2. Extract buildEnrollmentUrls to a pure helper, fix bare-host bugs (`0e827da`)

The URL builder #116 added was structurally an improvement over the inline duplication that preceded it, so it stays - just moved to module-level. Two latent bugs in its bare-host fallback are fixed while we are there:

- `const isSecure = !normalized.includes('localhost') && !normalized.match(/:\d+$/)` caused any host with an explicit port to be classified as insecure, so a production deployment configured as `brain.example.com:443` was emitting `ws://brain.example.com:443/...` (and `http://...` for JWKS). Fixed: the check now matches a known-local host shape, not a port shape.
- `normalized.includes('localhost')` matched `notlocalhost.example.com` and downgraded it the same way. Fixed by anchoring the localhost check to an exact host pattern (`localhost`, `127.0.0.1`, `0.0.0.0`, `[::1]`, with optional port).

The helper is now `export function buildEnrollmentUrls(brainBase: string)`. The test file calls it directly, so it no longer needs to instantiate a `SidecarManager` (which opens DB and filesystem state) just to reach a private method via `as any`. Test count went from 2 to 23, including explicit regressions for both bugs above.

### 3. Source-aware startup log and localhost warning (`e184e67`)

This is the real answer to the operator-misconfiguration problem #116 tried to solve. `SidecarManager.setBrainUrl(url, source?)` now accepts an optional `'env' | 'config' | 'default'` tag and logs at startup:

```
[SidecarManager] Brain URL: wss://brain.example.com/sidecar/connect (source: config.yaml daemon.brain_domain)
```

When the configured value resolves to a localhost-class host, it follows with a loud warning:

```
[SidecarManager] Brain URL points at a local host. Sidecars on other machines will NOT be able to reach this URL - only enroll local sidecars, or set daemon.brain_domain to a routable hostname before enrolling remote sidecars.
```

The operator who set `brain_domain` to `localhost:3142` by mistake now sees the problem at boot, not three days later when the first remote sidecar silently fails to connect. The source attribution lets them see at a glance which knob is active when more than one is configured.

A new `isLocalhostBrainUrl` helper is exported and tested for the same host shapes the URL builder uses, so the warning logic and the URL logic stay in sync.

### 4. Document the contract on the config type (`43394da`)

The `JarvisConfig.daemon.brain_domain` JSDoc went from one line to a paragraph that states explicitly: this is the URL sidecars dial, not the brain's bind address; here are the shapes it accepts; here is the precedence (env -> config -> default fallback with warning); here is the per-sidecar override path for genuine multi-network cases. Future operators running `grep brain_domain` get the answer without reading source.

## Commits

| # | SHA       | Subject |
|---|-----------|---------|
| 1 | `416b310` | Revert request-derived enrollmentOrigin to close host-header credential-binding hole |
| 2 | `0e827da` | Extract buildEnrollmentUrls to pure helper, fix bare-host port heuristic |
| 3 | `e184e67` | Log brain URL with source attribution and warn on localhost-class hosts |
| 4 | `43394da` | Document daemon.brain_domain contract and precedence on the config type |

## What this PR keeps from #116

- The sidecar-side `Brain` field in `SidecarConfig` YAML, plus the Go `normalizeBrainOverride` helper. Security-neutral: the sidecar operator already controls their own token, so letting them override the dial target on their end widens no trust boundary. This is the correct escape hatch for the genuine multi-network case where the brain's canonical URL is not reachable from a particular sidecar's vantage point.
- The `buildEnrollmentUrls` URL-shaping logic, which is a strict improvement over the duplicated inline code that preceded #116 (just moved to module-level and bug-fixed in this PR).

## What's NOT in this PR

Reasonable follow-ups that were left out to keep this focused on the security revert:

- A `jarvis brain doctor` outbound-reachability self-test against the configured `brain_domain`.
- A verification hint in the enrollment response output (a copy-pastable `curl -I <jwksUrl>` runnable from the target sidecar's network) so the operator can verify reachability before installing the token.
- A commented-out `daemon.brain_domain:` block in the default config.yaml template carrying the same guidance the new JSDoc carries.

## Risk and migration

The behavioral revert in commit 1 will be visible to anyone whose deployment was relying on the #116 header-derivation path to mint tokens with a URL different from `brain_domain`. Per the analysis above, that path was the security regression being closed. The migration is one line: set `daemon.brain_domain` in config.yaml (or `JARVIS_BRAIN_DOMAIN` env) to the URL that should be signed into tokens. That is what the original contract was, and what it is again.

The bare-host bug fixes in commit 2 change the URL produced for two specific input shapes:

- `brain.example.com:443` -> now `wss://...` and `https://...` (was wrongly `ws://...` and `http://...`).
- `notlocalhost.example.com` -> now `wss://...` and `https://...` (was wrongly `ws://...` and `http://...`).

Both prior outputs were bugs. The new outputs are the intended behavior. Any deployment that was working around the old downgrade by, for example, prefixing an explicit `https://` scheme will continue to work unchanged (the URL-shape branch handles full URLs separately and was already correct).

Commits 3 and 4 are observability and documentation only; no URL produced for any well-formed input changes.

## Verification

- `bun test src/sidecar/manager.test.ts` -> 23 pass (was 2 in #116).
- `bun test` -> 623 pass (was 602 before this branch).
- `bunx tsc --noEmit` -> clean.
- Manually verified at startup: the `[SidecarManager] Brain URL: ...` log line renders the correct source attribution for each of the three sources (env, config, default), and the localhost warning fires when `brain_domain` resolves to a local host.
