### PR TITLE
fix(ui): don't crash the dashboard on non-secure origins (guard navigator.mediaDevices)

### DIFF
--- a/ui/src/hooks/useVoice.ts
+++ b/ui/src/hooks/useVoice.ts
@@ -483,6 +483,14 @@ export function useVoice({ wsRef, wakeWordEnabled = true, wakeEngine = "openwake
 
   // --- Check mic availability on mount ---
   useEffect(() => {
+    // `navigator.mediaDevices` is undefined in a non-secure context (plain
+    // HTTP to a non-localhost origin). Without this guard the call throws a
+    // synchronous TypeError that escapes the effect and aborts the entire app
+    // render — a blank dashboard. Degrade to "mic unavailable" instead.
+    if (!navigator.mediaDevices?.getUserMedia) {
+      setIsMicAvailable(false);
+      return;
+    }
     navigator.mediaDevices.getUserMedia({ audio: true })
       .then(stream => {
         stream.getTracks().forEach(t => t.stop());


### PR DESCRIPTION
## Problem

Opening the dashboard over a **non-secure origin** (plain `http://<ip>:3142`, the normal way to reach a self-hosted daemon from another machine) renders a **blank screen**. Console:

```
Uncaught TypeError: Cannot read properties of undefined (reading 'getUserMedia')
```

`navigator.mediaDevices` is `undefined` in a non-secure context, and `useVoice`'s mount effect calls `navigator.mediaDevices.getUserMedia(...)` unguarded. The throw is **synchronous** (so the existing `.catch` never fires) and aborts the entire React render. `localhost`/HTTPS are secure contexts, so it only shows up when reaching the daemon by IP.

## Fix

Guard `navigator.mediaDevices?.getUserMedia` in the mount effect; when absent, set mic unavailable and bail — instead of throwing.

## Verified

With the guard, the dashboard renders fully over plain `http://<ip>:3142` (no crash); mic features simply report unavailable on non-secure origins, as expected.

Fixes #247
