### PR TITLE
Fix Ollama model save + connection test in LLM settings

### DIFF
--- a/src/daemon/llm-settings.ts
+++ b/src/daemon/llm-settings.ts
@@ -185,24 +185,41 @@ export function saveLLMSettings(
     };
   }
 
-  // Ollama. An explicit empty base_url is a "disable / clear" signal: wipe the
-  // stored URL/model so the provider stops appearing as configured in the UI.
+  // Ollama. Two independent fields (base_url, model) saved by two
+  // independent UI buttons -- handle them independently so a "Save model"
+  // POST that doesn't include base_url still persists the new model.
+  //
+  // An explicit empty base_url is a "disable / clear" signal: wipe the
+  // stored URL/model so the provider stops appearing as configured in
+  // the UI. A `model` without `base_url` updates only the model and keeps
+  // the existing URL (the common case from the UI's "Save model" button).
   if (body.ollama) {
-    const url = body.ollama.base_url?.trim();
-    if (url) {
-      setSetting(SETTING_OLLAMA_BASE_URL, url);
-      if (body.ollama.model) {
-        setSetting(SETTING_OLLAMA_MODEL, body.ollama.model);
-      }
-      config.llm.ollama = {
-        ...config.llm.ollama,
-        model: body.ollama.model ?? config.llm.ollama?.model,
-        base_url: url,
-      };
-    } else if (body.ollama.base_url !== undefined) {
+    const trimmedUrl = body.ollama.base_url?.trim();
+    const clearingUrl = body.ollama.base_url !== undefined && !trimmedUrl;
+    if (clearingUrl) {
+      // Explicit clear: wipe everything.
       deleteSetting(SETTING_OLLAMA_BASE_URL);
       deleteSetting(SETTING_OLLAMA_MODEL);
       config.llm.ollama = undefined;
+    } else {
+      if (trimmedUrl) {
+        setSetting(SETTING_OLLAMA_BASE_URL, trimmedUrl);
+      }
+      if (body.ollama.model) {
+        setSetting(SETTING_OLLAMA_MODEL, body.ollama.model);
+      }
+      // Update in-memory config only if there's something useful to keep.
+      // Skip when neither field is present (defensive: shouldn't happen
+      // because we wouldn't be in this branch, but be safe).
+      const nextUrl = trimmedUrl ?? config.llm.ollama?.base_url;
+      const nextModel = body.ollama.model ?? config.llm.ollama?.model;
+      if (nextUrl || nextModel) {
+        config.llm.ollama = {
+          ...config.llm.ollama,
+          ...(nextModel ? { model: nextModel } : {}),
+          ...(nextUrl ? { base_url: nextUrl } : {}),
+        };
+      }
     }
   }
 

--- a/ui/src/v2/rooms/settings/tabs/LLMTab.tsx
+++ b/ui/src/v2/rooms/settings/tabs/LLMTab.tsx
@@ -265,7 +265,16 @@ function ProviderRow({
   const handleTest = async () => {
     setTesting(true);
     setTestResult(null);
-    const r = await data.testProvider(provider);
+    // Send the *currently-typed* model + baseUrl with the test request
+    // so the user can verify a change before committing it with Save.
+    // Without these overrides the server falls back to the stored config,
+    // which would test the previously-saved model even though the user
+    // already typed a new one in the textbox.
+    const overrides: { model?: string; baseUrl?: string } = {};
+    const m = resolveModel();
+    if (m) overrides.model = m;
+    if (provider === "ollama" && baseUrl) overrides.baseUrl = baseUrl.trim();
+    const r = await data.testProvider(provider, overrides);
     setTestResult({ ok: r.ok, text: r.message });
     setTesting(false);
   };

--- a/ui/src/v2/rooms/settings/useSettingsData.ts
+++ b/ui/src/v2/rooms/settings/useSettingsData.ts
@@ -406,12 +406,25 @@ export function useSettingsData() {
     [refresh],
   );
 
+  /**
+   * Test a provider's connection. Accepts optional `model` / `baseUrl`
+   * overrides so the UI can test what's currently in the textbox before
+   * the user clicks Save. Without overrides the server falls back to the
+   * stored config -- which would test the OLD model after the user typed
+   * a new one but hadn't saved yet.
+   */
   const testProvider = useCallback(
-    async (provider: LLMProvider): Promise<ActionResult> => {
+    async (
+      provider: LLMProvider,
+      overrides?: { model?: string; baseUrl?: string },
+    ): Promise<ActionResult> => {
       try {
+        const body: Record<string, unknown> = { provider };
+        if (overrides?.model) body.model = overrides.model;
+        if (overrides?.baseUrl) body.base_url = overrides.baseUrl;
         const r = await postJson<{ ok: boolean; model?: string; error?: string }>(
           "/api/config/llm/test",
-          { provider },
+          body,
         );
         if (r.ok) {
           return { ok: true, message: `${LLM_PROVIDER_LABELS[provider]}: ${r.model ?? "connected"}.` };


### PR DESCRIPTION
Summary

  Fixes two bugs in the LLM settings page that combined to make swapping the Ollama model effectively impossible:

  1. Save silently dropped the model. In saveLLMSettings, the Ollama branch gated the entire write on base_url being
  present in the POST body. The "Save model" button only sends {ollama: {model: "..."}} (no base_url), so the model change
  fell into an implicit do-nothing branch and was discarded. Every other provider handles model and api_key with
  independent if blocks; Ollama was the outlier.
  2. Test connection ignored the textbox. The UI's testProvider posted only {provider} to /api/config/llm/test. The server
  already accepts model / base_url overrides — they just weren't being sent. Result: clicking Test always tested whatever
  was previously saved, even after typing a new model in the field.

  Combined, these produced the bug report: typing a new model, clicking Test, getting a response from the OLD model,
  clicking Save, reloading, seeing the OLD model again.

  Changes

  - src/daemon/llm-settings.ts — rewrote the Ollama save branch to handle model and base_url independently. Explicit empty
  base_url still acts as a clear signal.
  - ui/src/v2/rooms/settings/useSettingsData.ts — testProvider now accepts optional {model, baseUrl} overrides and includes
   them in the POST body.
  - ui/src/v2/rooms/settings/tabs/LLMTab.tsx — handleTest reads the current form state (resolveModel() and baseUrl) and
  passes both as overrides so the user can verify a typed value before saving.