### PR TITLE
Multiline chat composer

### DIFF
--- a/ui/src/v2/shell/Composer.css
+++ b/ui/src/v2/shell/Composer.css
@@ -10,7 +10,7 @@
 .v2-composer__wrap {
   flex: 1;
   display: flex;
-  align-items: center;
+  align-items: flex-end;
   gap: var(--s-3);
   padding: 10px 14px;
   background: var(--paper-2);
@@ -42,6 +42,9 @@
   color: var(--ink);
   padding: 4px 0;
   line-height: 1.4;
+  resize: none;
+  overflow-y: auto;
+  max-height: 150px;
 }
 
 .v2-composer__input::placeholder {
@@ -59,6 +62,7 @@
   border-radius: var(--r-2);
   cursor: pointer;
   flex-shrink: 0;
+  align-self: center;
   line-height: 1.2;
   letter-spacing: 0.04em;
   transition: background var(--dur-fast) var(--ease-out);

--- a/ui/src/v2/shell/Composer.tsx
+++ b/ui/src/v2/shell/Composer.tsx
@@ -17,7 +17,7 @@ export function Composer({
   disabled,
 }: ComposerProps) {
   const [value, setValue] = useState("");
-  const inputRef = useRef<HTMLInputElement>(null);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
 
   // Global `/` opens the command palette directly. Suppressed inside any
   // editable element so it doesn't hijack normal typing — typing `/` in
@@ -37,11 +37,26 @@ export function Composer({
     return () => window.removeEventListener("keydown", onKey);
   }, [onSlash]);
 
+  const resetHeight = () => {
+    const el = inputRef.current;
+    if (el) el.style.height = "auto";
+  };
+
   const submit = () => {
     const text = value.trim();
     if (!text || disabled) return;
     onSubmit?.(text);
     setValue("");
+    resetHeight();
+  };
+
+  const autoGrow = () => {
+    const el = inputRef.current;
+    if (!el) return;
+    // Set to scrollHeight and let CSS max-height clamp the visible size;
+    // overflow-y: auto then handles scrolling past the cap.
+    el.style.height = "auto";
+    el.style.height = el.scrollHeight + "px";
   };
 
   return (
@@ -53,13 +68,14 @@ export function Composer({
       }}
     >
       <div className="v2-composer__wrap">
-        <input
+        <textarea
           ref={inputRef}
-          type="text"
+          rows={1}
           className="v2-composer__input"
           placeholder={placeholder}
           value={value}
           onChange={(e) => setValue(e.target.value)}
+          onInput={autoGrow}
           onKeyDown={(e) => {
             // Empty input + slash → open palette (same as the pill button
             // and the global hotkey). Mid-text slash types normally so
@@ -67,6 +83,19 @@ export function Composer({
             if (e.key === "/" && value.length === 0 && !e.metaKey && !e.ctrlKey && !e.altKey) {
               e.preventDefault();
               onSlash?.();
+              return;
+            }
+            // Enter submits; Shift+Enter inserts a newline. Textareas don't
+            // submit forms on Enter natively, so handle it here. Skip while
+            // an IME composition is active so confirming a CJK candidate
+            // doesn't accidentally send.
+            if (
+              e.key === "Enter" &&
+              !e.shiftKey && !e.metaKey && !e.ctrlKey && !e.altKey &&
+              !e.nativeEvent.isComposing
+            ) {
+              e.preventDefault();
+              submit();
             }
           }}
           disabled={disabled}

--- a/ui/src/v2/thread/items.css
+++ b/ui/src/v2/thread/items.css
@@ -63,6 +63,7 @@
   font-family: var(--font-display);
   font-style: italic;
   color: var(--ink-2);
+  white-space: pre-wrap;
 }
 
 .v2-item__mic {


### PR DESCRIPTION
## Summary
- Swap the chat composer `<input>` for a `<textarea>` so messages can span multiple lines. Enter sends, Shift+Enter inserts a newline.
- Auto-grow the textarea up to 150px, then scroll. Reset height on send.
- Preserve newlines in sent user messages by setting `white-space: pre-wrap` on the user message body (Jarvis side already handles whitespace via MarkdownBody).
- Keep the `/` palette shortcut working (still fires when the composer is empty), and skip Enter-to-send while an IME composition is active so confirming CJK candidates doesn't accidentally submit.
- Align buttons cleanly as the textarea grows: send button anchors to the bottom of the pill, slash pill stays vertically centered.