### PR TITLE
Nvidia: stop defaulting tool_choice to 'auto' (NIM rejects it)

### DIFF
--- a/src/llm/nvidia.ts
+++ b/src/llm/nvidia.ts
@@ -107,7 +107,9 @@ export class NVIDIAProvider implements LLMProvider {
     if (max_tokens !== undefined) body.max_tokens = max_tokens;
     if (tools && tools.length > 0) {
       body.tools = this.convertTools(tools);
-      body.tool_choice = tool_choice || 'auto';
+      // NVIDIA's hosted NIM rejects tool_choice unless the server was started
+      // with --enable-auto-tool-choice, so only forward an explicit caller value.
+      if (tool_choice !== undefined) body.tool_choice = tool_choice;
     }
 
     const response = await fetch(this.apiUrl, {
@@ -145,7 +147,9 @@ export class NVIDIAProvider implements LLMProvider {
     if (max_tokens !== undefined) body.max_tokens = max_tokens;
     if (tools && tools.length > 0) {
       body.tools = this.convertTools(tools);
-      body.tool_choice = tool_choice || 'auto';
+      // NVIDIA's hosted NIM rejects tool_choice unless the server was started
+      // with --enable-auto-tool-choice, so only forward an explicit caller value.
+      if (tool_choice !== undefined) body.tool_choice = tool_choice;
     }
 
     const response = await fetch(this.apiUrl, {


### PR DESCRIPTION
# Summary
  NVIDIA's hosted NIM endpoint rejects `tool_choice: 'auto'` with a 400 because the server is started without
  `--enable-auto-tool-choice` / `--tool-call-parser`. We were forcing `'auto'` as a default whenever `tools` were passed,
  so any interview turn that supplied tools failed with:

  > NVIDIA API error (400): "auto" tool choice requires --enable-auto-tool-choice and --tool-call-parser to be set

  Only forward `tool_choice` when the caller explicitly sets it. Omitting the field lets the server fall back to its own
  behavior and avoids the 400. Callers passing `'required'` or `'none'` are still honored.

  ## Changes
  - `src/llm/nvidia.ts`: drop the `|| 'auto'` default in both `chat` and `stream`; only set `body.tool_choice` when the
  caller provides a value. Added a short comment explaining the NIM quirk so this does not get "fixed" back.

  ## Known follow-up (not in this PR)
  The hosted catalog still cannot parse tool calls server-side, so when `tools` are supplied the model returns a generic
  refusal ("I'm not able to execute this task..."). That is a separate UX problem and will be handled in a follow-up.