### PR TITLE
Add LiteLLM as an LLM provider

### DIFF
--- a/src/agents/voice-intent-classifier.ts
+++ b/src/agents/voice-intent-classifier.ts
@@ -267,7 +267,7 @@ settings room ("room": "settings"):
    matches "open the LLM tab", "switch to channels", "go to general settings"
 - "read_status" — args: {}
    matches "read the current status", "what's the LLM config", "what's connected"
-- "set_primary_llm" — args: { "provider": "anthropic"|"openai"|"groq"|"gemini"|"ollama"|"openrouter"|"nvidia" }
+- "set_primary_llm" — args: { "provider": "anthropic"|"openai"|"groq"|"gemini"|"ollama"|"openrouter"|"nvidia"|"litellm" }
    matches "set primary to anthropic", "make openai the default", "switch to ollama"
 - "set_fallback_llm" — args: { "fallback": string[] | string }
    matches "set the fallback chain to openai and ollama", "use openai as fallback"

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -80,6 +80,13 @@ export async function runDoctor(): Promise<void> {
 
     if (primary === 'ollama') {
       results.push({ name: 'LLM Provider', status: 'ok', message: `ollama (${providerConfig?.model ?? 'llama3'})` });
+    } else if (primary === 'litellm' || primary === 'openai_compatible') {
+      const url = providerConfig?.base_url;
+      results.push({
+        name: 'LLM Provider',
+        status: url ? 'ok' : 'fail',
+        message: url ? `${primary} (${url})` : `${primary} base URL not set`,
+      });
     } else if (providerConfig?.api_key && providerConfig.api_key !== '') {
       results.push({
         name: 'LLM Provider',
@@ -98,7 +105,7 @@ export async function runDoctor(): Promise<void> {
   if (config) {
     const spin = startSpinner('Testing LLM connectivity...');
     try {
-      const { LLMManager, AnthropicProvider, OpenAIProvider, GroqProvider, GeminiProvider, OllamaProvider, OpenRouterProvider, OpenAICompatibleProvider } = await import('../llm/index.ts');
+      const { LLMManager, AnthropicProvider, OpenAIProvider, GroqProvider, GeminiProvider, OllamaProvider, OpenRouterProvider, OpenAICompatibleProvider, LiteLLMProvider } = await import('../llm/index.ts');
       const manager = new LLMManager();
       const primary = config.llm?.primary ?? 'anthropic';
 
@@ -119,6 +126,12 @@ export async function runDoctor(): Promise<void> {
           config.llm.openai_compatible.base_url,
           config.llm.openai_compatible.model,
           config.llm.openai_compatible.api_key,
+        ));
+      } else if (primary === 'litellm' && config.llm?.litellm?.base_url) {
+        manager.registerProvider(new LiteLLMProvider(
+          config.llm.litellm.base_url,
+          config.llm.litellm.model,
+          config.llm.litellm.api_key,
         ));
       }
 

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -93,6 +93,12 @@ function applyEnvOverrides(config: JarvisConfig): void {
     config.llm.nvidia.api_key = env.NVIDIA_API_KEY;
   }
 
+  if (env.JARVIS_LITELLM_URL || env.JARVIS_LITELLM_KEY) {
+    if (!config.llm.litellm) config.llm.litellm = { base_url: 'http://localhost:4000/v1', api_key: '', model: '' };
+    if (env.JARVIS_LITELLM_URL) config.llm.litellm.base_url = env.JARVIS_LITELLM_URL;
+    if (env.JARVIS_LITELLM_KEY) config.llm.litellm.api_key = env.JARVIS_LITELLM_KEY;
+  }
+
   if (env.JARVIS_BRAIN_DOMAIN) {
     config.daemon.brain_domain = env.JARVIS_BRAIN_DOMAIN;
   }

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -222,6 +222,7 @@ export type JarvisConfig = {
     openrouter?: { api_key: string; model?: string };
     nvidia?: { api_key: string; model?: string };
     openai_compatible?: { base_url?: string; api_key?: string; model?: string };
+    litellm?: { base_url?: string; api_key?: string; model?: string };
   };
   personality: {
     core_traits: string[];

--- a/src/daemon/agent-service.ts
+++ b/src/daemon/agent-service.ts
@@ -22,6 +22,7 @@ import { OllamaProvider } from '../llm/ollama.ts';
 import { OpenRouterProvider } from '../llm/openrouter.ts';
 import { NVIDIAProvider } from '../llm/nvidia.ts';
 import { OpenAICompatibleProvider } from '../llm/openai-compatible.ts';
+import { LiteLLMProvider } from '../llm/litellm.ts';
 import { AgentOrchestrator } from '../agents/orchestrator.ts';
 import { loadRole } from '../roles/loader.ts';
 import { ToolRegistry } from '../actions/tools/registry.ts';
@@ -431,6 +432,20 @@ export class AgentService implements Service, IAgentService {
       this.llmManager.registerProvider(provider);
       hasProvider = true;
       console.log('[AgentService] Registered OpenAI-compatible provider');
+    }
+
+    // Register LiteLLM proxy. Needs an explicit base_url so it doesn't
+    // appear active when no proxy is running; the virtual key is
+    // optional for unauthenticated local proxies.
+    if (llm.litellm?.base_url) {
+      const provider = new LiteLLMProvider(
+        llm.litellm.base_url,
+        llm.litellm.model,
+        llm.litellm.api_key,
+      );
+      this.llmManager.registerProvider(provider);
+      hasProvider = true;
+      console.log('[AgentService] Registered LiteLLM provider');
     }
 
     if (!hasProvider) {

--- a/src/daemon/api-routes.ts
+++ b/src/daemon/api-routes.ts
@@ -1257,6 +1257,12 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
                   model: config.llm.openai_compatible.model,
                 }
               : null,
+            litellm: config.llm.litellm
+              ? {
+                  base_url: config.llm.litellm.base_url,
+                  model: config.llm.litellm.model,
+                }
+              : null,
           },
           personality: config.personality,
           authority: config.authority,

--- a/src/daemon/llm-settings.ts
+++ b/src/daemon/llm-settings.ts
@@ -16,6 +16,7 @@ import { OllamaProvider } from '../llm/ollama.ts';
 import { OpenRouterProvider } from '../llm/openrouter.ts';
 import { NVIDIAProvider } from '../llm/nvidia.ts';
 import { OpenAICompatibleProvider } from '../llm/openai-compatible.ts';
+import { LiteLLMProvider } from '../llm/litellm.ts';
 import type { LLMProvider } from '../llm/provider.ts';
 import type { LLMManager } from '../llm/manager.ts';
 
@@ -27,6 +28,7 @@ const KEY_GEMINI = 'llm.gemini.api_key';
 const KEY_OPENROUTER = 'llm.openrouter.api_key';
 const KEY_NVIDIA = 'llm.nvidia.api_key';
 const KEY_OPENAI_COMPAT = 'llm.openai_compatible.api_key';
+const KEY_LITELLM = 'llm.litellm.api_key';
 
 // DB setting keys
 const SETTING_PRIMARY = 'llm.primary';
@@ -41,6 +43,8 @@ const SETTING_OPENROUTER_MODEL = 'llm.openrouter.model';
 const SETTING_NVIDIA_MODEL = 'llm.nvidia.model';
 const SETTING_OPENAI_COMPAT_MODEL = 'llm.openai_compatible.model';
 const SETTING_OPENAI_COMPAT_BASE_URL = 'llm.openai_compatible.base_url';
+const SETTING_LITELLM_MODEL = 'llm.litellm.model';
+const SETTING_LITELLM_BASE_URL = 'llm.litellm.base_url';
 
 export type LLMSettingsResponse = {
   primary: string;
@@ -53,6 +57,7 @@ export type LLMSettingsResponse = {
   openrouter: { model: string; has_api_key: boolean } | null;
   nvidia: { model: string; has_api_key: boolean } | null;
   openai_compatible: { base_url: string; model: string; has_api_key: boolean } | null;
+  litellm: { base_url: string; model: string; has_api_key: boolean } | null;
 };
 
 /**
@@ -105,6 +110,20 @@ export function getLLMSettings(config: JarvisConfig): LLMSettingsResponse {
       }
     : null;
 
+  // LiteLLM proxy: requires an explicit base_url to count as configured.
+  // Virtual key is optional (some local proxies run without auth).
+  const dbLiteLLMUrl = getSetting(SETTING_LITELLM_BASE_URL);
+  const dbLiteLLMModel = getSetting(SETTING_LITELLM_MODEL);
+  const liteLLMConfigured = !!(dbLiteLLMUrl || config.llm.litellm?.base_url);
+  const hasLiteLLMKey = hasSecret(KEY_LITELLM) || !!config.llm.litellm?.api_key;
+  const litellm = liteLLMConfigured
+    ? {
+        base_url: dbLiteLLMUrl ?? config.llm.litellm?.base_url ?? '',
+        model: dbLiteLLMModel ?? config.llm.litellm?.model ?? '',
+        has_api_key: hasLiteLLMKey,
+      }
+    : null;
+
   return {
     primary,
     fallback,
@@ -116,6 +135,7 @@ export function getLLMSettings(config: JarvisConfig): LLMSettingsResponse {
     openrouter: { model: openrouterModel, has_api_key: hasOpenrouterKey },
     nvidia: { model: nvidiaModel, has_api_key: hasNvidiaKey },
     openai_compatible,
+    litellm,
   };
 }
 
@@ -135,6 +155,7 @@ export function saveLLMSettings(
     openrouter?: { api_key?: string; model?: string };
     nvidia?: { api_key?: string; model?: string };
     openai_compatible?: { base_url?: string; api_key?: string; model?: string };
+    litellm?: { base_url?: string; api_key?: string; model?: string };
   },
 ): void {
   // Save non-secret settings to DB
@@ -275,6 +296,41 @@ export function saveLLMSettings(
     };
   }
 
+  // LiteLLM. Same independent-field model as openai_compatible — `base_url`,
+  // `model`, and `api_key` can each be saved independently. An explicit
+  // empty `base_url` clears the provider entirely.
+  if (body.litellm) {
+    const trimmedUrl = body.litellm.base_url?.trim();
+    const clearingUrl = body.litellm.base_url !== undefined && !trimmedUrl;
+    if (clearingUrl) {
+      deleteSetting(SETTING_LITELLM_BASE_URL);
+      deleteSetting(SETTING_LITELLM_MODEL);
+      deleteSecret(KEY_LITELLM);
+      config.llm.litellm = undefined;
+    } else {
+      if (trimmedUrl) {
+        setSetting(SETTING_LITELLM_BASE_URL, trimmedUrl);
+      }
+      if (body.litellm.model) {
+        setSetting(SETTING_LITELLM_MODEL, body.litellm.model);
+      }
+      if (body.litellm.api_key) {
+        setSecret(KEY_LITELLM, body.litellm.api_key);
+      }
+      const nextUrl = trimmedUrl ?? config.llm.litellm?.base_url;
+      const nextModel = body.litellm.model ?? config.llm.litellm?.model;
+      const nextKey = body.litellm.api_key ?? getLiteLLMApiKey(config) ?? '';
+      if (nextUrl || nextModel || nextKey) {
+        config.llm.litellm = {
+          ...config.llm.litellm,
+          ...(nextModel ? { model: nextModel } : {}),
+          ...(nextUrl ? { base_url: nextUrl } : {}),
+          ...(nextKey ? { api_key: nextKey } : {}),
+        };
+      }
+    }
+  }
+
   // OpenAI-compatible. Same independent-field model as Ollama: a `base_url`,
   // `model`, and `api_key` can each be saved independently. An explicit
   // empty `base_url` clears the provider entirely.
@@ -359,6 +415,14 @@ function getNvidiaApiKey(config: JarvisConfig): string | null {
  */
 function getOpenAICompatibleApiKey(config: JarvisConfig): string | null {
   return getSecret(KEY_OPENAI_COMPAT) ?? config.llm.openai_compatible?.api_key ?? null;
+}
+
+/**
+ * Resolve the LiteLLM virtual key: keychain > config.yaml.
+ * Optional — unauthenticated local LiteLLM proxies don't require a key.
+ */
+function getLiteLLMApiKey(config: JarvisConfig): string | null {
+  return getSecret(KEY_LITELLM) ?? config.llm.litellm?.api_key ?? null;
 }
 
 /**
@@ -476,6 +540,25 @@ export function mergeLLMSettingsIntoConfig(config: JarvisConfig): void {
       api_key: keychainCompatKey ?? config.llm.openai_compatible?.api_key ?? '',
     };
   }
+
+  // LiteLLM. Mirrors openai_compatible: leave `base_url` undefined when the
+  // user hasn't set one, so a stored key alone doesn't make the provider
+  // appear "configured" in the UI.
+  const dbLiteLLMModel = getSetting(SETTING_LITELLM_MODEL);
+  const dbLiteLLMUrl = getSetting(SETTING_LITELLM_BASE_URL);
+  const keychainLiteLLMKey = getSecret(KEY_LITELLM);
+  if (dbLiteLLMModel || dbLiteLLMUrl || keychainLiteLLMKey) {
+    config.llm.litellm = {
+      ...config.llm.litellm,
+      base_url: (!process.env.JARVIS_LITELLM_URL && dbLiteLLMUrl)
+        ? dbLiteLLMUrl
+        : config.llm.litellm?.base_url,
+      model: dbLiteLLMModel ?? config.llm.litellm?.model,
+      api_key: (!process.env.JARVIS_LITELLM_KEY && keychainLiteLLMKey)
+        ? keychainLiteLLMKey
+        : (config.llm.litellm?.api_key ?? ''),
+    };
+  }
 }
 
 /**
@@ -521,6 +604,14 @@ export function hotReloadLLMProviders(config: JarvisConfig, llmManager: LLMManag
       llm.openai_compatible.api_key,
     ));
     console.log('[LLM] Hot-reloaded OpenAI-compatible provider');
+  }
+  if (llm.litellm?.base_url) {
+    providers.push(new LiteLLMProvider(
+      llm.litellm.base_url,
+      llm.litellm.model,
+      llm.litellm.api_key,
+    ));
+    console.log('[LLM] Hot-reloaded LiteLLM provider');
   }
 
   const fallback = llm.fallback.filter(n => providers.some(p => p.name === n));
@@ -579,6 +670,12 @@ export async function testLLMProvider(
       const model = opts.model ?? config.llm.openai_compatible?.model;
       const key = opts.api_key ?? getOpenAICompatibleApiKey(config) ?? '';
       instance = new OpenAICompatibleProvider(baseUrl, model, key);
+    } else if (opts.provider === 'litellm') {
+      const baseUrl = opts.base_url ?? config.llm.litellm?.base_url;
+      if (!baseUrl) return { ok: false, error: 'Base URL required' };
+      const model = opts.model ?? config.llm.litellm?.model;
+      const key = opts.api_key ?? getLiteLLMApiKey(config) ?? '';
+      instance = new LiteLLMProvider(baseUrl, model, key);
     } else {
       return { ok: false, error: `Unknown provider: ${opts.provider}` };
     }

--- a/src/llm/index.ts
+++ b/src/llm/index.ts
@@ -17,6 +17,7 @@ export { GroqProvider } from './groq.ts';
 export { GeminiProvider } from './gemini.ts';
 export { OllamaProvider } from './ollama.ts';
 export { OpenRouterProvider } from './openrouter.ts';
+export { LiteLLMProvider } from './litellm.ts';
 
 // Manager
 export { LLMManager } from './manager.ts';

--- a/src/llm/litellm.ts
+++ b/src/llm/litellm.ts
@@ -1,0 +1,30 @@
+import { OpenAIProvider } from './openai.ts';
+
+/**
+ * LiteLLM provider. LiteLLM is an OpenAI-compatible proxy/gateway that
+ * routes requests to 100+ underlying LLM providers (OpenAI, Anthropic,
+ * Bedrock, Vertex, Azure, Ollama, etc.) behind a single endpoint.
+ *
+ * Speaks the OpenAI `/chat/completions` schema, so we extend
+ * `OpenAIProvider` and only override the identity and defaults.
+ *
+ * Defaults assume a self-hosted proxy at `http://localhost:4000/v1`.
+ * `OpenAIProvider` only appends `/chat/completions` to the `base_url`,
+ * so the URL stored here must already include whatever path prefix the
+ * proxy expects (typically `/v1`). Auth uses a LiteLLM "virtual key"
+ * passed as a Bearer token; for unauthenticated local proxies the key
+ * may be left blank.
+ *
+ * Docs: https://docs.litellm.ai/docs/
+ */
+export class LiteLLMProvider extends OpenAIProvider {
+  override name = 'litellm';
+
+  constructor(baseUrl = 'http://localhost:4000/v1', defaultModel = '', apiKey = '') {
+    super(apiKey, defaultModel, baseUrl);
+  }
+
+  protected override get errorLabel(): string {
+    return 'LiteLLM';
+  }
+}

--- a/src/llm/provider.test.ts
+++ b/src/llm/provider.test.ts
@@ -5,6 +5,7 @@ import { GroqProvider, relaxOptionalFieldsToNullable } from './groq.ts';
 import { OllamaProvider } from './ollama.ts';
 import { OpenRouterProvider } from './openrouter.ts';
 import { NVIDIAProvider } from './nvidia.ts';
+import { LiteLLMProvider } from './litellm.ts';
 import { LLMManager } from './manager.ts';
 import { guardImageSize, classifyHttpStatus, classifyErrorString, type LLMMessage, type ContentBlock } from './provider.ts';
 import { isToolResult, type ToolResult } from '../actions/tools/registry.ts';
@@ -38,6 +39,16 @@ describe('LLM Provider Types', () => {
   test('NVIDIAProvider can be instantiated', () => {
     const provider = new NVIDIAProvider('test-key');
     expect(provider.name).toBe('nvidia');
+  });
+
+  test('LiteLLMProvider can be instantiated', () => {
+    const provider = new LiteLLMProvider('http://localhost:4000/v1', 'gpt-4o', 'sk-test');
+    expect(provider.name).toBe('litellm');
+  });
+
+  test('LiteLLMProvider defaults to localhost:4000', () => {
+    const provider = new LiteLLMProvider();
+    expect(provider.name).toBe('litellm');
   });
 });
 

--- a/ui/src/v2/onboarding/SetupRoom.tsx
+++ b/ui/src/v2/onboarding/SetupRoom.tsx
@@ -23,7 +23,8 @@ type LLMProviderId =
   | "ollama"
   | "openrouter"
   | "nvidia"
-  | "openai_compatible";
+  | "openai_compatible"
+  | "litellm";
 
 const PROVIDERS: ReadonlyArray<{
   id: LLMProviderId;
@@ -107,6 +108,18 @@ const PROVIDERS: ReadonlyArray<{
     // so we leave the list empty and let the "Custom..." path handle it.
     id: "openai_compatible",
     label: "OpenAI-compatible",
+    needsKey: false,
+    needsBaseUrl: true,
+    optionalKey: true,
+    models: [],
+    defaultModel: "",
+  },
+  {
+    // LiteLLM proxy. OpenAI-compatible, but distinct row so users searching
+    // for "LiteLLM" find it and get the right defaults. Models depend on
+    // the aliases configured on the user's proxy, so the list stays empty.
+    id: "litellm",
+    label: "LiteLLM",
     needsKey: false,
     needsBaseUrl: true,
     optionalKey: true,
@@ -222,6 +235,8 @@ export function SetupRoom({ onComplete }: { onComplete: () => void }) {
     // submit an Ollama URL into an OpenAI-compatible setup and vice versa.
     if (id === "ollama") {
       setBaseUrl("http://localhost:11434");
+    } else if (id === "litellm") {
+      setBaseUrl("http://localhost:4000/v1");
     } else if (id === "openai_compatible") {
       setBaseUrl("");
     }
@@ -247,8 +262,8 @@ export function SetupRoom({ onComplete }: { onComplete: () => void }) {
         }
         body.base_url = baseUrl.trim();
       }
-      // openai_compatible: forward the typed key when present (optional).
-      if (providerId === "openai_compatible" && apiKey) {
+      // openai_compatible / litellm: forward the typed key when present (optional).
+      if ((providerId === "openai_compatible" || providerId === "litellm") && apiKey) {
         body.api_key = apiKey;
       }
       const r = await fetch("/api/config/llm/test", {
@@ -399,9 +414,11 @@ export function SetupRoom({ onComplete }: { onComplete: () => void }) {
                     <span className="v2-setup__provider-meta">
                       {p.id === "openai_compatible"
                         ? "self-hosted"
-                        : p.needsKey
-                          ? "API key"
-                          : "local"}
+                        : p.id === "litellm"
+                          ? "proxy"
+                          : p.needsKey
+                            ? "API key"
+                            : "local"}
                     </span>
                   </button>
                 ))}
@@ -411,7 +428,11 @@ export function SetupRoom({ onComplete }: { onComplete: () => void }) {
             {provider.needsBaseUrl && (
               <div className="v2-setup__field">
                 <label className="v2-setup__label" htmlFor="setup-baseurl">
-                  {providerId === "ollama" ? "Ollama base URL" : "Base URL"}
+                  {providerId === "ollama"
+                    ? "Ollama base URL"
+                    : providerId === "litellm"
+                      ? "LiteLLM proxy URL"
+                      : "Base URL"}
                 </label>
                 <input
                   id="setup-baseurl"
@@ -424,7 +445,9 @@ export function SetupRoom({ onComplete }: { onComplete: () => void }) {
                   placeholder={
                     providerId === "ollama"
                       ? "http://localhost:11434"
-                      : "http://localhost:8080/v1"
+                      : providerId === "litellm"
+                        ? "http://localhost:4000/v1"
+                        : "http://localhost:8080/v1"
                   }
                 />
                 {providerId === "openai_compatible" && (
@@ -435,6 +458,15 @@ export function SetupRoom({ onComplete }: { onComplete: () => void }) {
                     Any server that speaks /v1/chat/completions: llama.cpp,
                     vLLM, LM Studio, TGI, Together, Anyscale. Include the
                     /v1 suffix.
+                  </p>
+                )}
+                {providerId === "litellm" && (
+                  <p
+                    className="v2-setup__hint"
+                    style={{ color: "var(--ink-3)", marginTop: "var(--s-1)" }}
+                  >
+                    URL of your LiteLLM proxy (https://docs.litellm.ai/docs/).
+                    The model below must match an alias defined on the proxy.
                   </p>
                 )}
               </div>
@@ -578,7 +610,9 @@ export function SetupRoom({ onComplete }: { onComplete: () => void }) {
                     placeholder={
                       providerId === "openai_compatible"
                         ? "model id (whatever your server exposes)"
-                        : "model id (e.g. your local Ollama model name)"
+                        : providerId === "litellm"
+                          ? "model alias from your LiteLLM proxy config"
+                          : "model id (e.g. your local Ollama model name)"
                     }
                     autoComplete="off"
                     style={{

--- a/ui/src/v2/rooms/settings/tabs/LLMTab.tsx
+++ b/ui/src/v2/rooms/settings/tabs/LLMTab.tsx
@@ -72,6 +72,11 @@ const MODELS: Record<LLMProvider, string[]> = {
   // backends — model names are entirely user-defined, so the dropdown
   // starts empty and the user types or pastes a model id.
   openai_compatible: [],
+  // LiteLLM proxies to 100+ backend providers and uses provider-prefixed
+  // model names (e.g. `gpt-4o`, `anthropic/claude-3-opus`, `gemini/gemini-pro`)
+  // configured on the proxy itself. Leave empty so users type the alias
+  // that matches their proxy config.
+  litellm: [],
 };
 
 export function LLMTab({
@@ -183,7 +188,7 @@ function ProviderRow({
   // For Ollama and OpenAI-compatible "configured" means the user set a
   // base_url. The API key is optional in those flows (local servers often
   // skip auth). All other providers gate on `has_api_key`.
-  const usesBaseUrl = provider === "ollama" || provider === "openai_compatible";
+  const usesBaseUrl = provider === "ollama" || provider === "openai_compatible" || provider === "litellm";
   const hasKey = usesBaseUrl ? !!pCfg?.base_url : !!pCfg?.has_api_key;
   const currentModel: string = pCfg?.model ?? "";
   const currentBaseUrl: string = pCfg?.base_url ?? "";
@@ -275,7 +280,9 @@ function ProviderRow({
     const trimmed = baseUrl.trim();
     const r = provider === "openai_compatible"
       ? await data.setOpenAICompatibleBaseUrl(trimmed)
-      : await data.setOllamaBaseUrl(trimmed);
+      : provider === "litellm"
+        ? await data.setLiteLLMBaseUrl(trimmed)
+        : await data.setOllamaBaseUrl(trimmed);
     onToast(r.message, r.ok ? "ok" : "warn");
     setSaving(false);
   };
@@ -292,9 +299,11 @@ function ProviderRow({
     const m = resolveModel();
     if (m) overrides.model = m;
     if (usesBaseUrl && baseUrl) overrides.baseUrl = baseUrl.trim();
-    // For openai_compatible the freshly-typed key (if any) should be used
-    // for the test request. Ollama doesn't take a key.
-    if (provider === "openai_compatible" && apiKey) overrides.apiKey = apiKey;
+    // For openai_compatible and litellm the freshly-typed key (if any) should
+    // be used for the test request. Ollama doesn't take a key.
+    if ((provider === "openai_compatible" || provider === "litellm") && apiKey) {
+      overrides.apiKey = apiKey;
+    }
     const r = await data.testProvider(provider, overrides);
     setTestResult({ ok: r.ok, text: r.message });
     setTesting(false);
@@ -334,7 +343,9 @@ function ProviderRow({
                   placeholder={
                     provider === "ollama"
                       ? "http://localhost:11434"
-                      : "http://localhost:8080/v1"
+                      : provider === "litellm"
+                        ? "http://localhost:4000/v1"
+                        : "http://localhost:8080/v1"
                   }
                 />
                 {provider === "ollama" && (
@@ -344,6 +355,17 @@ function ProviderRow({
                     onClick={() => setBaseUrl("http://localhost:11434")}
                     disabled={saving}
                     title="Fill in the default localhost URL"
+                  >
+                    Default
+                  </button>
+                )}
+                {provider === "litellm" && (
+                  <button
+                    type="button"
+                    className="v2-set__btn"
+                    onClick={() => setBaseUrl("http://localhost:4000/v1")}
+                    disabled={saving}
+                    title="Fill in the default LiteLLM proxy URL"
                   >
                     Default
                   </button>
@@ -364,6 +386,13 @@ function ProviderRow({
                   Studio, TGI, Together, Anyscale. Include the /v1 suffix.
                 </p>
               )}
+              {provider === "litellm" && (
+                <p className="v2-set__hint">
+                  URL of your LiteLLM proxy (self-hosted or hosted). The model
+                  string must match an alias configured on the proxy
+                  (e.g. `gpt-4o`, `anthropic/claude-3-opus`). Include /v1.
+                </p>
+              )}
             </div>
           )}
 
@@ -371,7 +400,7 @@ function ProviderRow({
             <div className="v2-set__field">
               <label className="v2-set__field-label">
                 API Key
-                {provider === "openai_compatible" && (
+                {(provider === "openai_compatible" || provider === "litellm") && (
                   <span style={{ color: "var(--ink-3)", marginLeft: "var(--s-2)" }}>
                     (optional)
                   </span>
@@ -388,7 +417,9 @@ function ProviderRow({
                       ? "Stored -- leave empty to keep"
                       : provider === "openai_compatible"
                         ? "Optional bearer token"
-                        : "Enter API key"
+                        : provider === "litellm"
+                          ? "Optional LiteLLM virtual key (sk-...)"
+                          : "Enter API key"
                   }
                 />
                 <button
@@ -403,7 +434,9 @@ function ProviderRow({
               <p className="v2-set__hint">
                 {provider === "openai_compatible"
                   ? "Most local servers (llama.cpp, LM Studio) skip auth. Leave empty unless your endpoint requires a bearer token."
-                  : "Keys are stored in the keychain and never echoed back. Voice never sets keys -- use this field directly."}
+                  : provider === "litellm"
+                    ? "Use the LiteLLM virtual key minted on your proxy. Leave empty for unauthenticated local proxies."
+                    : "Keys are stored in the keychain and never echoed back. Voice never sets keys -- use this field directly."}
               </p>
             </div>
           )}

--- a/ui/src/v2/rooms/settings/useSettingsData.ts
+++ b/ui/src/v2/rooms/settings/useSettingsData.ts
@@ -10,7 +10,8 @@ export type LLMProvider =
   | "ollama"
   | "openrouter"
   | "nvidia"
-  | "openai_compatible";
+  | "openai_compatible"
+  | "litellm";
 
 export const LLM_PROVIDERS: readonly LLMProvider[] = [
   "anthropic",
@@ -21,6 +22,7 @@ export const LLM_PROVIDERS: readonly LLMProvider[] = [
   "openrouter",
   "nvidia",
   "openai_compatible",
+  "litellm",
 ] as const;
 
 export const LLM_PROVIDER_LABELS: Record<LLMProvider, string> = {
@@ -32,6 +34,7 @@ export const LLM_PROVIDER_LABELS: Record<LLMProvider, string> = {
   openrouter: "OpenRouter",
   nvidia: "NVIDIA NIM",
   openai_compatible: "OpenAI-compatible",
+  litellm: "LiteLLM",
 };
 
 export type STTProvider = "openai" | "groq" | "sarvam" | "local";
@@ -48,6 +51,7 @@ export interface LLMConfig {
   openrouter?: { model: string; has_api_key: boolean } | null;
   nvidia?: { model: string; has_api_key: boolean } | null;
   openai_compatible?: { base_url: string; model: string; has_api_key: boolean } | null;
+  litellm?: { base_url: string; model: string; has_api_key: boolean } | null;
 }
 
 export interface ChannelStatus {
@@ -311,8 +315,8 @@ export function useSettingsData() {
       for (const p of LLM_PROVIDERS) {
         const v = (llm as any)[p];
         if (!v) continue;
-        // Ollama and OpenAI-compatible are "configured" by a base_url, not a key.
-        if (p === "ollama" || p === "openai_compatible" || v.has_api_key) {
+        // Ollama, OpenAI-compatible, and LiteLLM are "configured" by a base_url, not a key.
+        if (p === "ollama" || p === "openai_compatible" || p === "litellm" || v.has_api_key) {
           providersWithKey++;
         }
       }
@@ -406,6 +410,22 @@ export function useSettingsData() {
         );
         await refresh();
         return { ok: true, message: r.message || `Ollama base URL updated.` };
+      } catch (err) {
+        return { ok: false, message: err instanceof Error ? err.message : "Failed" };
+      }
+    },
+    [refresh],
+  );
+
+  const setLiteLLMBaseUrl = useCallback(
+    async (baseUrl: string): Promise<ActionResult> => {
+      try {
+        const r = await postJson<{ ok: boolean; message: string }>(
+          "/api/config/llm",
+          { litellm: { base_url: baseUrl } },
+        );
+        await refresh();
+        return { ok: true, message: r.message || "LiteLLM base URL updated." };
       } catch (err) {
         return { ok: false, message: err instanceof Error ? err.message : "Failed" };
       }
@@ -764,6 +784,7 @@ export function useSettingsData() {
     setLLMApiKey,
     setOllamaBaseUrl,
     setOpenAICompatibleBaseUrl,
+    setLiteLLMBaseUrl,
     testProvider,
     setTelegram,
     setDiscord,


### PR DESCRIPTION
## Summary

  Adds LiteLLM (https://docs.litellm.ai/docs/) as a new LLM provider. LiteLLM is an OpenAI-compatible proxy/gateway that
  routes to 100+ underlying providers behind a single endpoint, so the new `LiteLLMProvider` extends `OpenAIProvider` (same
   pattern as `OpenAICompatibleProvider`) and just overrides identity + defaults.

  - Default `base_url`: `http://localhost:4000/v1` (matches LiteLLM's self-hosted proxy default).
  - Virtual key (Bearer token) is optional, since local proxies often skip auth.
  - Env overrides: `JARVIS_LITELLM_URL`, `JARVIS_LITELLM_KEY`.
  - Wired through config types, env loader, agent-service registration, DB/keychain persistence (save/test/hot-reload),
  `/api/config` response, the CLI doctor, the voice intent classifier, and the three UI surfaces (settings hook, settings
  tab, onboarding setup).