### PR TITLE
fix(settings): prevent background poll from overwriting in-progress profile edits

### DIFF
--- a/ui/src/v2/rooms/settings/tabs/ChannelsTab.tsx
+++ b/ui/src/v2/rooms/settings/tabs/ChannelsTab.tsx
@@ -76,18 +76,27 @@ export function ChannelsTab({
   const [elVoicesLoading, setElVoicesLoading] = useState(false);
   const [sarvKey, setSarvKey] = useState("");
 
+  // Seed editable fields from the server config. Depend on the primitive
+  // *values*, not the `channelCfg`/`sttCfg` objects: those get a fresh
+  // reference on every 10s settings poll, so depending on the object would
+  // re-seed (and clobber in-progress typing) on each poll. Value deps only
+  // re-fire when the server value actually changes (e.g. after a save).
+  const tgAllowedServer = channelCfg?.telegram.allowed_users.join(", ") ?? "";
+  const dcAllowedServer = channelCfg?.discord.allowed_users.join(", ") ?? "";
+  const dcGuildServer = channelCfg?.discord.guild_id ?? "";
+
   useEffect(() => {
-    if (channelCfg) {
-      setTgAllowed(channelCfg.telegram.allowed_users.join(", "));
-      setDcAllowed(channelCfg.discord.allowed_users.join(", "));
-      setDcGuild(channelCfg.discord.guild_id ?? "");
-    }
-  }, [channelCfg]);
+    if (!channelCfg) return;
+    setTgAllowed(tgAllowedServer);
+    setDcAllowed(dcAllowedServer);
+    setDcGuild(dcGuildServer);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tgAllowedServer, dcAllowedServer, dcGuildServer]);
 
   useEffect(() => {
     if (sttCfg?.local_endpoint) setSttEndpoint(sttCfg.local_endpoint);
     if (sttCfg?.local_server_type) setSttServerType(sttCfg.local_server_type);
-  }, [sttCfg]);
+  }, [sttCfg?.local_endpoint, sttCfg?.local_server_type]);
 
   useEffect(() => {
     if (ttsCfg?.provider !== "elevenlabs") return;

--- a/ui/src/v2/rooms/settings/tabs/ProfileTab.tsx
+++ b/ui/src/v2/rooms/settings/tabs/ProfileTab.tsx
@@ -15,10 +15,17 @@ export function ProfileTab({
   const [answers, setAnswers] = useState<Record<string, string>>({});
   const [saving, setSaving] = useState(false);
 
+  // Seed the local draft from the server profile, but NOT while the user is
+  // mid-edit. `profile` gets a fresh object reference on every 10s settings
+  // poll, so without the `editing` guard this effect would re-fire on each
+  // poll and overwrite in-progress typing with the last-saved values. While
+  // editing, the draft is owned by the user; we re-sync on the next idle
+  // render (after Save, Cancel, or Clear all flip `editing` back to false).
   useEffect(() => {
     if (!profile) return;
+    if (editing) return;
     setAnswers(profile.profile?.answers ?? {});
-  }, [profile]);
+  }, [profile, editing]);
 
   const steps = useMemo(() => {
     if (!profile) return [];

--- a/ui/src/v2/rooms/settings/useSettingsData.ts
+++ b/ui/src/v2/rooms/settings/useSettingsData.ts
@@ -321,6 +321,29 @@ async function postJson<T>(
 }
 
 /**
+ * Apply a freshly-fetched value to state only when it actually differs from
+ * the current one. Every poll's `fetch` produces a brand-new object even when
+ * the data is byte-for-byte identical; setting state with that new reference
+ * churns `===` identity and needlessly re-fires every downstream
+ * `useEffect([obj])` across the settings tabs. That churn is what let the 10s
+ * poll clobber in-progress form edits (issue #238). Comparing by JSON keeps
+ * the previous reference stable when nothing changed, so dependent effects
+ * only run on a real data change.
+ *
+ * Use it as the functional state updater: `setX((prev) => preserveRef(prev, next))`.
+ *
+ * Safe here because every payload is plain JSON straight from `fetch`, and
+ * `prev` came from the same server serializer, so key ordering is stable.
+ */
+function preserveRef<T>(prev: T, next: T): T {
+  try {
+    return JSON.stringify(prev) === JSON.stringify(next) ? prev : next;
+  } catch {
+    return next;
+  }
+}
+
+/**
  * Settings Room data hook.
  *
  * Polls the 8 read endpoints in parallel every 10s (paused while tab
@@ -382,19 +405,22 @@ export function useSettingsData() {
         getJson<SidecarInfo[]>("/api/sidecars"),
         getJson<UserProfileResponse>("/api/user-profile"),
       ]);
-      if (llmR) setLLM(llmR);
-      if (chanStatusR) setChannelStatus(chanStatusR);
-      if (chanCfgR) setChannelCfg(chanCfgR);
-      if (sttR) setSTTCfg(sttR);
-      if (ttsR) setTTSCfg(ttsR);
-      if (voiceR) setVoiceCfg(voiceR);
-      if (autoR) setAutostart(autoR);
-      if (rootR) setRootCfg(rootR);
-      if (persR) setPersonality(persR);
-      if (roleR) setRole(roleR);
-      if (gR) setGoogle(gR);
-      if (scR) setSidecars(scR);
-      if (profR) setProfile(profR);
+      // Functional updaters + preserveRef: keep the previous object reference
+      // when the re-fetched payload is unchanged, so dependent effects in the
+      // tabs don't re-fire on every poll (see preserveRef / issue #238).
+      if (llmR) setLLM((p) => preserveRef(p, llmR));
+      if (chanStatusR) setChannelStatus((p) => preserveRef(p, chanStatusR));
+      if (chanCfgR) setChannelCfg((p) => preserveRef(p, chanCfgR));
+      if (sttR) setSTTCfg((p) => preserveRef(p, sttR));
+      if (ttsR) setTTSCfg((p) => preserveRef(p, ttsR));
+      if (voiceR) setVoiceCfg((p) => preserveRef(p, voiceR));
+      if (autoR) setAutostart((p) => preserveRef(p, autoR));
+      if (rootR) setRootCfg((p) => preserveRef(p, rootR));
+      if (persR) setPersonality((p) => preserveRef(p, persR));
+      if (roleR) setRole((p) => preserveRef(p, roleR));
+      if (gR) setGoogle((p) => preserveRef(p, gR));
+      if (scR) setSidecars((p) => preserveRef(p, scR));
+      if (profR) setProfile((p) => preserveRef(p, profR));
     } finally {
       inFlightRef.current = false;
       setLoading(false);


### PR DESCRIPTION
## Summary

Fixes #238. Profile settings (and the Channels tab credential fields) could not be edited: the Settings room polls every 10s, and each poll's fetch produced a brand-new object that re-fired the form-seeding effects, overwriting whatever the user was typing with the last-saved values. This makes the profile wizard effectively impossible to fill in or save.

## Root cause

`useSettingsData` re-fetches all read endpoints every 10s and calls `setProfile(...)` / `setChannelCfg(...)` with a fresh object reference each time, even when the data is identical. `ProfileTab` and `ChannelsTab` seed their local form state from those objects via `useEffect([obj])`, so the new reference re-fired the effect on every poll and clobbered in-progress edits.

## Changes

- **`ProfileTab.tsx`** - skip the seed effect`if (editing) return`). The draft is owned bythe user while the wizard is open and re-syncs on the next idle render (after Save, Cancel, or Clear).
- **`ChannelsTab.tsx`** - depend on the primiof the `channelCfg` / `sttCfg` objects, so theeffect only re-seeds when the value actually changes (mirrors the existing `LLMTab` pattern).
- **`useSettingsData.ts`** - add `preserveRefeference when a re-fetched payload isunchanged, killing the reference churn at the source for every settings tab. This is the systemic fix; the two per-tab
guards are defense-in-depth.

## Behavior after the fix

- Manual edits stay intact while typing; backerwrite local form state.
- Values are only replaced after a successful save, a cancel, or an explicit clear.
- Onboarding answers continue to populate theaved server-side; they were just un-editablebehind the clobber).

## Testing

- `bun run build:ui` - clean build.
- `bunx tsc --noEmit` - 0 type errors.
- Pre-commit test suite + EE-import check pass.