### PR TITLE
Fix npm provenance failure by adding repository field to sidecar packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -220,11 +220,19 @@ jobs:
           FLAGS=""
           if [ "$DRY_RUN" = "true" ]; then FLAGS="$FLAGS --dry-run"; fi
           if echo "${{ steps.version.outputs.VERSION }}" | grep -q '-'; then FLAGS="$FLAGS --tag next"; fi
+          VERSION="${{ steps.version.outputs.VERSION }}"
 
           for platform in darwin-arm64 darwin-x64 linux-x64 linux-arm64 win32-x64; do
-            echo "Publishing @usejarvis/sidecar-${platform}... ${FLAGS}"
+            pkg="@usejarvis/sidecar-${platform}"
+            echo "Publishing ${pkg}@${VERSION}... ${FLAGS}"
             cd "sidecar/npm/${platform}"
-            npm publish --access public $FLAGS
+            if ! npm publish --access public $FLAGS; then
+              if [ "$DRY_RUN" != "true" ] && npm view "${pkg}@${VERSION}" version >/dev/null 2>&1; then
+                echo "${pkg}@${VERSION} is already on npm; treating as success."
+              else
+                exit 1
+              fi
+            fi
             cd "$GITHUB_WORKSPACE"
           done
 
@@ -233,9 +241,17 @@ jobs:
           FLAGS=""
           if [ "$DRY_RUN" = "true" ]; then FLAGS="$FLAGS --dry-run"; fi
           if echo "${{ steps.version.outputs.VERSION }}" | grep -q '-'; then FLAGS="$FLAGS --tag next"; fi
+          VERSION="${{ steps.version.outputs.VERSION }}"
+          pkg="@usejarvis/sidecar"
 
           cd sidecar/npm/jarvis-sidecar
-          npm publish --access public $FLAGS
+          if ! npm publish --access public $FLAGS; then
+            if [ "$DRY_RUN" != "true" ] && npm view "${pkg}@${VERSION}" version >/dev/null 2>&1; then
+              echo "${pkg}@${VERSION} is already on npm; treating as success."
+            else
+              exit 1
+            fi
+          fi
 
   # ─── Publish main brain package to npm ─────────────────────────
   publish-brain:
@@ -276,7 +292,16 @@ jobs:
           FLAGS=""
           if [ "$DRY_RUN" = "true" ]; then FLAGS="$FLAGS --dry-run"; fi
           if echo "${{ steps.version.outputs.VERSION }}" | grep -q '-'; then FLAGS="$FLAGS --tag next"; fi
-          npm publish --access public $FLAGS
+          VERSION="${{ steps.version.outputs.VERSION }}"
+          pkg="@usejarvis/brain"
+
+          if ! npm publish --access public $FLAGS; then
+            if [ "$DRY_RUN" != "true" ] && npm view "${pkg}@${VERSION}" version >/dev/null 2>&1; then
+              echo "${pkg}@${VERSION} is already on npm; treating as success."
+            else
+              exit 1
+            fi
+          fi
 
   # ─── Create GitHub Release with binaries ───────────────────────
   # Gated by publish-docker, which is itself gated by publish-sidecar and

--- a/sidecar/npm/darwin-arm64/package.json
+++ b/sidecar/npm/darwin-arm64/package.json
@@ -2,6 +2,11 @@
   "name": "@usejarvis/sidecar-darwin-arm64",
   "version": "0.1.0",
   "description": "Jarvis sidecar binary for macOS ARM64",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vierisid/jarvis.git",
