### PR TITLE
 Add STT provider selection to first-run onboarding

### DIFF
--- a/src/daemon/api-routes.ts
+++ b/src/daemon/api-routes.ts
@@ -1112,7 +1112,7 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
     },
 
     /**
-     * Atomic Phase A setup endpoint. Saves LLM + TTS config + flips
+     * Atomic Phase A setup endpoint. Saves LLM + STT + TTS config + flips
      * the `onboarding.setup_completed_at` flag in one shot, then hot-
      * reloads the LLM providers and TTS provider so the next chat
      * message goes through real services without a daemon restart.
@@ -1123,6 +1123,14 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
      *       primary: "anthropic" | "openai" | ... ,
      *       <provider>: { api_key?: string, model?: string, base_url?: string }
      *     },
+     *     stt: {
+     *       provider: "openai" | "groq" | "local" | "sarvam",
+     *       openai?:  { api_key?: string, model?: string },
+     *       groq?:    { api_key?: string, model?: string },
+     *       sarvam?:  { api_key?: string, model?: string, language?: string },
+     *       local?:   { endpoint: string, model?: string,
+     *                   server_type?: "whisper_cpp" | "openai_compatible" },
+     *     },
      *     tts: {
      *       enabled: boolean,
      *       provider?: "edge" | "elevenlabs" | "sarvam",
@@ -1132,9 +1140,12 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
      *     }
      *   }
      *
-     * Either field is optional; missing means "use current/default".
-     * The TTS block is required to be present (even if just `{enabled:false}`)
-     * so the user explicitly chose during the setup screen.
+     * Each field is optional; missing means "use current/default". The TTS
+     * block is required to be present (even if just `{enabled:false}`) so
+     * the user explicitly chose during the setup screen; STT is fully
+     * optional (omit when the user picks "skip"). Sub-blocks are merged
+     * via the shared mergeSTTConfig/mergeTTSConfig helpers so existing
+     * api_keys are preserved when the patch omits them.
      */
     '/api/onboarding/setup': {
       POST: async (req: Request) => {
@@ -1152,39 +1163,26 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
             hotReloadLLMProviders(ctx.config, ctx.agentService.getLLMManager());
           }
 
-          // 2. STT settings — mirrors /api/config/stt POST semantics so
-          //    the onboarding form can persist a Whisper choice (cloud or
-          //    local) without restart. STT itself is consumed at the next
-          //    transcription request, so no hot-swap is needed.
+          // 2. STT settings — mirrors /api/config/stt POST semantics via
+          //    the shared mergeSTTConfig helper. STT is consumed at the
+          //    next transcription request, so no hot-swap is needed.
           if (body.stt) {
             const { loadConfig: lc, saveConfig: sc } = await import('../config/loader.ts');
+            const { mergeSTTConfig } = await import('./config-merge.ts');
             const fresh = await lc();
-            if (!fresh.stt) fresh.stt = { provider: 'openai' };
-            const sttBody = { ...(body.stt as Record<string, unknown>) };
-            for (const p of ['openai', 'groq', 'sarvam'] as const) {
-              const incoming = sttBody[p] as Record<string, unknown> | undefined;
-              const existing = (fresh.stt as any)[p];
-              if (incoming) {
-                (fresh.stt as any)[p] = {
-                  ...existing,
-                  ...incoming,
-                  api_key: (incoming.api_key as string) || existing?.api_key || '',
-                };
-                delete sttBody[p];
-              }
-            }
-            fresh.stt = { ...fresh.stt, ...sttBody } as any;
+            fresh.stt = mergeSTTConfig(fresh.stt, body.stt);
             await sc(fresh);
             ctx.config.stt = fresh.stt;
           }
 
-          // 3. TTS settings — same path as /api/config/tts POST. Inline
-          //    the relevant write since the TTS endpoint is large; we
-          //    don't need provider hot-swap UI feedback here.
+          // 3. TTS settings — mirrors /api/config/tts POST via the shared
+          //    mergeTTSConfig helper, then hot-reloads the provider so the
+          //    post-setup "Welcome to Jarvis" reply is spoken immediately.
           if (body.tts) {
             const { loadConfig: lc, saveConfig: sc } = await import('../config/loader.ts');
+            const { mergeTTSConfig } = await import('./config-merge.ts');
             const fresh = await lc();
-            fresh.tts = { ...fresh.tts, ...(body.tts as any) };
+            fresh.tts = mergeTTSConfig(fresh.tts, body.tts);
             await sc(fresh);
             ctx.config.tts = fresh.tts;
             // Hot-reload TTS provider when possible so the post-setup
@@ -1200,7 +1198,7 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
             }
           }
 
