### PR TITLE
Fix onboarding skip, lost completion state, and TTS-off interview deadlock

### DIFF
--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -1,8 +1,8 @@
 import { test, expect, describe, beforeEach, afterEach } from 'bun:test';
 import { loadConfig, saveConfig } from './loader.ts';
 import { DEFAULT_CONFIG } from './types.ts';
-import { existsSync, statSync } from 'node:fs';
-import { chmod, mkdtemp, rm } from 'node:fs/promises';
+import { existsSync, lstatSync, statSync } from 'node:fs';
+import { chmod, mkdtemp, readdir, rm, symlink } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join, isAbsolute } from 'node:path';
 
@@ -391,6 +391,56 @@ voice:
     process.env.JARVIS_WAKE_ENGINE = 'siri';
     const config = await loadConfig('/tmp/jarvis-voice-invalid-env.yaml');
     expect(config.voice?.wake_engine).toBe('openwakeword');
+  });
+});
+
+describe('Atomic Save', () => {
+  beforeEach(async () => {
+    await createTestConfigPath();
+  });
+
+  afterEach(async () => {
+    await rm(TEST_CONFIG_DIR, { recursive: true, force: true });
+  });
+
+  test('leaves no tmp files behind after repeated saves', async () => {
+    const config = structuredClone(DEFAULT_CONFIG);
+    config.onboarding = { setup_completed_at: 1, tutorial_completed_at: null };
+    await saveConfig(config, TEST_CONFIG_PATH);
+    config.onboarding = { setup_completed_at: 2, tutorial_completed_at: null };
+    await saveConfig(config, TEST_CONFIG_PATH);
+
+    const loaded = await loadConfig(TEST_CONFIG_PATH);
+    expect(loaded.onboarding?.setup_completed_at).toBe(2);
+    expect(await readdir(TEST_CONFIG_DIR)).toEqual(['config.yaml']);
+  });
+
+  test('concurrent saves never leave a truncated or missing config', async () => {
+    const configs = [1, 2, 3, 4, 5].map((n) => {
+      const c = structuredClone(DEFAULT_CONFIG);
+      c.onboarding = { setup_completed_at: n, tutorial_completed_at: null };
+      return c;
+    });
+    await Promise.all(configs.map((c) => saveConfig(c, TEST_CONFIG_PATH)));
+
+    // Whichever save won, the file must be complete and parseable.
+    const loaded = await loadConfig(TEST_CONFIG_PATH);
+    expect([1, 2, 3, 4, 5]).toContain(loaded.onboarding?.setup_completed_at ?? 0);
+    expect(await readdir(TEST_CONFIG_DIR)).toEqual(['config.yaml']);
+  });
+
+  test('refuses to replace a symlinked config and leaves the link intact', async () => {
+    const decoy = join(TEST_CONFIG_DIR, 'decoy.yaml');
+    await Bun.write(decoy, 'daemon:\n  port: 4444\n');
+    await symlink(decoy, TEST_CONFIG_PATH);
+
+    expect(saveConfig(DEFAULT_CONFIG, TEST_CONFIG_PATH)).rejects.toThrow(/symlink/);
+
+    // Neither the link target nor the link itself was touched, and the
+    // rejected tmp file was cleaned up.
+    expect(await Bun.file(decoy).text()).toBe('daemon:\n  port: 4444\n');
+    expect(lstatSync(TEST_CONFIG_PATH).isSymbolicLink()).toBe(true);
+    expect((await readdir(TEST_CONFIG_DIR)).sort()).toEqual(['config.yaml', 'decoy.yaml']);
   });
 });
 

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1,7 +1,7 @@
 import YAML from 'yaml';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
-import { rename, unlink } from 'node:fs/promises';
+import { lstat, rename, unlink } from 'node:fs/promises';
 import type { JarvisConfig } from './types.ts';
 import { DEFAULT_CONFIG } from './types.ts';
 import { secureParentDirectory, secureWriteFile } from '../util/fs-secure.ts';
@@ -164,6 +164,9 @@ function stripLLMConfigForYAML(config: JarvisConfig): JarvisConfig {
   return clone;
 }
 
