### PR TITLE
harden pieces-catalog sync: npm retry, analysed PR body, and skip no-op PRs

### DIFF
--- a/.github/workflows/sync-pieces-catalog.yml
+++ b/.github/workflows/sync-pieces-catalog.yml
@@ -4,11 +4,14 @@
 #   1. `bun run scripts/sync-pieces-catalog.ts` -- walks the activepieces
 #      monorepo at the pinned SHA, queries npm for the latest version of
 #      every piece, and writes `src/workflows/pieces-library/catalog-generated.ts`.
+#      It also diffs against the committed catalog and emits two step outputs:
+#      `verdict` (safe | review) and `has_changes` (whether any entry moved).
 #   2. `bun test` and `tsc --noEmit` -- the catalog tests in
 #      `pieces-library/catalog.test.ts` guard against malformed entries
 #      (bad semver, missing displayName, ids that collide, etc.).
-#   3. If anything changed, open a PR with the diff. If nothing changed,
-#      exit silently.
+#   3. Open a PR ONLY when an entry actually changed (`has_changes == true`).
+#      A run that bumped nothing but the generation timestamp opens no PR. The
+#      PR title reflects the verdict and the body is the script's diff analysis.
 #
 # Why a PR (not a direct commit):
 #   - Every catalog change is reviewable. Pieces can be renamed or removed
@@ -44,9 +47,13 @@ jobs:
 
       - run: bun install
 
-      # Run the generator. Writes catalog-generated.ts in place.
+      # Run the generator. Writes catalog-generated.ts in place and, via
+      # --report, an analysed PR body to the runner temp dir (outside the repo,
+      # so create-pull-request never commits it). The step also emits a
+      # `verdict` output (safe | review) used to title the PR below.
       - name: Regenerate pieces catalog
-        run: bun run scripts/sync-pieces-catalog.ts
+        id: sync
+        run: bun run scripts/sync-pieces-catalog.ts --report "${{ runner.temp }}/catalog-pr-body.md"
         env:
           # Lift the GitHub API rate limit when the script needs it
           # (mostly for the sparse clone, which is unauthenticated by
@@ -65,28 +72,16 @@ jobs:
       # Open (or update) a PR with the catalog diff. peter-evans's
       # create-pull-request handles the branch creation, push, and PR
       # creation idempotently -- a second run on an already-open PR just
-      # updates the branch.
+      # updates the branch. The title reflects the analysed verdict and the
+      # body is the markdown the sync script wrote (body-path), so reviewers
+      # see "safe to merge" vs "manual review required" at a glance.
       - name: Open PR with catalog changes
+        if: steps.sync.outputs.has_changes == 'true'
         uses: peter-evans/create-pull-request@v7
         with:
           commit-message: "chore: refresh pieces catalog"
-          title: "chore: refresh pieces catalog"
-          body: |
-            Automated refresh of `src/workflows/pieces-library/catalog-generated.ts`.
-
-            The sync script walked the activepieces monorepo at the pinned SHA
-            (see `scripts/sync-pieces-catalog.ts`) and queried npm for the
-            latest published version of each piece.
-
-            Review checklist:
-            - [ ] Diff looks reasonable (no unexpected wholesale removal)
-            - [ ] No new pieces with suspicious names / licenses
-            - [ ] CI passed (catalog invariants + typecheck)
-
-            Hand-tuning lives in `catalog-overrides.ts` -- this PR doesn't
-            touch that file. If a newly-added piece needs a description
-            override, version pin, or exclusion, follow up with a separate
-            commit on the merged branch.
+          title: ${{ steps.sync.outputs.verdict == 'safe' && 'chore: refresh pieces catalog (safe)' || 'chore: refresh pieces catalog (review needed)' }}
+          body-path: ${{ runner.temp }}/catalog-pr-body.md
           branch: chore/sync-pieces-catalog
           labels: |
             pieces-catalog

