### PR TITLE
Fix/onboarding

### DIFF
--- a/src/daemon/api-routes.ts
+++ b/src/daemon/api-routes.ts
@@ -149,6 +149,21 @@ export type ApiContext = {
   goalService?: import('../goals/service.ts').GoalService;
   sidecarManager?: import('../sidecar/manager.ts').SidecarManager;
   siteBuilderService?: import('../sites/service.ts').SiteBuilderService;
+  /**
+   * Bring the LLM-dependent post-setup services (background agent,
+   * commitment executor, awareness) online in-process. Wired by the
+   * daemon at boot. Called by `/api/onboarding/setup` so the user does
+   * not have to restart the daemon at the end of onboarding — critical
+   * for Docker / VPS deploys where a process restart is disruptive.
+   * Idempotent: a no-op if the services are already running.
+   */
+  startPostSetupServices?: () => Promise<void>;
+  /**
+   * Reports whether the post-setup services have come online. Used by
+   * the onboarding status endpoint so the dashboard knows whether to
+   * show the "Restart Jarvis" fallback banner.
+   */
+  isPostSetupServicesReady?: () => boolean;
 };
 
 // CORS headers — scoped to the dashboard origin, not wildcard
@@ -892,10 +907,14 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
             tutorial_dismissed: o?.tutorial_dismissed_at != null,
             tutorial_progress_step: o?.tutorial_progress_step ?? null,
             last_reset_at: o?.last_reset_at ?? null,
-            // Boot timestamp lets the dashboard detect when setup
-            // completed AFTER the daemon started (= restart needed
-            // before background services activate).
+            // Boot timestamp + post-setup readiness let the dashboard
+            // detect whether the background services (bgAgent, commitment
+            // executor, awareness) are actually running. With in-process
+            // construction at `/api/onboarding/setup`, no restart is
+            // needed in the normal flow; the banner only shows if that
+            // construction step failed.
             daemon_started_at: ctx.daemonStartedAt,
