### PR TITLE
Follow-ups to #118: language plumbing, transcript hardening, type safety, tests

### DIFF
--- a/src/comms/voice.test.ts
+++ b/src/comms/voice.test.ts
@@ -5,7 +5,9 @@ import {
   OpenAIWhisperSTT,
   GroqWhisperSTT,
   LocalWhisperSTT,
+  SarvamSTT,
   EdgeTTSProvider,
+  SarvamTTSProvider,
   splitIntoSentences,
 } from './voice.ts';
 import type { STTConfig, TTSConfig } from '../config/types.ts';
@@ -99,6 +101,19 @@ describe('createSTTProvider factory', () => {
     const provider = createSTTProvider(config);
     expect(provider).toBeInstanceOf(OpenAIWhisperSTT);
   });
+
+  test('returns SarvamSTT when provider=sarvam and key present', () => {
+    const config: STTConfig = {
+      provider: 'sarvam',
+      sarvam: { api_key: 'sk_test_not_real' },
+    };
+    expect(createSTTProvider(config)).toBeInstanceOf(SarvamSTT);
+  });
+
+  test('returns null when provider=sarvam and no key', () => {
+    const config: STTConfig = { provider: 'sarvam' };
+    expect(createSTTProvider(config)).toBeNull();
+  });
 });
 
 describe('createTTSProvider factory', () => {
@@ -123,6 +138,20 @@ describe('createTTSProvider factory', () => {
     const config: TTSConfig = { enabled: true, rate: '+20%', volume: '-10%' };
     const provider = createTTSProvider(config);
     expect(provider).not.toBeNull();
+  });
+
+  test('returns SarvamTTSProvider when provider=sarvam and key present', () => {
+    const config: TTSConfig = {
+      enabled: true,
+      provider: 'sarvam',
+      sarvam: { api_key: 'sk_test_not_real' },
+    };
+    expect(createTTSProvider(config)).toBeInstanceOf(SarvamTTSProvider);
+  });
+
+  test('returns null when provider=sarvam and no key', () => {
+    const config: TTSConfig = { enabled: true, provider: 'sarvam' };
+    expect(createTTSProvider(config)).toBeNull();
   });
 });
 
