### PR TITLE
Restrict local secret file permissions

### DIFF
--- a/sidecar/config.go
+++ b/sidecar/config.go
@@ -99,14 +99,20 @@ func LoadConfig() (*SidecarConfig, error) {
 }
 
 func SaveConfig(cfg *SidecarConfig) error {
-	if err := os.MkdirAll(configDir, 0755); err != nil {
+	if err := os.MkdirAll(configDir, 0700); err != nil {
+		return err
+	}
+	if err := os.Chmod(configDir, 0700); err != nil {
 		return err
 	}
 	data, err := yaml.Marshal(cfg)
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(configFile, data, 0644)
+	if err := os.WriteFile(configFile, data, 0600); err != nil {
+		return err
+	}
+	return os.Chmod(configFile, 0600)
 }
 
 func DecodeJWTPayload(token string) (*SidecarTokenClaims, error) {

--- a/sidecar/config_test.go
+++ b/sidecar/config_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -42,5 +43,40 @@ func TestAwarenessCaptureDirDefault(t *testing.T) {
 	want := filepath.Join(homeDir(), ".jarvis", "captures")
 	if cfg.Awareness.CaptureDir != want {
 		t.Fatalf("CaptureDir = %q, want %q", cfg.Awareness.CaptureDir, want)
+	}
+}
+
+func TestSaveConfigRestrictsPermissions(t *testing.T) {
+	originalConfigDir := configDir
+	originalConfigFile := configFile
+	t.Cleanup(func() {
+		configDir = originalConfigDir
+		configFile = originalConfigFile
+	})
+
+	configDir = filepath.Join(t.TempDir(), ".jarvis-sidecar")
+	configFile = filepath.Join(configDir, "config.yaml")
+
+	cfg := defaultConfig()
+	cfg.Token = "secret-token"
+
+	if err := SaveConfig(&cfg); err != nil {
+		t.Fatalf("SaveConfig() error = %v", err)
+	}
+
+	dirInfo, err := os.Stat(configDir)
+	if err != nil {
+		t.Fatalf("stat config dir: %v", err)
+	}
+	if got := dirInfo.Mode().Perm(); got != 0700 {
+		t.Fatalf("config dir mode = %o, want 0700", got)
+	}
+
+	fileInfo, err := os.Stat(configFile)
+	if err != nil {
+		t.Fatalf("stat config file: %v", err)
+	}
+	if got := fileInfo.Mode().Perm(); got != 0600 {
+		t.Fatalf("config file mode = %o, want 0600", got)
 	}
 }

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -2,7 +2,8 @@ import { test, expect, describe, beforeEach, afterEach } from 'bun:test';
 import { loadConfig, saveConfig } from './loader.ts';
 import { DEFAULT_CONFIG } from './types.ts';
 import { existsSync, statSync } from 'node:fs';
-import { mkdir, rm } from 'node:fs/promises';
+import { chmod, mkdir, mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
 import { dirname, join, isAbsolute } from 'node:path';
 
 const TEST_CONFIG_DIR = '/tmp/jarvis-test-config';
@@ -47,6 +48,23 @@ describe('Config Loader', () => {
 
     expect(statSync(dirname(TEST_CONFIG_PATH)).mode & 0o777).toBe(0o700);
     expect(statSync(TEST_CONFIG_PATH).mode & 0o777).toBe(0o600);
+  });
+
+  test('does not chmod cwd for bare relative config paths', async () => {
+    const originalCwd = process.cwd();
+    const dir = await mkdtemp(join(tmpdir(), 'jarvis-config-cwd-'));
+    await chmod(dir, 0o755);
+
+    try {
+      process.chdir(dir);
+      await saveConfig(DEFAULT_CONFIG, 'config.yaml');
+
+      expect(statSync(dir).mode & 0o777).toBe(0o755);
+      expect(statSync(join(dir, 'config.yaml')).mode & 0o777).toBe(0o600);
+    } finally {
+      process.chdir(originalCwd);
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 
   test('deep merges partial config with defaults', async () => {

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -2,16 +2,21 @@ import { test, expect, describe, beforeEach, afterEach } from 'bun:test';
 import { loadConfig, saveConfig } from './loader.ts';
 import { DEFAULT_CONFIG } from './types.ts';
 import { existsSync, statSync } from 'node:fs';
-import { chmod, mkdir, mkdtemp, rm } from 'node:fs/promises';
+import { chmod, mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join, isAbsolute } from 'node:path';
 
-const TEST_CONFIG_DIR = '/tmp/jarvis-test-config';
-const TEST_CONFIG_PATH = join(TEST_CONFIG_DIR, 'config.yaml');
+let TEST_CONFIG_DIR: string;
+let TEST_CONFIG_PATH: string;
+
+async function createTestConfigPath(): Promise<void> {
+  TEST_CONFIG_DIR = await mkdtemp(join(tmpdir(), 'jarvis-test-config-'));
+  TEST_CONFIG_PATH = join(TEST_CONFIG_DIR, 'config.yaml');
+}
 
 describe('Config Loader', () => {
   beforeEach(async () => {
-    await mkdir(TEST_CONFIG_DIR, { recursive: true });
+    await createTestConfigPath();
   });
 
   afterEach(async () => {
@@ -292,7 +297,7 @@ describe('Default Config', () => {
 
 describe('Config Parse Errors', () => {
   beforeEach(async () => {
-    await mkdir(TEST_CONFIG_DIR, { recursive: true });
+    await createTestConfigPath();
   });
 
   afterEach(async () => {
@@ -336,7 +341,7 @@ daemon:
 
 describe('Voice Config', () => {
   beforeEach(async () => {
-    await mkdir(TEST_CONFIG_DIR, { recursive: true });
+    await createTestConfigPath();
   });
 
   afterEach(async () => {

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -1,18 +1,20 @@
 import { test, expect, describe, beforeEach, afterEach } from 'bun:test';
 import { loadConfig, saveConfig } from './loader.ts';
 import { DEFAULT_CONFIG } from './types.ts';
-import { existsSync } from 'node:fs';
-import { unlink } from 'node:fs/promises';
-import { join, isAbsolute } from 'node:path';
+import { existsSync, statSync } from 'node:fs';
+import { mkdir, rm } from 'node:fs/promises';
+import { dirname, join, isAbsolute } from 'node:path';
 
-const TEST_CONFIG_PATH = '/tmp/jarvis-test-config.yaml';
+const TEST_CONFIG_DIR = '/tmp/jarvis-test-config';
+const TEST_CONFIG_PATH = join(TEST_CONFIG_DIR, 'config.yaml');
 
 describe('Config Loader', () => {
+  beforeEach(async () => {
+    await mkdir(TEST_CONFIG_DIR, { recursive: true });
+  });
+
   afterEach(async () => {
-    // Clean up test config file
-    if (existsSync(TEST_CONFIG_PATH)) {
-      await unlink(TEST_CONFIG_PATH);
-    }
+    await rm(TEST_CONFIG_DIR, { recursive: true, force: true });
   });
 
   test('returns default config when file does not exist', async () => {
@@ -38,6 +40,13 @@ describe('Config Loader', () => {
     const loaded = await loadConfig(TEST_CONFIG_PATH);
     expect(loaded.daemon.port).toBe(9999);
     expect(loaded.llm.primary).toBe('openai');
+  });
+
+  test('saves config with owner-only permissions', async () => {
+    await saveConfig(DEFAULT_CONFIG, TEST_CONFIG_PATH);
+
+    expect(statSync(dirname(TEST_CONFIG_PATH)).mode & 0o777).toBe(0o700);
+    expect(statSync(TEST_CONFIG_PATH).mode & 0o777).toBe(0o600);
   });
 
   test('deep merges partial config with defaults', async () => {
@@ -264,10 +273,12 @@ describe('Default Config', () => {
 });
 
 describe('Config Parse Errors', () => {
+  beforeEach(async () => {
+    await mkdir(TEST_CONFIG_DIR, { recursive: true });
+  });
+
   afterEach(async () => {
-    if (existsSync(TEST_CONFIG_PATH)) {
-      await unlink(TEST_CONFIG_PATH);
-    }
+    await rm(TEST_CONFIG_DIR, { recursive: true, force: true });
   });
 
   test('throws on malformed YAML when file exists', async () => {
@@ -306,11 +317,13 @@ daemon:
 });
 
 describe('Voice Config', () => {
+  beforeEach(async () => {
+    await mkdir(TEST_CONFIG_DIR, { recursive: true });
+  });
+
   afterEach(async () => {
     delete process.env.JARVIS_WAKE_ENGINE;
-    if (existsSync(TEST_CONFIG_PATH)) {
-      await unlink(TEST_CONFIG_PATH);
-    }
+    await rm(TEST_CONFIG_DIR, { recursive: true, force: true });
   });
 
   test('defaults wake_engine to openwakeword (privacy-preserving local path)', async () => {

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1,6 +1,7 @@
 import YAML from 'yaml';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { homedir } from 'node:os';
+import { chmod, mkdir, writeFile } from 'node:fs/promises';
 import type { JarvisConfig } from './types.ts';
 import { DEFAULT_CONFIG } from './types.ts';
 
@@ -170,7 +171,11 @@ export async function saveConfig(
       defaultKeyType: 'PLAIN',
     });
 
-    await Bun.write(path, yaml);
+    const configDir = dirname(path);
+    await mkdir(configDir, { recursive: true, mode: 0o700 });
+    await chmod(configDir, 0o700);
+    await writeFile(path, yaml, { mode: 0o600 });
+    await chmod(path, 0o600);
     console.log(`Config saved to ${path}`);
   } catch (err) {
     throw new Error(`Failed to save config to ${path}: ${err}`);

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -12,6 +12,13 @@ function expandTilde(filepath: string): string {
   return filepath;
 }
 
+async function secureParentDirectory(filePath: string): Promise<void> {
+  const dir = dirname(filePath);
+  if (dir === '.' || dir === '') return;
+  await mkdir(dir, { recursive: true, mode: 0o700 });
+  await chmod(dir, 0o700);
+}
+
 function deepMerge(target: any, source: any): any {
   if (!source || typeof source !== 'object') {
     // If source is absent, return a clone of target so callers (or subsequent
@@ -171,9 +178,7 @@ export async function saveConfig(
       defaultKeyType: 'PLAIN',
     });
 
-    const configDir = dirname(path);
-    await mkdir(configDir, { recursive: true, mode: 0o700 });
-    await chmod(configDir, 0o700);
+    await secureParentDirectory(path);
     await writeFile(path, yaml, { mode: 0o600 });
     await chmod(path, 0o600);
     console.log(`Config saved to ${path}`);

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1,22 +1,16 @@
 import YAML from 'yaml';
-import { dirname, join } from 'node:path';
+import { join } from 'node:path';
 import { homedir } from 'node:os';
-import { chmod, mkdir, writeFile } from 'node:fs/promises';
+import { chmod, writeFile } from 'node:fs/promises';
 import type { JarvisConfig } from './types.ts';
 import { DEFAULT_CONFIG } from './types.ts';
+import { secureParentDirectory } from '../util/fs-secure.ts';
 
 function expandTilde(filepath: string): string {
   if (filepath.startsWith('~/')) {
     return join(homedir(), filepath.slice(2));
   }
   return filepath;
-}
-
-async function secureParentDirectory(filePath: string): Promise<void> {
-  const dir = dirname(filePath);
-  if (dir === '.' || dir === '') return;
-  await mkdir(dir, { recursive: true, mode: 0o700 });
-  await chmod(dir, 0o700);
 }
 
 function deepMerge(target: any, source: any): any {

--- a/src/integrations/google-auth.test.ts
+++ b/src/integrations/google-auth.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import { existsSync, statSync } from 'node:fs';
-import { mkdtemp } from 'node:fs/promises';
+import { chmod, mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { GoogleAuth } from './google-auth.ts';
@@ -21,5 +21,31 @@ describe('GoogleAuth token storage', () => {
     expect(existsSync(tokensPath)).toBe(true);
     expect(statSync(dir).mode & 0o777).toBe(0o700);
     expect(statSync(tokensPath).mode & 0o777).toBe(0o600);
+  });
+
+  test('does not chmod cwd for bare relative token paths', async () => {
+    const originalCwd = process.cwd();
+    const dir = await mkdtemp(join(tmpdir(), 'jarvis-google-auth-cwd-'));
+    await chmod(dir, 0o755);
+
+    try {
+      process.chdir(dir);
+      const auth = new GoogleAuth('client-id', 'client-secret', {
+        tokensPath: 'google-tokens.json',
+      });
+
+      await auth.saveTokens({
+        access_token: 'access-token',
+        refresh_token: 'refresh-token',
+        expiry_date: Date.now() + 60_000,
+        token_type: 'Bearer',
+      });
+
+      expect(statSync(dir).mode & 0o777).toBe(0o755);
+      expect(statSync(join(dir, 'google-tokens.json')).mode & 0o777).toBe(0o600);
+    } finally {
+      process.chdir(originalCwd);
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/src/integrations/google-auth.test.ts
+++ b/src/integrations/google-auth.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from 'bun:test';
+import { existsSync, statSync } from 'node:fs';
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { GoogleAuth } from './google-auth.ts';
+
+describe('GoogleAuth token storage', () => {
+  test('saves OAuth tokens with owner-only permissions', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'jarvis-google-auth-'));
+    const tokensPath = join(dir, 'google-tokens.json');
+    const auth = new GoogleAuth('client-id', 'client-secret', { tokensPath });
+
+    await auth.saveTokens({
+      access_token: 'access-token',
+      refresh_token: 'refresh-token',
+      expiry_date: Date.now() + 60_000,
+      token_type: 'Bearer',
+    });
+
+    expect(existsSync(tokensPath)).toBe(true);
+    expect(statSync(dir).mode & 0o777).toBe(0o700);
+    expect(statSync(tokensPath).mode & 0o777).toBe(0o600);
+  });
+});

--- a/src/integrations/google-auth.ts
+++ b/src/integrations/google-auth.ts
@@ -9,6 +9,7 @@
 import path from 'node:path';
 import os from 'node:os';
 import { readFileSync, existsSync } from 'node:fs';
+import { chmod, mkdir, writeFile } from 'node:fs/promises';
 
 const TOKEN_ENDPOINT = 'https://oauth2.googleapis.com/token';
 const AUTH_ENDPOINT = 'https://accounts.google.com/o/oauth2/v2/auth';
@@ -62,7 +63,11 @@ export class GoogleAuth {
    */
   async saveTokens(tokens: GoogleTokens): Promise<void> {
     this.tokens = tokens;
-    await Bun.write(this.tokensPath, JSON.stringify(tokens, null, 2));
+    const tokensDir = path.dirname(this.tokensPath);
+    await mkdir(tokensDir, { recursive: true, mode: 0o700 });
+    await chmod(tokensDir, 0o700);
+    await writeFile(this.tokensPath, JSON.stringify(tokens, null, 2), { mode: 0o600 });
+    await chmod(this.tokensPath, 0o600);
   }
 
   /**

--- a/src/integrations/google-auth.ts
+++ b/src/integrations/google-auth.ts
@@ -9,17 +9,11 @@
 import path from 'node:path';
 import os from 'node:os';
 import { readFileSync, existsSync } from 'node:fs';
-import { chmod, mkdir, writeFile } from 'node:fs/promises';
+import { chmod, writeFile } from 'node:fs/promises';
+import { secureParentDirectory } from '../util/fs-secure.ts';
 
 const TOKEN_ENDPOINT = 'https://oauth2.googleapis.com/token';
 const AUTH_ENDPOINT = 'https://accounts.google.com/o/oauth2/v2/auth';
-
-async function secureParentDirectory(filePath: string): Promise<void> {
-  const dir = path.dirname(filePath);
-  if (dir === '.' || dir === '') return;
-  await mkdir(dir, { recursive: true, mode: 0o700 });
-  await chmod(dir, 0o700);
-}
 
 export type GoogleTokens = {
   access_token: string;

--- a/src/integrations/google-auth.ts
+++ b/src/integrations/google-auth.ts
@@ -14,6 +14,13 @@ import { chmod, mkdir, writeFile } from 'node:fs/promises';
 const TOKEN_ENDPOINT = 'https://oauth2.googleapis.com/token';
 const AUTH_ENDPOINT = 'https://accounts.google.com/o/oauth2/v2/auth';
 
+async function secureParentDirectory(filePath: string): Promise<void> {
+  const dir = path.dirname(filePath);
+  if (dir === '.' || dir === '') return;
+  await mkdir(dir, { recursive: true, mode: 0o700 });
+  await chmod(dir, 0o700);
+}
+
 export type GoogleTokens = {
   access_token: string;
   refresh_token: string;
@@ -63,9 +70,7 @@ export class GoogleAuth {
    */
   async saveTokens(tokens: GoogleTokens): Promise<void> {
     this.tokens = tokens;
-    const tokensDir = path.dirname(this.tokensPath);
-    await mkdir(tokensDir, { recursive: true, mode: 0o700 });
-    await chmod(tokensDir, 0o700);
+    await secureParentDirectory(this.tokensPath);
     await writeFile(this.tokensPath, JSON.stringify(tokens, null, 2), { mode: 0o600 });
     await chmod(this.tokensPath, 0o600);
   }

--- a/src/sidecar/manager.test.ts
+++ b/src/sidecar/manager.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from 'bun:test';
-import { buildEnrollmentUrls, isLocalhostBrainUrl } from './manager.ts';
+import { statSync } from 'node:fs';
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { buildEnrollmentUrls, isLocalhostBrainUrl, SidecarManager } from './manager.ts';
 
 describe('buildEnrollmentUrls', () => {
   test('parses https URL into wss/https pair', () => {
@@ -86,5 +90,23 @@ describe('isLocalhostBrainUrl', () => {
     ['notlocalhost.example.com', false],
   ])('isLocalhostBrainUrl(%p) === %p', (input, expected) => {
     expect(isLocalhostBrainUrl(input)).toBe(expected);
+  });
+});
+
+describe('SidecarManager key storage', () => {
+  test('stores the enrollment private key with owner-only permissions', async () => {
+    const dataDir = await mkdtemp(join(tmpdir(), 'jarvis-sidecar-manager-'));
+    const manager = new SidecarManager(dataDir);
+
+    await manager.start();
+    await manager.stop();
+
+    const keyDir = join(dataDir, 'sidecar-keys');
+    const privateKeyPath = join(keyDir, 'private.pem');
+    const publicKeyPath = join(keyDir, 'public.pem');
+
+    expect(statSync(keyDir).mode & 0o777).toBe(0o700);
+    expect(statSync(privateKeyPath).mode & 0o777).toBe(0o600);
+    expect(statSync(publicKeyPath).mode & 0o777).toBe(0o644);
   });
 });

--- a/src/sidecar/manager.test.ts
+++ b/src/sidecar/manager.test.ts
@@ -1,9 +1,25 @@
 import { describe, expect, test } from 'bun:test';
 import { statSync } from 'node:fs';
-import { mkdtemp } from 'node:fs/promises';
+import { chmod, mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { buildEnrollmentUrls, isLocalhostBrainUrl, SidecarManager } from './manager.ts';
+
+function keyPaths(dataDir: string): { keyDir: string; privateKeyPath: string; publicKeyPath: string } {
+  const keyDir = join(dataDir, 'sidecar-keys');
+  return {
+    keyDir,
+    privateKeyPath: join(keyDir, 'private.pem'),
+    publicKeyPath: join(keyDir, 'public.pem'),
+  };
+}
+
+function expectKeyModes(dataDir: string): void {
+  const { keyDir, privateKeyPath, publicKeyPath } = keyPaths(dataDir);
+  expect(statSync(keyDir).mode & 0o777).toBe(0o700);
+  expect(statSync(privateKeyPath).mode & 0o777).toBe(0o600);
+  expect(statSync(publicKeyPath).mode & 0o777).toBe(0o644);
+}
 
 describe('buildEnrollmentUrls', () => {
   test('parses https URL into wss/https pair', () => {
@@ -96,17 +112,37 @@ describe('isLocalhostBrainUrl', () => {
 describe('SidecarManager key storage', () => {
   test('stores the enrollment private key with owner-only permissions', async () => {
     const dataDir = await mkdtemp(join(tmpdir(), 'jarvis-sidecar-manager-'));
-    const manager = new SidecarManager(dataDir);
+    try {
+      const manager = new SidecarManager(dataDir);
 
-    await manager.start();
-    await manager.stop();
+      await manager.start();
+      await manager.stop();
 
-    const keyDir = join(dataDir, 'sidecar-keys');
-    const privateKeyPath = join(keyDir, 'private.pem');
-    const publicKeyPath = join(keyDir, 'public.pem');
+      expectKeyModes(dataDir);
+    } finally {
+      await rm(dataDir, { recursive: true, force: true });
+    }
+  });
 
-    expect(statSync(keyDir).mode & 0o777).toBe(0o700);
-    expect(statSync(privateKeyPath).mode & 0o777).toBe(0o600);
-    expect(statSync(publicKeyPath).mode & 0o777).toBe(0o644);
+  test('tightens existing enrollment key permissions on load', async () => {
+    const dataDir = await mkdtemp(join(tmpdir(), 'jarvis-sidecar-manager-'));
+    try {
+      const firstManager = new SidecarManager(dataDir);
+      await firstManager.start();
+      await firstManager.stop();
+
+      const { keyDir, privateKeyPath, publicKeyPath } = keyPaths(dataDir);
+      await chmod(keyDir, 0o777);
+      await chmod(privateKeyPath, 0o644);
+      await chmod(publicKeyPath, 0o666);
+
+      const secondManager = new SidecarManager(dataDir);
+      await secondManager.start();
+      await secondManager.stop();
+
+      expectKeyModes(dataDir);
+    } finally {
+      await rm(dataDir, { recursive: true, force: true });
+    }
   });
 });

--- a/src/sidecar/manager.ts
+++ b/src/sidecar/manager.ts
@@ -6,7 +6,7 @@
  */
 
 import { generateKeyPair, exportJWK, exportPKCS8, exportSPKI, importPKCS8, importSPKI, SignJWT, jwtVerify, createRemoteJWKSet, type JWK } from 'jose';
-import { chmodSync, existsSync, mkdirSync } from 'node:fs';
+import { existsSync } from 'node:fs';
 import { writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import type { ServerWebSocket } from 'bun';
@@ -25,6 +25,7 @@ import { DEFAULT_RPC_TIMEOUTS } from './protocol.ts';
 import { EventScheduler } from './scheduler.ts';
 import { RPCTracker } from './rpc.ts';
 import { SidecarConnection } from './connection.ts';
+import { chmodWithWarning, secureDirectory } from '../util/fs-secure.ts';
 
 const ALG = 'ES256';
 const KEY_DIR_NAME = 'sidecar-keys';
@@ -229,7 +230,7 @@ export class SidecarManager implements Service {
   private async loadOrGenerateKeys(): Promise<void> {
     if (existsSync(this.privateKeyPath) && existsSync(this.publicKeyPath)) {
       await this.loadKeys();
-      this.secureKeyFilePermissions();
+      await this.secureKeyFilePermissions();
       console.log('[SidecarManager] Loaded existing ES256 key pair');
     } else {
       await this.generateKeys();
@@ -242,8 +243,7 @@ export class SidecarManager implements Service {
   }
 
   private async generateKeys(): Promise<void> {
-    mkdirSync(this.keysDir, { recursive: true, mode: 0o700 });
-    chmodSync(this.keysDir, 0o700);
+    await secureDirectory(this.keysDir, 0o700);
 
     const { privateKey, publicKey } = await generateKeyPair(ALG, { extractable: true });
     this.privateKey = privateKey;
@@ -254,8 +254,9 @@ export class SidecarManager implements Service {
     const spki = await exportSPKI(publicKey);
 
     await writeFile(this.privateKeyPath, pkcs8, { mode: 0o600 });
+    // public.pem contains the SPKI public key, so world-readable 0644 is intentional.
     await writeFile(this.publicKeyPath, spki, { mode: 0o644 });
-    this.secureKeyFilePermissions();
+    await this.secureKeyFilePermissions();
   }
 
   private async loadKeys(): Promise<void> {
@@ -266,10 +267,10 @@ export class SidecarManager implements Service {
     this.publicKey = await importSPKI(publicPem, ALG, { extractable: true });
   }
 
-  private secureKeyFilePermissions(): void {
-    try { chmodSync(this.keysDir, 0o700); } catch {}
-    try { chmodSync(this.privateKeyPath, 0o600); } catch {}
-    try { chmodSync(this.publicKeyPath, 0o644); } catch {}
+  private async secureKeyFilePermissions(): Promise<void> {
+    await chmodWithWarning(this.keysDir, 0o700, 'SidecarManager');
+    await chmodWithWarning(this.privateKeyPath, 0o600, 'SidecarManager');
+    await chmodWithWarning(this.publicKeyPath, 0o644, 'SidecarManager');
   }
 
   // --------------- JWKS ---------------

--- a/src/sidecar/manager.ts
+++ b/src/sidecar/manager.ts
@@ -6,7 +6,8 @@
  */
 
 import { generateKeyPair, exportJWK, exportPKCS8, exportSPKI, importPKCS8, importSPKI, SignJWT, jwtVerify, createRemoteJWKSet, type JWK } from 'jose';
-import { existsSync, mkdirSync } from 'node:fs';
+import { chmodSync, existsSync, mkdirSync } from 'node:fs';
+import { writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import type { ServerWebSocket } from 'bun';
 import type { Service, ServiceStatus } from '../daemon/services.ts';
@@ -228,6 +229,7 @@ export class SidecarManager implements Service {
   private async loadOrGenerateKeys(): Promise<void> {
     if (existsSync(this.privateKeyPath) && existsSync(this.publicKeyPath)) {
       await this.loadKeys();
+      this.secureKeyFilePermissions();
       console.log('[SidecarManager] Loaded existing ES256 key pair');
     } else {
       await this.generateKeys();
@@ -240,7 +242,8 @@ export class SidecarManager implements Service {
   }
 
   private async generateKeys(): Promise<void> {
-    mkdirSync(this.keysDir, { recursive: true });
+    mkdirSync(this.keysDir, { recursive: true, mode: 0o700 });
+    chmodSync(this.keysDir, 0o700);
 
     const { privateKey, publicKey } = await generateKeyPair(ALG, { extractable: true });
     this.privateKey = privateKey;
@@ -250,8 +253,9 @@ export class SidecarManager implements Service {
     const pkcs8 = await exportPKCS8(privateKey);
     const spki = await exportSPKI(publicKey);
 
-    await Bun.write(this.privateKeyPath, pkcs8);
-    await Bun.write(this.publicKeyPath, spki);
+    await writeFile(this.privateKeyPath, pkcs8, { mode: 0o600 });
+    await writeFile(this.publicKeyPath, spki, { mode: 0o644 });
+    this.secureKeyFilePermissions();
   }
 
   private async loadKeys(): Promise<void> {
@@ -260,6 +264,12 @@ export class SidecarManager implements Service {
 
     this.privateKey = await importPKCS8(privatePem, ALG, { extractable: true });
     this.publicKey = await importSPKI(publicPem, ALG, { extractable: true });
+  }
+
+  private secureKeyFilePermissions(): void {
+    try { chmodSync(this.keysDir, 0o700); } catch {}
+    try { chmodSync(this.privateKeyPath, 0o600); } catch {}
+    try { chmodSync(this.publicKeyPath, 0o644); } catch {}
   }
 
   // --------------- JWKS ---------------

--- a/src/util/fs-secure.ts
+++ b/src/util/fs-secure.ts
@@ -1,0 +1,22 @@
+import { chmod, mkdir } from 'node:fs/promises';
+import { dirname } from 'node:path';
+
+export async function secureDirectory(dirPath: string, mode: number = 0o700): Promise<void> {
+  await mkdir(dirPath, { recursive: true, mode });
+  await chmod(dirPath, mode);
+}
+
+export async function secureParentDirectory(filePath: string, mode: number = 0o700): Promise<void> {
+  const dir = dirname(filePath);
+  if (dir === '.' || dir === '') return;
+  await secureDirectory(dir, mode);
+}
+
+export async function chmodWithWarning(filePath: string, mode: number, label: string): Promise<void> {
+  try {
+    await chmod(filePath, mode);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.warn(`[${label}] Failed to chmod ${filePath} to ${mode.toString(8)}: ${message}`);
+  }
+}


### PR DESCRIPTION
## Summary
- Save local config and Google OAuth tokens with owner-only file permissions.
- Restrict sidecar config and enrollment private-key storage permissions.
- Add regression tests for config, token, and sidecar key file modes.

Split out from #186 as requested, without the site preview sandbox changes.

## Tests
- `bun test src/config/loader.test.ts src/integrations/google-auth.test.ts src/sidecar/manager.test.ts`
- `go test ./...` from `sidecar/`
- `bun test` via pre-commit/typecheck hook