### PR TITLE
Fix Ollama provider showing as configured by default

### DIFF
--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -259,7 +259,7 @@ describe('Default Config', () => {
     expect(DEFAULT_CONFIG.llm.openai?.model).toBe('gpt-5.4');
     expect(DEFAULT_CONFIG.llm.gemini?.model).toBe('gemini-3-flash-preview');
     expect(DEFAULT_CONFIG.llm.ollama?.model).toBe('llama3');
-    expect(DEFAULT_CONFIG.llm.ollama?.base_url).toBe('http://localhost:11434');
+    expect(DEFAULT_CONFIG.llm.ollama?.base_url).toBe('');
   });
 });
 

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -287,7 +287,7 @@ export const DEFAULT_CONFIG: JarvisConfig = {
       model: 'gemini-3-flash-preview',
     },
     ollama: {
-      base_url: 'http://localhost:11434',
+      base_url: '',
       model: 'llama3',
     },
     openrouter: {

--- a/src/daemon/llm-settings.ts
+++ b/src/daemon/llm-settings.ts
@@ -5,7 +5,7 @@
  * API keys are stored in the encrypted secrets file via the keychain module.
  */
 
-import { getSetting, setSetting, getSettingsByPrefix } from '../vault/settings.ts';
+import { getSetting, setSetting, deleteSetting, getSettingsByPrefix } from '../vault/settings.ts';
 import { getSecret, setSecret, deleteSecret, hasSecret } from '../vault/keychain.ts';
 import type { JarvisConfig } from '../config/types.ts';
 import { AnthropicProvider } from '../llm/anthropic.ts';
@@ -177,19 +177,25 @@ export function saveLLMSettings(
     };
   }
 
-  // Ollama
+  // Ollama. An explicit empty base_url is a "disable / clear" signal: wipe the
+  // stored URL/model so the provider stops appearing as configured in the UI.
   if (body.ollama) {
-    if (body.ollama.model) {
-      setSetting(SETTING_OLLAMA_MODEL, body.ollama.model);
+    const url = body.ollama.base_url?.trim();
+    if (url) {
+      setSetting(SETTING_OLLAMA_BASE_URL, url);
+      if (body.ollama.model) {
+        setSetting(SETTING_OLLAMA_MODEL, body.ollama.model);
+      }
+      config.llm.ollama = {
+        ...config.llm.ollama,
+        model: body.ollama.model ?? config.llm.ollama?.model,
+        base_url: url,
+      };
+    } else if (body.ollama.base_url !== undefined) {
+      deleteSetting(SETTING_OLLAMA_BASE_URL);
+      deleteSetting(SETTING_OLLAMA_MODEL);
+      config.llm.ollama = undefined;
     }
-    if (body.ollama.base_url) {
-      setSetting(SETTING_OLLAMA_BASE_URL, body.ollama.base_url);
-    }
-    config.llm.ollama = {
-      ...config.llm.ollama,
-      model: body.ollama.model ?? config.llm.ollama?.model,
-      base_url: body.ollama.base_url ?? config.llm.ollama?.base_url,
-    };
   }
 
   // OpenRouter

--- a/ui/src/components/settings/LLMPanel.tsx
+++ b/ui/src/components/settings/LLMPanel.tsx
@@ -121,7 +121,7 @@ export function LLMPanel() {
   const [geminiCustomModel, setGeminiCustomModel] = useState("");
 
   // Ollama
-  const [ollamaBaseUrl, setOllamaBaseUrl] = useState("http://localhost:11434");
+  const [ollamaBaseUrl, setOllamaBaseUrl] = useState("");
   const [ollamaModel, setOllamaModel] = useState("llama3");
   const [ollamaCustomModel, setOllamaCustomModel] = useState("");
 
@@ -198,6 +198,8 @@ export function LLMPanel() {
         setOllamaModel("custom");
         setOllamaCustomModel(m);
       }
+    } else {
+      setOllamaBaseUrl("");
     }
     if (config.openrouter) {
       const m = config.openrouter.model;
@@ -250,7 +252,7 @@ export function LLMPanel() {
           ...(geminiKey ? { api_key: geminiKey } : {}),
         },
         ollama: {
-          base_url: ollamaBaseUrl,
+          base_url: ollamaBaseUrl.trim(),
           model: resolveModel(ollamaModel, ollamaCustomModel),
         },
         openrouter: {
@@ -658,13 +660,22 @@ function ProviderSection({
           {baseUrl !== undefined && onBaseUrlChange && (
             <div>
               <div style={fieldLabelStyle}>Base URL</div>
-              <input
-                type="text"
-                value={baseUrl}
-                onChange={(e) => onBaseUrlChange(e.target.value)}
-                placeholder="http://localhost:11434"
-                style={inputStyle}
-              />
+              <div style={{ display: "flex", gap: "6px" }}>
+                <input
+                  type="text"
+                  value={baseUrl}
+                  onChange={(e) => onBaseUrlChange(e.target.value)}
+                  placeholder="http://localhost:11434"
+                  style={{ ...inputStyle, flex: 1 }}
+                />
+                <button
+                  type="button"
+                  onClick={() => onBaseUrlChange("http://localhost:11434")}
+                  style={useDefaultBtnStyle}
+                >
+                  Default
+                </button>
+              </div>
             </div>
           )}
 
@@ -782,6 +793,17 @@ const selectStyle: React.CSSProperties = {
   color: "var(--j-text)",
   outline: "none",
   cursor: "pointer",
+};
+
+const useDefaultBtnStyle: React.CSSProperties = {
+  padding: "4px 12px",
+  fontSize: "11px",
+  background: "rgba(0, 212, 255, 0.1)",
+  border: "1px solid rgba(0, 212, 255, 0.3)",
+  borderRadius: "4px",
+  color: "var(--j-accent)",
+  cursor: "pointer",
+  whiteSpace: "nowrap",
 };
 
 const testBtnStyle: React.CSSProperties = {


### PR DESCRIPTION
## Summary

The Ollama provider was displaying as active (green dot) in the LLM settings page on fresh installs, even when the user had never configured an Ollama server.

The previous attempt (#177) added read-side guards but missed the actual root cause: the default `JarvisConfig.llm.ollama.base_url` was hardcoded to `http://localhost:11434`, so every "is configured" check that looked at `config.llm.ollama?.base_url` resolved to true regardless of whether the user had opted in.

## Changes

- `src/config/types.ts`: change the default `llm.ollama.base_url` to an empty string, matching how the other providers default empty `api_key`. This is the actual fix; everything else falls out of it.
- `src/daemon/llm-settings.ts`: an explicit empty `base_url` in a save payload now deletes the stored URL/model, letting users disable Ollama from the UI.
- `ui/src/components/settings/LLMPanel.tsx`:
  - `ollamaBaseUrl` form state starts empty and resets to empty when the API returns `ollama: null`.
  - Adds a "Default" button next to the Base URL input so users can fill in `http://localhost:11434` with one click without losing the hint as soon as they type.
- `src/config/loader.test.ts`: update default-config expectation.