### PR TITLE
Ollama: respect max_tokens (map to num_predict)

### DIFF
--- a/src/llm/ollama.ts
+++ b/src/llm/ollama.ts
@@ -83,8 +83,8 @@ export class OllamaProvider implements LLMProvider {
   }
 
   async chat(messages: LLMMessage[], options: LLMOptions = {}): Promise<LLMResponse> {
-    const { model = this.defaultModel, temperature, tools, tool_choice } = options;
-    
+    const { model = this.defaultModel, temperature, max_tokens, tools, tool_choice } = options;
+
     // Compact history for Ollama's context limits
     const budget = calculateHistoryBudget(32000);
     const compactedMessages = compactHistory(messages, budget);
@@ -95,9 +95,15 @@ export class OllamaProvider implements LLMProvider {
       stream: false,
     };
 
-    if (temperature !== undefined) {
-      body.options = { temperature };
-    }
+    // Map our cross-provider options to Ollama's `body.options` bag.
+    // Ollama's default `num_predict` is 128 -- way too short for a JSON
+    // composer reply or any structured response. Callers that don't
+    // pass `max_tokens` still get the Ollama default; pass it
+    // explicitly to lift the cap.
+    const ollamaOptions: Record<string, unknown> = {};
+    if (temperature !== undefined) ollamaOptions.temperature = temperature;
+    if (max_tokens !== undefined) ollamaOptions.num_predict = max_tokens;
+    if (Object.keys(ollamaOptions).length > 0) body.options = ollamaOptions;
 
     if (tools && tools.length > 0) {
       body.tools = this.convertTools(tools);
@@ -121,8 +127,8 @@ export class OllamaProvider implements LLMProvider {
   }
 
   async *stream(messages: LLMMessage[], options: LLMOptions = {}): AsyncIterable<LLMStreamEvent> {
-    const { model = this.defaultModel, temperature, tools, tool_choice } = options;
-    
+    const { model = this.defaultModel, temperature, max_tokens, tools, tool_choice } = options;
+
     // Compact history for Ollama's context limits
     const budget = calculateHistoryBudget(32000);
     const compactedMessages = compactHistory(messages, budget);
@@ -133,9 +139,12 @@ export class OllamaProvider implements LLMProvider {
       stream: true,
     };
 
-    if (temperature !== undefined) {
-      body.options = { temperature };
-    }
+    // See chat(): map our cross-provider options to Ollama's bag.
+    // `num_predict` lifts Ollama's 128-token default cap.
+    const ollamaOptions: Record<string, unknown> = {};
+    if (temperature !== undefined) ollamaOptions.temperature = temperature;
+    if (max_tokens !== undefined) ollamaOptions.num_predict = max_tokens;
+    if (Object.keys(ollamaOptions).length > 0) body.options = ollamaOptions;
 
     if (tools && tools.length > 0) {
       body.tools = this.convertTools(tools);


### PR DESCRIPTION
## Summary

  The Ollama provider silently dropped `max_tokens` from `LLMOptions`. Every caller passing a budget was ignored, and
  output was capped by whatever Ollama's internal default was (128 in older versions, -1 in newer ones, depending on the
  install). Replies that should have been long (structured JSON, code generation, multi-paragraph summaries) frequently
  truncated with no error.

  Fix: map `max_tokens` to `body.options.num_predict` in both `chat()` and `stream()`. Default behavior with no
  `max_tokens` is unchanged. Callers that pass a budget now get it.

  ## Why this matters

  Every consumer of `LLMManager.chat()` against an Ollama provider was affected, not just one feature:

  - Workflow composer (this is where the bug first surfaced loudly: truncated JSON, parser EOF)
  - Sub-agent delegation (`jarvis-agent.delegate`)
  - Vault entity extractor
  - Goal NL builder
  - Awareness summarizer
  - Site builder code-gen
  - Main chat agent

  Some callers were getting silently truncated output without anyone noticing. The composer just happened to expose it
  because its output is parsed + validated, so failures are loud.