### PR TITLE
Add OpenAI-compatible LLM provider for llama.cpp, vLLM, LM Studio, etc.

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -57,6 +57,14 @@ llm:
     base_url: "http://localhost:11434"
     model: "llama3"
 
+  # OpenAI-compatible (llama.cpp, vLLM, LM Studio, TGI, Together, Anyscale)
+  # Any backend that speaks /v1/chat/completions. The /v1 suffix is required.
+  # API key is optional -- most local servers skip auth.
+  # openai_compatible:
+  #   base_url: "http://localhost:8080/v1"
+  #   model: "your-model-name"
+  #   api_key: ""
+
 personality:
   core_traits:
     - "loyal"

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -98,7 +98,7 @@ export async function runDoctor(): Promise<void> {
   if (config) {
     const spin = startSpinner('Testing LLM connectivity...');
     try {
-      const { LLMManager, AnthropicProvider, OpenAIProvider, GroqProvider, GeminiProvider, OllamaProvider, OpenRouterProvider } = await import('../llm/index.ts');
+      const { LLMManager, AnthropicProvider, OpenAIProvider, GroqProvider, GeminiProvider, OllamaProvider, OpenRouterProvider, OpenAICompatibleProvider } = await import('../llm/index.ts');
       const manager = new LLMManager();
       const primary = config.llm?.primary ?? 'anthropic';
 
@@ -114,6 +114,12 @@ export async function runDoctor(): Promise<void> {
         manager.registerProvider(new OpenRouterProvider(config.llm.openrouter.api_key, config.llm.openrouter.model));
       } else if (primary === 'ollama') {
         manager.registerProvider(new OllamaProvider(config.llm.ollama?.base_url, config.llm.ollama?.model));
+      } else if (primary === 'openai_compatible' && config.llm?.openai_compatible?.base_url) {
+        manager.registerProvider(new OpenAICompatibleProvider(
+          config.llm.openai_compatible.base_url,
+          config.llm.openai_compatible.model,
+          config.llm.openai_compatible.api_key,
+        ));
       }
 
       manager.setPrimary(primary);

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -222,6 +222,7 @@ export type JarvisConfig = {
     ollama?: { base_url?: string; model?: string };
     openrouter?: { api_key: string; model?: string };
     nvidia?: { api_key: string; model?: string };
+    openai_compatible?: { base_url?: string; api_key?: string; model?: string };
   };
   personality: {
     core_traits: string[];

--- a/src/daemon/agent-service.ts
+++ b/src/daemon/agent-service.ts
@@ -21,6 +21,7 @@ import { GeminiProvider } from '../llm/gemini.ts';
 import { OllamaProvider } from '../llm/ollama.ts';
 import { OpenRouterProvider } from '../llm/openrouter.ts';
 import { NVIDIAProvider } from '../llm/nvidia.ts';
+import { OpenAICompatibleProvider } from '../llm/openai-compatible.ts';
 import { AgentOrchestrator } from '../agents/orchestrator.ts';
 import { loadRole } from '../roles/loader.ts';
 import { ToolRegistry } from '../actions/tools/registry.ts';
@@ -417,6 +418,19 @@ export class AgentService implements Service, IAgentService {
       this.llmManager.registerProvider(provider);
       hasProvider = true;
       console.log('[AgentService] Registered Ollama provider');
+    }
+
+    // Register OpenAI-compatible (llama.cpp, vLLM, LM Studio, etc.).
+    // Needs an explicit base_url; api_key is optional.
+    if (llm.openai_compatible?.base_url) {
+      const provider = new OpenAICompatibleProvider(
+        llm.openai_compatible.base_url,
+        llm.openai_compatible.model,
+        llm.openai_compatible.api_key,
+      );
+      this.llmManager.registerProvider(provider);
+      hasProvider = true;
+      console.log('[AgentService] Registered OpenAI-compatible provider');
     }
 
     if (!hasProvider) {

--- a/src/daemon/api-routes.ts
+++ b/src/daemon/api-routes.ts
@@ -1232,6 +1232,12 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
             openai: config.llm.openai ? { model: config.llm.openai.model } : null,
             groq: config.llm.groq ? { model: config.llm.groq.model } : null,
             ollama: config.llm.ollama ?? null,
+            openai_compatible: config.llm.openai_compatible
+              ? {
+                  base_url: config.llm.openai_compatible.base_url,
+                  model: config.llm.openai_compatible.model,
+                }
+              : null,
           },
           personality: config.personality,
           authority: config.authority,

--- a/src/daemon/llm-settings.ts
+++ b/src/daemon/llm-settings.ts
@@ -15,6 +15,7 @@ import { GeminiProvider } from '../llm/gemini.ts';
 import { OllamaProvider } from '../llm/ollama.ts';
 import { OpenRouterProvider } from '../llm/openrouter.ts';
 import { NVIDIAProvider } from '../llm/nvidia.ts';
+import { OpenAICompatibleProvider } from '../llm/openai-compatible.ts';
 import type { LLMProvider } from '../llm/provider.ts';
 import type { LLMManager } from '../llm/manager.ts';
 
@@ -25,6 +26,7 @@ const KEY_GROQ = 'llm.groq.api_key';
 const KEY_GEMINI = 'llm.gemini.api_key';
 const KEY_OPENROUTER = 'llm.openrouter.api_key';
 const KEY_NVIDIA = 'llm.nvidia.api_key';
+const KEY_OPENAI_COMPAT = 'llm.openai_compatible.api_key';
 
 // DB setting keys
 const SETTING_PRIMARY = 'llm.primary';
@@ -37,6 +39,8 @@ const SETTING_OLLAMA_MODEL = 'llm.ollama.model';
 const SETTING_OLLAMA_BASE_URL = 'llm.ollama.base_url';
 const SETTING_OPENROUTER_MODEL = 'llm.openrouter.model';
 const SETTING_NVIDIA_MODEL = 'llm.nvidia.model';
+const SETTING_OPENAI_COMPAT_MODEL = 'llm.openai_compatible.model';
+const SETTING_OPENAI_COMPAT_BASE_URL = 'llm.openai_compatible.base_url';
 
 export type LLMSettingsResponse = {
   primary: string;
@@ -48,6 +52,7 @@ export type LLMSettingsResponse = {
   ollama: { base_url: string; model: string } | null;
   openrouter: { model: string; has_api_key: boolean } | null;
   nvidia: { model: string; has_api_key: boolean } | null;
+  openai_compatible: { base_url: string; model: string; has_api_key: boolean } | null;
 };
 
 /**
@@ -85,6 +90,21 @@ export function getLLMSettings(config: JarvisConfig): LLMSettingsResponse {
       }
     : null;
 
+  // OpenAI-compatible: same rule as Ollama. Requires an explicit base_url
+  // since there's no sensible default — it could be llama.cpp, vLLM,
+  // LM Studio, or a hosted compatible endpoint. The API key is optional.
+  const dbCompatUrl = getSetting(SETTING_OPENAI_COMPAT_BASE_URL);
+  const dbCompatModel = getSetting(SETTING_OPENAI_COMPAT_MODEL);
+  const compatConfigured = !!(dbCompatUrl || config.llm.openai_compatible?.base_url);
+  const hasCompatKey = hasSecret(KEY_OPENAI_COMPAT) || !!config.llm.openai_compatible?.api_key;
+  const openai_compatible = compatConfigured
+    ? {
+        base_url: dbCompatUrl ?? config.llm.openai_compatible?.base_url ?? '',
+        model: dbCompatModel ?? config.llm.openai_compatible?.model ?? '',
+        has_api_key: hasCompatKey,
+      }
+    : null;
+
   return {
     primary,
     fallback,
@@ -95,6 +115,7 @@ export function getLLMSettings(config: JarvisConfig): LLMSettingsResponse {
     ollama,
     openrouter: { model: openrouterModel, has_api_key: hasOpenrouterKey },
     nvidia: { model: nvidiaModel, has_api_key: hasNvidiaKey },
+    openai_compatible,
   };
 }
 
@@ -113,6 +134,7 @@ export function saveLLMSettings(
     ollama?: { base_url?: string; model?: string };
     openrouter?: { api_key?: string; model?: string };
     nvidia?: { api_key?: string; model?: string };
+    openai_compatible?: { base_url?: string; api_key?: string; model?: string };
   },
 ): void {
   // Save non-secret settings to DB
@@ -252,6 +274,41 @@ export function saveLLMSettings(
       api_key: body.nvidia.api_key ?? getNvidiaApiKey(config) ?? '',
     };
   }
+
+  // OpenAI-compatible. Same independent-field model as Ollama: a `base_url`,
+  // `model`, and `api_key` can each be saved independently. An explicit
+  // empty `base_url` clears the provider entirely.
+  if (body.openai_compatible) {
+    const trimmedUrl = body.openai_compatible.base_url?.trim();
+    const clearingUrl = body.openai_compatible.base_url !== undefined && !trimmedUrl;
+    if (clearingUrl) {
+      deleteSetting(SETTING_OPENAI_COMPAT_BASE_URL);
+      deleteSetting(SETTING_OPENAI_COMPAT_MODEL);
+      deleteSecret(KEY_OPENAI_COMPAT);
+      config.llm.openai_compatible = undefined;
+    } else {
+      if (trimmedUrl) {
+        setSetting(SETTING_OPENAI_COMPAT_BASE_URL, trimmedUrl);
+      }
+      if (body.openai_compatible.model) {
+        setSetting(SETTING_OPENAI_COMPAT_MODEL, body.openai_compatible.model);
+      }
+      if (body.openai_compatible.api_key) {
+        setSecret(KEY_OPENAI_COMPAT, body.openai_compatible.api_key);
+      }
+      const nextUrl = trimmedUrl ?? config.llm.openai_compatible?.base_url;
+      const nextModel = body.openai_compatible.model ?? config.llm.openai_compatible?.model;
+      const nextKey = body.openai_compatible.api_key ?? getOpenAICompatibleApiKey(config) ?? '';
+      if (nextUrl || nextModel || nextKey) {
+        config.llm.openai_compatible = {
+          ...config.llm.openai_compatible,
+          ...(nextModel ? { model: nextModel } : {}),
+          ...(nextUrl ? { base_url: nextUrl } : {}),
+          ...(nextKey ? { api_key: nextKey } : {}),
+        };
+      }
+    }
+  }
 }
 
 /**
@@ -294,6 +351,14 @@ function getOpenRouterApiKey(config: JarvisConfig): string | null {
  */
 function getNvidiaApiKey(config: JarvisConfig): string | null {
   return getSecret(KEY_NVIDIA) ?? config.llm.nvidia?.api_key ?? null;
+}
+
+/**
+ * Resolve the OpenAI-compatible API key: keychain > config.yaml.
+ * Optional — many local servers (llama.cpp, LM Studio) don't require auth.
+ */
+function getOpenAICompatibleApiKey(config: JarvisConfig): string | null {
+  return getSecret(KEY_OPENAI_COMPAT) ?? config.llm.openai_compatible?.api_key ?? null;
 }
 
 /**
@@ -398,6 +463,19 @@ export function mergeLLMSettingsIntoConfig(config: JarvisConfig): void {
       model: dbNvidiaModel ?? config.llm.nvidia?.model,
     };
   }
+
+  // OpenAI-compatible
+  const dbCompatModel = getSetting(SETTING_OPENAI_COMPAT_MODEL);
+  const dbCompatUrl = getSetting(SETTING_OPENAI_COMPAT_BASE_URL);
+  const keychainCompatKey = getSecret(KEY_OPENAI_COMPAT);
+  if (dbCompatModel || dbCompatUrl || keychainCompatKey) {
+    config.llm.openai_compatible = {
+      ...config.llm.openai_compatible,
+      base_url: dbCompatUrl ?? config.llm.openai_compatible?.base_url,
+      model: dbCompatModel ?? config.llm.openai_compatible?.model,
+      api_key: keychainCompatKey ?? config.llm.openai_compatible?.api_key ?? '',
+    };
+  }
 }
 
 /**
@@ -435,6 +513,14 @@ export function hotReloadLLMProviders(config: JarvisConfig, llmManager: LLMManag
   if (llm.ollama?.base_url) {
     providers.push(new OllamaProvider(llm.ollama.base_url, llm.ollama.model));
     console.log('[LLM] Hot-reloaded Ollama provider');
+  }
+  if (llm.openai_compatible?.base_url) {
+    providers.push(new OpenAICompatibleProvider(
+      llm.openai_compatible.base_url,
+      llm.openai_compatible.model,
+      llm.openai_compatible.api_key,
+    ));
+    console.log('[LLM] Hot-reloaded OpenAI-compatible provider');
   }
 
   const fallback = llm.fallback.filter(n => providers.some(p => p.name === n));
@@ -487,6 +573,12 @@ export async function testLLMProvider(
         opts.base_url ?? config.llm.ollama?.base_url,
         opts.model ?? config.llm.ollama?.model,
       );
+    } else if (opts.provider === 'openai_compatible') {
+      const baseUrl = opts.base_url ?? config.llm.openai_compatible?.base_url;
+      if (!baseUrl) return { ok: false, error: 'Base URL required' };
+      const model = opts.model ?? config.llm.openai_compatible?.model;
+      const key = opts.api_key ?? getOpenAICompatibleApiKey(config) ?? '';
+      instance = new OpenAICompatibleProvider(baseUrl, model, key);
     } else {
       return { ok: false, error: `Unknown provider: ${opts.provider}` };
     }

--- a/src/llm/index.ts
+++ b/src/llm/index.ts
@@ -12,6 +12,7 @@ export type {
 // Provider implementations
 export { AnthropicProvider } from './anthropic.ts';
 export { OpenAIProvider } from './openai.ts';
+export { OpenAICompatibleProvider } from './openai-compatible.ts';
 export { GroqProvider } from './groq.ts';
 export { GeminiProvider } from './gemini.ts';
 export { OllamaProvider } from './ollama.ts';

--- a/src/llm/openai-compatible.ts
+++ b/src/llm/openai-compatible.ts
@@ -1,0 +1,23 @@
+import { OpenAIProvider } from './openai.ts';
+
+/**
+ * Generic OpenAI-compatible provider. Reuses the full OpenAI implementation
+ * but points at a user-supplied base URL — for llama.cpp, vLLM, LM Studio,
+ * TGI, Together, Anyscale, and anything else that speaks
+ * /v1/chat/completions. Distinct from the OpenAI provider in the UI so
+ * users see a clear "this needs a base URL" flow.
+ *
+ * The API key is optional: local servers commonly leave auth off, but some
+ * compatible cloud endpoints still require a bearer token.
+ */
+export class OpenAICompatibleProvider extends OpenAIProvider {
+  override name = 'openai_compatible';
+
+  constructor(baseUrl: string, defaultModel = '', apiKey = '') {
+    super(apiKey, defaultModel, baseUrl);
+  }
+
+  protected override get errorLabel(): string {
+    return 'OpenAI-compatible';
+  }
+}

--- a/src/llm/openai.ts
+++ b/src/llm/openai.ts
@@ -82,13 +82,23 @@ type OpenAIStreamChunk = {
 
 export class OpenAIProvider implements LLMProvider {
   name = 'openai';
-  private apiKey: string;
-  private defaultModel: string;
-  private apiUrl = 'https://api.openai.com/v1/chat/completions';
+  protected apiKey: string;
+  protected defaultModel: string;
+  protected baseUrl: string;
+  protected get apiUrl(): string {
+    return `${this.baseUrl}/chat/completions`;
+  }
+  protected get modelsUrl(): string {
+    return `${this.baseUrl}/models`;
+  }
+  protected get errorLabel(): string {
+    return 'OpenAI';
+  }
 
-  constructor(apiKey: string, defaultModel = 'gpt-4o') {
+  constructor(apiKey: string, defaultModel = 'gpt-4o', baseUrl = 'https://api.openai.com/v1') {
     this.apiKey = apiKey;
     this.defaultModel = defaultModel;
+    this.baseUrl = baseUrl.replace(/\/$/, '');
   }
 
   async chat(messages: LLMMessage[], options: LLMOptions = {}): Promise<LLMResponse> {
@@ -110,18 +120,20 @@ export class OpenAIProvider implements LLMProvider {
       body.tool_choice = tool_choice || 'auto';  // Enable tool calling
     }
 
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+    };
+    if (this.apiKey) headers['Authorization'] = `Bearer ${this.apiKey}`;
+
     const response = await fetch(this.apiUrl, {
       method: 'POST',
-      headers: {
-        'Authorization': `Bearer ${this.apiKey}`,
-        'Content-Type': 'application/json',
-      },
+      headers,
       body: JSON.stringify(body),
     });
 
     if (!response.ok) {
       const errorText = await response.text();
-      throw new Error(`OpenAI API error (${response.status}): ${errorText}`);
+      throw new Error(`${this.errorLabel} API error (${response.status}): ${errorText}`);
     }
 
     const data = await response.json() as OpenAIResponse;
@@ -148,12 +160,14 @@ export class OpenAIProvider implements LLMProvider {
       body.tool_choice = tool_choice || 'auto';  // Enable tool calling
     }
 
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+    };
+    if (this.apiKey) headers['Authorization'] = `Bearer ${this.apiKey}`;
+
     const response = await fetch(this.apiUrl, {
       method: 'POST',
-      headers: {
-        'Authorization': `Bearer ${this.apiKey}`,
-        'Content-Type': 'application/json',
-      },
+      headers,
       body: JSON.stringify(body),
     });
 
@@ -161,7 +175,7 @@ export class OpenAIProvider implements LLMProvider {
       const errorText = await response.text();
       yield {
         type: 'error',
-        error: `OpenAI API error (${response.status}): ${errorText}`,
+        error: `${this.errorLabel} API error (${response.status}): ${errorText}`,
         code: classifyHttpStatus(response.status),
       };
       return;
@@ -274,11 +288,9 @@ export class OpenAIProvider implements LLMProvider {
 
   async listModels(): Promise<string[]> {
     try {
-      const response = await fetch('https://api.openai.com/v1/models', {
-        headers: {
-          'Authorization': `Bearer ${this.apiKey}`,
-        },
-      });
+      const headers: Record<string, string> = {};
+      if (this.apiKey) headers['Authorization'] = `Bearer ${this.apiKey}`;
+      const response = await fetch(this.modelsUrl, { headers });
 
       if (!response.ok) {
         throw new Error(`Failed to list models: ${response.status}`);

--- a/ui/src/v2/onboarding/SetupRoom.tsx
+++ b/ui/src/v2/onboarding/SetupRoom.tsx
@@ -22,13 +22,18 @@ type LLMProviderId =
   | "gemini"
   | "ollama"
   | "openrouter"
-  | "nvidia";
+  | "nvidia"
+  | "openai_compatible";
 
 const PROVIDERS: ReadonlyArray<{
   id: LLMProviderId;
   label: string;
   /** True when the provider needs an API key (false for local Ollama). */
   needsKey: boolean;
+  /** True when the provider needs a base URL (Ollama, OpenAI-compatible). */
+  needsBaseUrl?: boolean;
+  /** True when the API key is optional (OpenAI-compatible local servers). */
+  optionalKey?: boolean;
   models: string[];
   /** Default model on first pick — the safest current model per provider. */
   defaultModel: string;
@@ -70,6 +75,7 @@ const PROVIDERS: ReadonlyArray<{
     id: "ollama",
     label: "Ollama (local)",
     needsKey: false,
+    needsBaseUrl: true,
     models: ["llama3.1", "llama3.2", "mistral", "qwen2.5", "deepseek-coder-v2"],
     defaultModel: "llama3.1",
   },
@@ -94,6 +100,18 @@ const PROVIDERS: ReadonlyArray<{
     needsKey: true,
     models: ["meta/llama-3.3-70b-instruct", "meta/llama-3.1-8b-instruct", "google/gemma-2-2b-it"],
     defaultModel: "meta/llama-3.3-70b-instruct",
+  },
+  {
+    // Generic /v1/chat/completions endpoint: llama.cpp, vLLM, LM Studio,
+    // TGI, Together, Anyscale, etc. The model id is entirely user-defined
+    // so we leave the list empty and let the "Custom..." path handle it.
+    id: "openai_compatible",
+    label: "OpenAI-compatible",
+    needsKey: false,
+    needsBaseUrl: true,
+    optionalKey: true,
+    models: [],
+    defaultModel: "",
   },
 ];
 
@@ -184,6 +202,13 @@ export function SetupRoom({ onComplete }: { onComplete: () => void }) {
     const p = PROVIDERS.find((x) => x.id === id)!;
     setModel(p.defaultModel);
     setApiKey("");
+    // Switch the base URL placeholder per provider so the user doesn't
+    // submit an Ollama URL into an OpenAI-compatible setup and vice versa.
+    if (id === "ollama") {
+      setBaseUrl("http://localhost:11434");
+    } else if (id === "openai_compatible") {
+      setBaseUrl("");
+    }
     setTestResult(null);
   };
 
@@ -198,8 +223,17 @@ export function SetupRoom({ onComplete }: { onComplete: () => void }) {
           return;
         }
         body.api_key = apiKey;
-      } else if (providerId === "ollama") {
-        body.base_url = baseUrl;
+      }
+      if (provider.needsBaseUrl) {
+        if (!baseUrl.trim()) {
+          setTestResult({ ok: false, error: "Enter a base URL first." });
+          return;
+        }
+        body.base_url = baseUrl.trim();
+      }
+      // openai_compatible: forward the typed key when present (optional).
+      if (providerId === "openai_compatible" && apiKey) {
+        body.api_key = apiKey;
       }
       const r = await fetch("/api/config/llm/test", {
         method: "POST",
@@ -229,7 +263,9 @@ export function SetupRoom({ onComplete }: { onComplete: () => void }) {
       const llmBlock: Record<string, unknown> = { primary: providerId };
       const provBlock: Record<string, unknown> = { model };
       if (provider.needsKey && apiKey) provBlock.api_key = apiKey;
-      if (providerId === "ollama") provBlock.base_url = baseUrl;
+      // openai_compatible: api_key is optional, forward when provided.
+      if (provider.optionalKey && apiKey) provBlock.api_key = apiKey;
+      if (provider.needsBaseUrl) provBlock.base_url = baseUrl.trim();
       llmBlock[providerId] = provBlock;
 
       // Build the TTS payload — explicit choice always sent so the
@@ -309,17 +345,53 @@ export function SetupRoom({ onComplete }: { onComplete: () => void }) {
                   >
                     <span className="v2-setup__provider-name">{p.label}</span>
                     <span className="v2-setup__provider-meta">
-                      {p.needsKey ? "API key" : "local"}
+                      {p.id === "openai_compatible"
+                        ? "self-hosted"
+                        : p.needsKey
+                          ? "API key"
+                          : "local"}
                     </span>
                   </button>
                 ))}
               </div>
             </div>
 
-            {provider.needsKey && (
+            {provider.needsBaseUrl && (
+              <div className="v2-setup__field">
+                <label className="v2-setup__label" htmlFor="setup-baseurl">
+                  {providerId === "ollama" ? "Ollama base URL" : "Base URL"}
+                </label>
+                <input
+                  id="setup-baseurl"
+                  className="v2-setup__input"
+                  value={baseUrl}
+                  onChange={(e) => {
+                    setBaseUrl(e.target.value);
+                    setTestResult(null);
+                  }}
+                  placeholder={
+                    providerId === "ollama"
+                      ? "http://localhost:11434"
+                      : "http://localhost:8080/v1"
+                  }
+                />
+                {providerId === "openai_compatible" && (
+                  <p
+                    className="v2-setup__hint"
+                    style={{ color: "var(--ink-3)", marginTop: "var(--s-1)" }}
+                  >
+                    Any server that speaks /v1/chat/completions: llama.cpp,
+                    vLLM, LM Studio, TGI, Together, Anyscale. Include the
+                    /v1 suffix.
+                  </p>
+                )}
+              </div>
+            )}
+
+            {(provider.needsKey || provider.optionalKey) && (
               <div className="v2-setup__field">
                 <label className="v2-setup__label" htmlFor="setup-key">
-                  API key
+                  API key{provider.optionalKey ? " (optional)" : ""}
                 </label>
                 <input
                   id="setup-key"
@@ -330,25 +402,12 @@ export function SetupRoom({ onComplete }: { onComplete: () => void }) {
                     setApiKey(e.target.value);
                     setTestResult(null);
                   }}
-                  placeholder="paste your key"
+                  placeholder={
+                    provider.optionalKey
+                      ? "leave empty if your server skips auth"
+                      : "paste your key"
+                  }
                   autoComplete="off"
-                />
-              </div>
-            )}
-
-            {providerId === "ollama" && (
-              <div className="v2-setup__field">
-                <label className="v2-setup__label" htmlFor="setup-baseurl">
-                  Ollama base URL
-                </label>
-                <input
-                  id="setup-baseurl"
-                  className="v2-setup__input"
-                  value={baseUrl}
-                  onChange={(e) => {
-                    setBaseUrl(e.target.value);
-                    setTestResult(null);
-                  }}
                 />
               </div>
             )}
@@ -437,23 +496,25 @@ export function SetupRoom({ onComplete }: { onComplete: () => void }) {
                 <label className="v2-setup__label" htmlFor="setup-model">
                   Model
                 </label>
-                <select
-                  id="setup-model"
-                  className="v2-setup__select"
-                  value={provider.models.includes(model) ? model : "custom"}
-                  onChange={(e) => {
-                    const v = e.target.value;
-                    setModel(v === "custom" ? "" : v);
-                    setTestResult(null);
-                  }}
-                >
-                  {provider.models.map((m) => (
-                    <option key={m} value={m}>
-                      {m}
-                    </option>
-                  ))}
-                  <option value="custom">Custom…</option>
-                </select>
+                {provider.models.length > 0 && (
+                  <select
+                    id="setup-model"
+                    className="v2-setup__select"
+                    value={provider.models.includes(model) ? model : "custom"}
+                    onChange={(e) => {
+                      const v = e.target.value;
+                      setModel(v === "custom" ? "" : v);
+                      setTestResult(null);
+                    }}
+                  >
+                    {provider.models.map((m) => (
+                      <option key={m} value={m}>
+                        {m}
+                      </option>
+                    ))}
+                    <option value="custom">Custom…</option>
+                  </select>
+                )}
                 {!provider.models.includes(model) && (
                   <input
                     className="v2-setup__input"
@@ -462,9 +523,15 @@ export function SetupRoom({ onComplete }: { onComplete: () => void }) {
                       setModel(e.target.value);
                       setTestResult(null);
                     }}
-                    placeholder="model id (e.g. your local Ollama model name)"
+                    placeholder={
+                      providerId === "openai_compatible"
+                        ? "model id (whatever your server exposes)"
+                        : "model id (e.g. your local Ollama model name)"
+                    }
                     autoComplete="off"
-                    style={{ marginTop: "var(--s-2)" }}
+                    style={{
+                      marginTop: provider.models.length > 0 ? "var(--s-2)" : 0,
+                    }}
                   />
                 )}
               </div>

--- a/ui/src/v2/rooms/settings/tabs/LLMTab.tsx
+++ b/ui/src/v2/rooms/settings/tabs/LLMTab.tsx
@@ -68,6 +68,10 @@ const MODELS: Record<LLMProvider, string[]> = {
   // NVIDIA models are fetched live from /api/config/llm/nvidia/models when
   // the row is expanded. These entries are the offline fallback.
   nvidia: ["meta/llama-3.3-70b-instruct", "meta/llama-3.1-8b-instruct", "google/gemma-2-2b-it"],
+  // OpenAI-compatible covers llama.cpp, vLLM, LM Studio, TGI and other
+  // backends — model names are entirely user-defined, so the dropdown
+  // starts empty and the user types or pastes a model id.
+  openai_compatible: [],
 };
 
 export function LLMTab({
@@ -176,10 +180,11 @@ function ProviderRow({
   onToggleExpanded: () => void;
 }) {
   const pCfg = data.llm ? (data.llm as any)[provider] : null;
-  // For Ollama "configured" means the user actually set a base_url. The
-  // default config now ships with an empty base_url (see PR 179) so a fresh
-  // install no longer reports Ollama as ready when it isn't.
-  const hasKey = provider === "ollama" ? !!pCfg?.base_url : !!pCfg?.has_api_key;
+  // For Ollama and OpenAI-compatible "configured" means the user set a
+  // base_url. The API key is optional in those flows (local servers often
+  // skip auth). All other providers gate on `has_api_key`.
+  const usesBaseUrl = provider === "ollama" || provider === "openai_compatible";
+  const hasKey = usesBaseUrl ? !!pCfg?.base_url : !!pCfg?.has_api_key;
   const currentModel: string = pCfg?.model ?? "";
   const currentBaseUrl: string = pCfg?.base_url ?? "";
 
@@ -211,11 +216,19 @@ function ProviderRow({
     provider === "nvidia" && liveNvidiaModels && liveNvidiaModels.length > 0
       ? liveNvidiaModels
       : MODELS[provider];
-  const isCustomModel = currentModel && !knownModels.includes(currentModel);
-  const [modelChoice, setModelChoice] = useState<string>(
-    isCustomModel ? "custom" : currentModel || knownModels[0]!,
+  // For openai_compatible the canonical list is empty: every model is a
+  // user-typed id, so the row always starts in "custom" mode unless we
+  // happen to know the model from a prior save.
+  const isCustomModel =
+    (currentModel && !knownModels.includes(currentModel)) ||
+    (knownModels.length === 0 && !currentModel);
+  const initialChoice = isCustomModel
+    ? "custom"
+    : currentModel || knownModels[0] || "custom";
+  const [modelChoice, setModelChoice] = useState<string>(initialChoice);
+  const [customModel, setCustomModel] = useState<string>(
+    isCustomModel ? currentModel : "",
   );
-  const [customModel, setCustomModel] = useState<string>(isCustomModel ? currentModel : "");
   const [apiKey, setApiKey] = useState("");
   const [baseUrl, setBaseUrl] = useState(currentBaseUrl);
   const [testing, setTesting] = useState(false);
@@ -223,7 +236,9 @@ function ProviderRow({
   const [saving, setSaving] = useState(false);
 
   useEffect(() => {
-    setModelChoice(isCustomModel ? "custom" : currentModel || knownModels[0]!);
+    setModelChoice(
+      isCustomModel ? "custom" : currentModel || knownModels[0] || "custom",
+    );
     setCustomModel(isCustomModel ? currentModel : "");
     setBaseUrl(currentBaseUrl);
   }, [currentModel, currentBaseUrl, isCustomModel, knownModels]);
@@ -257,7 +272,10 @@ function ProviderRow({
 
   const handleSaveBaseUrl = async () => {
     setSaving(true);
-    const r = await data.setOllamaBaseUrl(baseUrl.trim());
+    const trimmed = baseUrl.trim();
+    const r = provider === "openai_compatible"
+      ? await data.setOpenAICompatibleBaseUrl(trimmed)
+      : await data.setOllamaBaseUrl(trimmed);
     onToast(r.message, r.ok ? "ok" : "warn");
     setSaving(false);
   };
@@ -270,10 +288,13 @@ function ProviderRow({
     // Without these overrides the server falls back to the stored config,
     // which would test the previously-saved model even though the user
     // already typed a new one in the textbox.
-    const overrides: { model?: string; baseUrl?: string } = {};
+    const overrides: { model?: string; baseUrl?: string; apiKey?: string } = {};
     const m = resolveModel();
     if (m) overrides.model = m;
-    if (provider === "ollama" && baseUrl) overrides.baseUrl = baseUrl.trim();
+    if (usesBaseUrl && baseUrl) overrides.baseUrl = baseUrl.trim();
+    // For openai_compatible the freshly-typed key (if any) should be used
+    // for the test request. Ollama doesn't take a key.
+    if (provider === "openai_compatible" && apiKey) overrides.apiKey = apiKey;
     const r = await data.testProvider(provider, overrides);
     setTestResult({ ok: r.ok, text: r.message });
     setTesting(false);
@@ -302,7 +323,7 @@ function ProviderRow({
 
       {expanded && (
         <div className="v2-set__provider-fields">
-          {provider === "ollama" && (
+          {usesBaseUrl && (
             <div className="v2-set__field">
               <label className="v2-set__field-label">Base URL</label>
               <div style={{ display: "flex", gap: "var(--s-2)" }}>
@@ -310,17 +331,23 @@ function ProviderRow({
                   className="v2-set__input"
                   value={baseUrl}
                   onChange={(e) => setBaseUrl(e.target.value)}
-                  placeholder="http://localhost:11434"
+                  placeholder={
+                    provider === "ollama"
+                      ? "http://localhost:11434"
+                      : "http://localhost:8080/v1"
+                  }
                 />
-                <button
-                  type="button"
-                  className="v2-set__btn"
-                  onClick={() => setBaseUrl("http://localhost:11434")}
-                  disabled={saving}
-                  title="Fill in the default localhost URL"
-                >
-                  Default
-                </button>
+                {provider === "ollama" && (
+                  <button
+                    type="button"
+                    className="v2-set__btn"
+                    onClick={() => setBaseUrl("http://localhost:11434")}
+                    disabled={saving}
+                    title="Fill in the default localhost URL"
+                  >
+                    Default
+                  </button>
+                )}
                 <button
                   type="button"
                   className="v2-set__btn"
@@ -330,19 +357,39 @@ function ProviderRow({
                   Save
                 </button>
               </div>
+              {provider === "openai_compatible" && (
+                <p className="v2-set__hint">
+                  Point at any server that speaks the OpenAI Chat Completions
+                  API -- llama.cpp (e.g. http://localhost:8080/v1), vLLM, LM
+                  Studio, TGI, Together, Anyscale. Include the /v1 suffix.
+                </p>
+              )}
             </div>
           )}
 
-          {provider !== "ollama" && (
+          {(provider !== "ollama") && (
             <div className="v2-set__field">
-              <label className="v2-set__field-label">API Key</label>
+              <label className="v2-set__field-label">
+                API Key
+                {provider === "openai_compatible" && (
+                  <span style={{ color: "var(--ink-3)", marginLeft: "var(--s-2)" }}>
+                    (optional)
+                  </span>
+                )}
+              </label>
               <div style={{ display: "flex", gap: "var(--s-2)" }}>
                 <input
                   className="v2-set__input"
                   type="password"
                   value={apiKey}
                   onChange={(e) => setApiKey(e.target.value)}
-                  placeholder={hasKey ? "Stored — leave empty to keep" : "Enter API key"}
+                  placeholder={
+                    hasKey
+                      ? "Stored -- leave empty to keep"
+                      : provider === "openai_compatible"
+                        ? "Optional bearer token"
+                        : "Enter API key"
+                  }
                 />
                 <button
                   type="button"
@@ -354,8 +401,9 @@ function ProviderRow({
                 </button>
               </div>
               <p className="v2-set__hint">
-                Keys are stored in the keychain and never echoed back. Voice never sets keys —
-                use this field directly.
+                {provider === "openai_compatible"
+                  ? "Most local servers (llama.cpp, LM Studio) skip auth. Leave empty unless your endpoint requires a bearer token."
+                  : "Keys are stored in the keychain and never echoed back. Voice never sets keys -- use this field directly."}
               </p>
             </div>
           )}
@@ -384,25 +432,27 @@ function ProviderRow({
           <div className="v2-set__field">
             <label className="v2-set__field-label">Model</label>
             <div style={{ display: "flex", gap: "var(--s-2)" }}>
-              <select
-                className="v2-set__select"
-                value={modelChoice}
-                onChange={(e) => setModelChoice(e.target.value)}
-                style={{ flex: 1 }}
-              >
-                {filteredModels.map((m) => (
-                  <option key={m} value={m}>
-                    {m}
-                  </option>
-                ))}
-                {provider === "nvidia" && filteredModels.length === 0 && (
-                  <option value="" disabled>
-                    No models match "{nvidiaFilter}"
-                  </option>
-                )}
-                <option value="custom">Custom…</option>
-              </select>
-              {modelChoice === "custom" && (
+              {knownModels.length > 0 && (
+                <select
+                  className="v2-set__select"
+                  value={modelChoice}
+                  onChange={(e) => setModelChoice(e.target.value)}
+                  style={{ flex: 1 }}
+                >
+                  {filteredModels.map((m) => (
+                    <option key={m} value={m}>
+                      {m}
+                    </option>
+                  ))}
+                  {provider === "nvidia" && filteredModels.length === 0 && (
+                    <option value="" disabled>
+                      No models match "{nvidiaFilter}"
+                    </option>
+                  )}
+                  <option value="custom">Custom…</option>
+                </select>
+              )}
+              {(modelChoice === "custom" || knownModels.length === 0) && (
                 <input
                   className="v2-set__input"
                   value={customModel}

--- a/ui/src/v2/rooms/settings/useSettingsData.ts
+++ b/ui/src/v2/rooms/settings/useSettingsData.ts
@@ -9,7 +9,8 @@ export type LLMProvider =
   | "gemini"
   | "ollama"
   | "openrouter"
-  | "nvidia";
+  | "nvidia"
+  | "openai_compatible";
 
 export const LLM_PROVIDERS: readonly LLMProvider[] = [
   "anthropic",
@@ -19,6 +20,7 @@ export const LLM_PROVIDERS: readonly LLMProvider[] = [
   "ollama",
   "openrouter",
   "nvidia",
+  "openai_compatible",
 ] as const;
 
 export const LLM_PROVIDER_LABELS: Record<LLMProvider, string> = {
@@ -29,6 +31,7 @@ export const LLM_PROVIDER_LABELS: Record<LLMProvider, string> = {
   ollama: "Ollama",
   openrouter: "OpenRouter",
   nvidia: "NVIDIA NIM",
+  openai_compatible: "OpenAI-compatible",
 };
 
 export type STTProvider = "openai" | "groq" | "sarvam" | "local";
@@ -44,6 +47,7 @@ export interface LLMConfig {
   ollama?: { base_url: string; model: string } | null;
   openrouter?: { model: string; has_api_key: boolean } | null;
   nvidia?: { model: string; has_api_key: boolean } | null;
+  openai_compatible?: { base_url: string; model: string; has_api_key: boolean } | null;
 }
 
 export interface ChannelStatus {
@@ -307,7 +311,10 @@ export function useSettingsData() {
       for (const p of LLM_PROVIDERS) {
         const v = (llm as any)[p];
         if (!v) continue;
-        if (p === "ollama" || (v && v.has_api_key)) providersWithKey++;
+        // Ollama and OpenAI-compatible are "configured" by a base_url, not a key.
+        if (p === "ollama" || p === "openai_compatible" || v.has_api_key) {
+          providersWithKey++;
+        }
       }
     }
     const channelsEnabled =
@@ -406,6 +413,22 @@ export function useSettingsData() {
     [refresh],
   );
 
+  const setOpenAICompatibleBaseUrl = useCallback(
+    async (baseUrl: string): Promise<ActionResult> => {
+      try {
+        const r = await postJson<{ ok: boolean; message: string }>(
+          "/api/config/llm",
+          { openai_compatible: { base_url: baseUrl } },
+        );
+        await refresh();
+        return { ok: true, message: r.message || "OpenAI-compatible base URL updated." };
+      } catch (err) {
+        return { ok: false, message: err instanceof Error ? err.message : "Failed" };
+      }
+    },
+    [refresh],
+  );
+
   /**
    * Test a provider's connection. Accepts optional `model` / `baseUrl`
    * overrides so the UI can test what's currently in the textbox before
@@ -416,12 +439,13 @@ export function useSettingsData() {
   const testProvider = useCallback(
     async (
       provider: LLMProvider,
-      overrides?: { model?: string; baseUrl?: string },
+      overrides?: { model?: string; baseUrl?: string; apiKey?: string },
     ): Promise<ActionResult> => {
       try {
         const body: Record<string, unknown> = { provider };
         if (overrides?.model) body.model = overrides.model;
         if (overrides?.baseUrl) body.base_url = overrides.baseUrl;
+        if (overrides?.apiKey) body.api_key = overrides.apiKey;
         const r = await postJson<{ ok: boolean; model?: string; error?: string }>(
           "/api/config/llm/test",
           body,
@@ -739,6 +763,7 @@ export function useSettingsData() {
     setLLMModel,
     setLLMApiKey,
     setOllamaBaseUrl,
+    setOpenAICompatibleBaseUrl,
     testProvider,
     setTelegram,
     setDiscord,


### PR DESCRIPTION
## Summary

  Users running their own OpenAI-compatible inference servers (llama.cpp, vLLM,
  LM Studio, TGI, Together, Anyscale) currently have to abuse the Ollama option,
  which fails because Ollama and OpenAI-compatible servers speak different APIs
  (`/api/chat` vs `/v1/chat/completions`). See the issue referenced in the
  related thread.

  This adds a dedicated "OpenAI-compatible" provider:

  - New `OpenAICompatibleProvider` that subclasses `OpenAIProvider` with a
    user-supplied `base_url` and optional API key. Same chat / stream / tools
    code path as OpenAI under the hood.
  - Wired through config types, llm-settings (DB + keychain), agent-service,
    api-routes, and the CLI doctor.
  - Settings tab and onboarding screen expose it as a distinct provider with
    a Base URL field (required) and an optional API key. OpenAI users still
    see only the API key field, so the OpenAI flow is unchanged.

  The OpenAI provider now also accepts an optional `baseUrl` constructor arg
  and omits the `Authorization` header when no key is set, so local servers
  that skip auth work out of the box.