### PR TITLE
Fix NVIDIA onboarding and fetch its model catalog live

### DIFF
--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -88,7 +88,7 @@ function applyEnvOverrides(config: JarvisConfig): void {
   }
 
   if (env.NVIDIA_API_KEY) {
-    if (!config.llm.nvidia) config.llm.nvidia = { api_key: '', model: 'mistral-nemo-minitron-8b-base' };
+    if (!config.llm.nvidia) config.llm.nvidia = { api_key: '', model: 'meta/llama-3.3-70b-instruct' };
     config.llm.nvidia.api_key = env.NVIDIA_API_KEY;
   }
 

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -321,7 +321,7 @@ export const DEFAULT_CONFIG: JarvisConfig = {
     },
     nvidia: {
       api_key: '',
-      model: 'mistral-nemo-minitron-8b-base',
+      model: 'meta/llama-3.3-70b-instruct',
     },
   },
   personality: {

--- a/src/daemon/api-routes.ts
+++ b/src/daemon/api-routes.ts
@@ -1313,6 +1313,27 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
       },
     },
 
+    // Live model catalog for NVIDIA. NVIDIA's `/v1/models` is publicly
+    // readable, so this works during onboarding before any key is stored.
+    // We pass the user's key through when available so the call still
+    // authenticates if NVIDIA ever requires it. Mixes chat / embedding /
+    // vision models — the UI shows them all and relies on the connection
+    // test to weed out anything that can't speak /v1/chat/completions.
+    '/api/config/llm/nvidia/models': {
+      GET: async () => {
+        try {
+          const { NVIDIAProvider } = await import('../llm/nvidia.ts');
+          const key = ctx.config.llm.nvidia?.api_key ?? '';
+          const provider = new NVIDIAProvider(key);
+          const models = await provider.listModels();
+          return json({ ok: true, models });
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          return json({ ok: false, error: msg, models: [] });
+        }
+      },
+    },
+
     // --- Roles ---
     '/api/roles': {
       GET: () => {

--- a/src/daemon/llm-settings.ts
+++ b/src/daemon/llm-settings.ts
@@ -14,6 +14,7 @@ import { GroqProvider } from '../llm/groq.ts';
 import { GeminiProvider } from '../llm/gemini.ts';
 import { OllamaProvider } from '../llm/ollama.ts';
 import { OpenRouterProvider } from '../llm/openrouter.ts';
+import { NVIDIAProvider } from '../llm/nvidia.ts';
 import type { LLMProvider } from '../llm/provider.ts';
 import type { LLMManager } from '../llm/manager.ts';
 
@@ -23,6 +24,7 @@ const KEY_OPENAI = 'llm.openai.api_key';
 const KEY_GROQ = 'llm.groq.api_key';
 const KEY_GEMINI = 'llm.gemini.api_key';
 const KEY_OPENROUTER = 'llm.openrouter.api_key';
+const KEY_NVIDIA = 'llm.nvidia.api_key';
 
 // DB setting keys
 const SETTING_PRIMARY = 'llm.primary';
@@ -34,6 +36,7 @@ const SETTING_GEMINI_MODEL = 'llm.gemini.model';
 const SETTING_OLLAMA_MODEL = 'llm.ollama.model';
 const SETTING_OLLAMA_BASE_URL = 'llm.ollama.base_url';
 const SETTING_OPENROUTER_MODEL = 'llm.openrouter.model';
+const SETTING_NVIDIA_MODEL = 'llm.nvidia.model';
 
 export type LLMSettingsResponse = {
   primary: string;
@@ -44,6 +47,7 @@ export type LLMSettingsResponse = {
   gemini: { model: string; has_api_key: boolean } | null;
   ollama: { base_url: string; model: string } | null;
   openrouter: { model: string; has_api_key: boolean } | null;
+  nvidia: { model: string; has_api_key: boolean } | null;
 };
 
 /**
@@ -60,12 +64,14 @@ export function getLLMSettings(config: JarvisConfig): LLMSettingsResponse {
   const groqModel = getSetting(SETTING_GROQ_MODEL) ?? config.llm.groq?.model ?? 'llama-3.3-70b-versatile';
   const geminiModel = getSetting(SETTING_GEMINI_MODEL) ?? config.llm.gemini?.model ?? 'gemini-3-flash-preview';
   const openrouterModel = getSetting(SETTING_OPENROUTER_MODEL) ?? config.llm.openrouter?.model ?? 'anthropic/claude-sonnet-4';
+  const nvidiaModel = getSetting(SETTING_NVIDIA_MODEL) ?? config.llm.nvidia?.model ?? 'meta/llama-3.3-70b-instruct';
 
   const hasAnthropicKey = hasSecret(KEY_ANTHROPIC) || !!config.llm.anthropic?.api_key;
   const hasOpenaiKey = hasSecret(KEY_OPENAI) || !!config.llm.openai?.api_key;
   const hasGroqKey = hasSecret(KEY_GROQ) || !!config.llm.groq?.api_key;
   const hasGeminiKey = hasSecret(KEY_GEMINI) || !!config.llm.gemini?.api_key;
   const hasOpenrouterKey = hasSecret(KEY_OPENROUTER) || !!config.llm.openrouter?.api_key;
+  const hasNvidiaKey = hasSecret(KEY_NVIDIA) || !!config.llm.nvidia?.api_key;
 
   // Ollama is "configured" only when the user has explicitly set a base_url
   // (DB or env/yaml). Defaults alone shouldn't make it appear active in the UI.
@@ -88,6 +94,7 @@ export function getLLMSettings(config: JarvisConfig): LLMSettingsResponse {
     gemini: { model: geminiModel, has_api_key: hasGeminiKey },
     ollama,
     openrouter: { model: openrouterModel, has_api_key: hasOpenrouterKey },
+    nvidia: { model: nvidiaModel, has_api_key: hasNvidiaKey },
   };
 }
 
@@ -105,6 +112,7 @@ export function saveLLMSettings(
     gemini?: { api_key?: string; model?: string };
     ollama?: { base_url?: string; model?: string };
     openrouter?: { api_key?: string; model?: string };
+    nvidia?: { api_key?: string; model?: string };
   },
 ): void {
   // Save non-secret settings to DB
@@ -212,6 +220,21 @@ export function saveLLMSettings(
       api_key: body.openrouter.api_key ?? getOpenRouterApiKey(config) ?? '',
     };
   }
+
+  // NVIDIA
+  if (body.nvidia) {
+    if (body.nvidia.model) {
+      setSetting(SETTING_NVIDIA_MODEL, body.nvidia.model);
+    }
+    if (body.nvidia.api_key) {
+      setSecret(KEY_NVIDIA, body.nvidia.api_key);
+    }
+    config.llm.nvidia = {
+      ...config.llm.nvidia,
+      model: body.nvidia.model ?? config.llm.nvidia?.model,
+      api_key: body.nvidia.api_key ?? getNvidiaApiKey(config) ?? '',
+    };
+  }
 }
 
 /**
@@ -247,6 +270,13 @@ function getGeminiApiKey(config: JarvisConfig): string | null {
  */
 function getOpenRouterApiKey(config: JarvisConfig): string | null {
   return getSecret(KEY_OPENROUTER) ?? config.llm.openrouter?.api_key ?? null;
+}
+
+/**
+ * Resolve the NVIDIA API key: keychain > config.yaml > env var.
+ */
+function getNvidiaApiKey(config: JarvisConfig): string | null {
+  return getSecret(KEY_NVIDIA) ?? config.llm.nvidia?.api_key ?? null;
 }
 
 /**
@@ -338,6 +368,19 @@ export function mergeLLMSettingsIntoConfig(config: JarvisConfig): void {
       model: dbOpenrouterModel ?? config.llm.openrouter?.model,
     };
   }
+
+  // NVIDIA
+  const dbNvidiaModel = getSetting(SETTING_NVIDIA_MODEL);
+  const keychainNvidiaKey = getSecret(KEY_NVIDIA);
+  if (dbNvidiaModel || keychainNvidiaKey) {
+    config.llm.nvidia = {
+      ...config.llm.nvidia,
+      api_key: (!process.env.NVIDIA_API_KEY && keychainNvidiaKey)
+        ? keychainNvidiaKey
+        : (config.llm.nvidia?.api_key ?? ''),
+      model: dbNvidiaModel ?? config.llm.nvidia?.model,
+    };
+  }
 }
 
 /**
@@ -367,6 +410,10 @@ export function hotReloadLLMProviders(config: JarvisConfig, llmManager: LLMManag
   if (llm.openrouter?.api_key) {
     providers.push(new OpenRouterProvider(llm.openrouter.api_key, llm.openrouter.model));
     console.log('[LLM] Hot-reloaded OpenRouter provider');
+  }
+  if (llm.nvidia?.api_key) {
+    providers.push(new NVIDIAProvider(llm.nvidia.api_key, llm.nvidia.model));
+    console.log('[LLM] Hot-reloaded NVIDIA provider');
   }
   if (llm.ollama?.base_url) {
     providers.push(new OllamaProvider(llm.ollama.base_url, llm.ollama.model));
@@ -414,6 +461,10 @@ export async function testLLMProvider(
       const key = opts.api_key || getSecret(KEY_OPENROUTER) || config.llm.openrouter?.api_key;
       if (!key) return { ok: false, error: 'API key required' };
       instance = new OpenRouterProvider(key, opts.model ?? config.llm.openrouter?.model);
+    } else if (opts.provider === 'nvidia') {
+      const key = opts.api_key || getSecret(KEY_NVIDIA) || config.llm.nvidia?.api_key;
+      if (!key) return { ok: false, error: 'API key required' };
+      instance = new NVIDIAProvider(key, opts.model ?? config.llm.nvidia?.model);
     } else if (opts.provider === 'ollama') {
       instance = new OllamaProvider(
         opts.base_url ?? config.llm.ollama?.base_url,

--- a/src/llm/nvidia.ts
+++ b/src/llm/nvidia.ts
@@ -86,7 +86,7 @@ export class NVIDIAProvider implements LLMProvider {
   private defaultModel: string;
   private apiUrl = 'https://integrate.api.nvidia.com/v1/chat/completions';
 
-  constructor(apiKey: string, defaultModel = 'mistral-nemo-minitron-8b-base') {
+  constructor(apiKey: string, defaultModel = 'meta/llama-3.3-70b-instruct') {
     this.apiKey = apiKey;
     this.defaultModel = defaultModel;
   }
@@ -272,11 +272,19 @@ export class NVIDIAProvider implements LLMProvider {
   }
 
   async listModels(): Promise<string[]> {
-    return [
-      'mistral-nemo-minitron-8b-base',
-      'usdcode',
-      'gemma-2-2b-it',
-    ];
+    const url = 'https://integrate.api.nvidia.com/v1/models';
+    const resp = await fetch(url, {
+      headers: this.apiKey ? { Authorization: `Bearer ${this.apiKey}` } : {},
+    });
+    if (!resp.ok) {
+      throw new Error(`NVIDIA models API error (${resp.status})`);
+    }
+    const data = await resp.json() as { data?: Array<{ id?: string }> };
+    const ids = (data.data ?? [])
+      .map(m => m.id)
+      .filter((id): id is string => typeof id === 'string' && id.length > 0);
+    // The catalog occasionally returns duplicate ids; de-dupe and sort.
+    return [...new Set(ids)].sort();
   }
 
   private convertMessages(messages: LLMMessage[]): OpenAIMessage[] {

--- a/src/llm/provider.test.ts
+++ b/src/llm/provider.test.ts
@@ -292,7 +292,7 @@ describe('Default Models', () => {
 
   test('NVIDIAProvider has correct default model', () => {
     const provider = new NVIDIAProvider('test-key') as any;
-    expect(provider.defaultModel).toBe('mistral-nemo-minitron-8b-base');
+    expect(provider.defaultModel).toBe('meta/llama-3.3-70b-instruct');
   });
 
   test('can override default models', () => {

--- a/ui/src/v2/onboarding/SetupRoom.tsx
+++ b/ui/src/v2/onboarding/SetupRoom.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { ArrowRight, Check, Loader2, Volume2, VolumeX, type LucideIcon } from "lucide-react";
 import { Button, Icon } from "../ui";
 import "./SetupRoom.css";
@@ -86,11 +86,14 @@ const PROVIDERS: ReadonlyArray<{
     defaultModel: "anthropic/claude-sonnet-4",
   },
   {
+    // NVIDIA's catalog rotates often, so the live list from
+    // GET /api/config/llm/nvidia/models replaces this fallback once it
+    // arrives. These entries are only the offline safety net.
     id: "nvidia",
     label: "NVIDIA NIM",
     needsKey: true,
-    models: ["mistral-nemo-minitron-8b-base", "gemma-2-2b-it"],
-    defaultModel: "mistral-nemo-minitron-8b-base",
+    models: ["meta/llama-3.3-70b-instruct", "meta/llama-3.1-8b-instruct", "google/gemma-2-2b-it"],
+    defaultModel: "meta/llama-3.3-70b-instruct",
   },
 ];
 
@@ -120,6 +123,52 @@ export function SetupRoom({ onComplete }: { onComplete: () => void }) {
     | { ok: false; error: string }
     | null
   >(null);
+
+  // NVIDIA's catalog rotates, so we fetch live IDs. Falls back to the
+  // hardcoded `provider.models` if the call fails (offline, daemon down).
+  // The list mixes chat / embedding / vision models — there's no type
+  // field to filter on, so the connection test is the final guard.
+  const [nvidiaModels, setNvidiaModels] = useState<string[] | null>(null);
+  const [nvidiaFilter, setNvidiaFilter] = useState("");
+  const [nvidiaLoading, setNvidiaLoading] = useState(false);
+  useEffect(() => {
+    if (providerId !== "nvidia" || nvidiaModels !== null) return;
+    let cancelled = false;
+    setNvidiaLoading(true);
+    fetch("/api/config/llm/nvidia/models")
+      .then((r) => r.json())
+      .then((d: { ok: boolean; models?: string[] }) => {
+        if (cancelled) return;
+        if (d.ok && d.models && d.models.length > 0) {
+          setNvidiaModels(d.models);
+        } else {
+          setNvidiaModels([]);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setNvidiaModels([]);
+      })
+      .finally(() => {
+        if (!cancelled) setNvidiaLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [providerId, nvidiaModels]);
+
+  // When the NVIDIA list arrives and the user is still on the default
+  // fallback model, snap to the first live id so the test button works
+  // even if NVIDIA has dropped our hardcoded default from the catalog.
+  useEffect(() => {
+    if (providerId !== "nvidia") return;
+    if (!nvidiaModels || nvidiaModels.length === 0) return;
+    if (!nvidiaModels.includes(model)) {
+      const preferred =
+        nvidiaModels.find((m) => m === "meta/llama-3.3-70b-instruct") ??
+        nvidiaModels[0]!;
+      setModel(preferred);
+    }
+  }, [nvidiaModels, providerId]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // ── TTS screen state ───────────────────────────────────────────────
   const [ttsChoice, setTtsChoice] = useState<TTSChoice>("edge");
@@ -304,41 +353,122 @@ export function SetupRoom({ onComplete }: { onComplete: () => void }) {
               </div>
             )}
 
-            <div className="v2-setup__field">
-              <label className="v2-setup__label" htmlFor="setup-model">
-                Model
-              </label>
-              <select
-                id="setup-model"
-                className="v2-setup__select"
-                value={provider.models.includes(model) ? model : "custom"}
-                onChange={(e) => {
-                  const v = e.target.value;
-                  setModel(v === "custom" ? "" : v);
-                  setTestResult(null);
-                }}
-              >
-                {provider.models.map((m) => (
-                  <option key={m} value={m}>
-                    {m}
-                  </option>
-                ))}
-                <option value="custom">Custom…</option>
-              </select>
-              {!provider.models.includes(model) && (
-                <input
-                  className="v2-setup__input"
-                  value={model}
+            {providerId === "nvidia" ? (
+              (() => {
+                const liveModels = nvidiaModels && nvidiaModels.length > 0
+                  ? nvidiaModels
+                  : provider.models;
+                const filter = nvidiaFilter.trim().toLowerCase();
+                const filtered = filter
+                  ? liveModels.filter((m) => m.toLowerCase().includes(filter))
+                  : liveModels;
+                const selectValue = filtered.includes(model)
+                  ? model
+                  : liveModels.includes(model)
+                    ? "__hidden_by_filter"
+                    : "custom";
+                return (
+                  <div className="v2-setup__field">
+                    <label className="v2-setup__label" htmlFor="setup-model">
+                      Model
+                    </label>
+                    <input
+                      className="v2-setup__input"
+                      value={nvidiaFilter}
+                      onChange={(e) => setNvidiaFilter(e.target.value)}
+                      placeholder={
+                        nvidiaLoading
+                          ? "Loading model catalog…"
+                          : `Filter ${liveModels.length} models (e.g. llama, mistral, gemma)`
+                      }
+                      autoComplete="off"
+                      style={{ marginBottom: "var(--s-2)" }}
+                    />
+                    <select
+                      id="setup-model"
+                      className="v2-setup__select"
+                      value={selectValue}
+                      onChange={(e) => {
+                        const v = e.target.value;
+                        if (v === "__hidden_by_filter") return;
+                        setModel(v === "custom" ? "" : v);
+                        setTestResult(null);
+                      }}
+                    >
+                      {selectValue === "__hidden_by_filter" && (
+                        <option value="__hidden_by_filter" disabled>
+                          {model} (hidden by filter)
+                        </option>
+                      )}
+                      {filtered.map((m) => (
+                        <option key={m} value={m}>
+                          {m}
+                        </option>
+                      ))}
+                      {filtered.length === 0 && (
+                        <option value="" disabled>
+                          No models match "{nvidiaFilter}"
+                        </option>
+                      )}
+                      <option value="custom">Custom…</option>
+                    </select>
+                    {selectValue === "custom" && (
+                      <input
+                        className="v2-setup__input"
+                        value={model}
+                        onChange={(e) => {
+                          setModel(e.target.value);
+                          setTestResult(null);
+                        }}
+                        placeholder="model id (e.g. meta/llama-3.3-70b-instruct)"
+                        autoComplete="off"
+                        style={{ marginTop: "var(--s-2)" }}
+                      />
+                    )}
+                    <p className="v2-setup__hint">
+                      The catalog includes chat, embedding and vision models.
+                      Test connection confirms the model speaks chat.
+                    </p>
+                  </div>
+                );
+              })()
+            ) : (
+              <div className="v2-setup__field">
+                <label className="v2-setup__label" htmlFor="setup-model">
+                  Model
+                </label>
+                <select
+                  id="setup-model"
+                  className="v2-setup__select"
+                  value={provider.models.includes(model) ? model : "custom"}
                   onChange={(e) => {
-                    setModel(e.target.value);
+                    const v = e.target.value;
+                    setModel(v === "custom" ? "" : v);
                     setTestResult(null);
                   }}
-                  placeholder="model id (e.g. your local Ollama model name)"
-                  autoComplete="off"
-                  style={{ marginTop: "var(--s-2)" }}
-                />
-              )}
-            </div>
+                >
+                  {provider.models.map((m) => (
+                    <option key={m} value={m}>
+                      {m}
+                    </option>
+                  ))}
+                  <option value="custom">Custom…</option>
+                </select>
+                {!provider.models.includes(model) && (
+                  <input
+                    className="v2-setup__input"
+                    value={model}
+                    onChange={(e) => {
+                      setModel(e.target.value);
+                      setTestResult(null);
+                    }}
+                    placeholder="model id (e.g. your local Ollama model name)"
+                    autoComplete="off"
+                    style={{ marginTop: "var(--s-2)" }}
+                  />
+                )}
+              </div>
+            )}
 
             <div className="v2-setup__test-row">
               <Button

--- a/ui/src/v2/rooms/settings/tabs/LLMTab.tsx
+++ b/ui/src/v2/rooms/settings/tabs/LLMTab.tsx
@@ -65,7 +65,9 @@ const MODELS: Record<LLMProvider, string[]> = {
     "meta-llama/llama-4-maverick",
     "mistralai/mistral-large",
   ],
-  nvidia: ["usdcode", "mistral-nemo-minitron-8b-base", "gemma-2-2b-it"],
+  // NVIDIA models are fetched live from /api/config/llm/nvidia/models when
+  // the row is expanded. These entries are the offline fallback.
+  nvidia: ["meta/llama-3.3-70b-instruct", "meta/llama-3.1-8b-instruct", "google/gemma-2-2b-it"],
 };
 
 export function LLMTab({
@@ -181,7 +183,34 @@ function ProviderRow({
   const currentModel: string = pCfg?.model ?? "";
   const currentBaseUrl: string = pCfg?.base_url ?? "";
 
-  const knownModels = MODELS[provider];
+  // NVIDIA's catalog rotates often, so we fetch the live model list when the
+  // row opens. Falls back to the hardcoded MODELS[provider] entries when the
+  // call fails. The list mixes chat / embedding / vision models — the row's
+  // "Test connection" button is the final guard against picking a non-chat
+  // model.
+  const [liveNvidiaModels, setLiveNvidiaModels] = useState<string[] | null>(null);
+  const [nvidiaFilter, setNvidiaFilter] = useState("");
+  useEffect(() => {
+    if (provider !== "nvidia" || !expanded || liveNvidiaModels !== null) return;
+    let cancelled = false;
+    fetch("/api/config/llm/nvidia/models")
+      .then((r) => r.json())
+      .then((d: { ok: boolean; models?: string[] }) => {
+        if (cancelled) return;
+        setLiveNvidiaModels(d.ok && d.models && d.models.length > 0 ? d.models : []);
+      })
+      .catch(() => {
+        if (!cancelled) setLiveNvidiaModels([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [provider, expanded, liveNvidiaModels]);
+
+  const knownModels =
+    provider === "nvidia" && liveNvidiaModels && liveNvidiaModels.length > 0
+      ? liveNvidiaModels
+      : MODELS[provider];
   const isCustomModel = currentModel && !knownModels.includes(currentModel);
   const [modelChoice, setModelChoice] = useState<string>(
     isCustomModel ? "custom" : currentModel || knownModels[0]!,
@@ -198,6 +227,13 @@ function ProviderRow({
     setCustomModel(isCustomModel ? currentModel : "");
     setBaseUrl(currentBaseUrl);
   }, [currentModel, currentBaseUrl, isCustomModel, knownModels]);
+
+  const filteredModels =
+    provider === "nvidia" && nvidiaFilter.trim()
+      ? knownModels.filter((m) =>
+          m.toLowerCase().includes(nvidiaFilter.trim().toLowerCase()),
+        )
+      : knownModels;
 
   const resolveModel = () => (modelChoice === "custom" ? customModel : modelChoice);
 
@@ -315,6 +351,27 @@ function ProviderRow({
             </div>
           )}
 
+          {provider === "nvidia" && (
+            <div className="v2-set__field">
+              <label className="v2-set__field-label">
+                Filter models
+                <span style={{ color: "var(--ink-3)", marginLeft: "var(--s-2)" }}>
+                  ({knownModels.length} from NVIDIA catalog)
+                </span>
+              </label>
+              <input
+                className="v2-set__input"
+                value={nvidiaFilter}
+                onChange={(e) => setNvidiaFilter(e.target.value)}
+                placeholder="e.g. llama, mistral, gemma"
+              />
+              <p className="v2-set__hint">
+                Catalog mixes chat, embedding and vision models. Use Test
+                connection to confirm the chosen model supports chat.
+              </p>
+            </div>
+          )}
+
           <div className="v2-set__field">
             <label className="v2-set__field-label">Model</label>
             <div style={{ display: "flex", gap: "var(--s-2)" }}>
@@ -324,11 +381,16 @@ function ProviderRow({
                 onChange={(e) => setModelChoice(e.target.value)}
                 style={{ flex: 1 }}
               >
-                {knownModels.map((m) => (
+                {filteredModels.map((m) => (
                   <option key={m} value={m}>
                     {m}
                   </option>
                 ))}
+                {provider === "nvidia" && filteredModels.length === 0 && (
+                  <option value="" disabled>
+                    No models match "{nvidiaFilter}"
+                  </option>
+                )}
                 <option value="custom">Custom…</option>
               </select>
               {modelChoice === "custom" && (


### PR DESCRIPTION
## Summary
  - Fix "Unknown provider: nvidia" error on the onboarding test step. NVIDIA was wired in the UI, env loader, config types,
   and agent-service, but `src/daemon/llm-settings.ts` (the bridge that powers `/api/config/llm/test`, `saveLLMSettings`,
  `mergeLLMSettingsIntoConfig`, and `hotReloadLLMProviders`) never got the branch, so the test endpoint rejected the
  provider and onboarding couldn't complete.
  - Replace the hardcoded NVIDIA model defaults (`mistral-nemo-minitron-8b-base`, `usdcode`, `gemma-2-2b-it`) with live
  fetches from `GET https://integrate.api.nvidia.com/v1/models`. The old IDs were missing the required `org/` prefix and
  one was a non-chat base checkpoint, so even past the test-endpoint bug the user would have hit a 404 from NVIDIA.
  - Add a new `GET /api/config/llm/nvidia/models` route that proxies the catalog to the UI. Public endpoint, so it works
  during onboarding before any key is stored; passes the bearer token when available for future-proofing.
  - Rewrite `NVIDIAProvider.listModels()` to actually call that endpoint, de-dupe, and sort.
  - Surface the live list in `SetupRoom.tsx` and `LLMTab.tsx` behind a filter input. The catalog mixes
  chat/embedding/vision models with no type field, so the dropdown shows everything and the existing "Test connection"
  stays as the final guarantee. Falls back to a small hardcoded list on network failure.
  - Bump the safe default to `meta/llama-3.3-70b-instruct` everywhere (`config/types.ts`, `config/loader.ts`,
  `llm-settings.ts`, `nvidia.ts` constructor, and the provider test).