### PR TITLE
fix(llm): disable reasoning blocks for Ollama models (think:false)

### DIFF
--- a/src/llm/ollama.ts
+++ b/src/llm/ollama.ts
@@ -93,6 +93,10 @@ export class OllamaProvider implements LLMProvider {
       model,
       messages: this.convertMessages(compactedMessages),
       stream: false,
+      // Disable reasoning models' (e.g. qwen3) <think> blocks: they pollute
+      // agent output and tool-call parsing. Harmless no-op for non-thinking
+      // models, which Ollama simply ignores.
+      think: false,
     };
 
     // Map our cross-provider options to Ollama's `body.options` bag.
@@ -137,6 +141,8 @@ export class OllamaProvider implements LLMProvider {
       model,
       messages: this.convertMessages(compactedMessages),
       stream: true,
+      // See chat(): disable qwen3-style reasoning blocks; no-op otherwise.
+      think: false,
     };
 
     // See chat(): map our cross-provider options to Ollama's bag.


### PR DESCRIPTION
## Problem

Reasoning models served through Ollama (e.g. `qwen3`, and qwen3.5-based merges) emit `<think>…</think>` blocks by default. When such a model is used as JARVIS's brain:

- the reasoning text leaks into chat responses and can interfere with **tool-call parsing**;
- with a small token budget the visible answer can come back **empty**, because all generated tokens were consumed inside the (unclosed) `<think>` block.

## Fix

Send `think: false` in the `/api/chat` request body (both `chat()` and `stream()`). Ollama supports this flag for thinking-capable models and **ignores it for non-thinking models** — verified: a `llama3.2:3b` request with `think:false` returns HTTP 200 with normal content. So it's a safe global default that cleanly suppresses reasoning where applicable.

## Notes

No config surface added — reasoning is simply off for the agent path, which is what an automated tool-using loop wants. If desired, this could later be made configurable per provider/tier.