-          // 3. Flip the setup-completed flag.
+          // 4. Flip the setup-completed flag.
           const { loadConfig, saveConfig } = await import('../config/loader.ts');
           const fresh = await loadConfig();
           const now = Date.now();
@@ -1215,7 +1213,7 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
           await saveConfig(fresh);
           ctx.config.onboarding = fresh.onboarding;
 
-          // 4. Bring the LLM-dependent services (bgAgent, commitment
+          // 5. Bring the LLM-dependent services (bgAgent, commitment
           //    executor, awareness) online in-process. Without this the
           //    user would have to restart the daemon — fatal UX on
           //    Docker / VPS. Failure here is non-fatal: chat still works
@@ -1836,27 +1834,10 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
         try {
           const body = await req.json() as Record<string, unknown>;
           const { loadConfig, saveConfig } = await import('../config/loader.ts');
+          const { mergeSTTConfig } = await import('./config-merge.ts');
           const freshConfig = await loadConfig();
 
-          if (!freshConfig.stt) freshConfig.stt = { provider: 'openai' };
-          const stt = freshConfig.stt;
-
-          // Preserve keys for each provider if not provided in the update
-          const providers = ['openai', 'groq', 'sarvam'] as const;
-          for (const p of providers) {
-            const incoming = body[p] as Record<string, unknown> | undefined;
-            const existing = stt[p];
-            if (incoming) {
-              stt[p] = {
-                ...existing,
-                ...incoming,
-                api_key: (incoming.api_key as string) || (existing as any)?.api_key || '',
-              } as any;
-              delete body[p];
-            }
-          }
-
-          freshConfig.stt = { ...stt, ...body } as any;
+          freshConfig.stt = mergeSTTConfig(freshConfig.stt, body);
           await saveConfig(freshConfig);
           ctx.config.stt = freshConfig.stt;
           return json({ ok: true, message: 'STT config saved. Restart JARVIS to apply changes.' });
@@ -1896,39 +1877,10 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
         try {
           const body = await req.json() as Record<string, unknown>;
           const { loadConfig, saveConfig } = await import('../config/loader.ts');
+          const { mergeTTSConfig } = await import('./config-merge.ts');
           const freshConfig = await loadConfig();
 
-          if (!freshConfig.tts) freshConfig.tts = { enabled: false };
-
-          // Deep-merge elevenlabs sub-object to preserve API key across saves
-          const incomingEl = body.elevenlabs as Record<string, unknown> | undefined;
-          const existingEl = freshConfig.tts?.elevenlabs;
-          delete body.elevenlabs;
-
-          freshConfig.tts = { ...freshConfig.tts, ...body } as any;
-
-          if (incomingEl) {
-            freshConfig.tts!.elevenlabs = {
-              ...existingEl,
-              ...incomingEl,
-              // Keep existing API key if new one not provided
-              api_key: (incomingEl.api_key as string) || existingEl?.api_key || '',
-            } as any;
-          }
-
-          const incomingSarvam = body.sarvam as Record<string, unknown> | undefined;
-          const existingSarvam = freshConfig.tts?.sarvam;
-          delete body.sarvam;
-
-          if (incomingSarvam) {
-            freshConfig.tts!.sarvam = {
-              ...existingSarvam,
-              ...incomingSarvam,
-              // Keep existing API key if new one not provided
-              api_key: (incomingSarvam.api_key as string) || existingSarvam?.api_key || '',
-            } as any;
-          }
-
+          freshConfig.tts = mergeTTSConfig(freshConfig.tts, body);
           await saveConfig(freshConfig);
           ctx.config.tts = freshConfig.tts;
 

--- a/src/daemon/api-routes.ts
+++ b/src/daemon/api-routes.ts
@@ -1141,6 +1141,7 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
         try {
           const body = (await req.json()) as {
             llm?: Record<string, unknown>;
+            stt?: Record<string, unknown>;
             tts?: Record<string, unknown>;
           };
 
@@ -1151,7 +1152,33 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
             hotReloadLLMProviders(ctx.config, ctx.agentService.getLLMManager());
           }
 
-          // 2. TTS settings — same path as /api/config/tts POST. Inline
+          // 2. STT settings — mirrors /api/config/stt POST semantics so
+          //    the onboarding form can persist a Whisper choice (cloud or
+          //    local) without restart. STT itself is consumed at the next
+          //    transcription request, so no hot-swap is needed.
+          if (body.stt) {
+            const { loadConfig: lc, saveConfig: sc } = await import('../config/loader.ts');
+            const fresh = await lc();
+            if (!fresh.stt) fresh.stt = { provider: 'openai' };
+            const sttBody = { ...(body.stt as Record<string, unknown>) };
+            for (const p of ['openai', 'groq', 'sarvam'] as const) {
+              const incoming = sttBody[p] as Record<string, unknown> | undefined;
+              const existing = (fresh.stt as any)[p];
+              if (incoming) {
+                (fresh.stt as any)[p] = {
+                  ...existing,
+                  ...incoming,
+                  api_key: (incoming.api_key as string) || existing?.api_key || '',
+                };
+                delete sttBody[p];
+              }
+            }
+            fresh.stt = { ...fresh.stt, ...sttBody } as any;
+            await sc(fresh);
+            ctx.config.stt = fresh.stt;
+          }
+
+          // 3. TTS settings — same path as /api/config/tts POST. Inline
           //    the relevant write since the TTS endpoint is large; we
           //    don't need provider hot-swap UI feedback here.
           if (body.tts) {

--- a/src/daemon/config-merge.test.ts
+++ b/src/daemon/config-merge.test.ts
@@ -1,0 +1,138 @@
+import { test, expect, describe } from 'bun:test';
+import { mergeSTTConfig, mergeTTSConfig } from './config-merge.ts';
+import type { STTConfig, TTSConfig } from '../config/types.ts';
+
+describe('mergeSTTConfig', () => {
+  test('preserves a different provider key when patching only one provider', () => {
+    // This is the core invariant the onboarding/setup endpoint relies on:
+    // POSTing a Groq key must not wipe an existing OpenAI key (and vice
+    // versa). The endpoint was previously a verbatim copy of the dedicated
+    // STT POST handler — extracting the helper means this guarantee lives
+    // in one place and is tested once.
+    const existing: STTConfig = {
+      provider: 'openai',
+      openai: { api_key: 'sk-existing-openai' },
+    };
+    const merged = mergeSTTConfig(existing, {
+      provider: 'groq',
+      groq: { api_key: 'gsk-new-groq' },
+    });
+
+    expect(merged.openai?.api_key).toBe('sk-existing-openai');
+    expect(merged.groq?.api_key).toBe('gsk-new-groq');
+    expect(merged.provider).toBe('groq');
+  });
+
+  test('preserves api_key on the same provider when patch omits it', () => {
+    // GET /api/config/stt redacts api_keys, so a UI round-trip never sees
+    // the real value. Merging must treat an omitted key as "keep existing".
+    const existing: STTConfig = {
+      provider: 'openai',
+      openai: { api_key: 'sk-existing', model: 'whisper-1' },
+    };
+    const merged = mergeSTTConfig(existing, {
+      openai: { model: 'whisper-large-v3' },
+    });
+
+    expect(merged.openai?.api_key).toBe('sk-existing');
+    expect(merged.openai?.model).toBe('whisper-large-v3');
+  });
+
+  test('treats an empty-string api_key in the patch as "keep existing"', () => {
+    const existing: STTConfig = {
+      provider: 'openai',
+      openai: { api_key: 'sk-existing' },
+    };
+    const merged = mergeSTTConfig(existing, {
+      openai: { api_key: '', model: 'whisper-1' },
+    });
+
+    expect(merged.openai?.api_key).toBe('sk-existing');
+  });
+
+  test('deep-merges the local sub-block so partial updates keep model', () => {
+    // The pre-helper code shallow-merged `local` (it was not in the
+    // preserved-provider loop), so updating just the endpoint would have
+    // wiped `model` and `server_type`. The helper deep-merges it.
+    const existing: STTConfig = {
+      provider: 'local',
+      local: {
+        endpoint: 'http://localhost:8080',
+        model: 'base.en',
+        server_type: 'whisper_cpp',
+      },
+    };
+    const merged = mergeSTTConfig(existing, {
+      local: { endpoint: 'http://localhost:9000' },
+    });
+
+    expect(merged.local?.endpoint).toBe('http://localhost:9000');
+    expect(merged.local?.model).toBe('base.en');
+    expect(merged.local?.server_type).toBe('whisper_cpp');
+  });
+
+  test('handles a missing existing config (first-run onboarding case)', () => {
+    const merged = mergeSTTConfig(undefined, {
+      provider: 'openai',
+      openai: { api_key: 'sk-fresh' },
+    });
+
+    expect(merged.provider).toBe('openai');
+    expect(merged.openai?.api_key).toBe('sk-fresh');
+  });
+
+  test('shallow-merges top-level fields like provider', () => {
+    const existing: STTConfig = {
+      provider: 'openai',
+      openai: { api_key: 'sk-x' },
+      groq: { api_key: 'gsk-y' },
+    };
+    const merged = mergeSTTConfig(existing, { provider: 'groq' });
+
+    expect(merged.provider).toBe('groq');
+    expect(merged.openai?.api_key).toBe('sk-x');
+    expect(merged.groq?.api_key).toBe('gsk-y');
+  });
+});
+
+describe('mergeTTSConfig', () => {
+  test('preserves elevenlabs api_key when toggling enabled', () => {
+    const existing: TTSConfig = {
+      enabled: true,
+      provider: 'elevenlabs',
+      elevenlabs: { api_key: 'el-existing', voice_id: 'rachel' },
+    };
+    const merged = mergeTTSConfig(existing, { enabled: false });
+
+    expect(merged.enabled).toBe(false);
+    expect(merged.elevenlabs?.api_key).toBe('el-existing');
+    expect(merged.elevenlabs?.voice_id).toBe('rachel');
+  });
+
+  test('preserves a different provider key when patching only one provider', () => {
+    const existing: TTSConfig = {
+      enabled: true,
+      provider: 'elevenlabs',
+      elevenlabs: { api_key: 'el-key' },
+    };
+    const merged = mergeTTSConfig(existing, {
+      provider: 'sarvam',
+      sarvam: { api_key: 'sv-key' },
+    });
+
+    expect(merged.elevenlabs?.api_key).toBe('el-key');
+    expect(merged.sarvam?.api_key).toBe('sv-key');
+  });
+
+  test('handles a missing existing config', () => {
+    const merged = mergeTTSConfig(undefined, {
+      enabled: true,
+      provider: 'edge',
+      voice: 'en-US-AriaNeural',
+    });
+
+    expect(merged.enabled).toBe(true);
+    expect(merged.provider).toBe('edge');
+    expect(merged.voice).toBe('en-US-AriaNeural');
+  });
+});

--- a/src/daemon/config-merge.ts
+++ b/src/daemon/config-merge.ts
@@ -1,0 +1,86 @@
+/**
+ * Shared merge helpers for STT/TTS config patches.
+ *
+ * Used by /api/config/stt, /api/config/tts, and /api/onboarding/setup so the
+ * preserved-key + sub-block shape lives in one place. Without this, the
+ * onboarding endpoint was a near-verbatim copy of /api/config/stt POST and
+ * any future change to the preserved-provider list had to be made in
+ * lockstep or the omitted endpoint would silently drop keys.
+ *
+ * Both helpers:
+ *  - Deep-merge known sub-blocks so a partial patch (e.g. just `model`)
+ *    doesn't wipe sibling fields (e.g. `api_key`).
+ *  - Preserve `api_key` on cloud sub-blocks when the incoming patch omits it
+ *    or sends an empty string — required because the GET endpoints redact
+ *    keys, so a UI round-trip never sees the real value.
+ *  - Shallow-merge remaining top-level fields (provider, enabled, voice…).
+ */
+import type { STTConfig, TTSConfig } from '../config/types.ts';
+
+type AnyRec = Record<string, unknown>;
+
+function mergeCloudSubBlock(
+  existing: AnyRec | undefined,
+  incoming: AnyRec,
+): AnyRec {
+  return {
+    ...existing,
+    ...incoming,
+    api_key: (incoming.api_key as string) || (existing?.api_key as string) || '',
+  };
+}
+
+/**
+ * Merge a partial STT patch into the existing config. Cloud providers
+ * (openai/groq/sarvam) preserve their api_key when the patch omits it.
+ * Local block is deep-merged so a partial update (e.g. just `endpoint`)
+ * doesn't wipe `model` or `server_type`.
+ */
+export function mergeSTTConfig(
+  existing: STTConfig | undefined,
+  incoming: AnyRec,
+): STTConfig {
+  const base: STTConfig = existing ?? { provider: 'openai' };
+  const patch = { ...incoming };
+  const merged: AnyRec = { ...base };
+
+  for (const p of ['openai', 'groq', 'sarvam'] as const) {
+    const inc = patch[p] as AnyRec | undefined;
+    if (inc) {
+      merged[p] = mergeCloudSubBlock((base as AnyRec)[p] as AnyRec | undefined, inc);
+      delete patch[p];
+    }
+  }
+
+  const incLocal = patch.local as AnyRec | undefined;
+  if (incLocal) {
+    const existingLocal = (base as AnyRec).local as AnyRec | undefined;
+    merged.local = { ...existingLocal, ...incLocal };
+    delete patch.local;
+  }
+
+  return { ...merged, ...patch } as STTConfig;
+}
+
+/**
+ * Merge a partial TTS patch into the existing config. ElevenLabs and Sarvam
+ * sub-blocks preserve their api_key when the patch omits it.
+ */
+export function mergeTTSConfig(
+  existing: TTSConfig | undefined,
+  incoming: AnyRec,
+): TTSConfig {
+  const base: TTSConfig = existing ?? { enabled: false };
+  const patch = { ...incoming };
+  const merged: AnyRec = { ...base };
+
+  for (const p of ['elevenlabs', 'sarvam'] as const) {
+    const inc = patch[p] as AnyRec | undefined;
+    if (inc) {
+      merged[p] = mergeCloudSubBlock((base as AnyRec)[p] as AnyRec | undefined, inc);
+      delete patch[p];
+    }
+  }
+
+  return { ...merged, ...patch } as TTSConfig;
+}

--- a/ui/src/v2/onboarding/SetupRoom.tsx
+++ b/ui/src/v2/onboarding/SetupRoom.tsx
@@ -198,7 +198,10 @@ export function SetupRoom({ onComplete }: { onComplete: () => void }) {
   // Settings → Channels.
   const [sttChoice, setSttChoice] = useState<STTChoice>("skip");
   const [sttKey, setSttKey] = useState("");
-  const [sttLocalEndpoint, setSttLocalEndpoint] = useState("http://localhost:8189");
+  // Matches LocalWhisperSTT's constructor default in src/comms/voice.ts so
+  // a user who accepts the suggested endpoint hits a working whisper.cpp
+  // server out of the box. Keep these in sync if either changes.
+  const [sttLocalEndpoint, setSttLocalEndpoint] = useState("http://localhost:8080");
   const [sttLocalServer, setSttLocalServer] = useState<LocalSTTServer>("whisper_cpp");
 
   // ── TTS screen state ───────────────────────────────────────────────
@@ -267,6 +270,16 @@ export function SetupRoom({ onComplete }: { onComplete: () => void }) {
   };
 
   const llmReady = testResult?.ok === true;
+
+  // Gate the STT Continue button so we never persist a cloud provider with
+  // no key (which fails at first transcription) or a local endpoint of "".
+  // Skip is always ready — it just omits the stt block from the payload.
+  const sttReady =
+    sttChoice === "skip"
+      ? true
+      : sttChoice === "local"
+        ? sttLocalEndpoint.trim() !== ""
+        : sttKey.trim() !== "";
 
   const handleFinish = async () => {
     setSaving(true);
@@ -630,7 +643,7 @@ export function SetupRoom({ onComplete }: { onComplete: () => void }) {
             </p>
 
             <div className="v2-setup__tts-grid" role="radiogroup">
-              <STTCard
+              <ChoiceCard
                 id="skip"
                 active={sttChoice === "skip"}
                 onClick={() => setSttChoice("skip")}
@@ -638,7 +651,7 @@ export function SetupRoom({ onComplete }: { onComplete: () => void }) {
                 title="Skip for now"
                 body="Text only. Wire up STT later from Settings."
               />
-              <STTCard
+              <ChoiceCard
                 id="openai"
                 active={sttChoice === "openai"}
                 onClick={() => setSttChoice("openai")}
@@ -646,7 +659,7 @@ export function SetupRoom({ onComplete }: { onComplete: () => void }) {
                 title="OpenAI Whisper"
                 body="Cloud Whisper. Accurate, needs an OpenAI API key."
               />
-              <STTCard
+              <ChoiceCard
                 id="groq"
                 active={sttChoice === "groq"}
                 onClick={() => setSttChoice("groq")}
@@ -654,7 +667,7 @@ export function SetupRoom({ onComplete }: { onComplete: () => void }) {
                 title="Groq Whisper"
                 body="Fastest hosted Whisper. Needs a Groq API key."
               />
-              <STTCard
+              <ChoiceCard
                 id="local"
                 active={sttChoice === "local"}
                 onClick={() => setSttChoice("local")}
@@ -696,7 +709,7 @@ export function SetupRoom({ onComplete }: { onComplete: () => void }) {
                     className="v2-setup__input"
                     value={sttLocalEndpoint}
                     onChange={(e) => setSttLocalEndpoint(e.target.value)}
-                    placeholder="http://localhost:8189"
+                    placeholder="http://localhost:8080"
                     autoComplete="off"
                   />
                 </div>
@@ -729,6 +742,7 @@ export function SetupRoom({ onComplete }: { onComplete: () => void }) {
                 variant="primary"
                 size="md"
                 onClick={() => setScreen("tts")}
+                disabled={!sttReady}
               >
                 Continue
                 <Icon icon={ArrowRight} size="sm" />
@@ -744,7 +758,7 @@ export function SetupRoom({ onComplete }: { onComplete: () => void }) {
             </p>
 
             <div className="v2-setup__tts-grid" role="radiogroup">
-              <TTSCard
+              <ChoiceCard
                 id="off"
                 active={ttsChoice === "off"}
                 onClick={() => setTtsChoice("off")}
@@ -752,7 +766,7 @@ export function SetupRoom({ onComplete }: { onComplete: () => void }) {
                 title="No voice"
                 body="Text replies only. Lightest option."
               />
-              <TTSCard
+              <ChoiceCard
                 id="edge"
                 active={ttsChoice === "edge"}
                 onClick={() => setTtsChoice("edge")}
@@ -760,7 +774,7 @@ export function SetupRoom({ onComplete }: { onComplete: () => void }) {
                 title="Edge TTS"
                 body="Free, clean, ships with Jarvis. Pick a voice below."
               />
-              <TTSCard
+              <ChoiceCard
                 id="elevenlabs"
                 active={ttsChoice === "elevenlabs"}
                 onClick={() => setTtsChoice("elevenlabs")}
@@ -852,7 +866,7 @@ export function SetupRoom({ onComplete }: { onComplete: () => void }) {
   );
 }
 
-function TTSCard({
+function ChoiceCard({
   active,
   onClick,
   icon,
@@ -884,15 +898,3 @@ function TTSCard({
   );
 }
 
-// Visually identical to TTSCard — kept separate so future STT-only chrome
-// (e.g. a "fastest" badge on Groq) doesn't have to thread props through TTS.
-function STTCard(props: {
-  active: boolean;
-  onClick: () => void;
-  icon: LucideIcon;
-  title: string;
-  body: string;
-  id: string;
-}) {
-  return <TTSCard {...props} />;
-}

--- a/ui/src/v2/onboarding/SetupRoom.tsx
+++ b/ui/src/v2/onboarding/SetupRoom.tsx
@@ -1,16 +1,16 @@
 import React, { useEffect, useState } from "react";
-import { ArrowRight, Check, Loader2, Volume2, VolumeX, type LucideIcon } from "lucide-react";
+import { ArrowRight, Check, Loader2, Mic, MicOff, Volume2, VolumeX, type LucideIcon } from "lucide-react";
 import { Button, Icon } from "../ui";
 import "./SetupRoom.css";
 
 /**
- * Phase A — first-run setup. Two screens, then `POST /api/onboarding/setup`
- * which atomically saves LLM + TTS + flips the completion flag. Daemon
+ * Phase A — first-run setup. Three screens, then `POST /api/onboarding/setup`
+ * which atomically saves LLM + STT + TTS + flips the completion flag. Daemon
  * hot-reloads providers; gate refetches status; we fall through to the
  * normal AppShell (or to Phase B once that's built).
  *
  * Deliberately self-contained — no Settings Room hook reuse — because
- * setup runs BEFORE the daemon has any LLM/TTS state to read, and the
+ * setup runs BEFORE the daemon has any LLM/STT/TTS state to read, and the
  * tabbed Settings UI's polling would hammer 503s. Reuses only the v2
  * tokens + Button primitive.
  */
@@ -115,6 +115,10 @@ const PROVIDERS: ReadonlyArray<{
   },
 ];
 
+type STTChoice = "skip" | "openai" | "groq" | "local";
+
+type LocalSTTServer = "whisper_cpp" | "openai_compatible";
+
 type TTSChoice = "off" | "edge" | "elevenlabs";
 
 const EDGE_VOICES = [
@@ -127,7 +131,7 @@ const EDGE_VOICES = [
 ];
 
 export function SetupRoom({ onComplete }: { onComplete: () => void }) {
-  const [screen, setScreen] = useState<"llm" | "tts">("llm");
+  const [screen, setScreen] = useState<"llm" | "stt" | "tts">("llm");
 
   // ── LLM screen state ───────────────────────────────────────────────
   const [providerId, setProviderId] = useState<LLMProviderId>("anthropic");
@@ -187,6 +191,15 @@ export function SetupRoom({ onComplete }: { onComplete: () => void }) {
       setModel(preferred);
     }
   }, [nvidiaModels, providerId]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // ── STT screen state ───────────────────────────────────────────────
+  // Default to "skip" so users who only want text chat aren't forced to
+  // hand over a Whisper key on first run. They can wire STT later from
+  // Settings → Channels.
+  const [sttChoice, setSttChoice] = useState<STTChoice>("skip");
+  const [sttKey, setSttKey] = useState("");
+  const [sttLocalEndpoint, setSttLocalEndpoint] = useState("http://localhost:8189");
+  const [sttLocalServer, setSttLocalServer] = useState<LocalSTTServer>("whisper_cpp");
 
   // ── TTS screen state ───────────────────────────────────────────────
   const [ttsChoice, setTtsChoice] = useState<TTSChoice>("edge");
@@ -281,10 +294,28 @@ export function SetupRoom({ onComplete }: { onComplete: () => void }) {
         if (elevenKey) ttsBlock.elevenlabs = { api_key: elevenKey };
       }
 
+      // Build the STT payload — omitted entirely when the user skipped so
+      // the backend leaves the default config untouched. The backend
+      // mirrors /api/config/stt POST semantics (preserves existing keys
+      // when a sub-block omits api_key).
+      const payload: Record<string, unknown> = { llm: llmBlock, tts: ttsBlock };
+      if (sttChoice !== "skip") {
+        const sttBlock: Record<string, unknown> = { provider: sttChoice };
+        if (sttChoice === "openai" || sttChoice === "groq") {
+          if (sttKey) sttBlock[sttChoice] = { api_key: sttKey };
+        } else if (sttChoice === "local") {
+          sttBlock.local = {
+            endpoint: sttLocalEndpoint.trim(),
+            server_type: sttLocalServer,
+          };
+        }
+        payload.stt = sttBlock;
+      }
+
       const r = await fetch("/api/onboarding/setup", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ llm: llmBlock, tts: ttsBlock }),
+        body: JSON.stringify(payload),
       });
       if (!r.ok) {
         const text = await r.text().catch(() => `HTTP ${r.status}`);
@@ -314,9 +345,17 @@ export function SetupRoom({ onComplete }: { onComplete: () => void }) {
             <div className="v2-setup__progress-sep">·</div>
             <div
               className="v2-setup__progress-step"
+              data-active={screen === "stt"}
+              data-done={screen === "tts"}
+            >
+              2 · Voice In
+            </div>
+            <div className="v2-setup__progress-sep">·</div>
+            <div
+              className="v2-setup__progress-step"
               data-active={screen === "tts"}
             >
-              2 · Voice
+              3 · Voice Out
             </div>
           </div>
         </header>
@@ -573,8 +612,123 @@ export function SetupRoom({ onComplete }: { onComplete: () => void }) {
               <Button
                 variant="primary"
                 size="md"
-                onClick={() => setScreen("tts")}
+                onClick={() => setScreen("stt")}
                 disabled={!llmReady}
+              >
+                Continue
+                <Icon icon={ArrowRight} size="sm" />
+              </Button>
+            </div>
+          </section>
+        ) : screen === "stt" ? (
+          <section className="v2-setup__screen">
+            <h1 className="v2-setup__title">How should Jarvis hear you?</h1>
+            <p className="v2-setup__sub">
+              Speech-to-text powers voice messages and the mic button. Skip
+              for now if you only plan to type — you can wire this up later
+              in Settings → Channels.
+            </p>
+
+            <div className="v2-setup__tts-grid" role="radiogroup">
+              <STTCard
+                id="skip"
+                active={sttChoice === "skip"}
+                onClick={() => setSttChoice("skip")}
+                icon={MicOff}
+                title="Skip for now"
+                body="Text only. Wire up STT later from Settings."
+              />
+              <STTCard
+                id="openai"
+                active={sttChoice === "openai"}
+                onClick={() => setSttChoice("openai")}
+                icon={Mic}
+                title="OpenAI Whisper"
+                body="Cloud Whisper. Accurate, needs an OpenAI API key."
+              />
+              <STTCard
+                id="groq"
+                active={sttChoice === "groq"}
+                onClick={() => setSttChoice("groq")}
+                icon={Mic}
+                title="Groq Whisper"
+                body="Fastest hosted Whisper. Needs a Groq API key."
+              />
+              <STTCard
+                id="local"
+                active={sttChoice === "local"}
+                onClick={() => setSttChoice("local")}
+                icon={Mic}
+                title="Local Whisper.cpp"
+                body="Self-hosted on your machine. No API key needed."
+              />
+            </div>
+
+            {(sttChoice === "openai" || sttChoice === "groq") && (
+              <div className="v2-setup__field">
+                <label className="v2-setup__label" htmlFor="setup-stt-key">
+                  {sttChoice === "openai" ? "OpenAI" : "Groq"} API key
+                </label>
+                <input
+                  id="setup-stt-key"
+                  className="v2-setup__input"
+                  type="password"
+                  value={sttKey}
+                  onChange={(e) => setSttKey(e.target.value)}
+                  placeholder="paste your key"
+                  autoComplete="off"
+                />
+                <p className="v2-setup__hint">
+                  Stored locally in your JARVIS config — never sent anywhere
+                  except {sttChoice === "openai" ? "OpenAI" : "Groq"}.
+                </p>
+              </div>
+            )}
+
+            {sttChoice === "local" && (
+              <>
+                <div className="v2-setup__field">
+                  <label className="v2-setup__label" htmlFor="setup-stt-endpoint">
+                    Whisper endpoint
+                  </label>
+                  <input
+                    id="setup-stt-endpoint"
+                    className="v2-setup__input"
+                    value={sttLocalEndpoint}
+                    onChange={(e) => setSttLocalEndpoint(e.target.value)}
+                    placeholder="http://localhost:8189"
+                    autoComplete="off"
+                  />
+                </div>
+                <div className="v2-setup__field">
+                  <label className="v2-setup__label" htmlFor="setup-stt-server">
+                    Server type
+                  </label>
+                  <select
+                    id="setup-stt-server"
+                    className="v2-setup__select"
+                    value={sttLocalServer}
+                    onChange={(e) => setSttLocalServer(e.target.value as LocalSTTServer)}
+                  >
+                    <option value="whisper_cpp">whisper.cpp</option>
+                    <option value="openai_compatible">OpenAI-compatible</option>
+                  </select>
+                </div>
+              </>
+            )}
+
+            <div className="v2-setup__cta-row">
+              <Button
+                variant="ghost"
+                size="md"
+                onClick={() => setScreen("llm")}
+              >
+                ← Back
+              </Button>
+              <Button
+                variant="primary"
+                size="md"
+                onClick={() => setScreen("tts")}
               >
                 Continue
                 <Icon icon={ArrowRight} size="sm" />
@@ -667,7 +821,7 @@ export function SetupRoom({ onComplete }: { onComplete: () => void }) {
               <Button
                 variant="ghost"
                 size="md"
-                onClick={() => setScreen("llm")}
+                onClick={() => setScreen("stt")}
                 disabled={saving}
               >
                 ← Back
@@ -728,4 +882,17 @@ function TTSCard({
       <span className="v2-setup__tts-body">{body}</span>
     </button>
   );
+}
+
+// Visually identical to TTSCard — kept separate so future STT-only chrome
+// (e.g. a "fastest" badge on Groq) doesn't have to thread props through TTS.
+function STTCard(props: {
+  active: boolean;
+  onClick: () => void;
+  icon: LucideIcon;
+  title: string;
+  body: string;
+  id: string;
+}) {
+  return <TTSCard {...props} />;
 }


### PR DESCRIPTION
 ## What

  Adds a third onboarding screen between the LLM and TTS steps so first-run users can pick their speech-to-text provider
  without having to dive into Settings later. Without this, anyone who wanted voice input had to finish onboarding, find
  Settings → Channels, and configure STT before the mic button worked.

  Choices on the screen:
  - **Skip** (default) — text-only; STT block is omitted from the payload entirely so existing config is untouched.
  - **OpenAI Whisper** / **Groq Whisper** — cloud, needs an API key.
  - **Local Whisper.cpp** — self-hosted endpoint + server type (`whisper_cpp` or `openai_compatible`).

  `/api/onboarding/setup` now accepts an optional `stt` block alongside `llm` and `tts`, persisting it the same way
  `/api/config/stt` POST does (preserves api_keys when the patch omits them).

  ## How

  - **New screen** in `ui/src/v2/onboarding/SetupRoom.tsx` with four `ChoiceCard` options, a key/endpoint input that swaps
  based on choice, and a `sttReady` gate on the Continue button so we never persist a cloud provider with no key or `local`
  with an empty endpoint.
  - **Shared merge helpers** in `src/daemon/config-merge.ts` (`mergeSTTConfig`, `mergeTTSConfig`) consumed by
  `/api/onboarding/setup`, `/api/config/stt` POST, and `/api/config/tts` POST. Replaces three near-verbatim copies of the
  preserve-key loop. Deep-merges sub-blocks (including STT `local`, so a partial `endpoint` update no longer wipes `model` /
   `server_type`).
  - **Local endpoint default** aligned to `http://localhost:8080` to match `LocalWhisperSTT`'s constructor default in
  `src/comms/voice.ts`, so accepting the suggested value hits a working whisper.cpp server out of the box.
  - **JSDoc on `/api/onboarding/setup`** updated to document the `stt` block.