### PR TITLE
fix telegram connect hanging daemon startup on unreachable api

### DIFF
--- a/src/comms/channels/telegram.ts
+++ b/src/comms/channels/telegram.ts
@@ -86,9 +86,12 @@ export class TelegramAdapter implements ChannelAdapter {
       return;
     }
 
-    // Verify bot token by calling getMe
+    // Verify bot token by calling getMe (with timeout so an unreachable
+    // api.telegram.org or hung connection doesn't block daemon startup)
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 10000);
     try {
-      const response = await fetch(`${this.baseUrl}/getMe`);
+      const response = await fetch(`${this.baseUrl}/getMe`, { signal: controller.signal });
       const data = await response.json() as any;
 
       if (!data.ok) {
@@ -97,9 +100,12 @@ export class TelegramAdapter implements ChannelAdapter {
 
       console.log('[TelegramAdapter] Connected as:', data.result.username);
     } catch (error) {
-      throw new Error(
-        `Failed to connect to Telegram: ${error instanceof Error ? error.message : 'Unknown error'}`
-      );
+      const msg = error instanceof Error
+        ? (error.name === 'AbortError' ? 'getMe request timed out after 10s' : error.message)
+        : 'Unknown error';
+      throw new Error(`Failed to connect to Telegram: ${msg}`);
+    } finally {
+      clearTimeout(timeout);
     }
 
     this.polling = true;


### PR DESCRIPTION
Summary

- Add a 10s AbortController timeout to TelegramAdapter.connect()'s getMe call so an invalid token or unreachable
api.telegram.org no longer hangs fetch() forever.
- Without the timeout, ChannelManager.connectAll() never settles, ChannelService.start() never returns, and
ServiceRegistry.startAll() blocks the rest of the daemon (web dashboard, etc.) from starting.