### PR TITLE
Fix unhandled rejection on invalid Discord token

### DIFF
--- a/src/comms/channels/discord.ts
+++ b/src/comms/channels/discord.ts
@@ -60,6 +60,8 @@ export class DiscordAdapter implements ChannelAdapter {
         reject(err);
       });
     });
+    // Suppress unhandled-rejection if readyPromise rejects after connect() has already thrown.
+    readyPromise.catch(() => {});
 
     // Set up message handler
     this.client.on('messageCreate', async (message: Message) => {
@@ -72,14 +74,18 @@ export class DiscordAdapter implements ChannelAdapter {
 
     try {
       await this.client.login(this.token);
+      await readyPromise;
     } catch (err) {
-      // Clear the ready timeout to prevent unhandled rejection
       if (loginTimeout) clearTimeout(loginTimeout);
-      this.client.destroy();
+      try {
+        await this.client?.destroy();
+      } catch {
+        // ignore destroy errors during cleanup
+      }
       this.client = null;
+      this.connected = false;
       throw err;
     }
-    await readyPromise;
   }
 
   async disconnect(): Promise<void> {


### PR DESCRIPTION
## Summary

Fixes a process crash when the daemon is started with an invalid Discord bot token.

When `client.login()` rejected with `TokenInvalid`, the existing try/catch in `DiscordAdapter.connect()` correctly cleaned up and rethrew - but `readyPromise` (awaited *outside* the try/catch) was left dangling. The `client.once('error', ...)` listener then fired during `destroy()` and rejected `readyPromise` with no one listening, surfacing as a Bun unhandled-rejection crash:

```
error: An invalid token was provided.
  code: "TokenInvalid"
    at connect (.../discord.js/src/client/websocket/WebSocketManager.js:140:26)
    at login   (.../discord.js/src/client/Client.js:229:21)
    at connect (.../src/comms/channels/discord.ts:74:25)
```

## Changes

`src/comms/channels/discord.ts`:

- Move `await readyPromise` inside the same `try/catch` as `await this.client.login()`, so token errors from either path are handled together.
- Attach a no-op `readyPromise.catch(() => {})` at construction so any *late* rejection (e.g. the `once('error')` listener firing during cleanup, or the timeout firing after we've already given up) cannot escape as an unhandled rejection.
- `await this.client?.destroy()` (it's async in discord.js v14+) wrapped in its own try/catch, and reset `this.connected = false` on failure.

The error now propagates cleanly through `ChannelManager.connectAll`'s `Promise.allSettled` and is reported via `[ChannelManager] Failed to connect discord: ...`, allowing the daemon to keep running with the remaining channels.