+    "directory": "sidecar/npm/darwin-arm64"
+  },
   "os": ["darwin"],
   "cpu": ["arm64"],
   "bin": {

--- a/sidecar/npm/darwin-x64/package.json
+++ b/sidecar/npm/darwin-x64/package.json
@@ -2,6 +2,11 @@
   "name": "@usejarvis/sidecar-darwin-x64",
   "version": "0.1.0",
   "description": "Jarvis sidecar binary for macOS x64",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vierisid/jarvis.git",
+    "directory": "sidecar/npm/darwin-x64"
+  },
   "os": ["darwin"],
   "cpu": ["x64"],
   "bin": {

--- a/sidecar/npm/jarvis-sidecar/package.json
+++ b/sidecar/npm/jarvis-sidecar/package.json
@@ -1,7 +1,12 @@
 {
   "name": "@usejarvis/sidecar",
   "version": "0.1.0",
-  "description": "Jarvis sidecar client — connects to the brain and executes RPC requests locally",
+  "description": "Jarvis sidecar client -- connects to the brain and executes RPC requests locally",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vierisid/jarvis.git",
+    "directory": "sidecar/npm/jarvis-sidecar"
+  },
   "bin": {
     "jarvis-sidecar": "bin/jarvis-sidecar"
   },

--- a/sidecar/npm/linux-arm64/package.json
+++ b/sidecar/npm/linux-arm64/package.json
@@ -2,6 +2,11 @@
   "name": "@usejarvis/sidecar-linux-arm64",
   "version": "0.1.0",
   "description": "Jarvis sidecar binary for Linux ARM64",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vierisid/jarvis.git",
+    "directory": "sidecar/npm/linux-arm64"
+  },
   "os": ["linux"],
   "cpu": ["arm64"],
   "bin": {

--- a/sidecar/npm/linux-x64/package.json
+++ b/sidecar/npm/linux-x64/package.json
@@ -2,6 +2,11 @@
   "name": "@usejarvis/sidecar-linux-x64",
   "version": "0.1.0",
   "description": "Jarvis sidecar binary for Linux x64",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vierisid/jarvis.git",
+    "directory": "sidecar/npm/linux-x64"
+  },
   "os": ["linux"],
   "cpu": ["x64"],
   "bin": {

--- a/sidecar/npm/win32-x64/package.json
+++ b/sidecar/npm/win32-x64/package.json
@@ -2,6 +2,11 @@
   "name": "@usejarvis/sidecar-win32-x64",
   "version": "0.1.0",
   "description": "Jarvis sidecar binary for Windows x64",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vierisid/jarvis.git",
+    "directory": "sidecar/npm/win32-x64"
+  },
   "os": ["win32"],
   "cpu": ["x64"],
   "bin": {


### PR DESCRIPTION
## Why

The `publish-sidecar` job in the last release failed at `npm publish` with:

422 Unprocessable Entity - Error verifying sigstore provenance bundle:
Failed to validate repository information: package.json: "repository.url" is "",
expected to match "https://github.com/vierisid/jarvis" from provenance

npm now enforces that the `repository.url` in a tarball's `package.json` matches the repo URL attested in the provenance bundle (derived from the GHA `id-token`). All six sidecar packages under `sidecar/npm/*` had no `repository` field at all, so the registry saw `""` and rejected the publish.

The root `@usejarvis/brain` package already had a valid `repository` block, which is why `publish-brain` was never affected.

## What

### 1. Add `repository` to every sidecar package

Added an identical `repository` block to each sidecar `package.json`, with a per-package `directory` pointing at its monorepo path:

```json
"repository": {
  "type": "git",
  "url": "git+https://github.com/vierisid/jarvis.git",
  "directory": "sidecar/npm/<platform>"
}
```
Packages touched:

- @usejarvis/sidecar-darwin-arm64
- @usejarvis/sidecar-darwin-x64
- @usejarvis/sidecar-linux-arm64
- @usejarvis/sidecar-linux-x64
- @usejarvis/sidecar-win32-x64
- @usejarvis/sidecar (wrapper)

### 2. Make every npm publish step idempotent

Wrapped all three publish invocations in release.yml (sidecar platforms loop, sidecar wrapper, brain) so that if npm publish fails AND the version is already on the registry, the step logs and continues. Any other failure (provenance, auth, network) still aborts the release.