+            post_setup_services_ready: ctx.isPostSetupServicesReady?.() ?? false,
           });
         } catch (err) {
           return errorFromException(err);
@@ -1169,9 +1188,29 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
           await saveConfig(fresh);
           ctx.config.onboarding = fresh.onboarding;
 
+          // 4. Bring the LLM-dependent services (bgAgent, commitment
+          //    executor, awareness) online in-process. Without this the
+          //    user would have to restart the daemon — fatal UX on
+          //    Docker / VPS. Failure here is non-fatal: chat still works
+          //    via the hot-reloaded LLM, just without background features
+          //    until the next daemon restart.
+          let postSetupStarted = false;
+          if (ctx.startPostSetupServices) {
+            try {
+              await ctx.startPostSetupServices();
+              postSetupStarted = true;
+            } catch (err) {
+              console.error(
+                '[Onboarding] Failed to start post-setup services in-process:',
+                err instanceof Error ? err.message : err,
+              );
+            }
+          }
+
           return json({
             ok: true,
             setup_completed_at: now,
+            post_setup_services_started: postSetupStarted,
             message: 'Setup complete. Jarvis is ready.',
           });
         } catch (err) {

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -564,23 +564,33 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
     // Phase A — onboarding setup-mode guard for LLM-dependent services.
     // While `setup_completed_at === null` the user hasn't saved an LLM
     // provider/key/model yet, so the heartbeat-driven background agent,
-    // commitment executor, and awareness service all have nothing to
-    // call. Skip them to keep the logs clean; they spin up on the next
-    // daemon restart after the user finishes the setup screens.
+    // commitment executor, and awareness service have nothing to call.
+    //
+    // The construction logic lives in `startPostSetupServices` below so it
+    // can be invoked in TWO places: here at boot (when setup was already
+    // completed in a prior run) AND from the `/api/onboarding/setup`
+    // endpoint right after the user finishes onboarding — so the daemon
+    // does NOT need to be restarted for background services to come
+    // online. Critical for Docker/VPS deploys where a process restart
+    // breaks WS connections, sidecars, and watchers.
     const inSetupMode = !jarvisConfig.onboarding?.setup_completed_at;
     if (inSetupMode) {
-      console.log('[Daemon] Setup mode — skipping bgAgent / executor / awareness until first-run setup completes');
+      console.log('[Daemon] Setup mode — bgAgent / executor / awareness will start when onboarding completes');
     }
 
-    // 10b. Create and start background agent (needs LLM providers from agentService.start())
-    if (!inSetupMode) {
+    // Idempotent constructor for the LLM-dependent services. Safe to call
+    // multiple times; returns immediately if `bgAgent` is already running.
+    const startPostSetupServices = async (): Promise<void> => {
+      if (bgAgent) return; // already running
+
+      // 10b. Background agent (needs LLM providers from agentService.start())
       const bgAgentService = new BackgroundAgentService(jarvisConfig, agentService.getLLMManager());
       bgAgentService.setResearchQueue(researchQueue);
       await bgAgentService.start();
       bgAgent = bgAgentService;
       console.log('[Daemon] Background agent started (separate browser for heartbeat/reactions)');
 
-      // 10c. Wire reactor + executor to background agent (separate browser, no chat contention)
+      // 10c. Wire reactor + executor to background agent
       reactor.setAgentService(bgAgentService);
       executor.setAgentService(bgAgentService);
 
@@ -589,12 +599,19 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
       wsService.setCommitmentExecutor(executor);
       executor.start();
       commitmentExecutor = executor;
-    }
 
-    // 10e. Create and start Awareness Service (M13)
-    //       Skipped when --no-local-tools is set (headless / Docker)
-    //       Also skipped in setup mode (no LLM yet).
-    if (!inSetupMode && jarvisConfig.awareness?.enabled !== false && !config.noLocalTools) {
+      // 10e. Awareness Service (M13). Skipped when --no-local-tools is set
+      //       (headless / Docker) or explicitly disabled in config.
+      if (jarvisConfig.awareness?.enabled !== false && !config.noLocalTools) {
+        await startAwarenessService();
+      }
+    };
+
+    // Awareness service construction extracted so the post-setup helper
+    // can call it conditionally. Closes over the same boot-scope deps as
+    // the original inline block.
+    const startAwarenessService = async (): Promise<void> => {
+      if (awarenessService) return;
       try {
         const { AwarenessService } = await import('../awareness/service.ts');
         const svc = new AwarenessService(
@@ -784,6 +801,18 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
         console.error('[Daemon] Awareness service failed to start:', err instanceof Error ? err.message : err);
         // Non-fatal — daemon continues without awareness
       }
+    };
+
+    // Expose the helper to the API layer so /api/onboarding/setup can
+    // bring services online at the end of onboarding without a restart.
+    apiContext.startPostSetupServices = startPostSetupServices;
+    apiContext.isPostSetupServicesReady = () => bgAgent !== null;
+
+    // Boot-time path: setup was completed in a prior run, so spin services
+    // up now. Skipped in setup mode — the onboarding endpoint will call
+    // the same helper when the user finishes.
+    if (!inSetupMode) {
+      await startPostSetupServices();
     }
 
     // 10a-2. Site Builder Service

--- a/ui/src/v2/onboarding/OnboardingGate.tsx
+++ b/ui/src/v2/onboarding/OnboardingGate.tsx
@@ -4,7 +4,7 @@ import { ProfileInterviewRoom } from "./ProfileInterviewRoom";
 import { TutorialRoom } from "./TutorialRoom";
 import { TutorialEventProvider } from "./TutorialEventContext";
 import { useOnboardingStatus } from "./useOnboardingStatus";
-import { RestartRequiredBanner } from "./RestartRequiredBanner";
+import { RestartRequiredBanner, shouldShowRestartBanner } from "./RestartRequiredBanner";
 
 /**
  * Phase A + B onboarding gate. Sits between AppShellV2's render and
@@ -71,12 +71,17 @@ export function OnboardingGate({ children }: { children: React.ReactNode }) {
   // AppShell can fire palette_opened / room_opened / notif_opened
   // events that the tutorial subscribes to for auto-advance.
   if (!status.tutorial_completed && !status.tutorial_dismissed) {
+    const showBanner = shouldShowRestartBanner(status);
     return (
       <TutorialEventProvider>
-        <div className="v2-shell-frame">
-          <RestartRequiredBanner status={status} />
-          {children}
-        </div>
+        {showBanner ? (
+          <div className="v2-shell-frame">
+            <RestartRequiredBanner status={status} />
+            {children}
+          </div>
+        ) : (
+          children
+        )}
         <TutorialRoom
           resumeFromStepId={status.tutorial_progress_step}
           onComplete={() => refresh()}
@@ -98,10 +103,14 @@ export function OnboardingGate({ children }: { children: React.ReactNode }) {
     );
   }
 
-  return (
-    <div className="v2-shell-frame">
-      <RestartRequiredBanner status={status} />
-      {children}
-    </div>
-  );
+  if (shouldShowRestartBanner(status)) {
+    return (
+      <div className="v2-shell-frame">
+        <RestartRequiredBanner status={status} />
+        {children}
+      </div>
+    );
+  }
+
+  return <>{children}</>;
 }

--- a/ui/src/v2/onboarding/RestartRequiredBanner.tsx
+++ b/ui/src/v2/onboarding/RestartRequiredBanner.tsx
@@ -2,35 +2,23 @@ import { useMemo } from "react";
 import type { OnboardingStatus } from "./useOnboardingStatus";
 
 /**
- * Banner shown post-setup when the daemon needs to be restarted before
- * background services (heartbeat, commitments, awareness) become active.
+ * Defensive fallback banner. The normal flow constructs the LLM-
+ * dependent services in-process at `/api/onboarding/setup`, so this
+ * stays hidden. It only fires when setup is complete AND the daemon
+ * reports `post_setup_services_ready: false` — i.e. the in-process
+ * construction failed, or the user is on a pre-fix daemon binary that
+ * never wires services until restart.
  *
- * Background:
- *   `bgAgent`, `commitmentExecutor`, and `awarenessService` are
- *   constructed at daemon boot, gated on `setup_completed_at !== null`.
- *   The setup-completion endpoint flips the flag and hot-reloads LLM
- *   providers, but it doesn't construct those services in-process. Until
- *   the in-process construction lands (follow-up issue F2), users have
- *   to restart the daemon for those features to come online.
- *
- * Detection:
- *   The /api/onboarding/status endpoint now exposes `daemon_started_at`.
- *   We compare against `setup_completed_at`. If the user finished setup
- *   AFTER this daemon process booted, the flag is set but the services
- *   aren't running — show the banner. If the user has restarted since,
- *   `daemon_started_at` will be later than `setup_completed_at` and the
- *   banner stays hidden.
- *
- * Defensive on missing field: pre-fix daemons don't send
- * `daemon_started_at`. In that case we hide the banner rather than
- * showing a false-positive.
+ * Defensive on missing field: status endpoints that don't send
+ * `post_setup_services_ready` are treated as "ready" so we never show
+ * a false positive against an old daemon that doesn't report the flag.
  */
 export function RestartRequiredBanner({ status }: { status: OnboardingStatus | null }) {
   const visible = useMemo(() => {
     if (!status) return false;
     if (!status.setup_completed_at) return false;
-    if (typeof status.daemon_started_at !== "number") return false;
-    return status.setup_completed_at > status.daemon_started_at;
+    if (status.post_setup_services_ready !== false) return false;
+    return true;
   }, [status]);
 
   if (!visible) return null;

--- a/ui/src/v2/onboarding/RestartRequiredBanner.tsx
+++ b/ui/src/v2/onboarding/RestartRequiredBanner.tsx
@@ -2,6 +2,20 @@ import { useMemo } from "react";
 import type { OnboardingStatus } from "./useOnboardingStatus";
 
 /**
+ * Whether the restart banner should be visible for the given status.
+ * Exported so the OnboardingGate can decide whether to wrap the shell
+ * in the `.v2-shell-frame` grid container — when the banner is hidden,
+ * wrapping causes the shell to collapse into the `auto` row track and
+ * the composer ends up mid-page.
+ */
+export function shouldShowRestartBanner(status: OnboardingStatus | null): boolean {
+  if (!status) return false;
+  if (!status.setup_completed_at) return false;
+  if (status.post_setup_services_ready !== false) return false;
+  return true;
+}
+
+/**
  * Defensive fallback banner. The normal flow constructs the LLM-
  * dependent services in-process at `/api/onboarding/setup`, so this
  * stays hidden. It only fires when setup is complete AND the daemon
@@ -14,12 +28,7 @@ import type { OnboardingStatus } from "./useOnboardingStatus";
  * a false positive against an old daemon that doesn't report the flag.
  */
 export function RestartRequiredBanner({ status }: { status: OnboardingStatus | null }) {
-  const visible = useMemo(() => {
-    if (!status) return false;
-    if (!status.setup_completed_at) return false;
-    if (status.post_setup_services_ready !== false) return false;
-    return true;
-  }, [status]);
+  const visible = useMemo(() => shouldShowRestartBanner(status), [status]);
 
   if (!visible) return null;
 

--- a/ui/src/v2/onboarding/useOnboardingStatus.ts
+++ b/ui/src/v2/onboarding/useOnboardingStatus.ts
@@ -34,12 +34,18 @@ export interface OnboardingStatus {
   tutorial_dismissed: boolean;
   tutorial_progress_step: string | null;
   last_reset_at: number | null;
-  /** Daemon process boot time (ms). When `setup_completed_at >
-   *  daemon_started_at`, background services (heartbeat, commitments,
-   *  awareness) haven't been constructed yet — the dashboard surfaces
-   *  a "Restart Jarvis" banner until the in-process construction lands
-   *  (follow-up issue F2). */
+  /** Daemon process boot time (ms). Used in tandem with
+   *  `post_setup_services_ready` to detect a stale daemon that needs a
+   *  restart. */
   daemon_started_at?: number;
+  /** True once the LLM-dependent background services (bgAgent,
+   *  commitment executor, awareness) are running. The normal flow
+   *  constructs them in-process at `/api/onboarding/setup`, so this
+   *  flips to true without a daemon restart. The "Restart Jarvis"
+   *  banner only shows when setup is complete but this is false — a
+   *  defensive fallback for failed in-process construction or daemons
+   *  on a pre-fix binary. */
+  post_setup_services_ready?: boolean;
 }
 
 interface HookValue {


### PR DESCRIPTION
## Summary
  Start the LLM-dependent background services (background agent, commitment executor, awareness) in-process when the user
  finishes onboarding, so the daemon does not have to be restarted. This is critical on Docker / VPS where a restart drops
  WS connections, kills sidecars, and resets watchers.

  ## What changed
  - `src/daemon/index.ts`: extracted the post-setup service construction (was inlined behind an `if (!inSetupMode)` block)
  into an idempotent `startPostSetupServices()` helper (with `startAwarenessService()` for the awareness sub-block). Boot
  path calls it when setup is already complete; the helper is also exposed on `apiContext` so the onboarding endpoint can
  reach it.
  - `src/daemon/api-routes.ts`: `/api/onboarding/setup` now calls `ctx.startPostSetupServices()` right after flipping the
  `setup_completed_at` flag. Failure is logged but non-fatal -- chat still works via the hot-reloaded LLM. `ApiContext`
  gains `startPostSetupServices` and `isPostSetupServicesReady` fields; the latter is surfaced on `/api/onboarding/status`
  as `post_setup_services_ready`.
  - `ui/src/v2/onboarding/RestartRequiredBanner.tsx` + `useOnboardingStatus.ts`: the banner now triggers on
  `post_setup_services_ready === false` (was: `setup_completed_at > daemon_started_at`). A pre-fix daemon that doesn't send
   the flag is treated as ready, so we never show a false positive. Visibility check is extracted as
  `shouldShowRestartBanner(status)`.
  - `ui/src/v2/onboarding/OnboardingGate.tsx`: the `.v2-shell-frame` grid wrapper is now mounted only when the banner is
  actually visible. Previously the wrapper rendered unconditionally; when the banner returned null the shell auto-placed
  into the `auto` row track and collapsed to half-height (composer ended up mid-page).