### PR TITLE
Harden local secret storage and site preview isolation

### DIFF
--- a/sidecar/config.go
+++ b/sidecar/config.go
@@ -94,14 +94,20 @@ func LoadConfig() (*SidecarConfig, error) {
 }
 
 func SaveConfig(cfg *SidecarConfig) error {
-	if err := os.MkdirAll(configDir, 0755); err != nil {
+	if err := os.MkdirAll(configDir, 0700); err != nil {
+		return err
+	}
+	if err := os.Chmod(configDir, 0700); err != nil {
 		return err
 	}
 	data, err := yaml.Marshal(cfg)
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(configFile, data, 0644)
+	if err := os.WriteFile(configFile, data, 0600); err != nil {
+		return err
+	}
+	return os.Chmod(configFile, 0600)
 }
 
 func DecodeJWTPayload(token string) (*SidecarTokenClaims, error) {

--- a/sidecar/config_test.go
+++ b/sidecar/config_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSaveConfigRestrictsPermissions(t *testing.T) {
+	originalConfigDir := configDir
+	originalConfigFile := configFile
+	t.Cleanup(func() {
+		configDir = originalConfigDir
+		configFile = originalConfigFile
+	})
+
+	configDir = filepath.Join(t.TempDir(), ".jarvis-sidecar")
+	configFile = filepath.Join(configDir, "config.yaml")
+
+	cfg := defaultConfig()
+	cfg.Token = "secret-token"
+
+	if err := SaveConfig(&cfg); err != nil {
+		t.Fatalf("SaveConfig() error = %v", err)
+	}
+
+	dirInfo, err := os.Stat(configDir)
+	if err != nil {
+		t.Fatalf("stat config dir: %v", err)
+	}
+	if got := dirInfo.Mode().Perm(); got != 0700 {
+		t.Fatalf("config dir mode = %o, want 0700", got)
+	}
+
+	fileInfo, err := os.Stat(configFile)
+	if err != nil {
+		t.Fatalf("stat config file: %v", err)
+	}
+	if got := fileInfo.Mode().Perm(); got != 0600 {
+		t.Fatalf("config file mode = %o, want 0600", got)
+	}
+}

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -1,18 +1,20 @@
 import { test, expect, describe, beforeEach, afterEach } from 'bun:test';
 import { loadConfig, saveConfig } from './loader.ts';
 import { DEFAULT_CONFIG } from './types.ts';
-import { existsSync } from 'node:fs';
-import { unlink } from 'node:fs/promises';
-import { join, isAbsolute } from 'node:path';
+import { existsSync, statSync } from 'node:fs';
+import { mkdir, rm } from 'node:fs/promises';
+import { dirname, join, isAbsolute } from 'node:path';
 
-const TEST_CONFIG_PATH = '/tmp/jarvis-test-config.yaml';
+const TEST_CONFIG_DIR = '/tmp/jarvis-test-config';
+const TEST_CONFIG_PATH = join(TEST_CONFIG_DIR, 'config.yaml');
 
 describe('Config Loader', () => {
+  beforeEach(async () => {
+    await mkdir(TEST_CONFIG_DIR, { recursive: true });
+  });
+
   afterEach(async () => {
-    // Clean up test config file
-    if (existsSync(TEST_CONFIG_PATH)) {
-      await unlink(TEST_CONFIG_PATH);
-    }
+    await rm(TEST_CONFIG_DIR, { recursive: true, force: true });
   });
 
   test('returns default config when file does not exist', async () => {
@@ -38,6 +40,13 @@ describe('Config Loader', () => {
     const loaded = await loadConfig(TEST_CONFIG_PATH);
     expect(loaded.daemon.port).toBe(9999);
     expect(loaded.llm.primary).toBe('openai');
+  });
+
+  test('saves config with owner-only permissions', async () => {
+    await saveConfig(DEFAULT_CONFIG, TEST_CONFIG_PATH);
+
+    expect(statSync(dirname(TEST_CONFIG_PATH)).mode & 0o777).toBe(0o700);
+    expect(statSync(TEST_CONFIG_PATH).mode & 0o777).toBe(0o600);
   });
 
   test('deep merges partial config with defaults', async () => {
@@ -264,10 +273,12 @@ describe('Default Config', () => {
 });
 
 describe('Config Parse Errors', () => {
+  beforeEach(async () => {
+    await mkdir(TEST_CONFIG_DIR, { recursive: true });
+  });
+
   afterEach(async () => {
-    if (existsSync(TEST_CONFIG_PATH)) {
-      await unlink(TEST_CONFIG_PATH);
-    }
+    await rm(TEST_CONFIG_DIR, { recursive: true, force: true });
   });
 
   test('throws on malformed YAML when file exists', async () => {
@@ -306,11 +317,13 @@ daemon:
 });
 
 describe('Voice Config', () => {
+  beforeEach(async () => {
+    await mkdir(TEST_CONFIG_DIR, { recursive: true });
+  });
+
   afterEach(async () => {
     delete process.env.JARVIS_WAKE_ENGINE;
-    if (existsSync(TEST_CONFIG_PATH)) {
-      await unlink(TEST_CONFIG_PATH);
-    }
+    await rm(TEST_CONFIG_DIR, { recursive: true, force: true });
   });
 
   test('defaults wake_engine to openwakeword (privacy-preserving local path)', async () => {

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1,6 +1,7 @@
 import YAML from 'yaml';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { homedir } from 'node:os';
+import { chmod, mkdir, writeFile } from 'node:fs/promises';
 import type { JarvisConfig } from './types.ts';
 import { DEFAULT_CONFIG } from './types.ts';
 
@@ -170,7 +171,11 @@ export async function saveConfig(
       defaultKeyType: 'PLAIN',
     });
 
-    await Bun.write(path, yaml);
+    const configDir = dirname(path);
+    await mkdir(configDir, { recursive: true, mode: 0o700 });
+    await chmod(configDir, 0o700);
+    await writeFile(path, yaml, { mode: 0o600 });
+    await chmod(path, 0o600);
     console.log(`Config saved to ${path}`);
   } catch (err) {
     throw new Error(`Failed to save config to ${path}: ${err}`);

--- a/src/integrations/google-auth.test.ts
+++ b/src/integrations/google-auth.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from 'bun:test';
+import { existsSync, statSync } from 'node:fs';
+import { mkdtemp } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { GoogleAuth } from './google-auth.ts';
+
+describe('GoogleAuth token storage', () => {
+  test('saves OAuth tokens with owner-only permissions', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'jarvis-google-auth-'));
+    const tokensPath = join(dir, 'google-tokens.json');
+    const auth = new GoogleAuth('client-id', 'client-secret', { tokensPath });
+
+    await auth.saveTokens({
+      access_token: 'access-token',
+      refresh_token: 'refresh-token',
+      expiry_date: Date.now() + 60_000,
+      token_type: 'Bearer',
+    });
+
+    expect(existsSync(tokensPath)).toBe(true);
+    expect(statSync(dir).mode & 0o777).toBe(0o700);
+    expect(statSync(tokensPath).mode & 0o777).toBe(0o600);
+  });
+});

--- a/src/integrations/google-auth.ts
+++ b/src/integrations/google-auth.ts
@@ -9,6 +9,7 @@
 import path from 'node:path';
 import os from 'node:os';
 import { readFileSync, existsSync } from 'node:fs';
+import { chmod, mkdir, writeFile } from 'node:fs/promises';
 
 const TOKEN_ENDPOINT = 'https://oauth2.googleapis.com/token';
 const AUTH_ENDPOINT = 'https://accounts.google.com/o/oauth2/v2/auth';
@@ -62,7 +63,11 @@ export class GoogleAuth {
    */
   async saveTokens(tokens: GoogleTokens): Promise<void> {
     this.tokens = tokens;
-    await Bun.write(this.tokensPath, JSON.stringify(tokens, null, 2));
+    const tokensDir = path.dirname(this.tokensPath);
+    await mkdir(tokensDir, { recursive: true, mode: 0o700 });
+    await chmod(tokensDir, 0o700);
+    await writeFile(this.tokensPath, JSON.stringify(tokens, null, 2), { mode: 0o600 });
+    await chmod(this.tokensPath, 0o600);
   }
 
   /**

--- a/src/sidecar/manager.test.ts
+++ b/src/sidecar/manager.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from 'bun:test';
-import { buildEnrollmentUrls, isLocalhostBrainUrl } from './manager.ts';
+import { mkdtemp } from 'node:fs/promises';
+import { statSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { buildEnrollmentUrls, isLocalhostBrainUrl, SidecarManager } from './manager.ts';
 
 describe('buildEnrollmentUrls', () => {
   test('parses https URL into wss/https pair', () => {
@@ -86,5 +90,23 @@ describe('isLocalhostBrainUrl', () => {
     ['notlocalhost.example.com', false],
   ])('isLocalhostBrainUrl(%p) === %p', (input, expected) => {
     expect(isLocalhostBrainUrl(input)).toBe(expected);
+  });
+});
+
+describe('SidecarManager key storage', () => {
+  test('stores the enrollment private key with owner-only permissions', async () => {
+    const dataDir = await mkdtemp(join(tmpdir(), 'jarvis-sidecar-manager-'));
+    const manager = new SidecarManager(dataDir);
+
+    await manager.start();
+    await manager.stop();
+
+    const keyDir = join(dataDir, 'sidecar-keys');
+    const privateKeyPath = join(keyDir, 'private.pem');
+    const publicKeyPath = join(keyDir, 'public.pem');
+
+    expect(statSync(keyDir).mode & 0o777).toBe(0o700);
+    expect(statSync(privateKeyPath).mode & 0o777).toBe(0o600);
+    expect(statSync(publicKeyPath).mode & 0o777).toBe(0o644);
   });
 });

--- a/src/sidecar/manager.ts
+++ b/src/sidecar/manager.ts
@@ -6,7 +6,8 @@
  */
 
 import { generateKeyPair, exportJWK, exportPKCS8, exportSPKI, importPKCS8, importSPKI, SignJWT, jwtVerify, createRemoteJWKSet, type JWK } from 'jose';
-import { existsSync, mkdirSync } from 'node:fs';
+import { chmodSync, existsSync, mkdirSync } from 'node:fs';
+import { writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import type { ServerWebSocket } from 'bun';
 import type { Service, ServiceStatus } from '../daemon/services.ts';
@@ -227,6 +228,7 @@ export class SidecarManager implements Service {
   private async loadOrGenerateKeys(): Promise<void> {
     if (existsSync(this.privateKeyPath) && existsSync(this.publicKeyPath)) {
       await this.loadKeys();
+      this.secureKeyFilePermissions();
       console.log('[SidecarManager] Loaded existing ES256 key pair');
     } else {
       await this.generateKeys();
@@ -239,7 +241,8 @@ export class SidecarManager implements Service {
   }
 
   private async generateKeys(): Promise<void> {
-    mkdirSync(this.keysDir, { recursive: true });
+    mkdirSync(this.keysDir, { recursive: true, mode: 0o700 });
+    chmodSync(this.keysDir, 0o700);
 
     const { privateKey, publicKey } = await generateKeyPair(ALG, { extractable: true });
     this.privateKey = privateKey;
@@ -249,8 +252,9 @@ export class SidecarManager implements Service {
     const pkcs8 = await exportPKCS8(privateKey);
     const spki = await exportSPKI(publicKey);
 
-    await Bun.write(this.privateKeyPath, pkcs8);
-    await Bun.write(this.publicKeyPath, spki);
+    await writeFile(this.privateKeyPath, pkcs8, { mode: 0o600 });
+    await writeFile(this.publicKeyPath, spki, { mode: 0o644 });
+    this.secureKeyFilePermissions();
   }
 
   private async loadKeys(): Promise<void> {
@@ -259,6 +263,12 @@ export class SidecarManager implements Service {
 
     this.privateKey = await importPKCS8(privatePem, ALG, { extractable: true });
     this.publicKey = await importSPKI(publicPem, ALG, { extractable: true });
+  }
+
+  private secureKeyFilePermissions(): void {
+    try { chmodSync(this.keysDir, 0o700); } catch {}
+    try { chmodSync(this.privateKeyPath, 0o600); } catch {}
+    try { chmodSync(this.publicKeyPath, 0o644); } catch {}
   }
 
   // --------------- JWKS ---------------

--- a/src/sites/project-manager.test.ts
+++ b/src/sites/project-manager.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from 'bun:test';
+import { mkdtemp, mkdir } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { ProjectManager } from './project-manager.ts';
+
+function makeManager(projectsDir: string): ProjectManager {
+  return new ProjectManager({
+    enabled: true,
+    projects_dir: projectsDir,
+    port_range_start: 3000,
+    port_range_end: 3999,
+    auto_commit: false,
+    max_concurrent_servers: 1,
+  });
+}
+
+describe('ProjectManager path containment', () => {
+  test('blocks sibling directory traversal with a shared prefix', async () => {
+    const projectsDir = await mkdtemp(join(tmpdir(), 'jarvis-sites-'));
+    await mkdir(join(projectsDir, 'app'), { recursive: true });
+    await mkdir(join(projectsDir, 'app-backup'), { recursive: true });
+    const manager = makeManager(projectsDir);
+
+    await expect(manager.writeFile('app', '../app-backup/pwned.txt', 'owned'))
+      .rejects.toThrow('Path traversal attempt blocked');
+    expect(existsSync(join(projectsDir, 'app-backup', 'pwned.txt'))).toBe(false);
+  });
+});

--- a/src/sites/project-manager.ts
+++ b/src/sites/project-manager.ts
@@ -7,7 +7,7 @@
 import type { Project, ProjectMeta, FileEntry, SiteBuilderConfig } from './types.ts';
 import { GitManager } from './git-manager.ts';
 import { TEMPLATES, generateMakefile, scaffoldBunReact } from './templates.ts';
-import { join, relative, resolve } from 'node:path';
+import { isAbsolute, join, relative, resolve } from 'node:path';
 import { homedir } from 'node:os';
 import { readdirSync, statSync, existsSync, mkdirSync, rmSync } from 'node:fs';
 
@@ -309,17 +309,22 @@ export class ProjectManager {
     const projectPath = join(this.projectsDir, id);
     // Prevent path traversal
     const resolved = resolve(projectPath);
-    if (!resolved.startsWith(resolve(this.projectsDir))) return null;
+    if (!this.isWithin(resolved, resolve(this.projectsDir))) return null;
     if (!existsSync(resolved)) return null;
     return resolved;
   }
 
   private safeJoin(projectPath: string, relativePath: string): string {
     const resolved = resolve(join(projectPath, relativePath));
-    if (!resolved.startsWith(resolve(projectPath))) {
+    if (!this.isWithin(resolved, resolve(projectPath))) {
       throw new Error('Path traversal attempt blocked');
     }
     return resolved;
+  }
+
+  private isWithin(resolvedPath: string, basePath: string): boolean {
+    const rel = relative(basePath, resolvedPath);
+    return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel));
   }
 
   private sanitizeId(name: string): string {

--- a/src/sites/proxy.ts
+++ b/src/sites/proxy.ts
@@ -7,9 +7,9 @@
  *  1. Explicit:  /api/sites/:id/proxy/*  → sets __proj cookie, proxies to dev server
  *  2. Catch-all: any unmatched path      → reads __proj cookie, proxies to dev server
  *
- * Because the iframe uses allow-same-origin, absolute paths emitted by
- * frameworks (e.g. /src/main.tsx) naturally hit the main server. The
- * catch-all picks them up via the cookie — zero URL rewriting needed.
+ * Absolute paths emitted by frameworks (e.g. /src/main.tsx) naturally hit the
+ * main server. The catch-all picks them up via the project cookie — zero URL
+ * rewriting needed.
  */
 
 import type { DevServerManager } from './dev-server-manager.ts';

--- a/ui/src/components/sites/SitePreview.tsx
+++ b/ui/src/components/sites/SitePreview.tsx
@@ -46,9 +46,10 @@ export function SitePreview({ project }: Props) {
   // which hit the main server's catch-all and get routed via the cookie.
   const previewUrl = `/api/sites/${project.id}/proxy/`;
 
-  // allow-same-origin is required so that cookies, ES modules, and
-  // framework features (HMR WebSockets, fetch) work correctly.
-  const sandboxValue = "allow-scripts allow-forms allow-same-origin allow-popups";
+  // Keep generated/project code in an opaque sandbox origin. Forms and popups
+  // are useful preview capabilities; allow-same-origin is intentionally omitted
+  // because project JS is proxied from the daemon origin.
+  const sandboxValue = "allow-scripts allow-forms allow-popups";
 
   return (
     <div style={{ position: "relative", width: "100%", height: "100%", background: "#fff" }}>


### PR DESCRIPTION
## Summary
- keep generated site previews in an opaque iframe origin by removing allow-same-origin while preserving form and popup preview behavior
- tighten site builder path containment so sibling directories with shared prefixes cannot be reached
- write local config, Google OAuth tokens, sidecar enrollment private keys, and sidecar config with restrictive file and directory permissions

## Security notes
- Prevents previewed/generated project JavaScript from sharing the Jarvis daemon origin and issuing authenticated same-origin API requests.
- Prevents path containment bypasses such as ../app-backup when the project directory is app.
- Reduces local credential exposure for API keys, OAuth tokens, sidecar JWTs, and enrollment signing keys on multi-user systems.

## Tests
- .githooks/pre-commit
- bun test
- go test ./... (from sidecar/)
- git diff --check