### PR TITLE
fix(anthropic): drop `temperature` for claude-opus-4-7 models

### DIFF
--- a/src/llm/anthropic.ts
+++ b/src/llm/anthropic.ts
@@ -78,6 +78,20 @@ type AnthropicStreamEvent =
 const MAX_RETRIES = 0;
 const RETRY_BASE_DELAY_MS = 5000; // 5s, 10s, 20s
 
+/**
+ * Some Anthropic models reject sampling params (temperature, top_p, top_k)
+ * with 400 invalid_request_error ("temperature is deprecated for this model")
+ * if the field is present in the body -- even at default values. Opus 4.7 is
+ * the first family to enforce this; future models may follow.
+ *
+ * If you see that 400 again for a NEW model id, add its pattern to the regex
+ * below. Do NOT try to pick a "safe" temperature value: the check is on
+ * presence, not value. The only fix is to omit the field entirely.
+ */
+function modelRejectsTemperature(model: string): boolean {
+  return /claude-opus-4-7/i.test(model);
+}
+
 export class AnthropicProvider implements LLMProvider {
   name = 'anthropic';
   private apiKey: string;
@@ -142,7 +156,9 @@ export class AnthropicProvider implements LLMProvider {
     };
 
     if (system) body.system = system;
-    if (temperature !== undefined) body.temperature = temperature;
+    if (temperature !== undefined && !modelRejectsTemperature(model)) {
+      body.temperature = temperature;
+    }
     if (tools && tools.length > 0) {
       body.tools = this.convertTools(tools);
       // Anthropic uses budget_tokens for tool use (no explicit tool_choice needed)
@@ -169,7 +185,9 @@ export class AnthropicProvider implements LLMProvider {
     };
 
     if (system) body.system = system;
-    if (temperature !== undefined) body.temperature = temperature;
+    if (temperature !== undefined && !modelRejectsTemperature(model)) {
+      body.temperature = temperature;
+    }
     if (tools && tools.length > 0) {
       body.tools = this.convertTools(tools);
       // Anthropic automatically uses tools when provided (no explicit tool_choice needed)


### PR DESCRIPTION
Claude Opus 4.7 rejects requests that include `temperature` (and `top_p` / `top_k`) with:

```
400 invalid_request_error: "temperature is deprecated for this model"
```

The check is on **presence**, not value -- sending `temperature: 1.0` 400s the same way as `temperature: 0.6`. The only fix is to omit the field entirely.

Today `src/llm/anthropic.ts` forwards `temperature` unconditionally in both `chat()` and `stream()`, so any caller that sets one (e.g. `src/daemon/onboarding-interviewer.ts:223` uses `0.6`) breaks the moment the configured model is `claude-opus-4-7*`.

### Reported error

```
Provider 'anthropic' failed after 3 attempts: attempt 1:
Anthropic API error (400): {"type":"error","error":{
  "type":"invalid_request_error",
  "message":"temperature is deprecated for this model."
}}
```

### Change

- Added `modelRejectsTemperature(model)` helper matching `/claude-opus-4-7/i`.
- Gated `body.temperature = temperature` in both `chat()` and `stream()` behind that check.
- Added a doc-comment explaining the symptom, the invariant (presence-checked, not value-checked), and the recipe for future model families: extend the regex, do NOT try to retune the value.