### PR TITLE
Fix composer hidden when restart-required banner is shown

### DIFF
--- a/ui/src/v2/onboarding/OnboardingGate.tsx
+++ b/ui/src/v2/onboarding/OnboardingGate.tsx
@@ -73,8 +73,10 @@ export function OnboardingGate({ children }: { children: React.ReactNode }) {
   if (!status.tutorial_completed && !status.tutorial_dismissed) {
     return (
       <TutorialEventProvider>
-        <RestartRequiredBanner status={status} />
-        {children}
+        <div className="v2-shell-frame">
+          <RestartRequiredBanner status={status} />
+          {children}
+        </div>
         <TutorialRoom
           resumeFromStepId={status.tutorial_progress_step}
           onComplete={() => refresh()}
@@ -97,9 +99,9 @@ export function OnboardingGate({ children }: { children: React.ReactNode }) {
   }
 
   return (
-    <>
+    <div className="v2-shell-frame">
       <RestartRequiredBanner status={status} />
       {children}
-    </>
+    </div>
   );
 }

--- a/ui/src/v2/v2.css
+++ b/ui/src/v2/v2.css
@@ -22,6 +22,17 @@
   box-sizing: border-box;
 }
 
+/* When a top banner (e.g. restart-required) sits above the shell, share the
+   100vh root between banner and shell instead of stacking 100vh on top of
+   the banner — otherwise the composer is pushed below the viewport. */
+.v2-shell-frame {
+  display: grid;
+  grid-template-rows: auto 1fr;
+  height: 100%;
+  min-height: 0;
+  overflow: hidden;
+}
+
 /* Phase 7 Pass B — visually-hidden utility for screen-reader-only
    announcements (voice state changes, room transitions). Standard
    recipe: takes itself out of the visual tree without `display: none`


### PR DESCRIPTION
## Summary
  Fix a layout bug where the chat composer gets pushed below the viewport when the "Restart Jarvis" banner is shown on top
  of the main page.

  ## Root cause
  `.jarvis-v2-root` is `height: 100vh; overflow: hidden` and `.v2-shell` (AppShell) uses `height: 100%`. When
  `RestartRequiredBanner` was inserted as a sibling above the shell, the shell still claimed the full 100vh, so the
  banner's height pushed the composer past the bottom of the screen and into the clipped overflow region.

  ## Fix
  Wrap the banner + shell children in a new `.v2-shell-frame` container that uses a 2-row grid (`auto 1fr`). The banner
  gets its natural height and the shell fills only the remaining track, so the composer stays visible. Applied in both
  branches of `OnboardingGate` (tutorial overlay path and the live shell path). `TutorialRoom` stays outside the frame
  since it is `position: fixed`.