### PR TITLE
fix: fail fast on native Windows and document the platform limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Visit [opencove.host](https://opencove.host) to get started.
 
 - **Bun** >= 1.0 (installed automatically if missing)
 - **OS (native daemon install)**: macOS, Linux, or WSL
-- **Windows**: use WSL2 for the Bun install, or Docker for the daemon
+- **Windows**: native Windows is not supported for the daemon - use WSL2 for the Bun install, or Docker for the daemon
 - **LLM API key** — at least one of: Anthropic, OpenAI, Google Gemini, or a local Ollama instance
 
 ---
@@ -155,7 +155,7 @@ The first time you run `jarvis start`, the daemon boots in setup mode and the da
 
 > **Restart after first-time setup:** The daemon constructs background services (heartbeat, commitments, awareness) at boot, gated on setup having already been completed. Once you finish setup in the dashboard, those services don't activate until the next start — the dashboard shows a banner reminding you. Run `jarvis restart` (or stop/start) to bring them online. This will go away in a follow-up that constructs the services in-process at setup completion.
 
-> **Note:** Native Windows installs are blocked for the JARVIS daemon. On Windows, use WSL2 for the Bun install above, or use the Docker install instead.
+> **Note:** Native Windows is not a supported platform for the JARVIS daemon. JARVIS is built for Unix-like systems (macOS, Linux, and WSL); supporting native Windows would mean porting to a fundamentally different OS, which is out of scope. On Windows, use WSL2 for the Bun install above, or use the Docker install instead.
 
 ### Docker
 

--- a/src/daemon/pid.test.ts
+++ b/src/daemon/pid.test.ts
@@ -1,7 +1,7 @@
 import { test, expect, describe, beforeEach, afterEach } from 'bun:test';
 import { join } from 'node:path';
 import { homedir, tmpdir } from 'node:os';
-import { existsSync, readFileSync, writeFileSync, unlinkSync, mkdirSync } from 'node:fs';
+import { existsSync, readFileSync, writeFileSync, unlinkSync, mkdirSync, rmSync } from 'node:fs';
 import {
   acquireLock,
   isLocked,
@@ -351,6 +351,72 @@ describe('Process Lock Manager', () => {
       // Lock freed after process exits
       expect(isLocked()).toBeNull();
       expect(acquireLock(process.pid)).toBe(true);
+    }, { timeout: 15000 });
+  });
+
+  // ── native Windows guard (#252) ──────────────────────────────────
+  //
+  // On native Windows the daemon is unsupported and `flock.c` (POSIX-only)
+  // cannot be compiled. The cc() compile must be deferred so importing the
+  // module never crashes before the CLI's platform guard fires, and any
+  // flock path that *is* reached must surface a clear message rather than a
+  // low-level TinyCC `sys/file.h not found` error.
+
+  describe('native Windows guard', () => {
+    const PROBE_SCRIPT = join(tmpdir(), 'jarvis-test-win32-probe.ts');
+    const PROBE_HOME = join(tmpdir(), 'jarvis-test-win32-home');
+
+    afterEach(() => {
+      try { unlinkSync(PROBE_SCRIPT); } catch {}
+      try { rmSync(PROBE_HOME, { recursive: true, force: true }); } catch {}
+    });
+
+    /** Run a snippet in a child process with `process.platform` faked to win32. */
+    async function runOnFakeWin32(body: string): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+      writeFileSync(PROBE_SCRIPT, `
+Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+${body}
+`);
+      const proc = Bun.spawn(['bun', PROBE_SCRIPT], {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        // Isolate from the real ~/.jarvis so the probe can't touch a live lock.
+        env: { ...process.env, HOME: PROBE_HOME, USERPROFILE: PROBE_HOME },
+      });
+      const [stdout, stderr] = await Promise.all([
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+      ]);
+      const exitCode = await proc.exited;
+      return { stdout, stderr, exitCode };
+    }
+
+    // Smoke test only: on a POSIX CI host `<sys/file.h>` exists, so even the
+    // pre-fix eager compile would succeed here — this can only truly fail on
+    // real Windows. The genuine regression guard is the next test.
+    test('importing the module is side-effect-free (smoke)', async () => {
+      const { stdout, stderr, exitCode } = await runOnFakeWin32(`
+await import(${JSON.stringify(PID_MODULE)});
+console.log('IMPORT_OK');
+`);
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain('IMPORT_OK');
+      expect(stderr).not.toContain('sys/file.h');
+    }, { timeout: 15000 });
+
+    // Real regression guard: pre-fix, `acquireLock` ran the eager-compiled
+    // flock against the real POSIX libc (no win32 guard existed), so stderr
+    // would NOT contain the support message — this test fails on the old code.
+    test('acquireLock surfaces a clear unsupported message, not a TinyCC error', async () => {
+      const { stderr, exitCode } = await runOnFakeWin32(`
+const { acquireLock } = await import(${JSON.stringify(PID_MODULE)});
+const ok = acquireLock(process.pid);
+console.log('ACQUIRE=' + ok);
+`);
+      expect(exitCode).toBe(0);
+      // The clear, immediate daemon-support message — not a TinyCC header error.
+      expect(stderr).toContain('not compatible with native Windows');
+      expect(stderr).toContain('WSL2 or Docker');
+      expect(stderr).not.toContain('sys/file.h');
     }, { timeout: 15000 });
   });
 });

