### PR TITLE
fix personality default mutation leaking across getPersonality calls

### DIFF
--- a/src/personality/model.ts
+++ b/src/personality/model.ts
@@ -55,14 +55,15 @@ export function loadPersonality(): PersonalityModel {
   const row = stmt.get('default') as PersonalityStateRow | null;
 
   if (!row) {
-    return DEFAULT_PERSONALITY;
+    // Clone so callers (e.g. recordInteraction) can't mutate the shared default.
+    return structuredClone(DEFAULT_PERSONALITY);
   }
 
   try {
     return JSON.parse(row.data) as PersonalityModel;
   } catch (error) {
     console.error('Failed to parse personality data:', error);
-    return DEFAULT_PERSONALITY;
+    return structuredClone(DEFAULT_PERSONALITY);
   }
 }
 

--- a/src/personality/personality.test.ts
+++ b/src/personality/personality.test.ts
@@ -37,6 +37,16 @@ describe('Personality Engine', () => {
       expect(personality.relationship.message_count).toBe(0);
     });
 
+    test('default personality is not shared across calls', () => {
+      const first = getPersonality();
+      first.relationship.message_count = 99;
+      first.core_traits.push('mutated');
+
+      const second = getPersonality();
+      expect(second.relationship.message_count).toBe(0);
+      expect(second.core_traits).toEqual(['direct', 'strategic', 'resourceful']);
+    });
+
     test('should save and load personality', () => {
       const personality = getPersonality();
       personality.learned_preferences.verbosity = 8;


### PR DESCRIPTION
## Summary

`loadPersonality()` returned the module-level `DEFAULT_PERSONALITY` constant by reference whenever the
`personality_state` table had no row. Callers like `recordInteraction` (and `applySignals`) shallow-copy the object but
mutate nested fields (`relationship.message_count`, etc.), which silently mutates the shared default in place. Once that
happens, every subsequent `getPersonality()` against an empty DB returns the corrupted default.

This is normally invisible at runtime (the daemon writes a real row early and reads it back), but it's a problem for
tests: `beforeEach` resets the SQLite DB but cannot reset a JS module constant. PR #112 surfaces it - its new
agent-service tests call `handleMessage` -> `recordInteraction` -> mutates the default, and the personality test suite
that runs afterwards then sees `message_count: 2` instead of `0`.

Fix: clone the default on the way out of `loadPersonality()` so the constant stays pristine. Added a regression test that
 mutates a returned default and asserts the next call returns clean values.