+/** Monotonic per-process counter for unique save temp-file names. */
+let saveCounter = 0;
+
 export async function saveConfig(
   config: JarvisConfig,
   configPath?: string
@@ -182,10 +185,23 @@ export async function saveConfig(
     await secureParentDirectory(path);
     // Write-then-rename so the config is replaced atomically. A direct
     // O_TRUNC write leaves a truncated/empty config.yaml if the daemon is
-    // killed mid-write — on the next boot that parses as defaults and the
+    // killed mid-write -- on the next boot that parses as defaults and the
     // user loses onboarding state, authority overrides, everything.
-    const tmpPath = `${path}.tmp`;
+    // The tmp name carries pid + a counter so two concurrent saves can
+    // never rename each other's half-written file into place.
+    const tmpPath = `${path}.${process.pid}.${saveCounter++}.tmp`;
     await secureWriteFile(tmpPath, yaml, 0o600, 'Config');
+
+    // rename() would silently replace a symlinked config.yaml with a
+    // regular file (e.g. a link into a dotfiles repo). secureWriteFile
+    // refuses symlinks via O_NOFOLLOW; keep that contract here and fail
+    // loudly instead of clobbering the link.
+    const existing = await lstat(path).catch(() => null);
+    if (existing?.isSymbolicLink()) {
+      await unlink(tmpPath).catch(() => {});
+      throw new Error(`${path} is a symlink; refusing to replace it`);
+    }
+
     try {
       await rename(tmpPath, path);
     } catch {

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1,6 +1,7 @@
 import YAML from 'yaml';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
+import { rename, unlink } from 'node:fs/promises';
 import type { JarvisConfig } from './types.ts';
 import { DEFAULT_CONFIG } from './types.ts';
 import { secureParentDirectory, secureWriteFile } from '../util/fs-secure.ts';
@@ -179,7 +180,21 @@ export async function saveConfig(
     });
 
     await secureParentDirectory(path);
-    await secureWriteFile(path, yaml, 0o600, 'Config');
+    // Write-then-rename so the config is replaced atomically. A direct
+    // O_TRUNC write leaves a truncated/empty config.yaml if the daemon is
+    // killed mid-write — on the next boot that parses as defaults and the
+    // user loses onboarding state, authority overrides, everything.
+    const tmpPath = `${path}.tmp`;
+    await secureWriteFile(tmpPath, yaml, 0o600, 'Config');
+    try {
+      await rename(tmpPath, path);
+    } catch {
+      // Rename across-the-board works on POSIX; on Windows it can fail
+      // transiently (antivirus holding the target). Fall back to the
+      // in-place write rather than losing the save entirely.
+      await unlink(tmpPath).catch(() => {});
+      await secureWriteFile(path, yaml, 0o600, 'Config');
+    }
     console.log(`Config saved to ${path}`);
   } catch (err) {
     throw new Error(`Failed to save config to ${path}: ${err}`);

--- a/src/daemon/api-routes.ts
+++ b/src/daemon/api-routes.ts
@@ -980,6 +980,59 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
     },
 
     /**
+     * Skip the ENTIRE onboarding flow from the first setup screen. No LLM
+     * is configured, so the daemon stays chat-less until the user wires a
+     * provider up in Settings → LLM — but the dashboard becomes reachable
+     * immediately. Marks setup complete, opts out of the profile
+     * interview, and dismisses the tutorial in one write. Existing
+     * timestamps are preserved so a skip after a partial run never
+     * regresses state.
+     */
+    '/api/onboarding/skip': {
+      POST: async () => {
+        try {
+          const { loadConfig, saveConfig } = await import('../config/loader.ts');
+          const fresh = await loadConfig();
+          const now = Date.now();
+          fresh.onboarding = {
+            ...fresh.onboarding,
+            setup_completed_at: fresh.onboarding?.setup_completed_at ?? now,
+            tutorial_completed_at: fresh.onboarding?.tutorial_completed_at ?? null,
+            tutorial_dismissed_at: fresh.onboarding?.tutorial_dismissed_at ?? now,
+            setup_skipped_profile: true,
+          };
+          await saveConfig(fresh);
+          ctx.config.onboarding = fresh.onboarding;
+
+          // Best-effort service start so the "Restart Jarvis" banner
+          // doesn't nag after a skip. Failure is non-fatal — services
+          // that need an LLM just stay idle until one is configured.
+          let postSetupStarted = false;
+          if (ctx.startPostSetupServices) {
+            try {
+              await ctx.startPostSetupServices();
+              postSetupStarted = true;
+            } catch (err) {
+              console.warn(
+                '[Onboarding] Post-setup services skipped after onboarding skip:',
+                err instanceof Error ? err.message : err,
+              );
+            }
+          }
+
+          return json({
+            ok: true,
+            setup_completed_at: fresh.onboarding.setup_completed_at,
+            post_setup_services_started: postSetupStarted,
+            message: 'Onboarding skipped. Configure an LLM in Settings to start chatting.',
+          });
+        } catch (err) {
+          return errorFromException(err);
+        }
+      },
+    },
+
+    /**
      * Phase B — user skipped the conversational profile interview.
      * Sets `setup_skipped_profile: true` so the gate stops re-rendering
      * Phase B. Profile remains empty; user can fill it later via the
@@ -1156,30 +1209,39 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
             hotReloadLLMProviders(ctx.config, ctx.agentService.getLLMManager());
           }
 
-          // 2. STT settings — mirrors /api/config/stt POST semantics via
-          //    the shared mergeSTTConfig helper. STT is consumed at the
-          //    next transcription request, so no hot-swap is needed.
+          // 2. STT + TTS + the setup-completed flag in ONE config write.
+          //    These used to be three sequential load→save round-trips; a
+          //    daemon kill (or crash) between them persisted setup HALF-done
+          //    — TTS saved but the completion flag lost — and the user was
+          //    funneled back into onboarding on the next boot.
+          const { loadConfig, saveConfig } = await import('../config/loader.ts');
+          const { mergeSTTConfig, mergeTTSConfig } = await import('./config-merge.ts');
+          const fresh = await loadConfig();
           if (body.stt) {
-            const { loadConfig: lc, saveConfig: sc } = await import('../config/loader.ts');
-            const { mergeSTTConfig } = await import('./config-merge.ts');
-            const fresh = await lc();
+            // Mirrors /api/config/stt POST semantics. STT is consumed at
+            // the next transcription request, so no hot-swap is needed.
             fresh.stt = mergeSTTConfig(fresh.stt, body.stt);
-            await sc(fresh);
-            ctx.config.stt = fresh.stt;
           }
-
-          // 3. TTS settings — mirrors /api/config/tts POST via the shared
-          //    mergeTTSConfig helper, then hot-reloads the provider so the
-          //    post-setup "Welcome to Jarvis" reply is spoken immediately.
           if (body.tts) {
-            const { loadConfig: lc, saveConfig: sc } = await import('../config/loader.ts');
-            const { mergeTTSConfig } = await import('./config-merge.ts');
-            const fresh = await lc();
             fresh.tts = mergeTTSConfig(fresh.tts, body.tts);
-            await sc(fresh);
-            ctx.config.tts = fresh.tts;
-            // Hot-reload TTS provider when possible so the post-setup
-            // "Welcome to Jarvis" reply is spoken immediately.
+          }
+          const now = Date.now();
+          fresh.onboarding = {
+            setup_completed_at: now,
+            tutorial_completed_at: fresh.onboarding?.tutorial_completed_at ?? null,
+            setup_skipped_profile: fresh.onboarding?.setup_skipped_profile,
+            tutorial_dismissed_at: fresh.onboarding?.tutorial_dismissed_at,
+            tutorial_progress_step: fresh.onboarding?.tutorial_progress_step,
+            last_reset_at: fresh.onboarding?.last_reset_at,
+          };
+          await saveConfig(fresh);
+          if (body.stt) ctx.config.stt = fresh.stt;
+          if (body.tts) ctx.config.tts = fresh.tts;
+          ctx.config.onboarding = fresh.onboarding;
+
+          // 3. Hot-reload the TTS provider when possible so the post-setup
+          //    "Welcome to Jarvis" reply is spoken immediately.
+          if (body.tts) {
             try {
               if (ctx.config.tts && ctx.wsService) {
                 const { createTTSProvider } = await import('../comms/voice.ts');
@@ -1191,22 +1253,7 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
             }
           }
 
-          // 4. Flip the setup-completed flag.
-          const { loadConfig, saveConfig } = await import('../config/loader.ts');
-          const fresh = await loadConfig();
-          const now = Date.now();
-          fresh.onboarding = {
-            setup_completed_at: now,
-            tutorial_completed_at: fresh.onboarding?.tutorial_completed_at ?? null,
-            setup_skipped_profile: fresh.onboarding?.setup_skipped_profile,
-            tutorial_dismissed_at: fresh.onboarding?.tutorial_dismissed_at,
-            tutorial_progress_step: fresh.onboarding?.tutorial_progress_step,
-            last_reset_at: fresh.onboarding?.last_reset_at,
-          };
-          await saveConfig(fresh);
-          ctx.config.onboarding = fresh.onboarding;
-
-          // 5. Bring the LLM-dependent services (bgAgent, commitment
+          // 4. Bring the LLM-dependent services (bgAgent, commitment
           //    executor, awareness) online in-process. Without this the
           //    user would have to restart the daemon — fatal UX on
           //    Docker / VPS. Failure here is non-fatal: chat still works

--- a/src/daemon/ws-service.ts
+++ b/src/daemon/ws-service.ts
@@ -1487,9 +1487,10 @@ CRITICAL — when in genuine doubt between "make in a new project" vs "add to th
     // "speaking" state machine.
     if (willSpeak && this.ttsProvider) {
       const requestId = `interview-${Date.now()}`;
-      // tts_start is only sent right before the first chunk so a
-      // provider that fails instantly never strands the UI in
-      // "speaking" with no audio and no tts_end.
+      // Tracks whether the tts_start frame went out: the finally block
+      // below closes it with tts_end exactly when it was opened, so a
+      // provider that throws -- even before the first chunk -- never
+      // strands the UI in "speaking" with no audio and no tts_end.
       let ttsStarted = false;
       try {
         this.wsServer.sendToClient(ws, {

--- a/src/daemon/ws-service.ts
+++ b/src/daemon/ws-service.ts
@@ -1461,6 +1461,13 @@ CRITICAL — when in genuine doubt between "make in a new project" vs "add to th
 
     const text = result.assistantText.trim();
 
+    // Decide up-front whether audio will follow, and TELL the UI in the
+    // text message. The UI must not guess: when it assumed TTS based on
+    // its own (possibly stale) settings fetch and no `tts_start` ever
+    // arrived — e.g. TTS disabled, or no provider loaded — it sat in
+    // "Jarvis is thinking…" forever with the composer disabled.
+    const willSpeak = Boolean(speakReply && this.ttsProvider && text);
+
     // Send the text reply for the UI to render in the chat-bubble
     // layout (always — the bubble is the visual record even when TTS
     // is on).
@@ -1470,16 +1477,20 @@ CRITICAL — when in genuine doubt between "make in a new project" vs "add to th
         text,
         facts_recorded: result.factsRecorded,
         done: result.done,
+        will_speak: willSpeak,
       },
       timestamp: Date.now(),
     });
 
-    // If TTS is on AND the user wants the reply spoken AND we have a
-    // provider loaded, stream the audio. Reuse the existing
-    // `tts_start` + binary chunks pipeline so the UI's MicOrb plays
-    // it through the normal "speaking" state machine.
-    if (speakReply && this.ttsProvider && text) {
+    // Stream the audio via the existing `tts_start` + binary chunks
+    // pipeline so the UI's MicOrb plays it through the normal
+    // "speaking" state machine.
+    if (willSpeak && this.ttsProvider) {
       const requestId = `interview-${Date.now()}`;
+      // tts_start is only sent right before the first chunk so a
+      // provider that fails instantly never strands the UI in
+      // "speaking" with no audio and no tts_end.
+      let ttsStarted = false;
       try {
         this.wsServer.sendToClient(ws, {
           type: 'tts_start',
@@ -1490,17 +1501,23 @@ CRITICAL — when in genuine doubt between "make in a new project" vs "add to th
           id: requestId,
           timestamp: Date.now(),
         });
+        ttsStarted = true;
         for await (const chunk of this.ttsProvider.synthesizeStream(text)) {
           this.wsServer.sendBinary(ws, chunk);
         }
-        this.wsServer.sendToClient(ws, {
-          type: 'tts_end',
-          payload: { requestId },
-          id: requestId,
-          timestamp: Date.now(),
-        });
       } catch (err) {
         console.warn('[WSService] Interview TTS failed:', err);
+      } finally {
+        // Always close the TTS frame once it was opened — a synthesis
+        // failure mid-stream must not leave the UI waiting forever.
+        if (ttsStarted) {
+          this.wsServer.sendToClient(ws, {
+            type: 'tts_end',
+            payload: { requestId },
+            id: requestId,
+            timestamp: Date.now(),
+          });
+        }
       }
     }
 

--- a/ui/src/v2/onboarding/OnboardingGate.tsx
+++ b/ui/src/v2/onboarding/OnboardingGate.tsx
@@ -22,7 +22,11 @@ import { RestartRequiredBanner, shouldShowRestartBanner } from "./RestartRequire
  */
 export function OnboardingGate({ children }: { children: React.ReactNode }) {
   const { status, loading, refresh } = useOnboardingStatus();
-  const [ttsDisabled, setTtsDisabled] = useState(false);
+  // null = TTS state unknown (fetch in flight). The interview room must
+  // NOT mount until this resolves: it latches voice-vs-text mode at
+  // mount, so mounting with a guessed value put TTS-off users in voice
+  // mode — they then waited forever for audio that never came.
+  const [ttsDisabled, setTtsDisabled] = useState<boolean | null>(null);
 
   // Look up TTS state once we're past setup so Phase B can decide
   // whether to render in voice or text-only mode. Cheap one-shot
@@ -34,7 +38,7 @@ export function OnboardingGate({ children }: { children: React.ReactNode }) {
     fetch("/api/config/tts")
       .then((r) => (r.ok ? r.json() : null))
       .then((d) => {
-        if (d && typeof d.enabled === "boolean") setTtsDisabled(!d.enabled);
+        setTtsDisabled(d && typeof d.enabled === "boolean" ? !d.enabled : false);
       })
       .catch(() => setTtsDisabled(false));
   }, [status?.setup_completed, status?.profile_completed, status?.setup_skipped_profile]);
@@ -54,6 +58,11 @@ export function OnboardingGate({ children }: { children: React.ReactNode }) {
   }
 
   if (!status.profile_completed && !status.setup_skipped_profile) {
+    // Hold mount until the TTS check resolves (~50ms on localhost) —
+    // same blank-frame treatment as the status fetch above.
+    if (ttsDisabled === null) {
+      return null;
+    }
     return (
       <ProfileInterviewRoom
         ttsDisabled={ttsDisabled}

--- a/ui/src/v2/onboarding/SetupRoom.css
+++ b/ui/src/v2/onboarding/SetupRoom.css
@@ -69,6 +69,37 @@
 .v2-setup__progress-step[data-done="true"] { color: var(--ok); }
 .v2-setup__progress-sep { opacity: 0.4; }
 
+.v2-setup__skip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 12px;
+  background: transparent;
+  border: 1px solid var(--rule);
+  border-radius: var(--r-pill);
+  color: var(--ink-2);
+  font-family: var(--font-sans);
+  font-size: var(--text-xs);
+  cursor: pointer;
+  transition: background var(--dur-fast) var(--ease-out),
+              color var(--dur-fast) var(--ease-out);
+}
+
+.v2-setup__skip:hover {
+  background: var(--paper-3);
+  color: var(--ink);
+}
+
+.v2-setup__skip:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.v2-setup__skip:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
 /* ── Screen ── */
 
 .v2-setup__screen {

--- a/ui/src/v2/onboarding/SetupRoom.tsx
+++ b/ui/src/v2/onboarding/SetupRoom.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { ArrowRight, Check, Loader2, Mic, MicOff, Volume2, VolumeX, type LucideIcon } from "lucide-react";
+import { ArrowRight, Check, Loader2, Mic, MicOff, SkipForward, Volume2, VolumeX, type LucideIcon } from "lucide-react";
 import { Button, Icon } from "../ui";
 import "./SetupRoom.css";
 
@@ -246,6 +246,34 @@ export function SetupRoom({ onComplete }: { onComplete: () => void }) {
   // ── Submit state ───────────────────────────────────────────────────
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
+  const [skipping, setSkipping] = useState(false);
+  const [skipError, setSkipError] = useState<string | null>(null);
+
+  // Escape hatch available from every setup screen. No LLM gets
+  // configured, so Jarvis can't chat until the user wires a provider
+  // up in Settings — but they reach the dashboard immediately.
+  const handleSkipSetup = async () => {
+    if (
+      !confirm(
+        "Skip setup? Jarvis won't be able to respond until you configure an LLM in Settings. You can re-run onboarding any time from Settings.",
+      )
+    ) {
+      return;
+    }
+    setSkipping(true);
+    setSkipError(null);
+    try {
+      const r = await fetch("/api/onboarding/skip", { method: "POST" });
+      if (!r.ok) {
+        const text = await r.text().catch(() => `HTTP ${r.status}`);
+        throw new Error(text || `HTTP ${r.status}`);
+      }
+      onComplete();
+    } catch (err) {
+      setSkipError(err instanceof Error ? err.message : "Skip failed.");
+      setSkipping(false);
+    }
+  };
 
   const handlePickProvider = (id: LLMProviderId) => {
     setProviderId(id);
@@ -444,7 +472,22 @@ export function SetupRoom({ onComplete }: { onComplete: () => void }) {
               3 · Voice Out
             </div>
           </div>
+          <button
+            type="button"
+            className="v2-setup__skip"
+            onClick={handleSkipSetup}
+            disabled={skipping || saving}
+          >
+            <Icon icon={SkipForward} size="sm" />
+            {skipping ? "Skipping…" : "Skip setup"}
+          </button>
         </header>
+
+        {skipError && (
+          <div className="v2-setup__error" role="alert">
+            {skipError}
+          </div>
+        )}
 
         {screen === "llm" ? (
           <section className="v2-setup__screen">

--- a/ui/src/v2/onboarding/useInterviewSession.ts
+++ b/ui/src/v2/onboarding/useInterviewSession.ts
@@ -74,6 +74,7 @@ export function useInterviewSession(opts: {
   const audioQueueRef = useRef<ArrayBuffer[]>([]);
   const audioPlayingRef = useRef(false);
   const ttsPendingRef = useRef(false);
+  const ttsFallbackTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const [phase, setPhase] = useState<InterviewState["phase"]>("connecting");
   const [orbState, setOrbState] = useState<OrbState>("idle");
@@ -82,7 +83,37 @@ export function useInterviewSession(opts: {
   const [factsRecorded, setFactsRecorded] = useState(0);
   const [farewell, setFarewell] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [textOnly, setTextOnly] = useState(opts.ttsDisabled);
+  const [textOnly, setTextOnlyState] = useState(opts.ttsDisabled);
+  // The WS handlers below live in a mount-once effect, so reading the
+  // `textOnly` state there would see the value frozen at mount. The ref
+  // is the live view — without it, toggling "Continue with text only"
+  // mid-session left the handlers waiting for TTS that was no longer
+  // requested.
+  const textOnlyRef = useRef(textOnly);
+
+  const clearTtsFallbackTimer = useCallback(() => {
+    if (ttsFallbackTimerRef.current !== null) {
+      clearTimeout(ttsFallbackTimerRef.current);
+      ttsFallbackTimerRef.current = null;
+    }
+  }, []);
+
+  /** Toggle text-only mode. Turning it ON also rescues a session stuck
+   *  waiting on TTS audio — flip straight to listening so the composer
+   *  re-enables. */
+  const setTextOnly = useCallback(
+    (next: boolean) => {
+      textOnlyRef.current = next;
+      setTextOnlyState(next);
+      if (next && ttsPendingRef.current) {
+        ttsPendingRef.current = false;
+        clearTtsFallbackTimer();
+        setPhase("listening");
+        setOrbState("listening");
+      }
+    },
+    [clearTtsFallbackTimer],
+  );
 
   // ── WS lifecycle ─────────────────────────────────────────────────
   useEffect(() => {
@@ -97,7 +128,7 @@ export function useInterviewSession(opts: {
       ws.send(
         JSON.stringify({
           type: "interview_start",
-          payload: { speakReply: !textOnly },
+          payload: { speakReply: !textOnlyRef.current },
           timestamp: Date.now(),
         }),
       );
@@ -106,7 +137,7 @@ export function useInterviewSession(opts: {
     ws.onmessage = (event) => {
       // Binary frames are TTS audio chunks.
       if (event.data instanceof ArrayBuffer) {
-        if (textOnly) return; // ignore audio in text-only mode
+        if (textOnlyRef.current) return; // ignore audio in text-only mode
         audioQueueRef.current.push(event.data);
         if (!audioPlayingRef.current) playNextChunk();
         return;
@@ -133,18 +164,37 @@ export function useInterviewSession(opts: {
           }
           // We get the text immediately; if TTS will follow, the
           // orb stays in "thinking" until tts_start fires. If not,
-          // jump straight to listening so the user can reply.
-          if (textOnly || !text) {
+          // jump straight to listening so the user can reply. The
+          // daemon says explicitly whether audio is coming
+          // (`will_speak`) — trust it over our local mode guess, so
+          // a TTS-less daemon never strands us waiting for audio.
+          // (Older daemons omit the field; undefined falls through
+          // to the local guess + timeout fallback below.)
+          const willSpeak = msg.payload?.will_speak;
+          if (textOnlyRef.current || !text || willSpeak === false) {
             setPhase("listening");
             setOrbState("listening");
           } else {
             ttsPendingRef.current = true;
+            // Safety net: if tts_start never arrives (provider died,
+            // pre-will_speak daemon with TTS off), un-stick the
+            // composer rather than waiting forever.
+            clearTtsFallbackTimer();
+            ttsFallbackTimerRef.current = setTimeout(() => {
+              ttsFallbackTimerRef.current = null;
+              if (ttsPendingRef.current) {
+                ttsPendingRef.current = false;
+                setPhase("listening");
+                setOrbState("listening");
+              }
+            }, 10_000);
           }
           break;
         }
         case "tts_start":
-          if (!textOnly) {
+          if (!textOnlyRef.current) {
             ttsPendingRef.current = false;
+            clearTtsFallbackTimer();
             setPhase("speaking");
             setOrbState("speaking");
             // Pre-warm AudioContext so the first chunk plays cleanly.
@@ -213,6 +263,7 @@ export function useInterviewSession(opts: {
       }
       audioCtxRef.current = null;
       audioQueueRef.current = [];
+      clearTtsFallbackTimer();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -271,12 +322,12 @@ export function useInterviewSession(opts: {
       ws.send(
         JSON.stringify({
           type: "interview_user_message",
-          payload: { text: trimmed, speakReply: !textOnly },
+          payload: { text: trimmed, speakReply: !textOnlyRef.current },
           timestamp: Date.now(),
         }),
       );
     },
-    [textOnly],
+    [],
   );
 
   return {

--- a/ui/src/v2/onboarding/useOnboardingStatus.ts
+++ b/ui/src/v2/onboarding/useOnboardingStatus.ts
@@ -77,9 +77,7 @@ export function useOnboardingStatus(): HookValue {
   const refresh = useCallback(async () => {
     setLoading(true);
     try {
-      const r = await fetch("/api/onboarding/status");
-      if (!r.ok) throw new Error(`HTTP ${r.status}`);
-      const json = (await r.json()) as OnboardingStatus;
+      const json = await fetchStatusWithRetry();
       setStatus((prev) => {
         // Phase E — when this refresh was triggered locally (not by a
         // peer tab) and any phase flag flipped, broadcast so peers
@@ -100,11 +98,13 @@ export function useOnboardingStatus(): HookValue {
       setError(null);
     } catch (err) {
       // The status endpoint is one of the few routes that should
-      // ALWAYS work — even in setup mode. If it 5xxs we treat it as
-      // "not yet onboarded" rather than blocking the user behind a
-      // permanent error screen. The OnboardingGate's render path
-      // checks `status === null` to mean "still loading"; we set a
-      // sentinel below so the gate falls through to setup screens.
+      // ALWAYS work — even in setup mode. After retries are exhausted
+      // we treat failure as "not yet onboarded" rather than blocking
+      // the user behind a permanent error screen. The OnboardingGate's
+      // render path checks `status === null` to mean "still loading";
+      // we set a sentinel below so the gate falls through to setup
+      // screens. (The retries above keep a daemon that's mid-restart
+      // from flashing the setup flow at an already-onboarded user.)
       setError(err instanceof Error ? err.message : String(err));
       setStatus({
         setup_completed: false,
@@ -150,6 +150,29 @@ export function useOnboardingStatus(): HookValue {
   }, [refresh]);
 
   return { status, loading, error, refresh };
+}
+
+/** Fetch `/api/onboarding/status` with a few short retries. A daemon
+ *  that is mid-restart (or briefly 503ing while services come up) used
+ *  to fail the single fetch, and the error fallback re-showed the full
+ *  setup flow to an already-onboarded user. Three attempts over ~2s
+ *  ride out the transient without meaningfully delaying real new
+ *  installs (where the endpoint answers instantly). */
+async function fetchStatusWithRetry(): Promise<OnboardingStatus> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < 3; attempt++) {
+    if (attempt > 0) {
+      await new Promise((resolve) => setTimeout(resolve, attempt * 700));
+    }
+    try {
+      const r = await fetch("/api/onboarding/status");
+      if (!r.ok) throw new Error(`HTTP ${r.status}`);
+      return (await r.json()) as OnboardingStatus;
+    } catch (err) {
+      lastError = err;
+    }
+  }
+  throw lastError;
 }
 
 /** Compare phase-relevant flags between two snapshots. Returns true if


### PR DESCRIPTION
 Fix onboarding bugs: missing skip option, lost completion state, TTS-off interview deadlock

  This PR fixes three onboarding bugs: no way to skip setup, onboarding being re-asked after a daemon relaunch, and the
  profile interview hanging forever when voice is disabled.

  1. No way to skip setup

  The first-run setup had no escape hatch — the LLM screen hard-gated "Continue" on a successful connection test, so users
  without an API key on hand were stuck.

  - Added a "Skip setup" button to the SetupRoom header, visible on all three screens, with a confirmation warning that
  Jarvis can't chat until an LLM is configured in Settings.
  - New POST /api/onboarding/skip endpoint: marks setup complete, opts out of the profile interview, and dismisses the
  tutorial in a single config write. Existing timestamps are preserved so a skip after a partial run never regresses state.
  Post-setup services are started best-effort so the "Restart Jarvis" banner doesn't nag.

  2. Onboarding re-asked after relaunch

  The onboarding.setup_completed_at flag could genuinely get lost from config.yaml:

  - saveConfig was not atomic — it truncated the file in place (O_TRUNC). A daemon kill mid-write left a truncated/partial
  config that parses as defaults on next boot, wiping onboarding state (and everything else). Now writes to a .tmp file and
  renames it into place, with a fallback to the in-place write if the rename fails (Windows edge case).
  - /api/onboarding/setup did four sequential load→save round-trips (LLM, STT, TTS, completion flag). A crash between writes
  persisted setup half-done — TTS saved, flag lost — exactly the failure signature observed in the field. STT + TTS + the
  flag are now merged into one config write.
  - The dashboard treated any single failed status fetch as "never onboarded" and re-showed the setup flow.
  useOnboardingStatus now retries 3× over ~2s before falling back, so a daemon mid-restart no longer flashes setup at an
  already-onboarded user.

  3. Profile interview stuck on "Jarvis is thinking…" when TTS is off

  This was deterministic, not intermittent. OnboardingGate fetched /api/config/tts after mounting ProfileInterviewRoom,
  which latches voice-vs-text mode at mount (useState(opts.ttsDisabled)). With TTS off, the interview always started in
  voice mode, waited for a tts_start the daemon never sends (no TTS provider), and the composer stayed disabled forever.