### PR TITLE
Refresh GitHub repository documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ JARVIS is not a chatbot with tools. It is a persistent daemon that sees your scr
 | Voice with wake word | No | Yes — streaming TTS + openwakeword |
 | Goal pursuit (OKRs) | No | Yes — drill sergeant accountability |
 | Authority gating | No | Yes — runtime enforcement + audit trail |
-| LLM provider choice | Usually locked to one | 5 providers: Anthropic, OpenAI, Gemini, Ollama, Groq |
+| LLM provider choice | Usually locked to one | 7 built-in providers: Anthropic, OpenAI, Groq, Gemini, OpenRouter, Ollama, NVIDIA |
 
 ---
 
@@ -117,7 +117,7 @@ Visit [opencove.host](https://opencove.host) to get started.
 - **Bun** >= 1.0 (installed automatically if missing)
 - **OS (native daemon install)**: macOS, Linux, or WSL
 - **Windows**: use WSL2 for the Bun install, or Docker for the daemon
-- **LLM API key** — at least one of: Anthropic, OpenAI, Google Gemini, or a local Ollama instance
+- **LLM provider** — at least one of: Anthropic, OpenAI, Groq, Google Gemini, OpenRouter, NVIDIA, or a local Ollama instance
 - Google OAuth credentials (optional — Calendar and Gmail integration)
 - Telegram bot token (optional — notification channel)
 - Discord bot token (optional — notification channel)
@@ -223,6 +223,8 @@ The sidecar is what gives JARVIS physical reach beyond the machine it runs on. I
 
 This means you can run the daemon on an always-on server and still interact with your desktop machines as if JARVIS were running locally. Enroll as many sidecars as you want.
 
+> **Important:** If the daemon is not running on the same machine as the sidecar, set `daemon.brain_domain` (or `JARVIS_BRAIN_DOMAIN`) to the externally reachable hostname before enrolling. The enrollment token bakes that brain URL into the sidecar config, so enrolling against `localhost` only works for local sidecars.
+
 ### 1. Install the sidecar
 
 **Via bun:**
@@ -260,7 +262,7 @@ Once connected, the sidecar appears as online in the Settings page where you can
 
 ## 🧠 Core Capabilities
 
-**Conversations** — Multi-provider LLM routing (Anthropic Claude, OpenAI GPT, Google Gemini, Ollama). Streaming responses, personality engine, vault-injected memory context on every message.
+**Conversations** — Multi-provider LLM routing across Anthropic, OpenAI, Groq, Gemini, OpenRouter, Ollama, and NVIDIA. Streaming responses, personality engine, and vault-injected memory context on every message.
 
 **Tool Execution** — 14+ builtin tools with up to 200 iterations per turn. The agent loop runs until the task is complete, not until the response looks done.
 
@@ -315,13 +317,20 @@ daemon:
   port: 3142
   data_dir: "~/.jarvis"
   db_path: "~/.jarvis/jarvis.db"
+  brain_domain: "https://brain.example.com" # required for remote sidecars
 
 llm:
   primary: "anthropic"
-  fallback: ["openai", "gemini", "ollama"]
+  fallback: ["openai", "gemini", "openrouter", "ollama"]
   anthropic:
     api_key: "sk-ant-..."
     model: "claude-sonnet-4-6"
+  openrouter:
+    api_key: "sk-or-..."
+    model: "anthropic/claude-sonnet-4"
+  nvidia:
+    api_key: "nvapi-..."
+    model: "mistral-nemo-minitron-8b-base"
 
 personality:
   core_traits: ["loyal", "efficient", "proactive"]
@@ -333,7 +342,7 @@ authority:
 active_role: "personal-assistant"
 ```
 
-See [config.example.yaml](config.example.yaml) for the full reference including Google OAuth, Telegram, Discord, ElevenLabs, and voice settings.
+See [config.example.yaml](config.example.yaml) for the full reference including Google OAuth, Telegram, Discord, OpenRouter, NVIDIA, ElevenLabs, voice settings, and sidecar brain URL routing.
 
 ---
 

--- a/docs/LLM_PROVIDERS.md
+++ b/docs/LLM_PROVIDERS.md
@@ -17,7 +17,7 @@ Complete guide to the LLM provider abstraction layer for Project J.A.R.V.I.S.
 
 ## Overview
 
-The J.A.R.V.I.S. LLM provider system provides a unified abstraction layer for multiple Large Language Model providers, enabling seamless switching between Anthropic Claude, OpenAI GPT, and local Ollama models with automatic fallback support.
+The J.A.R.V.I.S. LLM provider system provides a unified abstraction layer for multiple Large Language Model providers, enabling seamless switching between Anthropic, OpenAI, Groq, Gemini, OpenRouter, Ollama, and NVIDIA models with automatic fallback support.
 
 ### Key Features
 
@@ -30,11 +30,15 @@ The J.A.R.V.I.S. LLM provider system provides a unified abstraction layer for mu
 
 ### Supported Providers
 
-| Provider | Models | Features | Cost |
-|----------|--------|----------|------|
-| **Anthropic** | Claude Opus 4.6, Sonnet 4.5 | Text, Streaming, Tools | Paid |
-| **OpenAI** | GPT-4o, GPT-4 Turbo | Text, Streaming, Functions | Paid |
-| **Ollama** | Llama 3, Mistral, etc. | Text, Streaming, Tools | Free |
+| Provider | Config key | Example default model | Notes |
+|----------|------------|-----------------------|-------|
+| **Anthropic** | `llm.anthropic` | `claude-sonnet-4-6` | Recommended default |
+| **OpenAI** | `llm.openai` | `gpt-5.4` | GPT family, tools, streaming |
+| **Groq** | `llm.groq` | `llama-3.3-70b-versatile` | Fast OpenAI-compatible inference |
+| **Gemini** | `llm.gemini` | `gemini-3-flash-preview` | Google models |
+| **OpenRouter** | `llm.openrouter` | `anthropic/claude-sonnet-4` | Broker for multi-vendor model access |
+| **Ollama** | `llm.ollama` | `llama3` | Local models via `base_url` |
+| **NVIDIA** | `llm.nvidia` | `mistral-nemo-minitron-8b-base` | Runtime/config supported; use YAML or env configuration |
 
 ## Quick Start
 
@@ -61,15 +65,15 @@ This will:
 ### 3. Use
 
 ```typescript
-import { loadConfig } from './src/config/index.ts';
-import { LLMManager, AnthropicProvider } from './src/llm/index.ts';
+import { loadConfig } from './src/config/loader.ts';
+import { LLMManager } from './src/llm/manager.ts';
+import { AnthropicProvider } from './src/llm/anthropic.ts';
 
 const config = await loadConfig();
 const manager = new LLMManager();
-
-manager.registerProvider(
-  new AnthropicProvider(config.llm.anthropic.api_key)
-);
+manager.registerProvider(new AnthropicProvider(config.llm.anthropic!.api_key));
+manager.setPrimary(config.llm.primary);
+manager.setFallbackChain(config.llm.fallback);
 
 const response = await manager.chat([
   { role: 'user', content: 'Hello!' }
@@ -98,15 +102,17 @@ console.log(response.content);
        │        │        │
        ▼        ▼        ▼
 ┌──────────┐ ┌─────────┐ ┌─────────┐
-│Anthropic │ │ OpenAI  │ │ Ollama  │
+│Anthropic │ │ OpenAI  │ │  Groq   │
 │Provider  │ │ Provider│ │ Provider│
 └────┬─────┘ └────┬────┘ └────┬────┘
      │            │            │
      ▼            ▼            ▼
 ┌─────────┐ ┌──────────┐ ┌──────────┐
-│Claude   │ │ OpenAI   │ │  Local   │
-│API      │ │ API      │ │  Models  │
+│Claude   │ │ OpenAI   │ │  Groq    │
+│API      │ │ API      │ │  API     │
 └─────────┘ └──────────┘ └──────────┘
+
+...plus Gemini, OpenRouter, NVIDIA, and local Ollama providers registered through the same `LLMManager`.
 ```
 
 ### Component Overview
@@ -120,6 +126,8 @@ console.log(response.content);
 **Configuration**: YAML-based config system with type-safe loading and defaults.
 
 ## Providers
+
+The runtime currently registers providers from `src/daemon/agent-service.ts` when the corresponding config block is populated. The dashboard settings flow covers the common hosted providers plus Ollama/OpenRouter; NVIDIA is also supported by the runtime and config loader.
 
 ### Anthropic (Claude)
 
@@ -214,25 +222,42 @@ Location: `~/.jarvis/config.yaml`
 
 ```yaml
 daemon:
-  port: 7777
+  port: 3142
   data_dir: "~/.jarvis"
   db_path: "~/.jarvis/jarvis.db"
+  brain_domain: "https://brain.example.com"
 
 llm:
   primary: "anthropic"
-  fallback: ["openai", "ollama"]
+  fallback: ["openai", "gemini", "openrouter", "ollama"]
 
   anthropic:
     api_key: "sk-ant-..."
-    model: "claude-sonnet-4-5-20250929"
+    model: "claude-sonnet-4-6"
 
   openai:
     api_key: "sk-..."
-    model: "gpt-4o"
+    model: "gpt-5.4"
+
+  groq:
+    api_key: "gsk_..."
+    model: "llama-3.3-70b-versatile"
+
+  gemini:
+    api_key: "AIza..."
+    model: "gemini-3-flash-preview"
+
+  openrouter:
+    api_key: "sk-or-..."
+    model: "anthropic/claude-sonnet-4"
 
   ollama:
     base_url: "http://localhost:11434"
     model: "llama3"
+
+  nvidia:
+    api_key: "nvapi-..."
+    model: "mistral-nemo-minitron-8b-base"
 
 personality:
   core_traits:
@@ -246,6 +271,20 @@ authority:
   default_level: 3
 
 active_role: "default"
+```
+
+### Environment Overrides
+
+The config loader also supports direct env overrides for common provider secrets and runtime routing:
+
+```bash
+JARVIS_API_KEY=...            # Anthropic
+JARVIS_OPENAI_KEY=...
+JARVIS_GROQ_KEY=...
+JARVIS_OPENROUTER_KEY=...
+NVIDIA_API_KEY=...
+JARVIS_OLLAMA_URL=http://localhost:11434
+JARVIS_BRAIN_DOMAIN=https://brain.example.com
 ```
 
 ### Loading Configuration

--- a/docs/LLM_PROVIDERS.md
+++ b/docs/LLM_PROVIDERS.md
@@ -71,9 +71,31 @@ import { AnthropicProvider } from './src/llm/anthropic.ts';
 
 const config = await loadConfig();
 const manager = new LLMManager();
-manager.registerProvider(new AnthropicProvider(config.llm.anthropic!.api_key));
-manager.setPrimary(config.llm.primary);
-manager.setFallbackChain(config.llm.fallback);
+const registeredProviders: string[] = [];
+
+if (config.llm.anthropic?.api_key) {
+  manager.registerProvider(
+    new AnthropicProvider(
+      config.llm.anthropic.api_key,
+      config.llm.anthropic.model
+    )
+  );
+  registeredProviders.push('anthropic');
+}
+
+if (registeredProviders.length === 0) {
+  throw new Error('No LLM providers are configured');
+}
+
+const primaryProvider = registeredProviders.includes(config.llm.primary)
+  ? config.llm.primary
+  : registeredProviders[0];
+const fallbackProviders = config.llm.fallback.filter((provider) =>
+  registeredProviders.includes(provider)
+);
+
+manager.setPrimary(primaryProvider);
+manager.setFallbackChain(fallbackProviders);
 
 const response = await manager.chat([
   { role: 'user', content: 'Hello!' }

--- a/sidecar/README.md
+++ b/sidecar/README.md
@@ -25,6 +25,26 @@ GOOS=windows go build -o jarvis-sidecar.exe .
 ./jarvis-sidecar
 ```
 
+The sidecar persists its token and local settings in:
+
+```text
+~/.jarvis-sidecar/config.yaml
+```
+
+For remote enrollments, make sure the brain generated the token with a routable `daemon.brain_domain` / `JARVIS_BRAIN_DOMAIN`. If the token points at `localhost`, only a sidecar on the same machine can connect.
+
+You can also override the brain URL per sidecar after enrollment by editing the saved config:
+
+```yaml
+token: "<jwt>"
+brain: "wss://brain.example.com/sidecar/connect"
+capabilities:
+  - terminal
+  - filesystem
+  - browser
+  - awareness
+```
+
 ## File Structure
 
 ### Core
@@ -32,7 +52,7 @@ GOOS=windows go build -o jarvis-sidecar.exe .
 | File | Purpose |
 |---|---|
 | `main.go` | Entry point, flag parsing, signal handling |
-| `config.go` | YAML config loading/saving (`~/.jarvis/sidecar.yaml`) |
+| `config.go` | YAML config loading/saving (`~/.jarvis-sidecar/config.yaml`) |
 | `types.go` | Shared types: capabilities, RPC messages, config structs |
 | `client.go` | WebSocket client, reconnect loop, preflight integration |
 | `handlers.go` | RPC handler registry (terminal, filesystem, clipboard, screenshot, config, system info) |


### PR DESCRIPTION
## Summary
- refresh the main README for the current LLM provider surface and remote sidecar enrollment requirements
- update the LLM provider guide to match the current config/runtime provider set and env overrides
- fix the sidecar README config path and document the saved sidecar config / brain URL override flow

## Testing
- bun test
- bunx tsc --noEmit