### PR TITLE
security: harden daemon auth, authority gating, comms, and dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -110,8 +110,14 @@ VOLUME ["/data"]
 
 USER jarvis
 
+# Use the public /health endpoint (no auth) — /api/health requires the auth
+# token, which is auto-generated when binding 0.0.0.0 below.
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-    CMD bun -e "fetch('http://localhost:3142/api/health').then(r=>{if(!r.ok)process.exit(1)}).catch(()=>process.exit(1))"
+    CMD bun -e "fetch('http://localhost:3142/health').then(r=>{if(!r.ok)process.exit(1)}).catch(()=>process.exit(1))"
 
 ENTRYPOINT ["jarvis"]
-CMD ["start", "--no-open", "--data-dir", "/data", "--no-local-tools"]
+# Bind 0.0.0.0 so the published port is reachable from the host. The container
+# is network-isolated and the operator controls exposure via `-p`; because this
+# is a non-loopback bind, the daemon auto-generates a dashboard auth token at
+# startup (printed in the logs) unless JARVIS_AUTH_TOKEN is set.
+CMD ["start", "--no-open", "--host", "0.0.0.0", "--data-dir", "/data", "--no-local-tools"]

--- a/bin/jarvis.ts
+++ b/bin/jarvis.ts
@@ -51,6 +51,7 @@ ${c.bold('Commands:')}
 
 ${c.bold('Start options:')}
   --port <N>        Override daemon port (default: 3142)
+  --host <addr>     Bind address (default: 127.0.0.1; use 0.0.0.0 to expose on the network)
   -d, --detach      Run as background daemon
   --no-open         Don't auto-open dashboard in browser
   --data-dir <path> Override data directory (default: ~/.jarvis)
@@ -103,6 +104,13 @@ async function cmdStart(args: string[]): Promise<void> {
     dataDir = args[dataDirIdx + 1]!;
   }
 
+  // Parse --host (bind address). Defaults to loopback inside the daemon.
+  let host: string | undefined;
+  const hostIdx = args.indexOf('--host');
+  if (hostIdx !== -1 && args[hostIdx + 1]) {
+    host = args[hostIdx + 1]!;
+  }
+
   // Friendly first-run hint — when no config exists yet, the daemon
   // boots in "setup mode" and the dashboard's onboarding gate handles
   // LLM/TTS/profile/tutorial. Print a one-liner so the user knows where
