### PR TITLE
Fix authority gate agents

### DIFF
--- a/src/actions/tools/agents.ts
+++ b/src/actions/tools/agents.ts
@@ -12,7 +12,7 @@ import type { AgentOrchestrator } from '../../agents/orchestrator.ts';
 import type { LLMManager } from '../../llm/manager.ts';
 import type { RoleDefinition } from '../../roles/types.ts';
 import type { ToolDefinition } from './registry.ts';
-import type { AgentTaskManager } from '../../agents/task-manager.ts';
+import type { AgentTaskManager, AsyncTask } from '../../agents/task-manager.ts';
 import { createScopedToolRegistry, type ProgressCallback } from '../../agents/sub-agent-runner.ts';
 
 export type AgentToolDeps = {
@@ -21,6 +21,9 @@ export type AgentToolDeps = {
   specialists: Map<string, RoleDefinition>;
   taskManager: AgentTaskManager;
   onProgress?: ProgressCallback;
+  /** Fires when an assigned task settles -- success OR failure (the
+   *  'done' progress event only fires on the success path). */
+  onTaskComplete?: (task: AsyncTask) => void;
 };
 
 export class HttpError extends Error {
@@ -113,6 +116,7 @@ export async function assignPersistentAgentTask(
     llmManager: deps.llmManager,
     toolRegistry: scopedRegistry,
     onProgress: deps.onProgress,
+    onComplete: deps.onTaskComplete,
   });
 
   console.log(`[ManageAgents] Assigned task ${taskId} to ${agent.agent.role.name}`);

--- a/src/agents/agent-spawn-authority.test.ts
+++ b/src/agents/agent-spawn-authority.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from 'bun:test';
+import { join } from 'node:path';
+import { AgentInstance, canSpawnChildren } from './agent.ts';
+import { AgentOrchestrator } from './orchestrator.ts';
+import { loadRole } from '../roles/loader.ts';
+import type { RoleDefinition } from '../roles/types.ts';
+import { AuthorityEngine, type AuthorityConfig } from '../authority/engine.ts';
+
+function makeEngine(overrides: AuthorityConfig['overrides'] = []): AuthorityEngine {
+  return new AuthorityEngine({
+    default_level: 5,
+    governed_categories: [],
+    overrides,
+    context_rules: [],
+    learning: { enabled: false, suggest_threshold: 5 },
+    emergency_state: 'normal',
+  });
+}
+
+const ROLES_DIR = join(import.meta.dir, '../../roles');
+
+function makeRole(overrides: Partial<RoleDefinition>): RoleDefinition {
+  return {
+    id: 'test-role',
+    name: 'Test Role',
+    description: 'A test role.',
+    responsibilities: ['Test things'],
+    autonomous_actions: [],
+    approval_required: [],
+    tools: [],
+    authority_level: 5,
+    ...overrides,
+  } as RoleDefinition;
+}
+
+describe('canSpawnChildren', () => {
+  it('is true for a role that declares the delegation tool (no sub_roles)', () => {
+    const role = makeRole({ tools: ['browser', 'delegation'] });
+    expect(canSpawnChildren(role)).toBe(true);
+  });
+
+  it('is true for a role with sub_roles templates (legacy path)', () => {
+    const role = makeRole({
+      sub_roles: [
+        {
+          role_id: 'helper',
+          name: 'Helper',
+          description: 'helps',
+          spawned_by: 'test-role',
+          reports_to: 'test-role',
+          max_budget_per_task: 1000,
+        },
+      ],
+    });
+    expect(canSpawnChildren(role)).toBe(true);
+  });
+
+  it('is false for a leaf role with neither', () => {
+    const role = makeRole({ tools: ['browser'], sub_roles: [] });
+    expect(canSpawnChildren(role)).toBe(false);
+  });
+});
+
+describe('AgentInstance default authority', () => {
+  it('grants can_spawn_children to delegation-capable roles', () => {
+    const agent = new AgentInstance(makeRole({ tools: ['delegation'] }));
+    expect(agent.agent.authority.can_spawn_children).toBe(true);
+  });
+
+  it('denies can_spawn_children to leaf roles', () => {
+    const agent = new AgentInstance(makeRole({ tools: ['browser'] }));
+    expect(agent.agent.authority.can_spawn_children).toBe(false);
+  });
+});
+
+describe('spawnSubAgent authority gate', () => {
+  // Regression for "Jarvis says it cannot spawn sub-agents despite max
+  // authority": the default personal-assistant role ships the delegation
+  // tool but no sub_roles, and the old sub_roles-derived flag refused
+  // every spawn from it.
+  it('lets the real personal-assistant role spawn a real specialist', () => {
+    const pa = loadRole(join(ROLES_DIR, 'personal-assistant.yaml'));
+    const specialist = loadRole(join(ROLES_DIR, 'specialists/research-analyst.yaml'));
+
+    const orch = new AgentOrchestrator();
+    const primary = orch.createPrimary(pa);
+    expect(primary.agent.authority.can_spawn_children).toBe(true);
+
+    const child = orch.spawnSubAgent(primary.id, specialist);
+    expect(child.agent.parent_id).toBe(primary.id);
+    // Specialists are leaves: no delegation tool, no sub_roles.
+    expect(child.agent.authority.can_spawn_children).toBe(false);
+  });
+
+  it('refuses spawning from a leaf role with a message naming the role (no engine wired)', () => {
+    const leaf = makeRole({ id: 'leaf-role', tools: ['browser'] });
+    const someRole = makeRole({ id: 'other' });
+
+    const orch = new AgentOrchestrator();
+    const primary = orch.createPrimary(leaf);
+
+    expect(() => orch.spawnSubAgent(primary.id, someRole)).toThrow(/leaf-role/);
+  });
+});
+
+describe('authority engine as prime decider for spawning', () => {
+  it('an explicit spawn_agent DENY blocks even a delegation-capable role', () => {
+    const pa = makeRole({ id: 'pa', tools: ['delegation'] });
+    const specialist = makeRole({ id: 'spec', tools: ['browser'] });
+
+    const orch = new AgentOrchestrator();
+    orch.setAuthorityEngine(
+      makeEngine([{ action: 'spawn_agent', allowed: false }]),
+    );
+    const primary = orch.createPrimary(pa);
+    expect(primary.agent.authority.can_spawn_children).toBe(true);
+
+    expect(() => orch.spawnSubAgent(primary.id, specialist)).toThrow(
+      /Authority denied/,
+    );
+  });
+
+  it('an explicit spawn_agent ALLOW unblocks a role without the delegation tool', () => {
+    const limited = makeRole({ id: 'limited', tools: ['browser'] });
+    const specialist = makeRole({ id: 'spec', tools: ['browser'] });
+
+    const orch = new AgentOrchestrator();
+    orch.setAuthorityEngine(
+      makeEngine([{ action: 'spawn_agent', allowed: true, requires_approval: false }]),
+    );
+    const primary = orch.createPrimary(limited);
+    expect(primary.agent.authority.can_spawn_children).toBe(false);
+
+    const child = orch.spawnSubAgent(primary.id, specialist);
+    expect(child.agent.parent_id).toBe(primary.id);
+  });
+
+  it('with an engine wired and no overrides, the level check decides (spawn_agent requires level 1)', () => {
+    const pa = makeRole({ id: 'pa', tools: ['delegation'], authority_level: 5 });
+    const specialist = makeRole({ id: 'spec', tools: ['browser'] });
+
+    const orch = new AgentOrchestrator();
+    orch.setAuthorityEngine(makeEngine());
+    const primary = orch.createPrimary(pa);
+
+    const child = orch.spawnSubAgent(primary.id, specialist);
+    expect(child.agent.parent_id).toBe(primary.id);
+  });
+
+  it('a role-scoped deny only blocks that role', () => {
+    const pa = makeRole({ id: 'pa', tools: ['delegation'] });
+    const specialist = makeRole({ id: 'spec', tools: ['browser'] });
+
+    const orch = new AgentOrchestrator();
+    orch.setAuthorityEngine(
+      makeEngine([{ action: 'spawn_agent', role_id: 'someone-else', allowed: false }]),
+    );
+    const primary = orch.createPrimary(pa);
+
+    const child = orch.spawnSubAgent(primary.id, specialist);
+    expect(child.agent.parent_id).toBe(primary.id);
+  });
+});

--- a/src/agents/agent.ts
+++ b/src/agents/agent.ts
@@ -24,6 +24,22 @@ export type Agent = {
 };
 
 /**
+ * Whether a role is allowed to spawn sub-agents.
+ *
+ * A role can delegate when it declares the `delegation` tool (the
+ * mechanism `delegate_task` / `manage_agents` actually use — specialists
+ * are discovered from roles/specialists/, not from the role file) OR
+ * when it defines legacy `sub_roles` templates. Deriving this from
+ * `sub_roles` alone broke delegation for the default personal-assistant
+ * role: it ships the delegation tool and a prompt that advertises
+ * delegation, but no `sub_roles`, so every spawn was refused regardless
+ * of the configured authority level.
+ */
+export function canSpawnChildren(role: RoleDefinition): boolean {
+  return role.tools.includes('delegation') || (role.sub_roles?.length ?? 0) > 0;
+}
+
+/**
  * Default authority bounds for an agent
  */
 function getDefaultAuthority(role: RoleDefinition): AuthorityBounds {
@@ -32,7 +48,7 @@ function getDefaultAuthority(role: RoleDefinition): AuthorityBounds {
     allowed_tools: role.tools,
     denied_tools: [],
     max_token_budget: 100000,
-    can_spawn_children: (role.sub_roles?.length ?? 0) > 0,
+    can_spawn_children: canSpawnChildren(role),
   };
 }
 

--- a/src/agents/orchestrator.ts
+++ b/src/agents/orchestrator.ts
@@ -3,7 +3,7 @@ import type { LLMMessage, LLMResponse, LLMStreamEvent, LLMToolCall, LLMTool, Con
 import { guardImageSize } from '../llm/provider.ts';
 import { LLMManager } from '../llm/manager.ts';
 import type { Tier } from '../llm/tiers.ts';
-import { AgentInstance } from './agent.ts';
+import { AgentInstance, canSpawnChildren } from './agent.ts';
 import { AgentHierarchy } from './hierarchy.ts';
 import { ToolRegistry, type ToolDefinition, isToolResult } from '../actions/tools/registry.ts';
 import { toolDefToLLMTool } from '../actions/tools/builtin.ts';
@@ -172,8 +172,35 @@ export class AgentOrchestrator {
       throw new Error(`Parent agent not found: ${parentId}`);
     }
 
-    if (!parent.agent.authority.can_spawn_children) {
-      throw new Error('Parent agent does not have authority to spawn children');
+    // The authority engine is the PRIME decider for spawning. The user's
+    // explicit configuration (per-action overrides, context rules, the
+    // authority slider) wins over the role-derived capability flag in
+    // BOTH directions: a `spawn_agent` deny blocks a delegation-capable
+    // role, and an allow unblocks a role that never declared delegation.
+    // This also covers spawn paths that bypass the tool-level gate
+    // (dashboard spawn dialog, workflow delegator). The role flag is
+    // only the fallback when no engine is wired (tests, embedded use).
+    if (this.authorityEngine) {
+      const decision = this.authorityEngine.checkAuthority({
+        agentId: parent.id,
+        agentAuthorityLevel: parent.agent.authority.max_authority_level,
+        agentRoleId: parent.agent.role.id,
+        toolName: 'spawn_sub_agent',
+        toolCategory: 'delegation',
+        actionCategory: 'spawn_agent',
+        temporaryGrants: this.temporaryGrants,
+      });
+      if (!decision.allowed) {
+        throw new Error(`Authority denied spawning a sub-agent: ${decision.reason}`);
+      }
+      // `requiresApproval` is intentionally treated as allowed here: the
+      // soft gate runs at the TOOL layer (executeTool intercepts
+      // delegate_task/manage_agents before they execute), so by the time
+      // we get here the approval either wasn't needed or was granted.
+    } else if (!parent.agent.authority.can_spawn_children) {
+      throw new Error(
+        `Agent role "${parent.agent.role.id}" cannot spawn sub-agents: the role declares neither the "delegation" tool nor any sub_roles. Add "delegation" to the role's tools list to enable delegation.`,
+      );
     }
 
     // Create child agent with reduced authority
@@ -187,7 +214,7 @@ export class AgentOrchestrator {
       ),
       denied_tools: parent.agent.authority.denied_tools,
       max_token_budget: Math.floor(parent.agent.authority.max_token_budget / 2),
-      can_spawn_children: (role.sub_roles?.length ?? 0) > 0,
+      can_spawn_children: canSpawnChildren(role),
     };
 
     const agent = new AgentInstance(role, {

--- a/src/daemon/api-routes.ts
+++ b/src/daemon/api-routes.ts
@@ -199,7 +199,35 @@ type AgentTaskSnapshot = {
   task: string;
   startedAt: number;
   completedAt?: number | null;
+  result?: {
+    success: boolean;
+    response: string;
+    toolsUsed: string[];
+    terminationReason: string;
+  } | null;
 };
+
+/** Serialize a task (with its result, when finished) for API responses.
+ *  The result is the ONLY place the sub-agent's final answer lives for
+ *  dashboard-spawned tasks — without it the UI could show that a task
+ *  completed but never what it produced. */
+function taskToJSON(task: AgentTaskSnapshot) {
+  return {
+    id: task.id,
+    status: task.status,
+    task: task.task,
+    started_at: task.startedAt,
+    completed_at: task.completedAt ?? null,
+    result: task.result
+      ? {
+          success: task.result.success,
+          response: task.result.response,
+          tools_used: task.result.toolsUsed,
+          termination_reason: task.result.terminationReason,
+        }
+      : null,
+  };
+}
 
 function buildAgentSnapshots(ctx: ApiContext) {
   const orchestrator = ctx.agentService.getOrchestrator();
@@ -227,13 +255,7 @@ function buildAgentSnapshots(ctx: ApiContext) {
     return {
       ...base,
       busy: busyAgents.has(agent.id),
-      latest_task: latestTask ? {
-        id: latestTask.id,
-        status: latestTask.status,
-        task: latestTask.task,
-        started_at: latestTask.startedAt,
-        completed_at: latestTask.completedAt,
-      } : null,
+      latest_task: latestTask ? taskToJSON(latestTask) : null,
     };
   });
 
@@ -706,6 +728,21 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
             llmManager: ctx.agentService.getLLMManager(),
             specialists: ctx.agentService.getSpecialists(),
             taskManager,
+            // Dashboard-spawned tasks used to run with NO progress callback:
+            // nothing streamed to the live ticker, nothing persisted to the
+            // activity timeline, and the user never learned the task had
+            // finished (let alone what it produced). Mirror the wiring the
+            // PA's manage_agents tool gets at boot, plus a completion
+            // notification pointing at the Agents room.
+            onProgress: (event: { type: 'text' | 'tool_call' | 'done'; agentName: string; agentId: string; data: unknown }) => {
+              ctx.wsService?.broadcastSubAgentProgress(event);
+              if (event.type === 'done') {
+                ctx.wsService?.broadcastNotification(
+                  `**${event.agentName} finished its task.** Open the Agents room to read the result.`,
+                  'normal',
+                );
+              }
+            },
           };
 
           const spawned = spawnPersistentAgent(deps, body.specialist ?? '');
@@ -723,13 +760,7 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
           return json({
             ...spawned.agent.toJSON(),
             busy: taskManager.isAgentBusy(spawned.agent.id),
-            latest_task: latestTask ? {
-              id: latestTask.id,
-              status: latestTask.status,
-              task: latestTask.task,
-              started_at: latestTask.startedAt,
-              completed_at: latestTask.completedAt,
-            } : null,
+            latest_task: latestTask ? taskToJSON(latestTask) : null,
             spawned: spawned.summary,
             assignment,
           }, 201);
@@ -823,6 +854,23 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
           specialists: ctx.agentService.getSpecialists(),
           taskManager: tm,
         }));
