### PR TITLE
Pin axios in engine staging install and strip global TLS bypass

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,13 @@
 # Prevents Windows (core.autocrlf=true) checkouts from introducing CRLF,
 # which breaks shebang-based executables (e.g. bin/jarvis.ts) in Linux containers.
 * text=auto eol=lf
+
+# Activepieces is vendored under src/workflows/activepieces/. Mark the tree
+# as vendored so GitHub Linguist excludes it from language stats and
+# Dependabot deprioritizes alerts on its nested package.json files. Only
+# the deps the engine actually installs (see WORKSPACE_PKG_RELS and
+# SECURITY_FLOOR in src/workflows/runner/engine-runtime/build.ts) need
+# security attention; everything else in this tree is upstream code we
+# ship verbatim and don't `npm install`. Bulk-dismiss remaining alerts
+# in the GitHub UI with reason "vulnerable code is not used".
+src/workflows/activepieces/** linguist-vendored=true

--- a/scripts/sync-activepieces.ts
+++ b/scripts/sync-activepieces.ts
@@ -209,19 +209,31 @@ const SCRUB_DEPS: Record<string, string[]> = {
 };
 
 /**
- * Strip dangling `export * from '<path>'` lines from barrel files where the
- * referenced path was filtered out by the EE / test-dir filters above. Without
- * this pass the engine bundle build fails to resolve the missing modules.
+ * Strip specific lines from vendored files after sync. Originally introduced
+ * to drop dangling `export * from '<path>'` lines in barrels where the target
+ * dir was filtered out (EE / test-dir filters above); also used to remove
+ * unsafe upstream code (e.g. a global TLS-verification bypass in the HTTP
+ * client) so the next sync can't silently re-introduce it.
  *
  * Each entry is a regex of full lines to remove. Anchored to start-of-line and
- * tolerant of leading whitespace. The barrel file must remain valid TS after
- * removal (i.e., other exports must still be present).
+ * tolerant of leading whitespace. The file must remain valid TS after removal.
+ * Fails loudly if zero matches: that means upstream restructured and the entry
+ * needs revisiting (either the issue is gone or the regex needs updating).
  */
