### PR TITLE
fix(ci): quote sync-pieces-catalog PR title to fix YAML syntax error

### DIFF
--- a/.github/workflows/sync-pieces-catalog.yml
+++ b/.github/workflows/sync-pieces-catalog.yml
@@ -80,7 +80,7 @@ jobs:
         uses: peter-evans/create-pull-request@v7
         with:
           commit-message: "chore: refresh pieces catalog"
-          title: ${{ steps.sync.outputs.verdict == 'safe' && 'chore: refresh pieces catalog (safe)' || 'chore: refresh pieces catalog (review needed)' }}
+          title: "${{ steps.sync.outputs.verdict == 'safe' && 'chore: refresh pieces catalog (safe)' || 'chore: refresh pieces catalog (review needed)' }}"
           body-path: ${{ runner.temp }}/catalog-pr-body.md
           branch: chore/sync-pieces-catalog
           labels: |


### PR DESCRIPTION
## Summary

The `Sync pieces catalog` workflow was failing on **every push** with:

```
Invalid workflow file: .github/workflows/sync-pieces-catalog.yml#L83
You have an error in your yaml syntax on line 83
```

GitHub couldn't parse the file, so the run died in `0s` without executing any step.

## Root cause

Line 83 set the PR `title` to an **unquoted** YAML scalar:

```yaml
title: ${{ steps.sync.outputs.verdict == 'safe' && 'chore: refresh pieces catalog (safe)' || 'chore: refresh pieces catalog (review needed)' }}
```

The embedded expression contains `chore: refresh pieces catalog (safe)` -- a colon followed by a space. In a plain (unquoted) YAML scalar, `: ` is parsed as a key/value separator, which is illegal mid-value. YAML rejected the file before GitHub ever evaluated the `${{ }}` expression.

## Fix

Wrap the value in double quotes. The expression only uses single quotes internally, so no escaping is required:

```yaml
title: "${{ steps.sync.outputs.verdict == 'safe' && 'chore: refresh pieces catalog (safe)' || 'chore: refresh pieces catalog (review needed)' }}"
```
