### PR TITLE
Anonymous usage telemetry (opt-out)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ JARVIS is not a chatbot with tools. It is a persistent daemon that sees your scr
     - [Stack](#stack)
   - [📖 Documentation](#-documentation)
   - [💬 Community](#-community)
+  - [📊 Telemetry](#-telemetry)
   - [🔒 Security](#-security)
   - [📄 License](#-license)
 
@@ -391,6 +392,7 @@ General:
 - [docs/LLM_PROVIDERS.md](docs/LLM_PROVIDERS.md) — LLM provider configuration and routing
 - [docs/VAULT_EXTRACTOR.md](docs/VAULT_EXTRACTOR.md) — Memory and knowledge vault
 - [docs/PERSONALITY_ENGINE.md](docs/PERSONALITY_ENGINE.md) — Personality and role system
+- [docs/TELEMETRY.md](docs/TELEMETRY.md) — What anonymous metrics are collected, and how to opt out
 
 Workflows (contributor reading order):
 
@@ -406,6 +408,30 @@ Workflows (contributor reading order):
 - [Discord](https://discord.gg/ytG2PHQ6rW) — Chat with other users, ask questions, share workflows
 - [Website](https://usejarvis.dev) — Project homepage and documentation
 - [GitHub Issues](https://github.com/vierisid/jarvis/issues) — Bug reports and feature requests
+
+---
+
+## 📊 Telemetry
+
+JARVIS sends **anonymous** usage metrics so the project can measure its unique
+user base and retention. Each ping contains only a hashed machine id (derived
+from hostname + username, never reversible to either), the app version, the
+install method, and the OS/arch. No personal data, config, content, or feature
+usage is ever sent. Pings go out at startup and every 4 hours.
+
+It is on by default (opt-out). Disable it with any of:
+
+```yaml
+# ~/.jarvis/config.yaml
+telemetry:
+  enabled: false
+```
+
+```bash
+JARVIS_TELEMETRY=0   # or the cross-tool standard: DO_NOT_TRACK=1
+```
+
+Full details: [docs/TELEMETRY.md](docs/TELEMETRY.md).
 
 ---
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -17,6 +17,15 @@ daemon:
 # auth:
 #   token: "your-secret-token-here"
 
+# Anonymous usage metrics (opt-out, enabled by default).
+# Sends a tiny anonymous ping at startup and every 4 hours so the project can
+# count unique installs and retention. No personal data, config, or content —
+# just a hashed machine id, app version, install method, and OS.
+# See docs/TELEMETRY.md for exactly what is collected.
+# Disable here, or via JARVIS_TELEMETRY=0, or DO_NOT_TRACK=1.
+telemetry:
+  enabled: true
+
 llm:
   # ── Providers ──
   # Each key is a NAME you'll reference in model strings ("name:model").

--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -1,0 +1,99 @@
+# Telemetry & Privacy
+
+JARVIS collects **anonymous** usage metrics so the project can answer two
+questions: how many people have run it at least once (the unique user base),
+and whether they keep using it over time (retention). That is the whole goal -
+there is no per-user analytics, no feature tracking, and no content of any
+kind.
+
+This document is the source of truth for what is collected. If the code and
+this file ever disagree, treat it as a bug.
+
+## What is sent
+
+Each ping is a small JSON object with exactly these fields:
+
+| Field            | Example            | Why                                  |
+| ---------------- | ------------------ | ------------------------------------ |
+| `anon_id`        | `9f86d081884c7d65` | Count unique machines + retention    |
+| `app_version`    | `0.5.0`            | Adoption of releases                 |
+| `install_method` | `docker`           | Which install paths people use       |
+| `os`             | `linux/x64`        | Platform/arch support priorities     |
+
+The collector adds a server-side `inserted_at` timestamp on receipt. That is
+everything stored.
+
+### The anonymous id
+
+`anon_id` is `sha256("jarvis-telemetry-v1:" + hostname + ":" + username)`,
+truncated to 128 bits of hex. It is:
+
+- **Stable** - the same machine produces the same id across restarts,
+  reinstalls, and database wipes, so unique-user and retention counts are
+  meaningful.
+- **Non-reversible** - we only ever transmit the digest. The raw hostname and
+  username never leave your machine.
+
+It is anonymous, not secret: hostname+username is low-entropy, so someone who
+already knows a specific machine's values could confirm a match. We consider
+that acceptable for aggregate metrics, since we never store or send the inputs
+and cannot recover them from the hash.
+
+### What is **never** sent
+
+No hostname, username, IP address (we never put one in the payload), config
+values, API keys, file paths, prompts, conversations, screen contents, or any
+feature-usage data.
+
+## When pings are sent
+
+- Once at daemon startup.
+- Then once every 4 hours while the process runs.
+
+The 4-hour heartbeat exists because JARVIS is a long-running server daemon:
+without it, a machine that starts once and stays up for weeks would look like a
+single brief session. Every send is fire-and-forget with a 5-second timeout; a
+failed or blocked request never affects the daemon.
+
+## How to opt out
+
+Any one of these disables telemetry completely:
+
+- **Config flag** - set in `~/.jarvis/config.yaml`:
+  ```yaml
+  telemetry:
+    enabled: false
+  ```
+- **Env var** - `JARVIS_TELEMETRY=0` (also accepts `false`/`no`/`off`).
+- **`DO_NOT_TRACK=1`** - the cross-tool community standard
+  (<https://consoledonottrack.com>) is honored.
+
+Precedence: `DO_NOT_TRACK` > `JARVIS_TELEMETRY` > config flag > default (on).
+
+On the first run a one-time notice is printed explaining all of the above; on
+later runs a single concise line reminds you telemetry is on and how to turn it
+off.
+
+## Verifying it works (for maintainers)
+
+Pings are fire-and-forget and failures are silent by design, so a broken
+collector would otherwise look identical to "no users." To make sends
+observable, set `JARVIS_TELEMETRY_DEBUG=1`:
+
+```bash
+JARVIS_TELEMETRY_DEBUG=1 jarvis start
+```
+
+Every ping then logs its outcome, e.g. `ping ok (HTTP 201)` or
+`ping failed (http: HTTP 401)`. This is the intended way to confirm telemetry
+reaches the collector after changing the endpoint, key, or RLS policy. Leave
+it unset in normal operation. It only affects logging - it never changes what
+is sent or whether telemetry runs.
+
+## Where data goes
+
+Pings are POSTed directly to a Supabase (PostgREST) table using the project's
+**public anon key**, which is scoped by an INSERT-only Row Level Security
+policy - clients can write but never read. The endpoint is set in
+`src/telemetry/constants.ts`. If the endpoint is unconfigured, the client
+simply does nothing.

--- a/scripts/ensure-bun.cjs
+++ b/scripts/ensure-bun.cjs
@@ -20,30 +20,46 @@ try {
 
 // ── Stamp install-method marker for global installs ─────────────────
 //
-// When `bun install -g @usejarvis/brain` runs, the package root ends up
-// under ~/.bun/install/global. The uninstall/update commands need to know
-// this later so they can dispatch to `bun uninstall -g` rather than
-// deleting files by hand. During Docker builds and dev checkouts this
-// check is false, so no marker is written — the Dockerfile stamps its
-// own `docker` marker, and dev checkouts intentionally have no marker.
+// When `bun install -g @usejarvis/brain` runs, the package root usually ends
+// up under ~/.bun/install/global. The uninstall/update commands (and usage
+// telemetry) need to know this later so update/uninstall dispatch correctly
+// and telemetry reports "bun-global" rather than "unknown".
+//
+// Two signals mark a global install:
+//   1. Package root under the default ~/.bun/install/global path.
+//   2. npm_config_global=true — set by bun/npm for lifecycle scripts of a
+//      `-g` install. This catches custom BUN_INSTALL / npm-prefix locations
+//      that the path check in (1) misses (those previously detected as the
+//      "unknown" install method).
+//
+// We deliberately skip writing during Docker builds (the Dockerfile stamps
+// its own `docker` marker) and dev checkouts (which have a .git dir and are
+// meant to detect as `dev` with no marker), and never clobber an existing
+// marker (e.g. the one install.sh writes for script installs).
 const packageRoot = resolve(__dirname, '..');
 const bunGlobalRoot = resolve(join(os.homedir(), '.bun', 'install', 'global'));
-const isBunGlobal =
+const underBunGlobalPath =
   packageRoot === bunGlobalRoot ||
   packageRoot.startsWith(bunGlobalRoot + sep);
+const isGlobalInstall =
+  underBunGlobalPath || process.env.npm_config_global === 'true';
+const isDevCheckout = existsSync(join(packageRoot, '.git'));
+const markerPath = join(packageRoot, '.install-method');
 
-if (isBunGlobal) {
-  const markerPath = join(packageRoot, '.install-method');
-  if (!existsSync(markerPath)) {
-    const marker = {
-      method: 'bun-global',
-      installedAt: new Date().toISOString(),
-    };
-    try {
-      writeFileSync(markerPath, JSON.stringify(marker) + '\n');
-    } catch {
-      // Non-fatal: detection falls back to path inference if the marker
-      // can't be written (e.g. read-only filesystem).
-    }
+if (
+  isGlobalInstall &&
+  !isDevCheckout &&
+  !process.env.JARVIS_INSTALL_METHOD &&
+  !existsSync(markerPath)
+) {
+  const marker = {
+    method: 'bun-global',
+    installedAt: new Date().toISOString(),
+  };
+  try {
+    writeFileSync(markerPath, JSON.stringify(marker) + '\n');
+  } catch {
+    // Non-fatal: detection falls back to path inference if the marker
+    // can't be written (e.g. read-only filesystem).
   }
 }

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -202,6 +202,16 @@ export type UserConfig = {
 };
 
 /**
+ * Anonymous usage telemetry. Opt-out model: enabled by default so the
+ * project can measure unique installs and retention. Disable with
+ * `enabled: false`, the `JARVIS_TELEMETRY=0` env var, or the community
+ * standard `DO_NOT_TRACK=1`.
+ */
+export type TelemetryConfig = {
+  enabled: boolean;
+};
+
+/**
  * Onboarding completion state — persists in `~/.jarvis/config.yaml` so
  * the dashboard knows which phase (setup / profile interview / tutorial)
  * to show on next load. Each `*_completed_at` is a `Date.now()` stamp;
@@ -330,6 +340,7 @@ export type LLMConfig = {
 export type JarvisConfig = {
   user?: UserConfig;
   onboarding?: OnboardingConfig;
+  telemetry?: TelemetryConfig;
   daemon: {
     port: number;
     data_dir: string;
@@ -389,6 +400,9 @@ export type JarvisConfig = {
 export const DEFAULT_CONFIG: JarvisConfig = {
   user: {
     name: '',
+  },
+  telemetry: {
+    enabled: true,
   },
   daemon: {
     port: 3142,

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -344,6 +344,15 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
     // 3. Create service registry
     registry = new ServiceRegistry();
 
+    // 3b. Anonymous usage telemetry (opt-out). Constructed here so it can be
+    //     registered before the LLM-dependent services and counts installs
+    //     even while the daemon is still in onboarding/setup mode.
+    const { TelemetryService } = await import('../telemetry/index.ts');
+    const telemetryService = new TelemetryService({
+      config: jarvisConfig,
+      packageRoot: path.join(import.meta.dir, '..', '..'),
+    });
+
     // 4. Create proactive modules
     const heartbeatConfig = jarvisConfig.heartbeat;
     const reactor = new EventReactor();
@@ -434,6 +443,7 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
 
     // 7. Register services in startup order
     //    Agent first (needs DB), Observers second, Channels third, Sidecar, WebSocket last (needs Agent)
+    registry.register(telemetryService);
     registry.register(agentService);
     if (observerService) registry.register(observerService);
     registry.register(channelService);

--- a/src/telemetry/anon-id.test.ts
+++ b/src/telemetry/anon-id.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from 'bun:test';
+import { computeAnonId } from './anon-id.ts';
+
+describe('computeAnonId', () => {
+  test('is deterministic for the same inputs', () => {
+    const a = computeAnonId({ hostname: 'box', username: 'alice' });
+    const b = computeAnonId({ hostname: 'box', username: 'alice' });
+    expect(a).toBe(b);
+  });
+
+  test('differs when hostname or username changes', () => {
+    const base = computeAnonId({ hostname: 'box', username: 'alice' });
+    expect(computeAnonId({ hostname: 'box2', username: 'alice' })).not.toBe(base);
+    expect(computeAnonId({ hostname: 'box', username: 'bob' })).not.toBe(base);
+  });
+
+  test('is a 128-bit (32 hex char) lowercase digest', () => {
+    const id = computeAnonId({ hostname: 'box', username: 'alice' });
+    expect(id).toMatch(/^[0-9a-f]{32}$/);
+  });
+
+  test('does not leak the raw inputs', () => {
+    const id = computeAnonId({ hostname: 'secret-host', username: 'secret-user' });
+    expect(id).not.toContain('secret-host');
+    expect(id).not.toContain('secret-user');
+  });
+
+  test('falls back to defaults without throwing when no input given', () => {
+    expect(() => computeAnonId()).not.toThrow();
+    expect(computeAnonId()).toMatch(/^[0-9a-f]{32}$/);
+  });
+});

--- a/src/telemetry/anon-id.ts
+++ b/src/telemetry/anon-id.ts
@@ -1,0 +1,48 @@
+import { createHash } from 'node:crypto';
+import os from 'node:os';
+
+/**
+ * Namespace prefix mixed into the hash so the digest is specific to JARVIS
+ * telemetry and can be rotated (bump the version) without colliding with any
+ * other hash of the same hostname+username.
+ */
+const ANON_ID_NAMESPACE = 'jarvis-telemetry-v1';
+
+/**
+ * Deterministic, non-reversible anonymous machine id.
+ *
+ * Derived from the OS hostname + username so the SAME machine produces the
+ * SAME id across restarts, reinstalls, and DB wipes -- which is what makes
+ * "unique user base" and retention numbers meaningful. We hash with a fixed
+ * namespace prefix and only ever transmit the 128-bit hex digest; the raw
+ * hostname/username never leave the machine.
+ *
+ * This is anonymous, not secret: hostname+username is low-entropy, so a
+ * party that already knows a specific machine's values could confirm a
+ * match. That is acceptable for aggregate usage metrics -- we never store
+ * or send the inputs, and we cannot reverse the digest back to them.
+ */
+export function computeAnonId(input?: { hostname?: string; username?: string }): string {
+  const hostname = input?.hostname ?? safeHostname();
+  const username = input?.username ?? safeUsername();
+  return createHash('sha256')
+    .update(`${ANON_ID_NAMESPACE}:${hostname}:${username}`)
+    .digest('hex')
+    .slice(0, 32);
+}
+
+function safeHostname(): string {
+  try {
+    return os.hostname() || 'unknown-host';
+  } catch {
+    return 'unknown-host';
+  }
+}
+
+function safeUsername(): string {
+  try {
+    return os.userInfo().username || 'unknown-user';
+  } catch {
+    return 'unknown-user';
+  }
+}

--- a/src/telemetry/client.test.ts
+++ b/src/telemetry/client.test.ts
@@ -1,0 +1,110 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import os from 'node:os';
+import { buildPayload, sendPing } from './client.ts';
+import { telemetryEndpoint } from './constants.ts';
+
+describe('buildPayload', () => {
+  test('contains exactly the four expected fields, all non-empty', () => {
+    const p = buildPayload(process.cwd());
+    expect(Object.keys(p).sort()).toEqual(['anon_id', 'app_version', 'install_method', 'os']);
+    expect(p.anon_id).toMatch(/^[0-9a-f]{32}$/);
+    expect(p.app_version.length).toBeGreaterThan(0);
+    expect(p.install_method.length).toBeGreaterThan(0);
+    expect(p.os).toBe(`${process.platform}/${process.arch}`);
+  });
+
+  test('carries no raw hostname', () => {
+    const hostname = os.hostname();
+    // Skip on the degenerate empty-hostname case so we never trivially pass.
+    if (hostname.length > 2) {
+      expect(JSON.stringify(buildPayload(process.cwd()))).not.toContain(hostname);
+    }
+  });
+
+  test('does not throw even when the package root is bogus', () => {
+    expect(() => buildPayload('/nonexistent/path/to/nowhere')).not.toThrow();
+  });
+});
+
+describe('telemetryEndpoint', () => {
+  test('resolves to the configured Supabase collector', () => {
+    const ep = telemetryEndpoint();
+    expect(ep).not.toBeNull();
+    expect(ep?.url).toMatch(/^https:\/\/.+\.supabase\.co\/rest\/v1\/telemetry_pings$/);
+    expect(ep?.key.length).toBeGreaterThan(0);
+  });
+});
+
+const PAYLOAD = { anon_id: 'x', app_version: '0.0.0', install_method: 'dev', os: 'linux/x64' } as const;
+
+describe('sendPing failure handling (never throws)', () => {
+  test('unconfigured endpoint -> {ok:false, reason:unconfigured}', async () => {
+    const out = await sendPing(PAYLOAD, { endpoint: null });
+    expect(out).toEqual({ ok: false, reason: 'unconfigured' });
+  });
+
+  // A real loopback server lets us prove the HTTP/network branches rather
+  // than mock fetch. Each test points sendPing at a throwaway endpoint.
+  describe('against a local server', () => {
+    let server: ReturnType<typeof Bun.serve>;
+    let received: unknown = null;
+
+    beforeAll(() => {
+      server = Bun.serve({
+        port: 0,
+        async fetch(req) {
+          const url = new URL(req.url);
+          if (url.pathname === '/ok') {
+            received = await req.json();
+            return new Response(null, { status: 201 });
+          }
+          if (url.pathname === '/boom') return new Response('nope', { status: 500 });
+          if (url.pathname === '/slow') {
+            await Bun.sleep(2000);
+            return new Response(null, { status: 201 });
+          }
+          return new Response(null, { status: 404 });
+        },
+      });
+    });
+
+    afterAll(() => server.stop(true));
+
+    const ep = (path: string) => ({ url: `http://localhost:${server.port}${path}`, key: 'test-key' });
+
+    test('2xx -> {ok:true} and posts the exact payload', async () => {
+      const out = await sendPing(PAYLOAD, { endpoint: ep('/ok') });
+      expect(out.ok).toBe(true);
+      expect(out.status).toBe(201);
+      expect(received).toEqual(PAYLOAD);
+    });
+
+    test('5xx -> {ok:false, reason:http, status:500}', async () => {
+      const out = await sendPing(PAYLOAD, { endpoint: ep('/boom') });
+      expect(out).toEqual({ ok: false, reason: 'http', status: 500 });
+    });
+
+    test('timeout -> {ok:false, reason:timeout}', async () => {
+      const out = await sendPing(PAYLOAD, { endpoint: ep('/slow'), timeoutMs: 100 });
+      expect(out).toEqual({ ok: false, reason: 'timeout' });
+    });
+  });
+
+  test('unreachable host -> {ok:false} (network or timeout, never throws)', async () => {
+    // Port 1 is never listening. Some OSes refuse instantly (network),
+    // others silently drop until our timeout fires -- both are acceptable
+    // non-fatal outcomes; the contract is "ok:false, no throw".
+    const out = await sendPing(PAYLOAD, {
+      endpoint: { url: 'http://127.0.0.1:1/x', key: 'k' },
+      timeoutMs: 1000,
+    });
+    expect(out.ok).toBe(false);
+    expect(out.reason === 'network' || out.reason === 'timeout').toBe(true);
+  });
+
+  test('malformed URL -> {ok:false, reason:network} (no throw)', async () => {
+    const out = await sendPing(PAYLOAD, { endpoint: { url: 'not-a-url', key: 'k' } });
+    expect(out.ok).toBe(false);
+    expect(out.reason).toBe('network');
+  });
+});

--- a/src/telemetry/client.ts
+++ b/src/telemetry/client.ts
@@ -1,0 +1,65 @@
+import { getInstalledVersion } from '../cli/version.ts';
+import { detectInstallMethod } from '../cli/install-method.ts';
+import { computeAnonId } from './anon-id.ts';
+import { telemetryEndpoint } from './constants.ts';
+
+export type TelemetryPayload = {
+  anon_id: string;
+  app_version: string;
+  install_method: string;
+  /** "<platform>/<arch>", e.g. "linux/x64", "darwin/arm64". */
+  os: string;
+};
+
+export type SendOutcome = {
+  ok: boolean;
+  reason?: 'unconfigured' | 'http' | 'network' | 'timeout';
+  status?: number;
+  error?: string;
+};
+
+export function buildPayload(packageRoot: string): TelemetryPayload {
+  return {
+    anon_id: computeAnonId(),
+    app_version: getInstalledVersion(packageRoot),
+    install_method: detectInstallMethod(packageRoot).method,
+    os: `${process.platform}/${process.arch}`,
+  };
+}
+
+export async function sendPing(
+  payload: TelemetryPayload,
+  opts: { timeoutMs?: number; endpoint?: { url: string; key: string } | null } = {},
+): Promise<SendOutcome> {
+  const endpoint = opts.endpoint !== undefined ? opts.endpoint : telemetryEndpoint();
+  if (!endpoint) return { ok: false, reason: 'unconfigured' };
+
+  const controller = new AbortController();
+  let timedOut = false;
+  const timer = setTimeout(() => {
+    timedOut = true;
+    controller.abort();
+  }, opts.timeoutMs ?? 5000);
+
+  try {
+    const res = await fetch(endpoint.url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        apikey: endpoint.key,
+        Authorization: `Bearer ${endpoint.key}`,
+        // PostgREST: don't bother returning the inserted row.
+        Prefer: 'return=minimal',
+      },
+      body: JSON.stringify(payload),
+      signal: controller.signal,
+    });
+    if (res.ok) return { ok: true, status: res.status };
+    return { ok: false, reason: 'http', status: res.status };
+  } catch (err) {
+    if (timedOut) return { ok: false, reason: 'timeout' };
+    return { ok: false, reason: 'network', error: err instanceof Error ? err.message : String(err) };
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/src/telemetry/config.test.ts
+++ b/src/telemetry/config.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from 'bun:test';
+import { resolveTelemetryEnabled } from './config.ts';
+
+const ON = { telemetry: { enabled: true } };
+const OFF = { telemetry: { enabled: false } };
+const UNSET = {};
+
+describe('resolveTelemetryEnabled', () => {
+  test('enabled by default when nothing is set', () => {
+    expect(resolveTelemetryEnabled(UNSET, {}).enabled).toBe(true);
+    expect(resolveTelemetryEnabled(ON, {}).enabled).toBe(true);
+  });
+
+  test('config flag false disables', () => {
+    const d = resolveTelemetryEnabled(OFF, {});
+    expect(d.enabled).toBe(false);
+    expect(d.reason).toContain('config');
+  });
+
+  test('JARVIS_TELEMETRY opt-out overrides an enabled config', () => {
+    for (const v of ['0', 'false', 'no', 'off', '']) {
+      expect(resolveTelemetryEnabled(ON, { JARVIS_TELEMETRY: v }).enabled).toBe(false);
+    }
+  });
+
+  test('JARVIS_TELEMETRY opt-in overrides a disabled config', () => {
+    expect(resolveTelemetryEnabled(OFF, { JARVIS_TELEMETRY: '1' }).enabled).toBe(true);
+  });
+
+  test('DO_NOT_TRACK takes precedence over everything', () => {
+    const d = resolveTelemetryEnabled(ON, { DO_NOT_TRACK: '1', JARVIS_TELEMETRY: '1' });
+    expect(d.enabled).toBe(false);
+    expect(d.reason).toContain('DO_NOT_TRACK');
+  });
+
+  test('DO_NOT_TRACK=0 does not disable', () => {
+    expect(resolveTelemetryEnabled(ON, { DO_NOT_TRACK: '0' }).enabled).toBe(true);
+  });
+});

--- a/src/telemetry/config.ts
+++ b/src/telemetry/config.ts
@@ -1,0 +1,35 @@
+import type { JarvisConfig } from '../config/types.ts';
+
+export type TelemetryDecision = {
+  enabled: boolean;
+  reason: string;
+};
+
+/** Treat unset/empty/0/false/no/off as "not enabled". */
+function isFalsy(value: string): boolean {
+  const s = value.trim().toLowerCase();
+  return s === '' || s === '0' || s === 'false' || s === 'no' || s === 'off';
+}
+
+export function resolveTelemetryEnabled(
+  config: Pick<JarvisConfig, 'telemetry'>,
+  env: NodeJS.ProcessEnv = process.env,
+): TelemetryDecision {
+  const dnt = env.DO_NOT_TRACK;
+  if (dnt !== undefined && !isFalsy(dnt)) {
+    return { enabled: false, reason: 'DO_NOT_TRACK is set' };
+  }
+
+  if (env.JARVIS_TELEMETRY !== undefined) {
+    if (isFalsy(env.JARVIS_TELEMETRY)) {
+      return { enabled: false, reason: 'JARVIS_TELEMETRY opt-out' };
+    }
+    return { enabled: true, reason: 'JARVIS_TELEMETRY opt-in' };
+  }
+
+  if (config.telemetry?.enabled === false) {
+    return { enabled: false, reason: 'telemetry.enabled=false in config' };
+  }
+
+  return { enabled: true, reason: 'enabled by default' };
+}

--- a/src/telemetry/constants.ts
+++ b/src/telemetry/constants.ts
@@ -1,0 +1,13 @@
+const TELEMETRY_URL = 'https://wmrxnfhghycxyabdhczn.supabase.co/rest/v1/telemetry_pings';
+const TELEMETRY_ANON_KEY =
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6IndtcnhuZmhnaHljeHlhYmRoY3puIiwicm9sZSI6ImFub24iLCJpYXQiOjE3ODA5OTQ4OTgsImV4cCI6MjA5NjU3MDg5OH0.phREIq3UEKPUyTNT077q-LWBqCw16wajIoTC50Z0J0E';
+
+/** 4 hours. Server processes that never restart still emit a heartbeat. */
+export const HEARTBEAT_INTERVAL_MS = 4 * 60 * 60 * 1000;
+
+export function telemetryEndpoint(): { url: string; key: string } | null {
+  if (!TELEMETRY_URL || TELEMETRY_URL.includes('YOUR_PROJECT_REF') || !TELEMETRY_ANON_KEY) {
+    return null;
+  }
+  return { url: TELEMETRY_URL, key: TELEMETRY_ANON_KEY };
+}

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -1,0 +1,5 @@
+export { TelemetryService, type TelemetryServiceOptions, type Sender } from './service.ts';
+export { resolveTelemetryEnabled, type TelemetryDecision } from './config.ts';
+export { buildPayload, sendPing, type TelemetryPayload, type SendOutcome } from './client.ts';
+export { computeAnonId } from './anon-id.ts';
+export { telemetryEndpoint, HEARTBEAT_INTERVAL_MS } from './constants.ts';

--- a/src/telemetry/service.test.ts
+++ b/src/telemetry/service.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from 'bun:test';
+import { TelemetryService, type Sender } from './service.ts';
+import type { JarvisConfig } from '../config/types.ts';
+import type { SendOutcome } from './client.ts';
+
+// Minimal config stand-in; the service only reads `telemetry`.
+const cfg = (enabled: boolean): JarvisConfig => ({ telemetry: { enabled } }) as unknown as JarvisConfig;
+
+// A sender that records calls; never touches the network.
+function recordingSender() {
+  const calls: unknown[] = [];
+  const fn: Sender = async (p) => {
+    calls.push(p);
+    return { ok: true, status: 201 } as SendOutcome;
+  };
+  return { fn, calls };
+}
+
+describe('TelemetryService lifecycle', () => {
+  test('disabled config: start() resolves running, sends nothing', async () => {
+    const { fn, calls } = recordingSender();
+    const svc = new TelemetryService({ config: cfg(false), packageRoot: process.cwd(), sender: fn });
+    await svc.start();
+    expect(svc.status()).toBe('running');
+    expect(calls.length).toBe(0);
+    await svc.stop();
+    expect(svc.status()).toBe('stopped');
+  });
+
+  test('enabled: start() fires exactly one startup ping', async () => {
+    const { fn, calls } = recordingSender();
+    const svc = new TelemetryService({ config: cfg(true), packageRoot: process.cwd(), sender: fn, debug: false });
+    await svc.start();
+    // Let the fire-and-forget startup ping settle.
+    await Bun.sleep(10);
+    expect(svc.status()).toBe('running');
+    expect(calls.length).toBe(1);
+    await svc.stop();
+  });
+
+  test('start() never throws even when the sender throws', async () => {
+    const throwing: Sender = async () => {
+      throw new Error('sender exploded');
+    };
+    const svc = new TelemetryService({ config: cfg(true), packageRoot: process.cwd(), sender: throwing });
+    // The whole point: a broken send path must not propagate out of start().
+    await expect(svc.start()).resolves.toBeUndefined();
+    await Bun.sleep(10);
+    expect(svc.status()).toBe('running');
+    await svc.stop();
+  });
+
+  test('stop() is safe to call when never started', async () => {
+    const svc = new TelemetryService({ config: cfg(true), packageRoot: process.cwd(), sender: async () => ({ ok: true }) });
+    await expect(svc.stop()).resolves.toBeUndefined();
+  });
+});

--- a/src/telemetry/service.ts
+++ b/src/telemetry/service.ts
@@ -1,0 +1,155 @@
+import type { Service, ServiceStatus } from '../daemon/services.ts';
+import type { JarvisConfig } from '../config/types.ts';
+import { getSetting, setSetting } from '../vault/settings.ts';
+import { resolveTelemetryEnabled } from './config.ts';
+import { buildPayload, sendPing, type SendOutcome, type TelemetryPayload } from './client.ts';
+import { HEARTBEAT_INTERVAL_MS } from './constants.ts';
+
+/** settings-table key marking the first time telemetry ran on this install. */
+const FIRST_SEEN_KEY = 'telemetry.first_seen_at';
+
+/** A send function; injectable so tests can avoid the network. */
+export type Sender = (payload: TelemetryPayload) => Promise<SendOutcome>;
+
+export type TelemetryServiceOptions = {
+  config: JarvisConfig;
+  packageRoot: string;
+  /** Override the sender (tests). Defaults to the real network sendPing. */
+  sender?: Sender;
+  /** Override debug logging (tests). Defaults to the JARVIS_TELEMETRY_DEBUG env. */
+  debug?: boolean;
+};
+
+/** Treat unset/empty/0/false/no/off as "off". */
+function envFlag(value: string | undefined): boolean {
+  if (value === undefined) return false;
+  const s = value.trim().toLowerCase();
+  return !(s === '' || s === '0' || s === 'false' || s === 'no' || s === 'off');
+}
+
+export class TelemetryService implements Service {
+  readonly name = 'telemetry';
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private state: ServiceStatus = 'stopped';
+  private payload: TelemetryPayload | null = null;
+  private readonly send: Sender;
+  private readonly debug: boolean;
+
+  constructor(private readonly opts: TelemetryServiceOptions) {
+    this.send = opts.sender ?? ((p) => sendPing(p));
+    this.debug = opts.debug ?? envFlag(process.env.JARVIS_TELEMETRY_DEBUG);
+  }
+
+  status(): ServiceStatus {
+    return this.state;
+  }
+
+  async start(): Promise<void> {
+    // Telemetry must never break daemon startup. The registry re-throws
+    // whatever a service.start() throws and aborts startAll(), and this
+    // service is registered first -- so any uncaught error here would take
+    // the whole daemon down. Swallow everything and always report running.
+    try {
+      const decision = resolveTelemetryEnabled(this.opts.config);
+      if (!decision.enabled) {
+        console.log(`[Telemetry] Disabled - ${decision.reason}.`);
+        return;
+      }
+
+      this.announce();
+      this.payload = buildPayload(this.opts.packageRoot);
+      if (this.debug) {
+        console.log(`[Telemetry] debug: payload=${JSON.stringify(this.payload)}`);
+      }
+
+      // Startup ping + 4-hourly heartbeat. Fire-and-forget; the .catch is
+      // belt-and-suspenders against an unhandled rejection (fire() already
+      // swallows its own errors).
+      this.fire().catch(() => {});
+      this.timer = setInterval(() => {
+        this.fire().catch(() => {});
+      }, HEARTBEAT_INTERVAL_MS);
+      // The heartbeat must not, by itself, keep the process alive.
+      (this.timer as unknown as { unref?: () => void }).unref?.();
+    } catch (err) {
+      console.warn(
+        `[Telemetry] Disabled - startup error: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    } finally {
+      this.state = 'running';
+    }
+  }
+
+  async stop(): Promise<void> {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+    this.state = 'stopped';
+  }
+
+  private async fire(): Promise<void> {
+    if (!this.payload) return;
+    let outcome: SendOutcome;
+    try {
+      outcome = await this.send(this.payload);
+    } catch (err) {
+      // The sender already swallows errors; this guards a misbehaving
+      // injected sender so fire() can never reject.
+      outcome = { ok: false, reason: 'network', error: err instanceof Error ? err.message : String(err) };
+    }
+    if (this.debug) {
+      if (outcome.ok) {
+        console.log(`[Telemetry] debug: ping ok (HTTP ${outcome.status}).`);
+      } else {
+        const detail =
+          outcome.reason === 'http'
+            ? `HTTP ${outcome.status}`
+            : outcome.reason === 'network'
+              ? outcome.error
+              : outcome.reason;
+        console.warn(`[Telemetry] debug: ping failed (${outcome.reason}: ${detail}).`);
+      }
+    }
+  }
+
+  /**
+   * Show a prominent one-time notice on the first run (per install), and a
+   * concise reminder on every subsequent start. The first-run flag is stored
+   * in the settings table; if that read/write fails we fall back to the short
+   * notice rather than risk crashing startup.
+   */
+  private announce(): void {
+    let firstRun = false;
+    try {
+      if (!getSetting(FIRST_SEEN_KEY)) {
+        firstRun = true;
+        setSetting(FIRST_SEEN_KEY, String(Date.now()));
+      }
+    } catch {
+      /* settings store not ready - degrade to the short notice below. */
+    }
+
+    if (firstRun) {
+      console.log(
+        [
+          '',
+          '+--- Anonymous usage metrics --------------------------------------+',
+          '| JARVIS sends a small anonymous ping at startup and every 4 hours  |',
+          '| so we can count unique installs and retention. No personal data,  |',
+          '| no config, no content - just a hashed machine id, app version,    |',
+          '| install method, and OS. Details: docs/TELEMETRY.md                |',
+          '|                                                                   |',
+          '| Opt out anytime: set `telemetry.enabled: false` in config.yaml,   |',
+          '| or run with JARVIS_TELEMETRY=0 (DO_NOT_TRACK=1 is honored too).    |',
+          '+-------------------------------------------------------------------+',
+          '',
+        ].join('\n'),
+      );
+    } else {
+      console.log(
+        '[Telemetry] Anonymous metrics on (opt out: telemetry.enabled=false or JARVIS_TELEMETRY=0).',
+      );
+    }
+  }
+}


### PR DESCRIPTION
## Anonymous usage telemetry (opt-out)

Adds a small, anonymous telemetry ping so we can measure the two things we
actually care about for a public, self-hosted daemon: the unique user base
(how many distinct machines have run JARVIS at least once) and retention
(usage over time).

### What gets sent

Exactly four fields, plus a server-side `inserted_at` timestamp:

| Field            | Example            | Purpose                       |
| ---------------- | ------------------ | ---
| `anon_id`        | `9f86d081884c7d65` | Unique-user count + retention |
| `app_version`    | `0.5.0`            | Rel
| `install_method` | `docker`           | Which install paths people use|
| `os`             | `linux/x64`        | Pla

No hostname, username, IP, config, file paths

`anon_id` is `sha256("jarvis-telemetry-v1:" +
truncated to 128 bits. It is stable across restarts/reinstalls/DB wipes (so
counts are meaningful) but non-reversible -- er
leave the machine.

### When

One ping at startup, then a heartbeat every 4 hours. The heartbeat matters
because this is a long-running server process
starts once and stays up for weeks would look like a single brief session.

### Opt-out

On by default, off via any of:

- `telemetry.enabled: false` in `~/.jarvis/config.yaml`
- `JARVIS_TELEMETRY=0`
- `DO_NOT_TRACK=1` (cross-tool standard)

Precedence: `DO_NOT_TRACK` > `JARVIS_TELEMETRY` > config flag > default.
A prominent one-time notice prints on first rery
later start.

### Where it goes

Direct POST to a Supabase (PostgREST) table with the project's public anon
key, scoped by an INSERT-only RLS policy (ther
read or mutate them). The table/policy live in the Supabase project, not in
this repo. The endpoint is set in `src/teleme
unconfigured the client silently does nothing.