-const STRIP_EXPORT_LINES: Record<string, RegExp[]> = {
+const STRIP_LINES: Record<string, RegExp[]> = {
   // EE re-exports of paths we never copy.
   "packages/shared/src/index.ts": [/^\s*export \* from ['"]\.\/lib\/ee\//],
   // Test-only re-exports of dirs filtered by TEST_DIR_NAMES.
   "packages/pieces/framework/src/lib/index.ts": [/^\s*export \* from ['"]\.\/test['"];?\s*$/],
+  // Upstream's HTTP client sets process.env.NODE_TLS_REJECT_UNAUTHORIZED='0'
+  // on every request, which disables TLS verification process-wide (not just
+  // for that one call). Webhook-triggered workflows make this an MITM hole
+  // on every outbound HTTPS request JARVIS makes. Strip it; if a user
+  // genuinely needs to talk to self-signed endpoints they can set the env
+  // var at the daemon level themselves.
+  "packages/pieces/common/src/lib/http/axios/axios-http-client.ts": [
+    /^\s*process\.env\['NODE_TLS_REJECT_UNAUTHORIZED'\]\s*=\s*'0';\s*$/,
+  ],
 };
 
 /**
@@ -494,20 +506,20 @@ for (const [relPath, depNames] of Object.entries(SCRUB_DEPS)) {
   writeFileSync(dst, JSON.stringify(pkg, null, 2) + "\n");
   info(`scrubbed ${removed} dep(s) from ${relPath}: [${depNames.join(", ")}]`);
 }
-for (const [relPath, patterns] of Object.entries(STRIP_EXPORT_LINES)) {
+for (const [relPath, patterns] of Object.entries(STRIP_LINES)) {
   const dst = join(VENDOR_DIR, relPath);
   if (!existsSync(dst)) {
-    fail(`strip-exports target missing: ${relPath}`);
+    fail(`strip-lines target missing: ${relPath}`);
   }
   const original = readFileSync(dst, "utf8");
   const lines = original.split("\n");
   const kept = lines.filter((line) => !patterns.some((re) => re.test(line)));
   const removed = lines.length - kept.length;
   if (removed === 0) {
-    fail(`strip-exports matched 0 lines in ${relPath} -- did upstream restructure the barrel?`);
+    fail(`strip-lines matched 0 lines in ${relPath} -- did upstream restructure the file or fix the issue?`);
   }
   writeFileSync(dst, kept.join("\n"));
-  info(`stripped ${removed} export line(s) from ${relPath}`);
+  info(`stripped ${removed} line(s) from ${relPath}`);
 }
 for (const [relPath, patches] of Object.entries(PATCH_INSERTIONS)) {
   const dst = join(VENDOR_DIR, relPath);

--- a/src/workflows/activepieces/packages/pieces/common/src/lib/http/axios/axios-http-client.ts
+++ b/src/workflows/activepieces/packages/pieces/common/src/lib/http/axios/axios-http-client.ts
@@ -28,7 +28,6 @@ export class AxiosHttpClient extends BaseHttpClient {
   ): Promise<HttpResponse<ResponseBody>> {
     try {
       const axiosInstance = axiosClient || axios.create();
-      process.env['NODE_TLS_REJECT_UNAUTHORIZED'] = '0';
       const { urlWithoutQueryParams, queryParams: urlQueryParams } =
         this.getUrl(request);
       const headers = this.getHeaders(request);

--- a/src/workflows/runner/engine-runtime/build.ts
+++ b/src/workflows/runner/engine-runtime/build.ts
@@ -68,10 +68,70 @@ const WORKSPACE_PKG_RELS = [
 ] as const;
 
 /**
+ * Security floor for transitive deps the staging install resolves. When a
+ * vendored manifest pins a dep at a version with a known advisory reachable
+ * from JARVIS (e.g. axios in pieces/common feeds the HTTP node, which webhook
+ * triggers can drive with untrusted internet payloads), pin it here. The floor
+ * is injected into the synthesized staging package.json as a bun `overrides`
+ * entry, which wins over the manifest pin during `bun install`.
+ *
+ * Triage when Dependabot flags a new vendored dep:
+ *
+ *   1. Does the dep appear in any WORKSPACE_PKG_RELS manifest as a non-dev
+ *      dependency? If no -> add to .github/dependabot.yml ignore. The dep
+ *      doesn't ship via this staging install; the alert is noise.
+ *
+ *   2. Is the vulnerability reachable from untrusted input (webhook payloads,
+ *      LLM-generated workflow params, etc.)? If no -> add to ignore with a
+ *      short "not reachable" note.
+ *
+ *   3. If reachable: is upstream already patched in a version we can sync?
+ *      If yes -> bump via upstream sync. If no -> add a SECURITY_FLOOR entry
+ *      here, link the advisory.
+ *
+ * Entries here are FLOORS, not clamps: when upstream's pin catches up to or
+ * exceeds the floor, the override is skipped and the build logs a one-line
+ * notice so the dead entry can be cleaned up by hand. No silent downgrade.
+ */
+const SECURITY_FLOOR: Record<string, string> = {
+  // pieces/common pins axios@1.15.0 exact; the HTTP node uses axios for all
+  // outbound requests. Webhook-triggered workflows can drive that node with
+  // untrusted payload data (URLs, headers), so SSRF/DoS classes in 1.15.x
+  // are reachable in production. 1.16.1 is the first patched release.
+  // GHSA-3g43-6gmg-66jw, GHSA-35jp-ww65-95wh, GHSA-pf86-5x62-jrwf.
+  axios: "1.16.1",
+};
+
+/**
+ * Compare two pinned/range versions for the "floor satisfied?" check.
+ * Tolerantly strips ^ / ~ prefixes and compares numerically. Sufficient for
+ * vendored manifests which use exact pins; if upstream ever switches to
+ * caret ranges we still answer "yes, floor is satisfied" correctly because
+ * we compare against the minimum of the range.
+ */
+function versionMeetsFloor(declared: string, floor: string): boolean {
+  const parse = (v: string): [number, number, number] => {
+    const parts = v.replace(/^[\^~>=<\s]+/, "").split(".");
+    return [
+      parseInt(parts[0] ?? "0", 10) || 0,
+      parseInt(parts[1] ?? "0", 10) || 0,
+      parseInt(parts[2] ?? "0", 10) || 0,
+    ];
+  };
+  const [da, db, dc] = parse(declared);
+  const [fa, fb, fc] = parse(floor);
+  if (da !== fa) return da > fa;
+  if (db !== fb) return db > fb;
+  return dc >= fc;
+}
+
+/**
  * Synthesize the staging-dir package.json: union of every non-workspace dep
  * across the four workspace packages the engine bundle imports, plus esbuild.
- * On version conflict, the latest entry wins -- we'd flag in CI if this ever
- * matters, but in practice the workspace pkgs all share pinned versions.
+ * Applies SECURITY_FLOOR via the `overrides` block when upstream's declared
+ * version sits below the floor. On dep version conflict between manifests,
+ * the latest entry wins -- we'd flag in CI if this ever matters, but in
+ * practice the workspace pkgs all share pinned versions.
  */
 function buildStagingPackageJson(): string {
   const deps: Record<string, string> = {};
@@ -87,12 +147,32 @@ function buildStagingPackageJson(): string {
   }
   deps["esbuild"] = ESBUILD_VERSION;
 
+  const overrides: Record<string, string> = {};
+  for (const [name, floor] of Object.entries(SECURITY_FLOOR)) {
+    const declared = deps[name];
+    if (!declared) {
+      // Dep removed upstream; the floor entry is dead and can be deleted.
+      console.warn(
+        `[engine-build] SECURITY_FLOOR entry '${name}' has no matching dep in vendored manifests; remove it.`,
+      );
+      continue;
+    }
+    if (versionMeetsFloor(declared, floor)) {
+      console.log(
+        `[engine-build] SECURITY_FLOOR '${name}@${floor}' satisfied by upstream '${declared}'; remove entry.`,
+      );
+      continue;
+    }
+    overrides[name] = floor;
+  }
+
   return JSON.stringify(
     {
       name: "jarvis-engine-build-staging",
       private: true,
       type: "commonjs",
       dependencies: deps,
+      ...(Object.keys(overrides).length > 0 ? { overrides } : {}),
     },
     null,
     2,
@@ -122,6 +202,13 @@ const PATCHED_VENDOR_SOURCES = [
   // doesn't ship the OLD operator list / executor.
   "shared/src/lib/automation/flows/actions/action.ts",
   "server/engine/src/lib/handler/router-executor.ts",
+  // Jarvis: upstream sets process.env.NODE_TLS_REJECT_UNAUTHORIZED='0'
+  // on every HTTP-node request, which disables TLS verification for the
+  // entire Node process (not just the one request). We strip that line
+  // via STRIP_LINES in sync-activepieces.ts; if a sync ever re-introduces
+  // it, the file content here changes and the bundle hash invalidates so
+  // the cached engine doesn't keep shipping the OLD bypass.
+  "pieces/common/src/lib/http/axios/axios-http-client.ts",
 ] as const;
 
 /**


### PR DESCRIPTION
## What this does

Two security fixes in the engine bundle, plus the supporting infrastructure to keep them durable across upstream syncs.

### 1. Axios floor in the staging install

`pieces/common` pins `axios@1.15.0` exact, and the HTTP node uses axios for every outbound request. Webhook-triggered workflows can drive that node with untrusted internet payload data, so the SSRF/DoS advisories in 1.15.x (GHSA-3g43-6gmg-66jw, GHSA-35jp-ww65-95wh, GHSA-pf86-5x62-jrwf) are reachable in production.

Rather than rewriting vendored `package.json` files (which fights upstream on every sync and silently downgrades when upstream catches up), I added a `SECURITY_FLOOR` map in `buildStagingPackageJson` that injects a bun `overrides` block into the synthesized staging package.json. The floor is applied only when the declared version sits below it; when upstream catches up, the build logs a one-line notice and the entry can be deleted by hand. No silent downgrade.

### 2. Global TLS-verification bypass removed

While auditing axios usage, I found `axios-http-client.ts:31` setting `process.env['NODE_TLS_REJECT_UNAUTHORIZED'] = '0'` on every HTTP-node request. That env var disables TLS verification for the **entire Node process**, not just the one call -- meaning every outbound HTTPS request JARVIS makes (LLM APIs, integrations, anything) accepts any certificate. Pure MITM hole.

Removed the line from the vendored file and added a `STRIP_LINES` entry in `sync-activepieces.ts` so the next upstream sync can't silently re-introduce it. If a user genuinely needs to talk to self-signed endpoints, they can set the env var at the daemon level themselves.

## Supporting changes

- **`STRIP_EXPORT_LINES` -> `STRIP_LINES`** in the sync script. The mechanism was always general (regex-based line removal with fail-loudly on zero matches); just misnamed. Existing barrel-export entries are unchanged.
- **`PATCHED_VENDOR_SOURCES` gains `axios-http-client.ts`** so the bundle hash invalidates if a sync ever re-injects the bypass.
- **`.gitattributes`** marks `src/workflows/activepieces/**` as `linguist-vendored=true` so GitHub deprioritizes alerts on upstream code we ship verbatim. Existing alerts still need per-alert dismissal in the UI.

## Future maintenance

Codified as a comment block above `SECURITY_FLOOR`:

1. Dep not in `WORKSPACE_PKG_RELS` non-devDeps -> doesn't ship, ignore the alert.
2. Reachable from untrusted input? If no, ignore with a note.
3. Reachable and upstream not yet patched -> add a `SECURITY_FLOOR` entry.
4. When the build log says "satisfied by upstream" -> delete the entry.
