### PR TITLE
Execute approved tools inline so results flow back to the conversation

### DIFF
--- a/src/agents/orchestrator.ts
+++ b/src/agents/orchestrator.ts
@@ -11,11 +11,17 @@ import type { ActionCategory } from '../roles/authority.ts';
 import type { AuthorityEngine } from '../authority/engine.ts';
 import type { ApprovalManager, ApprovalRequest } from '../authority/approval.ts';
 import type { AuditTrail } from '../authority/audit.ts';
+import type { DeferredExecutor } from '../authority/deferred-executor.ts';
 import type { EmergencyController } from '../authority/emergency.ts';
 import { getActionForTool } from '../authority/tool-action-map.ts';
 
 const MAX_TOOL_ITERATIONS = 200;
 const MAX_TOOL_RESULT_CHARS = 6000; // Cap individual tool results to control context size
+// How long the authority gate blocks waiting for the user to approve a
+// gated tool call before falling back to the deferred (fire-and-forget)
+// path. Long enough to click a permission panel, short enough that an
+// ignored panel doesn't hang the conversation turn indefinitely.
+const APPROVAL_WAIT_TIMEOUT_MS = 2 * 60 * 1000;
 
 /**
  * Special tool exposed only on processTaskCall. The orchestrator intercepts
@@ -58,6 +64,7 @@ export class AgentOrchestrator {
   // Authority engine components
   private authorityEngine: AuthorityEngine | null = null;
   private approvalManager: ApprovalManager | null = null;
+  private deferredExecutor: DeferredExecutor | null = null;
   private auditTrail: AuditTrail | null = null;
   private emergencyController: EmergencyController | null = null;
   private temporaryGrants: Map<string, ActionCategory[]> = new Map();
@@ -102,6 +109,15 @@ export class AgentOrchestrator {
 
   setApprovalManager(manager: ApprovalManager): void {
     this.approvalManager = manager;
+  }
+
+  /**
+   * Enables inline approval execution: the authority gate blocks on the
+   * user's decision and runs the approved tool itself, so the result flows
+   * back through the task loop instead of a detached notification.
+   */
+  setDeferredExecutor(executor: DeferredExecutor): void {
+    this.deferredExecutor = executor;
   }
 
   setAuditTrail(trail: AuditTrail): void {
@@ -454,7 +470,7 @@ export class AgentOrchestrator {
         });
 
         for (const tc of llmResponse.tool_calls) {
-          const result = await this.executeTool(tc);
+          const result = await this.executeTool(tc, opts.signal);
           messages.push({
             role: 'tool',
             content: result,
@@ -671,8 +687,11 @@ export class AgentOrchestrator {
    * Execute a single tool call via the ToolRegistry.
    * Includes authority gate: checks emergency state, authority level, and governed categories.
    * Returns a string for text-only results, or ContentBlock[] for multi-modal results (images).
+   *
+   * `signal` (task-tier calls) lets a cancelled task break out of the
+   * blocking approval wait instead of holding the dispatch open.
    */
-  private async executeTool(toolCall: LLMToolCall): Promise<string | ContentBlock[]> {
+  private async executeTool(toolCall: LLMToolCall, signal?: AbortSignal): Promise<string | ContentBlock[]> {
     if (!this.toolRegistry) {
       return `Error: No tool registry configured`;
     }
@@ -740,6 +759,12 @@ export class AgentOrchestrator {
       // 5. Requires approval
       if (decision.requiresApproval && this.approvalManager) {
         const urgency = this.determineUrgency(actionCategory);
+        // Inline mode: block here until the user decides, then execute the
+        // tool ourselves so the result returns through the task loop (and
+        // from there to the conversation tier), instead of being executed
+        // detached on approval and broadcast as a raw notification.
+        // Deferred mode is the fallback when no executor is wired.
+        const inline = this.deferredExecutor !== null;
         const request = this.approvalManager.createRequest({
           agentId: primary.id,
           agentName: primary.agent.role.name,
@@ -749,15 +774,68 @@ export class AgentOrchestrator {
           urgency,
           reason: decision.reason,
           context: `Agent attempted: ${toolCall.name}(${JSON.stringify(toolCall.arguments).slice(0, 200)})`,
+          executionMode: inline ? 'inline' : 'deferred',
         });
 
         // Emit approval request event
         this.onApprovalNeeded?.(request);
 
-        return `[AWAITING_APPROVAL] Request #${request.id.slice(0, 8)} submitted. ` +
-               `Action: ${toolCall.name} (${actionCategory}). ` +
-               `Reason: ${decision.reason}. ` +
-               `The user will be notified and can approve or deny this action.`;
+        if (!inline) {
+          return `[AWAITING_APPROVAL] Request #${request.id.slice(0, 8)} submitted. ` +
+                 `Action: ${toolCall.name} (${actionCategory}). ` +
+                 `Reason: ${decision.reason}. ` +
+                 `The user will be notified and can approve or deny this action.`;
+        }
+
+        const resolved = await this.approvalManager.waitForResolution(request.id, {
+          timeoutMs: APPROVAL_WAIT_TIMEOUT_MS,
+          signal,
+        });
+
+        switch (resolved.status) {
+          case 'approved':
+            // The approve endpoints skip execution for inline requests; we
+            // are the single executor. executeApproved handles markExecuted,
+            // audit, and approval learning.
+            return await this.deferredExecutor!.executeApproved(request.id);
+          case 'executed':
+            // Another path already ran it (shouldn't happen for inline
+            // requests; tolerated for robustness). Surface its result.
+            return resolved.execution_result ?? `[EXECUTED] ${toolCall.name} completed.`;
+          case 'denied':
+            return `[APPROVAL DENIED] The user denied permission to execute ${toolCall.name}. ` +
+                   `Do not retry the action. Briefly tell the user it was not performed.`;
+          case 'expired':
+            return `[APPROVAL EXPIRED] The approval request for ${toolCall.name} expired before the user decided. ` +
+                   `Ask the user whether they still want this done.`;
+          case 'pending':
+          default: {
+            // Timed out waiting (or the task was cancelled mid-wait). Hand
+            // the request to the deferred path so a late click still
+            // executes it. demoteToDeferred only succeeds while the request
+            // is still pending, so it cannot race an approve into a double
+            // execution: if the user approved in the meantime, the demotion
+            // fails and we execute inline after all.
+            if (!this.approvalManager.demoteToDeferred(request.id)) {
+              const recheck = this.approvalManager.getRequest(request.id);
+              if (recheck?.status === 'approved') {
+                return await this.deferredExecutor!.executeApproved(request.id);
+              }
+              if (recheck?.status === 'executed') {
+                return recheck.execution_result ?? `[EXECUTED] ${toolCall.name} completed.`;
+              }
+              if (recheck?.status === 'denied') {
+                return `[APPROVAL DENIED] The user denied permission to execute ${toolCall.name}. ` +
+                       `Do not retry the action. Briefly tell the user it was not performed.`;
+              }
+            }
+            return `[AWAITING_APPROVAL] Request #${request.id.slice(0, 8)} submitted. ` +
+                   `Action: ${toolCall.name} (${actionCategory}). ` +
+                   `Reason: ${decision.reason}. ` +
+                   `The user has not responded yet. They can still approve or deny it later; ` +
+                   `if approved later, it will be executed and the user will be notified.`;
+          }
+        }
       }
     }
 

--- a/src/authority/approval.ts
+++ b/src/authority/approval.ts
@@ -10,6 +10,17 @@ import type { ActionCategory } from '../roles/authority.ts';
 export type ApprovalStatus = 'pending' | 'approved' | 'denied' | 'expired' | 'executed';
 export type ApprovalUrgency = 'urgent' | 'normal';
 
+/**
+ * How an approved request gets executed:
+ *  - 'inline': the authority gate that created it is blocked on
+ *    waitForResolution and executes the tool itself, so the result flows
+ *    back through the task envelope to the conversation tier. Resolution
+ *    endpoints must only flip the status, never execute.
+ *  - 'deferred': nobody is waiting; whichever endpoint approves it runs
+ *    the tool via DeferredExecutor (the legacy fire-and-forget path).
+ */
+export type ApprovalExecutionMode = 'inline' | 'deferred';
+
 export type ApprovalRequest = {
   id: string;
   agent_id: string;
@@ -21,6 +32,7 @@ export type ApprovalRequest = {
   reason: string;
   context: string;
   status: ApprovalStatus;
+  execution_mode: ApprovalExecutionMode;
   decided_at: number | null;
   decided_by: string | null;
   executed_at: number | null;
@@ -41,16 +53,18 @@ export class ApprovalManager {
     urgency: ApprovalUrgency;
     reason: string;
     context: string;
+    executionMode?: ApprovalExecutionMode;
   }): ApprovalRequest {
     const db = getDb();
     const id = generateId();
     const now = Date.now();
     const toolArgs = JSON.stringify(params.toolArguments);
+    const executionMode = params.executionMode ?? 'deferred';
 
     db.run(
-      `INSERT INTO approval_requests (id, agent_id, agent_name, tool_name, tool_arguments, action_category, urgency, reason, context, status, created_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending', ?)`,
-      [id, params.agentId, params.agentName, params.toolName, toolArgs, params.actionCategory, params.urgency, params.reason, params.context, now]
+      `INSERT INTO approval_requests (id, agent_id, agent_name, tool_name, tool_arguments, action_category, urgency, reason, context, status, execution_mode, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending', ?, ?)`,
+      [id, params.agentId, params.agentName, params.toolName, toolArgs, params.actionCategory, params.urgency, params.reason, params.context, executionMode, now]
     );
 
     return {
@@ -64,6 +78,7 @@ export class ApprovalManager {
       reason: params.reason,
       context: params.context,
       status: 'pending',
+      execution_mode: executionMode,
       decided_at: null,
       decided_by: null,
       executed_at: null,
@@ -121,6 +136,39 @@ export class ApprovalManager {
 
     if (result.changes === 0) return null;
     return this.getRequest(requestId);
+  }
+
+  /**
+   * Hand an inline request over to the deferred path (used when the
+   * blocked authority gate times out waiting for the user). Conditional
+   * on the request still being pending+inline so it cannot race the
+   * approve endpoints into a double execution: if the user approved
+   * first, this returns false and the (still-blocked) gate executes;
+   * if the demotion lands first, the approve endpoints see 'deferred'
+   * and execute via DeferredExecutor as before.
+   */
+  demoteToDeferred(requestId: string): boolean {
+    const db = getDb();
+    const result = db.run(
+      `UPDATE approval_requests SET execution_mode = 'deferred' WHERE id = ? AND status = 'pending' AND execution_mode = 'inline'`,
+      [requestId]
+    );
+    return result.changes > 0;
+  }
+
+  /**
+   * Startup sweep: demote ALL pending inline requests to deferred. An
+   * inline request only makes sense while the authority gate that created
+   * it is blocked waiting on it; after a daemon restart no such gate
+   * exists, so approving one would flip the status without anything
+   * executing the tool. Returns the number of demoted requests.
+   */
+  demoteAllPendingInline(): number {
+    const db = getDb();
+    const result = db.run(
+      `UPDATE approval_requests SET execution_mode = 'deferred' WHERE status = 'pending' AND execution_mode = 'inline'`
+    );
+    return result.changes;
   }
 
   /**
@@ -196,17 +244,19 @@ export class ApprovalManager {
 
   /**
    * Block until a pending request resolves (approved / denied / expired / executed),
-   * or until the timeout fires — whichever comes first. Polling-based so it stays
-   * robust across the approve/deny paths (REST endpoint, channel handler, etc.)
-   * without needing to instrument every resolution site with event emission.
+   * or until the timeout fires or the optional signal aborts — whichever comes
+   * first. Polling-based so it stays robust across the approve/deny paths
+   * (REST endpoint, channel handler, etc.) without needing to instrument every
+   * resolution site with event emission.
    *
    * Returns the latest request state. If the request is missing, throws.
-   * If the timeout fires, returns the still-pending request — callers should
-   * treat `status === 'pending'` as a timeout and respond accordingly.
+   * If the timeout fires or the signal aborts, returns the still-pending
+   * request — callers should treat `status === 'pending'` as a timeout/abort
+   * and respond accordingly.
    */
   async waitForResolution(
     requestId: string,
-    opts: { timeoutMs?: number; pollMs?: number } = {},
+    opts: { timeoutMs?: number; pollMs?: number; signal?: AbortSignal } = {},
   ): Promise<ApprovalRequest> {
     const timeoutMs = opts.timeoutMs ?? 5 * 60 * 1000; // 5 min default
     const pollMs = opts.pollMs ?? 250;
@@ -217,6 +267,7 @@ export class ApprovalManager {
       if (!current) throw new Error(`Approval request ${requestId} not found`);
       if (current.status !== 'pending') return current;
 
+      if (opts.signal?.aborted) return current;
       if (Date.now() - start >= timeoutMs) return current;
       await new Promise((resolve) => setTimeout(resolve, pollMs));
     }

--- a/src/authority/authority.test.ts
+++ b/src/authority/authority.test.ts
@@ -3,6 +3,8 @@ import { initDatabase, closeDb, getDb } from '../vault/schema.ts';
 import { AuthorityEngine, type AuthorityConfig } from './engine.ts';
 import { ApprovalManager } from './approval.ts';
 import { AuditTrail } from './audit.ts';
+import { DeferredExecutor } from './deferred-executor.ts';
+import type { ToolRegistry } from '../actions/tools/registry.ts';
 import { AuthorityLearner } from './learning.ts';
 import { EmergencyController } from './emergency.ts';
 import { getActionForTool } from './tool-action-map.ts';
@@ -386,6 +388,56 @@ describe('ApprovalManager', () => {
     expect(found!.id).toBe(req.id);
   });
 
+  test('execution_mode defaults to deferred and persists when set inline', () => {
+    const mgr = new ApprovalManager();
+    const deferred = mgr.createRequest({
+      agentId: 'a1', agentName: 'PA', toolName: 'send_email',
+      toolArguments: {}, actionCategory: 'send_email',
+      urgency: 'normal', reason: 'test', context: '',
+    });
+    expect(deferred.execution_mode).toBe('deferred');
+    expect(mgr.getRequest(deferred.id)!.execution_mode).toBe('deferred');
+
+    const inline = mgr.createRequest({
+      agentId: 'a1', agentName: 'PA', toolName: 'manage_workflow',
+      toolArguments: {}, actionCategory: 'modify_settings',
+      urgency: 'normal', reason: 'test', context: '',
+      executionMode: 'inline',
+    });
+    expect(inline.execution_mode).toBe('inline');
+    expect(mgr.getRequest(inline.id)!.execution_mode).toBe('inline');
+  });
+
+  test('demoteToDeferred succeeds only while pending', () => {
+    const mgr = new ApprovalManager();
+    const req = mgr.createRequest({
+      agentId: 'a1', agentName: 'PA', toolName: 'manage_workflow',
+      toolArguments: {}, actionCategory: 'modify_settings',
+      urgency: 'normal', reason: 'test', context: '',
+      executionMode: 'inline',
+    });
+
+    expect(mgr.demoteToDeferred(req.id)).toBe(true);
+    expect(mgr.getRequest(req.id)!.execution_mode).toBe('deferred');
+
+    // Already deferred — nothing to demote.
+    expect(mgr.demoteToDeferred(req.id)).toBe(false);
+  });
+
+  test('demoteToDeferred fails after approval (inline gate keeps execution)', () => {
+    const mgr = new ApprovalManager();
+    const req = mgr.createRequest({
+      agentId: 'a1', agentName: 'PA', toolName: 'manage_workflow',
+      toolArguments: {}, actionCategory: 'modify_settings',
+      urgency: 'normal', reason: 'test', context: '',
+      executionMode: 'inline',
+    });
+
+    mgr.approve(req.id, 'dashboard');
+    expect(mgr.demoteToDeferred(req.id)).toBe(false);
+    expect(mgr.getRequest(req.id)!.execution_mode).toBe('inline');
+  });
+
   test('markExecuted updates fields', () => {
     const mgr = new ApprovalManager();
     const req = mgr.createRequest({
@@ -399,6 +451,87 @@ describe('ApprovalManager', () => {
     const updated = mgr.getRequest(req.id);
     expect(updated!.status).toBe('executed');
     expect(updated!.execution_result).toBe('Email sent successfully');
+  });
+
+  test('inline flow: gate waits, approve flips status, executor runs tool once', async () => {
+    const mgr = new ApprovalManager();
+    const req = mgr.createRequest({
+      agentId: 'a1', agentName: 'PA', toolName: 'manage_workflow',
+      toolArguments: { action: 'create' }, actionCategory: 'modify_settings',
+      urgency: 'normal', reason: 'test', context: '',
+      executionMode: 'inline',
+    });
+
+    let executions = 0;
+    const registry = {
+      execute: async () => { executions++; return '{"ok":true}'; },
+    } as unknown as ToolRegistry;
+    const executor = new DeferredExecutor(mgr, new AuditTrail());
+    executor.setToolRegistry(registry);
+
+    // Simulate the blocked authority gate: wait, then execute on approval.
+    const gate = (async () => {
+      const resolved = await mgr.waitForResolution(req.id, { timeoutMs: 5000, pollMs: 10 });
+      expect(resolved.status).toBe('approved');
+      return executor.executeApproved(req.id);
+    })();
+
+    // Simulate the approve endpoint: flip status, skip execution (inline).
+    const approved = mgr.approve(req.id, 'dashboard');
+    expect(approved!.execution_mode).toBe('inline');
+
+    const result = await gate;
+    expect(result).toBe('{"ok":true}');
+    expect(executions).toBe(1);
+    expect(mgr.getRequest(req.id)!.status).toBe('executed');
+  });
+
+  test('executeApproved refuses to run while system is paused', async () => {
+    const mgr = new ApprovalManager();
+    const req = mgr.createRequest({
+      agentId: 'a1', agentName: 'PA', toolName: 'send_email',
+      toolArguments: {}, actionCategory: 'send_email',
+      urgency: 'normal', reason: 'test', context: '',
+    });
+    mgr.approve(req.id, 'dashboard');
+
+    let executions = 0;
+    const registry = {
+      execute: async () => { executions++; return 'sent'; },
+    } as unknown as ToolRegistry;
+    const executor = new DeferredExecutor(mgr, new AuditTrail());
+    executor.setToolRegistry(registry);
+    const emergency = new EmergencyController();
+    executor.setEmergencyController(emergency);
+    emergency.pause();
+
+    const result = await executor.executeApproved(req.id);
+    expect(result).toContain('[SYSTEM PAUSED]');
+    expect(result).toContain('NOT executed');
+    expect(executions).toBe(0);
+    // Request is closed out, not left as an approved zombie.
+    expect(mgr.getRequest(req.id)!.status).toBe('executed');
+  });
+
+  test('waitForResolution returns early when the signal aborts', async () => {
+    const mgr = new ApprovalManager();
+    const req = mgr.createRequest({
+      agentId: 'a1', agentName: 'PA', toolName: 'manage_workflow',
+      toolArguments: {}, actionCategory: 'modify_settings',
+      urgency: 'normal', reason: 'test', context: '',
+      executionMode: 'inline',
+    });
+
+    const ctrl = new AbortController();
+    setTimeout(() => ctrl.abort(), 30);
+    const start = Date.now();
+    const resolved = await mgr.waitForResolution(req.id, {
+      timeoutMs: 10_000,
+      pollMs: 10,
+      signal: ctrl.signal,
+    });
+    expect(resolved.status).toBe('pending');
+    expect(Date.now() - start).toBeLessThan(2000);
   });
 
   test('expireOld expires old pending requests', () => {

--- a/src/authority/deferred-executor.ts
+++ b/src/authority/deferred-executor.ts
@@ -6,6 +6,7 @@ import type { ToolRegistry } from '../actions/tools/registry.ts';
 import type { ApprovalManager, ApprovalRequest } from './approval.ts';
 import type { AuditTrail } from './audit.ts';
 import type { AuthorityLearner } from './learning.ts';
+import type { EmergencyController } from './emergency.ts';
 import type { ActionCategory } from '../roles/authority.ts';
 
 export type ExecutionResultCallback = (requestId: string, request: ApprovalRequest, result: string) => void;
@@ -15,6 +16,7 @@ export class DeferredExecutor {
   private approvalManager: ApprovalManager;
   private auditTrail: AuditTrail;
   private learner: AuthorityLearner | null = null;
+  private emergencyController: EmergencyController | null = null;
   private onResult: ExecutionResultCallback | null = null;
 
   constructor(approvalManager: ApprovalManager, auditTrail: AuditTrail) {
@@ -28,6 +30,10 @@ export class DeferredExecutor {
 
   setLearner(learner: AuthorityLearner): void {
     this.learner = learner;
+  }
+
+  setEmergencyController(controller: EmergencyController): void {
+    this.emergencyController = controller;
   }
 
   setResultCallback(cb: ExecutionResultCallback): void {
@@ -45,6 +51,17 @@ export class DeferredExecutor {
 
     if (!this.toolRegistry) {
       return 'Error: No tool registry configured';
+    }
+
+    // Emergency gate: an approval clicked while the system is paused/killed
+    // must not execute. Close the request out (mirroring the error path)
+    // so it doesn't linger as an approved-but-never-executed zombie.
+    if (this.emergencyController && !this.emergencyController.canExecute()) {
+      const state = this.emergencyController.getState();
+      const blocked = `[SYSTEM ${state.toUpperCase()}] Approved action ${request.tool_name} was NOT executed: all tool execution is suspended because the user has ${state} the system.`;
+      this.approvalManager.markExecuted(requestId, blocked);
+      this.onResult?.(requestId, request, blocked);
+      return blocked;
     }
 
     const startTime = Date.now();

--- a/src/daemon/api-routes.ts
+++ b/src/daemon/api-routes.ts
@@ -2255,8 +2255,11 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
         // the originating `request_approval` tool call is blocked waiting for
         // the DB status to flip (via waitForResolution polling). Skipping
         // executeApproved avoids a recursive call into the tool registry.
+        // Inline-mode requests are likewise executed by the authority gate
+        // that is blocked on this status flip, so the result flows back to
+        // the conversation — executing here would run the tool twice.
         let result = '';
-        if (approved.tool_name !== 'request_approval') {
+        if (approved.tool_name !== 'request_approval' && approved.execution_mode !== 'inline') {
           result = await ctx.deferredExecutor.executeApproved(requestId);
         }
 

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -489,6 +489,15 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
     const approvalDelivery = new ApprovalDelivery();
     const deferredExecutor = new DeferredExecutor(approvalManager, auditTrail);
     deferredExecutor.setLearner(learner);
+    // Approved actions must respect the kill switch too, not just the gate.
+    deferredExecutor.setEmergencyController(emergencyController);
+    // Inline requests are owned by an authority gate blocked in-process;
+    // any that survived a restart have no gate anymore, so hand them to
+    // the deferred path or approving them would execute nothing.
+    const orphanedInline = approvalManager.demoteAllPendingInline();
+    if (orphanedInline > 0) {
+      console.log(`[Daemon] Demoted ${orphanedInline} orphaned inline approval(s) to deferred`);
+    }
     // Phase 6.3.5b — let WS service resolve approvals from voice intents.
     wsService.setApprovalManager(approvalManager);
     wsService.setDeferredExecutor(deferredExecutor);
@@ -518,6 +527,10 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
     const orchestrator = agentService.getOrchestrator();
     orchestrator.setAuthorityEngine(authorityEngine);
     orchestrator.setApprovalManager(approvalManager);
+    // Inline approval execution: the authority gate blocks on the user's
+    // decision and executes the approved tool itself, so results flow back
+    // through the task envelope to the conversation tier.
+    orchestrator.setDeferredExecutor(deferredExecutor);
     orchestrator.setAuditTrail(auditTrail);
     orchestrator.setEmergencyController(emergencyController);
 
@@ -542,10 +555,19 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
       if (action === 'approve') {
         const approved = approvalManager.approve(request.id, channel);
         if (!approved) return 'Request already decided';
-        const result = await deferredExecutor.executeApproved(request.id);
+        let reply: string;
+        if (approved.tool_name === 'request_approval' || approved.execution_mode === 'inline') {
+          // Intent-only and inline requests are executed by the blocked
+          // caller (request_approval tool / authority gate) once it sees
+          // the status flip — executing here would run the tool twice.
+          reply = 'Approved. The agent will continue and report back in chat.';
+        } else {
+          const result = await deferredExecutor.executeApproved(request.id);
+          reply = `Approved and executed. Result: ${result.slice(0, 200)}`;
+        }
         const updated = approvalManager.getRequest(request.id);
         if (updated) wsService.broadcastApprovalUpdate(updated);
-        return `Approved and executed. Result: ${result.slice(0, 200)}`;
+        return reply;
       } else {
         const denied = approvalManager.deny(request.id, channel);
         if (!denied) return 'Request already decided';
@@ -909,7 +931,11 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
     deferredExecutor.setResultCallback((requestId, request, result) => {
       // Notify via WS and channels that an approved action was executed.
       // Skip for intent-only approvals — they have no deferred execution.
+      // Skip for inline approvals too: their result returns through the
+      // task loop and the conversation tier verbalizes it, so a raw
+      // notification would duplicate it in the chat.
       if (request.tool_name === 'request_approval') return;
+      if (request.execution_mode === 'inline') return;
       const text = `[EXECUTED] ${request.tool_name}: ${result.slice(0, 200)}`;
       wsService.broadcastNotification(text, 'normal');
     });

--- a/src/daemon/ws-service.ts
+++ b/src/daemon/ws-service.ts
@@ -1895,8 +1895,9 @@ CRITICAL — when in genuine doubt between "make in a new project" vs "add to th
             executed: false,
             channel: 'voice',
           });
-          // Same skip-on-intent-only path as the REST endpoint.
-          if (this.deferredExecutor && approved.tool_name !== 'request_approval') {
+          // Same skip-on-intent-only and skip-on-inline path as the REST
+          // endpoint: inline requests are executed by the blocked gate.
+          if (this.deferredExecutor && approved.tool_name !== 'request_approval' && approved.execution_mode !== 'inline') {
             try {
               await this.deferredExecutor.executeApproved(latest.id);
             } catch (err) {

--- a/src/vault/schema.ts
+++ b/src/vault/schema.ts
@@ -362,6 +362,11 @@ function createTables(db: Database): void {
   db.run(`CREATE INDEX IF NOT EXISTS idx_approval_agent ON approval_requests(agent_id)`);
   db.run(`CREATE INDEX IF NOT EXISTS idx_approval_category ON approval_requests(action_category)`);
   db.run(`CREATE INDEX IF NOT EXISTS idx_approval_created ON approval_requests(created_at)`);
+  // Migration: 'inline' requests are executed by the authority gate that is
+  // blocked waiting on them (result flows back to the conversation); the
+  // approve endpoints only flip the status. 'deferred' keeps the legacy
+  // execute-on-approve behavior.
+  try { db.run(`ALTER TABLE approval_requests ADD COLUMN execution_mode TEXT NOT NULL DEFAULT 'deferred'`); } catch {}
 
   // Authority: Audit trail
   db.run(`


### PR DESCRIPTION
When a delegated task hit the authority gate, the gate created an approval request and immediately returned `[AWAITING_APPROVAL]` to the task LLM, so the task finished before the user ever decided. Approving the request later executed the tool detached from any conversation: the result had nowhere to go and was broadcast as a raw `[EXECUTED] manage_workflow: {...}` notification, dumped over the permission panel in the chat. The conv model never learned the action actually ran.

### Fix

The authority gate now blocks on the user's decision and executes the approved tool itself, so the result returns through the normal task envelope and the conv model verbalizes it as a regular chat reply.

- New `execution_mode` on approval requests (`inline` | `deferred`, migrated with a default of `deferred`). The gate creates `inline` requests and waits on them via the existing `waitForResolution` polling (2 min timeout).
- On approve, the gate is the single executor (via `DeferredExecutor.executeApproved`, reusing audit/learning/markExecuted). The three resolution endpoints (REST, channel, voice) only flip the status for inline requests instead of executing, and the `[EXECUTED]` broadcast is skipped for them.
- Deny/expire return clear `[APPROVAL DENIED]` / `[APPROVAL EXPIRED]` tool results so the task LLM reports honestly instead of pretending it acted.
- On timeout the request is demoted to `deferred` (legacy behavior) with a conditional UPDATE, so a late click still executes exactly once. A startup sweep demotes inline requests orphaned by a daemon restart.
- The task's `AbortSignal` is threaded into the gate, so cancelling a task no longer hangs the dispatch for the full wait window.
- Bonus hardening: `executeApproved` now respects the emergency pause/kill switch. Previously an approval clicked while the system was paused executed anyway.