--- a/src/daemon/pid.ts
+++ b/src/daemon/pid.ts
@@ -41,16 +41,39 @@ export function lockPathFor(dataDir?: string): string {
 }
 
 // ── flock() via Bun cc() ────────────────────────────────────────────
-// Compiled at startup by Bun's embedded TinyCC. Resolves libc via
-// system headers — works on Linux, macOS, and any POSIX platform
+// Compiled lazily on first use by Bun's embedded TinyCC. Resolves libc
+// via system headers — works on Linux, macOS, and any POSIX platform
 // without hardcoding a shared library path.
+//
+// Compilation is deferred (not run at module load) so that importing
+// this module's pure-fs helpers stays safe on platforms where the helper
+// can't be built. On native Windows the daemon is unsupported, and the C
+// source depends on POSIX headers that don't exist there — guarding here
+// surfaces a clear message instead of a low-level TinyCC header error.
 
-const { symbols: flock } = cc({
-  source: flockSource,
-  symbols: {
-    do_flock: { args: ['i32', 'i32'], returns: 'i32' },
-  },
-});
+type FlockSymbols = {
+  do_flock: (fd: number, operation: number) => number;
+};
+
+let flockSymbols: FlockSymbols | null = null;
+
+function getFlock(): FlockSymbols {
+  if (process.platform === 'win32') {
+    throw new Error(
+      'The JARVIS daemon is not compatible with native Windows. Use WSL2 or Docker.',
+    );
+  }
+  if (flockSymbols === null) {
+    const { symbols } = cc({
+      source: flockSource,
+      symbols: {
+        do_flock: { args: ['i32', 'i32'], returns: 'i32' },
+      },
+    });
+    flockSymbols = symbols as FlockSymbols;
+  }
+  return flockSymbols;
+}
 
 const LOCK_EX = 2;  // Exclusive lock
 const LOCK_NB = 4;  // Non-blocking
@@ -71,6 +94,10 @@ let lockFd: number | null = null;
  */
 export function acquireLock(pid: number): boolean {
   try {
+    // Resolve the flock helper first so an unsupported platform fails before
+    // we create the data dir or open an fd (nothing to leak / clean up).
+    const flock = getFlock();
+
     mkdirSync(JARVIS_DIR, { recursive: true });
 
     // Open (or create) the lock file — don't truncate before locking
@@ -116,10 +143,10 @@ export function isLocked(lockPath: string = LOCK_PATH): number | null {
 
   try {
     // Try non-blocking exclusive lock to probe
-    const result = flock.do_flock(fd, LOCK_EX | LOCK_NB);
+    const result = getFlock().do_flock(fd, LOCK_EX | LOCK_NB);
     if (result === 0) {
       // Lock acquired — no daemon running. Release immediately.
-      flock.do_flock(fd, LOCK_UN);
+      getFlock().do_flock(fd, LOCK_UN);
       closeSync(fd);
       return null;
     }
@@ -155,6 +182,7 @@ export function isLocked(lockPath: string = LOCK_PATH): number | null {
  */
 export function acquireLockAt(lockPath: string, pid: number): { release: () => void } | null {
   try {
+    const flock = getFlock();
     mkdirSync(join(lockPath, '..'), { recursive: true });
     const fd = openSync(lockPath, constants.O_WRONLY | constants.O_CREAT, 0o644);
     const result = flock.do_flock(fd, LOCK_EX | LOCK_NB);


### PR DESCRIPTION
## Summary

Native Windows installs reached the daemon's runtime C compile step and crashed
late with a cryptic `include file 'sys/file.h' not found` from TinyCC, even
though native Windows is already documented as unsupported. The root cause is
import-time evaluation: `src/daemon/pid.ts` compiled `flock.c` (POSIX-only) at
module load via `bun:ffi` `cc()`, and that static import is hoisted above the
existing `assertSupportedPlatform()` guard in `bin/jarvis.ts`, so the guard
never got a chance to run.

This makes the compile lazy so the platform guard fires first, and clarifies the
docs around why native Windows is out of scope.

## Changes

- Defer the `flock.c` compile into a lazy, cached `getFlock()` helper instead of
  running `cc()` at module load. Importing `pe, so
  `bin/jarvis.ts`'s platform guard runs first and exits with a clear message.
- Add a `win32` guard inside `getFlock()` as lock
  call on native Windows throws "The JARVIS daemon is not compatible with native
  Windows. Use WSL2 or Docker." instead of a
- Resolve the helper before opening any fd or creating `~/.jarvis`, so an
  unsupported platform fails with nothing to
- Clarify the README: native Windows is out of scope because the daemon targets
  Unix-like systems (macOS, Linux, WSL), not tail.

## Testing

- Added tests that fake `process.platform = '
  importing the module no longer crashes, and a lock call surfaces the clear
  message rather than `sys/file.h`.
- `bun test` full suite (via pre-commit hook) passes; `tsc --noEmit` is clean.

Closes #252
Closes #253