### PR TITLE
Pin installs to the latest release tag instead of `main`

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -286,28 +286,48 @@ main() {
     fi
   fi
 
+  # Resolve the latest release tag from the remote (no full clone needed).
+  # Shallow clones don't fetch tags, so we ask the remote directly and pick
+  # the highest version with a version-aware sort.
+  info "Resolving latest release tag..."
+  LATEST_TAG=$(git ls-remote --tags --refs "$REPO_URL" 2>/dev/null \
+    | awk -F/ '{print $NF}' \
+    | grep -E '^v[0-9]+(\.[0-9]+)*$' \
+    | sort -V \
+    | tail -n1)
+
+  if [ -z "$LATEST_TAG" ]; then
+    err "Could not resolve a release tag from $REPO_URL"
+    err "Check your internet connection and try again."
+    exit 1
+  fi
+  ok "Latest release: ${LATEST_TAG}"
+
   if [ -d "$INSTALL_DIR/.git" ]; then
-    info "Existing installation found. Updating..."
+    info "Existing installation found. Updating to ${LATEST_TAG}..."
     git -C "$INSTALL_DIR" checkout -- . 2>/dev/null || true
-    git -C "$INSTALL_DIR" pull --ff-only 2>/dev/null || {
-      warn "Could not fast-forward. Re-cloning..."
+    if git -C "$INSTALL_DIR" fetch --depth 1 origin "refs/tags/${LATEST_TAG}:refs/tags/${LATEST_TAG}" 2>/dev/null \
+       && git -C "$INSTALL_DIR" checkout -q "$LATEST_TAG" 2>/dev/null; then
+      ok "Updated to ${LATEST_TAG}"
+    else
+      warn "Could not update in place. Re-cloning..."
       rm -rf "$INSTALL_DIR"
-      git clone --depth 1 "$REPO_URL" "$INSTALL_DIR" || {
+      git clone --depth 1 --branch "$LATEST_TAG" "$REPO_URL" "$INSTALL_DIR" || {
         err "Failed to clone repository. Check your internet connection."
         exit 1
       }
-    }
-    ok "Updated to latest version"
+      ok "Installed ${LATEST_TAG}"
+    fi
   else
     if [ -d "$INSTALL_DIR" ]; then
       rm -rf "$INSTALL_DIR"
     fi
     mkdir -p "$(dirname "$INSTALL_DIR")"
-    git clone --depth 1 "$REPO_URL" "$INSTALL_DIR" || {
+    git clone --depth 1 --branch "$LATEST_TAG" "$REPO_URL" "$INSTALL_DIR" || {
       err "Failed to clone repository. Check your internet connection."
       exit 1
     }
-    ok "Downloaded JARVIS"
+    ok "Downloaded JARVIS ${LATEST_TAG}"
   fi
 
   echo ""

--- a/src/cli/install-method.ts
+++ b/src/cli/install-method.ts
@@ -179,7 +179,7 @@ export function getMethodCommands(method: InstallMethod): MethodCommands {
       };
     case 'script':
       return {
-        update: 'jarvis update   # runs `git pull` + `bun install`',
+        update: 'jarvis update   # checks out the latest release tag + `bun install`',
         uninstall: 'jarvis uninstall   # removes ~/.jarvis and the CLI wrapper',
       };
     case 'dev':

--- a/src/cli/update.test.ts
+++ b/src/cli/update.test.ts
@@ -118,11 +118,14 @@ describe('runUpdate — bun-global', () => {
 });
 
 describe('runUpdate — script install', () => {
-  test('skips when already up-to-date (HEAD == upstream)', async () => {
+  // ls-remote stdout fixtures: one tag ref per line, `<sha>\trefs/tags/<name>`.
+  const lsRemote = (...tags: string[]): string =>
+    tags.map((t, i) => `${'0'.repeat(40 - String(i).length)}${i}\trefs/tags/${t}`).join('\n') + '\n';
+
+  test('skips when already on the latest tag', async () => {
     const { spawn, calls } = recordingSpawner([
-      { exitCode: 0 }, // git fetch
-      { exitCode: 0, stdout: 'abc123\n' }, // git rev-parse HEAD
-      { exitCode: 0, stdout: 'abc123\n' }, // git rev-parse @{u}
+      { exitCode: 0, stdout: lsRemote('v0.9.0', 'v1.0.0') }, // git ls-remote (latest = v1.0.0)
+      { exitCode: 0, stdout: 'v1.0.0\n' }, // git describe --exact-match
     ]);
     const result = await runUpdate({
       packageRoot: workDir,
@@ -133,20 +136,20 @@ describe('runUpdate — script install', () => {
     });
     expect(result.outcome).toBe('up-to-date');
     expect(result.exitCode).toBe(0);
-    // No git pull / bun install should have run.
-    expect(calls.map((c) => c.cmd[0] + ' ' + c.cmd[1])).toEqual([
-      'git fetch',
-      'git rev-parse',
-      'git rev-parse',
+    // No fetch / checkout / bun install should have run.
+    expect(calls.map((c) => c.cmd.slice(0, 2).join(' '))).toEqual([
+      'git ls-remote',
+      'git describe',
     ]);
   });
 
-  test('runs git pull + bun install when upstream has new commits', async () => {
+  test('fetches + checks out the latest tag when a newer one exists', async () => {
     const { spawn, calls } = recordingSpawner([
-      { exitCode: 0 }, // fetch
-      { exitCode: 0, stdout: 'abc\n' }, // HEAD
-      { exitCode: 0, stdout: 'def\n' }, // upstream
-      { exitCode: 0 }, // git pull
+      { exitCode: 0, stdout: lsRemote('v1.0.0', 'v2.0.0') }, // ls-remote (latest = v2.0.0)
+      { exitCode: 0, stdout: 'v1.0.0\n' }, // describe (current = v1.0.0)
+      { exitCode: 0 }, // git checkout -- .
+      { exitCode: 0 }, // git fetch tag
+      { exitCode: 0 }, // git checkout tag
       { exitCode: 0 }, // bun install
     ]);
     const result = await runUpdate({
@@ -157,18 +160,22 @@ describe('runUpdate — script install', () => {
       restartDaemon: false,
     });
     expect(result.outcome).toBe('updated');
-    expect(calls[3]!.cmd).toEqual(['git', 'pull', '--ff-only']);
+    expect(calls[3]!.cmd).toEqual([
+      'git', 'fetch', '--depth', '1', 'origin', 'refs/tags/v2.0.0:refs/tags/v2.0.0',
+    ]);
     expect(calls[3]!.cwd).toBe(workDir);
-    expect(calls[4]!.cmd).toEqual(['bun', 'install']);
-    expect(calls[4]!.cwd).toBe(workDir);
+    expect(calls[4]!.cmd).toEqual(['git', 'checkout', '-q', 'v2.0.0']);
+    expect(calls[5]!.cmd).toEqual(['bun', 'install']);
+    expect(calls[5]!.cwd).toBe(workDir);
   });
 
-  test('proceeds with pull when git fetch fails (skips preflight)', async () => {
-    // If fetch fails (e.g. offline, no upstream), we can't preflight — just
-    // try the pull and let it surface the real error.
+  test('updates when HEAD is not on a tag (describe fails)', async () => {
     const { spawn, calls } = recordingSpawner([
-      { exitCode: 1, stderr: 'no upstream' }, // fetch fails
-      { exitCode: 0 }, // git pull still runs
+      { exitCode: 0, stdout: lsRemote('v2.0.0') }, // ls-remote
+      { exitCode: 128, stderr: 'no tag at HEAD' }, // describe fails -> treat as needs update
+      { exitCode: 0 }, // checkout -- .
+      { exitCode: 0 }, // fetch
+      { exitCode: 0 }, // checkout tag
       { exitCode: 0 }, // bun install
     ]);
     const result = await runUpdate({
@@ -180,16 +187,54 @@ describe('runUpdate — script install', () => {
     });
     expect(result.outcome).toBe('updated');
     expect(calls.map((c) => c.cmd.slice(0, 2).join(' '))).toEqual([
+      'git ls-remote',
+      'git describe',
+      'git checkout',
       'git fetch',
-      'git pull',
+      'git checkout',
       'bun install',
     ]);
   });
 
-  test('reports failure when git pull fails', async () => {
+  test('fails when the remote is unreachable (ls-remote fails)', async () => {
+    const { spawn, calls } = recordingSpawner([
+      { exitCode: 1, stderr: 'could not resolve host' }, // ls-remote fails
+    ]);
+    const result = await runUpdate({
+      packageRoot: workDir,
+      spawn,
+      detect: () => fakeInfo('script'),
+      checkRunning: () => null,
+      restartDaemon: false,
+    });
+    expect(result.outcome).toBe('failed');
+    expect(result.exitCode).toBe(1);
+    // Must not proceed past the remote probe.
+    expect(calls).toHaveLength(1);
+  });
+
+  test('fails when the remote has no version tags', async () => {
     const { spawn } = recordingSpawner([
-      { exitCode: 1 }, // fetch fails (skip preflight)
-      { exitCode: 1, stderr: 'not fast-forward' }, // pull fails
+      { exitCode: 0, stdout: '' }, // ls-remote returns nothing usable
+    ]);
+    const result = await runUpdate({
+      packageRoot: workDir,
+      spawn,
+      detect: () => fakeInfo('script'),
+      checkRunning: () => null,
+      restartDaemon: false,
+    });
+    expect(result.outcome).toBe('failed');
+    expect(result.exitCode).toBe(1);
+  });
+
+  test('reports failure when git checkout fails', async () => {
+    const { spawn } = recordingSpawner([
+      { exitCode: 0, stdout: lsRemote('v2.0.0') }, // ls-remote
+      { exitCode: 0, stdout: 'v1.0.0\n' }, // describe
+      { exitCode: 0 }, // checkout -- .
+      { exitCode: 0 }, // fetch
+      { exitCode: 1, stderr: 'checkout conflict' }, // checkout tag fails
     ]);
     const result = await runUpdate({
       packageRoot: workDir,
@@ -205,8 +250,11 @@ describe('runUpdate — script install', () => {
   test('stops running daemon before updating', async () => {
     let stopCalls = 0;
     const { spawn } = recordingSpawner([
-      { exitCode: 1 }, // fetch fails, skip preflight
-      { exitCode: 0 }, // pull
+      { exitCode: 0, stdout: lsRemote('v2.0.0') }, // ls-remote
+      { exitCode: 0, stdout: 'v1.0.0\n' }, // describe
+      { exitCode: 0 }, // checkout -- .
+      { exitCode: 0 }, // fetch
+      { exitCode: 0 }, // checkout tag
       { exitCode: 0 }, // bun install
     ]);
     const result = await runUpdate({
@@ -226,8 +274,11 @@ describe('runUpdate — script install', () => {
 
   test('bun install failure is a warning, not a hard failure', async () => {
     const { spawn } = recordingSpawner([
-      { exitCode: 1 }, // fetch fails
-      { exitCode: 0 }, // pull succeeds
+      { exitCode: 0, stdout: lsRemote('v2.0.0') }, // ls-remote
+      { exitCode: 0, stdout: 'v1.0.0\n' }, // describe
+      { exitCode: 0 }, // checkout -- .
+      { exitCode: 0 }, // fetch
+      { exitCode: 0 }, // checkout tag
       { exitCode: 2, stderr: 'disk full' }, // bun install fails
     ]);
     const result = await runUpdate({
@@ -237,8 +288,30 @@ describe('runUpdate — script install', () => {
       checkRunning: () => null,
       restartDaemon: false,
     });
-    // git pull was the meaningful operation; bun install is recoverable.
+    // The checkout was the meaningful operation; bun install is recoverable.
     expect(result.outcome).toBe('updated');
     expect(result.exitCode).toBe(0);
+  });
+});
+
+describe('pickLatestTag', () => {
+  const line = (tag: string) => `1111111111111111111111111111111111111111\trefs/tags/${tag}`;
+
+  test('picks the highest version, not lexicographic order', async () => {
+    const { pickLatestTag } = await import('./update.ts');
+    const stdout = [line('v0.6.0'), line('v0.6.1'), line('v0.10.0'), line('v0.9.0')].join('\n');
+    expect(pickLatestTag(stdout)).toBe('v0.10.0');
+  });
+
+  test('handles four-part versions like v0.4.3.1', async () => {
+    const { pickLatestTag } = await import('./update.ts');
+    const stdout = [line('v0.4.3'), line('v0.4.3.1'), line('v0.4.2')].join('\n');
+    expect(pickLatestTag(stdout)).toBe('v0.4.3.1');
+  });
+
+  test('ignores non-version refs and returns null when none match', async () => {
+    const { pickLatestTag } = await import('./update.ts');
+    const stdout = [line('latest'), line('nightly'), line('release-candidate')].join('\n');
+    expect(pickLatestTag(stdout)).toBeNull();
   });
 });

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -4,7 +4,7 @@
  * Dispatches based on how JARVIS was installed:
  *   docker      refuse, point user at host-side `docker pull`
  *   bun-global  `bun update -g @usejarvis/brain`
- *   script      git pull --ff-only + bun install
+ *   script      checkout the latest release tag + bun install
  *   dev         refuse, tell user to `git pull` themselves
  *   unknown     refuse with guidance
  *
@@ -183,40 +183,91 @@ function updateBunGlobal(
   };
 }
 
+/**
+ * Compare two `vX.Y.Z` (or `vX.Y.Z.N`) tags numerically, component by
+ * component. Returns >0 if `a` is newer, <0 if older, 0 if equal.
+ */
+function compareVersionTags(a: string, b: string): number {
+  const pa = a.replace(/^v/, '').split('.').map((n) => parseInt(n, 10) || 0);
+  const pb = b.replace(/^v/, '').split('.').map((n) => parseInt(n, 10) || 0);
+  const len = Math.max(pa.length, pb.length);
+  for (let i = 0; i < len; i++) {
+    const diff = (pa[i] ?? 0) - (pb[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}
+
+/**
+ * Pick the highest version tag from `git ls-remote --tags --refs` output.
+ * Mirrors install.sh's `grep -E '^v[0-9]…' | sort -V | tail -n1`. Returns
+ * null when no version-shaped tag is present.
+ */
+export function pickLatestTag(lsRemoteStdout: string): string | null {
+  const tags = lsRemoteStdout
+    .split('\n')
+    .map((line) => {
+      const idx = line.indexOf('refs/tags/');
+      return idx === -1 ? null : line.slice(idx + 'refs/tags/'.length).trim();
+    })
+    .filter((t): t is string => !!t && /^v\d+(\.\d+)*$/.test(t));
+
+  if (tags.length === 0) return null;
+  return tags.reduce((best, cur) => (compareVersionTags(cur, best) > 0 ? cur : best));
+}
+
 function updateScript(
   packageRoot: string,
   currentVersion: string,
   spawn: Spawner,
 ): UpdateResult {
-  // Preflight: fetch remote and check whether we're already up-to-date.
-  // Saves the daemon-restart round-trip when nothing has changed.
-  const fetch = spawn(['git', 'fetch', '--quiet'], { cwd: packageRoot });
-  if (fetch.exitCode === 0) {
-    const head = spawn(['git', 'rev-parse', 'HEAD'], { cwd: packageRoot });
-    const upstream = spawn(['git', 'rev-parse', '@{u}'], { cwd: packageRoot });
-    if (head.exitCode === 0 && upstream.exitCode === 0 && head.stdout.trim() === upstream.stdout.trim()) {
-      console.log(c.green(`✓ Already on the latest version (${currentVersion})`));
-      return {
-        method: 'script',
-        outcome: 'up-to-date',
-        exitCode: 0,
-        message: 'no-op',
-      };
-    }
+  // Script installs are pinned to a release tag (detached HEAD), so there is
+  // no upstream branch to pull. Resolve the latest tag from the remote and
+  // check it out instead. Mirrors install.sh's tag-pinning.
+  const ls = spawn(['git', 'ls-remote', '--tags', '--refs', 'origin'], { cwd: packageRoot });
+  if (ls.exitCode !== 0) {
+    console.log(c.red('✗ Update failed (could not reach remote):'));
+    const err = ls.stderr.trim() || ls.stdout.trim();
+    if (err) console.log(c.dim(`  ${err}`));
+    return { method: 'script', outcome: 'failed', exitCode: 1, message: 'git ls-remote failed' };
   }
 
-  console.log(c.dim('Running `git pull --ff-only`...'));
-  const pull = spawn(['git', 'pull', '--ff-only'], { cwd: packageRoot });
-  if (pull.exitCode !== 0) {
-    console.log(c.red('✗ Update failed (git pull):'));
-    const err = pull.stderr.trim() || pull.stdout.trim();
+  const latestTag = pickLatestTag(ls.stdout);
+  if (!latestTag) {
+    console.log(c.red('✗ Update failed: no release tags found on the remote.'));
+    return { method: 'script', outcome: 'failed', exitCode: 1, message: 'no remote tags' };
+  }
+
+  // Already on the latest tag? `git describe --exact-match` prints the tag at
+  // HEAD (and exits non-zero when HEAD isn't exactly on a tag — then we update).
+  const describe = spawn(['git', 'describe', '--tags', '--exact-match'], { cwd: packageRoot });
+  const currentTag = describe.exitCode === 0 ? describe.stdout.trim() : null;
+  if (currentTag === latestTag) {
+    console.log(c.green(`✓ Already on the latest version (${currentVersion})`));
+    return { method: 'script', outcome: 'up-to-date', exitCode: 0, message: 'no-op' };
+  }
+
+  console.log(c.dim(`Updating to ${latestTag}...`));
+  // Discard any local tracked changes so the checkout can't be blocked.
+  spawn(['git', 'checkout', '--', '.'], { cwd: packageRoot });
+
+  const fetch = spawn(
+    ['git', 'fetch', '--depth', '1', 'origin', `refs/tags/${latestTag}:refs/tags/${latestTag}`],
+    { cwd: packageRoot },
+  );
+  if (fetch.exitCode !== 0) {
+    console.log(c.red('✗ Update failed (git fetch):'));
+    const err = fetch.stderr.trim() || fetch.stdout.trim();
     if (err) console.log(c.dim(`  ${err}`));
-    return {
-      method: 'script',
-      outcome: 'failed',
-      exitCode: 1,
-      message: 'git pull failed',
-    };
+    return { method: 'script', outcome: 'failed', exitCode: 1, message: 'git fetch failed' };
+  }
+
+  const checkout = spawn(['git', 'checkout', '-q', latestTag], { cwd: packageRoot });
+  if (checkout.exitCode !== 0) {
+    console.log(c.red('✗ Update failed (git checkout):'));
+    const err = checkout.stderr.trim() || checkout.stdout.trim();
+    if (err) console.log(c.dim(`  ${err}`));
+    return { method: 'script', outcome: 'failed', exitCode: 1, message: 'git checkout failed' };
   }
 
   console.log(c.dim('Running `bun install`...'));
@@ -224,7 +275,7 @@ function updateScript(
   if (install.exitCode !== 0) {
     console.log(c.yellow('! Dependencies may need manual refresh:'));
     console.log(c.dim(`  cd ${packageRoot} && bun install`));
-    // Don't fail the update — the git pull succeeded, dependencies are a
+    // Don't fail the update — the checkout succeeded, dependencies are a
     // separate concern the user can resolve.
   }
 


### PR DESCRIPTION
The `install.sh` script cloned the repo with `git clone --depth 1` and no branch/tag, so every install and update tracked the bleeding edge of `main` -- whatever was last merged, even untagged/unreleased work. We already maintain tagged releases (`v0.6.1` etc.), so installs should track those.

### Changes

**`install.sh`** -- resolves the latest release tag and checks it out, no fallback to `main`:
- Queries the remote with `git ls-remote --tags --refs` and picks the highest version via `sort -V` (handles the four-part `v0.4.3.1` oddball too).
- Fresh install: `git clone --depth 1 --branch <tag>`.
- Update path: shallow tag fetch + checkout (replaces `git pull --ff-only`, which tracked `main`).
- Errors out if no tag can be resolved, rather than silently falling back.

**`src/cli/update.ts`** -- `jarvis update` for `script` installs was broken by the pinning change. A tag clone leaves HEAD detached with no upstream branch, so the old preflight (`HEAD` vs `@{u}`) and `git pull --ff-only` both failed. The `updateScript()` handler now mirrors `install.sh`:
- Resolves the latest tag from the remote (nelper).
- Compares against the tag at HEAD via `git describe --tags --exact-match`; reports up-to-date when they match.
- Otherwise discards local tracked changes, shallow-fetches the tag, checks it out, and runs `bun install`.
- Failure handling preserved: unreachable remure -> failed; `bun install` failure stays awarning.

**`src/cli/install-method.ts`** -- updated the `script` method's descriptive update command string.

**`src/cli/update.test.ts`** -- rewrote the script-install suite for the new tag-based spawn sequence and added `pickLatestTag` unit tests (version vs lexicographic ordering, four-part versions, non-version refs).