### PR TITLE
Fail sidecar RPCs immediately on send errors

### DIFF
--- a/src/sidecar/connection.ts
+++ b/src/sidecar/connection.ts
@@ -47,7 +47,8 @@ export class SidecarConnection {
     try {
       this.ws.send(JSON.stringify(request));
     } catch (err) {
-      console.error(`[SidecarConnection:${this.sidecarId}] Failed to send RPC:`, err);
+      const cause = err instanceof Error ? err.message : String(err);
+      throw new Error(`Failed to send RPC to sidecar ${this.sidecarId}: ${cause}`);
     }
   }
 

--- a/src/sidecar/manager.test.ts
+++ b/src/sidecar/manager.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import { buildEnrollmentUrls, isLocalhostBrainUrl } from './manager.ts';
+import { SidecarManager } from './manager.ts';
 
 describe('buildEnrollmentUrls', () => {
   test('parses https URL into wss/https pair', () => {
@@ -86,5 +87,24 @@ describe('isLocalhostBrainUrl', () => {
     ['notlocalhost.example.com', false],
   ])('isLocalhostBrainUrl(%p) === %p', (input, expected) => {
     expect(isLocalhostBrainUrl(input)).toBe(expected);
+  });
+});
+
+describe('dispatchRPC', () => {
+  test('rejects immediately when sending to the sidecar socket fails', async () => {
+    const manager = new SidecarManager('/tmp/jarvis-sidecar-manager-test');
+    const sendError = new Error('socket is closed');
+
+    (manager as any).sidecarConnections.set('sidecar-1', {
+      sendRPC() {
+        throw sendError;
+      },
+    });
+
+    await expect(
+      manager.dispatchRPC('sidecar-1', 'capture_screen'),
+    ).rejects.toThrow('socket is closed');
+
+    expect((manager as any).rpcTracker.size).toBe(0);
   });
 });

--- a/src/sidecar/manager.test.ts
+++ b/src/sidecar/manager.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { buildEnrollmentUrls, isLocalhostBrainUrl } from './manager.ts';
-import { SidecarManager } from './manager.ts';
+import { buildEnrollmentUrls, isLocalhostBrainUrl, SidecarManager } from './manager.ts';
 
 describe('buildEnrollmentUrls', () => {
   test('parses https URL into wss/https pair', () => {

--- a/src/sidecar/manager.ts
+++ b/src/sidecar/manager.ts
@@ -557,11 +557,17 @@ export class SidecarManager implements Service {
       params,
     };
 
-    // Send the request over WebSocket
-    connection.sendRPC(request);
+    // Track before sending so an immediate reply cannot beat registration.
+    const resultPromise = this.rpcTracker.dispatch(rpcId, sidecarId, method, timeouts);
 
-    // Track and await result
-    return this.rpcTracker.dispatch(rpcId, sidecarId, method, timeouts);
+    try {
+      connection.sendRPC(request);
+    } catch (err) {
+      const sendError = err instanceof Error ? err : new Error(String(err));
+      this.rpcTracker.fail(rpcId, sendError);
+    }
+
+    return resultPromise;
   }
 
   /** Register a listener for RPC progress events */


### PR DESCRIPTION
## Summary
- fail sidecar RPCs immediately when the WebSocket write throws instead of waiting for the RPC timeout path
- register RPC tracking before attempting the send so an immediate reply cannot beat tracker registration
- add a regression test covering the send-failure path in `dispatchRPC()`

## Testing
- bun test src/sidecar/manager.test.ts
- bun test
- bunx tsc --noEmit