--- a/scripts/lib/catalog-diff.test.ts
+++ b/scripts/lib/catalog-diff.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, test } from "bun:test";
+import {
+  diffCatalogs,
+  hasChanges,
+  renderReport,
+  verdictFor,
+  type GeneratedEntryLike,
+} from "./catalog-diff";
+
+const SHA = "d04e6807c485ecd788a72af0d04abffba78563c7";
+
+function entry(over: Partial<GeneratedEntryLike> & { id: string }): GeneratedEntryLike {
+  return {
+    npmPackage: `@activepieces/piece-${over.id}`,
+    versionRange: "^1.0.0",
+    latestVersion: "1.0.0",
+    displayName: over.id,
+    description: "",
+    sourceUrl: `https://example.com/${over.id}`,
+    licenseSpdx: "MIT",
+    ...over,
+  };
+}
+
+const meta = { oldSha: SHA, newSha: SHA };
+const reportOpts = {
+  shortSha: SHA.slice(0, 7),
+  generatedAt: "2026-06-30",
+  fileLabel: "src/workflows/pieces-library/catalog-generated.ts",
+  lineOf: (_id: string) => null as number | null,
+};
+
+describe("diffCatalogs", () => {
+  test("identical catalogs produce an empty, safe diff", () => {
+    const a = [entry({ id: "gmail" }), entry({ id: "slack" })];
+    const diff = diffCatalogs(a, a, meta);
+    expect(diff.added).toHaveLength(0);
+    expect(diff.removed).toHaveLength(0);
+    expect(diff.versionChanged).toHaveLength(0);
+    expect(diff.licenseChanged).toHaveLength(0);
+    expect(diff.otherChanged).toHaveLength(0);
+    expect(diff.shaChanged).toBeNull();
+    expect(verdictFor(diff)).toBe("safe");
+  });
+
+  test("a pure version bump is detected and stays safe", () => {
+    const oldE = [entry({ id: "gmail", latestVersion: "0.4.7" })];
+    const newE = [entry({ id: "gmail", latestVersion: "0.4.8" })];
+    const diff = diffCatalogs(oldE, newE, meta);
+    expect(diff.versionChanged).toEqual([{ id: "gmail", from: "0.4.7", to: "0.4.8" }]);
+    expect(diff.added).toHaveLength(0);
+    expect(verdictFor(diff)).toBe("safe");
+  });
+
+  test("an added piece flips the verdict to review", () => {
+    const oldE = [entry({ id: "gmail" })];
+    const newE = [entry({ id: "gmail" }), entry({ id: "acme-crm", licenseSpdx: "GPL-3.0" })];
+    const diff = diffCatalogs(oldE, newE, meta);
+    expect(diff.added.map((e) => e.id)).toEqual(["acme-crm"]);
+    expect(verdictFor(diff)).toBe("review");
+  });
+
+  test("a removed piece flips the verdict to review", () => {
+    const oldE = [entry({ id: "gmail" }), entry({ id: "old-piece" })];
+    const newE = [entry({ id: "gmail" })];
+    const diff = diffCatalogs(oldE, newE, meta);
+    expect(diff.removed.map((e) => e.id)).toEqual(["old-piece"]);
+    expect(verdictFor(diff)).toBe("review");
+  });
+
+  test("a license change is flagged even with no other movement", () => {
+    const oldE = [entry({ id: "gmail", licenseSpdx: "MIT" })];
+    const newE = [entry({ id: "gmail", licenseSpdx: "GPL-3.0" })];
+    const diff = diffCatalogs(oldE, newE, meta);
+    expect(diff.licenseChanged).toEqual([{ id: "gmail", from: "MIT", to: "GPL-3.0" }]);
+    expect(verdictFor(diff)).toBe("review");
+  });
+
+  test("a pinned-SHA bump forces review", () => {
+    const a = [entry({ id: "gmail" })];
+    const diff = diffCatalogs(a, a, { oldSha: "aaa", newSha: "bbb" });
+    expect(diff.shaChanged).toEqual({ from: "aaa", to: "bbb" });
+    expect(verdictFor(diff)).toBe("review");
+  });
+
+  test("displayName/description drift lands in otherChanged (not version)", () => {
+    const oldE = [entry({ id: "slack", displayName: "Slack", description: "old" })];
+    const newE = [entry({ id: "slack", displayName: "Slack v2", description: "new" })];
+    const diff = diffCatalogs(oldE, newE, meta);
+    expect(diff.otherChanged).toEqual([{ id: "slack", fields: ["displayName", "description"] }]);
+    expect(diff.versionChanged).toHaveLength(0);
+    expect(verdictFor(diff)).toBe("review");
+  });
+
+  test("first run (no previous) treats everything as added", () => {
+    const newE = [entry({ id: "gmail" }), entry({ id: "slack" })];
+    const diff = diffCatalogs([], newE, { oldSha: "", newSha: SHA });
+    expect(diff.added).toHaveLength(2);
+    expect(diff.shaChanged).toBeNull(); // empty oldSha is not a "change"
+    expect(verdictFor(diff)).toBe("review");
+  });
+});
+
+describe("hasChanges", () => {
+  test("identical catalogs report no changes (timestamp-only run)", () => {
+    const a = [entry({ id: "gmail" })];
+    expect(hasChanges(diffCatalogs(a, a, meta))).toBe(false);
+  });
+
+  test("a version bump counts as a change worth a PR", () => {
+    const oldE = [entry({ id: "gmail", latestVersion: "0.4.7" })];
+    const newE = [entry({ id: "gmail", latestVersion: "0.4.8" })];
+    expect(hasChanges(diffCatalogs(oldE, newE, meta))).toBe(true);
+  });
+
+  test("added / removed / sha bump all count as changes", () => {
+    const base = [entry({ id: "gmail" })];
+    expect(hasChanges(diffCatalogs(base, [...base, entry({ id: "x" })], meta))).toBe(true);
+    expect(hasChanges(diffCatalogs([...base, entry({ id: "x" })], base, meta))).toBe(true);
+    expect(hasChanges(diffCatalogs(base, base, { oldSha: "a", newSha: "b" }))).toBe(true);
+  });
+});
+
+describe("renderReport", () => {
+  test("safe diff renders the NOTE banner and 'Safe to merge'", () => {
+    const oldE = [entry({ id: "gmail", latestVersion: "0.4.7" })];
+    const newE = [entry({ id: "gmail", latestVersion: "0.4.8" })];
+    const { verdict, markdown } = renderReport(diffCatalogs(oldE, newE, meta), reportOpts);
+    expect(verdict).toBe("safe");
+    expect(markdown).toContain("> [!NOTE]");
+    expect(markdown).toContain("Safe to merge");
+    expect(markdown).toContain("`0.4.7` -> `0.4.8`");
+    expect(markdown).not.toContain("[!WARNING]");
+  });
+
+  test("added piece renders the WARNING banner with the file:line", () => {
+    const oldE = [entry({ id: "gmail" })];
+    const newE = [entry({ id: "gmail" }), entry({ id: "acme-crm", licenseSpdx: "Apache-2.0" })];
+    const { verdict, markdown } = renderReport(diffCatalogs(oldE, newE, meta), {
+      ...reportOpts,
+      lineOf: (id) => (id === "acme-crm" ? 42 : null),
+    });
+    expect(verdict).toBe("review");
+    expect(markdown).toContain("> [!WARNING]");
+    expect(markdown).toContain("Manual review required");
+    expect(markdown).toContain("1 piece added");
+    expect(markdown).toContain(
+      "`acme-crm` -- `@activepieces/piece-acme-crm` -- license `Apache-2.0` -- " +
+        "`src/workflows/pieces-library/catalog-generated.ts:42`",
+    );
+  });
+
+  test("empty license renders as (unspecified)", () => {
+    const oldE = [entry({ id: "gmail" })];
+    const newE = [entry({ id: "gmail" }), entry({ id: "weird", licenseSpdx: "" })];
+    const { markdown } = renderReport(diffCatalogs(oldE, newE, meta), reportOpts);
+    expect(markdown).toContain("license (unspecified)");
+  });
+
+  test("a backtick in an upstream license can't break out of the code span", () => {
+    const oldE = [entry({ id: "gmail" })];
+    const newE = [entry({ id: "gmail" }), entry({ id: "evil", licenseSpdx: "MIT` injected" })];
+    const { markdown } = renderReport(diffCatalogs(oldE, newE, meta), reportOpts);
+    expect(markdown).not.toContain("MIT` injected");
+    expect(markdown).toContain("MIT' injected");
+  });
+
+  test("no em dashes or fancy arrows leak into the body", () => {
+    const oldE = [entry({ id: "gmail", latestVersion: "1.0.0", licenseSpdx: "MIT" })];
+    const newE = [
+      entry({ id: "gmail", latestVersion: "1.1.0", licenseSpdx: "ISC" }),
+      entry({ id: "new-one" }),
+    ];
+    const { markdown } = renderReport(diffCatalogs(oldE, newE, { oldSha: "aaa", newSha: "bbb" }), reportOpts);
+    expect(markdown).not.toMatch(/[—–→⇒←]/);
+  });
+});

