### PR TITLE
fix(browser): fall back to headless Chrome when no $DISPLAY

### DIFF
--- a/src/actions/browser/chrome-launcher.ts
+++ b/src/actions/browser/chrome-launcher.ts
@@ -187,6 +187,14 @@ export async function launchChrome(port: number = 9222, profileDir?: string): Pr
     if (isWSL) {
       args.push('--ozone-platform=x11');
     }
+
+    // Headless servers/containers have no X server. Without a display a
+    // windowed launch dies with "Missing X server or $DISPLAY", so fall back
+    // to headless when no DISPLAY is present (CDP works identically). Machines
+    // with a real display — desktops and WSLg — keep the visible window.
+    if (!isWSL && !process.env.DISPLAY) {
+      args.push('--headless=new');
+    }
   }
 
   // Open a blank tab so a target exists


### PR DESCRIPTION
## Problem

On a headless host (server/container with no X server and no `$DISPLAY`), `chrome-launcher` always builds **windowed**-Chrome args. The browser exits immediately with:

```
ERROR ozone_platform_x11.cc: Missing X server or $DISPLAY
ERROR env.cc: The platform failed to initialize. Exiting.
```

so the remote-debugging port never opens and **every browser tool fails**. `jarvis doctor`'s Browser check still passes (it only checks that a binary exists at a known path), which makes this easy to miss until a tool is actually invoked.

## Fix

Add `--headless=new` **only when there is no `$DISPLAY`** — desktops and WSLg keep their visible window exactly as before (behavior-preserving for normal users), while headless servers/containers get a working CDP browser.

## Verification

On a no-display container, the same launch args + `--headless=new` bring up a reachable CDP endpoint (`/json/version` → `HeadlessChrome/…`), and JARVIS's browser tools work.

Fixes #243
