### PR TITLE
fix(llm): omit temperature for OpenAI reasoning models and replace in…

### DIFF
--- a/src/llm/openai.ts
+++ b/src/llm/openai.ts
@@ -10,6 +10,25 @@ import type {
 import { classifyHttpStatus } from './provider.ts';
 import { compactHistory, calculateHistoryBudget } from './history.ts';
 
+/**
+ * OpenAI reasoning models reject any `temperature` other than the default (1):
+ *   400 invalid_request_error "Unsupported value: 'temperature' does not
+ *   support 0.6 with this model. Only the default (1) value is supported."
+ * Unlike Anthropic's check (presence of the field), this one is on the VALUE —
+ * but the only accepted value is the default, so the fix is the same: omit the
+ * field and let the API apply its default.
+ *
+ * Covers the o-series (o1/o3/o4-mini/o3-pro…) and the GPT-5 reasoning family.
+ * `gpt-5-chat*` is the non-reasoning variant and DOES accept a custom
+ * temperature, so it's excluded. Add new families here if you see that 400.
+ */
+export function modelRejectsCustomTemperature(model: string): boolean {
+  const id = model.toLowerCase();
+  if (/^o\d/.test(id)) return true;
+  if (id.startsWith('gpt-5') && !id.startsWith('gpt-5-chat')) return true;
+  return false;
+}
+
 type OpenAIMessage = {
   role: 'system' | 'user' | 'assistant' | 'tool';
   content: string;
@@ -113,7 +132,9 @@ export class OpenAIProvider implements LLMProvider {
       messages: this.convertMessages(compactedMessages),
     };
 
-    if (temperature !== undefined) body.temperature = temperature;
+    if (temperature !== undefined && !modelRejectsCustomTemperature(model)) {
+      body.temperature = temperature;
+    }
     if (max_tokens !== undefined) body.max_completion_tokens = max_tokens;
     if (tools && tools.length > 0) {
       body.tools = this.convertTools(tools);
@@ -153,7 +174,9 @@ export class OpenAIProvider implements LLMProvider {
       stream: true,
     };
 
-    if (temperature !== undefined) body.temperature = temperature;
+    if (temperature !== undefined && !modelRejectsCustomTemperature(model)) {
+      body.temperature = temperature;
+    }
     if (max_tokens !== undefined) body.max_completion_tokens = max_tokens;
     if (tools && tools.length > 0) {
       body.tools = this.convertTools(tools);

--- a/src/llm/provider.test.ts
+++ b/src/llm/provider.test.ts
@@ -1,6 +1,6 @@
 import { test, expect, describe, beforeEach, afterEach, mock } from 'bun:test';
 import { AnthropicProvider } from './anthropic.ts';
-import { OpenAIProvider } from './openai.ts';
+import { OpenAIProvider, modelRejectsCustomTemperature } from './openai.ts';
 import { GroqProvider, relaxOptionalFieldsToNullable } from './groq.ts';
 import { OllamaProvider } from './ollama.ts';
 import { OpenRouterProvider } from './openrouter.ts';
@@ -843,6 +843,40 @@ describe('OpenAI request shaping', () => {
 
     expect(body.max_completion_tokens).toBe(321);
     expect(body.max_tokens).toBeUndefined();
+  });
+
+  test('OpenAIProvider keeps temperature for chat models that support it', async () => {
+    const provider = new OpenAIProvider('test-key', 'gpt-4o') as any;
+    await provider.chat([{ role: 'user', content: 'hi' }], { temperature: 0.6 });
+
+    const fetchMock = globalThis.fetch as unknown as ReturnType<typeof mock>;
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    const body = JSON.parse(String(init.body));
+    expect(body.temperature).toBe(0.6);
+  });
+
+  test('OpenAIProvider omits temperature for reasoning models that only accept the default', async () => {
+    const provider = new OpenAIProvider('test-key', 'o3-mini') as any;
+    await provider.chat([{ role: 'user', content: 'hi' }], { temperature: 0.6 });
+
+    const fetchMock = globalThis.fetch as unknown as ReturnType<typeof mock>;
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    const body = JSON.parse(String(init.body));
+    expect(body.temperature).toBeUndefined();
+  });
+});
+
+describe('modelRejectsCustomTemperature', () => {
+  test('rejects o-series and gpt-5 reasoning models', () => {
+    for (const m of ['o1', 'o1-mini', 'o3', 'o3-mini', 'o4-mini', 'o3-pro', 'gpt-5', 'gpt-5-mini', 'gpt-5-nano']) {
+      expect(modelRejectsCustomTemperature(m)).toBe(true);
+    }
+  });
+
+  test('allows chat models including gpt-5-chat', () => {
+    for (const m of ['gpt-4o', 'gpt-4o-mini', 'gpt-4-turbo', 'gpt-3.5-turbo', 'gpt-5-chat-latest']) {
+      expect(modelRejectsCustomTemperature(m)).toBe(false);
+    }
   });
 });
 

--- a/ui/src/v2/onboarding/SetupRoom.tsx
+++ b/ui/src/v2/onboarding/SetupRoom.tsx
@@ -55,7 +55,7 @@ const PROVIDERS: ReadonlyArray<{
     id: "openai",
     label: "OpenAI",
     needsKey: true,
-    models: ["gpt-5.4", "gpt-5.4-thinking", "gpt-5-mini", "o4-mini"],
+    models: ["gpt-5.5", "gpt-5.4", "gpt-5.4-pro", "gpt-5-mini"],
     defaultModel: "gpt-5.4",
   },
   {

--- a/ui/src/v2/rooms/settings/tabs/LLMTab.tsx
+++ b/ui/src/v2/rooms/settings/tabs/LLMTab.tsx
@@ -27,11 +27,15 @@ const MODELS_BY_KIND: Record<LLMProviderKind, string[]> = {
     "claude-haiku-4-5-20251001",
   ],
   openai: [
+    // API model ids ONLY — not ChatGPT product labels. Reasoning ("thinking")
+    // is a request param (reasoning.effort), not a separate "-thinking" model,
+    // so ids like "gpt-5.4-thinking"/"gpt-5.3-instant" 404 as model_not_found.
+    "gpt-5.5",
+    "gpt-5.5-pro",
     "gpt-5.4",
-    "gpt-5.4-mini",
-    "gpt-5.4-thinking",
     "gpt-5.4-pro",
-    "gpt-5.3-instant",
+    "gpt-5.4-mini",
+    "gpt-5.4-nano",
     "gpt-5-mini",
     "gpt-5-nano",
     "gpt-4.1",


### PR DESCRIPTION
## Summary

  Two onboarding-blocking bugs surfaced when configuring OpenAI as the provider. Both stem from the
  OpenAI reasoning-model API contract not being reflected in our code.

 ### 1. temperature 400 on reasoning models

  Onboarding chat failed immediately with:

  OpenAI API error (400): Unsupported value: 'temperature' does not support 0.6
  with this model. Only the default (1) value is supported.

  The onboarding interviewer sends temperature: 0.6, but OpenAI reasoning models (the o-series and
  the GPT‑5 family) only accept the default temperature of 1. The Anthropic provider already handles
  the analogous case via modelRejectsTemperature; this mirrors that pattern.

  - src/llm/openai.ts — added modelRejectsCustomTemperature(model) and gated the temperature field
  in both chat() and stream(). When the model is a reasoning model, the field is omitted and the API
  applies its default. Matches o\d… and gpt-5*, excluding the non‑reasoning gpt-5-chat*. Also
  covers the openai_compatible / litellm providers, which extend OpenAIProvider.

 ### 2. 404 model_not_found on "Test connection"

  Selecting "GPT‑5.4 thinking" as the High‑intelligence tier and clicking Test connection failed
  with:

  OpenAI API error (404): The model `gpt-5.4-thinking` does not exist or you do
  not have access to it.

  The model pickers were seeded with ChatGPT product labels rather than API model ids. On the OpenAI
  API, reasoning ("thinking") is a request parameter (reasoning.effort), not a separate model — so
  gpt-5.4-thinking and gpt-5.3-instant don't exist and 404. Verified against OpenAI's current API
  docs (valid ids: gpt-5.5, gpt-5.5-pro, gpt-5.4, gpt-5.4-pro, gpt-5.4-mini, gpt-5.4-nano, … — no
  -thinking/-instant suffixes).

  - ui/src/v2/rooms/settings/tabs/LLMTab.tsx — replaced the invalid ids with real ones and added a
  comment explaining the API‑id‑vs‑product‑label trap.
  - ui/src/v2/onboarding/SetupRoom.tsx — same for the onboarding OpenAI list.

 ### Tests

  - src/llm/provider.test.ts — added coverage: temperature kept for gpt-4o, dropped for o3-mini,
  plus unit tests of modelRejectsCustomTemperature (rejects o‑series + gpt-5*; allows chat models
  incl. gpt-5-chat-latest). Full suite green (pre‑commit hook ran it).

 ### Follow-up (separate PR)

  Exposing reasoning effort (none/low/medium/high/xhigh) as a configurable per‑tier setting — so
  users can pick e.g. "GPT‑5.4 at high effort" — is intentionally out of scope here and will land in
  its own PR.