+      },
+    },
+
+    // Full detail (including the sub-agent's final result) for a single
+    // async task. The list endpoints above intentionally truncate.
+    '/api/agents/tasks/:id': {
+      GET: (req: Request & { params: { id: string } }) => {
+        const tm = ctx.agentService.getTaskManager();
+        if (!tm) return error('Persistent agents are not available.', 503);
+        const task = tm.getTask(req.params.id);
+        if (!task) return error(`Task "${req.params.id}" not found.`, 404);
+        return json({
+          ...taskToJSON(task),
+          agent_id: task.agentId,
+          agent_name: task.agentName,
+          specialist_id: task.specialistId,
+        });
       },
     },
 

--- a/src/daemon/api-routes.ts
+++ b/src/daemon/api-routes.ts
@@ -55,6 +55,7 @@ import {
   spawnPersistentAgent,
   terminatePersistentAgent,
 } from '../actions/tools/agents.ts';
+import type { AsyncTask } from '../agents/task-manager.ts';
 
 import { mkdirSync, existsSync } from 'node:fs';
 import path from 'node:path';
@@ -207,11 +208,18 @@ type AgentTaskSnapshot = {
   } | null;
 };
 
+/** List payloads cap the response so the 5s roster poll never ships a
+ *  full research report per agent; /api/agents/tasks/:id returns it
+ *  whole and the UI fetches that on expand when `response_truncated`. */
+const LIST_RESPONSE_MAX_CHARS = 2000;
+
 /** Serialize a task (with its result, when finished) for API responses.
  *  The result is the ONLY place the sub-agent's final answer lives for
- *  dashboard-spawned tasks — without it the UI could show that a task
+ *  dashboard-spawned tasks -- without it the UI could show that a task
  *  completed but never what it produced. */
