### PR TITLE
fix(test): remove millisecond-boundary flakiness in job-queue failJob tests

### DIFF
--- a/src/workflows/queue/queue.test.ts
+++ b/src/workflows/queue/queue.test.ts
@@ -76,7 +76,7 @@ describe("job-queue repo", () => {
 
   test("failJob retries with exponential backoff while attempts remain", () => {
     const now = Date.now();
-    const j = enqueue({ jobType: "T", payload: {}, maxAttempts: 3 });
+    const j = enqueue({ jobType: "T", payload: {}, maxAttempts: 3, scheduledAt: now });
     const c1 = claimNextJob({ now });
     expect(c1?.attempt).toBe(1);
 
@@ -94,7 +94,7 @@ describe("job-queue repo", () => {
 
   test("failJob terminates as FAILED after maxAttempts", () => {
     const now = Date.now();
-    const j = enqueue({ jobType: "T", payload: {}, maxAttempts: 2 });
+    const j = enqueue({ jobType: "T", payload: {}, maxAttempts: 2, scheduledAt: now });
     claimNextJob({ now });
     failJob(j.id, "first", { backoffMs: 1, now });
     claimNextJob({ now: now + 1 });


### PR DESCRIPTION
## Summary

Fixes an intermittent CI failure in `src/workflows/queue/queue.test.ts`. The `job-queue repo > failJob terminates as FAILED after maxAttempts` test failed on `main` (run 28439999579) with:

error: failJob: job is QUEUED, expected RUNNING (id=...)
    at failJob (src/workflows/db/repos/job-queue.ts:214)
    at queue.test.ts:99

This is test flakiness, not a product bug.

## Root cause

The test captures `now` *before* enqueuing, but `enqueue` ignores that value and stamps `scheduled_at` with its own `Date.now()`:
                                                                                                                    ```js
const now = Date.now();                                           // T0                                             const j = enqueue({ jobType: "T", payload: {duled_at = T1 (its own Date.now(), >= T0)
claimNextJob({ now });                                            // claims WHERE scheduled_at <= now (T0)          
claimNextJob only matches rows where scheduled_at <= now. When the millisecond boundary ticks between capturing now and the enqueue call (T1 > T0), the predicat is false, nothing is claimed, the job staysQUEUED, and the next failJob throws job is QUEUED, expected RUNNING. It passes on most runs and fails on the rare boundary crossing, which is why CI was inter

Production is unaffected: real claims always-clock time, so the predicate always holdsthere.

Fix

Pass scheduledAt: now to enqueue in the two affected tests, pinning scheduled_at to exactly the now used for claiming so scheduled_at <= now always holds regardle the convention the priority + scheduled_atordering test in the same file already uses.
```
-    const j = enqueue({ jobType: "T", payload: {}, maxAttempts: 2 });
+    const j = enqueue({ jobType: "T", paylouledAt: now });
```
Both failJob retries with exponential backofailJob terminates as FAILED after maxAttempts had the same latent race; both are fixed. The expired lease test captures now after enqueue, so it was never exposed.