### PR TITLE
Realtime voice (gpt-realtime-2)

### DIFF
--- a/docs/GPT_REALTIME_2_INTEGRATION.md
+++ b/docs/GPT_REALTIME_2_INTEGRATION.md
@@ -124,8 +124,19 @@ triggering an irreversible action unattended.
   bills per token, but no live invoice is available mid-session), persisted per
   month under the data dir (`realtime-budget.ts`), and checked at session start.
   Once the estimate reaches the budget, new sessions are refused with a
-  `realtime_status` error and the standard pipeline is unaffected. This is an
-  approximate guard, not accounting.
+  `realtime_status: { state: 'closed', reason: 'budget', message }` (the client
+  surfaces the message as a system line and stops the mic), and the standard
+  pipeline is unaffected. This is an approximate guard, not accounting:
+  - Spend is only recorded at session close, and `canStart` reads fresh at
+    start, so concurrent sessions (e.g. multiple browser tabs) opened before any
+    close all observe the same pre-spend total and can overshoot the cap. This
+    is accepted for the single-user daemon; close it with an in-memory in-flight
+    reservation if multi-session overshoot ever matters.
+
+`GET /api/config/voice` reports the **effective** `blocked_categories` (the
+applied default when unset) plus `blocked_categories_default: true|false`, so a
+client can't misread the safe default as "nothing blocked" and a read-modify-
+write round-trip can't silently persist `[]` and disable the backstop.
 
 ## 5. Input validation
 

--- a/docs/GPT_REALTIME_2_INTEGRATION.md
+++ b/docs/GPT_REALTIME_2_INTEGRATION.md
@@ -1,0 +1,137 @@
+# GPT-Realtime-2 Integration
+
+Premium opt-in speech-to-speech voice via OpenAI's GA Realtime API
+(`gpt-realtime-2`). When enabled with a key, JARVIS streams mic audio to OpenAI
+and plays the model's audio back, with the daemon acting as both the audio relay
+and the tool executor. When disabled (the default) JARVIS uses the standard
+STT -> text LLM -> TTS pipeline, which is unaffected by anything here.
+
+This document is the rationale companion to the code; source files reference it
+by section. It is intentionally decision-focused rather than a full API spec.
+
+## 1. Entitlement & key resolution
+
+Entitlement is simply "the user supplies a working OpenAI key" - there is no
+separate licensing. Resolution (`resolveRealtimeVoice`, `src/config/realtime.ts`)
+never throws: when realtime is unavailable it returns `{ ok: false, reason }`
+and the caller logs a warning and falls back to the standard pipeline.
+
+Key resolution order:
+
+1. `voice.realtime.api_key`
+2. `llm.openai.api_key`
+3. env `JARVIS_OPENAI_KEY`, then `OPENAI_API_KEY`
+
+The user is billed by OpenAI directly (BYO key). The Settings > Voice GET
+endpoint redacts the key and reports `has_api_key` / `available` only.
+
+## 2. Protocol notes (GA, post-2026-05)
+
+These were confirmed via the live smoke test (`scripts/realtime-smoke.ts`) and
+are load-bearing - they differ from the older beta:
+
+- Connect to `wss://api.openai.com/v1/realtime?model=...` with a Bearer key and
+  **no** `OpenAI-Beta` header.
+- Session config is nested under `session.audio.{input,output}` with
+  `session.type: 'realtime'`.
+- Reasoning effort is `session.reasoning.effort` (GPT-5 convention), not a
+  top-level field.
+- Output audio events use the `response.output_audio*` names
+  (`response.output_audio.delta`, `response.output_audio_transcript.*`).
+- `format.rate` is **required** on both input and output audio formats. OpenAI
+  rejects an input rate below 24 kHz (`MIN_REALTIME_INPUT_RATE`); transports
+  capturing lower (e.g. a 16 kHz mic) must upsample before streaming.
+- Turn detection uses plain `semantic_vad` - the low-latency, preamble-friendly
+  default. `server_vad` and eagerness tuning both measured worse. The first-turn
+  "doesn't start" symptom was dropped opening audio (fixed by transport
+  buffering), not the VAD - leave it alone.
+
+### Latency decisions
+
+- A lean ~100-token voice prompt is used instead of the full ~5.6k-token agent
+  prompt; the big context dominated per-turn latency for simple questions. Tools
+  are still attached so capability is unchanged.
+- The opening words of a turn are buffered during the connect window
+  (`MAX_PENDING_MIC_FRAMES`, a sliding ~3s window of the most recent audio) so
+  the first utterance isn't lost. The window keeps the most recent audio for VAD
+  continuity rather than the absolute earliest frames.
+
+## 3. Audio transport (§3a)
+
+`AudioTransport` (`src/comms/audio-transport.ts`) decouples `RealtimeSession`
+from where audio comes from / goes to. Contract: PCM signed-16 little-endian,
+mono; the transport declares its sample rate so the session announces a matching
+`audio.input.format.rate`.
+
+`BrowserAudioTransport` is the only implementation today: mic frames arrive as
+binary WS frames (`pushMicChunk`) and output audio is relayed to the browser via
+the `sendAudio` hook. Playback timing/queueing lives in the browser
+(`RealtimeVoiceController`, `ui/src/lib/`). A `PebbleAudioTransport` can be added
+later against the same interface with no session changes.
+
+### Barge-in
+
+On `input_audio_buffer.speech_started` the session both cancels the in-flight
+response server-side (`response.cancel`) and stops local playback. Cancelling
+matters: without it OpenAI keeps generating tokens/audio the user will never
+hear, and trailing deltas can replay over the interruption. Deltas that arrive
+after a cancel (before the next `response.created`) are suppressed.
+
+## 4. Daemon wiring
+
+### Phase 2 - session wiring
+
+`RealtimeVoiceSession` (`src/daemon/realtime-voice.ts`) glues a
+`RealtimeSession` to an `AudioTransport` and to the tool executor. It is kept
+separate from `ws-service` so it is unit-testable with an injected session
+factory. ws-service opens (or reuses) one session per socket; a session spans
+the whole conversation (semantic VAD detects turns), and is closed on
+disconnect, on `max_session_minutes`, or when the monthly budget is reached.
+
+When the server closes a session it sends `realtime_status: { state: 'closed' }`;
+the browser must stop streaming on this, or it keeps a hot mic streaming into a
+session that no longer exists.
+
+### Phase 3 - auto-approve tool bridge
+
+`orchestrator.executeRealtimeToolCall` mirrors the text-path authority gate but
+**auto-approves**: a `requiresApproval` decision is executed so the audio loop is
+never blocked on a dashboard click. Still enforced:
+
+- emergency state,
+- explicit hard denies,
+- the `blocked_categories` backstop.
+
+Every realtime tool call is written to the audit trail tagged `channel: 'voice'`;
+an auto-approved call is logged as `approval_required` + `executed: true` so the
+trail shows no human confirmed it.
+
+**Safe defaults.** Because the mic is open and tools auto-approve, the backstop
+must be safe by default. When `blocked_categories` is unset it defaults to every
+`destructive`-impact action category (`DEFAULT_BLOCKED_CATEGORIES`): payments,
+deletes, shell exec, software installs, settings changes, agent termination.
+These stay blocked unless the user explicitly opts them back in by setting
+`blocked_categories` to an explicit array (including `[]` to disable the backstop
+entirely). This prevents an open mic - or TTS echo / background speech - from
+triggering an irreversible action unattended.
+
+### Cost guards
+
+- `max_session_minutes` - hard cap on a single session; the daemon closes it on
+  timeout.
+- `monthly_budget_usd` - soft monthly ceiling. Spend is **estimated** from
+  session wall-clock at the ~$/min figure shown in Settings > Voice (OpenAI
+  bills per token, but no live invoice is available mid-session), persisted per
+  month under the data dir (`realtime-budget.ts`), and checked at session start.
+  Once the estimate reaches the budget, new sessions are refused with a
+  `realtime_status` error and the standard pipeline is unaffected. This is an
+  approximate guard, not accounting.
+
+## 5. Input validation
+
+`POST /api/config/voice` validates the patch (`validateVoicePatch`,
+`src/daemon/config-merge.ts`) before merge/persist: known top-level keys only,
+`wake_engine` and `reasoning_effort` against their enums, `max_session_minutes`
+bounded numeric, `monthly_budget_usd` non-negative-or-null, `blocked_categories`
+an array of strings. The merge preserves the stored `api_key` when the patch
+omits it (the GET endpoint redacts it, so a UI round-trip never sees the value).

--- a/scripts/realtime-smoke.ts
+++ b/scripts/realtime-smoke.ts
@@ -1,0 +1,121 @@
+#!/usr/bin/env bun
+/**
+ * Live smoke test for the gpt-realtime-2 integration (Phase 0-1).
+ *
+ * Validates the parts unit tests CAN'T: that our GA `session.update` shape is
+ * actually accepted by OpenAI (especially `reasoning.effort` placement and the
+ * `semantic_vad` turn detection), that auth works, and that the server event
+ * names we parse are correct. Sends a TEXT prompt (no mic needed) and asks for
+ * an audio response, then prints every event — errors loudly.
+ *
+ * Usage:
+ *   OPENAI_API_KEY=sk-... bun run scripts/realtime-smoke.ts
+ *   # optional overrides:
+ *   REALTIME_MODEL=gpt-realtime-2 REALTIME_EFFORT=medium REALTIME_VOICE=marin \
+ *     bun run scripts/realtime-smoke.ts "Say hello in exactly five words."
+ *
+ * This is a throwaway diagnostic, not part of the daemon. It exercises the real
+ * `buildSessionUpdate` from src/comms/realtime.ts so a green run means Phase 2
+ * can build on a verified protocol.
+ */
+
+import { REALTIME_URL, buildSessionUpdate } from '../src/comms/realtime.ts';
+import type { ResolvedRealtimeVoice } from '../src/config/realtime.ts';
+import type { RealtimeReasoningEffort } from '../src/config/types.ts';
+
+const key = (process.env.OPENAI_API_KEY || process.env.JARVIS_OPENAI_KEY || '').trim();
+if (!key) {
+  console.error('✗ No API key. Set OPENAI_API_KEY (or JARVIS_OPENAI_KEY) and retry.');
+  process.exit(1);
+}
+
+const resolved: ResolvedRealtimeVoice = {
+  apiKey: key,
+  model: process.env.REALTIME_MODEL || 'gpt-realtime-2',
+  voice: process.env.REALTIME_VOICE || 'marin',
+  reasoningEffort: (process.env.REALTIME_EFFORT as RealtimeReasoningEffort) || 'low',
+  maxSessionMinutes: 5,
+  blockedCategories: [],
+};
+
+const prompt = process.argv.slice(2).join(' ') || 'Say hello and tell me you are working, in one short sentence.';
+const url = `${REALTIME_URL}?model=${encodeURIComponent(resolved.model)}`;
+
+console.log(`→ Connecting: ${url}`);
+console.log(`→ Model=${resolved.model}  effort=${resolved.reasoningEffort}  voice=${resolved.voice}`);
+
+// Bun's WebSocket accepts a non-standard { headers } option.
+const ws = new WebSocket(url, { headers: { Authorization: `Bearer ${key}` } } as any);
+
+let assistantText = '';
+let audioBytes = 0;
+let sawError = false;
+
+const done = (code: number) => { try { ws.close(); } catch {} process.exit(code); };
+const timeout = setTimeout(() => {
+  console.error('✗ Timed out after 30s with no response.done');
+  done(sawError ? 1 : 2);
+}, 30_000);
+
+ws.addEventListener('open', () => {
+  console.log('✓ Socket open — sending session.update');
+  // 24kHz is the realtime input minimum (16kHz is rejected). Pebble's 16kHz mic
+  // must be upsampled before streaming — see MIN_REALTIME_INPUT_RATE.
+  const sessionUpdate = buildSessionUpdate(resolved, [], 'You are a terse test agent.', 24000, 24000);
+  console.log('  session.update payload:\n' + JSON.stringify(sessionUpdate, null, 2));
+  ws.send(JSON.stringify(sessionUpdate));
+
+  // Drive a turn with text input (no mic), then request a response.
+  ws.send(JSON.stringify({
+    type: 'conversation.item.create',
+    item: { type: 'message', role: 'user', content: [{ type: 'input_text', text: prompt }] },
+  }));
+  ws.send(JSON.stringify({ type: 'response.create' }));
+});
+
+ws.addEventListener('message', (ev: MessageEvent) => {
+  let evt: any;
+  try { evt = JSON.parse(String(ev.data)); } catch { return; }
+  const t = evt.type as string;
+
+  switch (t) {
+    case 'session.created':
+    case 'session.updated':
+      console.log(`✓ ${t}`);
+      break;
+    case 'response.output_audio.delta':
+      audioBytes += Buffer.from(evt.delta || '', 'base64').length;
+      break;
+    case 'response.output_audio_transcript.delta':
+      assistantText += evt.delta || '';
+      break;
+    case 'response.output_audio_transcript.done':
+      console.log(`✓ assistant transcript: "${evt.transcript ?? assistantText}"`);
+      break;
+    case 'response.done':
+      console.log(`✓ response.done — received ${audioBytes} bytes of audio`);
+      clearTimeout(timeout);
+      console.log(sawError ? '\n✗ Completed WITH errors (see above).' : '\n✓ SMOKE TEST PASSED — GA session shape accepted, audio + transcript received.');
+      done(sawError ? 1 : 0);
+      break;
+    case 'error':
+      sawError = true;
+      console.error(`✗ ERROR event: ${JSON.stringify(evt.error, null, 2)}`);
+      console.error('  (If this complains about session fields, our session.update shape needs adjusting — note it in the roadmap.)');
+      break;
+    default:
+      // Comment this in for full event tracing:
+      // console.log(`  · ${t}`);
+      break;
+  }
+});
+
+ws.addEventListener('error', () => {
+  console.error('✗ WebSocket error (auth/network). Check the API key and that your account has realtime access.');
+  clearTimeout(timeout);
+  done(1);
+});
+
+ws.addEventListener('close', (ev: CloseEvent) => {
+  if (ev.code !== 1000) console.error(`✗ Socket closed: code=${ev.code} reason="${ev.reason}"`);
+});

--- a/src/agents/orchestrator-realtime.test.ts
+++ b/src/agents/orchestrator-realtime.test.ts
@@ -1,0 +1,100 @@
+import { test, expect, describe, beforeEach, afterEach } from 'bun:test';
+import { AgentOrchestrator } from './orchestrator.ts';
+import { ToolRegistry, type ToolDefinition } from '../actions/tools/registry.ts';
+import { AuthorityEngine, type AuthorityConfig } from '../authority/engine.ts';
+import { AuditTrail } from '../authority/audit.ts';
+import { initDatabase, closeDb } from '../vault/schema.ts';
+import type { RoleDefinition } from '../roles/types.ts';
+
+const ROLE = {
+  id: 'personal-assistant',
+  name: 'PA',
+  authority_level: 5,
+  tools: [],
+  sub_roles: [],
+} as unknown as RoleDefinition;
+
+function authorityConfig(overrides?: Partial<AuthorityConfig>): AuthorityConfig {
+  return {
+    default_level: 3,
+    governed_categories: [],
+    overrides: [],
+    context_rules: [],
+    learning: { enabled: false, suggest_threshold: 5 },
+    emergency_state: 'normal',
+    ...overrides,
+  };
+}
+
+let executed: string[] = [];
+function makeRegistry(): ToolRegistry {
+  const reg = new ToolRegistry();
+  const readFile: ToolDefinition = {
+    name: 'read_file', // maps to actionCategory 'read_data'
+    description: 'Read a file',
+    category: 'file-ops',
+    parameters: { path: { type: 'string', description: 'path', required: true } },
+    execute: async (p) => { executed.push(`read_file:${p.path}`); return `contents of ${p.path}`; },
+  };
+  reg.register(readFile);
+  return reg;
+}
+
+function makeOrchestrator(authConfig: AuthorityConfig): { orch: AgentOrchestrator; audit: AuditTrail } {
+  const orch = new AgentOrchestrator();
+  orch.setToolRegistry(makeRegistry());
+  orch.setAuthorityEngine(new AuthorityEngine(authConfig));
+  const audit = new AuditTrail();
+  orch.setAuditTrail(audit);
+  orch.createPrimary(ROLE);
+  return { orch, audit };
+}
+
+describe('orchestrator.executeRealtimeToolCall (auto-approve bridge)', () => {
+  beforeEach(() => { initDatabase(':memory:'); executed = []; });
+  afterEach(() => { closeDb(); });
+
+  test('allowed tool executes and returns the result', async () => {
+    const { orch, audit } = makeOrchestrator(authorityConfig());
+    const out = await orch.executeRealtimeToolCall('read_file', { path: '/etc/hosts' });
+    expect(out).toBe('contents of /etc/hosts');
+    expect(executed).toEqual(['read_file:/etc/hosts']);
+    const log = audit.query({ limit: 10 });
+    expect(log[0]!.channel).toBe('voice');
+    expect(log[0]!.authority_decision).toBe('allowed');
+    expect(log[0]!.executed).toBe(1);
+  });
+
+  test('requiresApproval is AUTO-APPROVED (executes) and audited as approval_required', async () => {
+    // Force read_data to require approval via an override.
+    const cfg = authorityConfig({ overrides: [{ action: 'read_data', allowed: true, requires_approval: true }] });
+    const { orch, audit } = makeOrchestrator(cfg);
+    const out = await orch.executeRealtimeToolCall('read_file', { path: '/x' });
+    expect(out).toBe('contents of /x');           // executed despite needing approval
+    expect(executed).toEqual(['read_file:/x']);
+    const log = audit.query({ limit: 10 });
+    expect(log[0]!.authority_decision).toBe('approval_required');
+    expect(log[0]!.executed).toBe(1);             // auto-approved
+  });
+
+  test('hard deny is enforced — tool does NOT execute', async () => {
+    const cfg = authorityConfig({ overrides: [{ action: 'read_data', allowed: false }] });
+    const { orch } = makeOrchestrator(cfg);
+    const out = await orch.executeRealtimeToolCall('read_file', { path: '/x' });
+    expect(out).toContain('[AUTHORITY DENIED]');
+    expect(executed).toEqual([]);
+  });
+
+  test('blocked_categories backstop blocks even under auto-approve', async () => {
+    const { orch } = makeOrchestrator(authorityConfig());
+    const out = await orch.executeRealtimeToolCall('read_file', { path: '/x' }, { blockedCategories: ['read_data'] });
+    expect(out).toContain('[BLOCKED]');
+    expect(executed).toEqual([]);
+  });
+
+  test('unknown tool returns an error string, never throws', async () => {
+    const { orch } = makeOrchestrator(authorityConfig());
+    const out = await orch.executeRealtimeToolCall('does_not_exist', {});
+    expect(out.toLowerCase()).toContain('error');
+  });
+});

--- a/src/agents/orchestrator.ts
+++ b/src/agents/orchestrator.ts
@@ -51,6 +51,15 @@ export class AgentOrchestrator {
     return this.toolRegistry;
   }
 
+  /**
+   * Public tool schema for realtime voice sessions. Same shared `LLMTool[]`
+   * the text providers consume (decision #3 — single source of truth).
+   */
+  getRealtimeTools(): LLMTool[] {
+    if (!this.toolRegistry || this.toolRegistry.count() === 0) return [];
+    return this.toolRegistry.list().map(toolDefToLLMTool);
+  }
+
   // --- Authority setters ---
 
   setAuthorityEngine(engine: AuthorityEngine): void {
@@ -592,6 +601,95 @@ export class AgentOrchestrator {
       return result;
     } catch (err) {
       return `Error executing ${toolCall.name}: ${err instanceof Error ? err.message : String(err)}`;
+    }
+  }
+
+  /**
+   * Execute a tool call originating from a premium realtime (gpt-realtime-2)
+   * voice session. Mirrors `executeTool`'s authority gate BUT auto-approves:
+   * a `requiresApproval` decision is treated as granted so the audio loop is
+   * never blocked (decision #2, see docs/GPT_REALTIME_2_INTEGRATION.md §4 Phase 3).
+   *
+   * Still enforced: emergency state, explicit hard denies, and the
+   * user-configured `blockedCategories` backstop. Every call is written to the
+   * audit trail tagged `channel:'voice'`; an auto-approved call is recorded as
+   * `approval_required` + `executed:true` so the trail shows no human confirmed it.
+   *
+   * Always returns a string (the tool result or an error/denial marker) — the
+   * realtime session feeds this straight back to the model as function output.
+   */
+  async executeRealtimeToolCall(
+    name: string,
+    args: Record<string, unknown>,
+    opts: { blockedCategories?: string[] } = {},
+  ): Promise<string> {
+    if (!this.toolRegistry) return 'Error: No tool registry configured';
+
+    // 1. Emergency check (same as text path).
+    if (this.emergencyController && !this.emergencyController.canExecute()) {
+      const state = this.emergencyController.getState();
+      return `[SYSTEM ${state.toUpperCase()}] Tool execution is currently suspended.`;
+    }
+
+    const primary = this.getPrimary();
+    const tool = this.toolRegistry.get(name);
+    const actionCategory = getActionForTool(name, tool?.category ?? 'unknown');
+
+    const logAudit = (decision: 'allowed' | 'denied' | 'approval_required', executed: boolean) => {
+      if (!primary) return;
+      this.auditTrail?.log({
+        agent_id: primary.id,
+        agent_name: primary.agent.role.name,
+        tool_name: name,
+        action_category: actionCategory,
+        authority_decision: decision,
+        approval_id: null,
+        executed,
+        channel: 'voice',
+      });
+    };
+
+    // 2. User backstop: categories that stay blocked even under auto-approve.
+    if (opts.blockedCategories?.includes(actionCategory)) {
+      logAudit('denied', false);
+      return `[BLOCKED] ${name} (${actionCategory}) is in the realtime blocked-categories list and was not executed.`;
+    }
+
+    // 3. Authority check — hard denies enforced; approval auto-granted.
+    if (this.authorityEngine && primary) {
+      const decision = this.authorityEngine.checkAuthority({
+        agentId: primary.id,
+        agentAuthorityLevel: primary.agent.authority.max_authority_level,
+        agentRoleId: primary.agent.role.id,
+        toolName: name,
+        toolCategory: tool?.category ?? 'unknown',
+        actionCategory,
+        temporaryGrants: this.temporaryGrants,
+      });
+
+      if (!decision.allowed) {
+        logAudit('denied', false);
+        return `[AUTHORITY DENIED] Cannot execute ${name}: ${decision.reason}.`;
+      }
+
+      // requiresApproval -> auto-approved in realtime; audited as such.
+      logAudit(decision.requiresApproval ? 'approval_required' : 'allowed', true);
+    }
+
+    // 4. Execute.
+    try {
+      const raw = await this.toolRegistry.execute(name, args);
+      if (isToolResult(raw)) {
+        // Realtime function output is text; flatten non-text blocks to a tag.
+        return raw.content.map((c) => (c.type === 'text' ? c.text : `[${c.type}]`)).join('\n');
+      }
+      let result = typeof raw === 'string' ? raw : JSON.stringify(raw);
+      if (result.length > MAX_TOOL_RESULT_CHARS) {
+        result = result.slice(0, MAX_TOOL_RESULT_CHARS) + `\n... (truncated, was ${result.length} chars)`;
+      }
+      return result;
+    } catch (err) {
+      return `Error executing ${name}: ${err instanceof Error ? err.message : String(err)}`;
     }
   }
 