-function taskToJSON(task: AgentTaskSnapshot) {
+function taskToJSON(task: AgentTaskSnapshot, opts: { full?: boolean } = {}) {
+  const response = task.result?.response ?? '';
+  const truncate = !opts.full && response.length > LIST_RESPONSE_MAX_CHARS;
   return {
     id: task.id,
     status: task.status,
@@ -221,7 +229,8 @@ function taskToJSON(task: AgentTaskSnapshot) {
     result: task.result
       ? {
           success: task.result.success,
-          response: task.result.response,
+          response: truncate ? response.slice(0, LIST_RESPONSE_MAX_CHARS) : response,
+          response_truncated: truncate,
           tools_used: task.result.toolsUsed,
           termination_reason: task.result.terminationReason,
         }
@@ -732,16 +741,22 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
             // nothing streamed to the live ticker, nothing persisted to the
             // activity timeline, and the user never learned the task had
             // finished (let alone what it produced). Mirror the wiring the
-            // PA's manage_agents tool gets at boot, plus a completion
-            // notification pointing at the Agents room.
+            // PA's manage_agents tool gets at boot.
             onProgress: (event: { type: 'text' | 'tool_call' | 'done'; agentName: string; agentId: string; data: unknown }) => {
               ctx.wsService?.broadcastSubAgentProgress(event);
-              if (event.type === 'done') {
-                ctx.wsService?.broadcastNotification(
-                  `**${event.agentName} finished its task.** Open the Agents room to read the result.`,
-                  'normal',
-                );
-              }
+            },
+            // The completion notification hangs off onTaskComplete, NOT the
+            // 'done' progress event: 'done' only fires on the success path
+            // inside runSubAgent, so a failed task would never notify at
+            // all -- and it carries no success flag to word the message by.
+            onTaskComplete: (task: AsyncTask) => {
+              const ok = task.result?.success ?? false;
+              ctx.wsService?.broadcastNotification(
+                ok
+                  ? `**${task.agentName} finished its task.** Open the Agents room to read the result.`
+                  : `**${task.agentName} could not complete its task.** Open the Agents room for details.`,
+                'normal',
+              );
             },
           };
 
@@ -857,8 +872,9 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
       },
     },
 
-    // Full detail (including the sub-agent's final result) for a single
-    // async task. The list endpoints above intentionally truncate.
+    // Full detail for a single async task. The list payloads cap the
+    // result response at LIST_RESPONSE_MAX_CHARS; this returns it whole
+    // (the UI fetches it on expand when `response_truncated` is set).
     '/api/agents/tasks/:id': {
       GET: (req: Request & { params: { id: string } }) => {
         const tm = ctx.agentService.getTaskManager();
@@ -866,7 +882,7 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
         const task = tm.getTask(req.params.id);
         if (!task) return error(`Task "${req.params.id}" not found.`, 404);
         return json({
-          ...taskToJSON(task),
+          ...taskToJSON(task, { full: true }),
           agent_id: task.agentId,
           agent_name: task.agentName,
           specialist_id: task.specialistId,

--- a/ui/src/v2/rooms/agents/AgentsRoom.css
+++ b/ui/src/v2/rooms/agents/AgentsRoom.css
@@ -271,6 +271,60 @@
   font-style: italic;
 }
 
+/* ── Card result (finished task's answer) ── */
+
+.v2-agents__card-result {
+  border-top: var(--hair-soft);
+  padding-top: var(--s-2);
+}
+
+.v2-agents__card-result-summary {
+  display: flex;
+  align-items: center;
+  gap: var(--s-2);
+  cursor: pointer;
+  list-style: none;
+}
+
+.v2-agents__card-result-summary::-webkit-details-marker {
+  display: none;
+}
+
+.v2-agents__card-result-summary::after {
+  content: "▸";
+  font-size: var(--text-xs);
+  color: var(--ink-3);
+  margin-left: auto;
+  transition: transform var(--dur-fast) var(--ease-out);
+}
+
+.v2-agents__card-result[open] .v2-agents__card-result-summary::after {
+  transform: rotate(90deg);
+}
+
+.v2-agents__card-result-hint {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--ink-3);
+}
+
+.v2-agents__card-result-body {
+  margin-top: var(--s-2);
+  padding: var(--s-2) var(--s-3);
+  background: var(--paper-2);
+  border: 1px solid var(--rule);
+  border-radius: var(--r-1);
+  font-family: var(--font-sans);
+  font-size: var(--text-xs);
+  color: var(--ink-2);
+  line-height: var(--lh-body);
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 220px;
+  overflow-y: auto;
+  user-select: text;
+}
+
 .v2-agents__card-foot {
   display: flex;
   align-items: center;
@@ -470,6 +524,31 @@
   font-size: var(--text-xs);
   color: var(--ink-2);
   line-height: var(--lh-body);
+}
+
+.v2-agents__orbital-detail-result {
+  font-family: var(--font-sans);
+  font-size: var(--text-xs);
+  color: var(--ink-2);
+  line-height: var(--lh-body);
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 160px;
+  overflow-y: auto;
+  padding: var(--s-2) var(--s-3);
+  background: var(--paper-2);
+  border: 1px solid var(--rule);
+  border-radius: var(--r-1);
+  user-select: text;
+}
+
+.v2-agents__orbital-detail-result-label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+  margin-bottom: var(--s-1);
 }
 
 .v2-agents__orbital-detail-meta {

--- a/ui/src/v2/rooms/agents/AgentsRoom.tsx
+++ b/ui/src/v2/rooms/agents/AgentsRoom.tsx
@@ -25,6 +25,7 @@ import { useRoomActions } from "../useRoomActionBus";
 import { useRovingTabs } from "../useRovingTabs";
 import {
   useAgentsData,
+  useFullTaskResponse,
   type AgentRosterEntry,
   type SpecialistInfo,
 } from "./useAgentsData";
@@ -345,6 +346,10 @@ function AgentCard({ agent }: { agent: AgentRosterEntry }) {
   // this is where the user actually reads what the sub-agent produced.
   const finishedResult =
     !agent.live?.busy && latestTask?.result ? latestTask.result : null;
+  // The roster poll caps long responses; fetch the full text only once
+  // the user actually expands the result.
+  const [resultOpen, setResultOpen] = useState(false);
+  const fullResponse = useFullTaskResponse(latestTask, resultOpen);
 
   let statusLabel: string;
   let statusTone: "ok" | "warn" | "neutral" | "accent";
@@ -383,7 +388,10 @@ function AgentCard({ agent }: { agent: AgentRosterEntry }) {
         </Chip>
       </div>
       {finishedResult && (
-        <details className="v2-agents__card-result">
+        <details
+          className="v2-agents__card-result"
+          onToggle={(e) => setResultOpen((e.target as HTMLDetailsElement).open)}
+        >
           <summary className="v2-agents__card-result-summary">
             <Chip tone={finishedResult.success ? "ok" : "warn"} dot>
               {finishedResult.success ? "Result ready" : "Task failed"}
@@ -395,7 +403,7 @@ function AgentCard({ agent }: { agent: AgentRosterEntry }) {
             </span>
           </summary>
           <div className="v2-agents__card-result-body">
-            {finishedResult.response}
+            {fullResponse ?? finishedResult.response}
           </div>
         </details>
       )}
@@ -441,6 +449,15 @@ function Orbital({
   const selected = selectedRoleId
     ? roster.find((a) => a.roleId === selectedRoleId) ?? null
     : null;
+  // The detail panel shows the result as soon as an agent is selected,
+  // so fetch the full text right away when the poll truncated it.
+  const selectedResultShown = Boolean(
+    selected && !selected.live?.busy && selected.live?.latest_task?.result,
+  );
+  const selectedFullResponse = useFullTaskResponse(
+    selected?.live?.latest_task,
+    selectedResultShown,
+  );
 
   // Ticker: most recent 20 events. Duplicated for seamless loop scroll.
   const tickerEvents = liveActivity.slice(0, 20);
@@ -523,7 +540,7 @@ function Orbital({
                     ? "Latest result"
                     : "Latest task failed"}
                 </div>
-                {selected.live.latest_task.result.response}
+                {selectedFullResponse ?? selected.live.latest_task.result.response}
               </div>
             )}
             <div className="v2-agents__orbital-detail-meta">

--- a/ui/src/v2/rooms/agents/AgentsRoom.tsx
+++ b/ui/src/v2/rooms/agents/AgentsRoom.tsx
@@ -340,6 +340,11 @@ function AgentCard({ agent }: { agent: AgentRosterEntry }) {
   const currentTask =
     agent.live?.current_task ?? agent.live?.latest_task?.task ?? null;
   const sinceTs = agent.live?.created_at ?? null;
+  const latestTask = agent.live?.latest_task ?? null;
+  // Show the finished task's answer once the agent is no longer busy —
+  // this is where the user actually reads what the sub-agent produced.
+  const finishedResult =
+    !agent.live?.busy && latestTask?.result ? latestTask.result : null;
 
   let statusLabel: string;
   let statusTone: "ok" | "warn" | "neutral" | "accent";
@@ -377,6 +382,23 @@ function AgentCard({ agent }: { agent: AgentRosterEntry }) {
           {statusLabel}
         </Chip>
       </div>
+      {finishedResult && (
+        <details className="v2-agents__card-result">
+          <summary className="v2-agents__card-result-summary">
+            <Chip tone={finishedResult.success ? "ok" : "warn"} dot>
+              {finishedResult.success ? "Result ready" : "Task failed"}
+            </Chip>
+            <span className="v2-agents__card-result-hint">
+              {latestTask?.completed_at
+                ? formatRelative(latestTask.completed_at)
+                : ""}
+            </span>
+          </summary>
+          <div className="v2-agents__card-result-body">
+            {finishedResult.response}
+          </div>
+        </details>
+      )}
       <div className="v2-agents__card-foot">
         <AuthorityBar authority={agent.authority} active={agent.isActive} />
         <div className="v2-agents__card-foot-spacer" />
@@ -492,6 +514,16 @@ function Orbital({
             {selected.live?.current_task && (
               <div className="v2-agents__orbital-detail-task">
                 {selected.live.current_task}
+              </div>
+            )}
+            {!selected.live?.busy && selected.live?.latest_task?.result && (
+              <div className="v2-agents__orbital-detail-result">
+                <div className="v2-agents__orbital-detail-result-label">
+                  {selected.live.latest_task.result.success
+                    ? "Latest result"
+                    : "Latest task failed"}
+                </div>
+                {selected.live.latest_task.result.response}
               </div>
             )}
             <div className="v2-agents__orbital-detail-meta">

--- a/ui/src/v2/rooms/agents/useAgentsData.ts
+++ b/ui/src/v2/rooms/agents/useAgentsData.ts
@@ -6,9 +6,22 @@ const POLL_INTERVAL_MS = 5000;
 export interface AgentTaskResult {
   success: boolean;
   response: string;
+  /** True when the list payload capped `response`; the full text is at
+   *  GET /api/agents/tasks/:id (see useFullTaskResponse). */
+  response_truncated?: boolean;
   tools_used: string[];
   termination_reason: string;
 }
+
+export type LiveAgentTask = {
+  id: string;
+  status: string;
+  task: string;
+  started_at: number;
+  completed_at: number | null;
+  /** The sub-agent's final answer — present once the task finished. */
+  result?: AgentTaskResult | null;
+};
 
 export interface LiveAgentInfo {
   id: string;
@@ -17,15 +30,42 @@ export interface LiveAgentInfo {
   current_task: string | null;
   created_at: number;
   busy?: boolean;
-  latest_task?: {
-    id: string;
-    status: string;
-    task: string;
-    started_at: number;
-    completed_at: number | null;
-    /** The sub-agent's final answer — present once the task finished. */
-    result?: AgentTaskResult | null;
-  } | null;
+  latest_task?: LiveAgentTask | null;
+}
+
+/**
+ * Lazily fetch a task's full result text. The roster poll caps long
+ * responses (`response_truncated`); when `active` flips true (the user
+ * expanded the result), this pulls the untruncated text from
+ * /api/agents/tasks/:id. Returns null until then — callers fall back
+ * to the truncated preview.
+ */
+export function useFullTaskResponse(
+  task: LiveAgentTask | null | undefined,
+  active: boolean,
+): string | null {
+  const [full, setFull] = useState<string | null>(null);
+  const taskId = task?.id ?? null;
+  const truncated = task?.result?.response_truncated === true;
+
+  useEffect(() => {
+    setFull(null);
+    if (!taskId || !truncated || !active) return;
+    let cancelled = false;
+    fetch(`/api/agents/tasks/${taskId}`)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d) => {
+        if (!cancelled && typeof d?.result?.response === "string") {
+          setFull(d.result.response);
+        }
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [taskId, truncated, active]);
+
+  return full;
 }
 
 export interface SpecialistInfo {

--- a/ui/src/v2/rooms/agents/useAgentsData.ts
+++ b/ui/src/v2/rooms/agents/useAgentsData.ts
@@ -3,6 +3,13 @@ import { useLiveData } from "../../shell/LiveDataContext";
 
 const POLL_INTERVAL_MS = 5000;
 
+export interface AgentTaskResult {
+  success: boolean;
+  response: string;
+  tools_used: string[];
+  termination_reason: string;
+}
+
 export interface LiveAgentInfo {
   id: string;
   role: { id: string; name: string };
@@ -16,6 +23,8 @@ export interface LiveAgentInfo {
     task: string;
     started_at: number;
     completed_at: number | null;
+    /** The sub-agent's final answer — present once the task finished. */
+    result?: AgentTaskResult | null;
   } | null;
 }
 


### PR DESCRIPTION
Fix sub-agent spawning blocked despite max authority + surface agent task results

  This PR fixes two related problems with sub-agents: Jarvis refusing to spawn specialists even with maximum authority
  configured, and finished background tasks having no visible results anywhere in the dashboard.

  1. "Parent agent does not have authority to spawn children" despite max authority

  Root cause: an agent's can_spawn_children flag was derived solely from whether its role YAML defines legacy sub_roles
  templates:

  can_spawn_children: (role.sub_roles?.length ?? 0) > 0

  The default personal-assistant role ships the delegation tool and a prompt that explicitly advertises delegating to
  sub-agents — but no sub_roles key. So every delegate_task / manage_agents spawn was refused at
  orchestrator.spawnSubAgent(), regardless of authority settings. The authority engine (level slider, spawn_agent overrides)
  was never consulted on this path — it's a separate system that the flag check ignored. The mismatch dates from when
  delegation moved to specialists discovered from roles/specialists/ while the spawn gate stayed keyed to the old sub_roles
  hierarchy model.

  Fixes:
  - New canSpawnChildren(role) helper (src/agents/agent.ts): a role can spawn if it declares the delegation tool (the
  mechanism the delegation tools actually use) or has legacy sub_roles. Specialists remain leaves — none declares either.
  - The authority engine is now the prime decider in spawnSubAgent(): it evaluates spawn_agent through the full decision
  chain (temporary grants → per-action overrides → context rules → level check → governed categories) before the role flag
  is considered:
    - An explicit spawn_agent deny blocks spawning even for delegation-capable roles — including the paths that bypass the
  tool-level gate entirely (dashboard spawn dialog, workflow delegator), where a deny was previously unenforceable.
    - An explicit allow unblocks a role that never declared delegation. User configuration always wins over role metadata,
  in both directions.
    - The role-derived flag is only the fallback when no engine is wired (tests, embedded use).
    - requiresApproval is treated as allowed at this layer by design: the soft-gate approval flow runs at the tool layer
  (executeTool intercepts delegate_task/manage_agents before execution), so denying again here would dead-lock approved
  delegations.
  - The refusal error now names the role and the actual cause instead of the misleading "does not have authority" phrasing.

  2. No way to see what a spawned agent produced

  Results of async tasks lived only in the in-memory AgentTaskManager — no endpoint exposed them, and dashboard-spawned
  tasks (POST /api/agents) were launched without a progress callback, so they never streamed to the live ticker or persisted
  to the activity timeline either. A research agent could finish and its answer was simply unreachable.
