### PR TITLE
Contain scroll inside chat thread so nested scrollables don't move the page

### DIFF
--- a/ui/src/v2/thread/MarkdownBody.css
+++ b/ui/src/v2/thread/MarkdownBody.css
@@ -83,6 +83,9 @@
   border: var(--hair);
   border-radius: var(--r-2);
   overflow-x: auto;
+  /* Contain horizontal scroll so dragging a wide code block to its edge
+     doesn't bleed the scroll into the thread/page. */
+  overscroll-behavior: contain;
   font-family: var(--font-mono);
   font-size: 0.88em;
   line-height: 1.5;

--- a/ui/src/v2/thread/Thread.css
+++ b/ui/src/v2/thread/Thread.css
@@ -11,6 +11,10 @@
   flex: 1;
   overflow-y: auto;
   overflow-x: hidden;
+  /* Keep scroll momentum contained to the thread so reaching the top/bottom
+     (or scrolling a nested scrollable inside a message) doesn't chain out to
+     the page. */
+  overscroll-behavior: contain;
   scroll-behavior: smooth;
 }
 


### PR DESCRIPTION
Fixes a scroll-chaining bug in the chat page: when a scrollable element (a wide code block, or the conversation reaching its top/bottom) was scrolled, the scroll bled out and moved the whole page instead of staying in the in-chat scrollable.

Root cause: overscroll-behavior wasn't set anywhere, so scroll chained at every boundary in the chat.

Fix adds overscroll-behavior: contain to the two containers in the live v2 thread that actually scroll:

- .v2-thread__scroll - the conversation scroll, so hitting top/bottom (or scrolling a nested scrollable in a message) no longer chains to the page.
- .v2-md pre - so dragging a wide code block to its horizontal edge doesn't move the thread/page.

CSS-only, scoped to the chat, no behavior change beyond killing the scroll chain. Vertical wheel over a horizontal-only code block still scrolls the thread as before (containment only applies on the axis the element actually scrolls).

Not in scope: wide tables are still clipped (thread is overflow-x: hidden, tables have no scroll wrapper) - that's a separate defect, not the chaining bug.