--- a/scripts/lib/catalog-diff.ts
+++ b/scripts/lib/catalog-diff.ts
@@ -1,0 +1,340 @@
+/**
+ * Diff two generations of the pieces catalog and turn the delta into a
+ * human-readable PR body.
+ *
+ * Pure + side-effect free so it can be unit-tested and reused: the sync script
+ * feeds it the previously-committed `GENERATED` array and the freshly computed
+ * one, and gets back a verdict ("safe" vs "review") plus the markdown that
+ * becomes the auto-PR description.
+ *
+ * Why a "safe" verdict can exist at all:
+ *   On a normal weekly run the pinned SHA is fixed, so every field sourced from
+ *   the monorepo (displayName, description, license, sourceUrl) is frozen --
+ *   only npm-derived versions and the generation timestamp can move. A diff
+ *   containing nothing but version bumps is therefore mechanical and safe to
+ *   merge without a human reading it. Anything else -- a piece entering or
+ *   leaving the catalog, a license change, a pinned-SHA bump -- puts
+ *   third-party code or a trust assertion in motion and asks for human eyes.
+ */
+
+/**
+ * The shape we diff on. Matches `GeneratedCatalogEntry` from
+ * `catalog-generated.ts` field-for-field; declared locally so this module has
+ * no dependency on the generated file (which the sync script overwrites).
+ */
+export interface GeneratedEntryLike {
+  id: string;
+  npmPackage: string;
+  versionRange: string;
+  latestVersion: string;
+  displayName: string;
+  description: string;
+  sourceUrl: string;
+  licenseSpdx: string;
+}
+
+export interface CatalogDiff {
+  /** Ids present in the new catalog but not the old one. Third-party code. */
+  added: GeneratedEntryLike[];
+  /** Ids present in the old catalog but gone from the new one. */
+  removed: GeneratedEntryLike[];
+  /** Same id, different npm version. The mechanical, expected change. */
+  versionChanged: Array<{ id: string; from: string; to: string }>;
+  /** Same id, different SPDX license. A trust/legal signal -- always flagged. */
+  licenseChanged: Array<{ id: string; from: string; to: string }>;
+  /**
+   * Same id, drift in displayName / description / npmPackage. `sourceUrl` is
+   * deliberately excluded -- when the pinned SHA moves every entry's sourceUrl
+   * changes at once, which the dedicated `shaChanged` line already explains.
+   */
+  otherChanged: Array<{ id: string; fields: string[] }>;
+  /** Non-null when the pinned SHA moved (a manual bump of the sync script). */
+  shaChanged: { from: string; to: string } | null;
+  oldCount: number;
+  newCount: number;
+}
+
+export type Verdict = "safe" | "review";
+
+const byId = (a: { id: string }, b: { id: string }) => a.id.localeCompare(b.id);
+
+/** Compute the categorised delta between two catalog generations. */
+export function diffCatalogs(
+  oldEntries: GeneratedEntryLike[],
+  newEntries: GeneratedEntryLike[],
+  meta: { oldSha: string; newSha: string },
+): CatalogDiff {
+  const oldById = new Map(oldEntries.map((e) => [e.id, e]));
+  const newById = new Map(newEntries.map((e) => [e.id, e]));
+
+  const added = newEntries.filter((e) => !oldById.has(e.id)).sort(byId);
+  const removed = oldEntries.filter((e) => !newById.has(e.id)).sort(byId);
+
+  const versionChanged: CatalogDiff["versionChanged"] = [];
+  const licenseChanged: CatalogDiff["licenseChanged"] = [];
+  const otherChanged: CatalogDiff["otherChanged"] = [];
+
+  for (const e of newEntries) {
+    const prev = oldById.get(e.id);
+    if (!prev) continue; // handled by `added`
+    if (prev.latestVersion !== e.latestVersion) {
+      versionChanged.push({ id: e.id, from: prev.latestVersion, to: e.latestVersion });
+    }
+    if (prev.licenseSpdx !== e.licenseSpdx) {
+      licenseChanged.push({ id: e.id, from: prev.licenseSpdx, to: e.licenseSpdx });
+    }
+    const fields: string[] = [];
+    if (prev.displayName !== e.displayName) fields.push("displayName");
+    if (prev.description !== e.description) fields.push("description");
+    if (prev.npmPackage !== e.npmPackage) fields.push("npmPackage");
+    if (fields.length > 0) otherChanged.push({ id: e.id, fields });
+  }
+
+  versionChanged.sort(byId);
+  licenseChanged.sort(byId);
+  otherChanged.sort(byId);
+
+  const shaChanged =
+    meta.oldSha && meta.oldSha !== meta.newSha
+      ? { from: meta.oldSha, to: meta.newSha }
+      : null;
+
+  return {
+    added,
+    removed,
+    versionChanged,
+    licenseChanged,
+    otherChanged,
+    shaChanged,
+    oldCount: oldEntries.length,
+    newCount: newEntries.length,
+  };
+}
+
+/**
+ * "safe" only when the diff is purely mechanical: version bumps (and the
+ * always-changing timestamp, which isn't represented here). The moment a piece
+ * is added/removed, a license changes, metadata drifts, or the pinned SHA
+ * moves, a human should look.
+ */
+export function verdictFor(diff: CatalogDiff): Verdict {
+  const needsReview =
+    diff.added.length > 0 ||
+    diff.removed.length > 0 ||
+    diff.licenseChanged.length > 0 ||
+    diff.otherChanged.length > 0 ||
+    diff.shaChanged !== null;
+  return needsReview ? "review" : "safe";
+}
+
+/**
+ * True when the diff carries a real catalog update -- anything an entry could
+ * change. The generation timestamp is NOT represented here, so a run that only
+ * bumped the timestamp returns false. The sync workflow keys PR creation off
+ * this: no material change -> no PR (a "safe" verdict with version bumps still
+ * counts as a change worth shipping).
+ */
+export function hasChanges(diff: CatalogDiff): boolean {
+  return (
+    diff.added.length > 0 ||
+    diff.removed.length > 0 ||
+    diff.versionChanged.length > 0 ||
+    diff.licenseChanged.length > 0 ||
+    diff.otherChanged.length > 0 ||
+    diff.shaChanged !== null
+  );
+}
+
+export interface ReportOptions {
+  /** Short pinned SHA for the summary line. */
+  shortSha: string;
+  /** ISO date the catalog was generated. */
+  generatedAt: string;
+  /** Repo-relative path used in `path:Lnn` references for added pieces. */
+  fileLabel: string;
+  /** Resolve an id to its 1-based line in the generated file, or null. */
+  lineOf: (id: string) => number | null;
+}
+
+/** Collapse a list into a `<details>` block once it gets long. */
+const COLLAPSE_THRESHOLD = 12;
+
+/**
+ * Make an arbitrary upstream string safe to drop inside an inline code span: a
+ * stray backtick would break out of the span and a newline would break the
+ * bullet. ids and npm package names are already constrained by the generator's
+ * id regex, so only free-form fields (license, npm version) get run through it.
+ */
+function codeSafe(s: string): string {
+  return s.replace(/`/g, "'").replace(/\s+/g, " ").trim();
+}
+
+function fmtLicense(spdx: string): string {
+  return spdx === "" ? "(unspecified)" : `\`${codeSafe(spdx)}\``;
+}
+
+/** Build the full PR body markdown + the verdict it implies. */
+export function renderReport(
+  diff: CatalogDiff,
+  opts: ReportOptions,
+): { verdict: Verdict; markdown: string } {
+  const verdict = verdictFor(diff);
+  const out: string[] = [];
+  const p = (line = "") => out.push(line);
+
+  p("## Automated pieces-catalog refresh");
+  p();
+  p(
+    `The sync script walked the activepieces monorepo at \`${opts.shortSha}\` ` +
+      "and queried npm for the latest published version of every piece.",
+  );
+  p();
+
+  // Verdict callout (GitHub alert syntax -- renders as a coloured banner).
+  if (verdict === "safe") {
+    const n = diff.versionChanged.length;
+    const bumps =
+      n === 0
+        ? "only the generation timestamp moved"
+        : `the only entry changes are ${n} version bump${n === 1 ? "" : "s"} from npm`;
+    p("> [!NOTE]");
+    p(
+      `> **Safe to merge.** No pieces were added, removed, or relicensed and the ` +
+        `pinned SHA is unchanged -- ${bumps}. CI (catalog invariants + typecheck) ` +
+        `still gates this PR.`,
+    );
+  } else {
+    p("> [!WARNING]");
+    p(`> **Manual review required** -- ${reviewReasons(diff)}. See the flagged sections below.`);
+  }
+  p();
+
+  // Summary table.
+  p("### Summary");
+  p();
+  p("| metric | value |");
+  p("| --- | --- |");
+  p(`| Generated at | ${opts.generatedAt} |`);
+  p(
+    `| Pinned SHA | \`${opts.shortSha}\` (${diff.shaChanged ? "changed" : "unchanged"}) |`,
+  );
+  p(`| Catalog size | ${diff.newCount} (was ${diff.oldCount}) |`);
+  p(`| Added | ${diff.added.length} |`);
+  p(`| Removed | ${diff.removed.length} |`);
+  p(`| Version bumps | ${diff.versionChanged.length} |`);
+  p(`| License changes | ${diff.licenseChanged.length} |`);
+  p(`| Other metadata | ${diff.otherChanged.length} |`);
+  p();
+
+  if (diff.shaChanged) {
+    p("### Pinned SHA changed");
+    p();
+    p(
+      `\`${diff.shaChanged.from}\` -> \`${diff.shaChanged.to}\`. Every piece's ` +
+        "`sourceUrl` now points at the new commit, and descriptions / licenses may " +
+        "have shifted with it. Treat this as a full re-review, not a routine refresh.",
+    );
+    p();
+  }
+
+  if (diff.added.length > 0) {
+    p("### Added pieces -- review required");
+    p();
+    p(
+      "Each entry below is new and installs third-party code that has not been " +
+        "vetted. Confirm the package name and license before merging:",
+    );
+    p();
+    for (const e of diff.added) {
+      const line = opts.lineOf(e.id);
+      const where = line === null ? "" : ` -- \`${opts.fileLabel}:${line}\``;
+      p(`- \`${e.id}\` -- \`${e.npmPackage}\` -- license ${fmtLicense(e.licenseSpdx)}${where}`);
+    }
+    p();
+  }
+
+  if (diff.removed.length > 0) {
+    p("### Removed pieces");
+    p();
+    p(
+      "A piece leaving the catalog means it was unpublished from npm (or the npm " +
+        "retry budget was exhausted during sync). Confirm this is intentional and " +
+        "not a transient failure:",
+    );
+    p();
+    for (const e of diff.removed) {
+      p(`- \`${e.id}\` -- was \`${e.npmPackage}\``);
+    }
+    p();
+  }
+
+  if (diff.licenseChanged.length > 0) {
+    p("### License changes -- review required");
+    p();
+    for (const c of diff.licenseChanged) {
+      p(`- \`${c.id}\`: ${fmtLicense(c.from)} -> ${fmtLicense(c.to)}`);
+    }
+    p();
+  }
+
+  if (diff.versionChanged.length > 0) {
+    p(`### Version bumps (${diff.versionChanged.length})`);
+    p();
+    const rows = diff.versionChanged.map(
+      (c) => `- \`${c.id}\`: \`${codeSafe(c.from)}\` -> \`${codeSafe(c.to)}\``,
+    );
+    if (rows.length > COLLAPSE_THRESHOLD) {
+      p(`<details><summary>Show ${rows.length} version bumps</summary>`);
+      p();
+      for (const r of rows) p(r);
+      p();
+      p("</details>");
+    } else {
+      for (const r of rows) p(r);
+    }
+    p();
+  }
+
+  if (diff.otherChanged.length > 0) {
+    p("### Other metadata changes");
+    p();
+    for (const c of diff.otherChanged) {
+      p(`- \`${c.id}\`: ${c.fields.join(", ")}`);
+    }
+    p();
+  }
+
+  p("---");
+  p();
+  p(
+    "Hand-tuning (verified status, exclusions, version pins, sizes, descriptions) " +
+      "lives in `catalog-overrides.ts`, which this refresh does not touch. If a " +
+      "newly added piece needs an exclusion, pin, or description override, follow " +
+      "up with a commit on this branch.",
+  );
+
+  return { verdict, markdown: out.join("\n") + "\n" };
+}
+
+/** One-line summary of why review is needed, for the warning callout. */
+function reviewReasons(diff: CatalogDiff): string {
+  const parts: string[] = [];
+  if (diff.added.length > 0) {
+    parts.push(`${diff.added.length} piece${diff.added.length === 1 ? "" : "s"} added`);
+  }
+  if (diff.removed.length > 0) {
+    parts.push(`${diff.removed.length} removed`);
+  }
+  if (diff.licenseChanged.length > 0) {
+    parts.push(
+      `${diff.licenseChanged.length} license change${diff.licenseChanged.length === 1 ? "" : "s"}`,
+    );
+  }
+  if (diff.shaChanged) {
+    parts.push("pinned SHA bumped");
+  }
+  if (diff.otherChanged.length > 0) {
+    parts.push(`${diff.otherChanged.length} metadata change${diff.otherChanged.length === 1 ? "" : "s"}`);
+  }
+  return parts.join(", ");
+}

--- a/scripts/sync-pieces-catalog.ts
+++ b/scripts/sync-pieces-catalog.ts
@@ -6,6 +6,7 @@
  *
  * Run locally:
  *   bun run scripts/sync-pieces-catalog.ts
+ *   bun run scripts/sync-pieces-catalog.ts --report /tmp/pr-body.md  # preview the PR analysis
  *
  * Run in CI (weekly):
  *   .github/workflows/sync-pieces-catalog.yml
@@ -18,6 +19,10 @@
  *   4. Query the npm registry for the latest published version.
  *      Pieces with no npm release are skipped (still in development).
  *   5. Build a sorted entry list and write catalog-generated.ts.
+ *   6. With --report <path> (or env CATALOG_REPORT_PATH): diff against the
+ *      previously-committed catalog and write a markdown PR body that calls out
+ *      "safe to merge" (version bumps only) vs "manual review required" (pieces
+ *      added/removed, license or SHA changes). See scripts/lib/catalog-diff.ts.
  *
  * What the script does NOT do:
  *   - Probe install size (slow, flaky in CI). Sizes come from the
@@ -31,10 +36,26 @@
  * if running in CI alongside other GH actions.
  */
 
-import { existsSync, readFileSync, writeFileSync, mkdirSync, rmSync, readdirSync, statSync } from "node:fs";
-import { join, resolve } from "node:path";
+import {
+  existsSync,
+  readFileSync,
+  writeFileSync,
+  appendFileSync,
+  mkdirSync,
+  rmSync,
+  readdirSync,
+  statSync,
+} from "node:fs";
+import { join, resolve, dirname } from "node:path";
 import { tmpdir } from "node:os";
+import { pathToFileURL } from "node:url";
 import { spawnSync } from "node:child_process";
+import {
+  diffCatalogs,
+  renderReport,
+  hasChanges,
+  type GeneratedEntryLike,
+} from "./lib/catalog-diff";
 
 /**
  * Activepieces commit walked when generating the list. Keep this in sync
@@ -66,10 +87,12 @@ interface PieceMetadata {
 async function main(): Promise<void> {
   const checkOnly = process.argv.includes("--check");
   const verbose = process.argv.includes("--verbose") || process.argv.includes("-v");
+  const reportPath = resolveReportPath();
 
   info(`Pinned SHA: ${PINNED_SHA}`);
   info(`Output:     ${OUT_FILE}`);
   info(`Mode:       ${checkOnly ? "check-only (no write)" : "write"}`);
+  if (reportPath) info(`PR report:  ${reportPath}`);
 
   // 1. Sparse-clone packages/pieces/community.
   ensureWorkdir();
@@ -109,8 +132,14 @@ async function main(): Promise<void> {
     for (const s of skipped) console.log(`  - ${s.id}: ${s.reason}`);
   }
 
-  // 5. Write the file.
+  // 5. Render + (optionally) analyse the diff for the auto-PR body. Read the
+  // previous generation BEFORE the file is overwritten below.
   const rendered = renderCatalogFile(found);
+  if (reportPath) {
+    const previous = await readPreviousGeneration();
+    await writePrReport(reportPath, previous, found, rendered);
+  }
+
   if (checkOnly) {
     const current = existsSync(OUT_FILE) ? readFileSync(OUT_FILE, "utf8") : "";
     if (current === rendered) {
@@ -206,20 +235,66 @@ async function extractPiece(dir: string, verbose: boolean): Promise<ExtractResul
   };
 }
 
+/**
+ * How many times to attempt an npm registry GET before giving up. The sync
+ * fires ~300 unauthenticated GETs from a shared CI IP, so transient 429s /
+ * 5xx / connection resets are expected -- retrying absorbs them instead of
+ * silently dropping a piece (which trips the "every VERIFIED id materializes"
+ * catalog invariant when the dropped piece happens to be verified).
+ */
+const NPM_MAX_ATTEMPTS = 4;
+/** Base backoff in ms. Grows exponentially per attempt (500, 1000, 2000...). */
+const NPM_BACKOFF_BASE_MS = 500;
+/** Cap on a single backoff wait so a large Retry-After can't stall the run. */
+const NPM_BACKOFF_MAX_MS = 10_000;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Parse a `Retry-After` header (RFC 7231: delay-seconds form only -- npm
+ * sends integer seconds). Returns ms, or null when absent/unparseable.
+ */
+function retryAfterMs(res: Response): number | null {
+  const raw = res.headers.get("retry-after");
+  if (!raw) return null;
+  const secs = Number(raw.trim());
+  return Number.isFinite(secs) && secs >= 0 ? secs * 1000 : null;
+}
+
 async function fetchNpmLatest(pkg: string): Promise<NpmInfo | null> {
-  try {
-    const url = `https://registry.npmjs.org/${pkg}/latest`;
-    const res = await fetch(url);
-    if (res.status === 404) return null;
-    if (!res.ok) throw new Error(`HTTP ${res.status}`);
-    const body = (await res.json()) as NpmInfo;
-    return body;
-  } catch (e) {
-    // Soft-fail: if the network is flaky on one package, skip it rather
-    // than aborting the whole sync. The next run will pick it up.
-    console.warn(`[warn] npm fetch failed for ${pkg}: ${(e as Error).message}`);
-    return null;
+  const url = `https://registry.npmjs.org/${pkg}/latest`;
+  let lastError = "";
+  for (let attempt = 1; attempt <= NPM_MAX_ATTEMPTS; attempt++) {
+    let serverDelayMs: number | null = null;
+    try {
+      const res = await fetch(url);
+      // A genuine 404 means the piece has no npm release -- deterministic,
+      // not worth retrying. Skip it.
+      if (res.status === 404) return null;
+      if (res.ok) return (await res.json()) as NpmInfo;
+      // 429 (rate limit) / 5xx / anything else non-OK -- transient. Honour
+      // Retry-After when the server sends it, otherwise back off.
+      lastError = `HTTP ${res.status}`;
+      serverDelayMs = retryAfterMs(res);
+    } catch (e) {
+      // Network-level failure (DNS, reset, timeout) -- transient.
+      lastError = (e as Error).message;
+    }
+    if (attempt < NPM_MAX_ATTEMPTS) {
+      const backoff = NPM_BACKOFF_BASE_MS * 2 ** (attempt - 1);
+      const jitter = Math.floor(Math.random() * NPM_BACKOFF_BASE_MS);
+      const waitMs = Math.min(serverDelayMs ?? backoff + jitter, NPM_BACKOFF_MAX_MS);
+      await sleep(waitMs);
+    }
   }
+  // Exhausted retries. Soft-fail so one persistently broken package doesn't
+  // abort the whole sync; the piece is skipped this run and picked up next.
+  console.warn(
+    `[warn] npm fetch failed for ${pkg} after ${NPM_MAX_ATTEMPTS} attempts: ${lastError}`,
+  );
+  return null;
 }
 
 function humanise(id: string): string {
@@ -275,7 +350,7 @@ function renderCatalogFile(entries: PieceMetadata[]): string {
   lines.push("export const GENERATED: GeneratedCatalogEntry[] = [");
   for (const e of entries) {
     const versionRange = `^${e.latestVersion}`;
-    const sourceUrl = `https://github.com/activepieces/activepieces/tree/${PINNED_SHA}/packages/pieces/community/${e.id}`;
+    const sourceUrl = sourceUrlFor(e.id);
     lines.push("  {");
     lines.push(`    id: ${JSON.stringify(e.id)},`);
     lines.push(`    npmPackage: ${JSON.stringify(e.npmPackage)},`);
@@ -290,6 +365,120 @@ function renderCatalogFile(entries: PieceMetadata[]): string {
   lines.push("];");
   lines.push("");
   return lines.join("\n");
+}
+
+/** GitHub source URL for a piece folder at the pinned SHA. */
+function sourceUrlFor(id: string): string {
+  return `https://github.com/activepieces/activepieces/tree/${PINNED_SHA}/packages/pieces/community/${id}`;
+}
+
+// ─── PR diff report ────────────────────────────────────────────────────────
+//
+// When `--report <path>` (or env CATALOG_REPORT_PATH) is set, the script diffs
+// the freshly generated catalog against the previously-committed one and writes
+// a markdown PR body to that path. The sync workflow feeds it to
+// peter-evans/create-pull-request via `body-path`, so reviewers get an
+// up-front "safe to merge" vs "manual review required" verdict instead of a
+// raw diff. See scripts/lib/catalog-diff.ts for the analysis itself.
+
+/** Where to write the PR-body markdown, or null when reporting is off. */
+function resolveReportPath(): string | null {
+  const idx = process.argv.indexOf("--report");
+  const next = idx !== -1 ? process.argv[idx + 1] : undefined;
+  // Ignore a missing value or an accidental following flag (`--report --verbose`).
+  const fromFlag = next && !next.startsWith("--") ? next : undefined;
+  const raw = fromFlag ?? process.env.CATALOG_REPORT_PATH;
+  return raw ? resolve(raw) : null;
+}
+
+interface PreviousGeneration {
+  entries: GeneratedEntryLike[];
+  sha: string;
+}
+
+/**
+ * Load the previously-committed catalog for diffing. Imports the on-disk
+ * generated module (so we get the structured entries, not a regex parse).
+ * MUST be called before the file is overwritten. Returns null on first run or
+ * if the old file can't be read -- the diff then treats everything as added.
+ */
+async function readPreviousGeneration(): Promise<PreviousGeneration | null> {
+  if (!existsSync(OUT_FILE)) return null;
+  try {
+    const mod = (await import(pathToFileURL(OUT_FILE).href)) as {
+      GENERATED?: GeneratedEntryLike[];
+      GENERATED_FROM_SHA?: string;
+    };
+    return { entries: mod.GENERATED ?? [], sha: mod.GENERATED_FROM_SHA ?? "" };
+  } catch (e) {
+    console.warn(`[warn] could not read previous catalog for diff: ${(e as Error).message}`);
+    return null;
+  }
+}
+
+/** Map each id to its 1-based line in the rendered file (for `path:Lnn` refs). */
+function buildLineIndex(rendered: string): Map<string, number> {
+  const index = new Map<string, number>();
+  const lines = rendered.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    const m = /^    id: "(.+)",$/.exec(lines[i]!);
+    if (m) index.set(m[1]!, i + 1);
+  }
+  return index;
+}
+
+/** Build the new catalog in the diff's shape (versionRange + sourceUrl derived). */
+function toGeneratedEntries(found: PieceMetadata[]): GeneratedEntryLike[] {
+  return found.map((e) => ({
+    id: e.id,
+    npmPackage: e.npmPackage,
+    versionRange: `^${e.latestVersion}`,
+    latestVersion: e.latestVersion,
+    displayName: e.displayName,
+    description: e.description,
+    sourceUrl: sourceUrlFor(e.id),
+    licenseSpdx: e.licenseSpdx,
+  }));
+}
+
+/** Render the PR body, write it to `reportPath`, and surface the verdict. */
+async function writePrReport(
+  reportPath: string,
+  previous: PreviousGeneration | null,
+  found: PieceMetadata[],
+  rendered: string,
+): Promise<void> {
+  const diff = diffCatalogs(previous?.entries ?? [], toGeneratedEntries(found), {
+    oldSha: previous?.sha ?? "",
+    newSha: PINNED_SHA,
+  });
+  const lineIndex = buildLineIndex(rendered);
+  const { verdict, markdown } = renderReport(diff, {
+    shortSha: PINNED_SHA.slice(0, 7),
+    generatedAt: new Date().toISOString().slice(0, 10),
+    fileLabel: "src/workflows/pieces-library/catalog-generated.ts",
+    lineOf: (id) => lineIndex.get(id) ?? null,
+  });
+
+  mkdirSync(dirname(reportPath), { recursive: true });
+  writeFileSync(reportPath, markdown);
+  const changed = hasChanges(diff);
+  info(`Wrote PR report to ${reportPath} (verdict: ${verdict}, changes: ${changed})`);
+  if (!changed) {
+    info("No catalog updates beyond the timestamp -- the workflow will skip the PR.");
+  }
+
+  // When running under GitHub Actions, expose the verdict + whether anything
+  // material changed as step outputs. The workflow titles the PR from `verdict`
+  // and gates PR creation on `has_changes`. Harmless no-op locally.
+  const githubOutput = process.env.GITHUB_OUTPUT;
+  if (githubOutput) {
+    try {
+      appendFileSync(githubOutput, `verdict=${verdict}\nhas_changes=${changed}\n`);
+    } catch (e) {
+      console.warn(`[warn] could not write GITHUB_OUTPUT: ${(e as Error).message}`);
+    }
+  }
 }
 
 function run(cmd: string, args: string[], verbose: boolean, cwd?: string): void {


### PR DESCRIPTION
## Why

The weekly "Sync pieces catalog" action failed on its last run -- `catalog.test.ts` tripped the "every VERIFIED id materializes as a verified-tier entry" invariant. Root cause was a transient npm flake during the sync, not a real catalog problem: `fetchNpmLatest` soft-failed on the first hiccup and silently dropped a verified piece from the regenerated catalog (all 10 verified packages still resolve 200 on npm; the committed catalog passes locally). While fixing that I also made the auto-PR carry a real analysis of the diff instead of a static checklist.

## What changed

**1. npm cross-check now retries (fixes the flake)**
- `fetchNpmLatest` retries up to 4 times with exponential backoff + jitter, and honors `Retry-After`.
- A real 404 still skips immediately (piece genuinely unpublished); only 429 / 5xx / network errors retry.
- After exhausting retries it still soft-fails to a skip, so one persistently broken package never aborts the whole sync.

**2. The auto-PR now analyses its own diff**
- New `scripts/lib/catalog-diff.ts` (pure + ualog against the committed one and classifiesthe delta: added, removed, version bumps, license changes, metadata drift, pinned-SHA bump.                            - The PR body opens with a verdict:
  - **Safe to merge** (NOTE banner) when the only entry changes are version bumps -- nothing added, removed, or        relicensed and the pinned SHA is unchanged.
  - **Manual review required** (WARNING banner) otherwise, listing each new piece by id, npm package, license, and its `catalog-generated.ts:NNN` line.
- The PR title reflects the verdict: `(safe)` vs `(review needed)`, defaulting to review if the verdict output is ever missing.

**3. No PR when nothing actually changed**
- The generation timestamp moves every run, so the file always diffed and a PR was always opened. The workflow now gates
PR creation on `has_changes`, so a run that bmp opens no PR. A version bump still counts asa change worth shipping.

## Notes
- `catalog-overrides.ts` is untouched -- veriions stay hand-edited.
- Upstream license / version strings are escaped before going into the PR markdown so a stray backtick can't break the formatting.
                                                                                                                       ## Test plan
- `bun test` -- 1515 pass, 0 fail (16 new tests in `catalog-diff.test.ts` cover each verdict path, the no-op skip, and license-injection escaping).
- `bunx tsc --noEmit` clean; sync script bundles clean.
- Smoke-tested the report renderer against the-index regex matched all 656).