### PR TITLE
Groq: relax optional tool params to nullable so strict validator stops 400-ing

### DIFF
--- a/src/llm/groq.ts
+++ b/src/llm/groq.ts
@@ -78,6 +78,52 @@ type GroqStreamChunk = {
   }>;
 };
 
+/**
+ * Groq strict-validates tool call arguments server-side against the
+ * tool's JSON Schema. The Llama/Kimi/etc. models it hosts have a
+ * habit of emitting *every* declared property — including optional
+ * ones — and filling absent values with `null` instead of omitting
+ * the key. Standard JSON Schema treats "not required" as "may be
+ * omitted", not "may be null", so the validator 400s the call before
+ * we ever see it (error: `expected string, but got null`).
+ *
+ * We can't change the model's habit and we can't sanitize after the
+ * fact (Groq rejects upstream). The fix is to walk the schema before
+ * sending and expand every optional property's `type` to also accept
+ * `null`. Tool handlers across the codebase already normalize null
+ * back to `undefined`, so this is purely a wire-format adjustment.
+ */
+export function relaxOptionalFieldsToNullable(schema: unknown): unknown {
+  if (!schema || typeof schema !== 'object') return schema;
+  if (Array.isArray(schema)) return schema.map(relaxOptionalFieldsToNullable);
+
+  const node = schema as Record<string, unknown>;
+  const out: Record<string, unknown> = { ...node };
+
+  if (node.type === 'object' && node.properties && typeof node.properties === 'object') {
+    const required = new Set(Array.isArray(node.required) ? (node.required as string[]) : []);
+    const props = node.properties as Record<string, unknown>;
+    const newProps: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(props)) {
+      const relaxed = relaxOptionalFieldsToNullable(value) as Record<string, unknown> | unknown;
+      if (!required.has(key) && relaxed && typeof relaxed === 'object' && 'type' in (relaxed as object)) {
+        const t = (relaxed as Record<string, unknown>).type;
+        if (typeof t === 'string' && t !== 'null') {
+          (relaxed as Record<string, unknown>).type = [t, 'null'];
+        } else if (Array.isArray(t) && !t.includes('null')) {
+          (relaxed as Record<string, unknown>).type = [...t, 'null'];
+        }
+      }
+      newProps[key] = relaxed;
+    }
+    out.properties = newProps;
+  }
+
+  if (node.items) out.items = relaxOptionalFieldsToNullable(node.items);
+
+  return out;
+}
+
 export class GroqProvider implements LLMProvider {
   name = 'groq';
   private apiKey: string;
@@ -497,7 +543,7 @@ export class GroqProvider implements LLMProvider {
       function: {
         name: tool.name,
         description: tool.description,
-        parameters: tool.parameters,
+        parameters: relaxOptionalFieldsToNullable(tool.parameters) as Record<string, unknown>,
       },
     }));
   }

--- a/src/llm/provider.test.ts
+++ b/src/llm/provider.test.ts
@@ -1,7 +1,7 @@
 import { test, expect, describe, beforeEach, afterEach, mock } from 'bun:test';
 import { AnthropicProvider } from './anthropic.ts';
 import { OpenAIProvider } from './openai.ts';
-import { GroqProvider } from './groq.ts';
+import { GroqProvider, relaxOptionalFieldsToNullable } from './groq.ts';
 import { OllamaProvider } from './ollama.ts';
 import { OpenRouterProvider } from './openrouter.ts';
 import { NVIDIAProvider } from './nvidia.ts';
@@ -496,6 +496,76 @@ describe('Groq request shaping', () => {
 
   afterEach(() => {
     globalThis.fetch = originalFetch;
+  });
+
+  test('relaxOptionalFieldsToNullable makes optional fields accept null', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        city: { type: 'string' },
+        notes: { type: 'string' },
+        tags: { type: 'array', items: { type: 'string' } },
+        nested: {
+          type: 'object',
+          properties: {
+            required_inner: { type: 'string' },
+            optional_inner: { type: 'number' },
+          },
+          required: ['required_inner'],
+        },
+      },
+      required: ['city'],
+    };
+    const out = relaxOptionalFieldsToNullable(schema) as any;
+    expect(out.properties.city.type).toBe('string');
+    expect(out.properties.notes.type).toEqual(['string', 'null']);
+    expect(out.properties.tags.type).toEqual(['array', 'null']);
+    expect(out.properties.nested.type).toEqual(['object', 'null']);
+    expect(out.properties.nested.properties.required_inner.type).toBe('string');
+    expect(out.properties.nested.properties.optional_inner.type).toEqual(['number', 'null']);
+  });
+
+  test('GroqProvider relaxes optional tool params to accept null before sending', async () => {
+    const provider = new GroqProvider('test-key') as any;
+    await provider.chat(
+      [
+        { role: 'system', content: 'sys' },
+        { role: 'user', content: 'hi' },
+      ],
+      {
+        tools: [
+          {
+            name: 'record_profile_facts',
+            description: 'd',
+            parameters: {
+              type: 'object',
+              properties: {
+                facts: {
+                  type: 'array',
+                  items: {
+                    type: 'object',
+                    properties: {
+                      theme: { type: 'string' },
+                      summary: { type: 'string' },
+                      raw_quote: { type: 'string' },
+                    },
+                    required: ['theme', 'summary'],
+                  },
+                },
+              },
+              required: ['facts'],
+            },
+          },
+        ],
+      },
+    );
+    const fetchMock = globalThis.fetch as unknown as ReturnType<typeof mock>;
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    const body = JSON.parse(String(init.body));
+    const itemProps = body.tools[0].function.parameters.properties.facts.items.properties;
+    expect(itemProps.theme.type).toBe('string');
+    expect(itemProps.summary.type).toBe('string');
+    expect(itemProps.raw_quote.type).toEqual(['string', 'null']);
   });
 
   test('GroqProvider uses Groq-compatible tool fields', async () => {


### PR DESCRIPTION
 ## Summary

  - Onboarding's first user message crashed with `Groq API error (400): tool call validation failed: parameters for tool
  record_profile_facts did not match schema: errors: [/facts/0/raw_quote: expected string, but got null]`.
  - Root cause: Groq-hosted models (Llama, Kimi, etc.) emit *every* declared property on tool calls, filling absent values
  with `null`. Standard JSON Schema treats "not required" as "may be omitted", not "may be null", so Groq's server-side
  validator rejects the call before we ever see it.
  - Fixed at the provider boundary: `convertTools` now runs `relaxOptionalFieldsToNullable` over each tool schema, which
  walks the JSON Schema and expands every non-required property's `type` to also accept `null` (recursing through nested
  objects and array `items`). Tool handlers across the codebase already normalize null to `undefined`, so this is a
  wire-format-only change.
  - Doing it once at the Groq provider beats patching every individual tool schema -- no future tool author has to
  remember.