### PR TITLE
Consolidate path containment checks under src/util/path.ts

### DIFF
--- a/src/comms/websocket.ts
+++ b/src/comms/websocket.ts
@@ -1,6 +1,7 @@
 import type { Server, ServerWebSocket } from 'bun';
 import { timingSafeEqual } from 'node:crypto';
 import path from 'node:path';
+import { isWithin } from '../util/path.ts';
 import type { SidecarManager } from '../sidecar/manager.ts';
 
 /** Constant-time string comparison to prevent timing attacks */
@@ -334,14 +335,14 @@ export class WebSocketServer {
           let filePath: string;
 
           if (pathname === '/' || pathname === '/index.html') {
-            filePath = path.join(self.staticDir, 'index.html');
+            filePath = path.resolve(self.staticDir, 'index.html');
           } else {
             // Serve JS/CSS/assets — resolve and validate within staticDir
             filePath = path.resolve(self.staticDir, '.' + pathname);
           }
 
           // Prevent path traversal outside staticDir
-          if (!filePath.startsWith(path.resolve(self.staticDir) + path.sep) && filePath !== path.resolve(self.staticDir, 'index.html')) {
+          if (!isWithin(filePath, path.resolve(self.staticDir))) {
             return new Response('Forbidden', { status: 403 });
           }
 
@@ -359,7 +360,7 @@ export class WebSocketServer {
         if (self.publicDir) {
           const publicPath = path.resolve(self.publicDir, '.' + pathname);
           // Prevent path traversal outside publicDir
-          if (!publicPath.startsWith(path.resolve(self.publicDir) + path.sep)) {
+          if (!isWithin(publicPath, path.resolve(self.publicDir))) {
             return new Response('Forbidden', { status: 403 });
           }
           const publicFile = Bun.file(publicPath);

--- a/src/daemon/api-routes.ts
+++ b/src/daemon/api-routes.ts
@@ -56,6 +56,7 @@ import {
 import { mkdirSync, existsSync } from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
+import { isWithin } from '../util/path.ts';
 
 // --- Security helpers ---
 
@@ -67,13 +68,6 @@ function escapeHtml(str: string): string {
 /** Sanitize a single path segment — strip directory separators and dot-dot sequences */
 function sanitizePathSegment(segment: string): string {
   return path.basename(segment.replace(/\.\./g, ''));
-}
-
-/** Validate that a resolved path is within the expected base directory */
-function isWithinBase(resolvedPath: string, baseDir: string): boolean {
-  const normalizedBase = path.resolve(baseDir) + path.sep;
-  const normalizedPath = path.resolve(resolvedPath);
-  return normalizedPath.startsWith(normalizedBase) || normalizedPath === path.resolve(baseDir);
 }
 
 /** Escape SQL LIKE wildcard characters in user input */
@@ -1519,7 +1513,7 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
 
           const diskPath = path.resolve(baseDir, safeName);
           // Verify resolved path stays within the content directory
-          if (!isWithinBase(diskPath, baseDir)) {
+          if (!isWithin(diskPath, path.resolve(baseDir))) {
             return error('Invalid filename', 400);
           }
 
@@ -1570,7 +1564,7 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
         const filePath = path.resolve(baseDir, safeContentId, safeFilename);
 
         // Verify resolved path stays within the content directory
-        if (!isWithinBase(filePath, baseDir)) {
+        if (!isWithin(filePath, path.resolve(baseDir))) {
           return error('Invalid path', 400);
         }
 
@@ -2681,7 +2675,7 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
         // points to brain-local disk. Serve from there as a fallback.
         if (!capture.sidecar_id) {
           const jarvisDir = path.join(os.homedir(), '.jarvis');
-          if (!isWithinBase(capture.image_path, jarvisDir)) {
+          if (!isWithin(path.resolve(capture.image_path), path.resolve(jarvisDir))) {
             return error('Image not found', 404);
           }
           try {

--- a/src/sites/path-utils.ts
+++ b/src/sites/path-utils.ts
@@ -1,6 +1,0 @@
-import { isAbsolute, relative, sep } from 'node:path';
-
-export function isWithin(resolvedPath: string, basePath: string): boolean {
-  const rel = relative(basePath, resolvedPath);
-  return rel === '' || (rel !== '..' && !rel.startsWith(`..${sep}`) && !isAbsolute(rel));
-}

--- a/src/sites/project-manager.ts
+++ b/src/sites/project-manager.ts
@@ -10,7 +10,7 @@ import { TEMPLATES, generateMakefile, scaffoldBunReact } from './templates.ts';
 import { join, relative, resolve } from 'node:path';
 import { homedir } from 'node:os';
 import { readdirSync, statSync, existsSync, mkdirSync, rmSync } from 'node:fs';
-import { isWithin } from './path-utils.ts';
+import { isWithin } from '../util/path.ts';
 
 const META_FILE = '.jarvis-project.json';
 

--- a/src/util/path.test.ts
+++ b/src/util/path.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from 'bun:test';
+import { resolve, sep } from 'node:path';
+import { isWithin } from './path.ts';
+
+describe('isWithin', () => {
+  const base = resolve('/foo/app');
+
+  test('allows same directory (rel === "")', () => {
+    expect(isWithin(base, base)).toBe(true);
+  });
+
+  test('allows descendant paths', () => {
+    expect(isWithin(resolve('/foo/app/sub/file.txt'), base)).toBe(true);
+  });
+
+  test('allows descendant whose first segment starts with two dots', () => {
+    expect(isWithin(resolve('/foo/app/..config/settings.json'), base)).toBe(true);
+  });
+
+  test('rejects sibling directory with shared prefix (the original bug)', () => {
+    expect(isWithin(resolve('/foo/app-backup/pwned.txt'), base)).toBe(false);
+    expect(isWithin(resolve('/foo/app-backup'), base)).toBe(false);
+  });
+
+  test('rejects parent directory traversal', () => {
+    expect(isWithin(resolve('/foo/other/file.txt'), base)).toBe(false);
+    expect(isWithin(resolve('/foo'), base)).toBe(false);
+  });
+
+  test('rejects exact "../" relative result', () => {
+    expect(isWithin(resolve('/foo'), resolve('/foo/app'))).toBe(false);
+  });
+
+  test('rejects paths in unrelated trees (treated as absolute rel on POSIX)', () => {
+    // On POSIX, relative('/foo/app', '/bar') returns '../../bar' (starts with ..sep) -> rejected.
+    expect(isWithin(resolve('/bar/baz'), base)).toBe(false);
+  });
+
+  test('uses the platform separator in the .. check', () => {
+    // Regression guard: a forward-slash-only check would mishandle Windows paths.
+    // The helper relies on `sep` so this should hold on every platform.
+    const escaping = `..${sep}escape`;
+    expect(escaping.startsWith(`..${sep}`)).toBe(true);
+  });
+});

--- a/src/util/path.ts
+++ b/src/util/path.ts
@@ -1,0 +1,21 @@
+import { isAbsolute, relative, sep } from 'node:path';
+
+/**
+ * Strict path-containment check.
+ *
+ * Returns true iff `resolvedPath` is `basePath` itself or a descendant of it.
+ *
+ * Both arguments are expected to be absolute, already-resolved paths. We rely
+ * on `path.relative` rather than `startsWith`, because string-prefix checks
+ * accept sibling-prefix traversal (e.g. base `/foo/app` matching `/foo/app-backup`).
+ *
+ * - `rel === ''` is the same-directory case (resolvedPath === basePath) and is allowed.
+ * - `rel === '..'` and `rel.startsWith('..' + sep)` mean we'd have to walk up out
+ *   of basePath, so the path escapes containment.
+ * - `isAbsolute(rel)` catches the Windows case where `relative` returns an
+ *   absolute path (e.g. different drive letters), which also means escape.
+ */
+export function isWithin(resolvedPath: string, basePath: string): boolean {
+  const rel = relative(basePath, resolvedPath);
+  return rel === '' || (rel !== '..' && !rel.startsWith(`..${sep}`) && !isAbsolute(rel));
+}


### PR DESCRIPTION
Follow-up to #202. The isWithin helper introduced there is now reused by every path-containment site in the daemon and
  websocket layer, so we have a single audited implementation instead of three parallel ones.

  Changes

  - Moved isWithin from src/sites/path-utils.ts to src/util/path.ts (it's no longer site-specific) and added a JSDoc
  explaining the rel === '' same-directory case, the .. / ..${sep} rejection, and the isAbsolute guard for the Windows
  cross-drive case.
  - Removed the local isWithinBase in src/daemon/api-routes.ts and migrated its three call sites (content upload, content
  download, awareness capture image) to the shared helper.
  - Replaced the inline startsWith(... + path.sep) checks in src/comms/websocket.ts (staticDir and publicDir). The
  staticDir branch no longer needs the filePath !== path.resolve(self.staticDir, 'index.html') special case since isWithin
  already accepts the same-directory case.
  - Updated src/sites/project-manager.ts to import from the new location; deleted the old src/sites/path-utils.ts.

  Tests

  - New src/util/path.test.ts exercises isWithin in isolation: same-dir, descendant, ..config-prefixed descendant,
  sibling-prefix (the original #202 bug), parent traversal, exact .. rel, unrelated tree, and a platform-separator
  regression guard.
  - Existing src/sites/project-manager.test.ts integration coverage still passes against the moved helper.

  Verification

  - bun test: 818/818 pass.
  - bunx tsc --noEmit: clean