### PR TITLE
Fix project path containment check

### DIFF
--- a/src/sites/path-utils.ts
+++ b/src/sites/path-utils.ts
@@ -1,0 +1,6 @@
+import { isAbsolute, relative, sep } from 'node:path';
+
+export function isWithin(resolvedPath: string, basePath: string): boolean {
+  const rel = relative(basePath, resolvedPath);
+  return rel === '' || (rel !== '..' && !rel.startsWith(`..${sep}`) && !isAbsolute(rel));
+}

--- a/src/sites/project-manager.test.ts
+++ b/src/sites/project-manager.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import { existsSync } from 'node:fs';
-import { mkdir, mkdtemp } from 'node:fs/promises';
+import { mkdir, mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { ProjectManager } from './project-manager.ts';
@@ -19,12 +19,30 @@ function makeManager(projectsDir: string): ProjectManager {
 describe('ProjectManager path containment', () => {
   test('blocks sibling directory traversal with a shared prefix', async () => {
     const projectsDir = await mkdtemp(join(tmpdir(), 'jarvis-sites-'));
-    await mkdir(join(projectsDir, 'app'), { recursive: true });
-    await mkdir(join(projectsDir, 'app-backup'), { recursive: true });
-    const manager = makeManager(projectsDir);
+    try {
+      await mkdir(join(projectsDir, 'app'), { recursive: true });
+      await mkdir(join(projectsDir, 'app-backup'), { recursive: true });
+      const manager = makeManager(projectsDir);
 
-    await expect(manager.writeFile('app', '../app-backup/pwned.txt', 'owned'))
-      .rejects.toThrow('Path traversal attempt blocked');
-    expect(existsSync(join(projectsDir, 'app-backup', 'pwned.txt'))).toBe(false);
+      await expect(manager.writeFile('app', '../app-backup/pwned.txt', 'owned'))
+        .rejects.toThrow('Path traversal attempt blocked');
+      expect(existsSync(join(projectsDir, 'app-backup', 'pwned.txt'))).toBe(false);
+    } finally {
+      await rm(projectsDir, { recursive: true, force: true });
+    }
+  });
+
+  test('allows descendant paths whose segment starts with two dots', async () => {
+    const projectsDir = await mkdtemp(join(tmpdir(), 'jarvis-sites-'));
+    try {
+      await mkdir(join(projectsDir, 'app'), { recursive: true });
+      const manager = makeManager(projectsDir);
+
+      await manager.writeFile('app', '..config/settings.json', '{}');
+
+      expect(existsSync(join(projectsDir, 'app', '..config', 'settings.json'))).toBe(true);
+    } finally {
+      await rm(projectsDir, { recursive: true, force: true });
+    }
   });
 });

--- a/src/sites/project-manager.test.ts
+++ b/src/sites/project-manager.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from 'bun:test';
+import { existsSync } from 'node:fs';
+import { mkdir, mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { ProjectManager } from './project-manager.ts';
+
+function makeManager(projectsDir: string): ProjectManager {
+  return new ProjectManager({
+    enabled: true,
+    projects_dir: projectsDir,
+    port_range_start: 3000,
+    port_range_end: 3999,
+    auto_commit: false,
+    max_concurrent_servers: 1,
+  });
+}
+
+describe('ProjectManager path containment', () => {
+  test('blocks sibling directory traversal with a shared prefix', async () => {
+    const projectsDir = await mkdtemp(join(tmpdir(), 'jarvis-sites-'));
+    await mkdir(join(projectsDir, 'app'), { recursive: true });
+    await mkdir(join(projectsDir, 'app-backup'), { recursive: true });
+    const manager = makeManager(projectsDir);
+
+    await expect(manager.writeFile('app', '../app-backup/pwned.txt', 'owned'))
+      .rejects.toThrow('Path traversal attempt blocked');
+    expect(existsSync(join(projectsDir, 'app-backup', 'pwned.txt'))).toBe(false);
+  });
+});

--- a/src/sites/project-manager.test.ts
+++ b/src/sites/project-manager.test.ts
@@ -17,6 +17,17 @@ function makeManager(projectsDir: string): ProjectManager {
 }
 
 describe('ProjectManager path containment', () => {
+  test('returns null for project ids that resolve outside projects dir', async () => {
+    const projectsDir = await mkdtemp(join(tmpdir(), 'jarvis-sites-'));
+    try {
+      const manager = makeManager(projectsDir);
+
+      expect(manager.getProjectPath('../etc')).toBe(null);
+    } finally {
+      await rm(projectsDir, { recursive: true, force: true });
+    }
+  });
+
   test('blocks sibling directory traversal with a shared prefix', async () => {
     const projectsDir = await mkdtemp(join(tmpdir(), 'jarvis-sites-'));
     try {

--- a/src/sites/project-manager.ts
+++ b/src/sites/project-manager.ts
@@ -7,9 +7,10 @@
 import type { Project, ProjectMeta, FileEntry, SiteBuilderConfig } from './types.ts';
 import { GitManager } from './git-manager.ts';
 import { TEMPLATES, generateMakefile, scaffoldBunReact } from './templates.ts';
-import { isAbsolute, join, relative, resolve, sep } from 'node:path';
+import { join, relative, resolve } from 'node:path';
 import { homedir } from 'node:os';
 import { readdirSync, statSync, existsSync, mkdirSync, rmSync } from 'node:fs';
+import { isWithin } from './path-utils.ts';
 
 const META_FILE = '.jarvis-project.json';
 
@@ -309,22 +310,17 @@ export class ProjectManager {
     const projectPath = join(this.projectsDir, id);
     // Prevent path traversal
     const resolved = resolve(projectPath);
-    if (!this.isWithin(resolved, resolve(this.projectsDir))) return null;
+    if (!isWithin(resolved, resolve(this.projectsDir))) return null;
     if (!existsSync(resolved)) return null;
     return resolved;
   }
 
   private safeJoin(projectPath: string, relativePath: string): string {
     const resolved = resolve(join(projectPath, relativePath));
-    if (!this.isWithin(resolved, resolve(projectPath))) {
+    if (!isWithin(resolved, resolve(projectPath))) {
       throw new Error('Path traversal attempt blocked');
     }
     return resolved;
-  }
-
-  private isWithin(resolvedPath: string, basePath: string): boolean {
-    const rel = relative(basePath, resolvedPath);
-    return rel === '' || (rel !== '..' && !rel.startsWith(`..${sep}`) && !isAbsolute(rel));
   }
 
   private sanitizeId(name: string): string {

--- a/src/sites/project-manager.ts
+++ b/src/sites/project-manager.ts
@@ -7,7 +7,7 @@
 import type { Project, ProjectMeta, FileEntry, SiteBuilderConfig } from './types.ts';
 import { GitManager } from './git-manager.ts';
 import { TEMPLATES, generateMakefile, scaffoldBunReact } from './templates.ts';
-import { join, relative, resolve } from 'node:path';
+import { isAbsolute, join, relative, resolve } from 'node:path';
 import { homedir } from 'node:os';
 import { readdirSync, statSync, existsSync, mkdirSync, rmSync } from 'node:fs';
 
@@ -309,17 +309,22 @@ export class ProjectManager {
     const projectPath = join(this.projectsDir, id);
     // Prevent path traversal
     const resolved = resolve(projectPath);
-    if (!resolved.startsWith(resolve(this.projectsDir))) return null;
+    if (!this.isWithin(resolved, resolve(this.projectsDir))) return null;
     if (!existsSync(resolved)) return null;
     return resolved;
   }
 
   private safeJoin(projectPath: string, relativePath: string): string {
     const resolved = resolve(join(projectPath, relativePath));
-    if (!resolved.startsWith(resolve(projectPath))) {
+    if (!this.isWithin(resolved, resolve(projectPath))) {
       throw new Error('Path traversal attempt blocked');
     }
     return resolved;
+  }
+
+  private isWithin(resolvedPath: string, basePath: string): boolean {
+    const rel = relative(basePath, resolvedPath);
+    return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel));
   }
 
   private sanitizeId(name: string): string {

--- a/src/sites/project-manager.ts
+++ b/src/sites/project-manager.ts
@@ -7,7 +7,7 @@
 import type { Project, ProjectMeta, FileEntry, SiteBuilderConfig } from './types.ts';
 import { GitManager } from './git-manager.ts';
 import { TEMPLATES, generateMakefile, scaffoldBunReact } from './templates.ts';
-import { isAbsolute, join, relative, resolve } from 'node:path';
+import { isAbsolute, join, relative, resolve, sep } from 'node:path';
 import { homedir } from 'node:os';
 import { readdirSync, statSync, existsSync, mkdirSync, rmSync } from 'node:fs';
 
@@ -324,7 +324,7 @@ export class ProjectManager {
 
   private isWithin(resolvedPath: string, basePath: string): boolean {
     const rel = relative(basePath, resolvedPath);
-    return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel));
+    return rel === '' || (rel !== '..' && !rel.startsWith(`..${sep}`) && !isAbsolute(rel));
   }
 
   private sanitizeId(name: string): string {


### PR DESCRIPTION
## Summary
- Replace prefix-based path containment checks with `path.relative` + `isAbsolute` validation.
- Add a regression test for sibling directory traversal with a shared prefix.

Split out from #186 as requested, without the site preview sandbox changes.

## Tests
- `bun test src/sites/project-manager.test.ts`
- `bun test`