### PR TITLE
Drop deprecated `baseUrl` from tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,9 +6,8 @@
     "moduleDetection": "force",
     "jsx": "react-jsx",
     "allowJs": true,
-    "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["./src/*"]
     },
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,


### PR DESCRIPTION
## Summary
- Removed `baseUrl: "."` from `tsconfig.json`, which TypeScript 6.x flags as deprecated and will stop functioning in TypeScript 7.0.
- Updated the `paths` entry for `@/*` to be explicitly relative (`./src/*`) so path resolution remains anchored to the `tsconfig.json` location.

## Why
TypeScript 5.0+ resolves `paths` relative to the `tsconfig.json` file when `baseUrl` is absent, so `baseUrl: "."` was redundant and only served to surface a deprecation warning. Removing it silences the warning without changing resolution behavior — `@/foo` still resolves to `src/foo`.
