### PR TITLE
Allow custom Ollama model name in onboarding LLM selection

### DIFF
--- a/ui/src/v2/onboarding/SetupRoom.tsx
+++ b/ui/src/v2/onboarding/SetupRoom.tsx
@@ -311,9 +311,10 @@ export function SetupRoom({ onComplete }: { onComplete: () => void }) {
               <select
                 id="setup-model"
                 className="v2-setup__select"
-                value={model}
+                value={provider.models.includes(model) ? model : "custom"}
                 onChange={(e) => {
-                  setModel(e.target.value);
+                  const v = e.target.value;
+                  setModel(v === "custom" ? "" : v);
                   setTestResult(null);
                 }}
               >
@@ -322,7 +323,21 @@ export function SetupRoom({ onComplete }: { onComplete: () => void }) {
                     {m}
                   </option>
                 ))}
+                <option value="custom">Custom…</option>
               </select>
+              {!provider.models.includes(model) && (
+                <input
+                  className="v2-setup__input"
+                  value={model}
+                  onChange={(e) => {
+                    setModel(e.target.value);
+                    setTestResult(null);
+                  }}
+                  placeholder="model id (e.g. your local Ollama model name)"
+                  autoComplete="off"
+                  style={{ marginTop: "var(--s-2)" }}
+                />
+              )}
             </div>
 
             <div className="v2-setup__test-row">


### PR DESCRIPTION
The onboarding LLM step rendered a fixed dropdown of models per provider, with no way to enter a custom name. This broke Ollama in particular, where users typically pull models under their own tags (e.g. mymodel:latest) that don't appear in the hardcoded list.

Mirrors the pattern already used in Settings -> LLM: the model dropdown gains a Custom... option, and selecting it reveals a text input for an arbitrary model id. The settings page already handled this correctly, so no changes there.