### PR TITLE
Fix OpenAI provider to use `max_completion_tokens` for GPT-5 compatibility

### DIFF
--- a/src/llm/openai.ts
+++ b/src/llm/openai.ts
@@ -104,7 +104,7 @@ export class OpenAIProvider implements LLMProvider {
     };
 
     if (temperature !== undefined) body.temperature = temperature;
-    if (max_tokens !== undefined) body.max_tokens = max_tokens;
+    if (max_tokens !== undefined) body.max_completion_tokens = max_tokens;
     if (tools && tools.length > 0) {
       body.tools = this.convertTools(tools);
       body.tool_choice = tool_choice || 'auto';  // Enable tool calling
@@ -142,7 +142,7 @@ export class OpenAIProvider implements LLMProvider {
     };
 
     if (temperature !== undefined) body.temperature = temperature;
-    if (max_tokens !== undefined) body.max_tokens = max_tokens;
+    if (max_tokens !== undefined) body.max_completion_tokens = max_tokens;
     if (tools && tools.length > 0) {
       body.tools = this.convertTools(tools);
       body.tool_choice = tool_choice || 'auto';  // Enable tool calling

--- a/src/llm/provider.test.ts
+++ b/src/llm/provider.test.ts
@@ -715,6 +715,56 @@ describe('Groq request shaping', () => {
   });
 });
 
+describe('OpenAI request shaping', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    globalThis.fetch = mock(async (_url: string, init?: RequestInit) => {
+      return new Response(JSON.stringify({
+        id: 'cmpl_test',
+        object: 'chat.completion',
+        created: Date.now(),
+        model: 'gpt-5.4',
+        choices: [
+          {
+            index: 0,
+            message: { role: 'assistant', content: 'ok' },
+            finish_reason: 'stop',
+          },
+        ],
+        usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+      }), {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+          'x-test-body': typeof init?.body === 'string' ? init.body : '',
+        },
+      });
+    }) as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test('OpenAIProvider sends max_completion_tokens, not max_tokens', async () => {
+    const provider = new OpenAIProvider('test-key') as any;
+    const messages: LLMMessage[] = [
+      { role: 'user', content: 'hello' },
+    ];
+
+    await provider.chat(messages, { max_tokens: 321 });
+
+    const fetchMock = globalThis.fetch as unknown as ReturnType<typeof mock>;
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    const body = JSON.parse(String(init.body));
+
+    expect(body.max_completion_tokens).toBe(321);
+    expect(body.max_tokens).toBeUndefined();
+  });
+});
+
 describe('classifyHttpStatus', () => {
   test('401/403 → auth', () => {
     expect(classifyHttpStatus(401)).toBe('auth');


### PR DESCRIPTION
## Summary

The OpenAI provider was sending the legacy `max_tokens` parameter, which the GPT-5 series (the current default model `gpt-5.4`) and reasoning models (o1, o3) reject with a 400:

```
OpenAI API error (400): Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.
```

This made the onboarding LLM connectivity test fail out-of-the-box for any user keeping the default model.

## Root cause

`src/llm/openai.ts` serialized the `LLMOptions.max_tokens` field as `max_tokens` on the wire for both `chat()` and `stream()`. OpenAI's Chat Completions API now requires `max_completion_tokens` for GPT-5 / o1 / o3 series; `max_tokens` is being phased out.

## Change

- `src/llm/openai.ts` - serialize `max_tokens` option as `max_completion_tokens` in both the `chat()` and `stream()` request bodies. The internal `LLMOptions.max_tokens` field name is unchanged, so no callers need updating.
- `src/llm/provider.test.ts` - new `OpenAI request shaping` describe block asserting the body contains `max_completion_tokens` and not `max_tokens`.

## Compatibility

`max_completion_tokens` is supported by OpenAI Chat Completions across both newer (GPT-5, o1, o3) and legacy chat models (gpt-4o, gpt-4-turbo, gpt-4, gpt-3.5-turbo), so no per-model branching is needed. This provider only targets `/v1/chat/completions`, so the legacy `/v1/completions` endpoint is not affected.