### PR TITLE
Exclude data dir from file-watcher to fix sidecar-manager startup deadlock

### DIFF
--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -304,7 +304,7 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
     agentService.setResearchQueue(researchQueue);
     const observerService = config.noLocalTools
       ? null
-      : new ObserverService(reactor, coalescer, googleAuth ?? undefined);
+      : new ObserverService(reactor, coalescer, googleAuth ?? undefined, config.dataDir);
     const wsService = new WebSocketService(config.port, agentService);
 
     // 5b. Create channel service for external comms (Telegram, Discord)

--- a/src/daemon/observer-service.ts
+++ b/src/daemon/observer-service.ts
@@ -68,12 +68,19 @@ export class ObserverService implements Service {
   private reactor: EventReactor | null;
   private coalescer: EventCoalescer | null;
   private googleAuth: GoogleAuth | null;
+  private dataDir: string;
 
-  constructor(reactor?: EventReactor, coalescer?: EventCoalescer, googleAuth?: GoogleAuth) {
+  constructor(
+    reactor?: EventReactor,
+    coalescer?: EventCoalescer,
+    googleAuth?: GoogleAuth,
+    dataDir?: string,
+  ) {
     this.manager = new ObserverManager();
     this.reactor = reactor ?? null;
     this.coalescer = coalescer ?? null;
     this.googleAuth = googleAuth ?? null;
+    this.dataDir = dataDir ?? `${homedir()}/.jarvis`;
   }
 
   async start(): Promise<void> {
@@ -81,7 +88,7 @@ export class ObserverService implements Service {
 
     try {
       // Register core observers
-      this.manager.register(new FileWatcher([homedir()]));
+      this.manager.register(new FileWatcher([homedir()], [this.dataDir]));
       this.manager.register(new ClipboardMonitor());
       this.manager.register(new ProcessMonitor());
 

--- a/src/observers/file-watcher.ts
+++ b/src/observers/file-watcher.ts
@@ -6,6 +6,7 @@
  */
 
 import { watch, type FSWatcher } from 'node:fs';
+import { resolve, sep } from 'node:path';
 import type { Observer, ObserverEvent, ObserverEventHandler } from './index';
 
 type DebounceEntry = {
@@ -17,13 +18,15 @@ export class FileWatcher implements Observer {
   name = 'file-watcher';
   private watchers: FSWatcher[] = [];
   private paths: string[];
+  private excludedPrefixes: string[];
   private handler: ObserverEventHandler | null = null;
   private running = false;
   private recentChanges: Map<string, number> = new Map();
   private debounceMs = 100; // Ignore duplicate events within 100ms
 
-  constructor(paths: string[]) {
+  constructor(paths: string[], excludePaths: string[] = []) {
     this.paths = paths;
+    this.excludedPrefixes = excludePaths.map((p) => resolve(p) + sep);
   }
 
   async start(): Promise<void> {
@@ -88,6 +91,18 @@ export class FileWatcher implements Observer {
     }
 
     const fullPath = `${basePath}/${filename}`;
+
+    // Drop events from excluded subtrees (e.g. the daemon's own data dir).
+    // Watching ~/.jarvis recursively while the daemon writes to it creates an
+    // inotify -> SQLite -> inotify loop that can starve Bun's microtask queue
+    // and deadlock async file I/O on the brain side. See issue #128.
+    const resolvedPath = resolve(fullPath) + sep;
+    for (const prefix of this.excludedPrefixes) {
+      if (resolvedPath.startsWith(prefix)) {
+        return;
+      }
+    }
+
     const now = Date.now();
 
     // Debounce: skip if same file changed within debounceMs


### PR DESCRIPTION
## Summary

  Fixes #128. The daemon was hanging at `[ServiceRegistry] Starting sidecar-manager...` and never reaching the point
  where the web dashboard becomes available.

  ## Root cause

  `ObserverService` registers a `FileWatcher` over `homedir()` recursively, and the watcher's event handler does a
  synchronous SQLite write (`createObservation`) inline on the inotify callback. Because `homedir()` contains
  `~/.jarvis` (the daemon's own data dir), every read/write the daemon does against its own keys, DB, WAL, etc. fires
  inotify events that synchronously trigger more DB writes -- which themselves fire more inotify events.

  In Bun, those native I/O callbacks take priority over Promise microtasks, so the `await
  Bun.file(privateKeyPath).text()` in `SidecarManager.loadKeys()` never resolves. Deadlock.

  ## Fix

  Exclude the configured data dir from the file-watcher's event stream:

  - `FileWatcher` now takes an optional `excludePaths: string[]`. Each is normalized via `path.resolve()` and stored
  with a trailing `sep`, so prefix matching is unambiguous (`/foo/.jarvis/` will not match `/foo/.jarvisOther/x`).
  - `handleFileEvent` drops events whose resolved path falls inside any excluded prefix, before the debounce bookkeeping
   or the vault write.
  - The exclusion is checked at event-time rather than at watch-registration time because Node's `recursive: true` mode
  walks the tree and registers a watch per subdir; you can't tell `fs.watch` to skip a subtree, only to ignore its
  events.
  - `ObserverService` accepts a `dataDir` and passes it as the exclusion list to `FileWatcher`.
  - `daemon/index.ts` threads `config.dataDir` (which already respects `--data-dir` and `daemon.data_dir` in YAML) into
  `ObserverService`, so users with a relocated data dir get the correct exclusion automatically.

  The daemon's awareness layer continues to observe the rest of `homedir()` -- only the daemon's own internal directory
  is filtered out.

  ## Why not the simpler fix?

  The original report suggested swapping `Bun.file().text()` for `readFileSync` in `loadKeys()`. That would have
  unblocked startup, but it only papers over `loadKeys()`; any future async file op against `~/.jarvis` (config reads,
  sidecar artifacts, log rotation) could re-introduce the same starvation. Excluding the data dir from the watcher
  eliminates the entire class.