### PR TITLE
Fix `jarvis log` / `jarvis logs` ReferenceError

### DIFF
--- a/bin/jarvis.ts
+++ b/bin/jarvis.ts
@@ -14,7 +14,7 @@
  */
 
 import { join } from 'node:path';
-import { openSync } from 'node:fs';
+import { existsSync, openSync } from 'node:fs';
 import { spawn } from 'node:child_process';
 import { acquireLock, releaseLock, isLocked, getLogPath } from '../src/daemon/pid.ts';
 import { c } from '../src/cli/helpers.ts';


### PR DESCRIPTION
## Summary

`jarvis log` and `jarvis logs` were throwing `ReferenceError: existsSync is not defined` and never tailing the daemon log.

## Root cause

`bin/jarvis.ts` only imported `openSync` from `node:fs`, but `cmdLogs` calls `existsSync(logPath)` on line 296 to check whether a log file exists before tailing it. Because the symbol was never imported, the command crashed before doing any work.

## Fix

Added `existsSync` to the existing `node:fs` import in `bin/jarvis.ts`. One line change, no behavior change beyond the command now functioning.

```diff
-import { openSync } from 'node:fs';
+import { existsSync, openSync } from 'node:fs';
```