--- a/src/comms/audio-transport.ts
+++ b/src/comms/audio-transport.ts
@@ -54,11 +54,22 @@ export type BrowserTransportHooks = {
  * to the browser through the `sendAudio` hook. Playback timing/queueing lives
  * in the browser client; this class is a thin relay.
  */
+/**
+ * Max mic frames buffered while the OpenAI socket is still connecting. At
+ * 24kHz/~5ms frames this is ~3s of audio — enough to capture the user's opening
+ * words during the connect window without growing unbounded.
+ */
+const MAX_PENDING_MIC_FRAMES = 600;
+
 export class BrowserAudioTransport implements AudioTransport {
   readonly inputSampleRate: number;
   readonly outputSampleRate: number;
   private micCb: ((pcm: Buffer) => void) | null = null;
   private hooks: BrowserTransportHooks;
+  // Frames that arrive before the realtime session wires its mic listener (i.e.
+  // while the OpenAI socket is still connecting). Without this they were
+  // dropped, so the user's first words vanished and the turn never registered.
+  private pending: Buffer[] = [];
 
   constructor(hooks: BrowserTransportHooks) {
     this.hooks = hooks;
@@ -70,11 +81,23 @@ export class BrowserAudioTransport implements AudioTransport {
 
   onMicChunk(cb: (pcm: Buffer) => void): void {
     this.micCb = cb;
+    // Flush anything captured during the connect window so no audio is lost.
+    if (this.pending.length > 0) {
+      const queued = this.pending;
+      this.pending = [];
+      for (const frame of queued) cb(frame);
+    }
   }
 
   /** Called by ws-service when a binary mic frame arrives from the browser. */
   pushMicChunk(pcm: Buffer): void {
-    this.micCb?.(pcm);
+    if (this.micCb) {
+      this.micCb(pcm);
+      return;
+    }
+    // Session not connected yet — buffer (bounded) instead of dropping.
+    this.pending.push(pcm);
+    if (this.pending.length > MAX_PENDING_MIC_FRAMES) this.pending.shift();
   }
 
   playback(chunk: Buffer): void {
@@ -91,5 +114,6 @@ export class BrowserAudioTransport implements AudioTransport {
 
   stop(): void {
     this.micCb = null;
+    this.pending = [];
   }
 }

--- a/src/comms/audio-transport.ts
+++ b/src/comms/audio-transport.ts
@@ -1,0 +1,95 @@
+/**
+ * Audio transport abstraction for premium realtime voice (gpt-realtime-2).
+ *
+ * The realtime session must not know *where* mic audio comes from or *where*
+ * output audio goes. This interface has (so far) one implementation —
+ * `BrowserAudioTransport`, which bridges the existing binary-WebSocket voice
+ * path. A `PebbleAudioTransport` (sidecar mic via miniaudio + pebble.play_audio)
+ * lands once `refractor/UI_UX_phase2` merges; it implements the same interface
+ * so `RealtimeSession` needs no changes.
+ *
+ * Audio contract: PCM signed-16 little-endian, mono. Sample rate is declared by
+ * the transport via `inputSampleRate` so the realtime session can announce the
+ * matching `audio.input.format.rate` to OpenAI. The Pebble already produces
+ * s16/16kHz/mono natively; the browser path may need resampling upstream.
+ *
+ * See docs/GPT_REALTIME_2_INTEGRATION.md §3a.
+ */
+
+export interface AudioTransport {
+  /** Sample rate (Hz) of the PCM frames this transport emits/expects. */
+  readonly inputSampleRate: number;
+  readonly outputSampleRate: number;
+
+  /** Register the mic-chunk listener. Frames are raw PCM s16/mono. */
+  onMicChunk(cb: (pcm: Buffer) => void): void;
+
+  /** Play a chunk of realtime output audio (PCM s16/mono). */
+  playback(chunk: Buffer): void;
+
+  /** Barge-in: stop/flush any audio currently playing or queued. */
+  stopPlayback(): void;
+
+  /** Begin capturing/output. Resolves once the transport is ready. */
+  start(): Promise<void>;
+
+  /** Tear down capture + playback and release resources. */
+  stop(): void;
+}
+
+/** Hooks a `BrowserAudioTransport` needs from the ws-service layer. */
+export type BrowserTransportHooks = {
+  /** Send a binary audio frame to the browser client (e.g. ws.sendBinary). */
+  sendAudio: (chunk: Buffer) => void;
+  /** Notify the browser that playback should stop/flush (barge-in). */
+  signalStopPlayback?: () => void;
+  /** Sample rates negotiated with the browser capture/playback pipeline. */
+  inputSampleRate?: number;
+  outputSampleRate?: number;
+};
+
+/**
+ * Browser transport: mic audio arrives as binary WS frames (fed in via
+ * `pushMicChunk` from the ws-service binary handler), output audio is sent back
+ * to the browser through the `sendAudio` hook. Playback timing/queueing lives
+ * in the browser client; this class is a thin relay.
+ */
+export class BrowserAudioTransport implements AudioTransport {
+  readonly inputSampleRate: number;
+  readonly outputSampleRate: number;
+  private micCb: ((pcm: Buffer) => void) | null = null;
+  private hooks: BrowserTransportHooks;
+
+  constructor(hooks: BrowserTransportHooks) {
+    this.hooks = hooks;
+    // OpenAI realtime default is 24kHz; browsers commonly capture at 48kHz and
+    // resample client-side. Default to 24kHz unless the caller overrides.
+    this.inputSampleRate = hooks.inputSampleRate ?? 24000;
+    this.outputSampleRate = hooks.outputSampleRate ?? 24000;
+  }
+
+  onMicChunk(cb: (pcm: Buffer) => void): void {
+    this.micCb = cb;
+  }
+
+  /** Called by ws-service when a binary mic frame arrives from the browser. */
+  pushMicChunk(pcm: Buffer): void {
+    this.micCb?.(pcm);
+  }
+
+  playback(chunk: Buffer): void {
+    this.hooks.sendAudio(chunk);
+  }
+
+  stopPlayback(): void {
+    this.hooks.signalStopPlayback?.();
+  }
+
+  async start(): Promise<void> {
+    // Browser capture is driven by the client; nothing to open server-side.
+  }
+
+  stop(): void {
+    this.micCb = null;
+  }
+}

--- a/src/comms/realtime.test.ts
+++ b/src/comms/realtime.test.ts
@@ -203,6 +203,21 @@ describe('RealtimeSession lifecycle', () => {
     expect(errs).toEqual(['boom']);
   });
 
+  test('swallows benign barge-in cancel race errors (no active response)', async () => {
+    const { socket, session } = makeSession();
+    const errs: string[] = [];
+    session.onError((e) => errs.push(e));
+    await session.connect();
+    socket.onopen!();
+    // Both the message form and the code form must be swallowed.
+    socket.emit({ type: 'error', error: { message: 'Cancellation failed: no active response found' } });
+    socket.emit({ type: 'error', error: { code: 'response_cancel_not_active', message: 'x' } });
+    expect(errs).toEqual([]);
+    // A real error still surfaces.
+    socket.emit({ type: 'error', error: { message: 'boom' } });
+    expect(errs).toEqual(['boom']);
+  });
+
   test('warns when transport input rate is below the realtime 24kHz minimum', async () => {
     const socket = new FakeSocket();
     const transport = new BrowserAudioTransport({ sendAudio: () => {}, inputSampleRate: 16000 });

--- a/src/comms/realtime.test.ts
+++ b/src/comms/realtime.test.ts
@@ -163,6 +163,36 @@ describe('RealtimeSession lifecycle', () => {
     expect(stopped).toBe(1);
   });
 
+  test('barge-in cancels the active response and suppresses its trailing audio', async () => {
+    const { socket, session, sentAudio } = makeSession();
+    await session.connect();
+    socket.onopen!();
+    // A response is in flight and producing audio.
+    socket.emit({ type: 'response.created' });
+    socket.emit({ type: 'response.output_audio.delta', delta: Buffer.from([1, 2]).toString('base64') });
+    expect(sentAudio).toHaveLength(1);
+    socket.sent = [];
+    // User barges in mid-response.
+    socket.emit({ type: 'input_audio_buffer.speech_started' });
+    expect(socket.sentTypes()).toContain('response.cancel');
+    // Late deltas from the cancelled response are dropped (not played).
+    socket.emit({ type: 'response.output_audio.delta', delta: Buffer.from([3, 4]).toString('base64') });
+    expect(sentAudio).toHaveLength(1);
+    // The next response clears suppression and plays again.
+    socket.emit({ type: 'response.created' });
+    socket.emit({ type: 'response.output_audio.delta', delta: Buffer.from([5, 6]).toString('base64') });
+    expect(sentAudio).toHaveLength(2);
+  });
+
+  test('barge-in with no active response does not send response.cancel', async () => {
+    const { socket, session } = makeSession();
+    await session.connect();
+    socket.onopen!();
+    socket.sent = [];
+    socket.emit({ type: 'input_audio_buffer.speech_started' });
+    expect(socket.sentTypes()).not.toContain('response.cancel');
+  });
+
   test('error events surface via onError', async () => {
     const { socket, session } = makeSession();
     const errs: string[] = [];

--- a/src/comms/realtime.test.ts
+++ b/src/comms/realtime.test.ts
@@ -1,0 +1,191 @@
+import { test, expect, describe } from 'bun:test';
+import {
+  RealtimeSession,
+  buildSessionUpdate,
+  convertToolsForRealtime,
+  type RealtimeSocket,
+  type RealtimeSocketFactory,
+} from './realtime.ts';
+import type { ResolvedRealtimeVoice } from '../config/realtime.ts';
+import type { LLMTool } from '../llm/provider.ts';
+import { BrowserAudioTransport } from './audio-transport.ts';
+
+const RESOLVED: ResolvedRealtimeVoice = {
+  apiKey: 'sk-test',
+  model: 'gpt-realtime-2',
+  voice: 'marin',
+  reasoningEffort: 'medium',
+  maxSessionMinutes: 10,
+  blockedCategories: [],
+};
+
+const TOOLS: LLMTool[] = [
+  { name: 'read_file', description: 'Read a file', parameters: { type: 'object', properties: { path: { type: 'string' } }, required: ['path'] } },
+];
+
+describe('convertToolsForRealtime', () => {
+  test('maps LLMTool to GA realtime function entries', () => {
+    const out = convertToolsForRealtime(TOOLS);
+    expect(out).toEqual([
+      { type: 'function', name: 'read_file', description: 'Read a file', parameters: TOOLS[0]!.parameters },
+    ]);
+  });
+});
+
+describe('buildSessionUpdate', () => {
+  test('produces GA session shape with reasoning.effort and audio nesting', () => {
+    const msg = buildSessionUpdate(RESOLVED, TOOLS, 'Be helpful', 24000, 24000) as any;
+    expect(msg.type).toBe('session.update');
+    expect(msg.session.type).toBe('realtime');
+    expect(msg.session.model).toBe('gpt-realtime-2');
+    expect(msg.session.reasoning).toEqual({ effort: 'medium' });
+    expect(msg.session.audio.input.format).toEqual({ type: 'audio/pcm', rate: 24000 });
+    expect(msg.session.audio.output.format).toEqual({ type: 'audio/pcm', rate: 24000 });
+    expect(msg.session.audio.output.voice).toBe('marin');
+    expect(msg.session.tools).toHaveLength(1);
+    expect(msg.session.tool_choice).toBe('auto');
+  });
+
+  test('omits voice and tools when not provided', () => {
+    const noVoice = { ...RESOLVED, voice: undefined };
+    const msg = buildSessionUpdate(noVoice, [], 'hi', 24000, 48000) as any;
+    expect(msg.session.audio.output.format).toEqual({ type: 'audio/pcm', rate: 48000 });
+    expect(msg.session.audio.output.voice).toBeUndefined();
+    expect(msg.session.tools).toBeUndefined();
+    expect(msg.session.tool_choice).toBeUndefined();
+  });
+});
+
+// --- Fake socket for session lifecycle / event dispatch ---
+
+class FakeSocket implements RealtimeSocket {
+  sent: string[] = [];
+  onopen: ((ev?: unknown) => void) | null = null;
+  onmessage: ((ev: { data: unknown }) => void) | null = null;
+  onerror: ((ev?: unknown) => void) | null = null;
+  onclose: ((ev?: unknown) => void) | null = null;
+  send(data: string): void { this.sent.push(data); }
+  close(): void { this.onclose?.(); }
+  emit(evt: object): void { this.onmessage?.({ data: JSON.stringify(evt) }); }
+  sentTypes(): string[] { return this.sent.map((s) => JSON.parse(s).type); }
+}
+
+function makeSession() {
+  const socket = new FakeSocket();
+  const factory: RealtimeSocketFactory = () => socket;
+  const sentAudio: Buffer[] = [];
+  const transport = new BrowserAudioTransport({
+    sendAudio: (c) => sentAudio.push(c),
+    inputSampleRate: 24000,
+  });
+  const session = new RealtimeSession({
+    resolved: RESOLVED,
+    tools: TOOLS,
+    instructions: 'Be helpful',
+    transport,
+    socketFactory: factory,
+  });
+  return { socket, session, transport, sentAudio };
+}
+
+describe('RealtimeSession lifecycle', () => {
+  test('sends session.update on open', async () => {
+    const { socket, session } = makeSession();
+    await session.connect();
+    socket.onopen!();
+    expect(socket.sentTypes()).toContain('session.update');
+  });
+
+  test('mic chunks become input_audio_buffer.append', async () => {
+    const { socket, session, transport } = makeSession();
+    await session.connect();
+    socket.onopen!();
+    (transport as BrowserAudioTransport).pushMicChunk(Buffer.from([1, 2, 3, 4]));
+    const appendMsg = socket.sent.map((s) => JSON.parse(s)).find((m) => m.type === 'input_audio_buffer.append');
+    expect(appendMsg).toBeTruthy();
+    expect(appendMsg.audio).toBe(Buffer.from([1, 2, 3, 4]).toString('base64'));
+  });
+
+  test('output audio delta is decoded and routed to transport playback', async () => {
+    const { socket, session, sentAudio } = makeSession();
+    await session.connect();
+    socket.onopen!();
+    const pcm = Buffer.from([9, 8, 7, 6]);
+    socket.emit({ type: 'response.output_audio.delta', delta: pcm.toString('base64') });
+    expect(sentAudio).toHaveLength(1);
+    expect(sentAudio[0]!.equals(pcm)).toBe(true);
+  });
+
+  test('transcripts (user + assistant) are emitted', async () => {
+    const { socket, session } = makeSession();
+    const got: Array<{ role: string; text: string; final: boolean }> = [];
+    session.onTranscript((t) => got.push(t));
+    await session.connect();
+    socket.onopen!();
+    socket.emit({ type: 'conversation.item.input_audio_transcription.completed', transcript: 'hello' });
+    socket.emit({ type: 'response.output_audio_transcript.done', transcript: 'hi there' });
+    expect(got).toEqual([
+      { role: 'user', text: 'hello', final: true },
+      { role: 'assistant', text: 'hi there', final: true },
+    ]);
+  });
+
+  test('function call (name from output_item.added + args from done) is emitted', async () => {
+    const { socket, session } = makeSession();
+    const calls: any[] = [];
+    session.onFunctionCall((c) => calls.push(c));
+    await session.connect();
+    socket.onopen!();
+    socket.emit({ type: 'response.output_item.added', item: { type: 'function_call', call_id: 'c1', name: 'read_file' } });
+    socket.emit({ type: 'response.function_call_arguments.done', call_id: 'c1', arguments: '{"path":"/etc/hosts"}' });
+    expect(calls).toEqual([{ callId: 'c1', name: 'read_file', args: { path: '/etc/hosts' } }]);
+  });
+
+  test('sendFunctionResult emits function_call_output + response.create', async () => {
+    const { socket, session } = makeSession();
+    await session.connect();
+    socket.onopen!();
+    socket.sent = [];
+    session.sendFunctionResult('c1', { ok: true });
+    expect(socket.sentTypes()).toEqual(['conversation.item.create', 'response.create']);
+    const item = JSON.parse(socket.sent[0]!).item;
+    expect(item).toEqual({ type: 'function_call_output', call_id: 'c1', output: '{"ok":true}' });
+  });
+
+  test('speech_started triggers transport.stopPlayback (barge-in)', async () => {
+    const { socket, session, transport } = makeSession();
+    let stopped = 0;
+    const orig = transport.stopPlayback.bind(transport);
+    transport.stopPlayback = () => { stopped++; orig(); };
+    await session.connect();
+    socket.onopen!();
+    socket.emit({ type: 'input_audio_buffer.speech_started' });
+    expect(stopped).toBe(1);
+  });
+
+  test('error events surface via onError', async () => {
+    const { socket, session } = makeSession();
+    const errs: string[] = [];
+    session.onError((e) => errs.push(e));
+    await session.connect();
+    socket.onopen!();
+    socket.emit({ type: 'error', error: { message: 'boom' } });
+    expect(errs).toEqual(['boom']);
+  });
+
+  test('warns when transport input rate is below the realtime 24kHz minimum', async () => {
+    const socket = new FakeSocket();
+    const transport = new BrowserAudioTransport({ sendAudio: () => {}, inputSampleRate: 16000 });
+    const session = new RealtimeSession({
+      resolved: RESOLVED,
+      tools: [],
+      instructions: 'x',
+      transport,
+      socketFactory: () => socket,
+    });
+    const errs: string[] = [];
+    session.onError((e) => errs.push(e));
+    await session.connect();
+    expect(errs.some((e) => e.includes('24000') && e.includes('upsampled'))).toBe(true);
+  });
+});

--- a/src/comms/realtime.ts
+++ b/src/comms/realtime.ts
@@ -1,0 +1,294 @@
+/**
+ * RealtimeSession — native WebSocket client for OpenAI's GA Realtime API
+ * (`gpt-realtime-2`), driving premium speech-to-speech voice.
+ *
+ * No SDK — raw `fetch`/`WebSocket`, consistent with src/llm/*. JARVIS sits in
+ * the middle as an audio relay (via an `AudioTransport`) AND as the tool
+ * executor: OpenAI requests a function, the caller gates + runs it, then calls
+ * `sendFunctionResult`.
+ *
+ * Protocol notes (GA, post-2026-05): connect to
+ * `wss://api.openai.com/v1/realtime?model=...` with a Bearer key and NO
+ * `OpenAI-Beta` header. Session config is nested under `session.audio.{input,output}`
+ * with `session.type:'realtime'`; reasoning effort is `session.reasoning.effort`;
+ * output events use the `response.output_audio*` names. See
+ * docs/GPT_REALTIME_2_INTEGRATION.md.
+ */
+
+import type { LLMTool } from '../llm/provider.ts';
+import type { ResolvedRealtimeVoice } from '../config/realtime.ts';
+import type { AudioTransport } from './audio-transport.ts';
+
+export const REALTIME_URL = 'wss://api.openai.com/v1/realtime';
+
+/**
+ * OpenAI realtime rejects an input audio rate below 24 kHz
+ * (`integer_below_min_value` on `session.audio.input.format.rate`). Transports
+ * that capture at a lower rate (e.g. the Pebble's 16 kHz mic) MUST upsample to
+ * at least this before streaming. Confirmed via live smoke test 2026-06-01.
+ */
+export const MIN_REALTIME_INPUT_RATE = 24000;
+
+export type RealtimeFunctionCall = {
+  callId: string;
+  name: string;
+  args: Record<string, unknown>;
+};
+
+export type RealtimeTranscript = {
+  role: 'user' | 'assistant';
+  text: string;
+  /** true once the utterance is complete (vs. a streaming delta). */
+  final: boolean;
+};
+
+/** Minimal WebSocket surface we depend on — lets tests inject a fake. */
+export interface RealtimeSocket {
+  send(data: string): void;
+  close(): void;
+  onopen: ((ev?: unknown) => void) | null;
+  onmessage: ((ev: { data: unknown }) => void) | null;
+  onerror: ((ev?: unknown) => void) | null;
+  onclose: ((ev?: unknown) => void) | null;
+}
+
+export type RealtimeSocketFactory = (
+  url: string,
+  opts: { headers: Record<string, string> },
+) => RealtimeSocket;
+
+export type RealtimeSessionOptions = {
+  resolved: ResolvedRealtimeVoice;
+  /** Shared tool schema (same `LLMTool[]` the text providers use). */
+  tools: LLMTool[];
+  /** System prompt / persona for the voice agent. */
+  instructions: string;
+  /** Audio in/out bridge (browser or Pebble). */
+  transport: AudioTransport;
+  /** Hashed user id for OpenAI abuse monitoring (optional). */
+  safetyIdentifier?: string;
+  /** Injectable socket factory (defaults to a Bun WebSocket). */
+  socketFactory?: RealtimeSocketFactory;
+};
+
+/** Convert shared `LLMTool`s into the GA realtime `tools` entry format. */
+export function convertToolsForRealtime(tools: LLMTool[]): Array<Record<string, unknown>> {
+  return tools.map((t) => ({
+    type: 'function',
+    name: t.name,
+    description: t.description,
+    parameters: t.parameters,
+  }));
+}
+
+/** Build the `session.update` payload for a speech-to-speech session. */
+export function buildSessionUpdate(
+  resolved: ResolvedRealtimeVoice,
+  tools: LLMTool[],
+  instructions: string,
+  inputSampleRate: number,
+  outputSampleRate: number,
+): Record<string, unknown> {
+  const session: Record<string, unknown> = {
+    type: 'realtime',
+    model: resolved.model,
+    output_modalities: ['audio'],
+    instructions,
+    audio: {
+      input: {
+        // OpenAI requires rate >= MIN_REALTIME_INPUT_RATE (24kHz).
+        format: { type: 'audio/pcm', rate: inputSampleRate },
+        turn_detection: { type: 'semantic_vad' },
+      },
+      output: {
+        // `rate` is required on output format too (confirmed via live smoke test).
+        format: { type: 'audio/pcm', rate: outputSampleRate },
+        ...(resolved.voice ? { voice: resolved.voice } : {}),
+      },
+    },
+    // GA reasoning control lives under `reasoning.effort` (GPT-5 convention).
+    reasoning: { effort: resolved.reasoningEffort },
+  };
+
+  if (tools.length > 0) {
+    session.tools = convertToolsForRealtime(tools);
+    session.tool_choice = 'auto';
+  }
+
+  return { type: 'session.update', session };
+}
+
+function defaultSocketFactory(url: string, opts: { headers: Record<string, string> }): RealtimeSocket {
+  // Bun's WebSocket accepts a headers option (non-standard but supported).
+  return new WebSocket(url, opts as unknown as string[]) as unknown as RealtimeSocket;
+}
+
+export class RealtimeSession {
+  private opts: RealtimeSessionOptions;
+  private ws: RealtimeSocket | null = null;
+  private closed = false;
+
+  // Pending function calls: call_id -> name (captured from output_item.added,
+  // joined with arguments from function_call_arguments.done).
+  private pendingCalls = new Map<string, string>();
+
+  private audioCb: ((chunk: Buffer) => void) | null = null;
+  private transcriptCb: ((t: RealtimeTranscript) => void) | null = null;
+  private functionCallCb: ((c: RealtimeFunctionCall) => void) | null = null;
+  private errorCb: ((err: string) => void) | null = null;
+  private openCb: (() => void) | null = null;
+  private closeCb: (() => void) | null = null;
+  private speechStartedCb: (() => void) | null = null;
+
+  constructor(opts: RealtimeSessionOptions) {
+    this.opts = opts;
+  }
+
+  onAudio(cb: (chunk: Buffer) => void): void { this.audioCb = cb; }
+  onTranscript(cb: (t: RealtimeTranscript) => void): void { this.transcriptCb = cb; }
+  onFunctionCall(cb: (c: RealtimeFunctionCall) => void): void { this.functionCallCb = cb; }
+  onError(cb: (err: string) => void): void { this.errorCb = cb; }
+  onOpen(cb: () => void): void { this.openCb = cb; }
+  onClose(cb: () => void): void { this.closeCb = cb; }
+  /** Fired when the model detects the user started speaking (barge-in). */
+  onSpeechStarted(cb: () => void): void { this.speechStartedCb = cb; }
+
+  /** Connect, send session.update, and wire the transport's mic + playback. */
+  async connect(): Promise<void> {
+    const { resolved, safetyIdentifier, socketFactory, transport } = this.opts;
+    const url = `${REALTIME_URL}?model=${encodeURIComponent(resolved.model)}`;
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${resolved.apiKey}`,
+    };
+    if (safetyIdentifier) headers['OpenAI-Safety-Identifier'] = safetyIdentifier;
+
+    if (transport.inputSampleRate < MIN_REALTIME_INPUT_RATE) {
+      this.errorCb?.(
+        `Transport input rate ${transport.inputSampleRate}Hz is below the realtime ` +
+        `minimum of ${MIN_REALTIME_INPUT_RATE}Hz — audio must be upsampled or OpenAI ` +
+        `will reject the input buffer.`,
+      );
+    }
+
+    const factory = socketFactory ?? defaultSocketFactory;
+    const ws = factory(url, { headers });
+    this.ws = ws;
+
+    ws.onopen = () => {
+      this.send(buildSessionUpdate(resolved, this.opts.tools, this.opts.instructions, transport.inputSampleRate, transport.outputSampleRate));
+      // Route mic audio straight into the realtime input buffer.
+      transport.onMicChunk((pcm) => this.pushAudio(pcm));
+      // Route realtime output audio to the speaker.
+      this.onAudio((chunk) => transport.playback(chunk));
+      // Barge-in: stop playback the moment the user starts talking.
+      this.onSpeechStarted(() => transport.stopPlayback());
+      this.openCb?.();
+    };
+    ws.onmessage = (ev) => {
+      try {
+        const data = typeof ev.data === 'string' ? ev.data : String(ev.data);
+        this.handleServerEvent(JSON.parse(data));
+      } catch (err) {
+        this.errorCb?.(`Failed to parse realtime event: ${err}`);
+      }
+    };
+    ws.onerror = () => this.errorCb?.('Realtime WebSocket error');
+    ws.onclose = () => { this.closed = true; this.closeCb?.(); };
+  }
+
+  /** Append a PCM s16/mono frame to the realtime input buffer. */
+  pushAudio(pcm: Buffer): void {
+    if (this.closed) return;
+    this.send({ type: 'input_audio_buffer.append', audio: pcm.toString('base64') });
+  }
+
+  /** Return a tool result to the model, then ask it to continue speaking. */
+  sendFunctionResult(callId: string, result: unknown): void {
+    this.send({
+      type: 'conversation.item.create',
+      item: {
+        type: 'function_call_output',
+        call_id: callId,
+        output: typeof result === 'string' ? result : JSON.stringify(result),
+      },
+    });
+    this.send({ type: 'response.create' });
+  }
+
+  /** Cancel the in-flight response (used on barge-in). */
+  interrupt(): void {
+    this.send({ type: 'response.cancel' });
+  }
+
+  close(): void {
+    this.closed = true;
+    try { this.ws?.close(); } catch { /* ignore */ }
+    this.ws = null;
+  }
+
+  private send(payload: Record<string, unknown>): void {
+    if (!this.ws || this.closed) return;
+    this.ws.send(JSON.stringify(payload));
+  }
+
+  /** Dispatch a parsed server event. Exposed for unit testing. */
+  handleServerEvent(evt: Record<string, unknown>): void {
+    const type = evt.type as string;
+    switch (type) {
+      case 'response.output_audio.delta': {
+        const delta = evt.delta as string | undefined;
+        if (delta) this.audioCb?.(Buffer.from(delta, 'base64'));
+        break;
+      }
+      case 'response.output_audio_transcript.delta': {
+        const delta = evt.delta as string | undefined;
+        if (delta) this.transcriptCb?.({ role: 'assistant', text: delta, final: false });
+        break;
+      }
+      case 'response.output_audio_transcript.done': {
+        const text = evt.transcript as string | undefined;
+        if (text) this.transcriptCb?.({ role: 'assistant', text, final: true });
+        break;
+      }
+      case 'conversation.item.input_audio_transcription.completed': {
+        const text = evt.transcript as string | undefined;
+        if (text) this.transcriptCb?.({ role: 'user', text, final: true });
+        break;
+      }
+      case 'input_audio_buffer.speech_started': {
+        this.speechStartedCb?.();
+        break;
+      }
+      case 'response.output_item.added': {
+        const item = evt.item as { type?: string; name?: string; call_id?: string } | undefined;
+        if (item?.type === 'function_call' && item.call_id && item.name) {
+          this.pendingCalls.set(item.call_id, item.name);
+        }
+        break;
+      }
+      case 'response.function_call_arguments.done': {
+        const callId = evt.call_id as string | undefined;
+        if (!callId) break;
+        // `name` may arrive on this event or earlier via output_item.added.
+        const name = (evt.name as string | undefined) ?? this.pendingCalls.get(callId) ?? '';
+        this.pendingCalls.delete(callId);
+        let args: Record<string, unknown> = {};
+        const raw = evt.arguments as string | undefined;
+        if (raw) {
+          try { args = JSON.parse(raw); } catch { args = {}; }
+        }
+        if (name) this.functionCallCb?.({ callId, name, args });
+        break;
+      }
+      case 'error': {
+        const e = evt.error as { message?: string } | undefined;
+        this.errorCb?.(e?.message || 'Unknown realtime error');
+        break;
+      }
+      default:
+        // Unhandled event types (session.created/updated, response.done, etc.)
+        // are intentionally ignored.
+        break;
+    }
+  }
+}

--- a/src/comms/realtime.ts
+++ b/src/comms/realtime.ts
@@ -146,6 +146,13 @@ export class RealtimeSession {
   // Response-latency instrumentation (user-stopped → first audio).
   private turnEndedAt = 0;
   private loggedResponseLatency = false;
+  // True while the model is generating a response (response.created..done).
+  // Gates barge-in cancel so we don't send response.cancel with nothing active
+  // (which OpenAI rejects with an error event).
+  private responseActive = false;
+  // Set on barge-in: suppress any output audio deltas still arriving from the
+  // response we just cancelled, until the next response begins.
+  private suppressOutputAudio = false;
 
   constructor(opts: RealtimeSessionOptions) {
     this.opts = opts;
@@ -248,7 +255,20 @@ export class RealtimeSession {
         this.loggedResponseLatency = false;
         break;
       }
+      case 'response.created': {
+        // A new response is in flight — clear any barge-in suppression so its
+        // audio plays, and arm the cancel gate.
+        this.responseActive = true;
+        this.suppressOutputAudio = false;
+        break;
+      }
+      case 'response.done': {
+        this.responseActive = false;
+        break;
+      }
       case 'response.output_audio.delta': {
+        // Drop deltas from a response we cancelled on barge-in.
+        if (this.suppressOutputAudio) break;
         const delta = evt.delta as string | undefined;
         if (delta) {
           if (!this.loggedResponseLatency && this.turnEndedAt > 0) {
@@ -275,6 +295,15 @@ export class RealtimeSession {
         break;
       }
       case 'input_audio_buffer.speech_started': {
+        // Barge-in: cancel the in-flight response server-side (stops token/audio
+        // billing for speech the user will never hear) and suppress any deltas
+        // still in flight from it. `stopPlayback` (local) is wired via the
+        // callback; without the cancel, OpenAI keeps generating server-side.
+        if (this.responseActive) {
+          this.interrupt();
+          this.responseActive = false;
+          this.suppressOutputAudio = true;
+        }
         this.speechStartedCb?.();
         break;
       }

--- a/src/comms/realtime.ts
+++ b/src/comms/realtime.ts
@@ -143,6 +143,9 @@ export class RealtimeSession {
   private openCb: (() => void) | null = null;
   private closeCb: (() => void) | null = null;
   private speechStartedCb: (() => void) | null = null;
+  // Response-latency instrumentation (user-stopped → first audio).
+  private turnEndedAt = 0;
+  private loggedResponseLatency = false;
 
   constructor(opts: RealtimeSessionOptions) {
     this.opts = opts;
@@ -239,9 +242,21 @@ export class RealtimeSession {
   handleServerEvent(evt: Record<string, unknown>): void {
     const type = evt.type as string;
     switch (type) {
+      case 'input_audio_buffer.speech_stopped': {
+        // User finished talking — start the response-latency clock.
+        this.turnEndedAt = Date.now();
+        this.loggedResponseLatency = false;
+        break;
+      }
       case 'response.output_audio.delta': {
         const delta = evt.delta as string | undefined;
-        if (delta) this.audioCb?.(Buffer.from(delta, 'base64'));
+        if (delta) {
+          if (!this.loggedResponseLatency && this.turnEndedAt > 0) {
+            console.log(`[realtime] response latency: ${Date.now() - this.turnEndedAt}ms (user stopped → first audio)`);
+            this.loggedResponseLatency = true;
+          }
+          this.audioCb?.(Buffer.from(delta, 'base64'));
+        }
         break;
       }
       case 'response.output_audio_transcript.delta': {

--- a/src/comms/realtime.ts
+++ b/src/comms/realtime.ts
@@ -343,8 +343,8 @@ export class RealtimeSession {
         break;
       }
       default:
-        // Unhandled event types (session.created/updated, response.done, etc.)
-        // are intentionally ignored.
+        // Unhandled event types (session.created/updated, etc.) are
+        // intentionally ignored.
         break;
     }
   }

--- a/src/comms/realtime.ts
+++ b/src/comms/realtime.ts
@@ -329,8 +329,17 @@ export class RealtimeSession {
         break;
       }
       case 'error': {
-        const e = evt.error as { message?: string } | undefined;
-        this.errorCb?.(e?.message || 'Unknown realtime error');
+        const e = evt.error as { message?: string; code?: string } | undefined;
+        const msg = e?.message || 'Unknown realtime error';
+        // Benign barge-in race: we sent response.cancel after the model had
+        // just finished server-side (its response.done hadn't reached us yet),
+        // so there was nothing left to cancel. Harmless — the response is over.
+        // Swallow it: surfacing it churned the browser session (it reset the
+        // stream on every interrupt → voice_end/voice_start spam).
+        if (e?.code === 'response_cancel_not_active' || /no active response|cancellation failed/i.test(msg)) {
+          break;
+        }
+        this.errorCb?.(msg);
         break;
       }
       default:

--- a/src/comms/realtime.ts
+++ b/src/comms/realtime.ts
@@ -98,6 +98,10 @@ export function buildSessionUpdate(
       input: {
         // OpenAI requires rate >= MIN_REALTIME_INPUT_RATE (24kHz).
         format: { type: 'audio/pcm', rate: inputSampleRate },
+        // Plain semantic_vad — the low-latency, natural, preamble-friendly
+        // default. (server_vad and eagerness tuning both made it worse.) The
+        // first-turn "doesn't start" was dropped opening audio, fixed by the
+        // transport buffering — not the VAD. Leave this alone.
         turn_detection: { type: 'semantic_vad' },
       },
       output: {

--- a/src/comms/websocket.ts
+++ b/src/comms/websocket.ts
@@ -18,6 +18,10 @@ export type WSMessage = {
       | 'workflow_event'
       | 'goal_event'
       | 'site_event'
+      // Premium realtime voice (gpt-realtime-2). `realtime_status` reports
+      // session live/closed/error for the UI indicator; `realtime_transcript`
+      // streams user/assistant transcript text. See docs/GPT_REALTIME_2_INTEGRATION.md.
+      | 'realtime_status' | 'realtime_transcript'
       // Emitted when a pending voice confirmation (clarifier / repeat-back)
       // expires from the server-side TTL sweep. Payload: { id: string }.
       // Clients should dismiss the corresponding card from their UI.

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -117,6 +117,15 @@ function applyEnvOverrides(config: JarvisConfig): void {
       console.warn(`[Config] Invalid JARVIS_WAKE_ENGINE="${engine}" — must be openwakeword|webspeech|auto; ignoring.`);
     }
   }
+
+  // Premium realtime voice (gpt-realtime-2). Truthy values enable; "0"/"false"
+  // explicitly disable. See docs/GPT_REALTIME_2_INTEGRATION.md.
+  if (env.JARVIS_REALTIME_VOICE !== undefined) {
+    if (!config.voice) config.voice = { wake_engine: 'openwakeword' };
+    if (!config.voice.realtime) config.voice.realtime = { enabled: false };
+    const v = env.JARVIS_REALTIME_VOICE.trim().toLowerCase();
+    config.voice.realtime.enabled = v !== '' && v !== '0' && v !== 'false' && v !== 'no';
+  }
 }
 
 export async function loadConfig(configPath?: string): Promise<JarvisConfig> {

--- a/src/config/realtime.test.ts
+++ b/src/config/realtime.test.ts
@@ -1,0 +1,89 @@
+import { test, expect, describe } from 'bun:test';
+import { resolveRealtimeVoice } from './realtime.ts';
+import { DEFAULT_CONFIG } from './types.ts';
+import type { JarvisConfig } from './types.ts';
+
+function makeConfig(overrides: Partial<JarvisConfig> = {}): JarvisConfig {
+  return { ...structuredClone(DEFAULT_CONFIG), ...overrides };
+}
+
+describe('resolveRealtimeVoice', () => {
+  test('disabled by default', () => {
+    const res = resolveRealtimeVoice(makeConfig(), {});
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toContain('disabled');
+  });
+
+  test('enabled but no key resolves -> not ok, never throws', () => {
+    const config = makeConfig();
+    config.voice!.realtime!.enabled = true;
+    const res = resolveRealtimeVoice(config, {});
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toContain('no OpenAI API key');
+  });
+
+  test('uses explicit realtime api_key first', () => {
+    const config = makeConfig();
+    config.voice!.realtime = { enabled: true, api_key: 'rt-key' };
+    config.llm.openai = { api_key: 'llm-key' };
+    const res = resolveRealtimeVoice(config, { JARVIS_OPENAI_KEY: 'env-key' });
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.resolved.apiKey).toBe('rt-key');
+  });
+
+  test('falls back to llm.openai key then env', () => {
+    const c1 = makeConfig();
+    c1.voice!.realtime = { enabled: true };
+    c1.llm.openai = { api_key: 'llm-key' };
+    const r1 = resolveRealtimeVoice(c1, { JARVIS_OPENAI_KEY: 'env-key' });
+    expect(r1.ok && r1.resolved.apiKey).toBe('llm-key');
+
+    const c2 = makeConfig();
+    c2.voice!.realtime = { enabled: true };
+    c2.llm.openai = undefined;
+    const r2 = resolveRealtimeVoice(c2, { OPENAI_API_KEY: 'env-key' });
+    expect(r2.ok && r2.resolved.apiKey).toBe('env-key');
+  });
+
+  test('applies defaults for model / effort / session cap', () => {
+    const config = makeConfig();
+    config.voice!.realtime = { enabled: true, api_key: 'k' };
+    const res = resolveRealtimeVoice(config, {});
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.resolved.model).toBe('gpt-realtime-2');
+      expect(res.resolved.reasoningEffort).toBe('low');
+      expect(res.resolved.maxSessionMinutes).toBe(10);
+      expect(res.resolved.blockedCategories).toEqual([]);
+    }
+  });
+
+  test('honors user-selected reasoning effort and rejects invalid', () => {
+    const valid = makeConfig();
+    valid.voice!.realtime = { enabled: true, api_key: 'k', reasoning_effort: 'xhigh' };
+    const r1 = resolveRealtimeVoice(valid, {});
+    expect(r1.ok && r1.resolved.reasoningEffort).toBe('xhigh');
+
+    const invalid = makeConfig();
+    // @ts-expect-error testing invalid runtime value
+    invalid.voice!.realtime = { enabled: true, api_key: 'k', reasoning_effort: 'bogus' };
+    const r2 = resolveRealtimeVoice(invalid, {});
+    expect(r2.ok && r2.resolved.reasoningEffort).toBe('low');
+  });
+
+  test('passes through blocked_categories and budget', () => {
+    const config = makeConfig();
+    config.voice!.realtime = {
+      enabled: true,
+      api_key: 'k',
+      blocked_categories: ['file_delete', 'shell'],
+      monthly_budget_usd: 25,
+    };
+    const res = resolveRealtimeVoice(config, {});
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.resolved.blockedCategories).toEqual(['file_delete', 'shell']);
+      expect(res.resolved.monthlyBudgetUsd).toBe(25);
+    }
+  });
+});

--- a/src/config/realtime.test.ts
+++ b/src/config/realtime.test.ts
@@ -1,5 +1,5 @@
 import { test, expect, describe } from 'bun:test';
-import { resolveRealtimeVoice } from './realtime.ts';
+import { resolveRealtimeVoice, DEFAULT_BLOCKED_CATEGORIES } from './realtime.ts';
 import { DEFAULT_CONFIG } from './types.ts';
 import type { JarvisConfig } from './types.ts';
 
@@ -54,8 +54,20 @@ describe('resolveRealtimeVoice', () => {
       expect(res.resolved.model).toBe('gpt-realtime-2');
       expect(res.resolved.reasoningEffort).toBe('low');
       expect(res.resolved.maxSessionMinutes).toBe(10);
-      expect(res.resolved.blockedCategories).toEqual([]);
+      // Safe-by-default: destructive categories blocked when unconfigured.
+      expect(res.resolved.blockedCategories).toEqual(DEFAULT_BLOCKED_CATEGORIES);
+      expect(res.resolved.blockedCategories).toContain('make_payment');
+      expect(res.resolved.blockedCategories).toContain('delete_data');
+      expect(res.resolved.blockedCategories).toContain('execute_command');
     }
+  });
+
+  test('an explicit blocked_categories array (even empty) overrides the default', () => {
+    const config = makeConfig();
+    config.voice!.realtime = { enabled: true, api_key: 'k', blocked_categories: [] };
+    const res = resolveRealtimeVoice(config, {});
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.resolved.blockedCategories).toEqual([]);
   });
 
   test('honors user-selected reasoning effort and rejects invalid', () => {

--- a/src/config/realtime.ts
+++ b/src/config/realtime.ts
@@ -1,0 +1,88 @@
+import type { JarvisConfig, RealtimeReasoningEffort } from './types.ts';
+
+/**
+ * Resolved, ready-to-use realtime voice settings. Produced by
+ * `resolveRealtimeVoice` once gating + key resolution have passed.
+ */
+export type ResolvedRealtimeVoice = {
+  apiKey: string;
+  model: string;
+  voice?: string;
+  reasoningEffort: RealtimeReasoningEffort;
+  maxSessionMinutes: number;
+  monthlyBudgetUsd?: number;
+  blockedCategories: string[];
+};
+
+export type RealtimeVoiceResolution =
+  | { ok: true; resolved: ResolvedRealtimeVoice }
+  | { ok: false; reason: string };
+
+const DEFAULT_MODEL = 'gpt-realtime-2';
+const DEFAULT_EFFORT: RealtimeReasoningEffort = 'low';
+const DEFAULT_MAX_SESSION_MINUTES = 10;
+const VALID_EFFORTS: RealtimeReasoningEffort[] = ['minimal', 'low', 'medium', 'high', 'xhigh'];
+
+/**
+ * Gate + resolve the premium realtime voice mode.
+ *
+ * Decision (see docs/GPT_REALTIME_2_INTEGRATION.md): entitlement is simply
+ * "user supplies a working OpenAI key". This NEVER throws — when realtime is
+ * unavailable it returns `{ ok: false, reason }` so the caller can log a
+ * warning and fall back to the standard STT -> LLM -> TTS pipeline.
+ *
+ * Key resolution order: `voice.realtime.api_key` -> `llm.openai.api_key` -> env
+ * (JARVIS_OPENAI_KEY / OPENAI_API_KEY).
+ */
+export function resolveRealtimeVoice(
+  config: JarvisConfig,
+  env: Record<string, string | undefined> = process.env,
+): RealtimeVoiceResolution {
+  const rt = config.voice?.realtime;
+
+  if (!rt?.enabled) {
+    return { ok: false, reason: 'Realtime voice disabled (voice.realtime.enabled is false)' };
+  }
+
+  const apiKey = (
+    rt.api_key ||
+    config.llm?.openai?.api_key ||
+    env.JARVIS_OPENAI_KEY ||
+    env.OPENAI_API_KEY ||
+    ''
+  ).trim();
+
+  if (!apiKey) {
+    return {
+      ok: false,
+      reason:
+        'Realtime voice enabled but no OpenAI API key resolved ' +
+        '(set voice.realtime.api_key, llm.openai.api_key, or JARVIS_OPENAI_KEY)',
+    };
+  }
+
+  const reasoningEffort = VALID_EFFORTS.includes(rt.reasoning_effort as RealtimeReasoningEffort)
+    ? (rt.reasoning_effort as RealtimeReasoningEffort)
+    : DEFAULT_EFFORT;
+
+  const maxSessionMinutes =
+    typeof rt.max_session_minutes === 'number' && rt.max_session_minutes > 0
+      ? rt.max_session_minutes
+      : DEFAULT_MAX_SESSION_MINUTES;
+
+  return {
+    ok: true,
+    resolved: {
+      apiKey,
+      model: rt.model?.trim() || DEFAULT_MODEL,
+      voice: rt.voice,
+      reasoningEffort,
+      maxSessionMinutes,
+      monthlyBudgetUsd:
+        typeof rt.monthly_budget_usd === 'number' && rt.monthly_budget_usd > 0
+          ? rt.monthly_budget_usd
+          : undefined,
+      blockedCategories: Array.isArray(rt.blocked_categories) ? rt.blocked_categories : [],
+    },
+  };
+}

--- a/src/config/realtime.ts
+++ b/src/config/realtime.ts
@@ -1,4 +1,17 @@
 import type { JarvisConfig, RealtimeReasoningEffort } from './types.ts';
+import { IMPACT_MAP, type ActionCategory } from '../roles/authority.ts';
+
+/**
+ * Safe-by-default backstop for the realtime auto-approve bridge: every action
+ * whose impact is `destructive` (irreversible or costly — payments, deletes,
+ * shell exec, software installs, settings changes, agent termination) stays
+ * BLOCKED unless the user explicitly opts it back in via
+ * `voice.realtime.blocked_categories`. Without this, an open mic + auto-approve
+ * could execute a payment or `rm`-class tool with no human confirmation. See
+ * docs/GPT_REALTIME_2_INTEGRATION.md §4 Phase 3.
+ */
+export const DEFAULT_BLOCKED_CATEGORIES: string[] = (Object.keys(IMPACT_MAP) as ActionCategory[])
+  .filter((cat) => IMPACT_MAP[cat] === 'destructive');
 
 /**
  * Resolved, ready-to-use realtime voice settings. Produced by
@@ -82,7 +95,11 @@ export function resolveRealtimeVoice(
         typeof rt.monthly_budget_usd === 'number' && rt.monthly_budget_usd > 0
           ? rt.monthly_budget_usd
           : undefined,
-      blockedCategories: Array.isArray(rt.blocked_categories) ? rt.blocked_categories : [],
+      // Unconfigured -> safe destructive-category backstop. An explicit array
+      // (even empty) is the user's deliberate choice and is honored as-is.
+      blockedCategories: Array.isArray(rt.blocked_categories)
+        ? rt.blocked_categories
+        : DEFAULT_BLOCKED_CATEGORIES,
     },
   };
 }

--- a/src/config/realtime.ts
+++ b/src/config/realtime.ts
@@ -10,7 +10,7 @@ import { IMPACT_MAP, type ActionCategory } from '../roles/authority.ts';
  * could execute a payment or `rm`-class tool with no human confirmation. See
  * docs/GPT_REALTIME_2_INTEGRATION.md §4 Phase 3.
  */
-export const DEFAULT_BLOCKED_CATEGORIES: string[] = (Object.keys(IMPACT_MAP) as ActionCategory[])
+export const DEFAULT_BLOCKED_CATEGORIES: ActionCategory[] = (Object.keys(IMPACT_MAP) as ActionCategory[])
   .filter((cat) => IMPACT_MAP[cat] === 'destructive');
 
 /**

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -61,7 +61,10 @@ export type RealtimeVoiceConfig = {
   /**
    * Action categories that stay BLOCKED even though realtime auto-approves
    * everything else (safety backstop for destructive/irreversible tools).
-   * Default empty = truly auto-approve all. See docs Phase 3.
+   * When unset, defaults to all `destructive`-impact categories (payments,
+   * deletes, shell exec, installs, settings changes, agent termination) so an
+   * open mic can't trigger them unattended — see DEFAULT_BLOCKED_CATEGORIES.
+   * Set to an explicit array (including `[]`) to override the default. Phase 3.
    */
   blocked_categories?: string[];
 };

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -25,6 +25,47 @@ export type ChannelConfig = {
 
 export type WakeEngine = 'openwakeword' | 'webspeech' | 'auto';
 
+/**
+ * OpenAI realtime reasoning-effort ladder. Higher = more deliberate answers at
+ * the cost of latency and tokens. User-selectable in the Voice settings UI.
+ * Default is "low" (OpenAI's default for gpt-realtime-2).
+ */
+export type RealtimeReasoningEffort = 'minimal' | 'low' | 'medium' | 'high' | 'xhigh';
+
+/**
+ * Premium opt-in speech-to-speech voice via OpenAI's Realtime API
+ * (`gpt-realtime-2`). BYO OpenAI key — the user pays OpenAI directly. When
+ * disabled (default) JARVIS uses the standard STT -> text LLM -> TTS pipeline.
+ *
+ * See docs/GPT_REALTIME_2_INTEGRATION.md.
+ */
+export type RealtimeVoiceConfig = {
+  /** Master opt-in. Default false. Env: JARVIS_REALTIME_VOICE. */
+  enabled: boolean;
+  /**
+   * OpenAI API key for the realtime session. If unset, resolution falls back to
+   * the existing `llm.openai.api_key`, then env. Never hard-fails the daemon —
+   * if no key resolves while enabled, JARVIS warns and uses the standard path.
+   */
+  api_key?: string;
+  /** Realtime model id. Default 'gpt-realtime-2'. */
+  model?: string;
+  /** OpenAI realtime voice id (e.g. 'marin', 'cedar'). */
+  voice?: string;
+  /** User-selectable reasoning effort (settings UI). Default 'low'. */
+  reasoning_effort?: RealtimeReasoningEffort;
+  /** Hard cap on a single realtime session length (cost guard). Default 10. */
+  max_session_minutes?: number;
+  /** Optional monthly USD spend ceiling; block new sessions past it. */
+  monthly_budget_usd?: number;
+  /**
+   * Action categories that stay BLOCKED even though realtime auto-approves
+   * everything else (safety backstop for destructive/irreversible tools).
+   * Default empty = truly auto-approve all. See docs Phase 3.
+   */
+  blocked_categories?: string[];
+};
+
 export type VoiceConfig = {
   /**
    * Wake-word engine used by the browser UI.
@@ -35,6 +76,8 @@ export type VoiceConfig = {
    * Env: JARVIS_WAKE_ENGINE
    */
   wake_engine: WakeEngine;
+  /** Premium opt-in realtime speech-to-speech voice (gpt-realtime-2). */
+  realtime?: RealtimeVoiceConfig;
 };
 
 export type STTConfig = {
@@ -268,6 +311,12 @@ export const DEFAULT_CONFIG: JarvisConfig = {
   },
   voice: {
     wake_engine: 'openwakeword',
+    realtime: {
+      enabled: false,
+      model: 'gpt-realtime-2',
+      reasoning_effort: 'low',
+      max_session_minutes: 10,
+    },
   },
   desktop: {
     enabled: true,

--- a/src/daemon/agent-service.ts
+++ b/src/daemon/agent-service.ts
@@ -514,6 +514,33 @@ export class AgentService implements Service, IAgentService {
    * knowledge / webapp instructions from the vault to inject into the
    * prompt. Pass it for "the user said X" turns; omit for heartbeats.
    */
+  /**
+   * Lean system prompt for premium realtime voice (gpt-realtime-2).
+   *
+   * The full agent prompt is ~5.6k tokens and, with ~32 tool definitions
+   * (~3.4k tokens), made the realtime model digest ~10k tokens of context
+   * before EVERY spoken reply — the dominant per-turn latency (a simple "how
+   * are you" took 1–2s). The realtime model is built for a concise,
+   * conversational prompt, so here we give it just identity + tone + a
+   * live-voice framing (~100 tokens). Tools stay available, so JARVIS can still
+   * act; we only drop the heavyweight role/KPI/commitments/vault context that a
+   * spoken chat doesn't need. This is removal of bloat, NOT a behavioral
+   * directive (no "be brief / don't narrate" — those suppressed preambles and
+   * made it deliberate).
+   */
+  buildRealtimeVoiceInstructions(): string {
+    const name = this.config.personality?.assistant_name?.trim() || this.role?.name || 'JARVIS';
+    const userName = this.config.user?.name?.trim() || getUserProfile()?.answers.preferred_name?.trim();
+    const traits = (this.config.personality?.core_traits ?? []).slice(0, 6).join(', ');
+    return [
+      `You are ${name}${userName ? `, ${userName}'s personal AI assistant` : ', a personal AI assistant'}, in a live, real-time voice conversation.`,
+      'Speak naturally and conversationally, the way a person talks out loud.',
+      traits ? `Your character: ${traits}.` : '',
+      'You can take real actions with your tools whenever the user asks.',
+      `Current time: ${new Date().toISOString()}.`,
+    ].filter(Boolean).join('\n');
+  }
+
   buildFullSystemPrompt(channel: string, userMessage?: string): string {
     if (!this.role) return '';
 

--- a/src/daemon/api-routes.ts
+++ b/src/daemon/api-routes.ts
@@ -1931,10 +1931,13 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
         try {
           const body = await req.json() as Record<string, unknown>;
           const { loadConfig, saveConfig } = await import('../config/loader.ts');
-          const { mergeVoiceConfig } = await import('./config-merge.ts');
-          const freshConfig = await loadConfig();
+          const { mergeVoiceConfig, validateVoicePatch } = await import('./config-merge.ts');
 
-          freshConfig.voice = mergeVoiceConfig(freshConfig.voice, body);
+          const validation = validateVoicePatch(body);
+          if (!validation.ok) return error(validation.error, 400);
+
+          const freshConfig = await loadConfig();
+          freshConfig.voice = mergeVoiceConfig(freshConfig.voice, validation.patch);
           await saveConfig(freshConfig);
           // Update in-memory config so the next voice_start resolves with the
           // new settings — resolveRealtimeVoice reads ctx.config live, so no

--- a/src/daemon/api-routes.ts
+++ b/src/daemon/api-routes.ts
@@ -8,6 +8,7 @@
 import type { HealthMonitor } from './health.ts';
 import type { AgentService } from './agent-service.ts';
 import type { JarvisConfig } from '../config/types.ts';
+import { resolveRealtimeVoice } from '../config/realtime.ts';
 import type { EntityType } from '../vault/entities.ts';
 import type { CommitmentPriority, CommitmentStatus } from '../vault/commitments.ts';
 import type { ObservationType } from '../vault/observations.ts';
@@ -1894,6 +1895,54 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
           return json({ ok: true, message: 'TTS config saved.' });
         } catch (err) {
           console.error('[API] Error saving TTS config:', err);
+          return error('Invalid request body');
+        }
+      },
+    },
+
+    // --- Voice (wake engine + premium realtime gpt-realtime-2) ---
+    '/api/config/voice': {
+      GET: () => {
+        const voice = ctx.config.voice;
+        const rt = voice?.realtime;
+        // Surface whether realtime would actually resolve (BYO key cascade),
+        // so the UI can show "active / no key" without exposing secrets.
+        let available = false;
+        try {
+          available = resolveRealtimeVoice(ctx.config).ok;
+        } catch { available = false; }
+        return json({
+          wake_engine: voice?.wake_engine ?? 'openwakeword',
+          realtime: {
+            enabled: rt?.enabled ?? false,
+            has_api_key: !!rt?.api_key,
+            model: rt?.model ?? 'gpt-realtime-2',
+            voice: rt?.voice ?? null,
+            reasoning_effort: rt?.reasoning_effort ?? 'low',
+            max_session_minutes: rt?.max_session_minutes ?? 10,
+            monthly_budget_usd: rt?.monthly_budget_usd ?? null,
+            blocked_categories: rt?.blocked_categories ?? [],
+            // true when enabled AND a key resolves (own key, llm.openai, or env).
+            available,
+          },
+        });
+      },
+      POST: async (req: Request) => {
+        try {
+          const body = await req.json() as Record<string, unknown>;
+          const { loadConfig, saveConfig } = await import('../config/loader.ts');
+          const { mergeVoiceConfig } = await import('./config-merge.ts');
+          const freshConfig = await loadConfig();
+
+          freshConfig.voice = mergeVoiceConfig(freshConfig.voice, body);
+          await saveConfig(freshConfig);
+          // Update in-memory config so the next voice_start resolves with the
+          // new settings — resolveRealtimeVoice reads ctx.config live, so no
+          // provider hot-reload is needed (unlike TTS/LLM).
+          ctx.config.voice = freshConfig.voice;
+          return json({ ok: true, message: 'Voice config saved.' });
+        } catch (err) {
+          console.error('[API] Error saving voice config:', err);
           return error('Invalid request body');
         }
       },

--- a/src/daemon/api-routes.ts
+++ b/src/daemon/api-routes.ts
@@ -8,7 +8,7 @@
 import type { HealthMonitor } from './health.ts';
 import type { AgentService } from './agent-service.ts';
 import type { JarvisConfig } from '../config/types.ts';
-import { resolveRealtimeVoice } from '../config/realtime.ts';
+import { resolveRealtimeVoice, DEFAULT_BLOCKED_CATEGORIES } from '../config/realtime.ts';
 import type { EntityType } from '../vault/entities.ts';
 import type { CommitmentPriority, CommitmentStatus } from '../vault/commitments.ts';
 import type { ObservationType } from '../vault/observations.ts';
@@ -1921,7 +1921,14 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
             reasoning_effort: rt?.reasoning_effort ?? 'low',
             max_session_minutes: rt?.max_session_minutes ?? 10,
             monthly_budget_usd: rt?.monthly_budget_usd ?? null,
-            blocked_categories: rt?.blocked_categories ?? [],
+            // Report the EFFECTIVE backstop, not the raw field. When unset the
+            // resolver applies DEFAULT_BLOCKED_CATEGORIES, so returning `[]`
+            // here would both misreport ("nothing blocked" while payments/etc.
+            // are blocked) and let a read-modify-write round-trip persist `[]`,
+            // silently disabling the safe default. `default` flags which case
+            // it is so a client can tell "using the default" from an explicit set.
+            blocked_categories: rt?.blocked_categories ?? DEFAULT_BLOCKED_CATEGORIES,
+            blocked_categories_default: rt?.blocked_categories === undefined,
             // true when enabled AND a key resolves (own key, llm.openai, or env).
             available,
           },

--- a/src/daemon/config-merge.test.ts
+++ b/src/daemon/config-merge.test.ts
@@ -1,6 +1,6 @@
 import { test, expect, describe } from 'bun:test';
-import { mergeSTTConfig, mergeTTSConfig } from './config-merge.ts';
-import type { STTConfig, TTSConfig } from '../config/types.ts';
+import { mergeSTTConfig, mergeTTSConfig, mergeVoiceConfig } from './config-merge.ts';
+import type { STTConfig, TTSConfig, VoiceConfig } from '../config/types.ts';
 
 describe('mergeSTTConfig', () => {
   test('preserves a different provider key when patching only one provider', () => {
@@ -134,5 +134,47 @@ describe('mergeTTSConfig', () => {
     expect(merged.enabled).toBe(true);
     expect(merged.provider).toBe('edge');
     expect(merged.voice).toBe('en-US-AriaNeural');
+  });
+});
+
+describe('mergeVoiceConfig', () => {
+  test('preserves realtime api_key when patch omits it', () => {
+    const existing: VoiceConfig = {
+      wake_engine: 'openwakeword',
+      realtime: { enabled: true, api_key: 'sk-secret', model: 'gpt-realtime-2', reasoning_effort: 'low' },
+    };
+    const merged = mergeVoiceConfig(existing, { realtime: { reasoning_effort: 'high' } });
+    expect(merged.realtime?.api_key).toBe('sk-secret');     // preserved
+    expect(merged.realtime?.reasoning_effort).toBe('high');  // updated
+    expect(merged.realtime?.model).toBe('gpt-realtime-2');   // sibling intact
+  });
+
+  test('empty api_key string does not wipe the stored key', () => {
+    const existing: VoiceConfig = {
+      wake_engine: 'openwakeword',
+      realtime: { enabled: true, api_key: 'sk-secret' },
+    };
+    const merged = mergeVoiceConfig(existing, { realtime: { enabled: false, api_key: '' } });
+    expect(merged.realtime?.api_key).toBe('sk-secret');
+    expect(merged.realtime?.enabled).toBe(false);
+  });
+
+  test('accepts a new api_key when provided', () => {
+    const existing: VoiceConfig = { wake_engine: 'openwakeword', realtime: { enabled: false, api_key: 'old' } };
+    const merged = mergeVoiceConfig(existing, { realtime: { enabled: true, api_key: 'new' } });
+    expect(merged.realtime?.api_key).toBe('new');
+  });
+
+  test('shallow-merges wake_engine without touching realtime', () => {
+    const existing: VoiceConfig = { wake_engine: 'openwakeword', realtime: { enabled: true, api_key: 'k' } };
+    const merged = mergeVoiceConfig(existing, { wake_engine: 'webspeech' });
+    expect(merged.wake_engine).toBe('webspeech');
+    expect(merged.realtime?.enabled).toBe(true);
+  });
+
+  test('initializes from undefined', () => {
+    const merged = mergeVoiceConfig(undefined, { realtime: { enabled: true, api_key: 'k', voice: 'marin' } });
+    expect(merged.wake_engine).toBe('openwakeword');
+    expect(merged.realtime?.voice).toBe('marin');
   });
 });

--- a/src/daemon/config-merge.test.ts
+++ b/src/daemon/config-merge.test.ts
@@ -1,5 +1,5 @@
 import { test, expect, describe } from 'bun:test';
-import { mergeSTTConfig, mergeTTSConfig, mergeVoiceConfig } from './config-merge.ts';
+import { mergeSTTConfig, mergeTTSConfig, mergeVoiceConfig, validateVoicePatch } from './config-merge.ts';
 import type { STTConfig, TTSConfig, VoiceConfig } from '../config/types.ts';
 
 describe('mergeSTTConfig', () => {
@@ -176,5 +176,63 @@ describe('mergeVoiceConfig', () => {
     const merged = mergeVoiceConfig(undefined, { realtime: { enabled: true, api_key: 'k', voice: 'marin' } });
     expect(merged.wake_engine).toBe('openwakeword');
     expect(merged.realtime?.voice).toBe('marin');
+  });
+});
+
+describe('validateVoicePatch', () => {
+  test('accepts a well-formed patch', () => {
+    const res = validateVoicePatch({
+      wake_engine: 'webspeech',
+      realtime: {
+        enabled: true,
+        reasoning_effort: 'high',
+        max_session_minutes: 30,
+        monthly_budget_usd: 25,
+        blocked_categories: ['make_payment'],
+      },
+    });
+    expect(res.ok).toBe(true);
+  });
+
+  test('accepts null monthly_budget_usd (UI "no cap")', () => {
+    expect(validateVoicePatch({ realtime: { monthly_budget_usd: null } }).ok).toBe(true);
+  });
+
+  test('rejects non-object bodies', () => {
+    expect(validateVoicePatch(null).ok).toBe(false);
+    expect(validateVoicePatch([]).ok).toBe(false);
+    expect(validateVoicePatch('nope').ok).toBe(false);
+  });
+
+  test('rejects unknown top-level fields', () => {
+    const res = validateVoicePatch({ haxx: 1 });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toContain('Unknown');
+  });
+
+  test('rejects an invalid wake_engine', () => {
+    expect(validateVoicePatch({ wake_engine: 'bogus' }).ok).toBe(false);
+  });
+
+  test('rejects an invalid reasoning_effort', () => {
+    expect(validateVoicePatch({ realtime: { reasoning_effort: 'ludicrous' } }).ok).toBe(false);
+  });
+
+  test('rejects out-of-range or non-numeric max_session_minutes', () => {
+    expect(validateVoicePatch({ realtime: { max_session_minutes: -1 } }).ok).toBe(false);
+    expect(validateVoicePatch({ realtime: { max_session_minutes: 0 } }).ok).toBe(false);
+    expect(validateVoicePatch({ realtime: { max_session_minutes: 99999 } }).ok).toBe(false);
+    expect(validateVoicePatch({ realtime: { max_session_minutes: 'ten' } }).ok).toBe(false);
+  });
+
+  test('rejects a negative budget and non-array blocked_categories', () => {
+    expect(validateVoicePatch({ realtime: { monthly_budget_usd: -5 } }).ok).toBe(false);
+    expect(validateVoicePatch({ realtime: { blocked_categories: 'notanarray' } }).ok).toBe(false);
+    expect(validateVoicePatch({ realtime: { blocked_categories: [1, 2] } }).ok).toBe(false);
+  });
+
+  test('rejects wrong-typed enabled / realtime', () => {
+    expect(validateVoicePatch({ realtime: { enabled: 'yes' } }).ok).toBe(false);
+    expect(validateVoicePatch({ realtime: 'nope' }).ok).toBe(false);
   });
 });

--- a/src/daemon/config-merge.test.ts
+++ b/src/daemon/config-merge.test.ts
@@ -231,6 +231,15 @@ describe('validateVoicePatch', () => {
     expect(validateVoicePatch({ realtime: { blocked_categories: [1, 2] } }).ok).toBe(false);
   });
 
+  test('rejects unknown action categories but accepts known ones', () => {
+    expect(validateVoicePatch({ realtime: { blocked_categories: ['make_payment', 'delete_data'] } }).ok).toBe(true);
+    const res = validateVoicePatch({ realtime: { blocked_categories: ['make_payment', 'file_delete'] } });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toContain('file_delete');
+    // An explicit empty array (disable the backstop) is still allowed.
+    expect(validateVoicePatch({ realtime: { blocked_categories: [] } }).ok).toBe(true);
+  });
+
   test('rejects wrong-typed enabled / realtime', () => {
     expect(validateVoicePatch({ realtime: { enabled: 'yes' } }).ok).toBe(false);
     expect(validateVoicePatch({ realtime: 'nope' }).ok).toBe(false);

--- a/src/daemon/config-merge.ts
+++ b/src/daemon/config-merge.ts
@@ -16,11 +16,14 @@
  *  - Shallow-merge remaining top-level fields (provider, enabled, voice…).
  */
 import type { STTConfig, TTSConfig, VoiceConfig } from '../config/types.ts';
+import { IMPACT_MAP } from '../roles/authority.ts';
 
 type AnyRec = Record<string, unknown>;
 
 const VALID_WAKE_ENGINES = ['openwakeword', 'webspeech', 'auto'];
 const VALID_REASONING_EFFORTS = ['minimal', 'low', 'medium', 'high', 'xhigh'];
+/** Known action categories — a blocked-category typo silently blocks nothing. */
+const VALID_ACTION_CATEGORIES = Object.keys(IMPACT_MAP);
 /** Upper bound on a single realtime session (minutes) accepted from the API. */
 const MAX_SESSION_MINUTES_LIMIT = 1440;
 
@@ -86,6 +89,10 @@ export function validateVoicePatch(body: unknown): VoicePatchValidation {
     if ('blocked_categories' in r) {
       if (!Array.isArray(r.blocked_categories) || r.blocked_categories.some((c) => typeof c !== 'string')) {
         return { ok: false, error: 'realtime.blocked_categories must be an array of strings' };
+      }
+      const unknown = r.blocked_categories.filter((c) => !VALID_ACTION_CATEGORIES.includes(c as string));
+      if (unknown.length > 0) {
+        return { ok: false, error: `realtime.blocked_categories has unknown categories: ${unknown.join(', ')}` };
       }
     }
   }

--- a/src/daemon/config-merge.ts
+++ b/src/daemon/config-merge.ts
@@ -19,6 +19,80 @@ import type { STTConfig, TTSConfig, VoiceConfig } from '../config/types.ts';
 
 type AnyRec = Record<string, unknown>;
 
+const VALID_WAKE_ENGINES = ['openwakeword', 'webspeech', 'auto'];
+const VALID_REASONING_EFFORTS = ['minimal', 'low', 'medium', 'high', 'xhigh'];
+/** Upper bound on a single realtime session (minutes) accepted from the API. */
+const MAX_SESSION_MINUTES_LIMIT = 1440;
+
+export type VoicePatchValidation =
+  | { ok: true; patch: AnyRec }
+  | { ok: false; error: string };
+
+/**
+ * Validate an untrusted `/api/config/voice` POST body before it is merged and
+ * persisted. Only fields that are present are checked; unknown top-level keys
+ * are rejected so garbage can't be written to disk. Mirrors the validation
+ * rigor of the other config POST routes (which the original handler lacked).
+ */
+export function validateVoicePatch(body: unknown): VoicePatchValidation {
+  if (typeof body !== 'object' || body === null || Array.isArray(body)) {
+    return { ok: false, error: 'Body must be a JSON object' };
+  }
+  const patch = body as AnyRec;
+
+  for (const key of Object.keys(patch)) {
+    if (key !== 'wake_engine' && key !== 'realtime') {
+      return { ok: false, error: `Unknown voice config field: ${key}` };
+    }
+  }
+
+  if ('wake_engine' in patch) {
+    if (typeof patch.wake_engine !== 'string' || !VALID_WAKE_ENGINES.includes(patch.wake_engine)) {
+      return { ok: false, error: `wake_engine must be one of: ${VALID_WAKE_ENGINES.join(', ')}` };
+    }
+  }
+
+  if ('realtime' in patch) {
+    const rt = patch.realtime;
+    if (typeof rt !== 'object' || rt === null || Array.isArray(rt)) {
+      return { ok: false, error: 'realtime must be an object' };
+    }
+    const r = rt as AnyRec;
+
+    if ('enabled' in r && typeof r.enabled !== 'boolean') {
+      return { ok: false, error: 'realtime.enabled must be a boolean' };
+    }
+    for (const strField of ['api_key', 'model', 'voice'] as const) {
+      if (strField in r && typeof r[strField] !== 'string') {
+        return { ok: false, error: `realtime.${strField} must be a string` };
+      }
+    }
+    if ('reasoning_effort' in r &&
+        (typeof r.reasoning_effort !== 'string' || !VALID_REASONING_EFFORTS.includes(r.reasoning_effort))) {
+      return { ok: false, error: `realtime.reasoning_effort must be one of: ${VALID_REASONING_EFFORTS.join(', ')}` };
+    }
+    if ('max_session_minutes' in r) {
+      const n = r.max_session_minutes;
+      if (typeof n !== 'number' || !Number.isFinite(n) || n <= 0 || n > MAX_SESSION_MINUTES_LIMIT) {
+        return { ok: false, error: `realtime.max_session_minutes must be a number between 1 and ${MAX_SESSION_MINUTES_LIMIT}` };
+      }
+    }
+    if ('monthly_budget_usd' in r) {
+      const n = r.monthly_budget_usd;
+      if (n !== null && (typeof n !== 'number' || !Number.isFinite(n) || n < 0)) {
+        return { ok: false, error: 'realtime.monthly_budget_usd must be a non-negative number or null' };
+      }
+    }
+    if ('blocked_categories' in r) {
+      if (!Array.isArray(r.blocked_categories) || r.blocked_categories.some((c) => typeof c !== 'string')) {
+        return { ok: false, error: 'realtime.blocked_categories must be an array of strings' };
+      }
+    }
+  }
+
+  return { ok: true, patch };
+}
+
 function mergeCloudSubBlock(
   existing: AnyRec | undefined,
   incoming: AnyRec,

--- a/src/daemon/config-merge.ts
+++ b/src/daemon/config-merge.ts
@@ -15,7 +15,7 @@
  *    keys, so a UI round-trip never sees the real value.
  *  - Shallow-merge remaining top-level fields (provider, enabled, voice…).
  */
-import type { STTConfig, TTSConfig } from '../config/types.ts';
+import type { STTConfig, TTSConfig, VoiceConfig } from '../config/types.ts';
 
 type AnyRec = Record<string, unknown>;
 
@@ -83,4 +83,28 @@ export function mergeTTSConfig(
   }
 
   return { ...merged, ...patch } as TTSConfig;
+}
+
+/**
+ * Merge a partial voice patch into the existing config. The `realtime`
+ * sub-block (premium gpt-realtime-2) is deep-merged so a partial update (e.g.
+ * just `reasoning_effort`) doesn't wipe siblings, and its `api_key` is
+ * preserved when the patch omits it or sends an empty string — the GET
+ * endpoint redacts the key, so a UI round-trip never sees the real value.
+ */
+export function mergeVoiceConfig(
+  existing: VoiceConfig | undefined,
+  incoming: AnyRec,
+): VoiceConfig {
+  const base: VoiceConfig = existing ?? { wake_engine: 'openwakeword' };
+  const patch = { ...incoming };
+  const merged: AnyRec = { ...base };
+
+  const incRealtime = patch.realtime as AnyRec | undefined;
+  if (incRealtime) {
+    merged.realtime = mergeCloudSubBlock((base as AnyRec).realtime as AnyRec | undefined, incRealtime);
+    delete patch.realtime;
+  }
+
+  return { ...merged, ...patch } as VoiceConfig;
 }

--- a/src/daemon/realtime-budget.test.ts
+++ b/src/daemon/realtime-budget.test.ts
@@ -1,4 +1,7 @@
-import { test, expect, describe } from 'bun:test';
+import { test, expect, describe, afterEach } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import {
   RealtimeBudgetTracker,
   estimateSessionCostUsd,
@@ -74,5 +77,44 @@ describe('RealtimeBudgetTracker', () => {
     expect(t.canStart(1, NOW)).toBe(false);
     // No cap -> always allowed.
     expect(t.canStart(undefined, NOW)).toBe(true);
+  });
+});
+
+describe('RealtimeBudgetTracker file persistence', () => {
+  const NOW = new Date('2026-06-04T12:00:00Z');
+  const dirs: string[] = [];
+  function tmpFile(): string {
+    const dir = mkdtempSync(join(tmpdir(), 'jarvis-budget-'));
+    dirs.push(dir);
+    return join(dir, 'nested', 'realtime-budget.json');
+  }
+  afterEach(() => { for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true }); });
+
+  test('persists across tracker instances (survives restart) and creates the dir', () => {
+    const path = tmpFile();
+    RealtimeBudgetTracker.fromFile(path).recordSessionSeconds(120, NOW); // $0.60
+    // A fresh tracker reading the same file sees the prior spend.
+    expect(RealtimeBudgetTracker.fromFile(path).getMonthSpend(NOW)).toBeCloseTo(0.60, 6);
+    // And the persisted shape is what we expect.
+    expect(JSON.parse(readFileSync(path, 'utf8'))).toEqual({ month: '2026-06', spentUsd: 0.60 });
+  });
+
+  test('missing file reads as zero spend', () => {
+    expect(RealtimeBudgetTracker.fromFile(tmpFile()).getMonthSpend(NOW)).toBe(0);
+  });
+
+  test('corrupt or malformed JSON is treated as empty, not a crash', () => {
+    const path = tmpFile();
+    mkdirSync(join(path, '..'), { recursive: true });
+    writeFileSync(path, '{ not valid json', 'utf8');
+    const t = RealtimeBudgetTracker.fromFile(path);
+    expect(t.getMonthSpend(NOW)).toBe(0);
+    // Recovers by overwriting with a valid state on the next record.
+    t.recordSessionSeconds(60, NOW);
+    expect(t.getMonthSpend(NOW)).toBeCloseTo(0.30, 6);
+
+    // Wrong-typed fields are also rejected.
+    writeFileSync(path, JSON.stringify({ month: 5, spentUsd: 'lots' }), 'utf8');
+    expect(RealtimeBudgetTracker.fromFile(path).getMonthSpend(NOW)).toBe(0);
   });
 });

--- a/src/daemon/realtime-budget.test.ts
+++ b/src/daemon/realtime-budget.test.ts
@@ -1,0 +1,78 @@
+import { test, expect, describe } from 'bun:test';
+import {
+  RealtimeBudgetTracker,
+  estimateSessionCostUsd,
+  isOverBudget,
+  monthKey,
+  ESTIMATED_USD_PER_MINUTE,
+  type BudgetState,
+  type BudgetStore,
+} from './realtime-budget.ts';
+
+/** In-memory store so tracker logic is tested without touching disk. */
+function memStore(initial: BudgetState | null = null): BudgetStore & { state: BudgetState | null } {
+  return {
+    state: initial,
+    load() { return this.state; },
+    save(s) { this.state = s; },
+  };
+}
+
+describe('pure helpers', () => {
+  test('monthKey is UTC YYYY-MM', () => {
+    expect(monthKey(new Date('2026-06-04T12:00:00Z'))).toBe('2026-06');
+    expect(monthKey(new Date('2026-01-01T00:00:00Z'))).toBe('2026-01');
+    expect(monthKey(new Date('2026-12-31T23:59:59Z'))).toBe('2026-12');
+  });
+
+  test('estimateSessionCostUsd scales with minutes', () => {
+    expect(estimateSessionCostUsd(60)).toBeCloseTo(ESTIMATED_USD_PER_MINUTE, 6);
+    expect(estimateSessionCostUsd(120)).toBeCloseTo(ESTIMATED_USD_PER_MINUTE * 2, 6);
+    expect(estimateSessionCostUsd(0)).toBe(0);
+    expect(estimateSessionCostUsd(-5)).toBe(0);
+    expect(estimateSessionCostUsd(NaN)).toBe(0);
+  });
+
+  test('isOverBudget treats unset/non-positive budget as no cap', () => {
+    expect(isOverBudget(1000, undefined)).toBe(false);
+    expect(isOverBudget(1000, 0)).toBe(false);
+    expect(isOverBudget(1000, -5)).toBe(false);
+    expect(isOverBudget(4.99, 5)).toBe(false);
+    expect(isOverBudget(5, 5)).toBe(true);
+    expect(isOverBudget(5.01, 5)).toBe(true);
+  });
+});
+
+describe('RealtimeBudgetTracker', () => {
+  const NOW = new Date('2026-06-04T12:00:00Z');
+
+  test('records and accumulates spend within a month', () => {
+    const store = memStore();
+    const t = new RealtimeBudgetTracker(store);
+    t.recordSessionSeconds(60, NOW);   // +$0.30
+    t.recordSessionSeconds(120, NOW);  // +$0.60
+    expect(t.getMonthSpend(NOW)).toBeCloseTo(0.90, 6);
+    expect(store.state?.month).toBe('2026-06');
+  });
+
+  test('spend resets when the month rolls over', () => {
+    const store = memStore({ month: '2026-05', spentUsd: 99 });
+    const t = new RealtimeBudgetTracker(store);
+    // Reading in June ignores May's total.
+    expect(t.getMonthSpend(NOW)).toBe(0);
+    // Recording in June starts fresh, not 99 + cost.
+    t.recordSessionSeconds(60, NOW);
+    expect(t.getMonthSpend(NOW)).toBeCloseTo(0.30, 6);
+  });
+
+  test('canStart blocks once spend reaches the budget', () => {
+    const store = memStore();
+    const t = new RealtimeBudgetTracker(store);
+    expect(t.canStart(1, NOW)).toBe(true);
+    // ~3.4 min of session puts us over a $1 cap.
+    t.recordSessionSeconds(60 * 4, NOW);
+    expect(t.canStart(1, NOW)).toBe(false);
+    // No cap -> always allowed.
+    expect(t.canStart(undefined, NOW)).toBe(true);
+  });
+});

--- a/src/daemon/realtime-budget.ts
+++ b/src/daemon/realtime-budget.ts
@@ -1,0 +1,102 @@
+/**
+ * Monthly spend guard for premium realtime voice (gpt-realtime-2).
+ *
+ * `voice.realtime.monthly_budget_usd` is a soft cost ceiling: once the running
+ * monthly estimate reaches it, new realtime sessions are refused (the user is
+ * told, and the standard pipeline is unaffected). OpenAI bills per token, but
+ * we don't see a live invoice mid-session, so spend is ESTIMATED from session
+ * wall-clock at the same ~$/min figure shown in Settings > Voice. This is an
+ * approximate guard, not an accounting system — it errs toward stopping a
+ * runaway session rather than billing precision. State persists to a small JSON
+ * file so the cap survives daemon restarts and resets at each month boundary.
+ *
+ * See docs/GPT_REALTIME_2_INTEGRATION.md §4 Phase 3.
+ */
+
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { dirname } from 'node:path';
+
+/** Approximate blended $/min for gpt-realtime-2 (matches the Voice settings hint). */
+export const ESTIMATED_USD_PER_MINUTE = 0.30;
+
+export type BudgetState = { month: string; spentUsd: number };
+
+/** UTC `YYYY-MM` bucket key for a given instant. */
+export function monthKey(now: Date): string {
+  const y = now.getUTCFullYear();
+  const m = String(now.getUTCMonth() + 1).padStart(2, '0');
+  return `${y}-${m}`;
+}
+
+/** Estimate the USD cost of a session given its duration in seconds. */
+export function estimateSessionCostUsd(seconds: number): number {
+  if (!Number.isFinite(seconds) || seconds <= 0) return 0;
+  return (seconds / 60) * ESTIMATED_USD_PER_MINUTE;
+}
+
+/**
+ * Pure: would this much spend be at/over the budget? A non-positive or
+ * undefined budget means "no cap" and never blocks.
+ */
+export function isOverBudget(spentUsd: number, budgetUsd: number | undefined): boolean {
+  if (budgetUsd === undefined || budgetUsd <= 0) return false;
+  return spentUsd >= budgetUsd;
+}
+
+/** Pluggable persistence so the tracker is unit-testable without disk. */
+export interface BudgetStore {
+  load(): BudgetState | null;
+  save(state: BudgetState): void;
+}
+
+class FileBudgetStore implements BudgetStore {
+  constructor(private filePath: string) {}
+  load(): BudgetState | null {
+    try {
+      if (!existsSync(this.filePath)) return null;
+      const parsed = JSON.parse(readFileSync(this.filePath, 'utf8'));
+      if (parsed && typeof parsed.month === 'string' && typeof parsed.spentUsd === 'number') {
+        return parsed as BudgetState;
+      }
+    } catch { /* corrupt/unreadable -> treat as empty */ }
+    return null;
+  }
+  save(state: BudgetState): void {
+    try {
+      mkdirSync(dirname(this.filePath), { recursive: true });
+      writeFileSync(this.filePath, JSON.stringify(state), 'utf8');
+    } catch (err) {
+      console.warn('[RealtimeBudget] failed to persist spend:', err);
+    }
+  }
+}
+
+export class RealtimeBudgetTracker {
+  constructor(private store: BudgetStore) {}
+
+  static fromFile(filePath: string): RealtimeBudgetTracker {
+    return new RealtimeBudgetTracker(new FileBudgetStore(filePath));
+  }
+
+  /** Spend recorded for the current month (0 once the month rolls over). */
+  getMonthSpend(now: Date = new Date()): number {
+    const state = this.store.load();
+    if (!state || state.month !== monthKey(now)) return 0;
+    return state.spentUsd;
+  }
+
+  /** True if a new session may start under the given budget. */
+  canStart(budgetUsd: number | undefined, now: Date = new Date()): boolean {
+    return !isOverBudget(this.getMonthSpend(now), budgetUsd);
+  }
+
+  /** Add an estimated session cost (from its duration) to the monthly total. */
+  recordSessionSeconds(seconds: number, now: Date = new Date()): void {
+    const cost = estimateSessionCostUsd(seconds);
+    if (cost <= 0) return;
+    const key = monthKey(now);
+    const prev = this.store.load();
+    const base = prev && prev.month === key ? prev.spentUsd : 0;
+    this.store.save({ month: key, spentUsd: base + cost });
+  }
+}

--- a/src/daemon/realtime-nav-tools.ts
+++ b/src/daemon/realtime-nav-tools.ts
@@ -1,0 +1,99 @@
+/**
+ * Dashboard navigation + in-room actions exposed as TOOLS the realtime voice
+ * model (gpt-realtime-2) can call. This is the "as intended" way to do voice
+ * navigation: the LLM decides to act and calls a function, rather than a
+ * parallel transcript classifier guessing (which fought the session and added
+ * latency). Executed in ws-service against the existing broadcast* methods, so
+ * the dashboard reacts exactly as it did for the old voice path.
+ *
+ * Keep the in-room action vocabulary here in sync with the classifier prompt in
+ * src/agents/voice-intent-classifier.ts (the standard voice path's source).
+ */
+
+import type { LLMTool } from '../llm/provider.ts';
+
+/** Room keys that map 1:1 to RoomKey in src/voice/intent.ts. */
+export const REALTIME_ROOM_KEYS = [
+  'workflows', 'memory', 'tools', 'agents', 'authority', 'logs',
+  'calendar', 'goals', 'tasks', 'content', 'workspaces', 'settings',
+] as const;
+
+export const REALTIME_NAV_TOOL_NAMES = new Set([
+  'open_dashboard_room',
+  'go_back_to_thread',
+  'control_dashboard_window',
+  'dashboard_room_action',
+]);
+
+// Compact action reference — action names + arg keys per room (the verbose
+// "matches ..." examples from the classifier are omitted to keep token cost
+// low; the GPT-5-class model infers usage from names + args).
+const ROOM_ACTION_REFERENCE = `Available actions by room (pass via dashboard_room_action):
+- settings: switch_tab{tab: general|profile|llm|channels|integrations|sidecar}, set_primary_llm{provider}, set_fallback_llm{fallback}, set_model{provider,model}, test_provider{provider}, enable_telegram, disable_telegram, enable_discord, disable_discord, set_stt_provider{provider}, enable_tts, disable_tts, set_tts_provider{provider}, set_tts_voice{voice}, set_heartbeat_interval{minutes}, set_heartbeat_aggressiveness{level: passive|moderate|aggressive}, restart_daemon, replay_onboarding{scope?: all|setup|profile|tutorial}. (Do NOT set API keys by voice.)
+- tools: set_filter{filter: all|read|write|external|destructive}, search{query}, select{name}
+- workflows: switch_tab{tab: list|editor|builder}, search{query}, set_filter{filter: all|active|paused}, select{name}, run{name?}, pause{name?}, enable{name?}, create_from_nl{prompt}
+- agents: switch_tab{tab: command|orbital}, open_spawn_dialog, close_dialog, set_search{query}, spawn_agent{specialist,task?,context?}
+- content: switch_view{view: kanban|list}, search{query}, set_filter{field: stage|type, value}, select{name}, create_content{title,type?}, advance{name?}, regress{name?}, schedule{name?,when}
+- tasks: set_filter{status}, search{query}
+- goals: set_filter{health}`;
+
+/**
+ * Navigation + in-room-action tools. Appended to the realtime toolset so the
+ * model can drive the dashboard by voice ("open settings", "turn off TTS",
+ * "go back to the thread", "close this window").
+ */
+export const REALTIME_NAV_TOOLS: LLMTool[] = [
+  {
+    name: 'open_dashboard_room',
+    description:
+      'Open a room/page in the JARVIS dashboard (navigate the UI). Use when the user asks to open, show, or go to a section.',
+    parameters: {
+      type: 'object',
+      properties: {
+        room: {
+          type: 'string',
+          enum: [...REALTIME_ROOM_KEYS],
+          description: 'Which dashboard room to open.',
+        },
+      },
+      required: ['room'],
+    },
+  },
+  {
+    name: 'go_back_to_thread',
+    description:
+      'Close any open room and return to the main conversation thread (home). Use for "back to the thread", "close the room", "go home".',
+    parameters: { type: 'object', properties: {}, required: [] },
+  },
+  {
+    name: 'control_dashboard_window',
+    description:
+      'Control an open room window: close, minimize, expand (fullscreen), or restore it.',
+    parameters: {
+      type: 'object',
+      properties: {
+        action: { type: 'string', enum: ['close', 'minimize', 'expand', 'restore'] },
+        target: {
+          type: 'string',
+          description: 'Room key to target, or "most_recent" for the most recently opened window (default).',
+        },
+      },
+      required: ['action'],
+    },
+  },
+  {
+    name: 'dashboard_room_action',
+    description:
+      'Perform an action INSIDE a dashboard room — filtering, switching tabs, toggling a setting, running a workflow, etc. The room is auto-opened first, so use this (not open_dashboard_room) when the user asks to DO something in a room (e.g. "turn off TTS in settings", "show paused workflows").\n\n' +
+      ROOM_ACTION_REFERENCE,
+    parameters: {
+      type: 'object',
+      properties: {
+        room: { type: 'string', enum: [...REALTIME_ROOM_KEYS], description: 'Room the action belongs to.' },
+        action: { type: 'string', description: 'Action name from the reference for that room.' },
+        args: { type: 'object', description: 'Action arguments object (may be empty).' },
+      },
+      required: ['room', 'action'],
+    },
+  },
+];

--- a/src/daemon/realtime-voice.test.ts
+++ b/src/daemon/realtime-voice.test.ts
@@ -1,0 +1,99 @@
+import { test, expect, describe } from 'bun:test';
+import { RealtimeVoiceSession } from './realtime-voice.ts';
+import type { RealtimeSession, RealtimeFunctionCall, RealtimeTranscript } from '../comms/realtime.ts';
+import { BrowserAudioTransport } from '../comms/audio-transport.ts';
+import type { ResolvedRealtimeVoice } from '../config/realtime.ts';
+
+const RESOLVED: ResolvedRealtimeVoice = {
+  apiKey: 'k', model: 'gpt-realtime-2', reasoningEffort: 'low', maxSessionMinutes: 10, blockedCategories: [],
+};
+
+/** Fake RealtimeSession capturing wired callbacks + outgoing results. */
+class FakeRealtimeSession {
+  fnCb: ((c: RealtimeFunctionCall) => void) | null = null;
+  transcriptCb: ((t: RealtimeTranscript) => void) | null = null;
+  errorCb: ((e: string) => void) | null = null;
+  closeCb: (() => void) | null = null;
+  results: Array<{ callId: string; result: unknown }> = [];
+  connected = false;
+  closed = false;
+  onAudio() {}
+  onTranscript(cb: (t: RealtimeTranscript) => void) { this.transcriptCb = cb; }
+  onFunctionCall(cb: (c: RealtimeFunctionCall) => void) { this.fnCb = cb; }
+  onError(cb: (e: string) => void) { this.errorCb = cb; }
+  onOpen() {}
+  onClose(cb: () => void) { this.closeCb = cb; }
+  onSpeechStarted() {}
+  async connect() { this.connected = true; }
+  sendFunctionResult(callId: string, result: unknown) { this.results.push({ callId, result }); }
+  interrupt() {}
+  close() { this.closed = true; }
+}
+
+function setup(executeToolCall: (n: string, a: Record<string, unknown>) => Promise<string>) {
+  const fake = new FakeRealtimeSession();
+  const transport = new BrowserAudioTransport({ sendAudio: () => {}, inputSampleRate: 24000 });
+  const transcripts: RealtimeTranscript[] = [];
+  let closeCalls = 0;
+  const rv = new RealtimeVoiceSession(RESOLVED, transport, {
+    tools: [],
+    instructions: 'persona',
+    executeToolCall,
+    onTranscript: (t) => transcripts.push(t),
+    onClose: () => { closeCalls++; },
+    sessionFactory: () => fake as unknown as RealtimeSession,
+  });
+  return { fake, rv, transcripts, getCloseCalls: () => closeCalls };
+}
+
+describe('RealtimeVoiceSession', () => {
+  test('connect() delegates to the underlying session', async () => {
+    const { fake, rv } = setup(async () => 'ok');
+    await rv.connect();
+    expect(fake.connected).toBe(true);
+  });
+
+  test('function call runs executeToolCall and returns the result to the model', async () => {
+    const calls: Array<{ name: string; args: unknown }> = [];
+    const { fake, rv } = setup(async (name, args) => { calls.push({ name, args }); return 'FILE CONTENTS'; });
+    await rv.connect();
+    await fake.fnCb!({ callId: 'c1', name: 'read_file', args: { path: '/x' } });
+    // allow the async handler microtask to settle
+    await Promise.resolve();
+    expect(calls).toEqual([{ name: 'read_file', args: { path: '/x' } }]);
+    expect(fake.results).toEqual([{ callId: 'c1', result: 'FILE CONTENTS' }]);
+  });
+
+  test('executor errors are returned as a result string, never thrown', async () => {
+    const { fake, rv } = setup(async () => { throw new Error('boom'); });
+    await rv.connect();
+    await fake.fnCb!({ callId: 'c2', name: 'bad', args: {} });
+    await Promise.resolve();
+    expect(fake.results).toHaveLength(1);
+    expect(String(fake.results[0]!.result)).toContain('boom');
+  });
+
+  test('transcripts are forwarded', async () => {
+    const { fake, rv, transcripts } = setup(async () => 'ok');
+    await rv.connect();
+    fake.transcriptCb!({ role: 'assistant', text: 'hi', final: true });
+    expect(transcripts).toEqual([{ role: 'assistant', text: 'hi', final: true }]);
+  });
+
+  test('underlying close propagates to onClose', async () => {
+    const { fake, rv, getCloseCalls } = setup(async () => 'ok');
+    await rv.connect();
+    fake.closeCb!();
+    expect(getCloseCalls()).toBe(1);
+  });
+
+  test('close() tears down the session and suppresses late results', async () => {
+    const { fake, rv } = setup(async () => 'late');
+    await rv.connect();
+    rv.close();
+    expect(fake.closed).toBe(true);
+    await fake.fnCb!({ callId: 'c3', name: 'read_file', args: {} });
+    await Promise.resolve();
+    expect(fake.results).toHaveLength(0); // not sent after close
+  });
+});

--- a/src/daemon/realtime-voice.ts
+++ b/src/daemon/realtime-voice.ts
@@ -1,0 +1,91 @@
+/**
+ * Realtime voice session wiring (Phase 2).
+ *
+ * Glues a `RealtimeSession` (the OpenAI WS client) to an `AudioTransport`
+ * (browser today; Pebble once phase2 lands) and to JARVIS's tool executor.
+ * Kept separate from ws-service so the wiring is unit-testable with an injected
+ * session factory. See docs/GPT_REALTIME_2_INTEGRATION.md §4 Phase 2.
+ */
+
+import {
+  RealtimeSession,
+  type RealtimeSessionOptions,
+  type RealtimeTranscript,
+} from '../comms/realtime.ts';
+import type { AudioTransport } from '../comms/audio-transport.ts';
+import type { ResolvedRealtimeVoice } from '../config/realtime.ts';
+import type { LLMTool } from '../llm/provider.ts';
+
+export type RealtimeVoiceDeps = {
+  /** Shared tool schema (same `LLMTool[]` the text providers use). */
+  tools: LLMTool[];
+  /** System prompt / persona for the voice agent. */
+  instructions: string;
+  /**
+   * Auto-approve tool executor — bind to
+   * `orchestrator.executeRealtimeToolCall(name, args, { blockedCategories })`.
+   * Always resolves to a string (result or denial marker).
+   */
+  executeToolCall: (name: string, args: Record<string, unknown>) => Promise<string>;
+  /** Transcript sink (UI captions + vault writes). */
+  onTranscript?: (t: RealtimeTranscript) => void;
+  /** Error sink. */
+  onError?: (err: string) => void;
+  /** Fired when the underlying session closes (for ws-service cleanup). */
+  onClose?: () => void;
+  /** Hashed user id for OpenAI abuse monitoring. */
+  safetyIdentifier?: string;
+  /** Injectable session factory (tests). Defaults to a real `RealtimeSession`. */
+  sessionFactory?: (opts: RealtimeSessionOptions) => RealtimeSession;
+};
+
+/**
+ * Create + wire a realtime voice session. The returned object owns the session
+ * lifecycle; the caller pushes mic audio via the transport and calls `close()`
+ * on disconnect / session timeout.
+ */
+export class RealtimeVoiceSession {
+  private session: RealtimeSession;
+  private deps: RealtimeVoiceDeps;
+  private closed = false;
+
+  constructor(resolved: ResolvedRealtimeVoice, transport: AudioTransport, deps: RealtimeVoiceDeps) {
+    this.deps = deps;
+    const opts: RealtimeSessionOptions = {
+      resolved,
+      tools: deps.tools,
+      instructions: deps.instructions,
+      transport,
+      safetyIdentifier: deps.safetyIdentifier,
+    };
+    this.session = deps.sessionFactory ? deps.sessionFactory(opts) : new RealtimeSession(opts);
+
+    this.session.onTranscript((t) => this.deps.onTranscript?.(t));
+    this.session.onError((e) => this.deps.onError?.(e));
+    this.session.onClose(() => {
+      this.closed = true;
+      this.deps.onClose?.();
+    });
+
+    // The critical path: model requests a tool -> run it through the
+    // auto-approve executor -> return the result so the model keeps talking.
+    this.session.onFunctionCall(async (call) => {
+      let result: string;
+      try {
+        result = await this.deps.executeToolCall(call.name, call.args);
+      } catch (err) {
+        result = `Error executing ${call.name}: ${err instanceof Error ? err.message : String(err)}`;
+      }
+      if (!this.closed) this.session.sendFunctionResult(call.callId, result);
+    });
+  }
+
+  connect(): Promise<void> {
+    return this.session.connect();
+  }
+
+  close(): void {
+    this.closed = true;
+    this.session.close();
+  }
+}

--- a/src/daemon/ws-service.ts
+++ b/src/daemon/ws-service.ts
@@ -39,6 +39,7 @@ import { StreamRelay } from '../comms/streaming.ts';
 import { resolveRealtimeVoice, type ResolvedRealtimeVoice } from '../config/realtime.ts';
 import { BrowserAudioTransport } from '../comms/audio-transport.ts';
 import { RealtimeVoiceSession } from './realtime-voice.ts';
+import { REALTIME_NAV_TOOLS, REALTIME_NAV_TOOL_NAMES } from './realtime-nav-tools.ts';
 import { classifyErrorString } from '../llm/provider.ts';
 import { getOrCreateConversation, addMessage } from '../vault/conversations.ts';
 import { maybeCreateUserProfileFollowupPrompt, recordUserProfileTurn } from '../user/profile-followup.ts';
@@ -1214,13 +1215,20 @@ CRITICAL — when in genuine doubt between "make in a new project" vs "add to th
     });
 
     const session = new RealtimeVoiceSession(resolved, transport, {
-      tools: orchestrator.getRealtimeTools(),
+      // Agent tools + dashboard navigation/in-room-action tools so the model
+      // can drive the UI by voice (open settings, turn off TTS, go back…).
+      tools: [...orchestrator.getRealtimeTools(), ...REALTIME_NAV_TOOLS],
       // Lean voice prompt (~100 tokens) instead of the full ~5.6k-token agent
       // prompt — the big context was the dominant per-turn latency for simple
       // questions. Tools stay, so capability is unchanged. See agent-service.
       instructions: this.agentService.buildRealtimeVoiceInstructions(),
-      executeToolCall: (name, args) =>
-        orchestrator.executeRealtimeToolCall(name, args, { blockedCategories: resolved.blockedCategories }),
+      executeToolCall: (name, args) => {
+        // Dashboard nav/in-room actions are handled here (they broadcast to the
+        // dashboard); everything else goes through the auto-approve tool bridge.
+        const nav = this.executeRealtimeNavTool(name, args);
+        if (nav !== null) return Promise.resolve(nav);
+        return orchestrator.executeRealtimeToolCall(name, args, { blockedCategories: resolved.blockedCategories });
+      },
       onTranscript: (t) =>
         this.wsServer.sendToClient(ws, {
           type: 'realtime_transcript',
@@ -1248,6 +1256,50 @@ CRITICAL — when in genuine doubt between "make in a new project" vs "add to th
       },
     );
     return true;
+  }
+
+  /**
+   * Execute a dashboard navigation / in-room-action tool called by the realtime
+   * voice model. Returns a short result string for the model to acknowledge, or
+   * null if `name` isn't a navigation tool (so the caller falls through to the
+   * normal tool bridge). Reuses the same broadcast* methods the standard voice
+   * path uses, so the dashboard reacts identically.
+   */
+  private executeRealtimeNavTool(name: string, args: Record<string, unknown>): string | null {
+    if (!REALTIME_NAV_TOOL_NAMES.has(name)) return null;
+    const reqId = crypto.randomUUID();
+    switch (name) {
+      case 'open_dashboard_room': {
+        const room = String(args.room ?? '');
+        if (!room) return 'No room specified.';
+        this.broadcastRoomNavigation(room as RoomKey, reqId);
+        return `Opened the ${room} room.`;
+      }
+      case 'go_back_to_thread': {
+        this.broadcastNavigateHome(reqId);
+        return 'Back to the thread.';
+      }
+      case 'control_dashboard_window': {
+        const action = String(args.action ?? '');
+        const target = (args.target ? String(args.target) : 'most_recent') as RoomKey | 'most_recent';
+        if (!action) return 'No window action specified.';
+        this.broadcastWindowControl({ action: action as WindowControl['action'], target }, reqId);
+        return `${action} done.`;
+      }
+      case 'dashboard_room_action': {
+        const room = String(args.room ?? '');
+        const action = String(args.action ?? '');
+        if (!room || !action) return 'Room and action are required.';
+        const innerArgs = (args.args && typeof args.args === 'object') ? args.args as Record<string, unknown> : {};
+        // Auto-open the room first (no-op if already open), then dispatch —
+        // mirrors the classifier path so the qualifier isn't dropped.
+        this.broadcastRoomNavigation(room as RoomKey, reqId);
+        this.broadcastRoomAction({ room, action, args: innerArgs }, reqId);
+        return `Done: ${action} in ${room}.`;
+      }
+      default:
+        return null;
+    }
   }
 
   /** Tear down a realtime voice session and notify the client. */

--- a/src/daemon/ws-service.ts
+++ b/src/daemon/ws-service.ts
@@ -1214,15 +1214,18 @@ CRITICAL — when in genuine doubt between "make in a new project" vs "add to th
 
     // Monthly spend guard: refuse new sessions once the estimated budget is
     // hit. Returns true (caller skips the standard accumulator) but opens no
-    // session — the client's onError handler stops streaming. Falling through
-    // to the standard pipeline would be wrong: the client is already streaming
-    // raw realtime PCM, which the WAV-based path can't consume.
+    // session. Sent as `closed` (not `error`) + a message so the client stops
+    // the mic via the normal close path and surfaces the reason, rather than a
+    // bare error flash. Falling through to the standard pipeline would be wrong:
+    // the client is already streaming raw realtime PCM, which the WAV-based path
+    // can't consume.
     if (resolved.monthlyBudgetUsd && !this.getRealtimeBudget().canStart(resolved.monthlyBudgetUsd)) {
       console.warn('[WSService] realtime monthly budget reached — refusing new session');
       this.wsServer.sendToClient(ws, {
         type: 'realtime_status',
         payload: {
-          state: 'error',
+          state: 'closed',
+          reason: 'budget',
           message: `Monthly realtime voice budget ($${resolved.monthlyBudgetUsd}) reached. Voice is paused until next month or until you raise the limit in Settings > Voice.`,
         },
         timestamp: Date.now(),

--- a/src/daemon/ws-service.ts
+++ b/src/daemon/ws-service.ts
@@ -6,6 +6,8 @@
  */
 
 import type { ServerWebSocket } from 'bun';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
 import type { Service, ServiceStatus } from './services.ts';
 import type { AgentService } from './agent-service.ts';
 import type { CommitmentExecutor } from './commitment-executor.ts';
@@ -40,6 +42,7 @@ import { resolveRealtimeVoice, type ResolvedRealtimeVoice } from '../config/real
 import { BrowserAudioTransport } from '../comms/audio-transport.ts';
 import { RealtimeVoiceSession } from './realtime-voice.ts';
 import { REALTIME_NAV_TOOLS, REALTIME_NAV_TOOL_NAMES } from './realtime-nav-tools.ts';
+import { RealtimeBudgetTracker } from './realtime-budget.ts';
 import { classifyErrorString } from '../llm/provider.ts';
 import { getOrCreateConversation, addMessage } from '../vault/conversations.ts';
 import { maybeCreateUserProfileFollowupPrompt, recordUserProfileTurn } from '../user/profile-followup.ts';
@@ -155,8 +158,14 @@ export class WebSocketService implements Service {
    */
   private realtimeSessions = new Map<
     ServerWebSocket<unknown>,
-    { session: RealtimeVoiceSession; transport: BrowserAudioTransport; timeout: ReturnType<typeof setTimeout> }
+    { session: RealtimeVoiceSession; transport: BrowserAudioTransport; timeout: ReturnType<typeof setTimeout>; startedAt: number }
   >();
+  /**
+   * Lazily-created monthly spend guard for realtime voice. Only used when a
+   * `monthly_budget_usd` is configured; persists to the daemon data dir so the
+   * cap survives restarts. See realtime-budget.ts.
+   */
+  private realtimeBudget: RealtimeBudgetTracker | null = null;
   /**
    * Phase B — per-WS onboarding interview sessions. Created on
    * `interview_start`, torn down on disconnect or after the agent
@@ -1203,6 +1212,24 @@ CRITICAL — when in genuine doubt between "make in a new project" vs "add to th
       return false;
     }
 
+    // Monthly spend guard: refuse new sessions once the estimated budget is
+    // hit. Returns true (caller skips the standard accumulator) but opens no
+    // session — the client's onError handler stops streaming. Falling through
+    // to the standard pipeline would be wrong: the client is already streaming
+    // raw realtime PCM, which the WAV-based path can't consume.
+    if (resolved.monthlyBudgetUsd && !this.getRealtimeBudget().canStart(resolved.monthlyBudgetUsd)) {
+      console.warn('[WSService] realtime monthly budget reached — refusing new session');
+      this.wsServer.sendToClient(ws, {
+        type: 'realtime_status',
+        payload: {
+          state: 'error',
+          message: `Monthly realtime voice budget ($${resolved.monthlyBudgetUsd}) reached. Voice is paused until next month or until you raise the limit in Settings > Voice.`,
+        },
+        timestamp: Date.now(),
+      });
+      return true;
+    }
+
     const orchestrator = this.agentService.getOrchestrator();
     const transport = new BrowserAudioTransport({
       sendAudio: (chunk) => this.wsServer.sendBinary(ws, chunk),
@@ -1247,7 +1274,7 @@ CRITICAL — when in genuine doubt between "make in a new project" vs "add to th
       this.closeRealtimeVoice(ws);
     }, resolved.maxSessionMinutes * 60_000);
 
-    this.realtimeSessions.set(ws, { session, transport, timeout });
+    this.realtimeSessions.set(ws, { session, transport, timeout, startedAt: Date.now() });
     session.connect().then(
       () => this.wsServer.sendToClient(ws, { type: 'realtime_status', payload: { state: 'live', model: resolved.model }, timestamp: Date.now() }),
       (err) => {
@@ -1302,12 +1329,29 @@ CRITICAL — when in genuine doubt between "make in a new project" vs "add to th
     }
   }
 
+  /** Lazily build the monthly spend tracker, persisted under the data dir. */
+  private getRealtimeBudget(): RealtimeBudgetTracker {
+    if (!this.realtimeBudget) {
+      const dataDir = this.agentService.getConfig().daemon?.data_dir || join(homedir(), '.jarvis');
+      this.realtimeBudget = RealtimeBudgetTracker.fromFile(join(dataDir, 'realtime-budget.json'));
+    }
+    return this.realtimeBudget;
+  }
+
   /** Tear down a realtime voice session and notify the client. */
   private closeRealtimeVoice(ws: ServerWebSocket<unknown>): void {
     const entry = this.realtimeSessions.get(ws);
     if (!entry) return;
     this.realtimeSessions.delete(ws);
     clearTimeout(entry.timeout);
+    // Record estimated spend against the monthly budget (only meaningful when a
+    // budget is set; recording always is cheap and keeps the cap honest if one
+    // is added mid-month).
+    try {
+      this.getRealtimeBudget().recordSessionSeconds((Date.now() - entry.startedAt) / 1000);
+    } catch (err) {
+      console.warn('[WSService] failed to record realtime spend:', err);
+    }
     try { entry.session.close(); } catch { /* ignore */ }
     try {
       this.wsServer.sendToClient(ws, { type: 'realtime_status', payload: { state: 'closed' }, timestamp: Date.now() });

--- a/src/daemon/ws-service.ts
+++ b/src/daemon/ws-service.ts
@@ -36,6 +36,9 @@ import { createCommitment, updateCommitmentStatus, updateCommitmentAssignee } fr
 import { recordAgentActivity } from '../vault/agent-activity.ts';
 import { WebSocketServer, type WSMessage } from '../comms/websocket.ts';
 import { StreamRelay } from '../comms/streaming.ts';
+import { resolveRealtimeVoice, type ResolvedRealtimeVoice } from '../config/realtime.ts';
+import { BrowserAudioTransport } from '../comms/audio-transport.ts';
+import { RealtimeVoiceSession } from './realtime-voice.ts';
 import { classifyErrorString } from '../llm/provider.ts';
 import { getOrCreateConversation, addMessage } from '../vault/conversations.ts';
 import { maybeCreateUserProfileFollowupPrompt, recordUserProfileTurn } from '../user/profile-followup.ts';
@@ -143,6 +146,16 @@ export class WebSocketService implements Service {
   private sttProvider: STTProvider | null = null;
   private voiceSessions = new Map<ServerWebSocket<unknown>, VoiceSession>();
   private pendingVoiceConfirmations = new Map<string, PendingVoiceConfirmation>();
+  /**
+   * Premium realtime voice (gpt-realtime-2) sessions, keyed by socket. Present
+   * only when `voice.realtime.enabled` resolves with a key. A realtime session
+   * owns the full duplex audio loop (STT+LLM+TTS in one OpenAI connection), so
+   * the socket's normal `voiceSessions` accumulator is bypassed while it lives.
+   */
+  private realtimeSessions = new Map<
+    ServerWebSocket<unknown>,
+    { session: RealtimeVoiceSession; transport: BrowserAudioTransport; timeout: ReturnType<typeof setTimeout> }
+  >();
   /**
    * Phase B — per-WS onboarding interview sessions. Created on
    * `interview_start`, torn down on disconnect or after the agent
@@ -297,6 +310,8 @@ export class WebSocketService implements Service {
           console.log('[WSService] Client connected');
         },
         onDisconnect: (ws) => {
+          // Tear down any realtime voice session (closes the OpenAI WS + timer).
+          this.closeRealtimeVoice(ws);
           // Clean up every per-socket map so a long-running daemon doesn't
           // accumulate dead-socket entries across reconnects. See
           // cleanupPerSocketMaps for the contract; tested in
@@ -715,6 +730,9 @@ export class WebSocketService implements Service {
 
       case 'voice_start': {
         const { requestId, currentRoom } = msg.payload as { requestId: string; currentRoom?: string };
+        // Premium path: if realtime voice is enabled + keyed, open (or reuse) a
+        // full-duplex realtime session and skip the STT accumulator entirely.
+        if (this.tryStartRealtimeVoice(ws)) return undefined;
         this.voiceSessions.set(ws, {
           requestId,
           chunks: [],
@@ -1148,12 +1166,97 @@ CRITICAL — when in genuine doubt between "make in a new project" vs "add to th
    * Accumulates chunks into the active voice session for this client.
    */
   private async handleVoiceAudio(data: Buffer, ws: ServerWebSocket<unknown>): Promise<void> {
+    // Realtime path: stream the mic frame straight into the OpenAI session.
+    const realtime = this.realtimeSessions.get(ws);
+    if (realtime) {
+      realtime.transport.pushMicChunk(data);
+      return;
+    }
     const session = this.voiceSessions.get(ws);
     if (!session) {
       console.warn('[WSService] Binary audio received with no active voice session');
       return;
     }
     session.chunks.push(data);
+  }
+
+  /**
+   * Open (or reuse) a premium realtime voice session for this socket. Returns
+   * true if realtime handled the `voice_start` (so the caller skips the normal
+   * STT accumulator), false if realtime is disabled/unavailable.
+   *
+   * A single session spans the conversation: `voice_end` is a no-op for
+   * realtime (OpenAI's semantic VAD detects turns), and the session is closed
+   * on disconnect or after `max_session_minutes` (cost guard).
+   */
+  private tryStartRealtimeVoice(ws: ServerWebSocket<unknown>): boolean {
+    if (this.realtimeSessions.has(ws)) return true; // already streaming
+
+    let resolved: ResolvedRealtimeVoice;
+    try {
+      const res = resolveRealtimeVoice(this.agentService.getConfig());
+      if (!res.ok) return false;
+      resolved = res.resolved;
+    } catch (err) {
+      console.warn('[WSService] realtime voice resolve failed, using standard pipeline:', err);
+      return false;
+    }
+
+    const orchestrator = this.agentService.getOrchestrator();
+    const transport = new BrowserAudioTransport({
+      sendAudio: (chunk) => this.wsServer.sendBinary(ws, chunk),
+      signalStopPlayback: () =>
+        this.wsServer.sendToClient(ws, { type: 'tts_end', payload: { bargeIn: true }, timestamp: Date.now() }),
+      // OpenAI requires input rate >= 24kHz; the browser client must capture/
+      // resample to this. Output is also 24kHz PCM.
+      inputSampleRate: 24000,
+      outputSampleRate: 24000,
+    });
+
+    const session = new RealtimeVoiceSession(resolved, transport, {
+      tools: orchestrator.getRealtimeTools(),
+      instructions: this.agentService.buildFullSystemPrompt('voice'),
+      executeToolCall: (name, args) =>
+        orchestrator.executeRealtimeToolCall(name, args, { blockedCategories: resolved.blockedCategories }),
+      onTranscript: (t) =>
+        this.wsServer.sendToClient(ws, {
+          type: 'realtime_transcript',
+          payload: { role: t.role, text: t.text, final: t.final },
+          timestamp: Date.now(),
+        }),
+      onError: (err) => {
+        console.error('[WSService] realtime voice error:', err);
+        this.wsServer.sendToClient(ws, { type: 'realtime_status', payload: { state: 'error', message: err }, timestamp: Date.now() });
+      },
+      onClose: () => this.closeRealtimeVoice(ws),
+    });
+
+    const timeout = setTimeout(() => {
+      console.log('[WSService] realtime session hit max_session_minutes, closing');
+      this.closeRealtimeVoice(ws);
+    }, resolved.maxSessionMinutes * 60_000);
+
+    this.realtimeSessions.set(ws, { session, transport, timeout });
+    session.connect().then(
+      () => this.wsServer.sendToClient(ws, { type: 'realtime_status', payload: { state: 'live', model: resolved.model }, timestamp: Date.now() }),
+      (err) => {
+        console.error('[WSService] realtime connect failed:', err);
+        this.closeRealtimeVoice(ws);
+      },
+    );
+    return true;
+  }
+
+  /** Tear down a realtime voice session and notify the client. */
+  private closeRealtimeVoice(ws: ServerWebSocket<unknown>): void {
+    const entry = this.realtimeSessions.get(ws);
+    if (!entry) return;
+    this.realtimeSessions.delete(ws);
+    clearTimeout(entry.timeout);
+    try { entry.session.close(); } catch { /* ignore */ }
+    try {
+      this.wsServer.sendToClient(ws, { type: 'realtime_status', payload: { state: 'closed' }, timestamp: Date.now() });
+    } catch { /* socket may already be gone */ }
   }
 
   /**

--- a/src/daemon/ws-service.ts
+++ b/src/daemon/ws-service.ts
@@ -1215,7 +1215,10 @@ CRITICAL — when in genuine doubt between "make in a new project" vs "add to th
 
     const session = new RealtimeVoiceSession(resolved, transport, {
       tools: orchestrator.getRealtimeTools(),
-      instructions: this.agentService.buildFullSystemPrompt('voice'),
+      // Lean voice prompt (~100 tokens) instead of the full ~5.6k-token agent
+      // prompt — the big context was the dominant per-turn latency for simple
+      // questions. Tools stay, so capability is unchanged. See agent-service.
+      instructions: this.agentService.buildRealtimeVoiceInstructions(),
       executeToolCall: (name, args) =>
         orchestrator.executeRealtimeToolCall(name, args, { blockedCategories: resolved.blockedCategories }),
       onTranscript: (t) =>

--- a/ui/src/hooks/useVoice.ts
+++ b/ui/src/hooks/useVoice.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from "react";
+import { RealtimeVoiceController } from "../lib/RealtimeVoiceController";
 
 const SPEECH_WAKE_INTERRUPT_COMMANDS = new Set([
   "stop",
@@ -318,6 +319,12 @@ export function useVoice({ wsRef, wakeWordEnabled = true, wakeEngine = "openwake
   const autoStopRef = useRef(false);
   const cancelTTSRef = useRef<() => void>(() => {});
   const forceIdleRef = useRef<() => void>(() => {});
+  // Premium realtime voice (gpt-realtime-2). When enabled+keyed, recording and
+  // playback take a continuous 24kHz PCM path via RealtimeVoiceController
+  // instead of the push-to-talk WAV flow. Defaults off; only flips true after
+  // /api/config/voice reports the realtime mode is available.
+  const realtimeActiveRef = useRef(false);
+  const realtimeCtrlRef = useRef<RealtimeVoiceController | null>(null);
 
   // Keep refs in sync with state for use inside callbacks
   useEffect(() => { voiceStateRef.current = voiceState; }, [voiceState]);
@@ -345,6 +352,60 @@ export function useVoice({ wsRef, wakeWordEnabled = true, wakeEngine = "openwake
     }
     return audioContextRef.current;
   }, []);
+
+  // --- Premium realtime voice availability ---
+  // Poll the voice config so the recording/playback path can switch to the
+  // realtime streaming flow. Cheap; mirrors the settings poll cadence.
+  useEffect(() => {
+    let cancelled = false;
+    const check = async () => {
+      try {
+        const res = await fetch("/api/config/voice");
+        if (!res.ok) return;
+        const cfg = await res.json();
+        if (!cancelled) {
+          realtimeActiveRef.current = Boolean(cfg?.realtime?.enabled && cfg?.realtime?.available);
+        }
+      } catch { /* leave previous value; default false */ }
+    };
+    check();
+    const id = window.setInterval(() => {
+      if (typeof document !== "undefined" && document.hidden) return;
+      check();
+    }, 15000);
+    return () => { cancelled = true; window.clearInterval(id); };
+  }, []);
+
+  // Tear down the realtime controller (mic + playback contexts) on unmount.
+  useEffect(() => () => {
+    realtimeCtrlRef.current?.dispose();
+    realtimeCtrlRef.current = null;
+  }, []);
+
+  // Lazily create the realtime controller bound to the live WebSocket. State
+  // transitions are driven by playback start/idle since the realtime server
+  // streams audio without the tts_start/tts_end envelope.
+  const getRealtimeController = useCallback((): RealtimeVoiceController | null => {
+    const ws = wsRef.current;
+    if (!ws) return null;
+    if (!realtimeCtrlRef.current) {
+      realtimeCtrlRef.current = new RealtimeVoiceController({
+        ws,
+        getCurrentRoom: () => getCurrentRoom?.() ?? "home",
+        onPlaybackStart: () => setVoiceState("speaking"),
+        onPlaybackIdle: () => {
+          // Only fall to idle if we're not actively capturing the next turn.
+          if (!realtimeCtrlRef.current?.isStreaming) setVoiceState("idle");
+        },
+        onError: (msg) => {
+          console.error("[Voice] realtime error:", msg);
+          setVoiceState("error");
+          setTimeout(() => setVoiceState("idle"), 3000);
+        },
+      });
+    }
+    return realtimeCtrlRef.current;
+  }, [wsRef, getCurrentRoom]);
 
   const encodeWav = useCallback((chunks: Float32Array[], sampleRate: number): ArrayBuffer => {
     const totalLength = chunks.reduce((sum, chunk) => sum + chunk.length, 0);
@@ -770,11 +831,17 @@ export function useVoice({ wsRef, wakeWordEnabled = true, wakeEngine = "openwake
   }, [getAudioContext]);
 
   const handleTTSBinary = useCallback((data: ArrayBuffer) => {
+    // Realtime output is raw PCM s16 24kHz (no WAV/MP3 header) — route to the
+    // streaming player, not decodeAudioData.
+    if (realtimeActiveRef.current) {
+      getRealtimeController()?.enqueuePlayback(data);
+      return;
+    }
     ttsQueueRef.current.push(data);
     if (!ttsPlayingRef.current) {
       playNextTTSChunk();
     }
-  }, [playNextTTSChunk]);
+  }, [playNextTTSChunk, getRealtimeController]);
 
   const handleTTSStart = useCallback((requestId: string, containsWake = false) => {
     console.log("[Voice] TTS start:", requestId, containsWake ? "(contains wake)" : "");
@@ -817,7 +884,13 @@ export function useVoice({ wsRef, wakeWordEnabled = true, wakeEngine = "openwake
     }
   }, [stopSpeechWakeIfNeeded]);
 
-  const handleTTSEnd = useCallback(() => {
+  const handleTTSEnd = useCallback((bargeIn = false) => {
+    // Realtime: tts_end is used by the server only as a barge-in signal
+    // (user started speaking) — flush queued output so we stop talking over them.
+    if (realtimeActiveRef.current) {
+      if (bargeIn) realtimeCtrlRef.current?.flushPlayback();
+      return;
+    }
     ttsRequestIdRef.current = null;
     ttsContainsWakeRef.current = false;
     // If nothing is playing and queue is empty, transition now
@@ -829,6 +902,10 @@ export function useVoice({ wsRef, wakeWordEnabled = true, wakeEngine = "openwake
   }, []);
 
   const cancelTTS = useCallback(() => {
+    if (realtimeActiveRef.current && realtimeCtrlRef.current) {
+      realtimeCtrlRef.current.stopStreaming();
+      realtimeCtrlRef.current.flushPlayback();
+    }
     ttsQueueRef.current = [];
     ttsPlayingRef.current = false;
     ttsRequestIdRef.current = null;
@@ -845,6 +922,10 @@ export function useVoice({ wsRef, wakeWordEnabled = true, wakeEngine = "openwake
   }, [cancelTTS]);
 
   const handleError = useCallback(() => {
+    if (realtimeActiveRef.current && realtimeCtrlRef.current) {
+      realtimeCtrlRef.current.stopStreaming();
+      realtimeCtrlRef.current.flushPlayback();
+    }
     ttsQueueRef.current = [];
     ttsPlayingRef.current = false;
     ttsRequestIdRef.current = null;
@@ -944,6 +1025,13 @@ export function useVoice({ wsRef, wakeWordEnabled = true, wakeEngine = "openwake
 
   // --- Stop recording ---
   const stopRecordingInternal = useCallback(() => {
+    // Realtime path: stop streaming the mic (session stays open server-side).
+    // Output may still arrive; playback callbacks drive the state to idle.
+    if (realtimeActiveRef.current && realtimeCtrlRef.current?.isStreaming) {
+      realtimeCtrlRef.current.stopStreaming();
+      setVoiceState("processing");
+      return;
+    }
     streamRef.current?.getTracks().forEach(t => t.stop());
     streamRef.current = null;
     recordingWorkletRef.current?.disconnect();
@@ -974,6 +1062,19 @@ export function useVoice({ wsRef, wakeWordEnabled = true, wakeEngine = "openwake
   const startRecordingInternal = useCallback(async (autoStop = false) => {
     if (voiceStateRef.current === "recording") return;
     autoStopRef.current = autoStop;
+
+    // Premium realtime path: stream continuous 24kHz PCM instead of buffering
+    // a WAV. No client-side silence auto-stop — the server's semantic VAD
+    // handles turn-taking; the user ends the turn via stopRecording.
+    if (realtimeActiveRef.current) {
+      const ctrl = getRealtimeController();
+      if (ctrl) {
+        await ctrl.startStreaming();
+        setVoiceState("recording");
+        return;
+      }
+      // No controller (no WS) — fall through to the standard path.
+    }
 
     try {
       const stream = await navigator.mediaDevices.getUserMedia({
@@ -1072,6 +1173,10 @@ export function useVoice({ wsRef, wakeWordEnabled = true, wakeEngine = "openwake
    */
   const forceIdle = useCallback(() => {
     // Drain any in-flight TTS just in case
+    if (realtimeActiveRef.current && realtimeCtrlRef.current) {
+      realtimeCtrlRef.current.stopStreaming();
+      realtimeCtrlRef.current.flushPlayback();
+    }
     ttsQueueRef.current = [];
     ttsPlayingRef.current = false;
     ttsRequestIdRef.current = null;

--- a/ui/src/hooks/useVoice.ts
+++ b/ui/src/hooks/useVoice.ts
@@ -244,6 +244,8 @@ export type UseVoiceReturn = {
   handleTTSContainsWake: () => void;
   handleTTSEnd: () => void;
   handleError: (message?: string) => void;
+  /** Realtime session closed server-side — stop the mic, return to idle. */
+  handleRealtimeClosed: () => void;
   // v2 additions (Phase 4A)
   /** Mute the mic. While muted, wake-word is paused and `startRecording` is a no-op. */
   muted: boolean;
@@ -972,6 +974,19 @@ export function useVoice({ wsRef, wakeWordEnabled = true, wakeEngine = "openwake
     cancelTTSRef.current = cancelTTS;
   }, [cancelTTS]);
 
+  // Server ended the realtime session (max_session_minutes timeout or a
+  // server-side close). The session keeps the mic streaming for fast multi-turn
+  // while it's alive; once it's gone we must stop, or the browser keeps a hot
+  // mic streaming PCM into a session that no longer exists (the server silently
+  // drops it). Distinct from handleError: a normal close returns to idle with
+  // no error flash.
+  const handleRealtimeClosed = useCallback(() => {
+    if (!realtimeActiveRef.current) return;
+    realtimeCtrlRef.current?.stopStreaming();
+    realtimeCtrlRef.current?.flushPlayback();
+    setVoiceState("idle");
+  }, []);
+
   const handleError = useCallback(() => {
     if (realtimeActiveRef.current && realtimeCtrlRef.current) {
       realtimeCtrlRef.current.stopStreaming();
@@ -1377,6 +1392,7 @@ export function useVoice({ wsRef, wakeWordEnabled = true, wakeEngine = "openwake
     handleTTSContainsWake,
     handleTTSEnd,
     handleError,
+    handleRealtimeClosed,
     muted,
     setMuted,
     micLevel,

--- a/ui/src/hooks/useVoice.ts
+++ b/ui/src/hooks/useVoice.ts
@@ -353,6 +353,37 @@ export function useVoice({ wsRef, wakeWordEnabled = true, wakeEngine = "openwake
     return audioContextRef.current;
   }, []);
 
+  // Short "I'm listening" chime played the instant the wake word fires. Gives
+  // immediate feedback (so the user knows to start talking) and covers the
+  // realtime session's connect/setup window. Synthesized in Web Audio — no
+  // asset, no network. Two soft ascending sine notes (~150ms total).
+  const playWakeChime = useCallback(() => {
+    try {
+      const ctx = getAudioContext();
+      const t0 = ctx.currentTime;
+      const notes = [
+        { freq: 740, at: 0 },     // F#5
+        { freq: 988, at: 0.085 }, // B5
+      ];
+      for (const n of notes) {
+        const osc = ctx.createOscillator();
+        const gain = ctx.createGain();
+        osc.type = "sine";
+        osc.frequency.value = n.freq;
+        const start = t0 + n.at;
+        gain.gain.setValueAtTime(0.0001, start);
+        gain.gain.linearRampToValueAtTime(0.1, start + 0.015);
+        gain.gain.exponentialRampToValueAtTime(0.0001, start + 0.12);
+        osc.connect(gain);
+        gain.connect(ctx.destination);
+        osc.start(start);
+        osc.stop(start + 0.14);
+      }
+    } catch {
+      /* chime is cosmetic — never let it break the voice flow */
+    }
+  }, [getAudioContext]);
+
   // --- Premium realtime voice availability ---
   // Poll the voice config so the recording/playback path can switch to the
   // realtime streaming flow. Cheap; mirrors the settings poll cadence.
@@ -583,6 +614,13 @@ export function useVoice({ wsRef, wakeWordEnabled = true, wakeEngine = "openwake
         // so "Jarvis" can interrupt mid-thought.
         const sNow = voiceStateRef.current;
         if (sNow === "recording") return;
+        // Realtime voice streams the mic straight to OpenAI, which owns
+        // turn-taking + barge-in. This browser recognizer is only hearing the
+        // realtime TTS echo through the speakers; acting on a (false) wake or
+        // interrupt match here would cancelTTS → send voice_end → kill the
+        // session, forcing a re-wake mid-conversation. Ignore browser-SR matches
+        // during any active realtime turn. (Idle wake still works to start one.)
+        if (realtimeActiveRef.current && sNow !== "idle") return;
         // During speaking with "Jarvis" in the TTS text: ignore wake
         // matches; the recognizer is hearing its own voice through the
         // speakers. The daemon flips this flag; UI honors it.
@@ -733,7 +771,12 @@ export function useVoice({ wsRef, wakeWordEnabled = true, wakeEngine = "openwake
   // a containsWake speaking turn also forces "none" because TTS playing
   // "Jarvis" through speakers would self-trigger via the mic.
   useEffect(() => {
-    const blockedBySpeaking = voiceState === "speaking" && ttsContainsWakeRef.current;
+    // Block local wake engines during a containsWake speaking turn (echo) AND
+    // during ANY active realtime turn — realtime streams the mic to OpenAI and
+    // owns turn-taking, so a local engine here only self-triggers on TTS echo.
+    const blockedBySpeaking =
+      (voiceState === "speaking" && ttsContainsWakeRef.current) ||
+      (realtimeActiveRef.current && voiceState !== "idle");
     const active = (muted || blockedBySpeaking) ? "none" : selectActiveWakeEngine({
       isMicAvailable,
       wakeWordEnabled,
@@ -752,7 +795,12 @@ export function useVoice({ wsRef, wakeWordEnabled = true, wakeEngine = "openwake
   // effect tears the recognizer down. Gated on `blockedBySpeaking` so a
   // containsWake speaking turn doesn't echo-trigger.
   useEffect(() => {
-    const blockedBySpeaking = voiceState === "speaking" && ttsContainsWakeRef.current;
+    // Block local wake engines during a containsWake speaking turn (echo) AND
+    // during ANY active realtime turn — realtime streams the mic to OpenAI and
+    // owns turn-taking, so a local engine here only self-triggers on TTS echo.
+    const blockedBySpeaking =
+      (voiceState === "speaking" && ttsContainsWakeRef.current) ||
+      (realtimeActiveRef.current && voiceState !== "idle");
     const shouldRun = !muted && !blockedBySpeaking && shouldSpeechWakeBeRunning({
       isMicAvailable,
       wakeWordEnabled,
@@ -902,9 +950,12 @@ export function useVoice({ wsRef, wakeWordEnabled = true, wakeEngine = "openwake
   }, []);
 
   const cancelTTS = useCallback(() => {
-    if (realtimeActiveRef.current && realtimeCtrlRef.current) {
-      realtimeCtrlRef.current.stopStreaming();
-      realtimeCtrlRef.current.flushPlayback();
+    if (realtimeActiveRef.current) {
+      // Realtime: "stop talking" is a local flush (barge-in), NOT a session
+      // teardown. Keep the mic streaming so the conversation continues — calling
+      // stopStreaming here was sending voice_end and killing the session.
+      realtimeCtrlRef.current?.flushPlayback();
+      return;
     }
     ttsQueueRef.current = [];
     ttsPlayingRef.current = false;
@@ -1064,11 +1115,15 @@ export function useVoice({ wsRef, wakeWordEnabled = true, wakeEngine = "openwake
     autoStopRef.current = autoStop;
 
     // Premium realtime path: stream continuous 24kHz PCM instead of buffering
-    // a WAV. No client-side silence auto-stop — the server's semantic VAD
-    // handles turn-taking; the user ends the turn via stopRecording.
+    // a WAV. No client-side silence auto-stop — the server's VAD handles
+    // turn-taking; the user ends the turn via stopRecording.
     if (realtimeActiveRef.current) {
       const ctrl = getRealtimeController();
       if (ctrl) {
+        // Instant audible "I'm listening" — fires before the (brief) capture +
+        // session setup, so the user knows to start talking and the opening
+        // words (now buffered) land cleanly.
+        playWakeChime();
         await ctrl.startStreaming();
         setVoiceState("recording");
         return;
@@ -1143,7 +1198,7 @@ export function useVoice({ wsRef, wakeWordEnabled = true, wakeEngine = "openwake
       setVoiceState("error");
       setTimeout(() => setVoiceState("idle"), 3000);
     }
-  }, [stopRecordingInternal, sendAudioToServer]);
+  }, [stopRecordingInternal, sendAudioToServer, getRealtimeController, playWakeChime]);
 
   // Keep recording ref in sync for wake word callback
   useEffect(() => { startRecordingRef.current = startRecordingInternal; }, [startRecordingInternal]);
@@ -1172,11 +1227,12 @@ export function useVoice({ wsRef, wakeWordEnabled = true, wakeEngine = "openwake
    * stays in `thinking` until the 30s safety timeout fires.
    */
   const forceIdle = useCallback(() => {
+    // Realtime: the session is independent of UI navigation/room actions. The
+    // shell calls forceIdle on navigate/room/orb events; tearing the session
+    // down here sent a spurious voice_end and killed conversations mid-sentence.
+    // No-op in realtime — the session drives its own state.
+    if (realtimeActiveRef.current) return;
     // Drain any in-flight TTS just in case
-    if (realtimeActiveRef.current && realtimeCtrlRef.current) {
-      realtimeCtrlRef.current.stopStreaming();
-      realtimeCtrlRef.current.flushPlayback();
-    }
     ttsQueueRef.current = [];
     ttsPlayingRef.current = false;
     ttsRequestIdRef.current = null;

--- a/ui/src/hooks/useWebSocket.ts
+++ b/ui/src/hooks/useWebSocket.ts
@@ -498,6 +498,20 @@ export function useWebSocket() {
         // Premium realtime voice (gpt-realtime-2) status + live captions.
         if (msg.type === "realtime_status") {
           const state = msg.payload?.state;
+          // Surface any human-readable reason (e.g. budget reached) as a
+          // persistent system line — the v2 orb collapses error→idle and shows
+          // no text, so without this the message would be invisible.
+          if (msg.payload?.message) {
+            setMessages((prev) => [
+              ...prev,
+              {
+                id: crypto.randomUUID(),
+                role: "system" as MessageRole,
+                content: msg.payload.message,
+                timestamp: msg.timestamp,
+              },
+            ]);
+          }
           if (state === "error") voiceCallbacksRef.current?.onError(msg.payload?.message);
           // Server tore the session down (timeout/close) — stop the hot mic.
           else if (state === "closed") voiceCallbacksRef.current?.onRealtimeClosed?.();

--- a/ui/src/hooks/useWebSocket.ts
+++ b/ui/src/hooks/useWebSocket.ts
@@ -95,6 +95,10 @@ export type VoiceCallbacks = {
    *  starts speaking, so the player can flush queued output immediately. */
   onTTSEnd: (bargeIn?: boolean) => void;
   onError: (message?: string) => void;
+  /** Realtime session ended server-side (max_session_minutes timeout or
+   *  server close). The client must stop the mic — it's otherwise streaming
+   *  into a session that no longer exists. */
+  onRealtimeClosed?: () => void;
 };
 
 export type WorkflowEvent = {
@@ -495,6 +499,8 @@ export function useWebSocket() {
         if (msg.type === "realtime_status") {
           const state = msg.payload?.state;
           if (state === "error") voiceCallbacksRef.current?.onError(msg.payload?.message);
+          // Server tore the session down (timeout/close) — stop the hot mic.
+          else if (state === "closed") voiceCallbacksRef.current?.onRealtimeClosed?.();
           return;
         }
         if (msg.type === "realtime_transcript") {

--- a/ui/src/hooks/useWebSocket.ts
+++ b/ui/src/hooks/useWebSocket.ts
@@ -91,7 +91,9 @@ export type VoiceCallbacks = {
   onTTSStart: (requestId: string, containsWake: boolean) => void;
   /** Mid-turn flip: a later sentence in the same turn contains "Jarvis". */
   onTTSContainsWake?: () => void;
-  onTTSEnd: () => void;
+  /** `bargeIn` — realtime voice sends tts_end{bargeIn:true} when the user
+   *  starts speaking, so the player can flush queued output immediately. */
+  onTTSEnd: (bargeIn?: boolean) => void;
   onError: (message?: string) => void;
 };
 
@@ -486,7 +488,28 @@ export function useWebSocket() {
           return;
         }
         if (msg.type === "tts_end") {
-          voiceCallbacksRef.current?.onTTSEnd();
+          voiceCallbacksRef.current?.onTTSEnd(Boolean(msg.payload?.bargeIn));
+          return;
+        }
+        // Premium realtime voice (gpt-realtime-2) status + live captions.
+        if (msg.type === "realtime_status") {
+          const state = msg.payload?.state;
+          if (state === "error") voiceCallbacksRef.current?.onError(msg.payload?.message);
+          return;
+        }
+        if (msg.type === "realtime_transcript") {
+          // Only surface completed utterances as chat messages.
+          if (msg.payload?.final && msg.payload?.text) {
+            setMessages((prev) => [
+              ...prev,
+              {
+                id: crypto.randomUUID(),
+                role: (msg.payload.role === "assistant" ? "assistant" : "user") as MessageRole,
+                content: msg.payload.text,
+                timestamp: msg.timestamp,
+              },
+            ]);
+          }
           return;
         }
         if (msg.type === "thinking_start") {

--- a/ui/src/lib/RealtimeVoiceController.ts
+++ b/ui/src/lib/RealtimeVoiceController.ts
@@ -1,0 +1,174 @@
+/**
+ * Browser audio driver for premium realtime voice (gpt-realtime-2) — Phase 4c.
+ *
+ * Unlike the standard push-to-talk path (buffer → 16 kHz WAV at voice_end),
+ * realtime needs to:
+ *   - stream mic audio CONTINUOUSLY as 24 kHz PCM s16 binary frames, and
+ *   - play streamed 24 kHz PCM s16 output as it arrives, with barge-in.
+ *
+ * All Web Audio lives here so useVoice only flips a guarded branch. The pure
+ * sample math is in ./pcm.ts (unit-tested); this orchestration needs a real
+ * browser and is verified in-app. See docs/GPT_REALTIME_2_INTEGRATION.md.
+ */
+
+import { floatTo16BitPCM, pcm16ToFloat32, resampleFloat32 } from "./pcm.ts";
+
+const REALTIME_SAMPLE_RATE = 24000; // OpenAI realtime minimum.
+const CAPTURE_WORKLET_URL = "/audio/pcm-capture-processor.js";
+
+export type RealtimeControllerOpts = {
+  ws: WebSocket;
+  getCurrentRoom?: () => string;
+  /** Fired when output audio begins playing (drive UI → "speaking"). */
+  onPlaybackStart?: () => void;
+  /** Fired when the output queue drains (drive UI → "idle"). */
+  onPlaybackIdle?: () => void;
+  onError?: (msg: string) => void;
+};
+
+export class RealtimeVoiceController {
+  private opts: RealtimeControllerOpts;
+  private streaming = false;
+  private requestId: string | null = null;
+
+  // Capture graph
+  private stream: MediaStream | null = null;
+  private captureCtx: AudioContext | null = null;
+  private source: MediaStreamAudioSourceNode | null = null;
+  private worklet: AudioWorkletNode | null = null;
+
+  // Playback graph (scheduled queue)
+  private playbackCtx: AudioContext | null = null;
+  private playhead = 0;
+  private activeSources = new Set<AudioBufferSourceNode>();
+
+  constructor(opts: RealtimeControllerOpts) {
+    this.opts = opts;
+  }
+
+  get isStreaming(): boolean {
+    return this.streaming;
+  }
+
+  /** Open the mic and begin streaming continuous 24 kHz PCM frames. */
+  async startStreaming(): Promise<void> {
+    if (this.streaming) return;
+    const ws = this.opts.ws;
+    if (!ws || ws.readyState !== WebSocket.OPEN) {
+      this.opts.onError?.("WebSocket not open");
+      return;
+    }
+    try {
+      this.stream = await navigator.mediaDevices.getUserMedia({
+        audio: { echoCancellation: true, noiseSuppression: true },
+      });
+      // Request the context at the realtime rate; the MediaStreamSource is
+      // resampled into it automatically. We still resample defensively below
+      // in case a browser ignores the requested rate.
+      this.captureCtx = new AudioContext({ sampleRate: REALTIME_SAMPLE_RATE });
+      await this.captureCtx.audioWorklet.addModule(CAPTURE_WORKLET_URL);
+      this.source = this.captureCtx.createMediaStreamSource(this.stream);
+      this.worklet = new AudioWorkletNode(this.captureCtx, "pcm-capture-processor");
+
+      this.requestId = crypto.randomUUID();
+      ws.send(
+        JSON.stringify({
+          type: "voice_start",
+          payload: { requestId: this.requestId, currentRoom: this.opts.getCurrentRoom?.() ?? "home" },
+          timestamp: Date.now(),
+        }),
+      );
+
+      const ctxRate = this.captureCtx.sampleRate;
+      this.worklet.port.onmessage = (e: MessageEvent) => {
+        if (!this.streaming || ws.readyState !== WebSocket.OPEN) return;
+        const raw = new Float32Array(e.data as ArrayBuffer);
+        const float = ctxRate !== REALTIME_SAMPLE_RATE ? resampleFloat32(raw, ctxRate, REALTIME_SAMPLE_RATE) : raw;
+        ws.send(floatTo16BitPCM(float));
+      };
+
+      this.source.connect(this.worklet);
+      // Keep the worklet's graph alive with a muted sink (some browsers won't
+      // pull from a worklet that isn't connected to a destination).
+      const sink = this.captureCtx.createGain();
+      sink.gain.value = 0;
+      this.worklet.connect(sink);
+      sink.connect(this.captureCtx.destination);
+
+      this.streaming = true;
+    } catch (err) {
+      this.opts.onError?.(err instanceof Error ? err.message : String(err));
+      this.stopStreaming();
+    }
+  }
+
+  /** Stop the mic + tell the server this turn is done (session stays open). */
+  stopStreaming(): void {
+    if (this.streaming && this.requestId) {
+      try {
+        this.opts.ws.send(
+          JSON.stringify({ type: "voice_end", payload: { requestId: this.requestId }, timestamp: Date.now() }),
+        );
+      } catch { /* socket may be gone */ }
+    }
+    this.streaming = false;
+    this.stream?.getTracks().forEach((t) => t.stop());
+    this.stream = null;
+    this.worklet?.disconnect();
+    this.worklet = null;
+    this.source?.disconnect();
+    this.source = null;
+    this.captureCtx?.close().catch(() => {});
+    this.captureCtx = null;
+  }
+
+  /** Enqueue a raw PCM s16 24 kHz output frame for gapless playback. */
+  enqueuePlayback(pcm: ArrayBuffer): void {
+    const float = pcm16ToFloat32(pcm);
+    if (float.length === 0) return;
+    const ctx = this.getPlaybackCtx();
+    const buffer = ctx.createBuffer(1, float.length, REALTIME_SAMPLE_RATE);
+    buffer.copyToChannel(float, 0);
+    const src = ctx.createBufferSource();
+    src.buffer = buffer;
+    src.connect(ctx.destination);
+
+    const now = ctx.currentTime;
+    const wasIdle = this.activeSources.size === 0 && this.playhead <= now;
+    const startAt = Math.max(now, this.playhead);
+    src.start(startAt);
+    this.playhead = startAt + buffer.duration;
+    this.activeSources.add(src);
+    if (wasIdle) this.opts.onPlaybackStart?.();
+    src.onended = () => {
+      this.activeSources.delete(src);
+      if (this.activeSources.size === 0) this.opts.onPlaybackIdle?.();
+    };
+  }
+
+  /** Barge-in: stop and discard all queued/playing output. */
+  flushPlayback(): void {
+    for (const s of this.activeSources) {
+      try { s.stop(); } catch { /* already stopped */ }
+    }
+    this.activeSources.clear();
+    this.playhead = 0;
+    this.opts.onPlaybackIdle?.();
+  }
+
+  dispose(): void {
+    this.stopStreaming();
+    this.flushPlayback();
+    this.playbackCtx?.close().catch(() => {});
+    this.playbackCtx = null;
+  }
+
+  private getPlaybackCtx(): AudioContext {
+    if (!this.playbackCtx || this.playbackCtx.state === "closed") {
+      this.playbackCtx = new AudioContext();
+      this.playhead = 0;
+    }
+    if (this.playbackCtx.state === "suspended") this.playbackCtx.resume().catch(() => {});
+    return this.playbackCtx;
+  }
+}

--- a/ui/src/lib/pcm.test.ts
+++ b/ui/src/lib/pcm.test.ts
@@ -1,0 +1,59 @@
+import { test, expect, describe } from "bun:test";
+import { floatTo16BitPCM, pcm16ToFloat32, resampleFloat32 } from "./pcm.ts";
+
+describe("PCM conversion", () => {
+  test("floatTo16BitPCM produces 2 bytes per sample, little-endian", () => {
+    const buf = floatTo16BitPCM(new Float32Array([0, 1, -1]));
+    expect(buf.byteLength).toBe(6);
+    const v = new DataView(buf);
+    expect(v.getInt16(0, true)).toBe(0);
+    expect(v.getInt16(2, true)).toBe(32767); // +1 → 0x7fff
+    expect(v.getInt16(4, true)).toBe(-32768); // -1 → -0x8000
+  });
+
+  test("clamps out-of-range samples", () => {
+    const buf = floatTo16BitPCM(new Float32Array([2, -2]));
+    const v = new DataView(buf);
+    expect(v.getInt16(0, true)).toBe(32767);
+    expect(v.getInt16(2, true)).toBe(-32768);
+  });
+
+  test("round-trips float → pcm16 → float within quantization error", () => {
+    const input = new Float32Array([0, 0.5, -0.5, 0.25, -0.999]);
+    const back = pcm16ToFloat32(floatTo16BitPCM(input));
+    expect(back.length).toBe(input.length);
+    for (let i = 0; i < input.length; i++) {
+      expect(Math.abs(back[i]! - input[i]!)).toBeLessThan(0.0001);
+    }
+  });
+
+  test("pcm16ToFloat32 handles odd byte length by truncating", () => {
+    const out = pcm16ToFloat32(new ArrayBuffer(5)); // 2 full samples + 1 stray byte
+    expect(out.length).toBe(2);
+  });
+
+  describe("resampleFloat32", () => {
+    test("returns input unchanged when rates match", () => {
+      const input = new Float32Array([0.1, 0.2, 0.3]);
+      expect(resampleFloat32(input, 24000, 24000)).toBe(input);
+    });
+
+    test("downsamples 48k → 24k to ~half the samples", () => {
+      const input = new Float32Array(480);
+      const out = resampleFloat32(input, 48000, 24000);
+      expect(out.length).toBe(240);
+    });
+
+    test("upsamples 16k → 24k to ~1.5x samples", () => {
+      const input = new Float32Array(160);
+      const out = resampleFloat32(input, 16000, 24000);
+      expect(out.length).toBe(240);
+    });
+
+    test("preserves endpoints", () => {
+      const input = new Float32Array([1, 0, 0, 0, 1]);
+      const out = resampleFloat32(input, 16000, 24000);
+      expect(out[0]).toBeCloseTo(1, 5);
+    });
+  });
+});

--- a/ui/src/lib/pcm.ts
+++ b/ui/src/lib/pcm.ts
@@ -1,0 +1,51 @@
+/**
+ * PCM conversion helpers for premium realtime voice (gpt-realtime-2).
+ *
+ * The realtime path streams raw PCM signed-16 little-endian mono both ways
+ * (OpenAI requires >= 24 kHz). These pure functions convert between the
+ * Float32 samples Web Audio produces/consumes and the s16 wire format. Kept
+ * framework-free so they're unit-testable without a browser.
+ *
+ * See docs/GPT_REALTIME_2_INTEGRATION.md §4 Phase 4c.
+ */
+
+/** Float32 [-1,1] samples → little-endian PCM s16 ArrayBuffer. */
+export function floatTo16BitPCM(input: Float32Array): ArrayBuffer {
+  const out = new ArrayBuffer(input.length * 2);
+  const view = new DataView(out);
+  for (let i = 0; i < input.length; i++) {
+    const s = Math.max(-1, Math.min(1, input[i]!));
+    view.setInt16(i * 2, s < 0 ? s * 0x8000 : s * 0x7fff, true);
+  }
+  return out;
+}
+
+/** Little-endian PCM s16 ArrayBuffer → Float32 [-1,1] samples. */
+export function pcm16ToFloat32(buffer: ArrayBuffer): Float32Array<ArrayBuffer> {
+  const view = new DataView(buffer);
+  const n = Math.floor(buffer.byteLength / 2);
+  const out = new Float32Array(n);
+  for (let i = 0; i < n; i++) {
+    out[i] = view.getInt16(i * 2, true) / 0x8000;
+  }
+  return out;
+}
+
+/**
+ * Linear-interpolation resample of mono Float32 audio. Used as a fallback when
+ * an AudioContext can't be forced to the target rate. No-op when rates match.
+ */
+export function resampleFloat32(input: Float32Array, inRate: number, outRate: number): Float32Array {
+  if (inRate === outRate || input.length === 0) return input;
+  const ratio = inRate / outRate;
+  const outLength = Math.max(1, Math.round(input.length / ratio));
+  const out = new Float32Array(outLength);
+  for (let i = 0; i < outLength; i++) {
+    const srcPos = i * ratio;
+    const i0 = Math.floor(srcPos);
+    const i1 = Math.min(i0 + 1, input.length - 1);
+    const frac = srcPos - i0;
+    out[i] = input[i0]! * (1 - frac) + input[i1]! * frac;
+  }
+  return out;
+}

--- a/ui/src/v2/rooms/settings/SettingsRoom.tsx
+++ b/ui/src/v2/rooms/settings/SettingsRoom.tsx
@@ -5,6 +5,7 @@ import {
   Cable,
   Cog,
   MessagesSquare,
+  Mic,
   Server,
   UserCircle2,
   type LucideIcon,
@@ -22,6 +23,7 @@ import { GeneralTab } from "./tabs/GeneralTab";
 import { ProfileTab } from "./tabs/ProfileTab";
 import { LLMTab } from "./tabs/LLMTab";
 import { ChannelsTab } from "./tabs/ChannelsTab";
+import { VoiceTab } from "./tabs/VoiceTab";
 import { IntegrationsTab } from "./tabs/IntegrationsTab";
 import { SidecarTab } from "./tabs/SidecarTab";
 import "./SettingsRoom.css";
@@ -31,6 +33,7 @@ export type SettingsTab =
   | "profile"
   | "llm"
   | "channels"
+  | "voice"
   | "integrations"
   | "sidecar";
 
@@ -39,6 +42,7 @@ const TABS: ReadonlyArray<{ key: SettingsTab; label: string; icon: LucideIcon }>
   { key: "profile", label: "Profile", icon: UserCircle2 },
   { key: "llm", label: "LLM", icon: Bot },
   { key: "channels", label: "Channels", icon: MessagesSquare },
+  { key: "voice", label: "Voice", icon: Mic },
   { key: "integrations", label: "Integrations", icon: Cable },
   { key: "sidecar", label: "Sidecar", icon: Server },
 ];
@@ -387,6 +391,7 @@ export function SettingsRoomBody({ mode }: { mode: RoomBodyMode }) {
             {tab === "profile" && <ProfileTab data={data} onToast={showToast} />}
             {tab === "llm" && <LLMTab data={data} onToast={showToast} />}
             {tab === "channels" && <ChannelsTab data={data} onToast={showToast} />}
+            {tab === "voice" && <VoiceTab data={data} onToast={showToast} />}
             {tab === "integrations" && <IntegrationsTab data={data} onToast={showToast} />}
             {tab === "sidecar" && <SidecarTab data={data} onToast={showToast} />}
           </>

--- a/ui/src/v2/rooms/settings/tabs/VoiceTab.tsx
+++ b/ui/src/v2/rooms/settings/tabs/VoiceTab.tsx
@@ -1,0 +1,181 @@
+import React, { useState } from "react";
+import type { RealtimeReasoningEffort, SettingsHook } from "../useSettingsData";
+import { Chip } from "../../../ui";
+
+/** OpenAI realtime voices (gpt-realtime-2). */
+const REALTIME_VOICES = ["marin", "cedar", "alloy", "ash", "ballad", "coral", "sage", "shimmer", "verse"];
+
+const REASONING_EFFORTS: ReadonlyArray<{ id: RealtimeReasoningEffort; label: string }> = [
+  { id: "minimal", label: "Minimal — fastest, least deliberate" },
+  { id: "low", label: "Low — default, low latency" },
+  { id: "medium", label: "Medium — balanced" },
+  { id: "high", label: "High — more deliberate" },
+  { id: "xhigh", label: "X-High — most deliberate, highest latency/cost" },
+];
+
+export function VoiceTab({
+  data,
+  onToast,
+}: {
+  data: SettingsHook;
+  onToast: (text: string, tone?: "ok" | "warn") => void;
+}) {
+  const voice = data.voiceCfg;
+  const rt = voice?.realtime;
+  const [apiKey, setApiKey] = useState("");
+
+  const statusChip = !rt?.enabled
+    ? { label: "Off", tone: undefined }
+    : rt.available
+      ? { label: "Active", tone: "ok" as const }
+      : { label: "No API key", tone: "warn" as const };
+
+  return (
+    <div className="v2-set__tabpane">
+      <section className="v2-set__section">
+        <div className="v2-set__section-head">
+          <div>
+            <h3 className="v2-set__section-title">Premium Realtime Voice</h3>
+            <div className="v2-set__section-sub">
+              Speech-to-speech via OpenAI&apos;s gpt-realtime-2 — lower latency, natural
+              turn-taking, reasons mid-conversation. Bring your own OpenAI key; you are billed
+              by OpenAI (~$0.30/min). Off by default; the standard voice pipeline is unaffected.
+            </div>
+          </div>
+          <Chip tone={statusChip.tone}>{statusChip.label}</Chip>
+        </div>
+
+        <label className="v2-set__toggle-row">
+          <button
+            type="button"
+            className="v2-set__toggle"
+            data-checked={!!rt?.enabled}
+            aria-checked={!!rt?.enabled}
+            role="switch"
+            onClick={async () => {
+              const r = await data.setVoiceConfig({ realtime: { enabled: !rt?.enabled } });
+              onToast(r.message, r.ok ? "ok" : "warn");
+            }}
+          />
+          <span>Enable premium realtime voice</span>
+        </label>
+
+        {rt?.enabled && (
+          <>
+            {!rt.available && (
+              <p className="v2-set__hint" data-tone="warn">
+                Enabled, but no OpenAI key resolves yet. Add one below (or set the OpenAI provider
+                key under the LLM tab). Until then JARVIS uses the standard voice pipeline.
+              </p>
+            )}
+
+            {/* API key (BYO) */}
+            <div className="v2-set__field">
+              <label className="v2-set__field-label">OpenAI API key</label>
+              <div style={{ display: "flex", gap: "var(--s-2)" }}>
+                <input
+                  className="v2-set__input"
+                  type="password"
+                  placeholder="leave empty to keep existing / reuse LLM key"
+                  value={apiKey}
+                  onChange={(e) => setApiKey(e.target.value)}
+                />
+                <button
+                  type="button"
+                  className="v2-set__btn v2-set__btn--primary"
+                  disabled={!apiKey}
+                  onClick={async () => {
+                    const r = await data.setVoiceConfig({ realtime: { api_key: apiKey } });
+                    if (r.ok) setApiKey("");
+                    onToast(r.message, r.ok ? "ok" : "warn");
+                  }}
+                >
+                  Save key
+                </button>
+              </div>
+              <p className="v2-set__hint">
+                {rt.has_api_key
+                  ? "A realtime-specific key is configured."
+                  : "No realtime-specific key; falls back to the OpenAI LLM key or env."}
+              </p>
+            </div>
+
+            {/* Voice */}
+            <div className="v2-set__field">
+              <label className="v2-set__field-label">Voice</label>
+              <select
+                className="v2-set__select"
+                value={rt.voice ?? "marin"}
+                onChange={async (e) => {
+                  const r = await data.setVoiceConfig({ realtime: { voice: e.target.value } });
+                  onToast(r.message, r.ok ? "ok" : "warn");
+                }}
+              >
+                {REALTIME_VOICES.map((v) => (
+                  <option key={v} value={v}>
+                    {v}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            {/* Reasoning effort */}
+            <div className="v2-set__field">
+              <label className="v2-set__field-label">Reasoning effort</label>
+              <select
+                className="v2-set__select"
+                value={rt.reasoning_effort ?? "low"}
+                onChange={async (e) => {
+                  const r = await data.setVoiceConfig({
+                    realtime: { reasoning_effort: e.target.value as RealtimeReasoningEffort },
+                  });
+                  onToast(r.message, r.ok ? "ok" : "warn");
+                }}
+              >
+                {REASONING_EFFORTS.map((eff) => (
+                  <option key={eff.id} value={eff.id}>
+                    {eff.label}
+                  </option>
+                ))}
+              </select>
+              <p className="v2-set__hint">
+                Higher effort = more deliberate answers, but more latency and cost. Start with
+                Low for everyday use.
+              </p>
+            </div>
+
+            {/* Cost guards */}
+            <div className="v2-set__field">
+              <label className="v2-set__field-label">Max session length (minutes)</label>
+              <select
+                className="v2-set__select"
+                value={String(rt.max_session_minutes ?? 10)}
+                onChange={async (e) => {
+                  const r = await data.setVoiceConfig({
+                    realtime: { max_session_minutes: Number(e.target.value) },
+                  });
+                  onToast(r.message, r.ok ? "ok" : "warn");
+                }}
+              >
+                {[5, 10, 15, 30, 60].map((m) => (
+                  <option key={m} value={m}>
+                    {m} min
+                  </option>
+                ))}
+              </select>
+              <p className="v2-set__hint">
+                A session closes automatically at this limit to cap runaway cost.
+              </p>
+            </div>
+
+            <p className="v2-set__hint" data-tone="warn">
+              Continuous audio is streamed to OpenAI while a realtime session is live. Tool calls
+              are auto-approved during realtime sessions (hard denies still apply). Monitor usage
+              at platform.openai.com.
+            </p>
+          </>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/ui/src/v2/rooms/settings/useSettingsData.ts
+++ b/ui/src/v2/rooms/settings/useSettingsData.ts
@@ -100,6 +100,38 @@ export interface TTSConfig {
   } | null;
 }
 
+export type RealtimeReasoningEffort = "minimal" | "low" | "medium" | "high" | "xhigh";
+
+export interface VoiceConfig {
+  wake_engine: string;
+  realtime: {
+    enabled: boolean;
+    has_api_key: boolean;
+    model: string;
+    voice: string | null;
+    reasoning_effort: RealtimeReasoningEffort;
+    max_session_minutes: number;
+    monthly_budget_usd: number | null;
+    blocked_categories: string[];
+    /** true when enabled AND a key resolves (own key, llm.openai, or env). */
+    available: boolean;
+  };
+}
+
+/** Partial patch sent to POST /api/config/voice. */
+export interface VoiceConfigPatch {
+  wake_engine?: string;
+  realtime?: Partial<{
+    enabled: boolean;
+    api_key: string;
+    model: string;
+    voice: string;
+    reasoning_effort: RealtimeReasoningEffort;
+    max_session_minutes: number;
+    monthly_budget_usd: number;
+  }>;
+}
+
 export interface AutostartStatus {
   platform: string;
   manager: string;
@@ -239,6 +271,7 @@ export function useSettingsData() {
   const [channelCfg, setChannelCfg] = useState<ChannelConfig | null>(null);
   const [sttCfg, setSTTCfg] = useState<STTConfig | null>(null);
   const [ttsCfg, setTTSCfg] = useState<TTSConfig | null>(null);
+  const [voiceCfg, setVoiceCfg] = useState<VoiceConfig | null>(null);
   const [autostart, setAutostart] = useState<AutostartStatus | null>(null);
   const [rootCfg, setRootCfg] = useState<RootConfig | null>(null);
   const [personality, setPersonality] = useState<PersonalityModel | null>(null);
@@ -260,6 +293,7 @@ export function useSettingsData() {
         chanCfgR,
         sttR,
         ttsR,
+        voiceR,
         autoR,
         rootR,
         persR,
@@ -273,6 +307,7 @@ export function useSettingsData() {
         getJson<ChannelConfig>("/api/config/channels"),
         getJson<STTConfig>("/api/config/stt"),
         getJson<TTSConfig>("/api/config/tts"),
+        getJson<VoiceConfig>("/api/config/voice"),
         getJson<AutostartStatus>("/api/system/autostart"),
         getJson<RootConfig>("/api/config"),
         getJson<PersonalityModel>("/api/personality"),
@@ -286,6 +321,7 @@ export function useSettingsData() {
       if (chanCfgR) setChannelCfg(chanCfgR);
       if (sttR) setSTTCfg(sttR);
       if (ttsR) setTTSCfg(ttsR);
+      if (voiceR) setVoiceCfg(voiceR);
       if (autoR) setAutostart(autoR);
       if (rootR) setRootCfg(rootR);
       if (persR) setPersonality(persR);
@@ -598,6 +634,23 @@ export function useSettingsData() {
     [refresh, ttsCfg],
   );
 
+  // ── Voice / Premium realtime (config write — /api/config/voice) ─────
+  const setVoiceConfig = useCallback(
+    async (patch: VoiceConfigPatch): Promise<ActionResult> => {
+      try {
+        const r = await postJson<{ ok: boolean; message: string }>(
+          "/api/config/voice",
+          patch,
+        );
+        await refresh();
+        return { ok: true, message: r.message || "Voice settings saved." };
+      } catch (err) {
+        return { ok: false, message: err instanceof Error ? err.message : "Failed" };
+      }
+    },
+    [refresh],
+  );
+
   // ── Heartbeat (config write — root /api/config) ─────────────────────
   // Note: backend has no dedicated heartbeat endpoint; field-level writes
   // would go through /api/config (POST). This room exposes the read but
@@ -762,6 +815,7 @@ export function useSettingsData() {
     channelCfg,
     sttCfg,
     ttsCfg,
+    voiceCfg,
     autostart,
     rootCfg,
     personality,
@@ -790,6 +844,7 @@ export function useSettingsData() {
     setDiscord,
     setSTTProvider,
     setTTS,
+    setVoiceConfig,
     setHeartbeatInterval,
     setHeartbeatAggressiveness,
     restartDaemon,

--- a/ui/src/v2/shell/AppShell.tsx
+++ b/ui/src/v2/shell/AppShell.tsx
@@ -140,6 +140,7 @@ function AppShellLive() {
       onTTSContainsWake: voice.handleTTSContainsWake,
       onTTSEnd: voice.handleTTSEnd,
       onError: voice.handleError,
+      onRealtimeClosed: voice.handleRealtimeClosed,
     };
   }, [
     live.voiceCallbacksRef,
@@ -148,6 +149,7 @@ function AppShellLive() {
     voice.handleTTSContainsWake,
     voice.handleTTSEnd,
     voice.handleError,
+    voice.handleRealtimeClosed,
   ]);
 
   // Daemon-driven navigation (voice "open workflows" → navigate_room,


### PR DESCRIPTION
Adds an opt-in speech-to-speech voice mode built on OpenAI's GA Realtime API (`gpt-realtime-2`). When enabled with a key, JARVIS streams mic audio to OpenAI and plays the model's audio back, with the daemon acting as both the audio relay and the tool executor. When disabled (the default), nothing changes -- the standard STT -> text LLM -> TTS pipeline is untouched. BYO OpenAI key; the user is billed by OpenAI directly.

## What's included

- **Realtime client + transport.** A raw-WebSocket `RealtimeSession` (no SDK, consistent with `src/llm/*`) and a transport-agnostic `AudioTransport` abstraction, with a `BrowserAudioTransport` relay. Injectable socket/session factories keep the whole stack unit-testable without a browser or live socket.
- **Daemon wiring + auto-approve tool bridge.** One realtime session per socket spanning the conversation (semantic VAD handles turns). `executeRealtimeToolCall` mirrors the text-path authority gate but auto-approves so the audio loop never blocks on a dashboard click -- still enforcing emergency state, hard denies, and a blocked-category backstop, with every call written to the audit trail tagged `channel:'voice'`.
- **Voice-driven UI control.** Dashboard navigation and in-room actions exposed as realtime tools (open a room, go back, window control, room actions), reusing the same broadcast paths as the standard voice flow.
- **Browser audio path.** Continuous 24 kHz PCM capture/streaming and gapless scheduled playback with barge-in (`RealtimeVoiceController` + `pcm.ts`).
- **Settings.** A Voice tab and `/api/config/voice` GET/POST (key cascade: `voice.realtime.api_key` -> `llm.openai.api_key` -> env), with the key redacted on read.
- **Docs.** `docs/GPT_REALTIME_2_INTEGRATION.md` covering protocol notes, transport, the Phase 2/3 wiring, safe defaults, and cost guards.

## Safety and cost hardening

- **Safe-by-default tool blocking.** Because the mic is open and tools auto-approve, every `destructive`-impact category (payments, deletes, shell exec, installs, settings changes, agent termination) stays blocked unless the user explicitly opts it back in. The GET endpoint reports the *effective* backstop (plus a `blocked_categories_default` flag) so a config round-trip can't silently persist `[]` and disable it.
- **Barge-in cancels the model response.** On speech start the session sends `response.cancel` (not just local stop) and suppresses trailing audio from the cancelled response, so we stop paying for audio the user will never hear and never replay an interrupted reply. A benign "no active response" cancel race is swallowed.
- **Cost guards.** A hard `max_session_minutes` cap, and a persisted monthly budget that refuses new sessions over an estimated spend ceiling and surfaces a clear "voice paused" message to the user. Spend is estimated from session wall-clock (no live mid-session invoice exists); documented as an approximate guard.
- **Config validation.** `POST /api/config/voice` validates the patch (known keys only, enums, bounded numerics, known action categories) before persisting.
- **Lifecycle.** The client now handles server-side session close (`realtime_status: closed`) so a `max_session_minutes` timeout or budget pause can't leave a hot mic streaming into a dead session.