@@ -128,7 +136,7 @@ async function cmdStart(args: string[]): Promise<void> {
     process.on('SIGTERM', () => { releaseLock(); process.exit(0); });
 
     const { startDaemon } = await import('../src/daemon/index.ts');
-    await startDaemon({ port, dataDir, noLocalTools });
+    await startDaemon({ port, host, dataDir, noLocalTools });
 
     if (!noOpen) {
       openDashboard(port ?? 3142);
@@ -150,6 +158,9 @@ async function cmdStart(args: string[]): Promise<void> {
 
     const daemonArgs = [join(PACKAGE_ROOT, 'bin/jarvis.ts'), 'start', '--no-open'];
     if (port) daemonArgs.push('--port', String(port));
+    if (host) daemonArgs.push('--host', host);
+    if (dataDir) daemonArgs.push('--data-dir', dataDir);
+    if (noLocalTools) daemonArgs.push('--no-local-tools');
 
     const logFd = openSync(logPath, 'a');
     const child = spawn('bun', daemonArgs, {

--- a/bun.lock
+++ b/bun.lock
@@ -36,7 +36,7 @@
         "sharp": "^0.34.5",
         "socket.io": "^4.8.3",
         "tailwindcss": "^4.2.1",
-        "yaml": "^2.7.0",
+        "yaml": "^2.9.0",
       },
       "devDependencies": {
         "@types/bun": "latest",
@@ -46,6 +46,16 @@
         "typescript": "^5",
       },
     },
+  },
+  "overrides": {
+    "@protobufjs/utf8": "^1.1.1",
+    "axios": "^1.16.1",
+    "follow-redirects": "^1.16.0",
+    "lodash": "^4.18.1",
+    "protobufjs": "^7.6.2",
+    "undici": "^6.26.0",
+    "uuid": "^11.1.1",
+    "ws": "^8.21.0",
   },
   "packages": {
     "@codemirror/autocomplete": ["@codemirror/autocomplete@6.20.1", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.17.0", "@lezer/common": "^1.0.0" } }, "sha512-1cvg3Vz1dSSToCNlJfRA2WSI4ht3K+WplO0UMOgmUYPivCyy2oueZY6Lx7M9wThm7SDUBViRmuT+OG/i8+ON9A=="],
@@ -166,21 +176,21 @@
 
     "@protobufjs/base64": ["@protobufjs/base64@1.1.2", "", {}, "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="],
 
-    "@protobufjs/codegen": ["@protobufjs/codegen@2.0.4", "", {}, "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="],
+    "@protobufjs/codegen": ["@protobufjs/codegen@2.0.5", "", {}, "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g=="],
 
-    "@protobufjs/eventemitter": ["@protobufjs/eventemitter@1.1.0", "", {}, "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="],
+    "@protobufjs/eventemitter": ["@protobufjs/eventemitter@1.1.1", "", {}, "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg=="],
 
-    "@protobufjs/fetch": ["@protobufjs/fetch@1.1.0", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.1", "@protobufjs/inquire": "^1.1.0" } }, "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ=="],
+    "@protobufjs/fetch": ["@protobufjs/fetch@1.1.1", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.1" } }, "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw=="],
 
     "@protobufjs/float": ["@protobufjs/float@1.0.2", "", {}, "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="],
 
-    "@protobufjs/inquire": ["@protobufjs/inquire@1.1.0", "", {}, "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="],
+    "@protobufjs/inquire": ["@protobufjs/inquire@1.1.2", "", {}, "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw=="],
 
     "@protobufjs/path": ["@protobufjs/path@1.1.2", "", {}, "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="],
 
     "@protobufjs/pool": ["@protobufjs/pool@1.1.0", "", {}, "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="],
 
-    "@protobufjs/utf8": ["@protobufjs/utf8@1.1.0", "", {}, "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="],
+    "@protobufjs/utf8": ["@protobufjs/utf8@1.1.1", "", {}, "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg=="],
 
     "@sapphire/async-queue": ["@sapphire/async-queue@1.5.5", "", {}, "sha512-cvGzxbba6sav2zZkH8GPf2oGk9yYoD5qrNWdu9fRehifgnFZJMV+nuy2nON2roRO4yQQ+v7MK/Pktl/HgfsUXg=="],
 
@@ -214,8 +224,6 @@
 
     "@types/hast": ["@types/hast@3.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="],
 
-    "@types/long": ["@types/long@4.0.2", "", {}, "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="],
-
     "@types/mdast": ["@types/mdast@4.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA=="],
 
     "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
@@ -246,7 +254,7 @@
 
     "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
 
-    "axios": ["axios@1.13.5", "", { "dependencies": { "follow-redirects": "^1.15.11", "form-data": "^4.0.5", "proxy-from-env": "^1.1.0" } }, "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q=="],
+    "axios": ["axios@1.16.1", "", { "dependencies": { "follow-redirects": "^1.16.0", "form-data": "^4.0.5", "https-proxy-agent": "^5.0.1", "proxy-from-env": "^2.1.0" } }, "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A=="],
 
     "b4a": ["b4a@1.8.0", "", { "peerDependencies": { "react-native-b4a": "*" }, "optionalPeers": ["react-native-b4a"] }, "sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg=="],
 
@@ -388,7 +396,7 @@
 
     "flatbuffers": ["flatbuffers@25.9.23", "", {}, "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ=="],
 
-    "follow-redirects": ["follow-redirects@1.15.11", "", {}, "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ=="],
+    "follow-redirects": ["follow-redirects@1.16.0", "", { "peerDependencies": { "debug": "*" }, "optionalPeers": ["debug"] }, "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw=="],
 
     "form-data": ["form-data@4.0.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w=="],
 
@@ -452,7 +460,7 @@
 
     "jose": ["jose@6.2.0", "", {}, "sha512-xsfE1TcSCbUdo6U07tR0mvhg0flGxU8tPLbF03mirl2ukGQENhUg4ubGYQnhVH0b5stLlPM+WOqDkEl1R1y5sQ=="],
 
-    "lodash": ["lodash@4.17.23", "", {}, "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w=="],
+    "lodash": ["lodash@4.18.1", "", {}, "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="],
 
     "lodash.snakecase": ["lodash.snakecase@4.1.1", "", {}, "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw=="],
 
@@ -602,9 +610,9 @@
 
     "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
 
-    "protobufjs": ["protobufjs@7.5.4", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg=="],
+    "protobufjs": ["protobufjs@7.6.2", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.5", "@protobufjs/eventemitter": "^1.1.1", "@protobufjs/fetch": "^1.1.1", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.2", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.1", "@types/node": ">=13.7.0", "long": "^5.3.2" } }, "sha512-N9EiLovGEQOJSPF26Ij7qUGvahfEnq0eeYZ02aigIedkmz1qZSwjnP9SBITHJuF/6MYbIW4HDN8zdYjsjqJKXQ=="],
 
-    "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
+    "proxy-from-env": ["proxy-from-env@2.1.0", "", {}, "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA=="],
 
     "pump": ["pump@3.0.4", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA=="],
 
@@ -690,7 +698,7 @@
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
-    "undici": ["undici@6.21.3", "", {}, "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw=="],
+    "undici": ["undici@6.26.0", "", {}, "sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A=="],
 
     "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
@@ -712,7 +720,7 @@
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
-    "uuid": ["uuid@11.1.0", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="],
+    "uuid": ["uuid@11.1.1", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ=="],
 
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
@@ -728,13 +736,13 @@
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
-    "ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
+    "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
 
     "xml-escape": ["xml-escape@1.1.0", "", {}, "sha512-B/T4sDK8Z6aUh/qNr7mjKAwwncIljFuUP+DO/D5hloYFj+90O88z8Wf7oSucZTHxBAsC1/CTP4rtx/x1Uf72Mg=="],
 
     "xmlhttprequest-ssl": ["xmlhttprequest-ssl@2.1.2", "", {}, "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ=="],
 
-    "yaml": ["yaml@2.8.2", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A=="],
+    "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
 
     "zustand": ["zustand@4.5.7", "", { "dependencies": { "use-sync-external-store": "^1.2.2" }, "peerDependencies": { "@types/react": ">=16.8", "immer": ">=9.0.6", "react": ">=16.8" }, "optionalPeers": ["@types/react", "immer", "react"] }, "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw=="],
 
@@ -748,11 +756,7 @@
 
     "@xenova/transformers/sharp": ["sharp@0.32.6", "", { "dependencies": { "color": "^4.2.3", "detect-libc": "^2.0.2", "node-addon-api": "^6.1.0", "prebuild-install": "^7.1.1", "semver": "^7.5.4", "simple-get": "^4.0.1", "tar-fs": "^3.0.4", "tunnel-agent": "^0.6.0" } }, "sha512-KyLTWwgcR9Oe4d9HwCwNM2l7+J0dUQwn/yf7S0EnTtb0eVS4RxO0eUSvxPtzT4F3SY+C4K6fqdv/DO27sJ/v/w=="],
 
-    "engine.io/ws": ["ws@8.18.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="],
-
-    "engine.io-client/ws": ["ws@8.18.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="],
-
-    "onnx-proto/protobufjs": ["protobufjs@6.11.5", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/long": "^4.0.1", "@types/node": ">=13.7.0", "long": "^4.0.0" }, "bin": { "pbjs": "bin/pbjs", "pbts": "bin/pbts" } }, "sha512-OKjVH3hDoXdIZ/s5MLv8O2X0s+wOxGfV7ar6WFSKGaSAxi/6gYn3px5POS4vi+mc/0zCOdL7Jkwrj0oT1Yst2A=="],
+    "axios/https-proxy-agent": ["https-proxy-agent@5.0.1", "", { "dependencies": { "agent-base": "6", "debug": "4" } }, "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA=="],
 
     "onnxruntime-node/onnxruntime-common": ["onnxruntime-common@1.14.0", "", {}, "sha512-3LJpegM2iMNRX2wUmtYfeX/ytfOzNwAWKSq1HbRrKc9+uqG/FsEA0bbKZl1btQeZaXhC26l44NWpNUeXPII7Ew=="],
 
@@ -760,15 +764,13 @@
 
     "prebuild-install/tar-fs": ["tar-fs@2.1.4", "", { "dependencies": { "chownr": "^1.1.1", "mkdirp-classic": "^0.5.2", "pump": "^3.0.0", "tar-stream": "^2.1.4" } }, "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ=="],
 
-    "socket.io-adapter/ws": ["ws@8.18.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="],
-
     "@xenova/transformers/onnxruntime-web/flatbuffers": ["flatbuffers@1.12.0", "", {}, "sha512-c7CZADjRcl6j0PlvFy0ZqXQ67qSEZfrVPynmnL+2zPc+NtMvrF8Y0QceMo7QqnSPc7+uWjUIAbvCQ5WIKlMVdQ=="],
 
     "@xenova/transformers/onnxruntime-web/long": ["long@4.0.0", "", {}, "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="],
 
     "@xenova/transformers/onnxruntime-web/onnxruntime-common": ["onnxruntime-common@1.14.0", "", {}, "sha512-3LJpegM2iMNRX2wUmtYfeX/ytfOzNwAWKSq1HbRrKc9+uqG/FsEA0bbKZl1btQeZaXhC26l44NWpNUeXPII7Ew=="],
 
-    "onnx-proto/protobufjs/long": ["long@4.0.0", "", {}, "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="],
+    "axios/https-proxy-agent/agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
 
     "prebuild-install/tar-fs/tar-stream": ["tar-stream@2.2.0", "", { "dependencies": { "bl": "^4.0.3", "end-of-stream": "^1.4.1", "fs-constants": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.1.1" } }, "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ=="],
   }

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -3,6 +3,12 @@
 
 daemon:
   port: 3142
+  # Bind address. Defaults to 127.0.0.1 (loopback only) so a fresh install is
+  # not reachable from other machines. Set to 0.0.0.0 to expose on the network
+  # (the Docker image does this). Binding a non-loopback host without auth.token
+  # below makes the daemon auto-generate a token at startup (printed to logs).
+  # Env override: JARVIS_HOST=0.0.0.0
+  host: "127.0.0.1"
   data_dir: "~/.jarvis"
   db_path: "~/.jarvis/jarvis.db"
   # Public origin written into sidecar enrollment JWTs (`brain` + `jwks`).
@@ -12,8 +18,11 @@ daemon:
   # brain_domain: "https://brain.example.com"
 
 # Authentication — protects dashboard, API, and WebSocket.
-# If unset, the application is open (no auth).
-# Can also be set via JARVIS_AUTH_TOKEN env var.
+# If unset and bound to loopback (the default), the app is reachable only from
+# this machine; cross-site browser requests are still blocked by an Origin check.
+# If unset and bound to a non-loopback host (e.g. 0.0.0.0), the daemon
+# auto-generates a token at startup and prints it to the logs.
+# Set an explicit token here (or via JARVIS_AUTH_TOKEN) to choose your own.
 # auth:
 #   token: "your-secret-token-here"
 

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "sharp": "^0.34.5",
     "socket.io": "^4.8.3",
     "tailwindcss": "^4.2.1",
-    "yaml": "^2.7.0"
+    "yaml": "^2.9.0"
   },
   "devDependencies": {
     "@types/bun": "latest",
@@ -86,5 +86,16 @@
   },
   "peerDependencies": {
     "typescript": "^5"
+  },
+  "_comment_overrides": "Security pins for vulnerable transitive deps (see `bun audit`); each stays within the parent's major to avoid API breakage. Remove once upstreams update.",
+  "overrides": {
+    "protobufjs": "^7.6.2",
+    "@protobufjs/utf8": "^1.1.1",
+    "axios": "^1.16.1",
+    "undici": "^6.26.0",
+    "ws": "^8.21.0",
+    "follow-redirects": "^1.16.0",
+    "uuid": "^11.1.1",
+    "lodash": "^4.18.1"
   }
 }

--- a/src/actions/terminal/wsl-bridge.ts
+++ b/src/actions/terminal/wsl-bridge.ts
@@ -52,13 +52,16 @@ export class WSLBridge {
     }
 
     try {
-      const escapedScript = script
-        .replace(/\\/g, '\\\\')
-        .replace(/"/g, '\\"')
-        .replace(/\$/g, '\\$')
-        .replace(/`/g, '\\`');
-
-      return await this.executor.execute(`powershell.exe -Command "${escapedScript}"`);
+      // Pass the script via -EncodedCommand (base64 of UTF-16LE) instead of
+      // hand-escaping quotes/backticks/dollar-signs into a -Command string.
+      // Encoding sidesteps every shell-quoting edge case (the prior manual
+      // escaping was incomplete — e.g. it did not handle `;`, `&`, `|`, `(`)
+      // and the resulting base64 is plain [A-Za-z0-9+/=], safe to embed in the
+      // bash `-c` line with no further escaping. -NoProfile/-NonInteractive
+      // keep the child shell from sourcing the user profile or blocking on a
+      // prompt.
+      const encoded = Buffer.from(script, 'utf16le').toString('base64');
+      return await this.executor.execute(`powershell.exe -NoProfile -NonInteractive -EncodedCommand ${encoded}`);
     } catch (error) {
       throw new Error(`Failed to run PowerShell script: ${error instanceof Error ? error.message : String(error)}`);
     }

--- a/src/authority/authority.test.ts
+++ b/src/authority/authority.test.ts
@@ -224,8 +224,11 @@ describe('getActionForTool', () => {
     expect(getActionForTool('some_terminal_tool', 'terminal')).toBe('execute_command');
   });
 
-  test('defaults to read_data for completely unknown tools', () => {
-    expect(getActionForTool('unknown_tool', 'unknown_category')).toBe('read_data');
+  test('fails closed to execute_command for completely unknown tools', () => {
+    // Unmapped tools are treated as destructive + governed so a new/unknown
+    // capability requires high authority and explicit approval rather than
+    // being waved through as a harmless read.
+    expect(getActionForTool('unknown_tool', 'unknown_category')).toBe('execute_command');
   });
 });
 

--- a/src/authority/tool-action-map.ts
+++ b/src/authority/tool-action-map.ts
@@ -67,7 +67,13 @@ export const CATEGORY_ACTION_MAP: Record<string, ActionCategory> = {
 
 /**
  * Resolve the ActionCategory for a given tool.
- * Checks explicit tool name map first, then falls back to category map, then defaults to read_data.
+ * Checks explicit tool name map first, then falls back to category map.
+ *
+ * Fail CLOSED: a tool we don't recognise is treated as `execute_command`
+ * (destructive + governed by default), so an unmapped or newly-added
+ * capability requires high authority and explicit approval instead of being
+ * silently waved through as a harmless `read_data`. Map new tools explicitly
+ * above to grant them a narrower category.
  */
 export function getActionForTool(toolName: string, toolCategory: string): ActionCategory {
   if (TOOL_ACTION_MAP[toolName]) {
@@ -76,5 +82,5 @@ export function getActionForTool(toolName: string, toolCategory: string): Action
   if (CATEGORY_ACTION_MAP[toolCategory]) {
     return CATEGORY_ACTION_MAP[toolCategory];
   }
-  return 'read_data';
+  return 'execute_command';
 }

--- a/src/comms/channels/discord.ts
+++ b/src/comms/channels/discord.ts
@@ -11,6 +11,8 @@ export class DiscordAdapter implements ChannelAdapter {
   private allowedUsers: string[];
   private guildId: string | null;
   private sttProvider: STTProvider | null;
+  /** One-time warning latch so a busy server doesn't flood logs. */
+  private warnedNoAllowlist = false;
 
   constructor(token: string, opts?: {
     allowedUsers?: string[];
@@ -124,8 +126,16 @@ export class DiscordAdapter implements ChannelAdapter {
     if (message.author.bot) return;
     if (!this.handler) return;
 
-    // Security: check allowed users (empty = allow all)
-    if (this.allowedUsers.length > 0 && !this.allowedUsers.includes(message.author.id)) {
+    // Security: deny-by-default. An empty allowlist authorizes NO ONE
+    // (previously empty = allow-all, which let any sender drive the agent).
+    if (this.allowedUsers.length === 0) {
+      if (!this.warnedNoAllowlist) {
+        this.warnedNoAllowlist = true;
+        console.warn('[DiscordAdapter] Ignoring all messages: no allowed_users configured. Add Discord user IDs to channels.discord.allowed_users to authorize senders.');
+      }
+      return;
+    }
+    if (!this.allowedUsers.includes(message.author.id)) {
       return;
     }
 

--- a/src/comms/channels/telegram.ts
+++ b/src/comms/channels/telegram.ts
@@ -68,6 +68,8 @@ export class TelegramAdapter implements ChannelAdapter {
   private pollingInterval: number = 1000;
   private sttProvider: STTProvider | null = null;
   private allowedUsers: number[];
+  /** One-time warning latch so a busy chat doesn't flood logs. */
+  private warnedNoAllowlist = false;
 
   constructor(token: string, opts?: { sttProvider?: STTProvider; allowedUsers?: number[] }) {
     this.token = token;
@@ -208,8 +210,16 @@ export class TelegramAdapter implements ChannelAdapter {
 
     const { message } = update;
 
-    // Security: check allowed users
-    if (this.allowedUsers.length > 0 && !this.allowedUsers.includes(message.from.id)) {
+    // Security: deny-by-default. An empty allowlist authorizes NO ONE
+    // (previously empty = allow-all, which let any sender drive the agent).
+    if (this.allowedUsers.length === 0) {
+      if (!this.warnedNoAllowlist) {
+        this.warnedNoAllowlist = true;
+        console.warn('[TelegramAdapter] Ignoring all messages: no allowed_users configured. Add numeric Telegram user IDs to channels.telegram.allowed_users to authorize senders.');
+      }
+      return;
+    }
+    if (!this.allowedUsers.includes(message.from.id)) {
       console.log(`[TelegramAdapter] Ignoring message from unauthorized user: ${message.from.id} (${message.from.username ?? message.from.first_name})`);
       return;
     }

--- a/src/comms/websocket.ts
+++ b/src/comms/websocket.ts
@@ -89,6 +89,7 @@ export class WebSocketServer {
   private clients: Set<ServerWebSocket<unknown>> = new Set();
   private handler: WSClientHandler | null = null;
   private port: number;
+  private hostname: string;
   private startTime: number = 0;
   private apiRoutes: Map<string, MethodRoutes> = new Map();
   private staticDir: string | null = null;
@@ -98,8 +99,9 @@ export class WebSocketServer {
   private corsOrigin: string | null = null;
   private proxyLimiter = new ProxyRateLimiter();
 
-  constructor(port: number = 3142) {
+  constructor(port: number = 3142, hostname: string = '127.0.0.1') {
     this.port = port;
+    this.hostname = hostname;
     this.corsOrigin = `http://localhost:${port}`;
   }
 
@@ -157,6 +159,7 @@ export class WebSocketServer {
 
     this.server = Bun.serve<{ sidecar_id?: string; proxy_target?: string; _proxyUpstream?: WebSocket }>({
       port: this.port,
+      hostname: this.hostname, // default 127.0.0.1 (loopback only); set to 0.0.0.0 to expose on the network
       idleTimeout: 30, // seconds — prevent timeout during heavy processing (OCR, PowerShell)
 
       async fetch(req, server) {
@@ -289,6 +292,33 @@ export class WebSocketServer {
                 'Access-Control-Allow-Headers': 'Content-Type',
               },
             });
+          }
+
+          // CSRF / cross-origin defense for state-changing requests.
+          // Browsers attach an Origin header to cross-origin POST/PUT/PATCH/
+          // DELETE — including fetch-issued "simple" requests that skip the
+          // CORS preflight (e.g. Content-Type: text/plain carrying a JSON
+          // body). Rejecting a mismatched Origin stops a malicious web page
+          // from blind-driving the local daemon even when no auth token is
+          // set. Requests with no Origin (curl, native/server-to-server
+          // clients) are unaffected; public routes (webhooks, jwks) are exempt
+          // because external callers legitimately POST cross-origin.
+          if (req.method !== 'GET' && req.method !== 'HEAD' && !isPublicRoute(pathname, req.method)) {
+            const origin = req.headers.get('origin');
+            if (origin) {
+              const expectedOrigin = self.corsOrigin || `http://localhost:${self.port}`;
+              let sameHost = false;
+              try {
+                const originHost = new URL(origin).host;
+                const requestHost = req.headers.get('host');
+                sameHost = !!requestHost && originHost === requestHost;
+              } catch {
+                sameHost = false;
+              }
+              if (origin !== expectedOrigin && !sameHost) {
+                return Response.json({ error: 'Forbidden: origin mismatch' }, { status: 403 });
+              }
+            }
           }
 
           // Try exact match first

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -57,6 +57,10 @@ function applyEnvOverrides(config: JarvisConfig): void {
     if (!isNaN(port)) config.daemon.port = port;
   }
 
+  if (env.JARVIS_HOST) {
+    config.daemon.host = env.JARVIS_HOST;
+  }
+
   if (env.JARVIS_HOME) {
     const home = env.JARVIS_HOME;
     config.daemon.data_dir = home;

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -178,6 +178,18 @@ export type JarvisConfig = {
   onboarding?: OnboardingConfig;
   daemon: {
     port: number;
+    /**
+     * Network interface the daemon's HTTP/WebSocket server binds to.
+     *
+     * Defaults to `127.0.0.1` (loopback only) so a fresh install is NOT
+     * reachable from other machines. Set to `0.0.0.0` to expose it on the
+     * network (the Docker image does this, since the container is isolated and
+     * the operator controls exposure via `-p`). Binding a non-loopback host
+     * with no `auth.token` causes the daemon to auto-generate one at startup.
+     *
+     * Precedence: `JARVIS_HOST` env var > this field > `127.0.0.1`.
+     */
+    host?: string;
     data_dir: string;
     db_path: string;
     /**
@@ -344,7 +356,21 @@ export const DEFAULT_CONFIG: JarvisConfig = {
   },
   authority: {
     default_level: 3,
-    governed_categories: ['send_email', 'send_message', 'make_payment'],
+    // Secure default: every destructive / externally-visible category requires
+    // explicit approval even when the agent's authority level is high enough to
+    // perform it. Without this, a level-5+ role (e.g. the default
+    // personal-assistant) silently runs shell commands. Users can narrow this
+    // set in config once they trust a given automation.
+    governed_categories: [
+      'send_email',
+      'send_message',
+      'make_payment',
+      'execute_command',
+      'install_software',
+      'delete_data',
+      'modify_settings',
+      'terminate_agent',
+    ],
     overrides: [],
     context_rules: [],
     learning: {

--- a/src/daemon/api-routes.ts
+++ b/src/daemon/api-routes.ts
@@ -2457,7 +2457,15 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
 
           // Merge updates into current config
           if (body.governed_categories) currentConfig.governed_categories = body.governed_categories as ActionCategory[];
-          if (body.default_level !== undefined) currentConfig.default_level = body.default_level as number;
+          if (body.default_level !== undefined) {
+            // Clamp to the authority scale (0-10). Without this an arbitrary
+            // (or hostile) value could over-grant the agent's effective
+            // authority floor, since the engine uses
+            // max(role_level, default_level) when checking requirements.
+            const lvl = Number(body.default_level);
+            if (!Number.isFinite(lvl)) return error('default_level must be a number');
+            currentConfig.default_level = Math.max(0, Math.min(10, Math.floor(lvl)));
+          }
           if (body.overrides) currentConfig.overrides = body.overrides as any[];
           if (body.context_rules) currentConfig.context_rules = body.context_rules as any[];
           if (body.learning) currentConfig.learning = { ...currentConfig.learning, ...body.learning as any };

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -6,9 +6,11 @@
  * starts health monitoring, and handles graceful shutdown.
  */
 
-import { mkdirSync, existsSync } from "node:fs";
+import { mkdirSync, existsSync, readFileSync } from "node:fs";
+import { randomBytes } from "node:crypto";
 import path from "node:path";
 import os from "node:os";
+import { secureWriteFile } from "../util/fs-secure.ts";
 import { initDatabase, closeDb } from "../vault/schema.ts";
 import { ServiceRegistry } from "./services.ts";
 import { HealthMonitor } from "./health.ts";
@@ -61,6 +63,7 @@ const DEFAULT_DATA_DIR = path.join(os.homedir(), '.jarvis');
 
 export interface DaemonConfig {
   port: number;
+  host?: string;                 // bind address (default 127.0.0.1)
   dbPath: string;
   dataDir: string;
   healthCheckInterval?: number;  // ms
@@ -92,6 +95,9 @@ function parseArgs(): Partial<DaemonConfig> {
       case '--port':
         config.port = parseInt(args[++i]!, 10);
         break;
+      case '--host':
+        config.host = args[++i]!;
+        break;
       case '--db-path':
         config.dbPath = args[++i]!;
         break;
@@ -114,6 +120,7 @@ Usage:
 
 Options:
   --port <number>          WebSocket server port (default: ${DEFAULT_PORT})
+  --host <address>         Bind address (default: 127.0.0.1; use 0.0.0.0 to expose on the network)
   --db-path <path>         Database file path (default: ~/.jarvis/jarvis.db)
   --data-dir <path>        Data directory (default: ~/.jarvis)
   --health-interval <ms>   Health check interval in ms (default: 30000)
@@ -281,8 +288,13 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
 
   // Merge configuration
   const port = userConfig?.port ?? jarvisConfig.daemon.port ?? DEFAULT_PORT;
+  // Bind address: CLI --host > JARVIS_HOST/config (already merged into
+  // jarvisConfig.daemon.host by the loader) > loopback default. Loopback by
+  // default means a fresh install is not reachable from the network.
+  const host = userConfig?.host ?? jarvisConfig.daemon.host ?? '127.0.0.1';
   const config: DaemonConfig = {
     port,
+    host,
     dataDir,
     dbPath,
     healthCheckInterval: userConfig?.healthCheckInterval ?? 30000,
@@ -356,7 +368,7 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
     const observerService = config.noLocalTools
       ? null
       : new ObserverService(reactor, coalescer, googleAuth ?? undefined, config.dataDir);
-    const wsService = new WebSocketService(config.port, agentService);
+    const wsService = new WebSocketService(config.port, agentService, config.host);
 
     // 5b. Create channel service for external comms (Telegram, Discord)
     const channelService = new ChannelService(jarvisConfig, agentService);
@@ -431,7 +443,7 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
     const authorityConfig = jarvisConfig.authority ?? { default_level: 3 };
     const authorityEngine = new AuthorityEngine({
       default_level: authorityConfig.default_level,
-      governed_categories: (authorityConfig.governed_categories ?? ['send_email', 'send_message', 'make_payment']) as any,
+      governed_categories: (authorityConfig.governed_categories ?? ['send_email', 'send_message', 'make_payment', 'execute_command', 'install_software', 'delete_data', 'modify_settings', 'terminate_agent']) as any,
       overrides: (authorityConfig.overrides ?? []) as any,
       context_rules: (authorityConfig.context_rules ?? []) as any,
       learning: authorityConfig.learning ?? { enabled: true, suggest_threshold: 5 },
@@ -733,13 +745,47 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
     const uiPublicDir = path.join(import.meta.dir, '../../ui/public');
     wsService.setPublicDir(uiPublicDir);
 
-    // 9c. Configure auth token if set
-    const authToken = jarvisConfig.auth?.token;
+    // 9c. Configure dashboard auth.
+    //
+    // Precedence: an explicitly configured token (config.auth.token /
+    // JARVIS_AUTH_TOKEN) always wins. Otherwise, if the daemon is bound to a
+    // non-loopback address it is reachable from the network, so it must NOT
+    // run unauthenticated: auto-generate a token, persist it (0600) under the
+    // data dir so it stays stable across restarts, and print it prominently
+    // (readable via `docker logs` / the console) so the operator can still
+    // reach the dashboard. Loopback binds with no token stay open locally —
+    // the CSRF Origin check still blocks cross-site browser requests.
+    const isLoopbackHost = (h: string): boolean =>
+      h === '127.0.0.1' || h === 'localhost' || h === '::1' || h === '::ffff:127.0.0.1';
+    let authToken = jarvisConfig.auth?.token;
+    if (!authToken && !isLoopbackHost(config.host ?? '127.0.0.1')) {
+      const tokenPath = path.join(config.dataDir, '.auth-token');
+      try {
+        if (existsSync(tokenPath)) {
+          authToken = readFileSync(tokenPath, 'utf-8').trim();
+        }
+        if (!authToken) {
+          authToken = randomBytes(32).toString('base64url');
+          await secureWriteFile(tokenPath, authToken + '\n', 0o600, 'Daemon');
+        }
+      } catch (err) {
+        // If persistence fails, still use an in-memory token — better than
+        // running unauthenticated on a network-reachable bind.
+        if (!authToken) authToken = randomBytes(32).toString('base64url');
+        console.warn(`[Daemon] Could not persist auth token: ${err instanceof Error ? err.message : String(err)}`);
+      }
+      console.warn('[Daemon] ════════════════════════════════════════════════════');
+      console.warn(`[Daemon] Bound to ${config.host} with no auth.token configured.`);
+      console.warn('[Daemon] Auto-generated a dashboard auth token. Visit once to set the cookie:');
+      console.warn(`[Daemon]     http://<host>:${config.port}/?token=${authToken}`);
+      console.warn(`[Daemon] (saved to ${path.join(config.dataDir, '.auth-token')}; set auth.token or JARVIS_AUTH_TOKEN to choose your own)`);
+      console.warn('[Daemon] ════════════════════════════════════════════════════');
+    }
     if (authToken) {
       wsService.setAuthToken(authToken);
       console.log('[Daemon] Auth token configured — dashboard routes require ?token= or cookie');
     } else {
-      console.warn('[Daemon] No auth token configured — dashboard is open to anyone on the network');
+      console.log(`[Daemon] No auth token set — dashboard reachable on loopback only (${config.host}); cross-site requests are blocked by the Origin check.`);
     }
 
     // 9b. Apply --no-local-tools flag if set

--- a/src/daemon/ws-service.ts
+++ b/src/daemon/ws-service.ts
@@ -164,10 +164,10 @@ export class WebSocketService implements Service {
   // dashboard clicks. See gateVoiceApprovalResolution + resolveLatestPendingByVoice.
   private auditTrail: AuditTrail | null = null;
 
-  constructor(port: number, agentService: AgentService) {
+  constructor(port: number, agentService: AgentService, hostname: string = '127.0.0.1') {
     this.port = port;
     this.agentService = agentService;
-    this.wsServer = new WebSocketServer(port);
+    this.wsServer = new WebSocketServer(port, hostname);
     this.streamRelay = new StreamRelay(this.wsServer);
 
     // Wire delegation callback: when PA delegates to a specialist,


### PR DESCRIPTION
## Summary

Hardens the always-on JARVIS daemon against the highest-impact issues found in a security review. Every change was verified: **`bun audit` reports 0 vulnerabilities**, the **full test suite passes with no new failures** (1188 pass; pre-existing failures are POSIX-only tests on a Windows dev box), and a **Docker container exercises the new auth/CSRF behavior end-to-end**.

## Why

By default the daemon bound to `0.0.0.0` with **no authentication**, and the default role could run shell commands (`execute_command`) without approval — so anything on the network (or a malicious web page via a `text/plain` "simple" request) could drive the agent into running commands on the host. This PR closes that and several adjacent issues.

## Changes

### Network exposure & drive-by CSRF (High)
- Default bind is now **`127.0.0.1`** (new `daemon.host`, `JARVIS_HOST` env, and `--host` flag), threaded `WebSocketService → WebSocketServer → Bun.serve`.
- Binding a **non-loopback** host with no `auth.token` now **auto-generates, persists (`<dataDir>/.auth-token`, mode `0600`), and logs** a dashboard token instead of running open.
- Added an **Origin check** on state-changing `/api/` requests — blocks cross-site requests from driving the daemon even when no token is set, and even with a valid cookie.
- `bin/jarvis.ts` now actually parses and forwards `--host` (and `--data-dir` / `--no-local-tools` in detach mode), which the CLI previously dropped before calling `startDaemon`.
- `Dockerfile` opts into `0.0.0.0` explicitly and the `HEALTHCHECK` uses the public `/health` endpoint.

### Authority gating (High / Medium)
- Default `governed_categories` now also requires approval for `execute_command`, `install_software`, `delete_data`, `modify_settings`, `terminate_agent`.
- `getActionForTool` **fails closed**: an unmapped tool resolves to `execute_command` (needs approval) instead of `read_data`.
- `default_level` is clamped to `0–10` at the API boundary.

### Channel authorization (High)
- Telegram and Discord now **deny by default**: an empty `allowed_users` list authorizes no one (was allow-all), with a one-time warning.

### Dependencies (High) — `bun audit`: 1 critical + 15 high → **0**
- Bump direct `yaml` to `^2.9.0`.
- Add **same-major** `overrides` (no API breakage) for the vulnerable transitives: `protobufjs ^7.6.2`, `@protobufjs/utf8 ^1.1.1`, `axios ^1.16.1`, `undici ^6.26.0`, `ws ^8.21.0`, `follow-redirects ^1.16.0`, `uuid ^11.1.1`, `lodash ^4.18.1`.

### WSL bridge (Low)
- Invoke PowerShell via `-EncodedCommand` (base64 UTF-16LE) with `-NoProfile -NonInteractive` instead of hand-escaping into `-Command`.

## Verification
- `bun audit` → **No vulnerabilities found**.
- `bun test` → **1188 pass**, 0 new failures.
- Docker build + run: container healthy; `/health` → 200; `/api/health` → 401 without token; `?token=…` → 302 + `HttpOnly; SameSite=Lax` cookie; with cookie → 200; **POST with a foreign `Origin` → 403** (even with a valid cookie); same-origin POST → 200.

## Notes
- Backward-compat: existing Docker users now get an auto-generated dashboard token (printed in `docker logs`) or can set `JARVIS_AUTH_TOKEN`. Loopback installs need no token; the Origin check still protects them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