@@ -431,5 +460,68 @@ describe('LocalWhisperSTT.transcribe', () => {
     } catch (err: any) {
       expect(err.message).toBe('Connection refused');
     }
+  });
+});
+
+describe('SarvamSTT.transcribe', () => {
+  const originalFetch = globalThis.fetch;
+  afterEach(() => { globalThis.fetch = originalFetch; });
+
+  test('passes configured language_code through to Sarvam request', async () => {
+    const stt = new SarvamSTT('sk_test_not_real', 'saaras:v3', 'hi-IN');
+    const wav = makeWavBuffer();
+    let sentLanguage = '';
+
+    globalThis.fetch = mock(async (_url: string, init: any) => {
+      const body = init.body as FormData;
+      sentLanguage = String(body.get('language_code'));
+      return new Response(JSON.stringify({ transcript: 'namaste' }), {
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as any;
+
+    expect(await stt.transcribe(wav)).toBe('namaste');
+    expect(sentLanguage).toBe('hi-IN');
+  });
+
+  test('defaults language_code to "unknown" (auto-detect) when not configured', async () => {
+    const stt = new SarvamSTT('sk_test_not_real');
+    const wav = makeWavBuffer();
+    let sentLanguage = '';
+
+    globalThis.fetch = mock(async (_url: string, init: any) => {
+      const body = init.body as FormData;
+      sentLanguage = String(body.get('language_code'));
+      return new Response(JSON.stringify({ transcript: 'hi' }), {
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as any;
+
+    await stt.transcribe(wav);
+    expect(sentLanguage).toBe('unknown');
+  });
+
+  test('throws when response body has neither transcript nor text', async () => {
+    const stt = new SarvamSTT('sk_test_not_real');
+    const wav = makeWavBuffer();
+
+    globalThis.fetch = mock(async () =>
+      new Response(JSON.stringify({ unexpected: 'shape' }), {
+        headers: { 'content-type': 'application/json' },
+      })
+    ) as any;
+
+    await expect(stt.transcribe(wav)).rejects.toThrow('Sarvam STT returned no transcript');
+  });
+
+  test('throws on HTTP error with status', async () => {
+    const stt = new SarvamSTT('sk_test_not_real');
+    const wav = makeWavBuffer();
+
+    globalThis.fetch = mock(async () =>
+      new Response('unauthorized', { status: 401 })
+    ) as any;
+
+    await expect(stt.transcribe(wav)).rejects.toThrow(/Sarvam STT error \(401\)/);
   });
 });

--- a/src/comms/voice.ts
+++ b/src/comms/voice.ts
@@ -164,17 +164,19 @@ export class LocalWhisperSTT implements STTProvider {
 export class SarvamSTT implements STTProvider {
   private apiKey: string;
   private model: string;
+  private language: string;
 
-  constructor(apiKey: string, model: string = 'saaras:v3') {
+  constructor(apiKey: string, model: string = 'saaras:v3', language: string = 'unknown') {
     this.apiKey = apiKey;
     this.model = model;
+    this.language = language;
   }
 
   async transcribe(audio: Buffer): Promise<string> {
     const formData = new FormData();
     formData.append('file', new Blob([new Uint8Array(audio)], { type: 'audio/wav' }), 'audio.wav');
     formData.append('model', this.model);
-    formData.append('language_code', 'en-IN'); 
+    formData.append('language_code', this.language);
 
     const response = await fetch('https://api.sarvam.ai/speech-to-text', {
       method: 'POST',
@@ -187,8 +189,12 @@ export class SarvamSTT implements STTProvider {
       throw new Error(`Sarvam STT error (${response.status}): ${err}`);
     }
 
-    const result = await response.json() as any;
-    return result.transcript || result.text || '';
+    const result = await response.json() as { transcript?: string; text?: string };
+    const transcript = result.transcript ?? result.text;
+    if (typeof transcript !== 'string' || !transcript) {
+      throw new Error(`Sarvam STT returned no transcript: ${JSON.stringify(result).slice(0, 200)}`);
+    }
+    return transcript;
   }
 }
 
@@ -208,7 +214,7 @@ export function createSTTProvider(config: STTConfig): STTProvider | null {
       return new LocalWhisperSTT(config.local?.endpoint, config.local?.model, config.local?.server_type);
     case 'sarvam':
       if (!config.sarvam?.api_key) return null;
-      return new SarvamSTT(config.sarvam.api_key, config.sarvam.model);
+      return new SarvamSTT(config.sarvam.api_key, config.sarvam.model, config.sarvam.language);
     default:
       return null;
   }

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -42,7 +42,7 @@ export type STTConfig = {
   openai?: { api_key: string; model?: string };
   groq?: { api_key: string; model?: string };
   local?: { endpoint: string; model?: string; server_type?: 'whisper_cpp' | 'openai_compatible' };
-  sarvam?: { api_key: string; model?: string };
+  sarvam?: { api_key: string; model?: string; language?: string };
 };
 
 export type TTSConfig = {

--- a/src/daemon/api-routes.ts
+++ b/src/daemon/api-routes.ts
@@ -1313,6 +1313,7 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
           has_openai_key: !!stt?.openai?.api_key,
           has_groq_key: !!stt?.groq?.api_key,
           has_sarvam_key: !!stt?.sarvam?.api_key,
+          sarvam_language: stt?.sarvam?.language ?? 'unknown',
           local_endpoint: stt?.local?.endpoint ?? null,
           local_server_type: stt?.local?.server_type ?? 'whisper_cpp',
         });

--- a/src/daemon/api-routes.ts
+++ b/src/daemon/api-routes.ts
@@ -1686,7 +1686,9 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
           if (!body.action) return error('Missing "action" field');
           ctx.learner.resetPattern(body.action, body.tool_name ?? '');
           return json({ ok: true });
-        } catch (err) { return error('Invalid request body'); }
+        } catch (err) {
+          return error('Invalid request body');
+        }
       },
     },
 

--- a/src/daemon/api-routes.ts
+++ b/src/daemon/api-routes.ts
@@ -1324,8 +1324,8 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
           const { loadConfig, saveConfig } = await import('../config/loader.ts');
           const freshConfig = await loadConfig();
 
-          if (!freshConfig.stt) freshConfig.stt = {} as any;
-          const stt = freshConfig.stt!;
+          if (!freshConfig.stt) freshConfig.stt = { provider: 'openai' };
+          const stt = freshConfig.stt;
 
           // Preserve keys for each provider if not provided in the update
           const providers = ['openai', 'groq', 'sarvam'] as const;
@@ -1384,7 +1384,7 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
           const { loadConfig, saveConfig } = await import('../config/loader.ts');
           const freshConfig = await loadConfig();
 
-          if (!freshConfig.tts) freshConfig.tts = {} as any;
+          if (!freshConfig.tts) freshConfig.tts = { enabled: false };
 
           // Deep-merge elevenlabs sub-object to preserve API key across saves
           const incomingEl = body.elevenlabs as Record<string, unknown> | undefined;

--- a/ui/src/components/settings/ChannelsPanel.tsx
+++ b/ui/src/components/settings/ChannelsPanel.tsx
@@ -16,6 +16,7 @@ type STTConfigData = {
   has_openai_key: boolean;
   has_groq_key: boolean;
   has_sarvam_key: boolean;
+  sarvam_language: string;
   local_endpoint: string | null;
   local_server_type: string;
 };
@@ -70,6 +71,7 @@ export function ChannelsPanel() {
   const [sttKey, setSttKey] = useState("");
   const [sttEndpoint, setSttEndpoint] = useState("http://localhost:8080");
   const [sttServerType, setSttServerType] = useState("whisper_cpp");
+  const [sttSarvamLanguage, setSttSarvamLanguage] = useState("unknown");
 
   // TTS form
   const [ttsEnabled, setTtsEnabled] = useState(false);
@@ -114,6 +116,7 @@ export function ChannelsPanel() {
       setSttProvider(sttCfg.provider);
       if (sttCfg.local_endpoint) setSttEndpoint(sttCfg.local_endpoint);
       if (sttCfg.local_server_type) setSttServerType(sttCfg.local_server_type);
+      if (sttCfg.sarvam_language) setSttSarvamLanguage(sttCfg.sarvam_language);
     }
   }, [sttCfg]);
 
@@ -194,8 +197,11 @@ export function ChannelsPanel() {
         body.openai = { api_key: sttKey };
       } else if (sttProvider === "groq" && sttKey) {
         body.groq = { api_key: sttKey };
-      } else if (sttProvider === "sarvam" && sttKey) {
-        body.sarvam = { api_key: sttKey };
+      } else if (sttProvider === "sarvam") {
+        body.sarvam = {
+          ...(sttKey ? { api_key: sttKey } : {}),
+          language: sttSarvamLanguage,
+        };
       } else if (sttProvider === "local") {
         body.local = { endpoint: sttEndpoint, server_type: sttServerType };
       }
@@ -399,6 +405,29 @@ export function ChannelsPanel() {
               <span style={{ fontSize: "11px", color: "var(--j-text-muted)" }}>
                 API key configured
               </span>
+            )}
+            {sttProvider === "sarvam" && (
+              <div style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
+                <span style={{ fontSize: "11px", color: "var(--j-text-muted)" }}>Spoken language</span>
+                <select
+                  style={inputStyle}
+                  value={sttSarvamLanguage}
+                  onChange={e => setSttSarvamLanguage(e.target.value)}
+                >
+                  <option value="unknown">Auto-detect</option>
+                  <option value="en-IN">English (Indian Accent)</option>
+                  <option value="hi-IN">Hindi</option>
+                  <option value="ta-IN">Tamil</option>
+                  <option value="te-IN">Telugu</option>
+                  <option value="kn-IN">Kannada</option>
+                  <option value="ml-IN">Malayalam</option>
+                  <option value="bn-IN">Bengali</option>
+                  <option value="gu-IN">Gujarati</option>
+                  <option value="mr-IN">Marathi</option>
+                  <option value="pa-IN">Punjabi</option>
+                  <option value="od-IN">Odia</option>
+                </select>
+              </div>
             )}
           </>
         )}

--- a/ui/src/components/settings/ChannelsPanel.tsx
+++ b/ui/src/components/settings/ChannelsPanel.tsx
@@ -652,9 +652,9 @@ export function ChannelsPanel() {
                 value={sarvQuality}
                 onChange={e => setSarvQuality(Number(e.target.value))}
               >
+                <option value={16000}>Low (16kHz)</option>
                 <option value={24000}>Standard (24kHz)</option>
                 <option value={48000}>High Fidelity (48kHz)</option>
-                <option value={16000}>Low (16kHz)</option>
               </select>
             </div>
           </>


### PR DESCRIPTION
PR #118 added Sarvam AI as STT and TTS provider. The integration shape was right, but a few real correctness issues shipped with it. This PR closes them.

## What changed

### Plumb language config through Sarvam STT and throw on empty transcript

`SarvamSTT.transcribe` was hardcoded to `language_code='en-IN'` even though the TTS panel exposes the full Indian-language set. A user picking Hindi or Tamil for output would still have their input transcribed as Indian English, which defeats the point of choosing this provider in the first place. Adds `STTConfig.sarvam.language`, threads it through the constructor and the factory, and surfaces a language selector in the settings panel that defaults to "auto-detect" (Sarvam's `unknown` value) and lists the same languages the TTS section already supports.

The same handler used to return `result.transcript || result.text || ''` and silently feed an empty string to the orchestrator if the response shape changed. The TTS path already throws on missing audio; STT now matches by throwing `Sarvam STT returned no transcript: ...` with a truncated body preview instead of returning `''`.

### Replace `as any` partial init in STT/TTS handlers with typed defaults

The save handlers initialized missing config sections as `{} as any`, which lies to the type system: `STTConfig` requires `provider` and `TTSConfig` requires `enabled`. Replaces both with the typed defaults (`{ provider: 'openai' }` and `{ enabled: false }`) so a malformed request body cannot land an invalid config object. The form always sends those fields today, but the type erosion would have made future contract changes unsafe to refactor.

### Add factory and transcribe tests for Sarvam STT/TTS providers

PR #118 shipped without test coverage for either new provider class. Adds factory tests mirroring the OpenAI/Groq/Local set, plus four `SarvamSTT.transcribe` tests that exercise: language_code threading from config, the auto-detect default when no language is configured, the throw-on-empty-transcript path, and HTTP error reporting.

### Cosmetic cleanup

PR #118 also collapsed the `learning/dismiss` handler's `try/catch` onto a single line, unrelated to the Sarvam feature and inconsistent with every other handler in the file. Reverts that. Reorders the Sarvam quality dropdown so the options ascend (16k -> 24k -> 48k) instead of the original 24/48/16 ordering, which read as a bug.
