### PR TITLE
fix(observers): allow scoping file-watcher roots to avoid boot hang

### DIFF
--- a/src/daemon/observer-service.ts
+++ b/src/daemon/observer-service.ts
@@ -102,8 +102,20 @@ export class ObserverService implements Service {
     this._status = 'starting';
 
     try {
-      // Register core observers
-      this.manager.register(new FileWatcher([homedir()], [this.dataDir]));
+      // Register core observers.
+      //
+      // The file watcher recurses over its roots. Defaulting to the entire
+      // home directory hangs the daemon's boot on hosts whose $HOME holds
+      // large trees (multiple repos, node_modules, caches): Bun's recursive
+      // fs.watch blocks while registering watches, and because observers are
+      // awaited before the HTTP/WS service starts, the dashboard never binds.
+      // Allow scoping the watched roots via JARVIS_FILE_WATCH_PATHS (a
+      // colon-separated list); default stays [homedir()] so behavior is
+      // unchanged for everyone else.
+      const watchPaths = process.env.JARVIS_FILE_WATCH_PATHS
+        ? process.env.JARVIS_FILE_WATCH_PATHS.split(':').filter(Boolean)
+        : [homedir()];
+      this.manager.register(new FileWatcher(watchPaths, [this.dataDir]));
       this.manager.register(new ClipboardMonitor());
       this.manager.register(new ProcessMonitor());
 


### PR DESCRIPTION
## Problem

`ObserverService.start()` registers a `FileWatcher` over the **entire home directory, recursively**:

```ts
this.manager.register(new FileWatcher([homedir()], [this.dataDir]));
```

On hosts whose `$HOME` contains large trees (multiple repos, `node_modules`, caches), Bun's recursive `fs.watch` **blocks** while registering watches. Because `ObserverManager.startAll()` is awaited **before** the websocket/HTTP service starts, the daemon's dashboard never binds — `jarvis status` reports "running" (the process is alive) but `http://localhost:3142` is unreachable, with the boot log frozen right after `[file-watcher] Starting file system monitoring...`.

## Fix (minimal, non-breaking)

Make the watched roots configurable via `JARVIS_FILE_WATCH_PATHS` (a colon-separated list), defaulting to `[homedir()]` so existing behavior is unchanged. Affected hosts can scope the watch to a project dir and boot normally:

```bash
JARVIS_FILE_WATCH_PATHS=/home/me/projects jarvis start
```

## Follow-up (out of scope here)

This is the smallest safe mitigation. A fuller fix — not recursively watching all of `$HOME` by default, and/or binding the HTTP server independently of observer startup so a slow observer can't hold the dashboard hostage — is discussed in #242 and would be a good follow-up.

Refs #242
