### PR TITLE
Config split, unix-socket listener, JWT-only auth, enrollment CLIs, timezone crons, and hosted sidecar onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ Local development builds report `dev` and are never blocked.
 
 ## ⚙️ Configuration
 
-JARVIS stores its configuration at `~/.jarvis/config.yaml`. Open the dashboard at `http://localhost:3142` after `jarvis start` for guided setup — it walks through LLM provider, voice, and a profile interview the first time. The Settings room lets you tweak channels, personality, and authority later.
+JARVIS stores its system configuration at `~/.jarvis/config.yaml`; user-level settings live in its database and are managed from the dashboard. Access is **JWT-only by default**: run `jarvis enroll "<device-name>"` and paste the printed token into the sidecar (desktop app), which connects and gives you the dashboard. Setting up without a sidecar? Temporarily add `auth:\n  insecure_open_access: true` to config.yaml, open `http://localhost:3142` after `jarvis start` for the guided setup, then **remove the flag** once your device is enrolled. The Settings room lets you tweak channels, personality, and authority later.
 
 ```yaml
 daemon:

--- a/bin/jarvis.ts
+++ b/bin/jarvis.ts
@@ -46,6 +46,9 @@ ${c.bold('Commands:')}
   ${c.cyan('update')}    Update JARVIS (dispatches based on install method)
   ${c.cyan('uninstall')} Remove JARVIS (dispatches based on install method)
   ${c.cyan('doctor')}    Check environment and connectivity
+  ${c.cyan('enroll')}    Enroll a sidecar device: mint + store its JWT (no daemon needed)
+  ${c.cyan('sidecars')}  List enrolled devices (sidecars list [--json])
+  ${c.cyan('revoke')}    Revoke an enrolled device by sid
   ${c.cyan('version')}   Print version number
   ${c.cyan('help')}      Show this help message
 
@@ -68,6 +71,9 @@ ${c.bold('Examples:')}
   jarvis logs -f                Follow live log output
   jarvis update                 Update to latest version
   jarvis uninstall              Remove JARVIS from this machine
+  jarvis enroll "desktop-NA23"  Mint an enrollment token for a device
+  jarvis sidecars list --json   List devices (machine-readable)
+  jarvis revoke <sid>           Revoke a device's access
   jarvis doctor                 Check if everything is working
 `);
 }
@@ -402,6 +408,18 @@ switch (command) {
   case 'doctor':
     await cmdDoctor();
     break;
+  case 'enroll': {
+    const { cmdEnroll } = await import('../src/cli/devices.ts');
+    process.exit(await cmdEnroll(commandArgs));
+  }
+  case 'sidecars': {
+    const { cmdSidecars } = await import('../src/cli/devices.ts');
+    process.exit(await cmdSidecars(commandArgs));
+  }
+  case 'revoke': {
+    const { cmdRevoke } = await import('../src/cli/devices.ts');
+    process.exit(await cmdRevoke(commandArgs));
+  }
   case 'uninstall':
     await cmdUninstall();
     break;

--- a/bin/jarvis.ts
+++ b/bin/jarvis.ts
@@ -72,6 +72,7 @@ ${c.bold('Examples:')}
   jarvis update                 Update to latest version
   jarvis uninstall              Remove JARVIS from this machine
   jarvis enroll "desktop-NA23"  Mint an enrollment token for a device
+  jarvis enroll <name> --rotate Re-enroll invalidating all previous tokens
   jarvis sidecars list --json   List devices (machine-readable)
   jarvis revoke <sid>           Revoke a device's access
   jarvis doctor                 Check if everything is working
@@ -212,11 +213,18 @@ async function cmdStop(args: string[] = []): Promise<void> {
 
   const resolution = resolveStopPort({ cliPort });
   const port = resolution.port;
-  if (resolution.source !== 'lockfile' && resolution.source !== 'default') {
+  if (port !== null && resolution.source !== 'lockfile' && resolution.source !== 'default') {
     console.log(c.dim(`  Using port ${port} (from ${resolution.source})`));
+  }
+  if (port === null) {
+    console.log(c.dim('  Unix-socket mode (daemon.listen) — pid-only stop, no port cleanup'));
   }
 
   if (!pid) {
+    if (port === null) {
+      console.log(c.yellow('JARVIS is not running.'));
+      return;
+    }
     const cleanup = await ensurePortReleased(port);
     if (cleanup.terminated.length > 0 || cleanup.forced.length > 0) {
       const details = cleanup.forced.length > 0
@@ -245,6 +253,11 @@ async function cmdStop(args: string[] = []): Promise<void> {
       try { process.kill(pid, 'SIGKILL'); } catch { /* already gone */ }
     }
 
+    if (port === null) {
+      releaseLock();
+      console.log(c.green('✓ JARVIS daemon stopped.'));
+      return;
+    }
     const cleanup = await ensurePortReleased(port);
     releaseLock();
     if (!cleanup.released) {

--- a/bin/jarvis.ts
+++ b/bin/jarvis.ts
@@ -117,8 +117,12 @@ async function cmdStart(args: string[]): Promise<void> {
   const { homedir } = await import('node:os');
   const cfgPath = join(homedir(), '.jarvis', 'config.yaml');
   if (!_exists(cfgPath)) {
-    console.log(c.cyan('First-run detected — finish setup in your browser:'));
-    console.log(c.dim(`  → http://localhost:${port ?? 3142}`));
+    console.log(c.cyan('First-run detected. Jarvis is JWT-only by default:'));
+    console.log(c.dim('  1. jarvis enroll "<device-name>"   mint your device token'));
+    console.log(c.dim('  2. paste the token into the sidecar (desktop app) to connect'));
+    console.log(c.dim('  Setting up without a sidecar? Put "auth:\n  insecure_open_access: true"'));
+    console.log(c.dim(`  in ~/.jarvis/config.yaml, open http://localhost:${port ?? 3142}, and`));
+    console.log(c.dim('  REMOVE the flag once your device is enrolled.'));
     console.log('');
   }
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -11,11 +11,18 @@ daemon:
   # Env override: JARVIS_BRAIN_DOMAIN="https://brain.example.com"
   # brain_domain: "https://brain.example.com"
 
-# Authentication — protects dashboard, API, and WebSocket.
-# If unset, the application is open (no auth).
-# Can also be set via JARVIS_AUTH_TOKEN env var.
+# Authentication — JWT-only by DEFAULT. The dashboard, API, and WebSocket
+# require a token from an enrolled device. Correct setup order:
+#   1. jarvis enroll "my-desktop"     (prints the device's enrollment token)
+#   2. paste the token into the sidecar (desktop app) — it connects and the
+#      dashboard is reached through it.
+#
+# ESCAPE HATCH (first-time setup only): open the dashboard WITHOUT auth.
+# Anyone who can reach this machine can then use your Jarvis. The daemon
+# logs a loud warning while this is on — remove it as soon as enrollment
+# is done.
 # auth:
-#   token: "your-secret-token-here"
+#   insecure_open_access: true
 
 # Anonymous usage metrics (opt-out, enabled by default).
 # Sends a tiny anonymous ping at startup and every hour so the project can

--- a/sidecar/client.go
+++ b/sidecar/client.go
@@ -847,8 +847,9 @@ func (c *SidecarClient) sendRegistration(ctx context.Context) error {
 		Version:                 sidecarVersion,
 		Capabilities:            c.availableCaps,
 		UnavailableCapabilities: c.unavailableCaps,
+		Timezone:                DetectIANATimezone(),
 	}
-	log.Printf("[sidecar] Identified as %s (%s/%s) v%s", msg.Hostname, msg.OS, msg.Platform, msg.Version)
+	log.Printf("[sidecar] Identified as %s (%s/%s) v%s tz=%s", msg.Hostname, msg.OS, msg.Platform, msg.Version, msg.Timezone)
 	return c.sendJSON(ctx, msg)
 }
 

--- a/sidecar/hosted.go
+++ b/sidecar/hosted.go
@@ -49,6 +49,31 @@ func resolveHostedBaseURLWith(overrideAllowed bool, cfgValue, envValue string) s
 	return hostedDefaultBaseURL
 }
 
+// submitTokenHandler builds the `window.submitToken` binding. isActive gates
+// it to the LOCAL token form: bindings are callable by whatever page the
+// webview shows, and the hosted flow navigates to remote content - without
+// the gate, any page in the Clerk/Stripe redirect chain could silently
+// enroll this sidecar to an attacker-controlled brain (enrollment JWTs are
+// self-describing via their brain/jwks claims). accept receives a
+// structurally valid JWT and closes the window.
+func submitTokenHandler(isActive func() bool, accept func(token string)) func(string) error {
+	return func(raw string) error {
+		if !isActive() {
+			log.Printf("[hosted] submitToken called while the token form is not active - ignored")
+			return fmt.Errorf("Token entry is not active.")
+		}
+		raw = strings.TrimSpace(raw)
+		if raw == "" {
+			return fmt.Errorf("Paste your enrollment token to continue.")
+		}
+		if _, err := DecodeJWTPayload(raw); err != nil {
+			return fmt.Errorf("That doesn't look like a valid token. Copy the full token from the dashboard.")
+		}
+		accept(raw)
+		return nil
+	}
+}
+
 // generateHandshakeNonce returns a 256-bit unguessable correlation id.
 func generateHandshakeNonce() (string, error) {
 	buf := make([]byte, 32)
@@ -65,6 +90,12 @@ func connectPageURL(base, nonce string) string {
 // The long-poll request is held open server-side; keep the client timeout
 // comfortably above the server's hold (~55s).
 var hostedHTTPClient = &http.Client{Timeout: 75 * time.Second}
+
+// A well-behaved server holds the poll, so consecutive requests are ~55s
+// apart. If a poll returns "pending" faster than this (an intermediary that
+// buffers instead of holding, or a simple server), wait out the remainder -
+// verified without the floor: ~2900 requests/second.
+const minPendingPollInterval = 2 * time.Second
 
 // registerHandshake announces the nonce (+ this machine's hostname) so the
 // connect page can claim it after Clerk login.
@@ -140,6 +171,7 @@ func awaitHandshakeToken(ctx context.Context, base, nonce string, onProgress fun
 		if ctx.Err() != nil {
 			return "", ctx.Err()
 		}
+		pollStart := time.Now()
 		res, err := pollHandshakeOnce(ctx, base, nonce)
 		if err != nil {
 			if ctx.Err() != nil {
@@ -151,9 +183,7 @@ func awaitHandshakeToken(ctx context.Context, base, nonce string, onProgress fun
 			case <-ctx.Done():
 				return "", ctx.Err()
 			}
-			if backoff < 15*time.Second {
-				backoff *= 2
-			}
+			backoff = min(backoff*2, 15*time.Second)
 			continue
 		}
 		backoff = 2 * time.Second
@@ -170,9 +200,16 @@ func awaitHandshakeToken(ctx context.Context, base, nonce string, onProgress fun
 				reason = "setup failed on the server"
 			}
 			return "", &errHandshakeFailed{reason: reason}
-		default: // "pending" (or unknown) -> immediately re-issue the long-poll
+		default: // "pending" (or unknown) -> re-issue the long-poll
 			if onProgress != nil && res.Step != "" {
 				onProgress(res.Step)
+			}
+			if wait := minPendingPollInterval - time.Since(pollStart); wait > 0 {
+				select {
+				case <-time.After(wait):
+				case <-ctx.Done():
+					return "", ctx.Err()
+				}
 			}
 		}
 	}

--- a/sidecar/hosted.go
+++ b/sidecar/hosted.go
@@ -1,0 +1,179 @@
+package main
+
+// Hosted-onboarding handshake client (usejarvis).
+//
+// A sidecar with no token binds its Go process to the user's web identity via
+// a single-use NONCE (docs/ONBOARDING.md in the hosting repo): it registers
+// {nonce, hostname} with the hosted server, opens the connect page (Clerk +
+// Stripe) in a webview carrying only the nonce, and LONG-POLLS the server
+// until provisioning enrolls this device and resolves the handshake with the
+// enrollment JWT. The JWT travels Go <-> server only - it is never placed in
+// page JavaScript.
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+)
+
+// hostedDefaultBaseURL is the production connect origin. Overriding it (env
+// JARVIS_HOSTED_URL or sidecar.yaml hosted_base_url) is honored ONLY in
+// builds compiled with `-tags jarvisdebug` - a release binary always talks
+// to the real origin, so a tampered config/env cannot redirect the JWT
+// handshake to an attacker-controlled server.
+const hostedDefaultBaseURL = "https://app.usejarvis.dev"
+
+func resolveHostedBaseURL(cfgValue string) string {
+	return resolveHostedBaseURLWith(hostedOverrideAllowed, cfgValue, os.Getenv("JARVIS_HOSTED_URL"))
+}
+
+func resolveHostedBaseURLWith(overrideAllowed bool, cfgValue, envValue string) string {
+	if overrideAllowed {
+		if v := strings.TrimSpace(envValue); v != "" {
+			return strings.TrimRight(v, "/")
+		}
+		if v := strings.TrimSpace(cfgValue); v != "" {
+			return strings.TrimRight(v, "/")
+		}
+	}
+	return hostedDefaultBaseURL
+}
+
+// generateHandshakeNonce returns a 256-bit unguessable correlation id.
+func generateHandshakeNonce() (string, error) {
+	buf := make([]byte, 32)
+	if _, err := rand.Read(buf); err != nil {
+		return "", fmt.Errorf("generate handshake nonce: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(buf), nil
+}
+
+func connectPageURL(base, nonce string) string {
+	return base + "/connect?handshake=" + url.QueryEscape(nonce)
+}
+
+// The long-poll request is held open server-side; keep the client timeout
+// comfortably above the server's hold (~55s).
+var hostedHTTPClient = &http.Client{Timeout: 75 * time.Second}
+
+// registerHandshake announces the nonce (+ this machine's hostname) so the
+// connect page can claim it after Clerk login.
+func registerHandshake(ctx context.Context, base, nonce, hostname string) error {
+	body, _ := json.Marshal(map[string]string{
+		"nonce":    nonce,
+		"hostname": hostname,
+	})
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, base+"/api/handshake/register", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	res, err := hostedHTTPClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		return fmt.Errorf("handshake register: server returned %s", res.Status)
+	}
+	return nil
+}
+
+type handshakePollResponse struct {
+	// "pending" | "complete" | "failed"
+	Status string `json:"status"`
+	// Enrollment JWT, present when Status == "complete".
+	Token string `json:"token,omitempty"`
+	// Human-readable reason, present when Status == "failed".
+	Error string `json:"error,omitempty"`
+	// Optional progress hint while pending ("provisioning", "starting", ...).
+	Step string `json:"step,omitempty"`
+}
+
+// errHandshakeFailed marks a terminal server-side failure (vs a transient
+// network error, which awaitHandshakeToken retries).
+type errHandshakeFailed struct{ reason string }
+
+func (e *errHandshakeFailed) Error() string { return e.reason }
+
+func pollHandshakeOnce(ctx context.Context, base, nonce string) (*handshakePollResponse, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, base+"/api/handshake/poll?nonce="+url.QueryEscape(nonce), nil)
+	if err != nil {
+		return nil, err
+	}
+	res, err := hostedHTTPClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+	raw, err := io.ReadAll(io.LimitReader(res.Body, 1<<20))
+	if err != nil {
+		return nil, err
+	}
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		return nil, fmt.Errorf("handshake poll: server returned %s", res.Status)
+	}
+	var parsed handshakePollResponse
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		return nil, fmt.Errorf("handshake poll: unparseable response: %w", err)
+	}
+	return &parsed, nil
+}
+
+// awaitHandshakeToken long-polls until the handshake resolves with the JWT.
+// Transient errors and "pending" responses re-poll (the nonce stays valid
+// server-side until its TTL); a "failed" status is terminal. onProgress
+// receives step hints for the shell UI ("" filtered).
+func awaitHandshakeToken(ctx context.Context, base, nonce string, onProgress func(step string)) (string, error) {
+	backoff := 2 * time.Second
+	for {
+		if ctx.Err() != nil {
+			return "", ctx.Err()
+		}
+		res, err := pollHandshakeOnce(ctx, base, nonce)
+		if err != nil {
+			if ctx.Err() != nil {
+				return "", ctx.Err()
+			}
+			log.Printf("[hosted] handshake poll error (will retry in %s): %v", backoff, err)
+			select {
+			case <-time.After(backoff):
+			case <-ctx.Done():
+				return "", ctx.Err()
+			}
+			if backoff < 15*time.Second {
+				backoff *= 2
+			}
+			continue
+		}
+		backoff = 2 * time.Second
+
+		switch res.Status {
+		case "complete":
+			if _, err := DecodeJWTPayload(res.Token); err != nil {
+				return "", fmt.Errorf("handshake returned an invalid token: %w", err)
+			}
+			return res.Token, nil
+		case "failed":
+			reason := res.Error
+			if reason == "" {
+				reason = "setup failed on the server"
+			}
+			return "", &errHandshakeFailed{reason: reason}
+		default: // "pending" (or unknown) -> immediately re-issue the long-poll
+			if onProgress != nil && res.Step != "" {
+				onProgress(res.Step)
+			}
+		}
+	}
+}

--- a/sidecar/hosted_debug.go
+++ b/sidecar/hosted_debug.go
@@ -1,0 +1,8 @@
+//go:build jarvisdebug
+
+package main
+
+// Debug/staging builds (`go build -tags jarvisdebug`) honor JARVIS_HOSTED_URL
+// and sidecar.yaml `hosted_base_url` so the handshake can point at a local or
+// staging control plane.
+const hostedOverrideAllowed = true

--- a/sidecar/hosted_release.go
+++ b/sidecar/hosted_release.go
@@ -1,0 +1,9 @@
+//go:build !jarvisdebug
+
+package main
+
+// Release builds always talk to the production hosted origin: config/env
+// overrides of the handshake base URL are ignored so a tampered sidecar.yaml
+// or environment cannot redirect the JWT handoff. Build with
+// `-tags jarvisdebug` to enable overrides for dev/staging.
+const hostedOverrideAllowed = false

--- a/sidecar/hosted_test.go
+++ b/sidecar/hosted_test.go
@@ -1,0 +1,198 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestGenerateHandshakeNonce(t *testing.T) {
+	a, err := generateHandshakeNonce()
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, _ := generateHandshakeNonce()
+	if a == b {
+		t.Fatal("nonces must be unique")
+	}
+	// 32 bytes base64url unpadded = 43 chars, URL-safe alphabet only.
+	if len(a) != 43 {
+		t.Fatalf("unexpected nonce length %d", len(a))
+	}
+	if strings.ContainsAny(a, "+/=") {
+		t.Fatalf("nonce is not base64url: %q", a)
+	}
+}
+
+func TestResolveHostedBaseURL(t *testing.T) {
+	// Release builds: overrides ignored, production origin always.
+	if got := resolveHostedBaseURLWith(false, "https://evil.example", "https://evil2.example"); got != hostedDefaultBaseURL {
+		t.Fatalf("release build must ignore overrides, got %q", got)
+	}
+	// Debug builds: env wins, then config, then default; trailing slash trimmed.
+	if got := resolveHostedBaseURLWith(true, "https://cfg.example/", ""); got != "https://cfg.example" {
+		t.Fatalf("config override failed, got %q", got)
+	}
+	if got := resolveHostedBaseURLWith(true, "https://cfg.example", "https://env.example"); got != "https://env.example" {
+		t.Fatalf("env should beat config, got %q", got)
+	}
+	if got := resolveHostedBaseURLWith(true, "", ""); got != hostedDefaultBaseURL {
+		t.Fatalf("debug build without overrides should use default, got %q", got)
+	}
+}
+
+func TestConnectPageURLEscapesNonce(t *testing.T) {
+	got := connectPageURL("https://app.usejarvis.dev", "abc/+?=")
+	if got != "https://app.usejarvis.dev/connect?handshake=abc%2F%2B%3F%3D" {
+		t.Fatalf("unexpected URL: %q", got)
+	}
+}
+
+// fakeHandshakeServer scripts /api/handshake/register + /poll responses.
+func fakeHandshakeServer(t *testing.T, poll func(n int, w http.ResponseWriter)) (*httptest.Server, *atomic.Int32, *atomic.Int32) {
+	t.Helper()
+	var registers, polls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/handshake/register":
+			if r.Method != http.MethodPost {
+				w.WriteHeader(405)
+				return
+			}
+			var body map[string]string
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			if body["nonce"] == "" || body["hostname"] == "" {
+				w.WriteHeader(400)
+				return
+			}
+			registers.Add(1)
+			w.WriteHeader(200)
+		case "/api/handshake/poll":
+			if r.URL.Query().Get("nonce") == "" {
+				w.WriteHeader(400)
+				return
+			}
+			poll(int(polls.Add(1)), w)
+		default:
+			w.WriteHeader(404)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &registers, &polls
+}
+
+// A structurally valid unsigned-looking JWT for DecodeJWTPayload.
+func testJWT(t *testing.T) string {
+	t.Helper()
+	header := `{"alg":"ES256"}`
+	payload := `{"sid":"s1","name":"desktop","brain":"wss://x/sidecar/connect","jwks":"https://x/jwks.json","iat":1}`
+	enc := func(s string) string {
+		return strings.TrimRight(strings.NewReplacer("+", "-", "/", "_").Replace(
+			base64StdNoPad(s)), "=")
+	}
+	return enc(header) + "." + enc(payload) + ".sig"
+}
+
+func base64StdNoPad(s string) string {
+	const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+	var out []byte
+	data := []byte(s)
+	for i := 0; i < len(data); i += 3 {
+		var b [3]byte
+		n := copy(b[:], data[i:])
+		out = append(out, alphabet[b[0]>>2], alphabet[(b[0]&0x3)<<4|b[1]>>4])
+		if n > 1 {
+			out = append(out, alphabet[(b[1]&0xF)<<2|b[2]>>6])
+		}
+		if n > 2 {
+			out = append(out, alphabet[b[2]&0x3F])
+		}
+	}
+	return string(out)
+}
+
+func TestHandshakeRegisterAndPollToCompletion(t *testing.T) {
+	jwt := testJWT(t)
+	srv, registers, _ := fakeHandshakeServer(t, func(n int, w http.ResponseWriter) {
+		switch n {
+		case 1:
+			_ = json.NewEncoder(w).Encode(handshakePollResponse{Status: "pending", Step: "provisioning"})
+		case 2:
+			_ = json.NewEncoder(w).Encode(handshakePollResponse{Status: "complete", Token: jwt})
+		default:
+			t.Errorf("unexpected extra poll %d", n)
+		}
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	nonce, _ := generateHandshakeNonce()
+	if err := registerHandshake(ctx, srv.URL, nonce, "desktop-A"); err != nil {
+		t.Fatal(err)
+	}
+	if registers.Load() != 1 {
+		t.Fatalf("expected 1 register, got %d", registers.Load())
+	}
+
+	var steps []string
+	got, err := awaitHandshakeToken(ctx, srv.URL, nonce, func(s string) { steps = append(steps, s) })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != jwt {
+		t.Fatalf("wrong token: %q", got)
+	}
+	if len(steps) != 1 || steps[0] != "provisioning" {
+		t.Fatalf("progress steps not forwarded: %v", steps)
+	}
+}
+
+func TestHandshakeFailedIsTerminal(t *testing.T) {
+	srv, _, polls := fakeHandshakeServer(t, func(n int, w http.ResponseWriter) {
+		_ = json.NewEncoder(w).Encode(handshakePollResponse{Status: "failed", Error: "provisioning failed permanently"})
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	_, err := awaitHandshakeToken(ctx, srv.URL, "nonce", nil)
+	if err == nil || !strings.Contains(err.Error(), "provisioning failed permanently") {
+		t.Fatalf("expected terminal failure, got %v", err)
+	}
+	if polls.Load() != 1 {
+		t.Fatalf("a failed handshake must not be re-polled, got %d polls", polls.Load())
+	}
+}
+
+func TestHandshakeCompleteWithGarbageTokenErrors(t *testing.T) {
+	srv, _, _ := fakeHandshakeServer(t, func(n int, w http.ResponseWriter) {
+		_ = json.NewEncoder(w).Encode(handshakePollResponse{Status: "complete", Token: "not-a-jwt"})
+	})
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	_, err := awaitHandshakeToken(ctx, srv.URL, "nonce", nil)
+	if err == nil || !strings.Contains(err.Error(), "invalid token") {
+		t.Fatalf("garbage token must be rejected, got %v", err)
+	}
+}
+
+func TestHandshakeCancelledByContext(t *testing.T) {
+	srv, _, _ := fakeHandshakeServer(t, func(n int, w http.ResponseWriter) {
+		_ = json.NewEncoder(w).Encode(handshakePollResponse{Status: "pending"})
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(150 * time.Millisecond)
+		cancel() // window closed / self-host chosen
+	}()
+	_, err := awaitHandshakeToken(ctx, srv.URL, "nonce", nil)
+	if err != context.Canceled {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+}

--- a/sidecar/hosted_test.go
+++ b/sidecar/hosted_test.go
@@ -196,3 +196,65 @@ func TestHandshakeCancelledByContext(t *testing.T) {
 		t.Fatalf("expected context.Canceled, got %v", err)
 	}
 }
+
+func TestSubmitTokenHandlerGate(t *testing.T) {
+	jwt := testJWT(t)
+	active := false
+	var accepted string
+	handler := submitTokenHandler(func() bool { return active }, func(tok string) { accepted = tok })
+
+	// Regression (review major 1): with the hosted flow showing remote
+	// content (Clerk/Stripe redirects), any page can call the binding. While
+	// the local form is NOT active it must refuse even a valid JWT.
+	if err := handler(jwt); err == nil {
+		t.Fatal("submitToken must be refused while the token form is inactive")
+	}
+	if accepted != "" {
+		t.Fatalf("token must not be accepted while inactive, got %q", accepted)
+	}
+
+	// Active form: garbage rejected, valid JWT accepted.
+	active = true
+	if err := handler("not-a-jwt"); err == nil {
+		t.Fatal("garbage token must be rejected")
+	}
+	if err := handler("  " + jwt + "  "); err != nil {
+		t.Fatalf("valid token rejected: %v", err)
+	}
+	if accepted != jwt {
+		t.Fatalf("accepted token mismatch: %q", accepted)
+	}
+}
+
+func TestPendingRepollIsRateLimited(t *testing.T) {
+	// Regression (review major 2): a server/proxy answering "pending"
+	// instantly must not be hammered. Unfixed this measured ~2900 polls/s.
+	var polls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		polls.Add(1)
+		_ = json.NewEncoder(w).Encode(handshakePollResponse{Status: "pending"})
+	}))
+	t.Cleanup(srv.Close)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1100*time.Millisecond)
+	defer cancel()
+	_, _ = awaitHandshakeToken(ctx, srv.URL, "nonce", nil)
+
+	// With the 2s floor: one immediate poll, the second lands at ~2s (after
+	// the window). Allow slack for scheduling but nothing like a hot loop.
+	if n := polls.Load(); n > 2 {
+		t.Fatalf("pending re-poll not rate-limited: %d polls in 1.1s", n)
+	}
+}
+
+func TestHostedShellWithErrorBakesTheMessageIn(t *testing.T) {
+	// Regression (review medium 4): the error must be part of the document
+	// (boot script), not an Eval racing the fresh SetHtml.
+	html := hostedShellWithError("Setup did not complete: it's broken <script>")
+	if !strings.Contains(html, `window.__setError('Setup did not complete: it\'s broken \x3cscript>')`) {
+		t.Fatalf("boot script missing or badly escaped:\n%s", html)
+	}
+	if strings.Contains(html, "/*__BOOT__*/") {
+		t.Fatal("placeholder was not replaced")
+	}
+}

--- a/sidecar/hosted_window.go
+++ b/sidecar/hosted_window.go
@@ -1,0 +1,208 @@
+package main
+
+// First-run window, hosted-first (usejarvis).
+//
+// When no token is configured the sidecar starts the handshake and loads the
+// hosted connect page (Clerk login, plan/checkout for a first device) in the
+// webview; a "Self-hosting?" link on the local shell switches to the classic
+// paste-a-token form. The webview's Go binding surface is deliberately
+// minimal - progress/close UX only (`onProgress`, `onComplete`) - the JWT is
+// delivered over the nonce long-poll, never through page JavaScript.
+
+import (
+	"context"
+	"fmt"
+	"html"
+	"log"
+	"os"
+	"runtime"
+	"strings"
+
+	webview "github.com/webview/webview_go"
+)
+
+// hostedShellHTML is the local page shown while the handshake registers (and
+// as the fallback surface for errors). Styled like setupWindowHTML.
+const hostedShellHTML = `<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>
+  :root { color-scheme: light; }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; padding: 40px 36px;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Inter, sans-serif;
+    background: #f5f2eb; color: #1a1a1a;
+    display: flex; flex-direction: column; min-height: 92vh;
+  }
+  h1 { font-size: 20px; margin: 0 0 8px; }
+  .sub { font-size: 13px; margin: 0 0 24px; opacity: 0.8; line-height: 1.5; }
+  #status { font-size: 13px; color: #6a675f; min-height: 18px; }
+  #err { color: #c23a2a; font-size: 13px; min-height: 18px; margin-top: 6px; }
+  .spinner {
+    width: 22px; height: 22px; margin: 18px 0;
+    border: 3px solid #cbc3b2; border-top-color: #c23a2a; border-radius: 50%;
+    animation: spin 0.9s linear infinite;
+  }
+  @keyframes spin { to { transform: rotate(360deg); } }
+  .footer { margin-top: auto; font-size: 12px; color: #6a675f; }
+  .footer a { color: #c23a2a; cursor: pointer; text-decoration: underline; }
+  #retry { display: none; margin-top: 12px; }
+  button {
+    appearance: none; border: 0; border-radius: 8px; padding: 9px 16px;
+    background: #c23a2a; color: #fff; font-size: 13px; font-weight: 600; cursor: pointer;
+  }
+</style>
+</head>
+<body>
+  <h1>Connect this device</h1>
+  <p class="sub">Sign in to your usejarvis account to link this machine to your Jarvis.</p>
+  <div class="spinner" id="spin"></div>
+  <div id="status">Contacting usejarvis&hellip;</div>
+  <div id="err"></div>
+  <div id="retry"><button onclick="window.retryHosted()">Try again</button></div>
+  <p class="footer">Self-hosting your own brain? <a onclick="window.chooseSelfHost()">Paste your enrollment token</a></p>
+<script>
+  window.__setStatus = function (text) { document.getElementById('status').textContent = text; };
+  window.__setError = function (text) {
+    document.getElementById('err').textContent = text;
+    document.getElementById('spin').style.display = text ? 'none' : '';
+    document.getElementById('retry').style.display = text ? 'block' : 'none';
+  };
+</script>
+</body>
+</html>`
+
+// runFirstRunWindow drives the no-token first run: hosted connect by default,
+// self-host token form one click away. Returns the enrollment JWT ("" if the
+// user closed the window). Blocks; must run on the main OS thread.
+func runFirstRunWindow(cfg *SidecarConfig) (string, error) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	w := webview.New(false)
+	if w == nil {
+		return "", fmt.Errorf("could not open the setup window (no display, or the system webview runtime is missing)")
+	}
+	defer w.Destroy()
+
+	w.SetTitle("JARVIS - Connect")
+	w.SetSize(920, 720, webview.HintNone)
+
+	base := resolveHostedBaseURL(cfg.HostedBaseURL)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var token string
+
+	// Self-host path: swap to the classic token form (its submitToken binding
+	// is installed below and shared by both forms).
+	if err := w.Bind("chooseSelfHost", func() {
+		cancel() // stop the handshake goroutine; its nonce simply expires
+		w.Dispatch(func() { w.SetHtml(setupWindowHTML) })
+	}); err != nil {
+		return "", fmt.Errorf("bind chooseSelfHost: %w", err)
+	}
+
+	if err := w.Bind("submitToken", func(raw string) error {
+		raw = strings.TrimSpace(raw)
+		if raw == "" {
+			return fmt.Errorf("Paste your enrollment token to continue.")
+		}
+		if _, err := DecodeJWTPayload(raw); err != nil {
+			return fmt.Errorf("That doesn't look like a valid token. Copy the full token from the dashboard.")
+		}
+		token = raw
+		w.Terminate()
+		return nil
+	}); err != nil {
+		return "", fmt.Errorf("bind setup handler: %w", err)
+	}
+
+	// Minimal page bindings: progress/close UX ONLY, never token transport
+	// (the connect page shows its own progress; these let it inform the shell
+	// and close the window when its flow ends).
+	if err := w.Bind("onProgress", func(step string) {
+		log.Printf("[hosted] connect page progress: %s", step)
+	}); err != nil {
+		return "", fmt.Errorf("bind onProgress: %w", err)
+	}
+	if err := w.Bind("onComplete", func() {
+		// The long-poll should already have delivered the JWT; the page
+		// signaling completion without it means the user finished in-page UX
+		// early. The poll goroutine terminates the window when the token
+		// lands, so this is just a hint.
+		log.Printf("[hosted] connect page reports completion")
+	}); err != nil {
+		return "", fmt.Errorf("bind onComplete: %w", err)
+	}
+
+	startHandshake := func() {
+		go func() {
+			setStatus := func(text string) {
+				w.Dispatch(func() { w.Eval("window.__setStatus && window.__setStatus('" + jsEscape(text) + "')") })
+			}
+			setError := func(text string) {
+				w.Dispatch(func() { w.Eval("window.__setError && window.__setError('" + jsEscape(text) + "')") })
+			}
+
+			nonce, err := generateHandshakeNonce()
+			if err != nil {
+				setError("Could not start setup: " + err.Error())
+				return
+			}
+			hostname, _ := os.Hostname()
+
+			if err := registerHandshake(ctx, base, nonce, hostname); err != nil {
+				log.Printf("[hosted] handshake register failed: %v", err)
+				setError("Could not reach usejarvis. Check your connection and try again.")
+				return
+			}
+
+			// Hand the webview to the hosted connect page (nonce in the URL;
+			// the page claims it after Clerk login).
+			w.Dispatch(func() { w.Navigate(connectPageURL(base, nonce)) })
+
+			jwt, err := awaitHandshakeToken(ctx, base, nonce, func(step string) {
+				setStatus(step) // only visible if the shell is still showing
+			})
+			if err != nil {
+				if ctx.Err() != nil {
+					return // window closed or self-host chosen
+				}
+				log.Printf("[hosted] handshake failed: %v", err)
+				// Bring the user back to the local shell with the reason.
+				w.Dispatch(func() { w.SetHtml(hostedShellHTML) })
+				setError("Setup did not complete: " + err.Error())
+				return
+			}
+			token = jwt
+			log.Printf("[hosted] enrollment token received via handshake")
+			w.Dispatch(func() { w.Terminate() })
+		}()
+	}
+
+	if err := w.Bind("retryHosted", func() {
+		w.Dispatch(func() { w.SetHtml(hostedShellHTML) })
+		startHandshake()
+	}); err != nil {
+		return "", fmt.Errorf("bind retryHosted: %w", err)
+	}
+
+	revealWebviewOnLoad(w)
+	w.SetHtml(hostedShellHTML)
+	startHandshake()
+	w.Run() // blocks until Terminate() or the window is closed
+	return token, nil
+}
+
+// jsEscape makes a Go string safe inside a single-quoted JS literal.
+func jsEscape(s string) string {
+	s = html.EscapeString(s)
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `'`, `\'`)
+	s = strings.ReplaceAll(s, "\n", `\n`)
+	return s
+}

--- a/sidecar/hosted_window.go
+++ b/sidecar/hosted_window.go
@@ -8,11 +8,17 @@ package main
 // paste-a-token form. The webview's Go binding surface is deliberately
 // minimal - progress/close UX only (`onProgress`, `onComplete`) - the JWT is
 // delivered over the nonce long-poll, never through page JavaScript.
+//
+// SECURITY: webview bindings are reachable by WHATEVER page the webview is
+// showing, and the hosted flow navigates to remote content (connect page,
+// Clerk, Stripe's checkout redirects). `submitToken` is therefore gated: it
+// only accepts input while the LOCAL token form is the active document
+// (selfHostFormActive), so no remote page can silently enroll this sidecar
+// to an attacker-controlled brain by injecting a self-describing JWT.
 
 import (
 	"context"
 	"fmt"
-	"html"
 	"log"
 	"os"
 	"runtime"
@@ -22,7 +28,10 @@ import (
 )
 
 // hostedShellHTML is the local page shown while the handshake registers (and
-// as the fallback surface for errors). Styled like setupWindowHTML.
+// as the fallback surface for errors). Styled like the token form. The
+// /*__BOOT__*/ placeholder lets hostedShellWithError bake an error into the
+// document itself - an Eval racing a fresh SetHtml can silently lose the
+// message, a baked-in script cannot.
 const hostedShellHTML = `<!doctype html>
 <html>
 <head>
@@ -71,9 +80,17 @@ const hostedShellHTML = `<!doctype html>
     document.getElementById('spin').style.display = text ? 'none' : '';
     document.getElementById('retry').style.display = text ? 'block' : 'none';
   };
+  /*__BOOT__*/
 </script>
 </body>
 </html>`
+
+// hostedShellWithError renders the shell with the error already displayed by
+// the document's own boot script (no post-load Eval race).
+func hostedShellWithError(msg string) string {
+	boot := "window.__setError('" + jsEscape(msg) + "');"
+	return strings.Replace(hostedShellHTML, "/*__BOOT__*/", boot, 1)
+}
 
 // runFirstRunWindow drives the no-token first run: hosted connect by default,
 // self-host token form one click away. Returns the enrollment JWT ("" if the
@@ -97,43 +114,43 @@ func runFirstRunWindow(cfg *SidecarConfig) (string, error) {
 
 	var token string
 
+	// True only while the LOCAL paste-a-token form is the active document.
+	// All reads/writes happen on the webview main thread (bindings and
+	// Dispatch closures both run there), so a plain bool is race-free.
+	selfHostFormActive := false
+
 	// Self-host path: swap to the classic token form (its submitToken binding
-	// is installed below and shared by both forms).
+	// is installed below and only accepts input while this form is active).
 	if err := w.Bind("chooseSelfHost", func() {
 		cancel() // stop the handshake goroutine; its nonce simply expires
+		selfHostFormActive = true
 		w.Dispatch(func() { w.SetHtml(setupWindowHTML) })
 	}); err != nil {
 		return "", fmt.Errorf("bind chooseSelfHost: %w", err)
 	}
 
-	if err := w.Bind("submitToken", func(raw string) error {
-		raw = strings.TrimSpace(raw)
-		if raw == "" {
-			return fmt.Errorf("Paste your enrollment token to continue.")
-		}
-		if _, err := DecodeJWTPayload(raw); err != nil {
-			return fmt.Errorf("That doesn't look like a valid token. Copy the full token from the dashboard.")
-		}
-		token = raw
-		w.Terminate()
-		return nil
-	}); err != nil {
+	if err := w.Bind("submitToken", submitTokenHandler(
+		func() bool { return selfHostFormActive },
+		func(tok string) {
+			token = tok
+			w.Terminate()
+		},
+	)); err != nil {
 		return "", fmt.Errorf("bind setup handler: %w", err)
 	}
 
 	// Minimal page bindings: progress/close UX ONLY, never token transport
 	// (the connect page shows its own progress; these let it inform the shell
-	// and close the window when its flow ends).
+	// and close the window when its flow ends). Reachable from remote pages,
+	// which is fine: they log, they cannot move credentials.
 	if err := w.Bind("onProgress", func(step string) {
 		log.Printf("[hosted] connect page progress: %s", step)
 	}); err != nil {
 		return "", fmt.Errorf("bind onProgress: %w", err)
 	}
 	if err := w.Bind("onComplete", func() {
-		// The long-poll should already have delivered the JWT; the page
-		// signaling completion without it means the user finished in-page UX
-		// early. The poll goroutine terminates the window when the token
-		// lands, so this is just a hint.
+		// The long-poll delivers the JWT and terminates the window; the page
+		// signaling completion is only a UX hint.
 		log.Printf("[hosted] connect page reports completion")
 	}); err != nil {
 		return "", fmt.Errorf("bind onComplete: %w", err)
@@ -142,28 +159,48 @@ func runFirstRunWindow(cfg *SidecarConfig) (string, error) {
 	startHandshake := func() {
 		go func() {
 			setStatus := func(text string) {
-				w.Dispatch(func() { w.Eval("window.__setStatus && window.__setStatus('" + jsEscape(text) + "')") })
+				w.Dispatch(func() {
+					if ctx.Err() != nil {
+						return
+					}
+					w.Eval("window.__setStatus && window.__setStatus('" + jsEscape(text) + "')")
+				})
 			}
-			setError := func(text string) {
-				w.Dispatch(func() { w.Eval("window.__setError && window.__setError('" + jsEscape(text) + "')") })
+			showShellError := func(text string) {
+				w.Dispatch(func() {
+					if ctx.Err() != nil {
+						return // self-host chosen or window closing: leave the form alone
+					}
+					w.SetHtml(hostedShellWithError(text))
+				})
 			}
 
 			nonce, err := generateHandshakeNonce()
 			if err != nil {
-				setError("Could not start setup: " + err.Error())
+				showShellError("Could not start setup: " + err.Error())
 				return
 			}
 			hostname, _ := os.Hostname()
 
 			if err := registerHandshake(ctx, base, nonce, hostname); err != nil {
+				if ctx.Err() != nil {
+					return
+				}
 				log.Printf("[hosted] handshake register failed: %v", err)
-				setError("Could not reach usejarvis. Check your connection and try again.")
+				showShellError("Could not reach usejarvis. Check your connection and try again.")
 				return
 			}
 
 			// Hand the webview to the hosted connect page (nonce in the URL;
-			// the page claims it after Clerk login).
-			w.Dispatch(func() { w.Navigate(connectPageURL(base, nonce)) })
+			// the page claims it after Clerk login). Re-check ctx INSIDE the
+			// dispatched closure: if the user picked self-host in the gap, a
+			// late Navigate must not yank the token form away.
+			w.Dispatch(func() {
+				if ctx.Err() != nil {
+					return
+				}
+				w.Navigate(connectPageURL(base, nonce))
+			})
 
 			jwt, err := awaitHandshakeToken(ctx, base, nonce, func(step string) {
 				setStatus(step) // only visible if the shell is still showing
@@ -173,18 +210,24 @@ func runFirstRunWindow(cfg *SidecarConfig) (string, error) {
 					return // window closed or self-host chosen
 				}
 				log.Printf("[hosted] handshake failed: %v", err)
-				// Bring the user back to the local shell with the reason.
-				w.Dispatch(func() { w.SetHtml(hostedShellHTML) })
-				setError("Setup did not complete: " + err.Error())
+				showShellError("Setup did not complete: " + err.Error())
 				return
 			}
-			token = jwt
 			log.Printf("[hosted] enrollment token received via handshake")
-			w.Dispatch(func() { w.Terminate() })
+			w.Dispatch(func() {
+				// Assigned on the main thread so the read after w.Run()
+				// needs no cross-goroutine ordering argument.
+				token = jwt
+				w.Terminate()
+			})
 		}()
 	}
 
 	if err := w.Bind("retryHosted", func() {
+		if ctx.Err() != nil {
+			return // self-host already chosen; nothing to retry
+		}
+		selfHostFormActive = false
 		w.Dispatch(func() { w.SetHtml(hostedShellHTML) })
 		startHandshake()
 	}); err != nil {
@@ -198,11 +241,14 @@ func runFirstRunWindow(cfg *SidecarConfig) (string, error) {
 	return token, nil
 }
 
-// jsEscape makes a Go string safe inside a single-quoted JS literal.
+// jsEscape makes a Go string safe inside a single-quoted JS string literal.
+// Backslash first, then quotes and line terminators; `<` is escaped so the
+// literal can also sit inside an inline <script> without closing it.
 func jsEscape(s string) string {
-	s = html.EscapeString(s)
 	s = strings.ReplaceAll(s, `\`, `\\`)
 	s = strings.ReplaceAll(s, `'`, `\'`)
 	s = strings.ReplaceAll(s, "\n", `\n`)
+	s = strings.ReplaceAll(s, "\r", `\r`)
+	s = strings.ReplaceAll(s, "<", `\x3c`)
 	return s
 }

--- a/sidecar/main.go
+++ b/sidecar/main.go
@@ -86,8 +86,8 @@ Usage:
 	if cfg.Token == "" {
 		// Unconfigured: pop up the first-run window asking for the enrollment
 		// token instead of erroring out. (--token still works headlessly.)
-		log.Println("[sidecar] No token configured - opening setup window...")
-		tok, err := runSetupWindow()
+		log.Println("[sidecar] No token configured - opening connect window...")
+		tok, err := runFirstRunWindow(cfg)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\nAlternatively, run: jarvis-sidecar --token <jwt>\n", err)
 			os.Exit(1)

--- a/sidecar/setup_window.go
+++ b/sidecar/setup_window.go
@@ -13,14 +13,6 @@ package main
 // The token is validated only as a well-formed JWT here — the brain still does
 // the real cryptographic verification on connect.
 
-import (
-	"fmt"
-	"runtime"
-	"strings"
-
-	webview "github.com/webview/webview_go"
-)
-
 // setupWindowHTML is the (intentionally minimal, unbranded) first-run form.
 // `window.submitToken(value)` is the Go binding installed below; it rejects with
 // a message when the token is empty/malformed so the form can show it inline.
@@ -95,46 +87,7 @@ const setupWindowHTML = `<!doctype html>
 </body>
 </html>`
 
-// runSetupWindow shows the first-run token prompt and returns the entered token
-// (validated as a well-formed JWT). Returns "" if the user closed the window
-// without submitting. Blocks until the window closes and must run on the main OS
-// thread (webview/Cocoa requirement), so call it from main() before spawning
-// other goroutines.
-func runSetupWindow() (string, error) {
-	runtime.LockOSThread()
-	defer runtime.UnlockOSThread()
-
-	w := webview.New(false)
-	if w == nil {
-		return "", fmt.Errorf("could not open the setup window (no display, or the system webview runtime is missing)")
-	}
-	defer w.Destroy()
-
-	w.SetTitle("JARVIS Sidecar - Setup")
-	w.SetSize(560, 380, webview.HintFixed)
-
-	var token string
-	// window.submitToken(raw) -> resolves on success (and closes the window),
-	// rejects with a message the form displays inline.
-	if err := w.Bind("submitToken", func(raw string) error {
-		raw = strings.TrimSpace(raw)
-		if raw == "" {
-			return fmt.Errorf("Paste your enrollment token to continue.")
-		}
-		if _, err := DecodeJWTPayload(raw); err != nil {
-			return fmt.Errorf("That doesn't look like a valid token. Copy the full token from the dashboard.")
-		}
-		token = raw
-		w.Terminate()
-		return nil
-	}); err != nil {
-		return "", fmt.Errorf("bind setup handler: %w", err)
-	}
-
-	// The vendored webview creates the window hidden (no flash); reveal it once
-	// the form has loaded.
-	revealWebviewOnLoad(w)
-	w.SetHtml(setupWindowHTML)
-	w.Run() // blocks until Terminate() (submit) or the window is closed
-	return token, nil
-}
+// NOTE: the standalone runSetupWindow function was removed when the
+// hosted-first connect window (hosted_window.go) took over the no-token
+// first run; the HTML above is its self-host form, reached via the
+// "Paste your enrollment token" link (gated submitToken binding).

--- a/sidecar/timezone.go
+++ b/sidecar/timezone.go
@@ -1,0 +1,223 @@
+package main
+
+// Machine timezone detection (IANA name, e.g. "America/New_York").
+//
+// Reported to the brain on register (alongside hostname) so a HOSTED brain -
+// which runs on a UTC VPS - can fire its local-time crons in the user's real
+// timezone, and the hosting server can schedule maintenance follow-the-night.
+// Best-effort: an empty string means "unknown" and consumers fall back to
+// their own default (the brain then uses the VPS clock; the server uses its
+// unknown-timezone window).
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+)
+
+// ianaNameRe accepts "Area/City", "Area/Sub/City", "UTC", "Etc/UTC" - enough
+// to reject garbage (paths, Windows display names) without embedding tzdata.
+var ianaNameRe = regexp.MustCompile(`^[A-Za-z_+-]+(/[A-Za-z0-9_+-]+){0,2}$`)
+
+// DetectIANATimezone returns the machine's IANA timezone name, or "" when it
+// cannot be determined confidently.
+func DetectIANATimezone() string {
+	// 1. Explicit TZ env wins everywhere (POSIX; ":Area/City" form included).
+	if tz := strings.TrimPrefix(strings.TrimSpace(os.Getenv("TZ")), ":"); tz != "" && ianaNameRe.MatchString(tz) {
+		return tz
+	}
+
+	switch runtimeGOOS() {
+	case "windows":
+		return windowsIANATimezone()
+	default:
+		return unixIANATimezone("/etc/localtime", "/etc/timezone")
+	}
+}
+
+// runtimeGOOS is indirected for tests.
+var runtimeGOOS = func() string { return runtime.GOOS }
+
+// unixIANATimezone resolves the zone from the /etc/localtime symlink
+// (macOS + most Linux) with Debian's /etc/timezone as a fallback.
+func unixIANATimezone(localtimePath, timezonePath string) string {
+	if target, err := filepath.EvalSymlinks(localtimePath); err == nil {
+		// .../zoneinfo/Europe/Rome -> Europe/Rome (also handles the
+		// "zoneinfo.default" dir some distros use).
+		if idx := strings.LastIndex(target, "zoneinfo"); idx != -1 {
+			rest := target[idx:]
+			if slash := strings.Index(rest, "/"); slash != -1 {
+				name := rest[slash+1:]
+				if ianaNameRe.MatchString(name) {
+					return name
+				}
+			}
+		}
+	}
+
+	if raw, err := os.ReadFile(timezonePath); err == nil {
+		name := strings.TrimSpace(string(raw))
+		if ianaNameRe.MatchString(name) {
+			return name
+		}
+	}
+
+	return ""
+}
+
+// windowsIANATimezone maps `tzutil /g` output (a Windows zone id) to the
+// CLDR primary IANA zone. The map covers the standard Windows zone ids;
+// unknown ids return "" (server-side unknown-timezone fallback applies).
+func windowsIANATimezone() string {
+	out, err := exec.Command("tzutil", "/g").Output()
+	if err != nil {
+		return ""
+	}
+	return windowsZoneToIANA[strings.TrimSpace(string(out))]
+}
+
+// windowsZoneToIANA is the CLDR windowsZones "001" (primary) mapping.
+var windowsZoneToIANA = map[string]string{
+	"Dateline Standard Time":          "Etc/GMT+12",
+	"UTC-11":                          "Etc/GMT+11",
+	"Aleutian Standard Time":          "America/Adak",
+	"Hawaiian Standard Time":          "Pacific/Honolulu",
+	"Marquesas Standard Time":         "Pacific/Marquesas",
+	"Alaskan Standard Time":           "America/Anchorage",
+	"UTC-09":                          "Etc/GMT+9",
+	"Pacific Standard Time (Mexico)":  "America/Tijuana",
+	"UTC-08":                          "Etc/GMT+8",
+	"Pacific Standard Time":           "America/Los_Angeles",
+	"US Mountain Standard Time":       "America/Phoenix",
+	"Mountain Standard Time (Mexico)": "America/Mazatlan",
+	"Mountain Standard Time":          "America/Denver",
+	"Yukon Standard Time":             "America/Whitehorse",
+	"Central America Standard Time":   "America/Guatemala",
+	"Central Standard Time":           "America/Chicago",
+	"Easter Island Standard Time":     "Pacific/Easter",
+	"Central Standard Time (Mexico)":  "America/Mexico_City",
+	"Canada Central Standard Time":    "America/Regina",
+	"SA Pacific Standard Time":        "America/Bogota",
+	"Eastern Standard Time (Mexico)":  "America/Cancun",
+	"Eastern Standard Time":           "America/New_York",
+	"Haiti Standard Time":             "America/Port-au-Prince",
+	"Cuba Standard Time":              "America/Havana",
+	"US Eastern Standard Time":        "America/Indiana/Indianapolis",
+	"Turks And Caicos Standard Time":  "America/Grand_Turk",
+	"Paraguay Standard Time":          "America/Asuncion",
+	"Atlantic Standard Time":          "America/Halifax",
+	"Venezuela Standard Time":         "America/Caracas",
+	"Central Brazilian Standard Time": "America/Cuiaba",
+	"SA Western Standard Time":        "America/La_Paz",
+	"Pacific SA Standard Time":        "America/Santiago",
+	"Newfoundland Standard Time":      "America/St_Johns",
+	"Tocantins Standard Time":         "America/Araguaina",
+	"E. South America Standard Time":  "America/Sao_Paulo",
+	"SA Eastern Standard Time":        "America/Cayenne",
+	"Argentina Standard Time":         "America/Argentina/Buenos_Aires",
+	"Montevideo Standard Time":        "America/Montevideo",
+	"Magallanes Standard Time":        "America/Punta_Arenas",
+	"Saint Pierre Standard Time":      "America/Miquelon",
+	"Bahia Standard Time":             "America/Bahia",
+	"UTC-02":                          "Etc/GMT+2",
+	"Greenland Standard Time":         "America/Nuuk",
+	"Azores Standard Time":            "Atlantic/Azores",
+	"Cape Verde Standard Time":        "Atlantic/Cape_Verde",
+	"UTC":                             "Etc/UTC",
+	"GMT Standard Time":               "Europe/London",
+	"Greenwich Standard Time":         "Atlantic/Reykjavik",
+	"Sao Tome Standard Time":          "Africa/Sao_Tome",
+	"Morocco Standard Time":           "Africa/Casablanca",
+	"W. Europe Standard Time":         "Europe/Berlin",
+	"Central Europe Standard Time":    "Europe/Budapest",
+	"Romance Standard Time":           "Europe/Paris",
+	"Central European Standard Time":  "Europe/Warsaw",
+	"W. Central Africa Standard Time": "Africa/Lagos",
+	"GTB Standard Time":               "Europe/Bucharest",
+	"Middle East Standard Time":       "Asia/Beirut",
+	"Egypt Standard Time":             "Africa/Cairo",
+	"E. Europe Standard Time":         "Europe/Chisinau",
+	"West Bank Standard Time":         "Asia/Hebron",
+	"South Africa Standard Time":      "Africa/Johannesburg",
+	"FLE Standard Time":               "Europe/Kiev",
+	"Israel Standard Time":            "Asia/Jerusalem",
+	"South Sudan Standard Time":       "Africa/Juba",
+	"Kaliningrad Standard Time":       "Europe/Kaliningrad",
+	"Sudan Standard Time":             "Africa/Khartoum",
+	"Libya Standard Time":             "Africa/Tripoli",
+	"Namibia Standard Time":           "Africa/Windhoek",
+	"Jordan Standard Time":            "Asia/Amman",
+	"Arabic Standard Time":            "Asia/Baghdad",
+	"Syria Standard Time":             "Asia/Damascus",
+	"Turkey Standard Time":            "Europe/Istanbul",
+	"Arab Standard Time":              "Asia/Riyadh",
+	"Belarus Standard Time":           "Europe/Minsk",
+	"Russian Standard Time":           "Europe/Moscow",
+	"E. Africa Standard Time":         "Africa/Nairobi",
+	"Volgograd Standard Time":         "Europe/Volgograd",
+	"Iran Standard Time":              "Asia/Tehran",
+	"Arabian Standard Time":           "Asia/Dubai",
+	"Astrakhan Standard Time":         "Europe/Astrakhan",
+	"Azerbaijan Standard Time":        "Asia/Baku",
+	"Russia Time Zone 3":              "Europe/Samara",
+	"Mauritius Standard Time":         "Indian/Mauritius",
+	"Saratov Standard Time":           "Europe/Saratov",
+	"Georgian Standard Time":          "Asia/Tbilisi",
+	"Caucasus Standard Time":          "Asia/Yerevan",
+	"Afghanistan Standard Time":       "Asia/Kabul",
+	"West Asia Standard Time":         "Asia/Tashkent",
+	"Ekaterinburg Standard Time":      "Asia/Yekaterinburg",
+	"Pakistan Standard Time":          "Asia/Karachi",
+	"Qyzylorda Standard Time":         "Asia/Qyzylorda",
+	"India Standard Time":             "Asia/Kolkata",
+	"Sri Lanka Standard Time":         "Asia/Colombo",
+	"Nepal Standard Time":             "Asia/Kathmandu",
+	"Central Asia Standard Time":      "Asia/Almaty",
+	"Bangladesh Standard Time":        "Asia/Dhaka",
+	"Omsk Standard Time":              "Asia/Omsk",
+	"Myanmar Standard Time":           "Asia/Yangon",
+	"SE Asia Standard Time":           "Asia/Bangkok",
+	"Altai Standard Time":             "Asia/Barnaul",
+	"W. Mongolia Standard Time":       "Asia/Hovd",
+	"North Asia Standard Time":        "Asia/Krasnoyarsk",
+	"N. Central Asia Standard Time":   "Asia/Novosibirsk",
+	"Tomsk Standard Time":             "Asia/Tomsk",
+	"China Standard Time":             "Asia/Shanghai",
+	"North Asia East Standard Time":   "Asia/Irkutsk",
+	"Singapore Standard Time":         "Asia/Singapore",
+	"W. Australia Standard Time":      "Australia/Perth",
+	"Taipei Standard Time":            "Asia/Taipei",
+	"Ulaanbaatar Standard Time":       "Asia/Ulaanbaatar",
+	"Aus Central W. Standard Time":    "Australia/Eucla",
+	"Transbaikal Standard Time":       "Asia/Chita",
+	"Tokyo Standard Time":             "Asia/Tokyo",
+	"North Korea Standard Time":       "Asia/Pyongyang",
+	"Korea Standard Time":             "Asia/Seoul",
+	"Yakutsk Standard Time":           "Asia/Yakutsk",
+	"Cen. Australia Standard Time":    "Australia/Adelaide",
+	"AUS Central Standard Time":       "Australia/Darwin",
+	"E. Australia Standard Time":      "Australia/Brisbane",
+	"AUS Eastern Standard Time":       "Australia/Sydney",
+	"West Pacific Standard Time":      "Pacific/Port_Moresby",
+	"Tasmania Standard Time":          "Australia/Hobart",
+	"Vladivostok Standard Time":       "Asia/Vladivostok",
+	"Lord Howe Standard Time":         "Australia/Lord_Howe",
+	"Bougainville Standard Time":      "Pacific/Bougainville",
+	"Russia Time Zone 10":             "Asia/Srednekolymsk",
+	"Magadan Standard Time":           "Asia/Magadan",
+	"Norfolk Standard Time":           "Pacific/Norfolk",
+	"Sakhalin Standard Time":          "Asia/Sakhalin",
+	"Central Pacific Standard Time":   "Pacific/Guadalcanal",
+	"Russia Time Zone 11":             "Asia/Kamchatka",
+	"New Zealand Standard Time":       "Pacific/Auckland",
+	"UTC+12":                          "Etc/GMT-12",
+	"Fiji Standard Time":              "Pacific/Fiji",
+	"Chatham Islands Standard Time":   "Pacific/Chatham",
+	"UTC+13":                          "Etc/GMT-13",
+	"Tonga Standard Time":             "Pacific/Tongatapu",
+	"Samoa Standard Time":             "Pacific/Apia",
+	"Line Islands Standard Time":      "Pacific/Kiritimati",
+}

--- a/sidecar/timezone_test.go
+++ b/sidecar/timezone_test.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDetectIANATimezoneTZEnv(t *testing.T) {
+	t.Setenv("TZ", "Europe/Rome")
+	if got := DetectIANATimezone(); got != "Europe/Rome" {
+		t.Fatalf("TZ env should win, got %q", got)
+	}
+
+	// POSIX ":Area/City" form.
+	t.Setenv("TZ", ":America/New_York")
+	if got := DetectIANATimezone(); got != "America/New_York" {
+		t.Fatalf("colon-prefixed TZ should be accepted, got %q", got)
+	}
+
+	// Garbage TZ must not be reported as an IANA name.
+	t.Setenv("TZ", "/usr/share/zoneinfo/../evil")
+	if got := DetectIANATimezone(); got == "/usr/share/zoneinfo/../evil" {
+		t.Fatalf("garbage TZ leaked through: %q", got)
+	}
+}
+
+func TestUnixIANATimezoneFromLocaltimeSymlink(t *testing.T) {
+	dir := t.TempDir()
+	// Fake zoneinfo tree with a real file so EvalSymlinks resolves.
+	zoneFile := filepath.Join(dir, "zoneinfo", "Europe", "Rome")
+	if err := os.MkdirAll(filepath.Dir(zoneFile), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(zoneFile, []byte("TZif"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(dir, "localtime")
+	if err := os.Symlink(zoneFile, link); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := unixIANATimezone(link, filepath.Join(dir, "nope")); got != "Europe/Rome" {
+		t.Fatalf("symlink resolution failed, got %q", got)
+	}
+}
+
+func TestUnixIANATimezoneDebianFallback(t *testing.T) {
+	dir := t.TempDir()
+	tzFile := filepath.Join(dir, "timezone")
+	if err := os.WriteFile(tzFile, []byte("Asia/Kolkata\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := unixIANATimezone(filepath.Join(dir, "missing"), tzFile); got != "Asia/Kolkata" {
+		t.Fatalf("/etc/timezone fallback failed, got %q", got)
+	}
+}
+
+func TestUnixIANATimezoneUnknown(t *testing.T) {
+	dir := t.TempDir()
+	if got := unixIANATimezone(filepath.Join(dir, "a"), filepath.Join(dir, "b")); got != "" {
+		t.Fatalf("expected empty for unknown, got %q", got)
+	}
+}
+
+func TestWindowsZoneMapSpotChecks(t *testing.T) {
+	cases := map[string]string{
+		"W. Europe Standard Time": "Europe/Berlin",
+		"Eastern Standard Time":   "America/New_York",
+		"India Standard Time":     "Asia/Kolkata",
+		"UTC":                     "Etc/UTC",
+	}
+	for win, iana := range cases {
+		if got := windowsZoneToIANA[win]; got != iana {
+			t.Errorf("%s -> %q, want %q", win, got, iana)
+		}
+	}
+	// Every mapped value must look like an IANA name.
+	for win, iana := range windowsZoneToIANA {
+		if !ianaNameRe.MatchString(iana) {
+			t.Errorf("map entry %q has non-IANA value %q", win, iana)
+		}
+	}
+}

--- a/sidecar/types.go
+++ b/sidecar/types.go
@@ -103,6 +103,11 @@ type SidecarRegistration struct {
 	Version                 string                  `json:"version"`
 	Capabilities            []SidecarCapability     `json:"capabilities"`
 	UnavailableCapabilities []UnavailableCapability `json:"unavailable_capabilities,omitempty"`
+	// Timezone is the machine's IANA zone (e.g. "Europe/Rome"), best-effort
+	// ("" = unknown). Hosted brains run on UTC VPSs and use this for the
+	// user's local-time crons; the hosting server schedules follow-the-night
+	// maintenance with it.
+	Timezone string `json:"timezone,omitempty"`
 }
 
 // SidecarCapabilitiesUpdate is sent when config changes to sync capabilities with the brain.
@@ -114,15 +119,19 @@ type SidecarCapabilitiesUpdate struct {
 
 // SidecarConfig is the YAML config file structure.
 type SidecarConfig struct {
-	Token        string              `yaml:"token"`
-	Brain        string              `yaml:"brain"`
-	Capabilities []SidecarCapability `yaml:"capabilities"`
-	Terminal     TerminalConfig      `yaml:"terminal"`
-	Filesystem   FilesystemConfig    `yaml:"filesystem"`
-	Browser      BrowserConfig       `yaml:"browser"`
-	Awareness    AwarenessConfig     `yaml:"awareness"`
-	Preferences  PreferencesConfig   `yaml:"preferences"`
-	Telemetry    TelemetryConfig     `yaml:"telemetry"`
+	Token string `yaml:"token"`
+	Brain string `yaml:"brain"`
+	// HostedBaseURL overrides the usejarvis connect origin for the first-run
+	// handshake. Honored ONLY in `-tags jarvisdebug` builds (see hosted.go);
+	// release binaries always use the production origin.
+	HostedBaseURL string              `yaml:"hosted_base_url,omitempty"`
+	Capabilities  []SidecarCapability `yaml:"capabilities"`
+	Terminal      TerminalConfig      `yaml:"terminal"`
+	Filesystem    FilesystemConfig    `yaml:"filesystem"`
+	Browser       BrowserConfig       `yaml:"browser"`
+	Awareness     AwarenessConfig     `yaml:"awareness"`
+	Preferences   PreferencesConfig   `yaml:"preferences"`
+	Telemetry     TelemetryConfig     `yaml:"telemetry"`
 }
 
 // TelemetryConfig controls anonymous sidecar usage metrics. Independent of the

--- a/src/actions/browser/chrome-launcher.ts
+++ b/src/actions/browser/chrome-launcher.ts
@@ -147,6 +147,15 @@ function findWindowsCandidates(): BrowserExecutable[] {
  * Returns when the CDP port is reachable.
  */
 export async function launchChrome(port: number = 9222, profileDir?: string): Promise<RunningBrowser> {
+  // Single choke point for browser.local: false (hosted instances). EVERY
+  // local-browser path funnels through here lazily (builtin browser tools,
+  // the background agent's bg browser), so no CDP port can ever open when
+  // the system config disables the local browser.
+  const { isLocalBrowserDisabled } = await import('../tools/local-tools-guard.ts');
+  if (isLocalBrowserDisabled()) {
+    throw new Error('The local browser is disabled on this machine (browser.local: false). Use a sidecar browser instead.');
+  }
+
   const exe = findBrowserExecutable();
   if (!exe) {
     throw new Error(

--- a/src/actions/browser/session.ts
+++ b/src/actions/browser/session.ts
@@ -122,6 +122,16 @@ export class BrowserController {
   async connect(): Promise<void> {
     if (this._connected) return;
 
+    // browser.local: false is enforced HERE, not only in launchChrome:
+    // connect() first probes the CDP port and attaches to whatever is
+    // already listening, so on a shared host a guard on launch alone would
+    // let the agent adopt ANY process bound to 127.0.0.1:<port> - including
+    // another tenant's. No local CDP connection at all when disabled.
+    const { isLocalBrowserDisabled } = await import('../tools/local-tools-guard.ts');
+    if (isLocalBrowserDisabled()) {
+      throw new Error('The local browser is disabled on this machine (browser.local: false). Use a sidecar browser instead.');
+    }
+
     // If Chrome isn't running, launch it automatically
     if (!(await this.isAvailable())) {
       console.log('[BrowserController] Chrome not detected, launching automatically...');

--- a/src/actions/tools/builtin.ts
+++ b/src/actions/tools/builtin.ts
@@ -742,7 +742,11 @@ export const browserUploadFileTool: ToolDefinition = {
     },
   },
   execute: async (params) => {
-    if (isLocalBrowserDisabled()) return LOCAL_BROWSER_DISABLED_MSG;
+    // No sidecar route exists for uploads, so the generic "use a sidecar"
+    // guidance would send the agent in circles - say so explicitly.
+    if (isLocalBrowserDisabled()) {
+      return 'Error: browser_upload_file requires the LOCAL browser, which is disabled on this machine (browser.local: false), and file upload has no sidecar route yet. This action is unavailable - do NOT retry.';
+    }
     if (isNoLocalTools()) return LOCAL_DISABLED_MSG;
     try {
       return await browser.uploadFile(

--- a/src/actions/tools/builtin.ts
+++ b/src/actions/tools/builtin.ts
@@ -24,7 +24,7 @@ const terminal = new TerminalExecutor({ timeout: 30000 });
 // Shared browser controller (lazy-connected on first browser tool use)
 export const browser = new BrowserController();
 
-import { isNoLocalTools, LOCAL_DISABLED_MSG, getDefaultCwd } from './local-tools-guard.ts';
+import { isNoLocalTools, LOCAL_DISABLED_MSG, isLocalBrowserDisabled, LOCAL_BROWSER_DISABLED_MSG, getDefaultCwd } from './local-tools-guard.ts';
 // Re-export for convenience
 export { setNoLocalTools, isNoLocalTools, setDefaultCwd } from './local-tools-guard.ts';
 
@@ -575,6 +575,7 @@ export const browserNavigateTool: ToolDefinition = {
     if (target) {
       return routeToSidecar(target, 'browser_navigate', { url: params.url, headless: params.headless }, 'browser');
     }
+    if (isLocalBrowserDisabled()) return LOCAL_BROWSER_DISABLED_MSG;
     if (isNoLocalTools()) return LOCAL_DISABLED_MSG;
     try {
       const snap = await browser.navigate(params.url as string);
@@ -601,6 +602,7 @@ export const browserSnapshotTool: ToolDefinition = {
     if (target) {
       return routeToSidecar(target, 'browser_snapshot', {}, 'browser');
     }
+    if (isLocalBrowserDisabled()) return LOCAL_BROWSER_DISABLED_MSG;
     if (isNoLocalTools()) return LOCAL_DISABLED_MSG;
     try {
       const snap = await browser.snapshot();
@@ -632,6 +634,7 @@ export const browserClickTool: ToolDefinition = {
     if (target) {
       return routeToSidecar(target, 'browser_click', { element_id: params.element_id }, 'browser');
     }
+    if (isLocalBrowserDisabled()) return LOCAL_BROWSER_DISABLED_MSG;
     if (isNoLocalTools()) return LOCAL_DISABLED_MSG;
     try {
       return await browser.click(params.element_id as number);
@@ -676,6 +679,7 @@ export const browserTypeTool: ToolDefinition = {
         submit: params.submit,
       }, 'browser');
     }
+    if (isLocalBrowserDisabled()) return LOCAL_BROWSER_DISABLED_MSG;
     if (isNoLocalTools()) return LOCAL_DISABLED_MSG;
     try {
       return await browser.type(
@@ -705,6 +709,7 @@ export const browserScreenshotTool: ToolDefinition = {
     if (target) {
       return routeToSidecar(target, 'browser_screenshot', {}, 'browser');
     }
+    if (isLocalBrowserDisabled()) return LOCAL_BROWSER_DISABLED_MSG;
     if (isNoLocalTools()) return LOCAL_DISABLED_MSG;
     try {
       const { base64, mimeType } = await browser.screenshotBuffer();
@@ -737,6 +742,7 @@ export const browserUploadFileTool: ToolDefinition = {
     },
   },
   execute: async (params) => {
+    if (isLocalBrowserDisabled()) return LOCAL_BROWSER_DISABLED_MSG;
     if (isNoLocalTools()) return LOCAL_DISABLED_MSG;
     try {
       return await browser.uploadFile(
@@ -778,6 +784,7 @@ export const browserScrollTool: ToolDefinition = {
         amount: params.amount,
       }, 'browser');
     }
+    if (isLocalBrowserDisabled()) return LOCAL_BROWSER_DISABLED_MSG;
     if (isNoLocalTools()) return LOCAL_DISABLED_MSG;
     try {
       const direction = (params.direction as string) === 'up' ? 'up' : 'down';
@@ -810,6 +817,7 @@ export const browserEvaluateTool: ToolDefinition = {
     if (target) {
       return routeToSidecar(target, 'browser_evaluate', { expression: params.expression }, 'browser');
     }
+    if (isLocalBrowserDisabled()) return LOCAL_BROWSER_DISABLED_MSG;
     if (isNoLocalTools()) return LOCAL_DISABLED_MSG;
     try {
       const result = await browser.evaluate(params.expression as string);

--- a/src/actions/tools/local-browser-guard.test.ts
+++ b/src/actions/tools/local-browser-guard.test.ts
@@ -20,7 +20,37 @@ describe('browser.local: false', () => {
 
   test('launchChrome is a hard choke point: throws, no process spawned', async () => {
     setLocalBrowserDisabled(true);
-    expect(launchChrome(9222)).rejects.toThrow(/browser\.local: false/);
+    // The await matters: without it this assertion can never fail the test.
+    await expect(launchChrome(9222)).rejects.toThrow(/browser\.local: false/);
+  });
+
+  test('connect() refuses even when something already listens on the CDP port', async () => {
+    // Regression (review): connect() probes the port and ATTACHES to any
+    // existing listener before ever calling launchChrome - on a shared host
+    // that could be another tenant's process. Serve a fake CDP endpoint and
+    // verify the guard fires before the probe.
+    setLocalBrowserDisabled(true);
+    const fakeCdp = Bun.serve({
+      port: 0,
+      fetch: () => Response.json([]),
+    });
+    try {
+      const { BrowserController } = await import('../browser/session.ts');
+      const ctrl = new BrowserController(fakeCdp.port);
+      await expect(ctrl.connect()).rejects.toThrow(/browser\.local: false/);
+    } finally {
+      fakeCdp.stop();
+    }
+  });
+
+  test('background-agent browser tools surface the refusal (no silent bypass)', async () => {
+    setLocalBrowserDisabled(true);
+    const { createBrowserTools } = await import('./builtin.ts');
+    const { BrowserController } = await import('../browser/session.ts');
+    const tools = createBrowserTools(new BrowserController(39996));
+    const navigate = tools.find((t) => t.name === 'browser_navigate')!;
+    const result = await navigate.execute({ url: 'https://example.com' });
+    expect(result).toContain('browser.local: false');
   });
 
   test('browser tools return the sidecar guidance instead of launching locally', async () => {

--- a/src/actions/tools/local-browser-guard.test.ts
+++ b/src/actions/tools/local-browser-guard.test.ts
@@ -1,0 +1,36 @@
+import { test, expect, describe, afterEach } from 'bun:test';
+import {
+  setLocalBrowserDisabled,
+  isLocalBrowserDisabled,
+  LOCAL_BROWSER_DISABLED_MSG,
+} from './local-tools-guard.ts';
+import { launchChrome } from '../browser/chrome-launcher.ts';
+import { browserNavigateTool, browserSnapshotTool, browserClickTool } from './builtin.ts';
+
+describe('browser.local: false', () => {
+  afterEach(() => {
+    setLocalBrowserDisabled(false);
+  });
+
+  test('flag round-trips and defaults to enabled', () => {
+    expect(isLocalBrowserDisabled()).toBe(false);
+    setLocalBrowserDisabled(true);
+    expect(isLocalBrowserDisabled()).toBe(true);
+  });
+
+  test('launchChrome is a hard choke point: throws, no process spawned', async () => {
+    setLocalBrowserDisabled(true);
+    expect(launchChrome(9222)).rejects.toThrow(/browser\.local: false/);
+  });
+
+  test('browser tools return the sidecar guidance instead of launching locally', async () => {
+    setLocalBrowserDisabled(true);
+    // No sidecar is connected in tests, so auto-targeting finds none and the
+    // tools hit the local path, which must refuse before touching Chrome.
+    expect(await browserNavigateTool.execute({ url: 'https://example.com' })).toBe(
+      LOCAL_BROWSER_DISABLED_MSG,
+    );
+    expect(await browserSnapshotTool.execute({})).toBe(LOCAL_BROWSER_DISABLED_MSG);
+    expect(await browserClickTool.execute({ element_id: 1 })).toBe(LOCAL_BROWSER_DISABLED_MSG);
+  });
+});

--- a/src/actions/tools/local-tools-guard.ts
+++ b/src/actions/tools/local-tools-guard.ts
@@ -29,3 +29,25 @@ export function setDefaultCwd(cwd: string | null): void {
 export function getDefaultCwd(): string | null {
   return _defaultCwd;
 }
+
+// ── Local browser guard (browser.local: false) ──────────────────────────────
+//
+// Separate from --no-local-tools: hosted instances disable ONLY the local
+// Chrome (no CDP ports may open on a shared VPS) while other local tools
+// follow their own policy. Set once at daemon boot from the system config.
+
+let _localBrowserDisabled = false;
+
+export function setLocalBrowserDisabled(disabled: boolean): void {
+  _localBrowserDisabled = disabled;
+  if (disabled) {
+    console.log('[Tools] Local browser disabled (browser.local: false). Browser actions route to a sidecar browser.');
+  }
+}
+
+export function isLocalBrowserDisabled(): boolean {
+  return _localBrowserDisabled;
+}
+
+export const LOCAL_BROWSER_DISABLED_MSG =
+  'Error: The local browser is disabled on this machine (browser.local: false). Browser actions run on a connected sidecar with the "browser" capability - none is currently available. Ask the user to open their Jarvis desktop app, then retry. Do NOT retry without a sidecar.';

--- a/src/cli/devices.ts
+++ b/src/cli/devices.ts
@@ -45,15 +45,16 @@ async function openVault(io: CliIo): Promise<{ dataDir: string; brainUrl: string
 
 export async function cmdEnroll(args: string[], io: CliIo = defaultIo): Promise<number> {
   const json = args.includes('--json');
+  const rotate = args.includes('--rotate');
   const name = args.filter((a) => !a.startsWith('--'))[0];
   if (!name) {
-    io.err('usage: jarvis enroll <device-name> [--json]');
+    io.err('usage: jarvis enroll <device-name> [--json] [--rotate]');
     return 2;
   }
 
   try {
     const { dataDir, brainUrl } = await openVault(io);
-    const result = await enrollDevice(dataDir, brainUrl, name, { onExisting: 'upsert' });
+    const result = await enrollDevice(dataDir, brainUrl, name, { onExisting: 'upsert', rotate });
     if (json) {
       io.out(
         JSON.stringify({
@@ -67,7 +68,7 @@ export async function cmdEnroll(args: string[], io: CliIo = defaultIo): Promise<
       io.err(
         result.created
           ? `enrolled "${result.sidecar.name}" (${result.sidecar.id})`
-          : `re-minted token for existing device "${result.sidecar.name}" (${result.sidecar.id})`,
+          : `re-minted token for existing device "${result.sidecar.name}" (${result.sidecar.id}); previous tokens REMAIN VALID (use --rotate to invalidate them)`,
       );
       io.out(result.token);
     }
@@ -124,8 +125,10 @@ export async function cmdRevoke(args: string[], io: CliIo = defaultIo): Promise<
 
   try {
     await openVault(io);
-    // Same semantics as SidecarManager.revokeSidecar: the row is deleted and
-    // any live daemon rejects the token on its next DB check. Idempotent:
+    // Deletes the enrollment row: new connections are rejected immediately,
+    // and a running daemon severs any LIVE session for this sid within ~30s
+    // (its revocation sweep re-checks enrollment; this CLI is a separate
+    // process and cannot close the daemon's sockets itself). Idempotent:
     // revoking an unknown/already-revoked sid reports revoked=false, exit 0.
     const result = getDb().run('DELETE FROM sidecars WHERE id = ? AND status = ?', [sid, 'enrolled']);
     const revoked = result.changes > 0;

--- a/src/cli/devices.ts
+++ b/src/cli/devices.ts
@@ -98,6 +98,9 @@ export async function cmdSidecars(args: string[], io: CliIo = defaultIo): Promis
       status: r.status,
       enrolled_at: r.enrolled_at,
       last_seen_at: r.last_seen_at,
+      // The hosting server reads this (follow-the-night scheduling); null
+      // until the device's sidecar first registers.
+      timezone: r.timezone ?? null,
     }));
     if (json) {
       io.out(JSON.stringify({ devices }));

--- a/src/cli/devices.ts
+++ b/src/cli/devices.ts
@@ -1,0 +1,139 @@
+/**
+ * Standalone device (sidecar) management CLIs:
+ *
+ *   jarvis enroll <name> [--json]    mint + store an enrollment JWT (upsert by name)
+ *   jarvis sidecars list [--json]    list enrolled devices
+ *   jarvis revoke <sid> [--json]     revoke a device
+ *
+ * These run WITHOUT the daemon: they open the vault DB directly and share the
+ * enrollment module with the daemon's SidecarManager. That is what lets a
+ * hosting server mint the first device's JWT while the brain is still
+ * booting (ONBOARDING flow), and manage devices over SSH afterwards. The
+ * daemon (WAL mode, per-connect DB reads) picks changes up live.
+ *
+ * stdout is machine-readable (the token, or JSON with --json); progress goes
+ * to stderr so provisioning can capture stdout verbatim.
+ */
+
+import { loadConfig } from '../config/loader.ts';
+import { initDatabase, getDb } from '../vault/schema.ts';
+import { enrollDevice } from '../sidecar/enrollment.ts';
+import type { SidecarRecord } from '../sidecar/types.ts';
+
+interface CliIo {
+  out: (line: string) => void;
+  err: (line: string) => void;
+}
+
+const defaultIo: CliIo = {
+  out: (line) => console.log(line),
+  err: (line) => console.error(line),
+};
+
+async function openVault(io: CliIo): Promise<{ dataDir: string; brainUrl: string }> {
+  const config = await loadConfig();
+  initDatabase(config.daemon.db_path, { quiet: true });
+  const brainUrl = config.daemon.brain_domain ?? `localhost:${config.daemon.port}`;
+  if (!config.daemon.brain_domain) {
+    io.err(
+      'warning: daemon.brain_domain is not set; tokens will point at ' +
+        `localhost:${config.daemon.port} and only work for sidecars on this machine.`,
+    );
+  }
+  return { dataDir: config.daemon.data_dir, brainUrl };
+}
+
+export async function cmdEnroll(args: string[], io: CliIo = defaultIo): Promise<number> {
+  const json = args.includes('--json');
+  const name = args.filter((a) => !a.startsWith('--'))[0];
+  if (!name) {
+    io.err('usage: jarvis enroll <device-name> [--json]');
+    return 2;
+  }
+
+  try {
+    const { dataDir, brainUrl } = await openVault(io);
+    const result = await enrollDevice(dataDir, brainUrl, name, { onExisting: 'upsert' });
+    if (json) {
+      io.out(
+        JSON.stringify({
+          token: result.token,
+          sid: result.sidecar.id,
+          name: result.sidecar.name,
+          created: result.created,
+        }),
+      );
+    } else {
+      io.err(
+        result.created
+          ? `enrolled "${result.sidecar.name}" (${result.sidecar.id})`
+          : `re-minted token for existing device "${result.sidecar.name}" (${result.sidecar.id})`,
+      );
+      io.out(result.token);
+    }
+    return 0;
+  } catch (err) {
+    io.err(`error: ${err instanceof Error ? err.message : String(err)}`);
+    return 1;
+  }
+}
+
+export async function cmdSidecars(args: string[], io: CliIo = defaultIo): Promise<number> {
+  const sub = args.filter((a) => !a.startsWith('--'))[0] ?? 'list';
+  const json = args.includes('--json');
+  if (sub !== 'list') {
+    io.err('usage: jarvis sidecars list [--json]');
+    return 2;
+  }
+
+  try {
+    await openVault(io);
+    const rows = getDb()
+      .query('SELECT * FROM sidecars ORDER BY enrolled_at DESC')
+      .all() as SidecarRecord[];
+    const devices = rows.map((r) => ({
+      sid: r.id,
+      name: r.name,
+      status: r.status,
+      enrolled_at: r.enrolled_at,
+      last_seen_at: r.last_seen_at,
+    }));
+    if (json) {
+      io.out(JSON.stringify({ devices }));
+    } else if (devices.length === 0) {
+      io.out('no enrolled devices');
+    } else {
+      for (const d of devices) {
+        io.out(`${d.sid}  ${d.status.padEnd(8)}  ${d.name}  (enrolled ${d.enrolled_at}, last seen ${d.last_seen_at ?? 'never'})`);
+      }
+    }
+    return 0;
+  } catch (err) {
+    io.err(`error: ${err instanceof Error ? err.message : String(err)}`);
+    return 1;
+  }
+}
+
+export async function cmdRevoke(args: string[], io: CliIo = defaultIo): Promise<number> {
+  const json = args.includes('--json');
+  const sid = args.filter((a) => !a.startsWith('--'))[0];
+  if (!sid) {
+    io.err('usage: jarvis revoke <sid> [--json]');
+    return 2;
+  }
+
+  try {
+    await openVault(io);
+    // Same semantics as SidecarManager.revokeSidecar: the row is deleted and
+    // any live daemon rejects the token on its next DB check. Idempotent:
+    // revoking an unknown/already-revoked sid reports revoked=false, exit 0.
+    const result = getDb().run('DELETE FROM sidecars WHERE id = ? AND status = ?', [sid, 'enrolled']);
+    const revoked = result.changes > 0;
+    if (json) io.out(JSON.stringify({ sid, revoked }));
+    else io.out(revoked ? `revoked ${sid}` : `nothing to revoke for ${sid}`);
+    return 0;
+  } catch (err) {
+    io.err(`error: ${err instanceof Error ? err.message : String(err)}`);
+    return 1;
+  }
+}

--- a/src/cli/lifecycle.ts
+++ b/src/cli/lifecycle.ts
@@ -158,10 +158,35 @@ function validPort(value: unknown): number | null {
 
 export type StopPortSource = 'lockfile' | 'env' | 'cli' | 'config' | 'default';
 
-export type StopPortResolution = {
-  port: number;
-  source: StopPortSource;
-};
+export type StopPortResolution =
+  | { port: number; source: StopPortSource }
+  /**
+   * The config binds a unix socket (`daemon.listen: unix:...`) and no TCP
+   * port was recorded in the lockfile: there is NO port to verify or clear.
+   * `jarvis stop` must be pid-only - SIGTERM/SIGKILLing whatever same-user
+   * process happens to listen on daemon.port/3142 would murder an unrelated
+   * service on a hosted box.
+   */
+  | { port: null; source: 'unix-socket' };
+
+/**
+ * Read `daemon.listen` from the YAML config; returns the unix socket path
+ * when one is configured, else null.
+ */
+export function readConfiguredUnixListen(configPath = join(homedir(), '.jarvis', 'config.yaml')): string | null {
+  try {
+    if (!existsSync(configPath)) return null;
+    const text = readFileSync(configPath, 'utf-8');
+    const doc = YAML.parseDocument(text, { merge: true });
+    if (doc.errors.length > 0) return null;
+    const parsed = doc.toJS() as { daemon?: { listen?: unknown } } | null;
+    const listen = parsed?.daemon?.listen;
+    if (typeof listen === 'string' && listen.trim().startsWith('unix:')) return listen.trim().slice('unix:'.length);
+    return null;
+  } catch {
+    return null;
+  }
+}
 
 /**
  * Resolve which port `jarvis stop` should verify.
@@ -187,6 +212,13 @@ export function resolveStopPort(options?: {
 
   const locked = validPort(readLockedPort());
   if (locked !== null) return { port: locked, source: 'lockfile' };
+
+  // Unix-socket mode records no port (there is none). Every other source
+  // (env/cli/config/default) describes a TCP port the daemon never bound,
+  // so port cleanup must be skipped entirely.
+  if (readConfiguredUnixListen(options?.configPath) !== null) {
+    return { port: null, source: 'unix-socket' };
+  }
 
   const fromEnv = validPort(env.JARVIS_PORT);
   if (fromEnv !== null) return { port: fromEnv, source: 'env' };

--- a/src/comms/websocket-unix.test.ts
+++ b/src/comms/websocket-unix.test.ts
@@ -59,3 +59,13 @@ describe('unix-domain socket listener', () => {
     expect(tcpRefused).toBe(true);
   });
 });
+
+test('stop() removes the socket file (no dead-but-present socket)', async () => {
+  const { existsSync } = await import('node:fs');
+  const sockPath = join(tmpdir(), `jarvis-test-stop-${process.pid}-${Date.now()}.sock`);
+  const s = new WebSocketServer(39995, sockPath);
+  s.start();
+  expect(existsSync(sockPath)).toBe(true);
+  s.stop();
+  expect(existsSync(sockPath)).toBe(false);
+});

--- a/src/comms/websocket-unix.test.ts
+++ b/src/comms/websocket-unix.test.ts
@@ -1,0 +1,61 @@
+import { test, expect, describe, afterEach } from 'bun:test';
+import { existsSync, statSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { WebSocketServer } from './websocket.ts';
+import { resolveListen } from '../config/loader.ts';
+
+describe('resolveListen', () => {
+  test('defaults to TCP on daemon.port', () => {
+    expect(resolveListen({ port: 3142 })).toEqual({ kind: 'tcp', port: 3142 });
+    expect(resolveListen({ port: 3142, listen: '' })).toEqual({ kind: 'tcp', port: 3142 });
+  });
+
+  test('parses unix specs and requires an absolute path', () => {
+    expect(resolveListen({ port: 3142, listen: 'unix:/run/jarvis/u_42.sock' })).toEqual({
+      kind: 'unix',
+      path: '/run/jarvis/u_42.sock',
+    });
+    expect(() => resolveListen({ port: 3142, listen: 'unix:relative.sock' })).toThrow(/absolute/);
+  });
+
+  test('rejects unknown schemes loudly (never a silent TCP fallback)', () => {
+    // A malformed listen value on a shared host must NOT quietly bind a TCP
+    // port that other tenants could reach.
+    expect(() => resolveListen({ port: 3142, listen: 'tcp:0.0.0.0:80' })).toThrow(/Unsupported/);
+  });
+});
+
+describe('unix-domain socket listener', () => {
+  let server: WebSocketServer | null = null;
+
+  afterEach(() => {
+    server?.stop();
+    server = null;
+  });
+
+  test('serves HTTP over the socket, no TCP port bound, 0660 perms, stale file replaced', async () => {
+    const sockPath = join(tmpdir(), `jarvis-test-${process.pid}-${Date.now()}.sock`);
+    // Pre-create a stale socket file: a previous daemon run that crashed.
+    await Bun.write(sockPath, '');
+
+    server = new WebSocketServer(39997, sockPath);
+    server.start();
+
+    expect(existsSync(sockPath)).toBe(true);
+    expect(statSync(sockPath).mode & 0o777).toBe(0o660);
+
+    // Health endpoint answers through the socket...
+    const res = await fetch('http://localhost/health', { unix: sockPath });
+    expect(res.status).toBe(200);
+
+    // ...and nothing answers on the TCP port (it was never bound).
+    let tcpRefused = false;
+    try {
+      await fetch('http://localhost:39997/health', { signal: AbortSignal.timeout(500) });
+    } catch {
+      tcpRefused = true;
+    }
+    expect(tcpRefused).toBe(true);
+  });
+});

--- a/src/comms/websocket-unix.test.ts
+++ b/src/comms/websocket-unix.test.ts
@@ -69,3 +69,49 @@ test('stop() removes the socket file (no dead-but-present socket)', async () => 
   s.stop();
   expect(existsSync(sockPath)).toBe(false);
 });
+
+test('the socket is removed on graceful process exit even when stop() is never called', async () => {
+  // Regression: the daemon stops several slow services (goal, awareness, the
+  // bg-agent browser) BEFORE it reaches the WS service, so an ordered stop()
+  // can run late or be cut off by jarvis stop's SIGKILL. A process.on('exit')
+  // handler must clean the socket regardless of shutdown ordering. A child
+  // process binds the socket and process.exit(0)s WITHOUT calling stop().
+  const { existsSync } = await import('node:fs');
+  const sockPath = join(tmpdir(), `jarvis-test-exit-${process.pid}-${Date.now()}.sock`);
+  const child = `
+    import { WebSocketServer } from ${JSON.stringify(join(import.meta.dir, 'websocket.ts'))};
+    const s = new WebSocketServer(39994, ${JSON.stringify(sockPath)});
+    s.start();
+    if (!require('node:fs').existsSync(${JSON.stringify(sockPath)})) process.exit(2);
+    // Exit WITHOUT s.stop() — the exit handler is the only cleanup path.
+    process.exit(0);
+  `;
+  const proc = Bun.spawn(['bun', '-e', child], { stdout: 'ignore', stderr: 'ignore' });
+  const code = await proc.exited;
+  expect(code).toBe(0);                 // child bound the socket
+  expect(existsSync(sockPath)).toBe(false); // ...and the exit handler removed it
+});
+
+test('stop() deregisters the exit handler (restart-in-place on a new path is untouched)', async () => {
+  const { existsSync, writeFileSync, unlinkSync } = await import('node:fs');
+  const pathA = join(tmpdir(), `jarvis-test-a-${process.pid}-${Date.now()}.sock`);
+  const pathB = join(tmpdir(), `jarvis-test-b-${process.pid}-${Date.now()}.sock`);
+  // A child binds A, stops it, binds B, then exits without stopping B. If A's
+  // handler leaked, it could unlink whatever now sits at A. Prove B is cleaned
+  // and a decoy file left at A survives (A's handler was deregistered by stop).
+  const child = `
+    import { WebSocketServer } from ${JSON.stringify(join(import.meta.dir, 'websocket.ts'))};
+    const fs = require('node:fs');
+    const a = new WebSocketServer(39993, ${JSON.stringify(pathA)});
+    a.start(); a.stop();
+    fs.writeFileSync(${JSON.stringify(pathA)}, 'decoy'); // reclaim path A
+    const b = new WebSocketServer(39992, ${JSON.stringify(pathB)});
+    b.start();
+    process.exit(0);
+  `;
+  const proc = Bun.spawn(['bun', '-e', child], { stdout: 'ignore', stderr: 'ignore' });
+  expect(await proc.exited).toBe(0);
+  expect(existsSync(pathB)).toBe(false); // B's handler cleaned it
+  expect(existsSync(pathA)).toBe(true);  // A's decoy survived (handler deregistered)
+  try { unlinkSync(pathA); } catch { /* cleanup */ }
+});

--- a/src/comms/websocket.test.ts
+++ b/src/comms/websocket.test.ts
@@ -5,6 +5,9 @@ let server: WebSocketServer;
 
 beforeEach(() => {
   server = new WebSocketServer(3143); // Use different port for tests
+  // These tests exercise routing/WS mechanics, not the auth gate (the gate
+  // is on by default now; its own tests are below).
+  server.setInsecureOpenAccess(true);
 });
 
 afterEach(() => {
@@ -232,10 +235,19 @@ test('WebSocketServer - sendBinary reaches client', async () => {
 });
 
 // --- Auth tests (use dedicated ports to avoid port reuse timing issues) ---
+//
+// JWT-only by default: non-public routes require a valid short-lived sidecar
+// access token; auth.insecure_open_access is the sole (loud) escape hatch.
 
-test('WebSocketServer - auth token blocks unauthenticated requests', async () => {
+/** Minimal stand-in for the SidecarManager's access-token verification. */
+function fakeSidecarManager(validToken: string) {
+  return {
+    verifyAccessToken: async (tok: string) => (tok === validToken ? { sid: 's1' } : null),
+  } as unknown as import('../sidecar/manager.ts').SidecarManager;
+}
+
+test('WebSocketServer - JWT-only by DEFAULT: unauthenticated requests are blocked', async () => {
   const authServer = new WebSocketServer(3150);
-  authServer.setAuthToken('test-secret-123');
   authServer.start();
 
   try {
@@ -243,36 +255,30 @@ test('WebSocketServer - auth token blocks unauthenticated requests', async () =>
     const health = await fetch('http://localhost:3150/health');
     expect(health.ok).toBe(true);
 
-    // API without cookie → 401 JSON
+    // API without a token → 401 JSON
     const api = await fetch('http://localhost:3150/api/health');
     expect(api.status).toBe(401);
     const body = await api.json() as any;
     expect(body.error).toBe('Unauthorized');
 
-    // Dashboard without cookie → 401 HTML with hash-to-query bootstrap script
+    // Dashboard without a token → 401 HTML with hash-to-query bootstrap script
     const dash = await fetch('http://localhost:3150/');
     expect(dash.status).toBe(401);
     const html = await dash.text();
     expect(html).toContain("location.replace");
     expect(html).toContain(".get('token')");
 
-    // Query param with valid token → 302 + Set-Cookie
-    const withToken = await fetch('http://localhost:3150/?token=test-secret-123', { redirect: 'manual' });
-    expect(withToken.status).toBe(302);
-    expect(withToken.headers.get('Set-Cookie')).toContain('token=test-secret-123');
-    expect(withToken.headers.get('Location')).toBe('/');
-
-    // Query param with wrong token → 401
-    const wrongToken = await fetch('http://localhost:3150/?token=wrong', { redirect: 'manual' });
-    expect(wrongToken.status).toBe(401);
+    // WebSocket endpoint blocked too
+    const ws = await fetch('http://localhost:3150/ws');
+    expect(ws.status).toBe(401);
   } finally {
     authServer.stop();
   }
 });
 
-test('WebSocketServer - auth token allows requests with valid cookie', async () => {
+test('WebSocketServer - a valid sidecar access token authorizes via ?token= then cookie', async () => {
   const authServer = new WebSocketServer(3151);
-  authServer.setAuthToken('test-secret-123');
+  authServer.setSidecarManager(fakeSidecarManager('valid-access-token'));
   authServer.setApiRoutes({
     '/api/health': {
       GET: () => Response.json({ status: 'ok' }),
@@ -281,27 +287,37 @@ test('WebSocketServer - auth token allows requests with valid cookie', async () 
   authServer.start();
 
   try {
+    // Query param with a valid access token → 302 + Set-Cookie
+    const withToken = await fetch('http://localhost:3151/?token=valid-access-token', { redirect: 'manual' });
+    expect(withToken.status).toBe(302);
+    expect(withToken.headers.get('Set-Cookie')).toContain('token=valid-access-token');
+    expect(withToken.headers.get('Location')).toBe('/');
+
+    // Cookie authorizes API requests
     const res = await fetch('http://localhost:3151/api/health', {
-      headers: { Cookie: 'token=test-secret-123' },
+      headers: { Cookie: 'token=valid-access-token' },
     });
     expect(res.ok).toBe(true);
     const data = await res.json() as any;
     expect(data.status).toBe('ok');
+
+    // Wrong tokens stay out
+    expect((await fetch('http://localhost:3151/?token=wrong', { redirect: 'manual' })).status).toBe(401);
+    expect((await fetch('http://localhost:3151/api/health', { headers: { Cookie: 'token=wrong' } })).status).toBe(401);
   } finally {
     authServer.stop();
   }
 });
 
-test('WebSocketServer - auth token rejects wrong cookie', async () => {
+test('WebSocketServer - there is NO shared-token backdoor without a sidecar manager', async () => {
+  // A server with no sidecar manager wired can validate nothing → everything
+  // non-public fails closed, whatever token is presented.
   const authServer = new WebSocketServer(3152);
-  authServer.setAuthToken('test-secret-123');
   authServer.start();
 
   try {
-    const res = await fetch('http://localhost:3152/api/health', {
-      headers: { Cookie: 'token=wrong-token' },
-    });
-    expect(res.status).toBe(401);
+    expect((await fetch('http://localhost:3152/api/health', { headers: { Cookie: 'token=anything' } })).status).toBe(401);
+    expect((await fetch('http://localhost:3152/?token=anything', { redirect: 'manual' })).status).toBe(401);
   } finally {
     authServer.stop();
   }
@@ -309,7 +325,6 @@ test('WebSocketServer - auth token rejects wrong cookie', async () => {
 
 test('WebSocketServer - public routes bypass auth', async () => {
   const authServer = new WebSocketServer(3153);
-  authServer.setAuthToken('test-secret-123');
   authServer.start();
 
   try {
@@ -325,85 +340,20 @@ test('WebSocketServer - public routes bypass auth', async () => {
   }
 });
 
-test('WebSocketServer - WebSocket blocked without auth cookie', async () => {
+test('WebSocketServer - auth.insecure_open_access opens the dashboard (setup escape hatch)', async () => {
   const authServer = new WebSocketServer(3154);
-  authServer.setAuthToken('test-secret-123');
-  authServer.start();
-
-  try {
-    // Regular HTTP fetch to /ws without cookie → 401 JSON
-    const res = await fetch('http://localhost:3154/ws');
-    expect(res.status).toBe(401);
-  } finally {
-    authServer.stop();
-  }
-});
-
-test('WebSocketServer - WebSocket allowed with auth cookie', async () => {
-  const authServer = new WebSocketServer(3155);
-  authServer.setAuthToken('test-secret-123');
-  authServer.start();
-
-  try {
-    const ws = new WebSocket('ws://localhost:3155/ws', {
-      headers: { Cookie: 'token=test-secret-123' },
-    } as any);
-
-    const connected = await new Promise<boolean>((resolve) => {
-      ws.onopen = () => resolve(true);
-      ws.onerror = () => resolve(false);
-      setTimeout(() => resolve(false), 2000);
-    });
-
-    expect(connected).toBe(true);
-    ws.close();
-    await new Promise((resolve) => setTimeout(resolve, 100));
-  } finally {
-    authServer.stop();
-  }
-});
-
-test('WebSocketServer - sendToClient unicasts JSON', async () => {
-  let serverWsRef: any = null;
-
-  server.setHandler({
-    async onMessage(msg, ws) {
-      serverWsRef = ws;
-      return undefined;  // No auto-response
+  authServer.setInsecureOpenAccess(true);
+  authServer.setApiRoutes({
+    '/api/health': {
+      GET: () => Response.json({ status: 'ok' }),
     },
-    onConnect(_ws) {},
-    onDisconnect(_ws) {},
   });
+  authServer.start();
 
-  server.start();
-
-  const ws = new WebSocket('ws://localhost:3143/ws');
-  const received: WSMessage[] = [];
-
-  await new Promise<void>((resolve) => { ws.onopen = () => resolve(); });
-
-  ws.onmessage = (e) => {
-    if (typeof e.data === 'string') {
-      received.push(JSON.parse(e.data));
-    }
-  };
-
-  // Trigger to get ws ref
-  ws.send(JSON.stringify({ type: 'command', payload: {}, timestamp: Date.now() }));
-  await new Promise((resolve) => setTimeout(resolve, 200));
-
-  // Unicast a tts_start message
-  server.sendToClient(serverWsRef, {
-    type: 'tts_start',
-    payload: { requestId: 'test-123' },
-    timestamp: Date.now(),
-  });
-  await new Promise((resolve) => setTimeout(resolve, 200));
-
-  expect(received.length).toBe(1);
-  expect(received[0]!.type).toBe('tts_start');
-  expect((received[0]!.payload as any).requestId).toBe('test-123');
-
-  ws.close();
-  server.stop();
+  try {
+    const res = await fetch('http://localhost:3154/api/health');
+    expect(res.ok).toBe(true);
+  } finally {
+    authServer.stop();
+  }
 });

--- a/src/comms/websocket.test.ts
+++ b/src/comms/websocket.test.ts
@@ -357,3 +357,72 @@ test('WebSocketServer - auth.insecure_open_access opens the dashboard (setup esc
     authServer.stop();
   }
 });
+
+test('WebSocketServer - WebSocket upgrade allowed with a valid access-token cookie', async () => {
+  const authServer = new WebSocketServer(3155);
+  authServer.setSidecarManager(fakeSidecarManager('valid-access-token'));
+  authServer.start();
+
+  try {
+    const ws = new WebSocket('ws://localhost:3155/ws', {
+      headers: { Cookie: 'token=valid-access-token' },
+    } as any);
+
+    const connected = await new Promise<boolean>((resolve) => {
+      ws.onopen = () => resolve(true);
+      ws.onerror = () => resolve(false);
+      setTimeout(() => resolve(false), 2000);
+    });
+
+    expect(connected).toBe(true);
+    ws.close();
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  } finally {
+    authServer.stop();
+  }
+});
+
+test('WebSocketServer - sendToClient unicasts JSON', async () => {
+  let serverWsRef: any = null;
+
+  server.setHandler({
+    async onMessage(msg, ws) {
+      serverWsRef = ws;
+      return undefined;  // No auto-response
+    },
+    onConnect(_ws) {},
+    onDisconnect(_ws) {},
+  });
+
+  server.start();
+
+  const ws = new WebSocket('ws://localhost:3143/ws');
+  const received: WSMessage[] = [];
+
+  await new Promise<void>((resolve) => { ws.onopen = () => resolve(); });
+
+  ws.onmessage = (e) => {
+    if (typeof e.data === 'string') {
+      received.push(JSON.parse(e.data));
+    }
+  };
+
+  // Trigger to get ws ref
+  ws.send(JSON.stringify({ type: 'command', payload: {}, timestamp: Date.now() }));
+  await new Promise((resolve) => setTimeout(resolve, 200));
+
+  // Unicast a tts_start message
+  server.sendToClient(serverWsRef, {
+    type: 'tts_start',
+    payload: { requestId: 'test-123' },
+    timestamp: Date.now(),
+  });
+  await new Promise((resolve) => setTimeout(resolve, 200));
+
+  expect(received.length).toBe(1);
+  expect(received[0]!.type).toBe('tts_start');
+  expect((received[0]!.payload as any).requestId).toBe('test-123');
+
+  ws.close();
+  server.stop();
+});

--- a/src/comms/websocket.ts
+++ b/src/comms/websocket.ts
@@ -129,6 +129,8 @@ export class WebSocketServer {
   private clients: Set<ServerWebSocket<unknown>> = new Set();
   private handler: WSClientHandler | null = null;
   private port: number;
+  /** When set, bind a unix-domain socket instead of the TCP port (hosted mode). */
+  private unixPath: string | null = null;
   private startTime: number = 0;
   private apiRoutes: Map<string, MethodRoutes> = new Map();
   private staticDir: string | null = null;
@@ -138,8 +140,9 @@ export class WebSocketServer {
   private corsOrigin: string | null = null;
   private proxyLimiter = new ProxyRateLimiter();
 
-  constructor(port: number = 3142) {
+  constructor(port: number = 3142, unixPath?: string) {
     this.port = port;
+    this.unixPath = unixPath ?? null;
     this.corsOrigin = `http://localhost:${port}`;
   }
 
@@ -195,8 +198,19 @@ export class WebSocketServer {
     this.startTime = Date.now();
     const self = this;
 
+    // Unix mode: remove a stale socket file from a previous run first, or
+    // bind fails with EADDRINUSE even though nothing is listening.
+    if (this.unixPath) {
+      try { require('node:fs').unlinkSync(this.unixPath); } catch { /* absent */ }
+    }
+
+    // Bun accepts either { port } or { unix } (mutually exclusive variants of
+    // a discriminated union). TypeScript can't narrow a conditional spread to
+    // one variant, so the pair is cast to the port variant; at runtime Bun
+    // receives exactly one of the two keys.
+    const listenOpts = (this.unixPath ? { unix: this.unixPath } : { port: this.port }) as { port: number };
     this.server = Bun.serve<{ sidecar_id?: string; proxy_target?: string; _proxyUpstream?: WebSocket }>({
-      port: this.port,
+      ...listenOpts,
       idleTimeout: 30, // seconds — prevent timeout during heavy processing (OCR, PowerShell)
 
       async fetch(req, server) {
@@ -585,8 +599,17 @@ export class WebSocketServer {
       },
     });
 
-    console.log(`[WebSocketServer] Started on ws://localhost:${this.port}/ws`);
-    console.log(`[WebSocketServer] Health endpoint: http://localhost:${this.port}/health`);
+    if (this.unixPath) {
+      // Caddy (same group) must be able to connect; the socket dir itself is
+      // the per-tenant boundary. 0660 = owner + group only.
+      try { require('node:fs').chmodSync(this.unixPath, 0o660); } catch (err) {
+        console.warn(`[WebSocketServer] Could not chmod socket ${this.unixPath}:`, err);
+      }
+      console.log(`[WebSocketServer] Started on unix:${this.unixPath} (no TCP port bound)`);
+    } else {
+      console.log(`[WebSocketServer] Started on ws://localhost:${this.port}/ws`);
+      console.log(`[WebSocketServer] Health endpoint: http://localhost:${this.port}/health`);
+    }
     if (this.staticDir) {
       console.log(`[WebSocketServer] Dashboard: http://localhost:${this.port}/`);
     }

--- a/src/comms/websocket.ts
+++ b/src/comms/websocket.ts
@@ -5,11 +5,6 @@ import { isWithin } from '../util/path.ts';
 import type { SidecarManager } from '../sidecar/manager.ts';
 
 /** Constant-time string comparison to prevent timing attacks */
-function safeCompare(a: string, b: string): boolean {
-  if (a.length !== b.length) return false;
-  return timingSafeEqual(Buffer.from(a), Buffer.from(b));
-}
-
 export type WSMessage = {
   type: 'chat' | 'command' | 'status' | 'stream' | 'error' | 'notification'
       | 'tts_start' | 'tts_text' | 'tts_end' | 'voice_start' | 'voice_end' | 'voice_text'
@@ -136,7 +131,13 @@ export class WebSocketServer {
   private staticDir: string | null = null;
   private publicDir: string | null = null;
   private sidecarManager: SidecarManager | null = null;
-  private authToken: string | null = null;
+  /**
+   * JWT-only by default: every non-public route requires a valid short-lived
+   * sidecar access token (minted from an enrollment JWT). The ONLY way to
+   * open the dashboard without one is the explicit config escape hatch
+   * `auth.insecure_open_access: true` (pre-enrollment setup; see docs).
+   */
+  private insecureOpenAccess = false;
   private corsOrigin: string | null = null;
   private proxyLimiter = new ProxyRateLimiter();
 
@@ -146,8 +147,8 @@ export class WebSocketServer {
     this.corsOrigin = `http://localhost:${port}`;
   }
 
-  setAuthToken(token: string): void {
-    this.authToken = token;
+  setInsecureOpenAccess(enabled: boolean): void {
+    this.insecureOpenAccess = enabled;
   }
 
   setHandler(handler: WSClientHandler): void {
@@ -257,18 +258,17 @@ export class WebSocketServer {
           return Response.json({ access_token: minted.token, expires_in: minted.expiresIn });
         }
 
-        // 1. Auth check (if configured)
-        if (self.authToken && !isPublicRoute(pathname, req.method)) {
-          // A request is authorized by EITHER the dashboard token OR a valid
-          // short-lived sidecar ACCESS token. The sidecar's panel webviews carry
-          // an access token (minted from the enrollment JWT via /sidecar/token)
-          // so their content fetches authenticate without the dashboard token.
-          // The long-lived enrollment JWT is deliberately NOT accepted here —
-          // only on /sidecar/connect and the mint endpoint — so a leaked panel
-          // credential is bounded to the access-token TTL instead of forever.
+        // 1. Auth check. JWT-only by default: a request is authorized by a
+        // valid short-lived sidecar ACCESS token (minted from the enrollment
+        // JWT via /sidecar/token) - the sidecar's panel webviews carry one.
+        // The long-lived enrollment JWT is deliberately NOT accepted here —
+        // only on /sidecar/connect and the mint endpoint — so a leaked panel
+        // credential is bounded to the access-token TTL instead of forever.
+        // There is NO shared dashboard token: enroll a device or (setup only)
+        // set auth.insecure_open_access.
+        if (!self.insecureOpenAccess && !isPublicRoute(pathname, req.method)) {
           const accepts = async (tok: string | null): Promise<boolean> => {
             if (!tok) return false;
-            if (safeCompare(tok, self.authToken!)) return true;
             if (self.sidecarManager && (await self.sidecarManager.verifyAccessToken(tok))) return true;
             return false;
           };
@@ -416,7 +416,7 @@ export class WebSocketServer {
           const overlayPath = path.join(self.staticDir, '..', 'overlay.html');
           const overlayFile = Bun.file(overlayPath);
           if (await overlayFile.exists()) {
-            if (self.authToken) {
+            if (!self.insecureOpenAccess) {
               const html = await overlayFile.text();
               return new Response(injectTokenStrip(html), { headers: { 'Content-Type': 'text/html' } });
             }
@@ -442,7 +442,7 @@ export class WebSocketServer {
 
           const file = Bun.file(filePath);
           if (await file.exists()) {
-            if (self.authToken && filePath.endsWith('.html')) {
+            if (!self.insecureOpenAccess && filePath.endsWith('.html')) {
               const html = await file.text();
               return new Response(injectTokenStrip(html), { headers: { 'Content-Type': 'text/html' } });
             }

--- a/src/comms/websocket.ts
+++ b/src/comms/websocket.ts
@@ -200,9 +200,14 @@ export class WebSocketServer {
     const self = this;
 
     // Unix mode: remove a stale socket file from a previous run first, or
-    // bind fails with EADDRINUSE even though nothing is listening.
+    // bind fails with EADDRINUSE even though nothing is listening. The socket
+    // must also be BORN 0660 (umask), not chmod'd after the fact - between
+    // bind and a post-hoc chmod the file briefly carries the process umask,
+    // and on a shared host that window is the tenant boundary.
+    let restoreUmask: number | null = null;
     if (this.unixPath) {
       try { require('node:fs').unlinkSync(this.unixPath); } catch { /* absent */ }
+      restoreUmask = process.umask(0o117); // 0666 & ~0117 = 0660
     }
 
     // Bun accepts either { port } or { unix } (mutually exclusive variants of
@@ -599,11 +604,19 @@ export class WebSocketServer {
       },
     });
 
+    if (restoreUmask !== null) process.umask(restoreUmask);
     if (this.unixPath) {
       // Caddy (same group) must be able to connect; the socket dir itself is
-      // the per-tenant boundary. 0660 = owner + group only.
-      try { require('node:fs').chmodSync(this.unixPath, 0o660); } catch (err) {
-        console.warn(`[WebSocketServer] Could not chmod socket ${this.unixPath}:`, err);
+      // the per-tenant boundary. The umask above made the socket 0660 at
+      // birth; verify rather than trust, and fail CLOSED if it is wrong.
+      const fs = require('node:fs');
+      const mode = fs.statSync(this.unixPath).mode & 0o777;
+      if (mode !== 0o660) {
+        try { fs.chmodSync(this.unixPath, 0o660); } catch { /* verified below */ }
+        if ((fs.statSync(this.unixPath).mode & 0o777) !== 0o660) {
+          this.stop();
+          throw new Error(`[WebSocketServer] Socket ${this.unixPath} has mode ${mode.toString(8)}, expected 660 - refusing to serve`);
+        }
       }
       console.log(`[WebSocketServer] Started on unix:${this.unixPath} (no TCP port bound)`);
     } else {
@@ -620,6 +633,11 @@ export class WebSocketServer {
       this.server.stop();
       this.server = null;
       this.clients.clear();
+      // Remove the socket file so ops probes don't see a dead-but-present
+      // socket (the pre-bind unlink only covers the NEXT start).
+      if (this.unixPath) {
+        try { require('node:fs').unlinkSync(this.unixPath); } catch { /* absent */ }
+      }
       console.log('[WebSocketServer] Stopped');
     }
   }

--- a/src/comms/websocket.ts
+++ b/src/comms/websocket.ts
@@ -126,6 +126,16 @@ export class WebSocketServer {
   private port: number;
   /** When set, bind a unix-domain socket instead of the TCP port (hosted mode). */
   private unixPath: string | null = null;
+  /**
+   * Synchronous `process.on('exit')` cleanup for the unix socket, registered
+   * at bind. Guarantees the socket file is removed on ANY graceful process
+   * exit regardless of shutdown-ordering (the daemon stops several slow
+   * services before it reaches this one, and `jarvis stop`'s grace window can
+   * SIGKILL mid-shutdown before an ordered stop() runs). Removed by stop() to
+   * avoid stale handlers across restart-in-place. (SIGKILL is uncatchable; the
+   * next start's pre-bind unlink covers that abnormal case.)
+   */
+  private exitCleanup: (() => void) | null = null;
   private startTime: number = 0;
   private apiRoutes: Map<string, MethodRoutes> = new Map();
   private staticDir: string | null = null;
@@ -618,6 +628,14 @@ export class WebSocketServer {
           throw new Error(`[WebSocketServer] Socket ${this.unixPath} has mode ${mode.toString(8)}, expected 660 - refusing to serve`);
         }
       }
+      // Guarantee the socket is gone on any graceful process exit, whatever
+      // the shutdown ordering. Capture the path so the handler can't race a
+      // later reassignment of this.unixPath.
+      const socketPath = this.unixPath;
+      this.exitCleanup = () => {
+        try { require('node:fs').unlinkSync(socketPath); } catch { /* already gone */ }
+      };
+      process.once('exit', this.exitCleanup);
       console.log(`[WebSocketServer] Started on unix:${this.unixPath} (no TCP port bound)`);
     } else {
       console.log(`[WebSocketServer] Started on ws://localhost:${this.port}/ws`);
@@ -637,6 +655,13 @@ export class WebSocketServer {
       // socket (the pre-bind unlink only covers the NEXT start).
       if (this.unixPath) {
         try { require('node:fs').unlinkSync(this.unixPath); } catch { /* absent */ }
+      }
+      // Drop the exit-time cleanup: an explicit stop already removed the
+      // socket, and leaving it registered would let a restart-in-place on a
+      // new path be unlinked by this old instance's handler at process exit.
+      if (this.exitCleanup) {
+        process.removeListener('exit', this.exitCleanup);
+        this.exitCleanup = null;
       }
       console.log('[WebSocketServer] Stopped');
     }

--- a/src/config/README.md
+++ b/src/config/README.md
@@ -38,19 +38,24 @@ console.log(config.personality.core_traits);  // string[]
 
 ### Saving Configuration
 
+There is intentionally **no `saveConfig`**. `config.yaml` is a read-only
+SYSTEM config (daemon.*, auth, google) that the brain never writes; in hosted
+mode it is root-owned and managed by the hosting server.
+
+All user-owned sections (personality, voice, stt/tts, authority, channels,
+onboarding, ... — see `USER_OWNED_SECTIONS` in `types.ts`) persist to the
+vault DB settings store instead:
+
 ```typescript
-import { saveConfig } from './config/index.ts';
+import { saveUserSection } from '../daemon/user-settings.ts';
 
-// Modify config
-config.daemon.port = 8888;
-config.llm.primary = 'openai';
-
-// Save to default location
-await saveConfig(config);
-
-// Save to custom path
-await saveConfig(config, '/path/to/config.yaml');
+config.tts = { ...config.tts, enabled: true };
+saveUserSection('tts', config.tts);
 ```
+
+A legacy `config.yaml` that still carries user sections seeds the DB once at
+daemon boot (`importLegacyUserSettings`), after which the file's copies are
+ignored (`loadConfig` discards them, exactly like the `llm` block).
 
 ### Using Default Config
 
@@ -243,22 +248,18 @@ console.log(`Database path: ${config.daemon.db_path}`);
 
 ### Dynamic Configuration Updates
 
+Inside the daemon, mutate the live in-memory config (it is the DB-merged,
+authoritative view) and persist the touched section:
+
 ```typescript
-import { loadConfig, saveConfig } from './config/index.ts';
+import { saveUserSection } from '../daemon/user-settings.ts';
 
-// Load current config
-const config = await loadConfig();
-
-// Update settings
-config.daemon.port = 8888;
-config.llm.primary = 'openai';
-config.personality.core_traits.push('humorous');
-
-// Save changes
-await saveConfig(config);
-
-console.log('Configuration updated!');
+ctx.config.personality.core_traits.push('humorous');
+saveUserSection('personality', ctx.config.personality);
 ```
+
+System keys (`daemon.*`) cannot be changed at runtime — edit `config.yaml`
+and restart (self-host), or let the hosting server rewrite it (hosted).
 
 ## Setup Instructions
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,6 +1,8 @@
 // Config types
-export type { JarvisConfig } from './types.ts';
-export { DEFAULT_CONFIG } from './types.ts';
+export type { JarvisConfig, UserOwnedSection } from './types.ts';
+export { DEFAULT_CONFIG, USER_OWNED_SECTIONS } from './types.ts';
 
-// Config loader
-export { loadConfig, saveConfig } from './loader.ts';
+// Config loader. There is no saveConfig: config.yaml is read-only system
+// configuration; user-owned settings persist to the vault DB instead
+// (daemon/user-settings.ts).
+export { loadConfig, readRawConfigFile, applyEnvOverrides, deepMerge } from './loader.ts';

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -1,10 +1,9 @@
 import { test, expect, describe, beforeEach, afterEach } from 'bun:test';
-import { loadConfig, saveConfig } from './loader.ts';
-import { DEFAULT_CONFIG } from './types.ts';
-import { existsSync, lstatSync, statSync } from 'node:fs';
-import { chmod, mkdtemp, readdir, rm, symlink } from 'node:fs/promises';
+import { loadConfig, readRawConfigFile } from './loader.ts';
+import { DEFAULT_CONFIG, USER_OWNED_SECTIONS } from './types.ts';
+import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { dirname, join, isAbsolute } from 'node:path';
+import { join, isAbsolute } from 'node:path';
 
 let TEST_CONFIG_DIR: string;
 let TEST_CONFIG_PATH: string;
@@ -35,53 +34,9 @@ describe('Config Loader', () => {
     expect(config.active_role).toBe(DEFAULT_CONFIG.active_role);
   });
 
-  test('can save and load config; LLM config is never persisted to YAML', async () => {
-    const testConfig = structuredClone(DEFAULT_CONFIG);
-    testConfig.daemon.port = 9999;
-    // LLM config lives only in the DB + keychain (dashboard-managed). Even when
-    // present in the in-memory config, it must never be written to config.yaml.
-    testConfig.llm.providers = { openai: { api_key: 'sk-test' } };
-    testConfig.llm.default = 'openai:gpt-4o-mini';
-
-    await saveConfig(testConfig, TEST_CONFIG_PATH);
-    expect(existsSync(TEST_CONFIG_PATH)).toBe(true);
-    const text = await Bun.file(TEST_CONFIG_PATH).text();
-    expect(text).not.toContain('llm:');
-    expect(text).not.toContain('sk-test');
-
-    const loaded = await loadConfig(TEST_CONFIG_PATH);
-    expect(loaded.daemon.port).toBe(9999);
-    // The llm block was stripped on save and is discarded on load.
-    expect(loaded.llm).toEqual(DEFAULT_CONFIG.llm);
-  });
-
-  test('saves config with owner-only permissions', async () => {
-    await saveConfig(DEFAULT_CONFIG, TEST_CONFIG_PATH);
-
-    expect(statSync(dirname(TEST_CONFIG_PATH)).mode & 0o777).toBe(0o700);
-    expect(statSync(TEST_CONFIG_PATH).mode & 0o777).toBe(0o600);
-  });
-
-  test('does not chmod cwd for bare relative config paths', async () => {
-    const originalCwd = process.cwd();
-    const dir = await mkdtemp(join(tmpdir(), 'jarvis-config-cwd-'));
-    await chmod(dir, 0o755);
-
-    try {
-      process.chdir(dir);
-      await saveConfig(DEFAULT_CONFIG, 'config.yaml');
-
-      expect(statSync(dir).mode & 0o777).toBe(0o755);
-      expect(statSync(join(dir, 'config.yaml')).mode & 0o777).toBe(0o600);
-    } finally {
-      process.chdir(originalCwd);
-      await rm(dir, { recursive: true, force: true });
-    }
-  });
-
   test('deep merges partial config with defaults; any llm block is discarded', async () => {
-    // Save a partial config (only some fields). The llm block is legacy and
-    // must be ignored entirely - LLM config comes only from the DB.
+    // The llm block is legacy and must be ignored entirely - LLM config
+    // comes only from the DB.
     const partialYaml = `
 daemon:
   port: 8888
@@ -105,25 +60,58 @@ llm:
     expect(loaded.authority.default_level).toBe(DEFAULT_CONFIG.authority.default_level);
   });
 
-  test('preserves all config sections', async () => {
-    await saveConfig(DEFAULT_CONFIG, TEST_CONFIG_PATH);
+  test('user-owned sections in the file have no authority (discarded like llm)', async () => {
+    // config.yaml is a SYSTEM config. User sections live in the vault DB
+    // settings store; a file that still carries them (legacy) contributes
+    // nothing to loadConfig - they are imported into the DB once at daemon
+    // boot and merged from there.
+    const legacyYaml = `
+daemon:
+  port: 7777
+personality:
+  core_traits: ["sarcastic"]
+  assistant_name: "HAL"
+active_role: "villain"
+stt:
+  provider: groq
+channels:
+  telegram:
+    enabled: true
+    bot_token: "legacy-token"
+authority:
+  default_level: 1
+`;
+    await Bun.write(TEST_CONFIG_PATH, legacyYaml);
     const loaded = await loadConfig(TEST_CONFIG_PATH);
 
-    expect(loaded.daemon).toBeDefined();
-    expect(loaded.llm).toBeDefined();
-    expect(loaded.personality).toBeDefined();
-    expect(loaded.authority).toBeDefined();
-    expect(loaded.active_role).toBeDefined();
+    // System keys stick...
+    expect(loaded.daemon.port).toBe(7777);
+    // ...user sections do not.
+    expect(loaded.personality).toEqual(DEFAULT_CONFIG.personality);
+    expect(loaded.active_role).toBe(DEFAULT_CONFIG.active_role);
+    expect(loaded.stt).toEqual(DEFAULT_CONFIG.stt);
+    expect(loaded.channels).toEqual(DEFAULT_CONFIG.channels);
+    expect(loaded.authority.default_level).toBe(DEFAULT_CONFIG.authority.default_level);
   });
 
-  test('saves YAML without forcing quoted keys', async () => {
-    await saveConfig(DEFAULT_CONFIG, TEST_CONFIG_PATH);
-    const text = await Bun.file(TEST_CONFIG_PATH).text();
-
-    expect(text).toContain('daemon:');
-    expect(text).toContain('channels:');
-    expect(text).not.toContain('"daemon":');
-    expect(text).not.toContain('"channels":');
+  test('system-owned sections survive: daemon, auth, google', async () => {
+    const systemYaml = `
+daemon:
+  port: 9090
+  brain_domain: "u1.vps1.usejarvis.host"
+auth:
+  token: "legacy-shared-token"
+google:
+  client_id: "company-client.apps.googleusercontent.com"
+  client_secret: "company-secret"
+`;
+    await Bun.write(TEST_CONFIG_PATH, systemYaml);
+    const loaded = await loadConfig(TEST_CONFIG_PATH);
+    expect(loaded.daemon.brain_domain).toBe('u1.vps1.usejarvis.host');
+    expect(loaded.auth?.token).toBe('legacy-shared-token');
+    // google is system-owned when the file provides it (hosted: the shared
+    // company OAuth client). The DB fallback only applies when absent here.
+    expect(loaded.google?.client_id).toBe('company-client.apps.googleusercontent.com');
   });
 
   test('loadConfig does not mutate DEFAULT_CONFIG', async () => {
@@ -143,7 +131,13 @@ llm:
     expect(loaded.daemon.port).toBe(12345);
     expect(DEFAULT_CONFIG).toEqual(snapshot);
 
-    // 3) Missing config file — the "defaults only" path.
+    // 3) User-section discard clones defaults — mutating the loaded config
+    // must never leak back into DEFAULT_CONFIG.
+    loaded.personality.core_traits.push('mutated');
+    (loaded.authority as { default_level: number }).default_level = 99;
+    expect(DEFAULT_CONFIG).toEqual(snapshot);
+
+    // 4) Missing config file — the "defaults only" path.
     await loadConfig('/tmp/jarvis-loader-mutation-absent.yaml');
     expect(DEFAULT_CONFIG).toEqual(snapshot);
   });
@@ -177,95 +171,34 @@ llm:
       expect(msg).toMatch(/line \d+, column \d+/);
     }
   });
+});
 
-  test('preserves ambiguous scalar strings through save → load round-trip', async () => {
-    // With defaultStringType: 'PLAIN', YAML will auto-quote values that would
-    // otherwise type-coerce (booleans, numbers, dates). Verify the round-trip
-    // keeps them as strings so, e.g., a numeric-looking discord ID or a
-    // boolean-looking API token never silently mutates on reload.
-    const testConfig = structuredClone(DEFAULT_CONFIG);
-    testConfig.channels = {
-      telegram: {
-        enabled: true,
-        bot_token: 'yes',          // YAML 1.1 boolean trap
-        allowed_users: [12345],
-      },
-      discord: {
-        enabled: true,
-        bot_token: '2026-04-14',   // date-ish string
-        allowed_users: ['1234567890'],  // numeric-only string user ID
-        guild_id: '123.45',         // numeric-looking string
-      },
-    };
-
-    await saveConfig(testConfig, TEST_CONFIG_PATH);
-    const loaded = await loadConfig(TEST_CONFIG_PATH);
-
-    expect(loaded.channels?.telegram?.bot_token).toBe('yes');
-    expect(typeof loaded.channels?.telegram?.bot_token).toBe('string');
-    expect(loaded.channels?.discord?.bot_token).toBe('2026-04-14');
-    expect(typeof loaded.channels?.discord?.bot_token).toBe('string');
-    expect(loaded.channels?.discord?.guild_id).toBe('123.45');
-    expect(typeof loaded.channels?.discord?.guild_id).toBe('string');
-    expect(loaded.channels?.discord?.allowed_users).toEqual(['1234567890']);
-    expect(typeof loaded.channels?.discord?.allowed_users?.[0]).toBe('string');
+describe('readRawConfigFile', () => {
+  beforeEach(async () => {
+    await createTestConfigPath();
   });
 
-  test('save → load → save is idempotent after path normalization', async () => {
-    // loadConfig tilde-expands `daemon.data_dir` / `daemon.db_path`, so the
-    // very first save-load cycle will rewrite those values. After that, any
-    // further round-trip must be byte-identical — otherwise the YAML encoder
-    // is drifting (reordering keys, changing quoting, etc.).
-    await saveConfig(DEFAULT_CONFIG, TEST_CONFIG_PATH);
-    const stabilized = await loadConfig(TEST_CONFIG_PATH);
-    await saveConfig(stabilized, TEST_CONFIG_PATH);
-    const firstText = await Bun.file(TEST_CONFIG_PATH).text();
-
-    const reloaded = await loadConfig(TEST_CONFIG_PATH);
-    await saveConfig(reloaded, TEST_CONFIG_PATH);
-    const secondText = await Bun.file(TEST_CONFIG_PATH).text();
-
-    expect(secondText).toBe(firstText);
+  afterEach(async () => {
+    await rm(TEST_CONFIG_DIR, { recursive: true, force: true });
   });
 
-  test('round-trips channel config; the entire LLM block is stripped from YAML', async () => {
-    const testConfig = structuredClone(DEFAULT_CONFIG);
-    testConfig.channels = {
-      telegram: {
-        enabled: true,
-        bot_token: 'telegram-token',
-        allowed_users: [12345],
-      },
-      discord: {
-        enabled: true,
-        bot_token: 'discord-token',
-        allowed_users: ['user-1'],
-        guild_id: 'guild-123',
-      },
-    };
-    // All of this is dashboard/DB-managed and must never touch config.yaml.
-    testConfig.llm.providers = {
-      ollama: { base_url: 'http://localhost:11434' },
-      gemini: { api_key: 'gemini-key' },
-    };
-    testConfig.llm.tiers = {
-      conversation: 'gemini:gemini-3-flash-preview',
-      medium: 'ollama:llama3.1',
-    };
+  test('returns the raw sections loadConfig would discard (for the legacy import)', async () => {
+    await Bun.write(
+      TEST_CONFIG_PATH,
+      'daemon:\n  port: 7777\nstt:\n  provider: groq\nactive_role: "villain"\n',
+    );
+    const raw = await readRawConfigFile(TEST_CONFIG_PATH);
+    expect(raw).not.toBeNull();
+    expect((raw!.stt as { provider: string }).provider).toBe('groq');
+    expect(raw!.active_role).toBe('villain');
+    // No defaults are merged in: absent sections stay absent.
+    expect(raw!.personality).toBeUndefined();
+  });
 
-    await saveConfig(testConfig, TEST_CONFIG_PATH);
-    const text = await Bun.file(TEST_CONFIG_PATH).text();
-    // Non-LLM config persists; the LLM block (and any secret) is gone entirely.
-    expect(text).toContain('channels:');
-    expect(text).not.toContain('llm:');
-    expect(text).not.toContain('gemini-key');
-
-    const loaded = await loadConfig(TEST_CONFIG_PATH);
-    expect(loaded.channels?.discord?.enabled).toBe(true);
-    expect(loaded.channels?.discord?.guild_id).toBe('guild-123');
-    // LLM config has no authority in config.yaml: stripped on save, discarded
-    // on load. It is sourced solely from the DB at runtime.
-    expect(loaded.llm).toEqual(DEFAULT_CONFIG.llm);
+  test('returns null for a missing file and throws on bad YAML', async () => {
+    expect(await readRawConfigFile('/tmp/jarvis-definitely-not-here.yaml')).toBeNull();
+    await Bun.write(TEST_CONFIG_PATH, 'daemon:\n  port: 3142\n    bad: true\n');
+    expect(readRawConfigFile(TEST_CONFIG_PATH)).rejects.toThrow();
   });
 });
 
@@ -300,10 +233,22 @@ describe('Default Config', () => {
 
   test('has correct LLM defaults', () => {
     // Default config ships empty providers + tiers. Users configure their
-    // own providers via the dashboard / config.yaml.
+    // own providers via the dashboard.
     expect(DEFAULT_CONFIG.llm.providers).toEqual({});
     expect(DEFAULT_CONFIG.llm.tiers).toEqual({});
     expect(DEFAULT_CONFIG.llm.default).toBeUndefined();
+  });
+
+  test('every user-owned section is a real JarvisConfig key', () => {
+    // Guards the registry against typos: a misspelled section would silently
+    // never discard/import/merge.
+    const knownKeys = new Set(Object.keys(DEFAULT_CONFIG));
+    // Sections without a default (optional in JarvisConfig) are still valid;
+    // list them explicitly so a typo can't hide behind "optional".
+    const optionalWithoutDefault = new Set(['cron', 'desktop', 'sites', 'goals', 'workflows', 'onboarding']);
+    for (const section of USER_OWNED_SECTIONS) {
+      expect(knownKeys.has(section) || optionalWithoutDefault.has(section)).toBe(true);
+    }
   });
 });
 
@@ -366,17 +311,17 @@ describe('Voice Config', () => {
     expect(config.voice?.wake_engine).toBe('openwakeword');
   });
 
-  test('round-trips user-supplied wake_engine', async () => {
+  test('file-provided voice config is discarded (user-owned, DB is authoritative)', async () => {
     const yaml = `
 voice:
   wake_engine: webspeech
 `;
     await Bun.write(TEST_CONFIG_PATH, yaml);
     const config = await loadConfig(TEST_CONFIG_PATH);
-    expect(config.voice?.wake_engine).toBe('webspeech');
+    expect(config.voice?.wake_engine).toBe('openwakeword');
   });
 
-  test('JARVIS_WAKE_ENGINE env override wins over YAML', async () => {
+  test('JARVIS_WAKE_ENGINE env override wins over YAML and the discard', async () => {
     const yaml = `
 voice:
   wake_engine: openwakeword
@@ -394,7 +339,7 @@ voice:
   });
 });
 
-describe('Atomic Save', () => {
+describe('Path Expansion', () => {
   beforeEach(async () => {
     await createTestConfigPath();
   });
@@ -403,48 +348,6 @@ describe('Atomic Save', () => {
     await rm(TEST_CONFIG_DIR, { recursive: true, force: true });
   });
 
-  test('leaves no tmp files behind after repeated saves', async () => {
-    const config = structuredClone(DEFAULT_CONFIG);
-    config.onboarding = { setup_completed_at: 1, tutorial_completed_at: null };
-    await saveConfig(config, TEST_CONFIG_PATH);
-    config.onboarding = { setup_completed_at: 2, tutorial_completed_at: null };
-    await saveConfig(config, TEST_CONFIG_PATH);
-
-    const loaded = await loadConfig(TEST_CONFIG_PATH);
-    expect(loaded.onboarding?.setup_completed_at).toBe(2);
-    expect(await readdir(TEST_CONFIG_DIR)).toEqual(['config.yaml']);
-  });
-
-  test('concurrent saves never leave a truncated or missing config', async () => {
-    const configs = [1, 2, 3, 4, 5].map((n) => {
-      const c = structuredClone(DEFAULT_CONFIG);
-      c.onboarding = { setup_completed_at: n, tutorial_completed_at: null };
-      return c;
-    });
-    await Promise.all(configs.map((c) => saveConfig(c, TEST_CONFIG_PATH)));
-
-    // Whichever save won, the file must be complete and parseable.
-    const loaded = await loadConfig(TEST_CONFIG_PATH);
-    expect([1, 2, 3, 4, 5]).toContain(loaded.onboarding?.setup_completed_at ?? 0);
-    expect(await readdir(TEST_CONFIG_DIR)).toEqual(['config.yaml']);
-  });
-
-  test('refuses to replace a symlinked config and leaves the link intact', async () => {
-    const decoy = join(TEST_CONFIG_DIR, 'decoy.yaml');
-    await Bun.write(decoy, 'daemon:\n  port: 4444\n');
-    await symlink(decoy, TEST_CONFIG_PATH);
-
-    expect(saveConfig(DEFAULT_CONFIG, TEST_CONFIG_PATH)).rejects.toThrow(/symlink/);
-
-    // Neither the link target nor the link itself was touched, and the
-    // rejected tmp file was cleaned up.
-    expect(await Bun.file(decoy).text()).toBe('daemon:\n  port: 4444\n');
-    expect(lstatSync(TEST_CONFIG_PATH).isSymbolicLink()).toBe(true);
-    expect((await readdir(TEST_CONFIG_DIR)).sort()).toEqual(['config.yaml', 'decoy.yaml']);
-  });
-});
-
-describe('Path Expansion', () => {
   test('expands tilde in paths', async () => {
     const config = await loadConfig();
 
@@ -454,11 +357,10 @@ describe('Path Expansion', () => {
   });
 
   test('preserves non-tilde paths', async () => {
-    const testConfig = { ...DEFAULT_CONFIG };
-    testConfig.daemon.data_dir = '/absolute/path';
-    testConfig.daemon.db_path = '/absolute/db.db';
-
-    await saveConfig(testConfig, TEST_CONFIG_PATH);
+    await Bun.write(
+      TEST_CONFIG_PATH,
+      'daemon:\n  data_dir: "/absolute/path"\n  db_path: "/absolute/db.db"\n',
+    );
     const loaded = await loadConfig(TEST_CONFIG_PATH);
 
     expect(loaded.daemon.data_dir).toBe('/absolute/path');

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -198,7 +198,7 @@ describe('readRawConfigFile', () => {
   test('returns null for a missing file and throws on bad YAML', async () => {
     expect(await readRawConfigFile('/tmp/jarvis-definitely-not-here.yaml')).toBeNull();
     await Bun.write(TEST_CONFIG_PATH, 'daemon:\n  port: 3142\n    bad: true\n');
-    expect(readRawConfigFile(TEST_CONFIG_PATH)).rejects.toThrow();
+    await expect(readRawConfigFile(TEST_CONFIG_PATH)).rejects.toThrow();
   });
 });
 
@@ -270,7 +270,7 @@ daemon:
 `;
     await Bun.write(TEST_CONFIG_PATH, badYaml);
 
-    expect(loadConfig(TEST_CONFIG_PATH)).rejects.toThrow();
+    await expect(loadConfig(TEST_CONFIG_PATH)).rejects.toThrow();
   });
 
   test('uses defaults when file does not exist (no throw)', async () => {

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -100,7 +100,7 @@ daemon:
   port: 9090
   brain_domain: "u1.vps1.usejarvis.host"
 auth:
-  token: "legacy-shared-token"
+  insecure_open_access: true
 google:
   client_id: "company-client.apps.googleusercontent.com"
   client_secret: "company-secret"
@@ -108,7 +108,7 @@ google:
     await Bun.write(TEST_CONFIG_PATH, systemYaml);
     const loaded = await loadConfig(TEST_CONFIG_PATH);
     expect(loaded.daemon.brain_domain).toBe('u1.vps1.usejarvis.host');
-    expect(loaded.auth?.token).toBe('legacy-shared-token');
+    expect(loaded.auth?.insecure_open_access).toBe(true);
     // google is system-owned when the file provides it (hosted: the shared
     // company OAuth client). The DB fallback only applies when absent here.
     expect(loaded.google?.client_id).toBe('company-client.apps.googleusercontent.com');

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -73,11 +73,6 @@ export function applyEnvOverrides(config: JarvisConfig): void {
     config.daemon.brain_domain = env.JARVIS_BRAIN_DOMAIN;
   }
 
-  if (env.JARVIS_AUTH_TOKEN) {
-    if (!config.auth) config.auth = {};
-    config.auth.token = env.JARVIS_AUTH_TOKEN;
-  }
-
   if (env.JARVIS_WAKE_ENGINE) {
     const engine = env.JARVIS_WAKE_ENGINE;
     if (engine === 'openwakeword' || engine === 'webspeech' || engine === 'auto') {

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1,10 +1,8 @@
 import YAML from 'yaml';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
-import { lstat, rename, unlink } from 'node:fs/promises';
 import type { JarvisConfig } from './types.ts';
-import { DEFAULT_CONFIG } from './types.ts';
-import { secureParentDirectory, secureWriteFile } from '../util/fs-secure.ts';
+import { DEFAULT_CONFIG, USER_OWNED_SECTIONS } from './types.ts';
 
 function expandTilde(filepath: string): string {
   if (filepath.startsWith('~/')) {
@@ -13,7 +11,7 @@ function expandTilde(filepath: string): string {
   return filepath;
 }
 
-function deepMerge(target: any, source: any): any {
+export function deepMerge(target: any, source: any): any {
   if (!source || typeof source !== 'object') {
     // If source is absent, return a clone of target so callers (or subsequent
     // mutation of the returned value) can never alias shared defaults.
@@ -48,9 +46,11 @@ function deepMerge(target: any, source: any): any {
 
 /**
  * Apply environment variable overrides to config.
- * Env vars take highest precedence (over YAML and defaults).
+ * Env vars take highest precedence (over YAML, defaults, and DB-owned
+ * sections; the daemon re-applies this after merging user settings from
+ * the DB, so JARVIS_* stays a working self-host/dev convenience).
  */
-function applyEnvOverrides(config: JarvisConfig): void {
+export function applyEnvOverrides(config: JarvisConfig): void {
   const env = process.env;
 
   if (env.JARVIS_PORT) {
@@ -146,73 +146,49 @@ export async function loadConfig(configPath?: string): Promise<JarvisConfig> {
   // at daemon startup.
   config.llm = structuredClone(DEFAULT_CONFIG.llm);
 
+  // The same rule now covers every USER-OWNED section (personality, voice,
+  // authority, ...): they live in the vault DB settings store and the file
+  // has no authority over them. config.yaml is a SYSTEM config: daemon.*,
+  // auth, google. Legacy files that still carry user sections get a one-time
+  // import into the DB at daemon boot (daemon/user-settings.ts) before this
+  // discard makes them invisible; env overrides are re-applied on top by the
+  // daemon after the DB merge.
+  for (const section of USER_OWNED_SECTIONS) {
+    const def = (DEFAULT_CONFIG as Record<string, unknown>)[section];
+    if (def === undefined) {
+      delete (config as Record<string, unknown>)[section];
+    } else {
+      (config as Record<string, unknown>)[section] = structuredClone(def);
+    }
+  }
+  applyEnvOverrides(config); // env wins over the discard (e.g. JARVIS_WAKE_ENGINE)
+
   return config;
 }
 
 /**
- * Strip the ENTIRE `llm` block before writing config.yaml.
- *
- * LLM configuration (providers, credentials, single-LLM default, tiers) lives
- * exclusively in the database + encrypted keychain and is managed from the
- * settings dashboard. config.yaml has no authority over any LLM setting, so it
- * must never carry one - dropping the block here also self-heals any stale
- * `llm:` section left over from older installs on the next save.
+ * Read and parse the raw config.yaml WITHOUT defaults, env overrides, or the
+ * user-section discard. Used exactly once per boot by the legacy-settings
+ * import (daemon/user-settings.ts) to see what an old file still carries.
+ * Returns null when the file doesn't exist; throws on YAML parse errors
+ * (same as loadConfig).
  */
-function stripLLMConfigForYAML(config: JarvisConfig): JarvisConfig {
-  const clone = structuredClone(config);
-  delete (clone as { llm?: unknown }).llm;
-  return clone;
-}
-
-/** Monotonic per-process counter for unique save temp-file names. */
-let saveCounter = 0;
-
-export async function saveConfig(
-  config: JarvisConfig,
-  configPath?: string
-): Promise<void> {
+export async function readRawConfigFile(
+  configPath?: string,
+): Promise<Record<string, unknown> | null> {
   const path = configPath || expandTilde('~/.jarvis/config.yaml');
-
-  try {
-    const canonical = stripLLMConfigForYAML(config);
-    const yaml = YAML.stringify(canonical, {
-      indent: 2,
-      lineWidth: 100,
-      defaultStringType: 'PLAIN',
-      defaultKeyType: 'PLAIN',
-    });
-
-    await secureParentDirectory(path);
-    // Write-then-rename so the config is replaced atomically. A direct
-    // O_TRUNC write leaves a truncated/empty config.yaml if the daemon is
-    // killed mid-write -- on the next boot that parses as defaults and the
-    // user loses onboarding state, authority overrides, everything.
-    // The tmp name carries pid + a counter so two concurrent saves can
-    // never rename each other's half-written file into place.
-    const tmpPath = `${path}.${process.pid}.${saveCounter++}.tmp`;
-    await secureWriteFile(tmpPath, yaml, 0o600, 'Config');
-
-    // rename() would silently replace a symlinked config.yaml with a
-    // regular file (e.g. a link into a dotfiles repo). secureWriteFile
-    // refuses symlinks via O_NOFOLLOW; keep that contract here and fail
-    // loudly instead of clobbering the link.
-    const existing = await lstat(path).catch(() => null);
-    if (existing?.isSymbolicLink()) {
-      await unlink(tmpPath).catch(() => {});
-      throw new Error(`${path} is a symlink; refusing to replace it`);
-    }
-
-    try {
-      await rename(tmpPath, path);
-    } catch {
-      // Rename across-the-board works on POSIX; on Windows it can fail
-      // transiently (antivirus holding the target). Fall back to the
-      // in-place write rather than losing the save entirely.
-      await unlink(tmpPath).catch(() => {});
-      await secureWriteFile(path, yaml, 0o600, 'Config');
-    }
-    console.log(`Config saved to ${path}`);
-  } catch (err) {
-    throw new Error(`Failed to save config to ${path}: ${err}`);
+  const file = Bun.file(path);
+  if (!(await file.exists())) return null;
+  const doc = YAML.parseDocument(await file.text(), { merge: true });
+  if (doc.errors.length > 0) {
+    const formatted = doc.errors.map((entry) => entry.message);
+    throw new Error(`Failed to parse YAML config at ${path}:\n  ${formatted.join('\n  ')}`);
   }
+  return (doc.toJS() ?? {}) as Record<string, unknown>;
 }
+
+
+// NOTE: there is intentionally no saveConfig here. The brain treats
+// config.yaml as READ-ONLY system configuration (network/hosting keys,
+// root-owned in hosted mode). All user-chosen settings persist to the vault
+// DB settings store instead; see daemon/user-settings.ts.

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -192,3 +192,29 @@ export async function readRawConfigFile(
 // config.yaml as READ-ONLY system configuration (network/hosting keys,
 // root-owned in hosted mode). All user-chosen settings persist to the vault
 // DB settings store instead; see daemon/user-settings.ts.
+
+// ── Listen address ──────────────────────────────────────────────────────────
+
+export type ListenSpec =
+  | { kind: 'tcp'; port: number }
+  | { kind: 'unix'; path: string };
+
+/**
+ * Resolve where the daemon should listen. `daemon.listen: unix:/abs/path.sock`
+ * selects a unix-domain socket (no TCP port is bound at all - hosted mode,
+ * where Caddy fronts the socket); anything else falls back to TCP on
+ * `daemon.port`. Malformed unix specs are fatal: silently falling back to a
+ * TCP port on a shared host would expose the brain to other tenants.
+ */
+export function resolveListen(daemon: { port: number; listen?: string }): ListenSpec {
+  const listen = daemon.listen?.trim();
+  if (!listen) return { kind: 'tcp', port: daemon.port };
+  if (listen.startsWith('unix:')) {
+    const path = listen.slice('unix:'.length);
+    if (!path.startsWith('/')) {
+      throw new Error(`daemon.listen unix socket path must be absolute, got: ${listen}`);
+    }
+    return { kind: 'unix', path };
+  }
+  throw new Error(`Unsupported daemon.listen value: ${listen} (expected "unix:/abs/path.sock")`);
+}

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -343,6 +343,16 @@ export type JarvisConfig = {
     brain_domain?: string;
   };
   auth?: AuthConfig;
+  /**
+   * SYSTEM-owned (config.yaml, not the DB): whether a LOCAL Chrome may be
+   * launched on this machine. Hosted instances set `local: false` so no CDP
+   * ports ever open on the VPS; browser actions route to a connected
+   * sidecar's browser instead (the tools already prefer a `browser`-capable
+   * sidecar and only fall back to local).
+   */
+  browser?: {
+    local?: boolean;
+  };
   google?: GoogleConfig;
   channels?: ChannelConfig;
   stt?: STTConfig;
@@ -382,6 +392,9 @@ export const DEFAULT_CONFIG: JarvisConfig = {
     port: 3142,
     data_dir: '~/.jarvis',
     db_path: '~/.jarvis/jarvis.db',
+  },
+  browser: {
+    local: true,
   },
   channels: {
     telegram: { enabled: false, bot_token: '', allowed_users: [] },

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -317,6 +317,14 @@ export type JarvisConfig = {
   telemetry?: TelemetryConfig;
   daemon: {
     port: number;
+    /**
+     * SYSTEM-owned listen address. When set to `unix:/absolute/path.sock`
+     * the daemon binds a unix-domain socket INSTEAD of the TCP port (no
+     * port is opened at all). Hosted instances use this so Caddy is the
+     * only way in: `listen: unix:/run/jarvis/u_<id>.sock`. Omit for the
+     * self-host default (TCP on `port`).
+     */
+    listen?: string;
     data_dir: string;
     db_path: string;
     /**

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -394,6 +394,14 @@ export type JarvisConfig = {
   heartbeat: HeartbeatConfig;
   cron?: SystemCronConfig;
   active_role: string;  // role file name
+  /**
+   * SYSTEM-owned: the user's IANA timezone (e.g. "America/New_York").
+   * Hosted brains run on UTC VPSs; the hosting server writes this (from the
+   * sidecar-reported value) so morning/evening crons, workflow triggers and
+   * goal windows fire at the user's wall-clock times. Self-host: omit to use
+   * the machine's local time.
+   */
+  timezone?: string;
 };
 
 export const DEFAULT_CONFIG: JarvisConfig = {

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -212,9 +212,9 @@ export type TelemetryConfig = {
 };
 
 /**
- * Onboarding completion state — persists in `~/.jarvis/config.yaml` so
- * the dashboard knows which phase (setup / profile interview / tutorial)
- * to show on next load. Each `*_completed_at` is a `Date.now()` stamp;
+ * Onboarding completion state — persists in the vault DB settings store
+ * (user-owned section) so the dashboard knows which phase (setup / profile
+ * interview / tutorial) to show on next load. Each `*_completed_at` is a `Date.now()` stamp;
  * `null` means not yet done. Reset endpoint clears subsets per scope.
  *
  * See `docs/ONBOARDING_PLAN.md` for the gate logic and reset semantics.
@@ -469,3 +469,33 @@ export const DEFAULT_CONFIG: JarvisConfig = {
   },
   active_role: 'personal-assistant',
 };
+
+/**
+ * Config sections that are USER-OWNED: they live in the vault DB settings
+ * store (managed from the dashboard), never in config.yaml. loadConfig
+ * discards any such section found in the file (after a one-time legacy
+ * import at daemon boot; see daemon/user-settings.ts), exactly like the
+ * `llm` block. config.yaml keeps only network/system/hosting keys:
+ * daemon.*, auth, google (system-owned when present in the file).
+ */
+export const USER_OWNED_SECTIONS = [
+  'user',
+  'onboarding',
+  'telemetry',
+  'personality',
+  'active_role',
+  'authority',
+  'heartbeat',
+  'cron',
+  'stt',
+  'tts',
+  'voice',
+  'channels',
+  'desktop',
+  'awareness',
+  'sites',
+  'goals',
+  'workflows',
+] as const satisfies readonly (keyof JarvisConfig)[];
+
+export type UserOwnedSection = (typeof USER_OWNED_SECTIONS)[number];

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -193,8 +193,15 @@ export type GoalConfig = {
 };
 
 export type AuthConfig = {
-  /** Shared secret token. If unset, auth is disabled (open access). Env: JARVIS_AUTH_TOKEN */
-  token?: string;
+  /**
+   * DANGEROUS - allow dashboard/API access WITHOUT an enrolled-device token.
+   * The brain is JWT-only by default: enroll a device (`jarvis enroll`) and
+   * connect through the sidecar. Set this ONLY for first-time self-host
+   * setup before any device is enrolled, and remove it as soon as
+   * enrollment is done. The daemon logs a loud warning while it is on.
+   * SYSTEM-owned (config.yaml); there is no shared auth token anymore.
+   */
+  insecure_open_access?: boolean;
 };
 
 export type UserConfig = {

--- a/src/daemon/api-routes.ts
+++ b/src/daemon/api-routes.ts
@@ -966,9 +966,10 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
     '/api/onboarding/status': {
       GET: async () => {
         try {
-          const { loadConfig } = await import('../config/loader.ts');
-          const cfg = await loadConfig();
-          const o = cfg.onboarding;
+          // ctx.config is the live, DB-merged config; loadConfig() would
+          // return defaults here since onboarding is a user-owned section
+          // that the file no longer carries.
+          const o = ctx.config.onboarding;
           // `getUserProfile` and `hasUserProfile` are already imported
           // at the top of the file. Use `hasUserProfile()` so the
           // check counts wizard answers AND Phase B interview facts —
@@ -1015,8 +1016,8 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
             return error(`Invalid scope "${scope}".`, 400);
           }
 
-          const { loadConfig, saveConfig } = await import('../config/loader.ts');
-          const fresh = await loadConfig();
+          const { saveUserSection } = await import('./user-settings.ts');
+          const fresh = ctx.config;
           const o = fresh.onboarding ?? {
             setup_completed_at: null,
             tutorial_completed_at: null,
@@ -1040,7 +1041,7 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
           }
           o.last_reset_at = Date.now();
           fresh.onboarding = o;
-          await saveConfig(fresh);
+          saveUserSection('onboarding', fresh.onboarding);
 
           // Mirror to in-memory config so the next /status read is
           // immediately consistent (don't wait for daemon restart).
@@ -1080,8 +1081,8 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
     '/api/onboarding/skip': {
       POST: async () => {
         try {
-          const { loadConfig, saveConfig } = await import('../config/loader.ts');
-          const fresh = await loadConfig();
+          const { saveUserSection } = await import('./user-settings.ts');
+          const fresh = ctx.config;
           const now = Date.now();
           fresh.onboarding = {
             ...fresh.onboarding,
@@ -1090,7 +1091,7 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
             tutorial_dismissed_at: fresh.onboarding?.tutorial_dismissed_at ?? now,
             setup_skipped_profile: true,
           };
-          await saveConfig(fresh);
+          saveUserSection('onboarding', fresh.onboarding);
           ctx.config.onboarding = fresh.onboarding;
 
           // Best-effort service start so the "Restart Jarvis" banner
@@ -1130,15 +1131,15 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
     '/api/onboarding/profile/skip': {
       POST: async () => {
         try {
-          const { loadConfig, saveConfig } = await import('../config/loader.ts');
-          const fresh = await loadConfig();
+          const { saveUserSection } = await import('./user-settings.ts');
+          const fresh = ctx.config;
           fresh.onboarding = {
             setup_completed_at: fresh.onboarding?.setup_completed_at ?? null,
             tutorial_completed_at: fresh.onboarding?.tutorial_completed_at ?? null,
             ...fresh.onboarding,
             setup_skipped_profile: true,
           };
-          await saveConfig(fresh);
+          saveUserSection('onboarding', fresh.onboarding);
           ctx.config.onboarding = fresh.onboarding;
           return json({ ok: true, setup_skipped_profile: true });
         } catch (err) {
@@ -1151,15 +1152,15 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
     // Three small endpoints powering the spotlight walkthrough's
     // persistence: complete (user finished), dismiss (user skipped),
     // progress (resume-from-step support). All three write through
-    // the same loadConfig → mutate → saveConfig pattern as the rest
+    // the same mutate-then-saveUserSection pattern as the rest
     // of the onboarding routes; the existing reset endpoint with
     // `scope: "tutorial"` already clears all three fields.
 
     '/api/onboarding/tutorial/complete': {
       POST: async () => {
         try {
-          const { loadConfig, saveConfig } = await import('../config/loader.ts');
-          const fresh = await loadConfig();
+          const { saveUserSection } = await import('./user-settings.ts');
+          const fresh = ctx.config;
           const now = Date.now();
           fresh.onboarding = {
             setup_completed_at: fresh.onboarding?.setup_completed_at ?? null,
@@ -1167,7 +1168,7 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
             tutorial_completed_at: now,
             tutorial_progress_step: undefined,
           };
-          await saveConfig(fresh);
+          saveUserSection('onboarding', fresh.onboarding);
           ctx.config.onboarding = fresh.onboarding;
           return json({ ok: true, tutorial_completed_at: now });
         } catch (err) {
@@ -1179,8 +1180,8 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
     '/api/onboarding/tutorial/dismiss': {
       POST: async () => {
         try {
-          const { loadConfig, saveConfig } = await import('../config/loader.ts');
-          const fresh = await loadConfig();
+          const { saveUserSection } = await import('./user-settings.ts');
+          const fresh = ctx.config;
           const now = Date.now();
           fresh.onboarding = {
             setup_completed_at: fresh.onboarding?.setup_completed_at ?? null,
@@ -1188,7 +1189,7 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
             ...fresh.onboarding,
             tutorial_dismissed_at: now,
           };
-          await saveConfig(fresh);
+          saveUserSection('onboarding', fresh.onboarding);
           ctx.config.onboarding = fresh.onboarding;
           return json({ ok: true, tutorial_dismissed_at: now });
         } catch (err) {
@@ -1203,15 +1204,15 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
           const body = (await req.json().catch(() => ({}))) as { stepId?: string };
           const stepId = typeof body.stepId === 'string' ? body.stepId.trim() : '';
           if (!stepId) return error('Missing stepId.', 400);
-          const { loadConfig, saveConfig } = await import('../config/loader.ts');
-          const fresh = await loadConfig();
+          const { saveUserSection } = await import('./user-settings.ts');
+          const fresh = ctx.config;
           fresh.onboarding = {
             setup_completed_at: fresh.onboarding?.setup_completed_at ?? null,
             tutorial_completed_at: fresh.onboarding?.tutorial_completed_at ?? null,
             ...fresh.onboarding,
             tutorial_progress_step: stepId,
           };
-          await saveConfig(fresh);
+          saveUserSection('onboarding', fresh.onboarding);
           ctx.config.onboarding = fresh.onboarding;
           return json({ ok: true, tutorial_progress_step: stepId });
         } catch (err) {
@@ -1303,9 +1304,9 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
           //    daemon kill (or crash) between them persisted setup HALF-done
           //    — TTS saved but the completion flag lost — and the user was
           //    funneled back into onboarding on the next boot.
-          const { loadConfig, saveConfig } = await import('../config/loader.ts');
+          const { saveUserSection } = await import('./user-settings.ts');
           const { mergeSTTConfig, mergeTTSConfig } = await import('./config-merge.ts');
-          const fresh = await loadConfig();
+          const fresh = ctx.config;
           if (body.stt) {
             // Mirrors /api/config/stt POST semantics. STT is consumed at
             // the next transcription request, so no hot-swap is needed.
@@ -1323,7 +1324,9 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
             tutorial_progress_step: fresh.onboarding?.tutorial_progress_step,
             last_reset_at: fresh.onboarding?.last_reset_at,
           };
-          await saveConfig(fresh);
+          if (body.stt) saveUserSection('stt', fresh.stt);
+          if (body.tts) saveUserSection('tts', fresh.tts);
+          saveUserSection('onboarding', fresh.onboarding);
           if (body.stt) ctx.config.stt = fresh.stt;
           if (body.tts) ctx.config.tts = fresh.tts;
           ctx.config.onboarding = fresh.onboarding;
@@ -1924,10 +1927,11 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
             return error('Missing client_id or client_secret');
           }
 
-          const { loadConfig, saveConfig } = await import('../config/loader.ts');
-          const freshConfig = await loadConfig();
+          const { saveUserSection } = await import('./user-settings.ts');
+          const freshConfig = ctx.config;
           freshConfig.google = { client_id: body.client_id, client_secret: body.client_secret };
-          await saveConfig(freshConfig);
+          const { saveGoogleSettings } = await import('./user-settings.ts');
+          saveGoogleSettings(freshConfig.google);
 
           // Update in-memory config so callback route sees credentials immediately
           ctx.config.google = freshConfig.google;
@@ -2010,8 +2014,8 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
       POST: async (req: Request) => {
         try {
           const body = await req.json() as Record<string, unknown>;
-          const { loadConfig, saveConfig } = await import('../config/loader.ts');
-          const freshConfig = await loadConfig();
+          const { saveUserSection } = await import('./user-settings.ts');
+          const freshConfig = ctx.config;
 
           if (!freshConfig.channels) freshConfig.channels = {};
 
@@ -2028,7 +2032,7 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
             } as any;
           }
 
-          await saveConfig(freshConfig);
+          saveUserSection('channels', freshConfig.channels);
           ctx.config.channels = freshConfig.channels;
 
           return json({ ok: true, message: 'Channel config saved. Restart JARVIS to apply changes.' });
@@ -2055,12 +2059,12 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
       POST: async (req: Request) => {
         try {
           const body = await req.json() as Record<string, unknown>;
-          const { loadConfig, saveConfig } = await import('../config/loader.ts');
+          const { saveUserSection } = await import('./user-settings.ts');
           const { mergeSTTConfig } = await import('./config-merge.ts');
-          const freshConfig = await loadConfig();
+          const freshConfig = ctx.config;
 
           freshConfig.stt = mergeSTTConfig(freshConfig.stt, body);
-          await saveConfig(freshConfig);
+          saveUserSection('stt', freshConfig.stt);
           ctx.config.stt = freshConfig.stt;
           return json({ ok: true, message: 'STT config saved. Restart JARVIS to apply changes.' });
         } catch (err) {
@@ -2098,12 +2102,12 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
       POST: async (req: Request) => {
         try {
           const body = await req.json() as Record<string, unknown>;
-          const { loadConfig, saveConfig } = await import('../config/loader.ts');
+          const { saveUserSection } = await import('./user-settings.ts');
           const { mergeTTSConfig } = await import('./config-merge.ts');
-          const freshConfig = await loadConfig();
+          const freshConfig = ctx.config;
 
           freshConfig.tts = mergeTTSConfig(freshConfig.tts, body);
-          await saveConfig(freshConfig);
+          saveUserSection('tts', freshConfig.tts);
           ctx.config.tts = freshConfig.tts;
 
           // Hot-reload TTS provider if wsService available
@@ -2161,15 +2165,15 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
       POST: async (req: Request) => {
         try {
           const body = await req.json() as Record<string, unknown>;
-          const { loadConfig, saveConfig } = await import('../config/loader.ts');
+          const { saveUserSection } = await import('./user-settings.ts');
           const { mergeVoiceConfig, validateVoicePatch } = await import('./config-merge.ts');
 
           const validation = validateVoicePatch(body);
           if (!validation.ok) return error(validation.error, 400);
 
-          const freshConfig = await loadConfig();
+          const freshConfig = ctx.config;
           freshConfig.voice = mergeVoiceConfig(freshConfig.voice, validation.patch);
-          await saveConfig(freshConfig);
+          saveUserSection('voice', freshConfig.voice);
           // Update in-memory config so the next voice_start resolves with the
           // new settings — resolveRealtimeVoice reads ctx.config live, so no
           // provider hot-reload is needed (unlike TTS/LLM).
@@ -2792,8 +2796,8 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
           ctx.authorityEngine.updateConfig(currentConfig);
 
           // Persist to config.yaml
-          const { loadConfig, saveConfig } = await import('../config/loader.ts');
-          const freshConfig = await loadConfig();
+          const { saveUserSection } = await import('./user-settings.ts');
+          const freshConfig = ctx.config;
           freshConfig.authority = {
             ...freshConfig.authority,
             default_level: currentConfig.default_level,
@@ -2802,7 +2806,7 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
             context_rules: currentConfig.context_rules,
             learning: currentConfig.learning,
           };
-          await saveConfig(freshConfig);
+          saveUserSection('authority', freshConfig.authority);
 
           return json({ ok: true, config: currentConfig });
         } catch (err) {
@@ -2856,13 +2860,13 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
           ctx.authorityEngine.updateConfig(currentConfig);
 
           // Persist to config.yaml — same path as the full POST.
-          const { loadConfig, saveConfig } = await import('../config/loader.ts');
-          const freshConfig = await loadConfig();
+          const { saveUserSection } = await import('./user-settings.ts');
+          const freshConfig = ctx.config;
           freshConfig.authority = {
             ...freshConfig.authority,
             overrides: currentConfig.overrides,
           };
-          await saveConfig(freshConfig);
+          saveUserSection('authority', freshConfig.authority);
 
           return json({ ok: true, config: currentConfig });
         } catch (err) {
@@ -2898,13 +2902,13 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
           ctx.learner.markSuggestionSent(body.action, body.tool_name ?? '');
 
           // Persist
-          const { loadConfig, saveConfig } = await import('../config/loader.ts');
-          const freshConfig = await loadConfig();
+          const { saveUserSection } = await import('./user-settings.ts');
+          const freshConfig = ctx.config;
           freshConfig.authority = {
             ...freshConfig.authority,
             ...ctx.authorityEngine.getConfig(),
           };
-          await saveConfig(freshConfig);
+          saveUserSection('authority', freshConfig.authority);
 
           return json({ ok: true });
         } catch (err) {

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -3561,13 +3561,22 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
     const uiPublicDir = path.join(import.meta.dir, '../../ui/public');
     wsService.setPublicDir(uiPublicDir);
 
-    // 9c. Configure auth token if set
-    const authToken = jarvisConfig.auth?.token;
-    if (authToken) {
-      wsService.setAuthToken(authToken);
-      console.log('[Daemon] Auth token configured — dashboard routes require ?token= or cookie');
+    // 9c. Access model. JWT-only by default: the dashboard and every API
+    // route require a valid enrolled-device token. The one escape hatch is
+    // auth.insecure_open_access (system config), meant ONLY for first-time
+    // self-host setup before a device is enrolled.
+    if (jarvisConfig.auth?.insecure_open_access === true) {
+      wsService.setInsecureOpenAccess(true);
+      console.warn('[Daemon] ============================================================');
+      console.warn('[Daemon] WARNING: auth.insecure_open_access is enabled.');
+      console.warn('[Daemon] The dashboard and API accept requests WITHOUT authentication');
+      console.warn('[Daemon] from anyone who can reach this machine. Enroll your device');
+      console.warn('[Daemon] (`jarvis enroll "<device-name>"`, paste the token into the');
+      console.warn('[Daemon] sidecar) and remove this flag from config.yaml as soon as');
+      console.warn('[Daemon] enrollment is done.');
+      console.warn('[Daemon] ============================================================');
     } else {
-      console.warn('[Daemon] No auth token configured — dashboard is open to anyone on the network');
+      console.log('[Daemon] JWT-only access: routes require an enrolled device token (default)');
     }
 
     // 9b. Apply --no-local-tools flag if set

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -3564,6 +3564,15 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
       setNoLocalTools(true);
     }
 
+    // 9b'. browser.local: false (system config) - never launch a local
+    // Chrome on this machine. Hosted instances set this so no CDP port can
+    // open on a shared VPS; browser actions route to a sidecar browser
+    // (launchChrome is the enforcement choke point).
+    if (jarvisConfig.browser?.local === false) {
+      const { setLocalBrowserDisabled } = await import('../actions/tools/local-tools-guard.ts');
+      setLocalBrowserDisabled(true);
+    }
+
     // 10. Start all services
     await registry.startAll();
 
@@ -4047,7 +4056,7 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
         });
 
         // Auto-launch overlay widget (non-blocking, best-effort)
-        if (jarvisConfig.awareness?.overlay_autolaunch !== false) {
+        if (jarvisConfig.awareness?.overlay_autolaunch !== false && jarvisConfig.browser?.local !== false) {
           try {
             const overlayUrl = `http://localhost:${config.port}/overlay`;
             const browsers = ['chromium-browser', 'chromium', 'google-chrome', 'google-chrome-stable'];

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -345,6 +345,22 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
     mergeLLMSettingsIntoConfig(jarvisConfig);
     logWithTimestamp('LLM settings loaded from database');
 
+    // 2c. User-owned settings (personality, voice, authority, channels,
+    // onboarding, ...) follow the same rule: the DB is the sole authority,
+    // config.yaml is read-only system config the brain never writes. A
+    // legacy file that still carries user sections seeds the DB exactly
+    // once, then env overrides are re-applied so JARVIS_* still wins.
+    const { importLegacyUserSettings, mergeUserSettingsIntoConfig } = await import('./user-settings.ts');
+    const { readRawConfigFile, applyEnvOverrides } = await import('../config/loader.ts');
+    const rawConfigFile = await readRawConfigFile().catch(() => null);
+    const importedSections = importLegacyUserSettings(rawConfigFile);
+    if (importedSections.length > 0) {
+      logWithTimestamp(`Imported legacy config.yaml sections into the DB: ${importedSections.join(', ')}`);
+    }
+    mergeUserSettingsIntoConfig(jarvisConfig);
+    applyEnvOverrides(jarvisConfig);
+    logWithTimestamp('User settings loaded from database');
+
     // 3. Create service registry
     registry = new ServiceRegistry();
 
@@ -1072,13 +1088,11 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
       sidecarManager.onEvent(async (sidecarId, event) => {
         if (event.event_type !== 'pebble.blind_toggle') return;
         try {
-          const { loadConfig, saveConfig } = await import('../config/loader.ts');
-          const fresh = await loadConfig();
-          const wasEnabled = fresh.awareness?.enabled ?? true;
+          const { saveUserSection } = await import('./user-settings.ts');
+          const wasEnabled = jarvisConfig.awareness?.enabled ?? true;
           const nextEnabled = !wasEnabled;
-          if (fresh.awareness) fresh.awareness.enabled = nextEnabled;
-          await saveConfig(fresh);
           (jarvisConfig.awareness as { enabled?: boolean }).enabled = nextEnabled;
+          saveUserSection('awareness', jarvisConfig.awareness);
           // Toggle live awareness service if it exists.
           if (awarenessService) awarenessService.toggle(nextEnabled);
           // Push visual: blinded = !enabled.
@@ -1144,7 +1158,7 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
       const audioSessions = new (await import('./audio-sessions.ts')).AudioSessionRegistry();
       audioSessions.attach((cb) => sidecarManager.onEvent(cb));
       // T20 — voice-driven settings mutation. Patches `jarvisConfig`,
-      // persists via `saveConfig`, and rebuilds the live providers so
+      // persists via the DB settings store, and rebuilds the live providers so
       // the next response uses the new setting without a daemon
       // restart. The user explicitly hit this with "turn off TTS in
       // the settings" — the panel opened but the toggle didn't flip
@@ -1152,12 +1166,11 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
       // gap. New providers added to `jarvisConfig` (e.g. Groq STT)
       // become voice-switchable too.
       const applyTTSEnabled = async (enabled: boolean): Promise<void> => {
-        const { loadConfig, saveConfig } = await import('../config/loader.ts');
-        const fresh = await loadConfig();
-        if (!fresh.tts) fresh.tts = { enabled, provider: 'edge' };
-        else fresh.tts.enabled = enabled;
-        await saveConfig(fresh);
-        jarvisConfig.tts = fresh.tts;
+        const { saveUserSection } = await import('./user-settings.ts');
+        if (!jarvisConfig.tts) jarvisConfig.tts = { enabled, provider: 'edge' };
+        else jarvisConfig.tts.enabled = enabled;
+        saveUserSection('tts', jarvisConfig.tts);
+        const fresh = { tts: jarvisConfig.tts };
         // Rebuild the pebble's TTS provider so the next response cycle
         // either uses the new provider or skips TTS entirely.
         if (enabled) {
@@ -1184,20 +1197,19 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
       };
 
       const applySTTProvider = async (provider: 'openai' | 'groq' | 'sarvam' | 'local'): Promise<boolean> => {
-        const { loadConfig, saveConfig } = await import('../config/loader.ts');
-        const fresh = await loadConfig();
-        if (!fresh.stt) fresh.stt = { provider };
+        const { saveUserSection } = await import('./user-settings.ts');
+        if (!jarvisConfig.stt) jarvisConfig.stt = { provider };
         // Refuse the switch if the target provider has no API key
         // configured — we don't want to silently break STT.
         const hasKey = (() => {
-          if (provider === 'local') return !!fresh.stt.local?.endpoint;
-          const sub = (fresh.stt as unknown as Record<string, { api_key?: string } | undefined>)[provider];
+          if (provider === 'local') return !!jarvisConfig.stt!.local?.endpoint;
+          const sub = (jarvisConfig.stt as unknown as Record<string, { api_key?: string } | undefined>)[provider];
           return !!sub?.api_key;
         })();
         if (!hasKey) return false;
-        fresh.stt.provider = provider;
-        await saveConfig(fresh);
-        jarvisConfig.stt = fresh.stt;
+        jarvisConfig.stt.provider = provider;
+        saveUserSection('stt', jarvisConfig.stt);
+        const fresh = { stt: jarvisConfig.stt };
         try {
           const { createSTTProvider } = await import('../comms/voice.ts');
           pebbleSTT = createSTTProvider(fresh.stt);
@@ -3239,15 +3251,14 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
     if (savedEmergencyState === 'paused') emergencyController.pause();
     else if (savedEmergencyState === 'killed') emergencyController.kill();
 
-    // Persist emergency state changes to config.yaml
+    // Persist emergency state changes to the DB settings store
     emergencyController.setStateChangeCallback(async (state) => {
       wsService.broadcastEmergencyState(state);
       try {
-        const { loadConfig: reloadConfig, saveConfig: resaveConfig } = await import('../config/loader.ts');
-        const fresh = await reloadConfig();
-        if (!fresh.authority) fresh.authority = { default_level: 3 } as any;
-        fresh.authority.emergency_state = state;
-        await resaveConfig(fresh);
+        const { saveUserSection } = await import('./user-settings.ts');
+        if (!jarvisConfig.authority) jarvisConfig.authority = { default_level: 3 } as any;
+        jarvisConfig.authority.emergency_state = state;
+        saveUserSection('authority', jarvisConfig.authority);
       } catch (err) {
         console.error('[Daemon] Failed to persist emergency state:', err);
       }

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -365,6 +365,18 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
     applyEnvOverrides(jarvisConfig);
     logWithTimestamp('User settings loaded from database');
 
+    // 2d. Cron timezone: hosted brains run on UTC VPSs, so every cron in the
+    // process evaluates in the user's IANA timezone from the system config.
+    if (jarvisConfig.timezone) {
+      try {
+        const { setCronTimezone } = await import('../lib/cron-scheduler.ts');
+        setCronTimezone(jarvisConfig.timezone);
+        logWithTimestamp(`Cron timezone: ${jarvisConfig.timezone}`);
+      } catch {
+        console.warn(`[Daemon] Invalid timezone "${jarvisConfig.timezone}" in config - using machine local time`);
+      }
+    }
+
     // 3. Create service registry
     registry = new ServiceRegistry();
 

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -297,12 +297,24 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
     noLocalTools: userConfig?.noLocalTools ?? false,
   };
 
+  // Resolve the listen spec ONCE, before anything is persisted: a malformed
+  // `daemon.listen` must fail fast here, not after the lockfile write (a
+  // stale TCP lockfile from a mid-boot crash would mislead `jarvis stop`).
+  const { resolveListen } = await import('../config/loader.ts');
+  let listen: import('../config/loader.ts').ListenSpec;
+  try {
+    listen = resolveListen({ port, listen: jarvisConfig.daemon.listen });
+  } catch (err) {
+    console.error(`\n[Daemon] ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+  }
+
   // Record the actual bound port in the lockfile so `jarvis stop` knows which
   // port to verify even when the daemon was started with --port, JARVIS_PORT,
   // or a mid-run config change. No-op if we don't hold the lock (e.g. tests).
-  // In unix-socket mode (daemon.listen) no TCP port exists to verify, so
-  // nothing is recorded and `jarvis stop` falls back to pid-only handling.
-  if (!jarvisConfig.daemon.listen?.startsWith('unix:')) {
+  // In unix-socket mode no TCP port exists to verify, so nothing is recorded
+  // and `jarvis stop` is pid-only (resolveStopPort returns port null).
+  if (listen.kind === 'tcp') {
     writeLockedPort(port);
   }
 
@@ -417,9 +429,8 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
       ? null
       : new ObserverService(reactor, coalescer, googleAuth ?? undefined, config.dataDir);
     // Hosted mode: daemon.listen = unix:/run/jarvis/u_<id>.sock binds a unix
-    // socket and no TCP port at all (Caddy is the only way in).
-    const { resolveListen } = await import('../config/loader.ts');
-    const listen = resolveListen({ port: config.port, listen: jarvisConfig.daemon.listen });
+    // socket and no TCP port at all (Caddy is the only way in). `listen` was
+    // resolved (and validated) once, before the lockfile write above.
     const wsService = new WebSocketService(
       config.port,
       agentService,
@@ -3589,6 +3600,13 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
       console.warn('[Daemon] ============================================================');
     } else {
       console.log('[Daemon] JWT-only access: routes require an enrolled device token (default)');
+    }
+    // Upgrade UX: the shared dashboard token was removed (JWT-only). A config
+    // still carrying auth.token would otherwise be silently ignored while the
+    // operator's bookmarked ?token= URL just 401s.
+    if ((jarvisConfig.auth as Record<string, unknown> | undefined)?.token !== undefined) {
+      console.warn('[Daemon] auth.token is no longer supported and was ignored. Access is JWT-only:');
+      console.warn('[Daemon] enroll a device (`jarvis enroll`) or, for setup only, set auth.insecure_open_access.');
     }
 
     // 9b. Apply --no-local-tools flag if set

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -300,7 +300,11 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
   // Record the actual bound port in the lockfile so `jarvis stop` knows which
   // port to verify even when the daemon was started with --port, JARVIS_PORT,
   // or a mid-run config change. No-op if we don't hold the lock (e.g. tests).
-  writeLockedPort(port);
+  // In unix-socket mode (daemon.listen) no TCP port exists to verify, so
+  // nothing is recorded and `jarvis stop` falls back to pid-only handling.
+  if (!jarvisConfig.daemon.listen?.startsWith('unix:')) {
+    writeLockedPort(port);
+  }
 
   // If dbPath is relative, make it absolute within dataDir
   if (!path.isAbsolute(config.dbPath)) {
@@ -400,7 +404,15 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
     const observerService = config.noLocalTools
       ? null
       : new ObserverService(reactor, coalescer, googleAuth ?? undefined, config.dataDir);
-    const wsService = new WebSocketService(config.port, agentService);
+    // Hosted mode: daemon.listen = unix:/run/jarvis/u_<id>.sock binds a unix
+    // socket and no TCP port at all (Caddy is the only way in).
+    const { resolveListen } = await import('../config/loader.ts');
+    const listen = resolveListen({ port: config.port, listen: jarvisConfig.daemon.listen });
+    const wsService = new WebSocketService(
+      config.port,
+      agentService,
+      listen.kind === 'unix' ? listen.path : undefined,
+    );
 
     // 5b. Create channel service for external comms (Telegram, Discord)
     const channelService = new ChannelService(jarvisConfig, agentService);

--- a/src/daemon/user-settings.test.ts
+++ b/src/daemon/user-settings.test.ts
@@ -64,7 +64,7 @@ describe('user-settings', () => {
     expect(loadUserSection('tts')).toBeUndefined();
   });
 
-  test('legacy import seeds the DB once and never clobbers newer edits', () => {
+  test('import: UNCHANGED file never clobbers dashboard edits', () => {
     const legacyYaml = {
       daemon: { port: 7777 }, // system key: not imported
       stt: { provider: 'groq' },
@@ -78,7 +78,7 @@ describe('user-settings', () => {
     // The dashboard later edits stt...
     saveUserSection('stt', { provider: 'openai' });
 
-    // ...and a re-import from the same stale file must NOT clobber it.
+    // ...and a re-import from the SAME file must NOT clobber it.
     const reimported = importLegacyUserSettings(legacyYaml);
     expect(reimported).toEqual([]);
 
@@ -86,6 +86,43 @@ describe('user-settings', () => {
     mergeUserSettingsIntoConfig(config);
     expect(config.stt?.provider).toBe('openai');
     expect(config.active_role).toBe('villain');
+  });
+
+  test('import: an EDITED file value applies over the DB (editor-less sections stay tunable)', () => {
+    // Review finding: heartbeat/cron/goals/... have no dashboard editor, so
+    // write-once import made the file a lie. A changed file value is intent.
+    importLegacyUserSettings({ heartbeat: { interval_minutes: 15 } });
+    let config = freshConfig();
+    mergeUserSettingsIntoConfig(config);
+    expect(config.heartbeat.interval_minutes).toBe(15);
+
+    // Same file on the next boots: nothing happens.
+    expect(importLegacyUserSettings({ heartbeat: { interval_minutes: 15 } })).toEqual([]);
+
+    // The self-hoster edits the file: the new value must apply.
+    const imported = importLegacyUserSettings({ heartbeat: { interval_minutes: 5 } });
+    expect(imported).toEqual(['heartbeat']);
+    config = freshConfig();
+    mergeUserSettingsIntoConfig(config);
+    expect(config.heartbeat.interval_minutes).toBe(5);
+  });
+
+  test('import: pre-tracking DB values are baselined, not clobbered, then file edits apply', () => {
+    // Simulates an instance that imported under the old write-once behavior
+    // (DB row exists, no import record) and got a dashboard edit.
+    setSetting('cfg.stt', JSON.stringify({ provider: 'openai' }));
+
+    // First boot with tracking: file present but only baselined.
+    expect(importLegacyUserSettings({ stt: { provider: 'groq' } })).toEqual([]);
+    let config = freshConfig();
+    mergeUserSettingsIntoConfig(config);
+    expect(config.stt?.provider).toBe('openai');
+
+    // A LATER file edit applies.
+    expect(importLegacyUserSettings({ stt: { provider: 'sarvam' } })).toEqual(['stt']);
+    config = freshConfig();
+    mergeUserSettingsIntoConfig(config);
+    expect(config.stt?.provider).toBe('sarvam');
   });
 
   test('null rawYaml (no config file) imports nothing', () => {

--- a/src/daemon/user-settings.test.ts
+++ b/src/daemon/user-settings.test.ts
@@ -1,0 +1,135 @@
+import { test, expect, describe, beforeEach, afterEach } from 'bun:test';
+import { initDatabase, closeDb } from '../vault/schema.ts';
+import { getSetting, setSetting } from '../vault/settings.ts';
+import { loadConfig } from '../config/loader.ts';
+import { DEFAULT_CONFIG, type JarvisConfig } from '../config/types.ts';
+import {
+  saveUserSection,
+  loadUserSection,
+  importLegacyUserSettings,
+  mergeUserSettingsIntoConfig,
+  saveGoogleSettings,
+} from './user-settings.ts';
+
+function freshConfig(): JarvisConfig {
+  return structuredClone(DEFAULT_CONFIG);
+}
+
+describe('user-settings', () => {
+  beforeEach(() => {
+    initDatabase(':memory:');
+  });
+
+  afterEach(() => {
+    closeDb();
+  });
+
+  test('save -> merge round-trips a section into the config', () => {
+    saveUserSection('stt', { provider: 'groq', groq: { api_key: 'gk-1' } });
+    saveUserSection('active_role', 'researcher');
+
+    const config = freshConfig();
+    mergeUserSettingsIntoConfig(config);
+
+    expect(config.stt?.provider).toBe('groq');
+    expect(config.stt?.groq?.api_key).toBe('gk-1');
+    expect(config.active_role).toBe('researcher');
+  });
+
+  test('object sections merge OVER defaults so old rows never strip new fields', () => {
+    // Simulate a row written by an older build that predates a field.
+    setSetting('cfg.heartbeat', JSON.stringify({ interval_minutes: 5 }));
+
+    const config = freshConfig();
+    mergeUserSettingsIntoConfig(config);
+
+    expect(config.heartbeat.interval_minutes).toBe(5);
+    // Fields the stored row doesn't know about keep their defaults.
+    expect(config.heartbeat.active_hours).toEqual(DEFAULT_CONFIG.heartbeat.active_hours);
+    expect(config.heartbeat.aggressiveness).toBe(DEFAULT_CONFIG.heartbeat.aggressiveness);
+  });
+
+  test('absent sections leave the config untouched', () => {
+    const config = freshConfig();
+    const before = structuredClone(config);
+    mergeUserSettingsIntoConfig(config);
+    expect(config).toEqual(before);
+  });
+
+  test('corrupt stored JSON is ignored, not fatal', () => {
+    setSetting('cfg.tts', '{not json');
+    const config = freshConfig();
+    mergeUserSettingsIntoConfig(config);
+    expect(config.tts).toEqual(DEFAULT_CONFIG.tts);
+    expect(loadUserSection('tts')).toBeUndefined();
+  });
+
+  test('legacy import seeds the DB once and never clobbers newer edits', () => {
+    const legacyYaml = {
+      daemon: { port: 7777 }, // system key: not imported
+      stt: { provider: 'groq' },
+      active_role: 'villain',
+    };
+
+    const imported = importLegacyUserSettings(legacyYaml);
+    expect(imported.sort()).toEqual(['active_role', 'stt']);
+    expect(getSetting('cfg.daemon')).toBeNull();
+
+    // The dashboard later edits stt...
+    saveUserSection('stt', { provider: 'openai' });
+
+    // ...and a re-import from the same stale file must NOT clobber it.
+    const reimported = importLegacyUserSettings(legacyYaml);
+    expect(reimported).toEqual([]);
+
+    const config = freshConfig();
+    mergeUserSettingsIntoConfig(config);
+    expect(config.stt?.provider).toBe('openai');
+    expect(config.active_role).toBe('villain');
+  });
+
+  test('null rawYaml (no config file) imports nothing', () => {
+    expect(importLegacyUserSettings(null)).toEqual([]);
+  });
+
+  test('google: DB is only a fallback - a file-provided client always wins', () => {
+    saveGoogleSettings({ client_id: 'db-client', client_secret: 'db-secret' });
+
+    // Self-host: no file google -> DB fallback applies.
+    const selfHosted = freshConfig();
+    mergeUserSettingsIntoConfig(selfHosted);
+    expect(selfHosted.google?.client_id).toBe('db-client');
+
+    // Hosted: the system config carries the shared company client -> file wins.
+    const hosted = freshConfig();
+    hosted.google = { client_id: 'company-client', client_secret: 'company-secret' };
+    mergeUserSettingsIntoConfig(hosted);
+    expect(hosted.google.client_id).toBe('company-client');
+  });
+
+  test('end to end: legacy file -> import -> discard -> merge equals old behavior', async () => {
+    // The full boot path: a legacy config.yaml carrying user sections keeps
+    // working (values preserved via the DB) even though loadConfig now
+    // discards them from the file.
+    const dir = `${process.env.TMPDIR ?? '/tmp'}/jarvis-user-settings-${Date.now()}`;
+    const path = `${dir}/config.yaml`;
+    await Bun.write(
+      path,
+      'daemon:\n  port: 4242\nstt:\n  provider: sarvam\npersonality:\n  assistant_name: "Edith"\n',
+    );
+
+    const { readRawConfigFile } = await import('../config/loader.ts');
+    const raw = await readRawConfigFile(path);
+    importLegacyUserSettings(raw);
+
+    const config = await loadConfig(path); // discards user sections...
+    expect(config.stt?.provider).toBe(DEFAULT_CONFIG.stt?.provider);
+    mergeUserSettingsIntoConfig(config); // ...and the DB restores them.
+
+    expect(config.daemon.port).toBe(4242);
+    expect(config.stt?.provider).toBe('sarvam');
+    expect(config.personality.assistant_name).toBe('Edith');
+    // Merge over defaults kept the untouched personality fields.
+    expect(config.personality.core_traits).toEqual(DEFAULT_CONFIG.personality.core_traits);
+  });
+});

--- a/src/daemon/user-settings.ts
+++ b/src/daemon/user-settings.ts
@@ -6,7 +6,9 @@
  * This generalizes the pattern llm-settings.ts established for the `llm`
  * block: the vault DB settings store is the sole authority, config.yaml
  * contributes nothing (loadConfig discards user sections), and the daemon
- * merges the stored values into the in-memory config at boot. config.yaml is
+ * merges the stored values into the in-memory config at boot. File-provided
+ * sections import on first boot and re-import whenever the FILE value changes
+ * (change-tracked; see importLegacyUserSettings). config.yaml is
  * thereby reduced to a read-only SYSTEM config (daemon.*, auth, google) that
  * the brain never writes — in hosted mode it is root-owned and the server
  * manages it.
@@ -57,22 +59,62 @@ export function loadUserSection(section: UserOwnedSection): unknown {
   }
 }
 
+/** Meta row remembering the file value each section was last imported from. */
+const IMPORT_STATE_KEY = 'cfg.__import_state';
+
+function loadImportState(): Record<string, string> {
+  const raw = getSetting(IMPORT_STATE_KEY);
+  if (raw === null) return {};
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
 /**
- * One-time import of user sections that a legacy config.yaml still carries.
- * A section is imported only when the DB has no value for it yet, so a
- * dashboard edit is never clobbered by a stale file on later boots. Returns
- * the imported section names (for boot logging).
+ * Import user sections that a config.yaml still carries. Change-tracked, not
+ * write-once (review finding: 10 of 17 sections have no dashboard editor, so
+ * a pure first-boot import silently ignored every later file edit):
+ *
+ * - DB has no value        -> import, remember the file value.
+ * - file EDITED since the last import -> import (the edit is intent: for
+ *   editor-less sections the file is the user's only knob), remember it.
+ * - file unchanged          -> keep the DB value (dashboard edits persist).
+ * - DB value exists but no import record (pre-tracking upgrade) -> baseline
+ *   the current file value WITHOUT importing, so a dashboard edit made under
+ *   the old behavior is never clobbered; subsequent file edits then apply.
+ *
+ * Returns the imported section names (for boot logging).
  */
 export function importLegacyUserSettings(rawYaml: Record<string, unknown> | null): string[] {
   if (!rawYaml) return [];
   const imported: string[] = [];
+  const state = loadImportState();
+  let stateChanged = false;
+
   for (const section of USER_OWNED_SECTIONS) {
     const fileValue = rawYaml[section];
     if (fileValue === undefined || fileValue === null) continue;
-    if (getSetting(settingKey(section)) !== null) continue;
-    setSetting(settingKey(section), JSON.stringify(fileValue));
+    const fileJson = JSON.stringify(fileValue);
+    const hasDbValue = getSetting(settingKey(section)) !== null;
+    const lastImported = state[section];
+
+    if (hasDbValue && lastImported === undefined) {
+      state[section] = fileJson; // baseline only
+      stateChanged = true;
+      continue;
+    }
+    if (hasDbValue && fileJson === lastImported) continue;
+
+    setSetting(settingKey(section), fileJson);
+    state[section] = fileJson;
+    stateChanged = true;
     imported.push(section);
   }
+
+  if (stateChanged) setSetting(IMPORT_STATE_KEY, JSON.stringify(state));
   return imported;
 }
 

--- a/src/daemon/user-settings.ts
+++ b/src/daemon/user-settings.ts
@@ -1,0 +1,125 @@
+/**
+ * User-owned settings: DB persistence for every config section the user (not
+ * the host) controls — personality, voice, authority, channels, onboarding
+ * state, and the rest of `USER_OWNED_SECTIONS`.
+ *
+ * This generalizes the pattern llm-settings.ts established for the `llm`
+ * block: the vault DB settings store is the sole authority, config.yaml
+ * contributes nothing (loadConfig discards user sections), and the daemon
+ * merges the stored values into the in-memory config at boot. config.yaml is
+ * thereby reduced to a read-only SYSTEM config (daemon.*, auth, google) that
+ * the brain never writes — in hosted mode it is root-owned and the server
+ * manages it.
+ *
+ * Layout: one settings row per section, key `cfg.<section>`, value JSON.
+ *
+ * Requires the vault DB (initDatabase) to be open, same as llm-settings.
+ */
+
+import { getSetting, setSetting } from '../vault/settings.ts';
+import { deepMerge } from '../config/loader.ts';
+import {
+  DEFAULT_CONFIG,
+  USER_OWNED_SECTIONS,
+  type JarvisConfig,
+  type UserOwnedSection,
+} from '../config/types.ts';
+
+const CFG_PREFIX = 'cfg.';
+
+function settingKey(section: UserOwnedSection): string {
+  return `${CFG_PREFIX}${section}`;
+}
+
+/**
+ * Persist one section to the DB. Callers mutate the in-memory config first,
+ * then persist that section — the write is per-section, so there is no
+ * load-modify-save race across unrelated sections (which is what the old
+ * `loadConfig -> mutate -> saveConfig` dance existed to avoid).
+ */
+export function saveUserSection<K extends UserOwnedSection>(
+  section: K,
+  value: JarvisConfig[K],
+): void {
+  setSetting(settingKey(section), JSON.stringify(value ?? null));
+}
+
+/** Read one stored section; undefined when absent or unparseable. */
+export function loadUserSection(section: UserOwnedSection): unknown {
+  const raw = getSetting(settingKey(section));
+  if (raw === null) return undefined;
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed === null ? undefined : parsed;
+  } catch {
+    console.warn(`[UserSettings] Corrupt JSON for ${settingKey(section)}; ignoring stored value`);
+    return undefined;
+  }
+}
+
+/**
+ * One-time import of user sections that a legacy config.yaml still carries.
+ * A section is imported only when the DB has no value for it yet, so a
+ * dashboard edit is never clobbered by a stale file on later boots. Returns
+ * the imported section names (for boot logging).
+ */
+export function importLegacyUserSettings(rawYaml: Record<string, unknown> | null): string[] {
+  if (!rawYaml) return [];
+  const imported: string[] = [];
+  for (const section of USER_OWNED_SECTIONS) {
+    const fileValue = rawYaml[section];
+    if (fileValue === undefined || fileValue === null) continue;
+    if (getSetting(settingKey(section)) !== null) continue;
+    setSetting(settingKey(section), JSON.stringify(fileValue));
+    imported.push(section);
+  }
+  return imported;
+}
+
+/**
+ * Load every stored user section into the in-memory config. Object sections
+ * are merged over their defaults so a settings row written by an older build
+ * never strips fields a newer build added; scalars replace directly.
+ *
+ * Call AFTER loadConfig (which discarded any file-provided user sections)
+ * and re-apply env overrides afterwards if env must win (the daemon does).
+ */
+export function mergeUserSettingsIntoConfig(config: JarvisConfig): void {
+  for (const section of USER_OWNED_SECTIONS) {
+    const stored = loadUserSection(section);
+    if (stored === undefined) continue;
+    const def = (DEFAULT_CONFIG as Record<string, unknown>)[section];
+    const target = config as Record<string, unknown>;
+    if (typeof stored === 'object' && stored !== null && !Array.isArray(stored)) {
+      target[section] = deepMerge(def !== undefined ? structuredClone(def) : {}, stored);
+    } else {
+      target[section] = stored;
+    }
+  }
+  mergeGoogleSettingsIntoConfig(config);
+}
+
+// ── google: system-owned when the FILE provides it ─────────────────────────
+//
+// `google` is the one section with dual ownership. In hosted mode the system
+// config carries the shared company OAuth client (server-written), so the
+// file must win. Self-hosters without a file entry configure their own
+// client from the dashboard, which persists here in the DB as a fallback.
+
+const GOOGLE_KEY = `${CFG_PREFIX}google`;
+
+export function saveGoogleSettings(value: JarvisConfig['google']): void {
+  setSetting(GOOGLE_KEY, JSON.stringify(value ?? null));
+}
+
+function mergeGoogleSettingsIntoConfig(config: JarvisConfig): void {
+  if (config.google?.client_id) return; // file-provided: system-owned, file wins
+  const raw = getSetting(GOOGLE_KEY);
+  if (raw === null) return;
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === 'object') config.google = parsed;
+  } catch {
+    console.warn(`[UserSettings] Corrupt JSON for ${GOOGLE_KEY}; ignoring stored value`);
+  }
+}

--- a/src/daemon/ws-service.ts
+++ b/src/daemon/ws-service.ts
@@ -304,8 +304,8 @@ export class WebSocketService implements Service {
     this.wsServer.setPublicDir(dir);
   }
 
-  setAuthToken(token: string): void {
-    this.wsServer.setAuthToken(token);
+  setInsecureOpenAccess(enabled: boolean): void {
+    this.wsServer.setInsecureOpenAccess(enabled);
   }
 
   async start(): Promise<void> {

--- a/src/daemon/ws-service.ts
+++ b/src/daemon/ws-service.ts
@@ -187,10 +187,10 @@ export class WebSocketService implements Service {
   // dashboard clicks. See gateVoiceApprovalResolution + resolveLatestPendingByVoice.
   private auditTrail: AuditTrail | null = null;
 
-  constructor(port: number, agentService: AgentService) {
+  constructor(port: number, agentService: AgentService, unixPath?: string) {
     this.port = port;
     this.agentService = agentService;
-    this.wsServer = new WebSocketServer(port);
+    this.wsServer = new WebSocketServer(port, unixPath);
     this.streamRelay = new StreamRelay(this.wsServer);
 
     // Wire delegation callback: when PA delegates to a specialist,

--- a/src/lib/cron-scheduler.ts
+++ b/src/lib/cron-scheduler.ts
@@ -183,6 +183,7 @@ interface WallClock {
   dom: number;
   month: number;
   dow: number;
+  year: number;
 }
 
 /** Wall-clock components of a timestamp in the configured cron timezone. */
@@ -194,6 +195,7 @@ function wallClock(date: Date): WallClock {
       dom: date.getDate(),
       month: date.getMonth() + 1,
       dow: date.getDay(),
+      year: date.getFullYear(),
     };
   }
   wallClockFormatter ??= new Intl.DateTimeFormat('en-US', {
@@ -204,6 +206,7 @@ function wallClock(date: Date): WallClock {
     day: 'numeric',
     month: 'numeric',
     weekday: 'short',
+    year: 'numeric',
   });
   const parts: Record<string, string> = {};
   for (const part of wallClockFormatter.formatToParts(date)) {
@@ -215,20 +218,54 @@ function wallClock(date: Date): WallClock {
     dom: Number(parts.day),
     month: Number(parts.month),
     dow: DOW_INDEX[parts.weekday!] ?? 0,
+    year: Number(parts.year),
   };
 }
 
+/** Local calendar date as a single comparable number (yyyymmdd). */
+function localDateKey(wc: WallClock): number {
+  return wc.year * 10_000 + wc.month * 100 + wc.dom;
+}
+
 /**
- * Timestamp of the next local midnight in the cron timezone. DST-safe: lands
- * by wall-clock arithmetic, then snaps until the wall clock reads 00:xx.
+ * First timestamp of the NEXT local calendar date in the cron timezone.
+ * Anchored on the calendar date, not on "wall clock reads 00:00", because
+ * both can lie under DST:
+ *  - spring-forward days are 23h, so a fixed +24h jump overshoots and a
+ *    forward-only "snap to hour 0" then skips an entire day (the original
+ *    bug: nextRun for a Monday cron landing on the transition returned the
+ *    Monday AFTER);
+ *  - in zones where DST starts AT midnight (America/Santiago) the next day
+ *    has no 00:xx at all - its first instant reads 01:00.
+ * Strategy: jump to the vicinity of the next midnight by wall-clock
+ * arithmetic (bounded, over/undershoot at most an hour), then walk by
+ * minutes until the local date is exactly `current date + 1 day-key`,
+ * i.e. the first minute of the next date whatever its wall time is.
  */
 function startOfNextLocalDay(ts: number): number {
-  let candidate = ts;
-  for (let i = 0; i < 4; i++) {
-    const wc = wallClock(new Date(candidate));
-    const minutesIntoDay = wc.hour * 60 + wc.minute;
-    if (candidate !== ts && wc.hour === 0) return candidate;
-    candidate += (24 * 60 - minutesIntoDay) * 60_000;
+  const startKey = localDateKey(wallClock(new Date(ts)));
+
+  // Coarse jump: minutes remaining to nominal midnight. Lands within an hour
+  // of the real boundary regardless of a 23/24/25-hour day.
+  const wc = wallClock(new Date(ts));
+  let candidate = ts + (24 * 60 - (wc.hour * 60 + wc.minute)) * 60_000;
+
+  // A 25-hour day can leave us still on the starting date: take another
+  // bounded hop until the date changes.
+  for (let i = 0; i < 3 && localDateKey(wallClock(new Date(candidate))) <= startKey; i++) {
+    const w = wallClock(new Date(candidate));
+    candidate += (24 * 60 - (w.hour * 60 + w.minute)) * 60_000;
+  }
+
+  // Walk BACK by minutes while the previous minute is still past the start
+  // date - this finds the exact first minute of the next date, and never
+  // crosses back onto the start date (so a skipped-midnight day converges on
+  // its true first instant, e.g. 01:00 in Santiago).
+  let guard = 0;
+  while (guard++ < 180) {
+    const prev = candidate - 60_000;
+    if (localDateKey(wallClock(new Date(prev))) <= startKey) break;
+    candidate = prev;
   }
   return candidate;
 }

--- a/src/lib/cron-scheduler.ts
+++ b/src/lib/cron-scheduler.ts
@@ -147,6 +147,92 @@ function parseExpression(expression: string): {
   };
 }
 
+// ── Timezone support ──
+//
+// Cron expressions describe WALL-CLOCK times ("0 7 * * *" = 7am where the
+// user lives). By default that is the machine's local time (self-host). A
+// hosted brain runs on a UTC VPS, so the daemon sets the user's IANA
+// timezone here once at boot (from the system config `timezone` key, which
+// the hosting server writes from the sidecar-reported value) and every cron
+// in the process - system morning/evening/hourly, workflow triggers, goal
+// windows - evaluates in that timezone.
+
+let cronTimezone: string | null = null;
+
+/** Set (or clear) the process-wide cron timezone. Throws on unknown zones. */
+export function setCronTimezone(tz: string | null): void {
+  if (tz) {
+    // Throws RangeError for unknown zone names.
+    new Intl.DateTimeFormat('en-US', { timeZone: tz });
+  }
+  cronTimezone = tz;
+  wallClockFormatter = null;
+}
+
+export function getCronTimezone(): string | null {
+  return cronTimezone;
+}
+
+let wallClockFormatter: Intl.DateTimeFormat | null = null;
+
+const DOW_INDEX: Record<string, number> = { Sun: 0, Mon: 1, Tue: 2, Wed: 3, Thu: 4, Fri: 5, Sat: 6 };
+
+interface WallClock {
+  minute: number;
+  hour: number;
+  dom: number;
+  month: number;
+  dow: number;
+}
+
+/** Wall-clock components of a timestamp in the configured cron timezone. */
+function wallClock(date: Date): WallClock {
+  if (!cronTimezone) {
+    return {
+      minute: date.getMinutes(),
+      hour: date.getHours(),
+      dom: date.getDate(),
+      month: date.getMonth() + 1,
+      dow: date.getDay(),
+    };
+  }
+  wallClockFormatter ??= new Intl.DateTimeFormat('en-US', {
+    timeZone: cronTimezone,
+    hourCycle: 'h23',
+    minute: 'numeric',
+    hour: 'numeric',
+    day: 'numeric',
+    month: 'numeric',
+    weekday: 'short',
+  });
+  const parts: Record<string, string> = {};
+  for (const part of wallClockFormatter.formatToParts(date)) {
+    parts[part.type] = part.value;
+  }
+  return {
+    minute: Number(parts.minute),
+    hour: Number(parts.hour) % 24, // h23 still yields "24" for midnight in some ICU versions
+    dom: Number(parts.day),
+    month: Number(parts.month),
+    dow: DOW_INDEX[parts.weekday!] ?? 0,
+  };
+}
+
+/**
+ * Timestamp of the next local midnight in the cron timezone. DST-safe: lands
+ * by wall-clock arithmetic, then snaps until the wall clock reads 00:xx.
+ */
+function startOfNextLocalDay(ts: number): number {
+  let candidate = ts;
+  for (let i = 0; i < 4; i++) {
+    const wc = wallClock(new Date(candidate));
+    const minutesIntoDay = wc.hour * 60 + wc.minute;
+    if (candidate !== ts && wc.hour === 0) return candidate;
+    candidate += (24 * 60 - minutesIntoDay) * 60_000;
+  }
+  return candidate;
+}
+
 // ── CronScheduler ──
 
 export class CronScheduler {
@@ -159,11 +245,7 @@ export class CronScheduler {
     try {
       const { minutes, hours, daysOfMonth, months, daysOfWeek } = parseExpression(expression);
 
-      const minute = date.getMinutes();
-      const hour = date.getHours();
-      const dom = date.getDate();
-      const month = date.getMonth() + 1;  // getMonth() is 0-based
-      const dow = date.getDay();           // 0 = Sunday
+      const { minute, hour, dom, month, dow } = wallClock(date);
 
       return (
         minutes.includes(minute) &&
@@ -184,6 +266,7 @@ export class CronScheduler {
    * @returns Date of next execution, or null if none found within 1 year
    */
   static nextRun(expression: string, from: Date = new Date()): Date | null {
+    if (cronTimezone) return CronScheduler.nextRunInTimezone(expression, from);
     try {
       const { minutes, hours, daysOfMonth, months, daysOfWeek } = parseExpression(expression);
 
@@ -252,6 +335,46 @@ export class CronScheduler {
 
         // All fields match
         return new Date(candidate);
+      }
+
+      return null;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * nextRun for the configured cron timezone: walks timestamps and evaluates
+   * the WALL CLOCK at each step, so DST transitions are handled by the tz
+   * database instead of local Date setters. Coarse jumps (next local day /
+   * next hour boundary) keep it fast; hour offsets in :30/:45 zones are safe
+   * because jumps are derived from the wall-clock minute.
+   */
+  private static nextRunInTimezone(expression: string, from: Date): Date | null {
+    try {
+      const { minutes, hours, daysOfMonth, months, daysOfWeek } = parseExpression(expression);
+
+      // Start from the next whole minute.
+      let ts = Math.floor(from.getTime() / 60_000) * 60_000 + 60_000;
+      const limit = from.getTime() + 366 * 24 * 60 * 60_000;
+      let guard = 0;
+
+      while (ts < limit && ++guard < 600_000) {
+        const wc = wallClock(new Date(ts));
+        if (!months.includes(wc.month) || !daysOfMonth.includes(wc.dom) || !daysOfWeek.includes(wc.dow)) {
+          ts = startOfNextLocalDay(ts);
+          continue;
+        }
+        if (!hours.includes(wc.hour)) {
+          ts += (60 - wc.minute) * 60_000; // next local hour boundary
+          continue;
+        }
+        if (!minutes.includes(wc.minute)) {
+          const nextMinute = minutes.find((m) => m > wc.minute);
+          ts += nextMinute !== undefined ? (nextMinute - wc.minute) * 60_000 : (60 - wc.minute) * 60_000;
+          continue;
+        }
+        return new Date(ts);
       }
 
       return null;

--- a/src/lib/cron-timezone.test.ts
+++ b/src/lib/cron-timezone.test.ts
@@ -68,3 +68,47 @@ describe('cron timezone', () => {
     expect(CronScheduler.matches(expr, now)).toBe(true);
   });
 });
+
+describe('cron timezone: DST day-boundary regressions (review findings)', () => {
+  afterEach(() => {
+    setCronTimezone(null);
+  });
+
+  test('weekly cron lands ON the US spring-forward Monday, not a week later', () => {
+    setCronTimezone('America/New_York');
+    // From Saturday 2026-03-07 12:00 UTC, next "0 9 * * 1" must be Monday
+    // March 9 09:00 EDT (13:00 UTC) - the original startOfNextLocalDay
+    // skipped the whole transition day and returned March 16.
+    const next = CronScheduler.nextRun('0 9 * * 1', new Date('2026-03-07T12:00:00Z'));
+    expect(next?.toISOString()).toBe('2026-03-09T13:00:00.000Z');
+  });
+
+  test('date-specific cron on/after a transition is found (schedule() must not throw)', () => {
+    setCronTimezone('America/New_York');
+    // "0 9 9 3 *" = March 9, 09:00. The old day-skip jumped over March 9
+    // entirely and nextRun returned null, which made schedule() throw and
+    // the job silently never register.
+    const next = CronScheduler.nextRun('0 9 9 3 *', new Date('2026-03-01T00:00:00Z'));
+    expect(next?.toISOString()).toBe('2026-03-09T13:00:00.000Z');
+  });
+
+  test('zones where DST starts AT midnight (America/Santiago): the day has no 00:xx', () => {
+    setCronTimezone('America/Santiago');
+    // Chile DST 2026 begins the night of Sep 5 -> 6: 00:00 jumps to 01:00,
+    // so Sep 6 has no midnight. A cron for 01:30 must fire Sep 6 01:30 -03
+    // (04:30 UTC), and a date-specific cron for Sep 6 must not be skipped.
+    const next = CronScheduler.nextRun('30 1 * * *', new Date('2026-09-05T23:30:00-04:00'));
+    expect(next?.toISOString()).toBe('2026-09-06T04:30:00.000Z');
+
+    const dateCron = CronScheduler.nextRun('0 9 6 9 *', new Date('2026-09-01T00:00:00Z'));
+    expect(dateCron?.toISOString()).toBe('2026-09-06T12:00:00.000Z');
+  });
+
+  test('fall-back 25h day: next-day search does not stall on the repeated hour', () => {
+    setCronTimezone('America/New_York');
+    // US DST ends 2026-11-01 (25h day). A date cron for Nov 2 searched from
+    // Oct 31 must cross the long day cleanly.
+    const next = CronScheduler.nextRun('0 8 2 11 *', new Date('2026-10-31T00:00:00Z'));
+    expect(next?.toISOString()).toBe('2026-11-02T13:00:00.000Z'); // 8am EST
+  });
+});

--- a/src/lib/cron-timezone.test.ts
+++ b/src/lib/cron-timezone.test.ts
@@ -1,0 +1,70 @@
+import { test, expect, describe, afterEach } from 'bun:test';
+import { CronScheduler, setCronTimezone, getCronTimezone } from './cron-scheduler.ts';
+
+describe('cron timezone', () => {
+  afterEach(() => {
+    setCronTimezone(null);
+  });
+
+  test('setCronTimezone validates IANA names', () => {
+    setCronTimezone('America/New_York');
+    expect(getCronTimezone()).toBe('America/New_York');
+    expect(() => setCronTimezone('Mars/Olympus_Mons')).toThrow();
+    setCronTimezone(null);
+    expect(getCronTimezone()).toBeNull();
+  });
+
+  test('matches evaluates the WALL CLOCK of the configured zone, not the host', () => {
+    // 2026-07-03 11:00:00 UTC = 07:00 in New York (EDT, UTC-4).
+    const utcMoment = new Date('2026-07-03T11:00:00Z');
+
+    setCronTimezone('America/New_York');
+    expect(CronScheduler.matches('0 7 * * *', utcMoment)).toBe(true);
+    expect(CronScheduler.matches('0 11 * * *', utcMoment)).toBe(false);
+
+    // Same instant in Kolkata (UTC+5:30, a :30 offset zone) is 16:30.
+    setCronTimezone('Asia/Kolkata');
+    expect(CronScheduler.matches('30 16 * * *', utcMoment)).toBe(true);
+    expect(CronScheduler.matches('0 7 * * *', utcMoment)).toBe(false);
+  });
+
+  test('day-of-week fields follow the zone (it can be tomorrow in Tokyo)', () => {
+    // 2026-07-03 is a Friday; at 23:00 UTC it is already Saturday 08:00 in Tokyo.
+    const utcMoment = new Date('2026-07-03T23:00:00Z');
+    setCronTimezone('Asia/Tokyo');
+    expect(CronScheduler.matches('0 8 * * 6', utcMoment)).toBe(true); // Saturday in Tokyo
+    expect(CronScheduler.matches('0 8 * * 5', utcMoment)).toBe(false);
+  });
+
+  test('nextRun returns the next wall-clock firing as a UTC instant', () => {
+    setCronTimezone('America/New_York');
+    // From 2026-07-03 12:00 UTC (08:00 EDT), next "0 20 * * *" (8pm NY) is
+    // 2026-07-04 00:00 UTC.
+    const next = CronScheduler.nextRun('0 20 * * *', new Date('2026-07-03T12:00:00Z'));
+    expect(next?.toISOString()).toBe('2026-07-04T00:00:00.000Z');
+  });
+
+  test('nextRun crosses the fall-back DST transition correctly', () => {
+    setCronTimezone('America/New_York');
+    // US DST ends 2026-11-01 02:00 EDT (06:00 UTC). Morning cron the day
+    // after the shift: 7am EST = 12:00 UTC (was 11:00 UTC in EDT).
+    const before = CronScheduler.nextRun('0 7 * * *', new Date('2026-10-31T08:00:00Z'));
+    expect(before?.toISOString()).toBe('2026-10-31T11:00:00.000Z'); // still EDT (UTC-4)
+    const after = CronScheduler.nextRun('0 7 * * *', new Date('2026-11-01T12:00:00Z'));
+    expect(after?.toISOString()).toBe('2026-11-02T12:00:00.000Z'); // now EST
+  });
+
+  test('nextRun crosses the spring-forward transition (2:30am does not exist)', () => {
+    setCronTimezone('America/New_York');
+    // US DST starts 2026-03-08: 02:00 EST jumps to 03:00 EDT, so 02:30 never
+    // occurs that day. The next 02:30 wall time is March 9 (EDT, 06:30 UTC).
+    const next = CronScheduler.nextRun('30 2 * * *', new Date('2026-03-08T01:00:00-05:00'));
+    expect(next?.toISOString()).toBe('2026-03-09T06:30:00.000Z');
+  });
+
+  test('without a timezone, behavior is unchanged (machine local time)', () => {
+    const now = new Date();
+    const expr = `${now.getMinutes()} ${now.getHours()} * * *`;
+    expect(CronScheduler.matches(expr, now)).toBe(true);
+  });
+});

--- a/src/scripts/google-setup.ts
+++ b/src/scripts/google-setup.ts
@@ -21,8 +21,18 @@ async function main() {
   console.log('=== Google OAuth2 Setup for JARVIS ===');
   console.log('');
 
-  // Load config to get client_id / client_secret
+  // Load config to get client_id / client_secret. Dashboard-entered creds
+  // live in the vault DB (user-settings google fallback), so open it and
+  // merge before concluding nothing is configured.
   const config = await loadConfig();
+  try {
+    const { initDatabase } = await import('../vault/schema.ts');
+    const { mergeUserSettingsIntoConfig } = await import('../daemon/user-settings.ts');
+    initDatabase(config.daemon.db_path, { quiet: true });
+    mergeUserSettingsIntoConfig(config);
+  } catch {
+    // No DB yet (fresh install) - the interactive prompt below handles it.
+  }
 
   let clientId = config.google?.client_id ?? '';
   let clientSecret = config.google?.client_secret ?? '';

--- a/src/sidecar/enrollment.test.ts
+++ b/src/sidecar/enrollment.test.ts
@@ -1,0 +1,108 @@
+import { test, expect, describe, beforeEach, afterEach } from 'bun:test';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { jwtVerify, decodeJwt } from 'jose';
+import { initDatabase, closeDb, getDb } from '../vault/schema.ts';
+import {
+  enrollDevice,
+  loadOrGenerateSidecarKeys,
+  validateSidecarName,
+  sidecarKeyPaths,
+} from './enrollment.ts';
+
+let dataDir: string;
+
+describe('standalone enrollment', () => {
+  beforeEach(async () => {
+    dataDir = await mkdtemp(join(tmpdir(), 'jarvis-enroll-'));
+    initDatabase(':memory:');
+  });
+
+  afterEach(async () => {
+    closeDb();
+    await rm(dataDir, { recursive: true, force: true });
+  });
+
+  test('mints a verifiable ES256 JWT with self-describing claims and stores the record', async () => {
+    const result = await enrollDevice(dataDir, 'u1.vps1.usejarvis.host', 'desktop-NA23', {
+      onExisting: 'upsert',
+    });
+
+    expect(result.created).toBe(true);
+    const claims = decodeJwt(result.token);
+    expect(claims.brain).toBe('wss://u1.vps1.usejarvis.host/sidecar/connect');
+    expect(claims.jwks).toBe('https://u1.vps1.usejarvis.host/api/sidecars/.well-known/jwks.json');
+    expect(claims.sid).toBe(result.sidecar.id);
+    expect(claims.name).toBe('desktop-NA23');
+
+    // Verifies against the persisted public key (what the daemon serves as JWKS).
+    const keys = await loadOrGenerateSidecarKeys(dataDir);
+    const { payload } = await jwtVerify(result.token, keys.publicKey, { algorithms: ['ES256'] });
+    expect(payload.jti).toBe(result.sidecar.token_id);
+
+    const row = getDb().query('SELECT * FROM sidecars WHERE id = ?').get(result.sidecar.id) as {
+      name: string;
+      status: string;
+    };
+    expect(row.name).toBe('desktop-NA23');
+    expect(row.status).toBe('enrolled');
+  });
+
+  test('upsert by name: same device record, fresh jti, both tokens stay valid', async () => {
+    const first = await enrollDevice(dataDir, 'u1.vps1.usejarvis.host', 'desktop-NA23', {
+      onExisting: 'upsert',
+    });
+    const second = await enrollDevice(dataDir, 'u1.vps1.usejarvis.host', 'desktop-NA23', {
+      onExisting: 'upsert',
+    });
+
+    expect(second.created).toBe(false);
+    expect(second.sidecar.id).toBe(first.sidecar.id); // same sid: one device
+    expect(second.sidecar.token_id).not.toBe(first.sidecar.token_id); // fresh jti
+
+    // Exactly one row for the device.
+    const count = getDb().query('SELECT COUNT(*) as n FROM sidecars').get() as { n: number };
+    expect(count.n).toBe(1);
+  });
+
+  test('re-mint after a brain_domain change points the token at the new host (migration)', async () => {
+    await enrollDevice(dataDir, 'u1.vps1.usejarvis.host', 'desktop-NA23', { onExisting: 'upsert' });
+    const moved = await enrollDevice(dataDir, 'u1.vps2.usejarvis.host', 'desktop-NA23', {
+      onExisting: 'upsert',
+    });
+    expect(decodeJwt(moved.token).brain).toBe('wss://u1.vps2.usejarvis.host/sidecar/connect');
+  });
+
+  test('reject mode preserves the dashboard duplicate error', async () => {
+    await enrollDevice(dataDir, 'u1.vps1.usejarvis.host', 'desktop-NA23', { onExisting: 'upsert' });
+    expect(
+      enrollDevice(dataDir, 'u1.vps1.usejarvis.host', 'desktop-NA23', { onExisting: 'reject' }),
+    ).rejects.toThrow(/already enrolled/);
+  });
+
+  test('key files persist with tight permissions and reload identically', async () => {
+    const a = await loadOrGenerateSidecarKeys(dataDir);
+    const b = await loadOrGenerateSidecarKeys(dataDir);
+    expect(b.keyId).toBe(a.keyId); // same key on reload, not a regeneration
+
+    const { statSync } = await import('node:fs');
+    const paths = sidecarKeyPaths(dataDir);
+    expect(statSync(paths.dir).mode & 0o777).toBe(0o700);
+    expect(statSync(paths.privatePem).mode & 0o777).toBe(0o600);
+    expect(statSync(paths.publicPem).mode & 0o777).toBe(0o644);
+  });
+
+  test('name validation: rules shared with the manager', () => {
+    expect(validateSidecarName('  desktop-NA23  ')).toBe('desktop-NA23');
+    expect(() => validateSidecarName('')).toThrow(/1-64/);
+    expect(() => validateSidecarName('a'.repeat(65))).toThrow(/1-64/);
+    expect(() => validateSidecarName('bad name!')).toThrow(/letters, numbers/);
+  });
+
+  test('missing brain URL is a hard error, not a localhost token', async () => {
+    expect(enrollDevice(dataDir, '', 'desktop-NA23', { onExisting: 'upsert' })).rejects.toThrow(
+      /brain_domain/i,
+    );
+  });
+});

--- a/src/sidecar/enrollment.test.ts
+++ b/src/sidecar/enrollment.test.ts
@@ -76,7 +76,7 @@ describe('standalone enrollment', () => {
 
   test('reject mode preserves the dashboard duplicate error', async () => {
     await enrollDevice(dataDir, 'u1.vps1.usejarvis.host', 'desktop-NA23', { onExisting: 'upsert' });
-    expect(
+    await expect(
       enrollDevice(dataDir, 'u1.vps1.usejarvis.host', 'desktop-NA23', { onExisting: 'reject' }),
     ).rejects.toThrow(/already enrolled/);
   });
@@ -101,8 +101,32 @@ describe('standalone enrollment', () => {
   });
 
   test('missing brain URL is a hard error, not a localhost token', async () => {
-    expect(enrollDevice(dataDir, '', 'desktop-NA23', { onExisting: 'upsert' })).rejects.toThrow(
+    await expect(enrollDevice(dataDir, '', 'desktop-NA23', { onExisting: 'upsert' })).rejects.toThrow(
       /brain_domain/i,
     );
   });
+});
+
+test('rotate: fresh sid, old tokens die with the old row', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'jarvis-rotate-'));
+  initDatabase(':memory:');
+  try {
+    const first = await enrollDevice(dir, 'u1.vps1.usejarvis.host', 'desktop-A', { onExisting: 'upsert' });
+    const rotated = await enrollDevice(dir, 'u1.vps1.usejarvis.host', 'desktop-A', {
+      onExisting: 'upsert',
+      rotate: true,
+    });
+
+    expect(rotated.created).toBe(true);
+    expect(rotated.sidecar.id).not.toBe(first.sidecar.id);
+    // Old sid is gone -> every JWT carrying it fails enrollment checks.
+    const old = getDb().query('SELECT id FROM sidecars WHERE id = ?').get(first.sidecar.id);
+    expect(old).toBeNull();
+    // Exactly one row for the device name.
+    const count = getDb().query('SELECT COUNT(*) as n FROM sidecars').get() as { n: number };
+    expect(count.n).toBe(1);
+  } finally {
+    closeDb();
+    await rm(dir, { recursive: true, force: true });
+  }
 });

--- a/src/sidecar/enrollment.ts
+++ b/src/sidecar/enrollment.ts
@@ -1,0 +1,227 @@
+/**
+ * Standalone sidecar enrollment: key lifecycle + JWT mint + DB record,
+ * shared by the SidecarManager (daemon) and the `jarvis enroll` /
+ * `jarvis revoke` / `jarvis sidecars` CLIs.
+ *
+ * Deliberately free of daemon dependencies (no Service interface, no
+ * scheduler/RPC imports) so a provisioning server can mint a device's JWT
+ * BEFORE the daemon has ever started: open the vault DB, load or generate
+ * the ES256 keypair, sign, upsert the record, print the token. The daemon
+ * picks the record up live (validateToken reads the DB per connect and
+ * SQLite runs in WAL mode, so a concurrent daemon sees it too).
+ */
+
+import {
+  generateKeyPair,
+  exportJWK,
+  exportPKCS8,
+  exportSPKI,
+  importPKCS8,
+  importSPKI,
+  SignJWT,
+  type JWK,
+} from 'jose';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import { getDb, generateId } from '../vault/schema.ts';
+import type { SidecarRecord, SidecarTokenClaims } from './types.ts';
+import { chmodWithWarning, secureDirectory, secureWriteFile } from '../util/fs-secure.ts';
+import { computeAnonId } from '../telemetry/anon-id.ts';
+
+// Localhost host check anchored: matches `localhost`, `localhost:PORT`, but
+// not e.g. `notlocalhost.example.com`. Used both for enrollment URL scheme
+// inference and for startup warnings.
+const LOCALHOST_HOST_RE = /^(localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\])(:\d+)?$/;
+
+export function isLocalhostBrainUrl(brainBase: string): boolean {
+  const normalized = brainBase.trim();
+  if (/^(https?|wss?):\/\//.test(normalized)) {
+    try {
+      return LOCALHOST_HOST_RE.test(new URL(normalized).host);
+    } catch {
+      return false;
+    }
+  }
+  return LOCALHOST_HOST_RE.test(normalized);
+}
+
+// Build the JWT-bound enrollment URLs from a single canonical brain base —
+// either a full URL (`https://brain.example.com`, `wss://...`) or a bare
+// host[:port] (`brain.example.com`, `10.0.0.5:3142`). Pure function: no
+// request input, no env, no class state. The single source of truth is
+// whatever the brain operator configured at startup.
+export function buildEnrollmentUrls(brainBase: string): { brainWs: string; jwksUrl: string } {
+  const normalized = brainBase.trim();
+
+  if (/^(https?|wss?):\/\//.test(normalized)) {
+    const parsed = new URL(normalized);
+    const isSecure = parsed.protocol === 'https:' || parsed.protocol === 'wss:';
+    return {
+      brainWs: `${isSecure ? 'wss' : 'ws'}://${parsed.host}/sidecar/connect`,
+      jwksUrl: `${isSecure ? 'https' : 'http'}://${parsed.host}/api/sidecars/.well-known/jwks.json`,
+    };
+  }
+
+  // Bare host: assume insecure only for explicit local hosts. A remote
+  // host with an explicit port (`brain.example.com:443`) used to be
+  // misclassified as insecure by a `:\d+$` heuristic; require a known
+  // local host instead so production deployments default to wss/https.
+  const isSecure = !LOCALHOST_HOST_RE.test(normalized);
+  return {
+    brainWs: `${isSecure ? 'wss' : 'ws'}://${normalized}/sidecar/connect`,
+    jwksUrl: `${isSecure ? 'https' : 'http'}://${normalized}/api/sidecars/.well-known/jwks.json`,
+  };
+}
+
+export const ENROLLMENT_ALG = 'ES256';
+const KEY_DIR_NAME = 'sidecar-keys';
+const PRIVATE_KEY_FILE = 'private.pem';
+const PUBLIC_KEY_FILE = 'public.pem';
+
+export interface SidecarKeys {
+  privateKey: CryptoKey;
+  publicKey: CryptoKey;
+  publicJwk: JWK;
+  keyId: string;
+}
+
+export function sidecarKeyPaths(dataDir: string): { dir: string; privatePem: string; publicPem: string } {
+  const dir = path.join(dataDir, KEY_DIR_NAME);
+  return {
+    dir,
+    privatePem: path.join(dir, PRIVATE_KEY_FILE),
+    publicPem: path.join(dir, PUBLIC_KEY_FILE),
+  };
+}
+
+/**
+ * Load the brain's ES256 keypair, generating and persisting one on first
+ * use. Safe to call from the CLI while the daemon is stopped OR from the
+ * daemon itself - both sides converge on the same key files.
+ */
+export async function loadOrGenerateSidecarKeys(
+  dataDir: string,
+  log: (msg: string) => void = () => {},
+): Promise<SidecarKeys> {
+  const paths = sidecarKeyPaths(dataDir);
+  let privateKey: CryptoKey;
+  let publicKey: CryptoKey;
+
+  if (existsSync(paths.privatePem) && existsSync(paths.publicPem)) {
+    privateKey = await importPKCS8(await Bun.file(paths.privatePem).text(), ENROLLMENT_ALG, { extractable: true });
+    publicKey = await importSPKI(await Bun.file(paths.publicPem).text(), ENROLLMENT_ALG, { extractable: true });
+    await secureKeyFilePermissions(dataDir);
+    log('Loaded existing ES256 key pair');
+  } else {
+    await secureDirectory(paths.dir, 0o700);
+    ({ privateKey, publicKey } = await generateKeyPair(ENROLLMENT_ALG, { extractable: true }));
+    await secureWriteFile(paths.privatePem, await exportPKCS8(privateKey), 0o600, 'SidecarEnrollment');
+    // public.pem contains the SPKI public key, so world-readable 0644 is intentional.
+    await secureWriteFile(paths.publicPem, await exportSPKI(publicKey), 0o644, 'SidecarEnrollment');
+    await secureKeyFilePermissions(dataDir);
+    log('Generated new ES256 key pair');
+  }
+
+  const publicJwk = await exportJWK(publicKey);
+  return {
+    privateKey,
+    publicKey,
+    publicJwk,
+    keyId: publicJwk.x ?? 'default', // x-coordinate as kid (stable, unique)
+  };
+}
+
+export async function secureKeyFilePermissions(dataDir: string): Promise<void> {
+  const paths = sidecarKeyPaths(dataDir);
+  await chmodWithWarning(paths.dir, 0o700, 'SidecarEnrollment');
+  await chmodWithWarning(paths.privatePem, 0o600, 'SidecarEnrollment');
+  await chmodWithWarning(paths.publicPem, 0o644, 'SidecarEnrollment');
+}
+
+/** Shared device-name rules (1-64 chars, [a-zA-Z0-9_-]). Returns the trimmed name. */
+export function validateSidecarName(name: string): string {
+  const trimmed = name.trim();
+  if (!trimmed || trimmed.length > 64) {
+    throw new Error('Sidecar name must be 1-64 characters');
+  }
+  if (!/^[a-zA-Z0-9_-]+$/.test(trimmed)) {
+    throw new Error('Sidecar name may only contain letters, numbers, hyphens, and underscores');
+  }
+  return trimmed;
+}
+
+export interface EnrollResult {
+  token: string;
+  sidecar: SidecarRecord;
+  /** false when an enrolled device with this name already existed (re-mint). */
+  created: boolean;
+}
+
+export interface EnrollOptions {
+  /**
+   * What to do when an enrolled sidecar with this name already exists:
+   * - 'upsert' (CLI/provisioning): keep the sid, mint a fresh JWT, update
+   *   token_id. Retried device-adds and host migrations converge on the
+   *   same device record instead of erroring or duplicating.
+   * - 'reject' (dashboard API): error, preserving the historical behavior.
+   */
+  onExisting: 'upsert' | 'reject';
+  keys?: SidecarKeys;
+}
+
+/**
+ * Enroll (or re-mint for) a device by name. Requires an initialized vault DB
+ * (initDatabase) and a configured brain URL (`daemon.brain_domain`).
+ */
+export async function enrollDevice(
+  dataDir: string,
+  brainUrl: string,
+  name: string,
+  options: EnrollOptions,
+): Promise<EnrollResult> {
+  if (!brainUrl) {
+    throw new Error('Brain URL not configured - set daemon.brain_domain (or JARVIS_BRAIN_DOMAIN)');
+  }
+  const trimmed = validateSidecarName(name);
+  const keys = options.keys ?? (await loadOrGenerateSidecarKeys(dataDir));
+
+  const db = getDb();
+  const existing = db
+    .query('SELECT id FROM sidecars WHERE name = ? AND status = ?')
+    .get(trimmed, 'enrolled') as { id: string } | null;
+
+  if (existing && options.onExisting === 'reject') {
+    throw new Error(`Sidecar "${trimmed}" is already enrolled`);
+  }
+
+  const id = existing?.id ?? generateId();
+  const tokenId = generateId();
+  const { brainWs, jwksUrl } = buildEnrollmentUrls(brainUrl);
+
+  // `bid` is the brain's anonymous telemetry id so the sidecar can report
+  // which brain it belongs to; never the raw hostname/username.
+  const token = await new SignJWT({
+    sid: id,
+    name: trimmed,
+    brain: brainWs,
+    jwks: jwksUrl,
+    bid: computeAnonId(),
+  } satisfies Omit<SidecarTokenClaims, 'sub' | 'jti' | 'iat'>)
+    .setProtectedHeader({ alg: ENROLLMENT_ALG, kid: keys.keyId })
+    .setSubject(`sidecar:${id}`)
+    .setJti(tokenId)
+    .setIssuedAt()
+    .sign(keys.privateKey);
+
+  if (existing) {
+    // Re-mint: same device record, fresh jti. The previous JWT stays valid
+    // (validation checks enrollment by sid, not jti) so a retry can never
+    // strand a device that already received the earlier token.
+    db.run('UPDATE sidecars SET token_id = ? WHERE id = ?', [tokenId, id]);
+  } else {
+    db.run('INSERT INTO sidecars (id, name, token_id) VALUES (?, ?, ?)', [id, trimmed, tokenId]);
+  }
+
+  const sidecar = db.query('SELECT * FROM sidecars WHERE id = ?').get(id) as SidecarRecord;
+  return { token, sidecar, created: !existing };
+}

--- a/src/sidecar/enrollment.ts
+++ b/src/sidecar/enrollment.ts
@@ -166,6 +166,13 @@ export interface EnrollOptions {
    * - 'reject' (dashboard API): error, preserving the historical behavior.
    */
   onExisting: 'upsert' | 'reject';
+  /**
+   * With 'upsert': give the device a NEW sid instead of keeping the old one,
+   * which invalidates every previously minted JWT for it (validation is by
+   * sid; the old row is deleted). Use after a suspected token leak. A live
+   * session on the old sid is severed by the daemon's revocation sweep.
+   */
+  rotate?: boolean;
   keys?: SidecarKeys;
 }
 
@@ -186,12 +193,17 @@ export async function enrollDevice(
   const keys = options.keys ?? (await loadOrGenerateSidecarKeys(dataDir));
 
   const db = getDb();
-  const existing = db
+  let existing = db
     .query('SELECT id FROM sidecars WHERE name = ? AND status = ?')
     .get(trimmed, 'enrolled') as { id: string } | null;
 
   if (existing && options.onExisting === 'reject') {
     throw new Error(`Sidecar "${trimmed}" is already enrolled`);
+  }
+
+  if (existing && options.rotate) {
+    db.run('DELETE FROM sidecars WHERE id = ?', [existing.id]);
+    existing = null; // fall through to a brand-new sid
   }
 
   const id = existing?.id ?? generateId();

--- a/src/sidecar/manager.ts
+++ b/src/sidecar/manager.ts
@@ -349,8 +349,8 @@ export class SidecarManager implements Service {
     // Persist connection details to DB so they're available even when offline
     const db = getDb();
     db.run(
-      `UPDATE sidecars SET last_seen_at = datetime('now'), hostname = ?, os = ?, platform = ?, capabilities = ?, version = ? WHERE id = ?`,
-      [sidecar.hostname, sidecar.os, sidecar.platform, JSON.stringify(sidecar.capabilities), sidecar.version, sidecar.id],
+      `UPDATE sidecars SET last_seen_at = datetime('now'), hostname = ?, os = ?, platform = ?, capabilities = ?, version = ?, timezone = COALESCE(?, timezone) WHERE id = ?`,
+      [sidecar.hostname, sidecar.os, sidecar.platform, JSON.stringify(sidecar.capabilities), sidecar.version, sidecar.timezone || null, sidecar.id],
     );
     console.log(`[SidecarManager] Sidecar connected: ${sidecar.name} (${sidecar.id})`);
     // Fire both listener flavours — main uses onConnect(id) for routing,
@@ -567,6 +567,7 @@ export class SidecarManager implements Service {
             updateStatus: verdict,
             capabilities: parsed.capabilities ?? [],
             unavailableCapabilities: parsed.unavailable_capabilities ?? [],
+            timezone: typeof parsed.timezone === 'string' ? parsed.timezone : undefined,
             connectedAt: new Date(),
           });
           return;

--- a/src/sidecar/manager.ts
+++ b/src/sidecar/manager.ts
@@ -27,6 +27,9 @@ import { SidecarConnection } from './connection.ts';
 import { classifySidecarVersion, SIDECAR_MIN_VERSION, SIDECAR_RECOMMENDED_VERSION } from './compat.ts';
 import { chmodWithWarning, secureDirectory, secureWriteFile } from '../util/fs-secure.ts';
 import { computeAnonId } from '../telemetry/anon-id.ts';
+import { loadOrGenerateSidecarKeys, enrollDevice, buildEnrollmentUrls, isLocalhostBrainUrl } from './enrollment.ts';
+
+export { buildEnrollmentUrls, isLocalhostBrainUrl } from './enrollment.ts';
 
 const ALG = 'ES256';
 const KEY_DIR_NAME = 'sidecar-keys';
@@ -42,51 +45,6 @@ const PUBLIC_KEY_FILE = 'public.pem';
 // exp + aud, no DB hit) so a leak is bounded to the TTL rather than forever.
 const ACCESS_TOKEN_AUDIENCE = 'brain-api';
 const ACCESS_TOKEN_TTL_SECONDS = 600; // 10 minutes
-
-// Localhost host check anchored: matches `localhost`, `localhost:PORT`, but
-// not e.g. `notlocalhost.example.com`. Used both for enrollment URL scheme
-// inference and for startup warnings.
-const LOCALHOST_HOST_RE = /^(localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\])(:\d+)?$/;
-
-export function isLocalhostBrainUrl(brainBase: string): boolean {
-  const normalized = brainBase.trim();
-  if (/^(https?|wss?):\/\//.test(normalized)) {
-    try {
-      return LOCALHOST_HOST_RE.test(new URL(normalized).host);
-    } catch {
-      return false;
-    }
-  }
-  return LOCALHOST_HOST_RE.test(normalized);
-}
-
-// Build the JWT-bound enrollment URLs from a single canonical brain base —
-// either a full URL (`https://brain.example.com`, `wss://...`) or a bare
-// host[:port] (`brain.example.com`, `10.0.0.5:3142`). Pure function: no
-// request input, no env, no class state. The single source of truth is
-// whatever the brain operator configured at startup.
-export function buildEnrollmentUrls(brainBase: string): { brainWs: string; jwksUrl: string } {
-  const normalized = brainBase.trim();
-
-  if (/^(https?|wss?):\/\//.test(normalized)) {
-    const parsed = new URL(normalized);
-    const isSecure = parsed.protocol === 'https:' || parsed.protocol === 'wss:';
-    return {
-      brainWs: `${isSecure ? 'wss' : 'ws'}://${parsed.host}/sidecar/connect`,
-      jwksUrl: `${isSecure ? 'https' : 'http'}://${parsed.host}/api/sidecars/.well-known/jwks.json`,
-    };
-  }
-
-  // Bare host: assume insecure only for explicit local hosts. A remote
-  // host with an explicit port (`brain.example.com:443`) used to be
-  // misclassified as insecure by a `:\d+$` heuristic; require a known
-  // local host instead so production deployments default to wss/https.
-  const isSecure = !LOCALHOST_HOST_RE.test(normalized);
-  return {
-    brainWs: `${isSecure ? 'wss' : 'ws'}://${normalized}/sidecar/connect`,
-    jwksUrl: `${isSecure ? 'https' : 'http'}://${normalized}/api/sidecars/.well-known/jwks.json`,
-  };
-}
 
 export class SidecarManager implements Service {
   readonly name = 'sidecar-manager';
@@ -247,49 +205,13 @@ export class SidecarManager implements Service {
   }
 
   private async loadOrGenerateKeys(): Promise<void> {
-    if (existsSync(this.privateKeyPath) && existsSync(this.publicKeyPath)) {
-      await this.loadKeys();
-      await this.secureKeyFilePermissions();
-      console.log('[SidecarManager] Loaded existing ES256 key pair');
-    } else {
-      await this.generateKeys();
-      console.log('[SidecarManager] Generated new ES256 key pair');
-    }
-
-    // Export public key as JWK for the JWKS endpoint
-    this.publicJwk = await exportJWK(this.publicKey!);
-    this.keyId = this.publicJwk.x ?? 'default'; // use x-coordinate as kid (stable, unique)
-  }
-
-  private async generateKeys(): Promise<void> {
-    await secureDirectory(this.keysDir, 0o700);
-
-    const { privateKey, publicKey } = await generateKeyPair(ALG, { extractable: true });
-    this.privateKey = privateKey;
-    this.publicKey = publicKey;
-
-    // Export to PEM and write to disk
-    const pkcs8 = await exportPKCS8(privateKey);
-    const spki = await exportSPKI(publicKey);
-
-    await secureWriteFile(this.privateKeyPath, pkcs8, 0o600, 'SidecarManager');
-    // public.pem contains the SPKI public key, so world-readable 0644 is intentional.
-    await secureWriteFile(this.publicKeyPath, spki, 0o644, 'SidecarManager');
-    await this.secureKeyFilePermissions();
-  }
-
-  private async loadKeys(): Promise<void> {
-    const privatePem = await Bun.file(this.privateKeyPath).text();
-    const publicPem = await Bun.file(this.publicKeyPath).text();
-
-    this.privateKey = await importPKCS8(privatePem, ALG, { extractable: true });
-    this.publicKey = await importSPKI(publicPem, ALG, { extractable: true });
-  }
-
-  private async secureKeyFilePermissions(): Promise<void> {
-    await chmodWithWarning(this.keysDir, 0o700, 'SidecarManager');
-    await chmodWithWarning(this.privateKeyPath, 0o600, 'SidecarManager');
-    await chmodWithWarning(this.publicKeyPath, 0o644, 'SidecarManager');
+    const keys = await loadOrGenerateSidecarKeys(this.dataDir, (msg) =>
+      console.log(`[SidecarManager] ${msg}`),
+    );
+    this.privateKey = keys.privateKey;
+    this.publicKey = keys.publicKey;
+    this.publicJwk = keys.publicJwk;
+    this.keyId = keys.keyId;
   }
 
   // --------------- JWKS ---------------
@@ -318,58 +240,23 @@ export class SidecarManager implements Service {
 
   /**
    * Enroll a new sidecar. Returns the signed JWT enrollment token.
+   * Delegates to the standalone enrollment module (shared with the
+   * `jarvis enroll` CLI); the dashboard API keeps reject-on-duplicate.
    */
   async enrollSidecar(name: string): Promise<{ token: string; sidecar: SidecarRecord }> {
-    if (!this.privateKey) throw new Error('SidecarManager not started');
+    if (!this.privateKey || !this.publicJwk) throw new Error('SidecarManager not started');
     if (!this.brainUrl) throw new Error('Brain URL not configured — call setBrainUrl() first');
 
-    // Validate name
-    const trimmed = name.trim();
-    if (!trimmed || trimmed.length > 64) {
-      throw new Error('Sidecar name must be 1-64 characters');
-    }
-    if (!/^[a-zA-Z0-9_-]+$/.test(trimmed)) {
-      throw new Error('Sidecar name may only contain letters, numbers, hyphens, and underscores');
-    }
-
-    // Check uniqueness
-    const db = getDb();
-    const existing = db.query('SELECT id FROM sidecars WHERE name = ? AND status = ?').get(trimmed, 'enrolled') as { id: string } | null;
-    if (existing) {
-      throw new Error(`Sidecar "${trimmed}" is already enrolled`);
-    }
-
-    const id = generateId();
-    const tokenId = generateId();
-
-    const { brainWs, jwksUrl } = buildEnrollmentUrls(this.brainUrl);
-
-    // Sign JWT. `bid` is the brain's anonymous telemetry id so the sidecar can
-    // report which brain it belongs to (for the sidecars-per-brain analytics);
-    // it is the same digest the brain reports in its own telemetry, never the
-    // raw hostname/username.
-    const token = await new SignJWT({
-      sid: id,
-      name: trimmed,
-      brain: brainWs,
-      jwks: jwksUrl,
-      bid: computeAnonId(),
-    } satisfies Omit<SidecarTokenClaims, 'sub' | 'jti' | 'iat'>)
-      .setProtectedHeader({ alg: ALG, kid: this.keyId })
-      .setSubject(`sidecar:${id}`)
-      .setJti(tokenId)
-      .setIssuedAt()
-      .sign(this.privateKey);
-
-    // Store in database
-    db.run(
-      'INSERT INTO sidecars (id, name, token_id) VALUES (?, ?, ?)',
-      [id, trimmed, tokenId],
-    );
-
-    const sidecar = db.query('SELECT * FROM sidecars WHERE id = ?').get(id) as SidecarRecord;
-    console.log(`[SidecarManager] Enrolled sidecar "${trimmed}" (${id})`);
-
+    const { token, sidecar } = await enrollDevice(this.dataDir, this.brainUrl, name, {
+      onExisting: 'reject',
+      keys: {
+        privateKey: this.privateKey,
+        publicKey: this.publicKey!,
+        publicJwk: this.publicJwk,
+        keyId: this.keyId,
+      },
+    });
+    console.log(`[SidecarManager] Enrolled sidecar "${sidecar.name}" (${sidecar.id})`);
     return { token, sidecar };
   }
 

--- a/src/sidecar/manager.ts
+++ b/src/sidecar/manager.ts
@@ -46,6 +46,19 @@ const PUBLIC_KEY_FILE = 'public.pem';
 const ACCESS_TOKEN_AUDIENCE = 'brain-api';
 const ACCESS_TOKEN_TTL_SECONDS = 600; // 10 minutes
 
+/**
+ * Accept only strings shaped like IANA zone names ("Area/City", up to three
+ * segments, "UTC"), max 64 chars. Mirrors the Go sidecar's ianaNameRe.
+ */
+const IANA_TZ_RE = /^[A-Za-z_+-]+(\/[A-Za-z0-9_+-]+){0,2}$/;
+
+export function sanitizeIanaTimezone(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  if (trimmed.length === 0 || trimmed.length > 64) return undefined;
+  return IANA_TZ_RE.test(trimmed) ? trimmed : undefined;
+}
+
 export class SidecarManager implements Service {
   readonly name = 'sidecar-manager';
 
@@ -345,12 +358,17 @@ export class SidecarManager implements Service {
 
   /** Register a connected sidecar (called after WS handshake + registration message) */
   registerConnection(sidecar: ConnectedSidecar): void {
-    this.connected.set(sidecar.id, sidecar);
+    // The reported timezone is untrusted sidecar input headed for sensitive
+    // sinks: `jarvis sidecars list --json` (read by the hosting server) and,
+    // downstream, the root-owned system config the server writes. Persist it
+    // only when it LOOKS like an IANA zone name; anything else becomes null.
+    const timezone = sanitizeIanaTimezone(sidecar.timezone);
+    this.connected.set(sidecar.id, { ...sidecar, timezone });
     // Persist connection details to DB so they're available even when offline
     const db = getDb();
     db.run(
       `UPDATE sidecars SET last_seen_at = datetime('now'), hostname = ?, os = ?, platform = ?, capabilities = ?, version = ?, timezone = COALESCE(?, timezone) WHERE id = ?`,
-      [sidecar.hostname, sidecar.os, sidecar.platform, JSON.stringify(sidecar.capabilities), sidecar.version, sidecar.timezone || null, sidecar.id],
+      [sidecar.hostname, sidecar.os, sidecar.platform, JSON.stringify(sidecar.capabilities), sidecar.version, timezone ?? null, sidecar.id],
     );
     console.log(`[SidecarManager] Sidecar connected: ${sidecar.name} (${sidecar.id})`);
     // Fire both listener flavours — main uses onConnect(id) for routing,

--- a/src/sidecar/manager.ts
+++ b/src/sidecar/manager.ts
@@ -64,6 +64,7 @@ export class SidecarManager implements Service {
   private scheduler: EventScheduler;
   private rpcTracker: RPCTracker;
   private sidecarConnections = new Map<string, SidecarConnection>();
+  private revocationSweepTimer: ReturnType<typeof setInterval> | null = null;
   private progressListeners = new Set<(sidecarId: string, rpcId: string, progress: number, message?: string) => void>();
   private eventListeners = new Set<(sidecarId: string, event: SidecarEvent) => void>();
   // Two parallel notify APIs:
@@ -113,6 +114,16 @@ export class SidecarManager implements Service {
     this._status = 'starting';
     try {
       await this.loadOrGenerateKeys();
+
+      // CLI revocations happen in another process; sweep so they take
+      // effect on live sessions within ~30s, not only at the next connect.
+      this.revocationSweepTimer = setInterval(() => {
+        try {
+          this.sweepRevokedConnections();
+        } catch (err) {
+          console.error('[SidecarManager] Revocation sweep failed:', err);
+        }
+      }, 30_000);
 
       // Wire scheduler handlers
       this.scheduler.on('rpc_result', async (sidecarId, event) => {
@@ -167,6 +178,11 @@ export class SidecarManager implements Service {
 
   async stop(): Promise<void> {
     this._status = 'stopping';
+
+    if (this.revocationSweepTimer) {
+      clearInterval(this.revocationSweepTimer);
+      this.revocationSweepTimer = null;
+    }
 
     // Stop scheduler
     this.scheduler.stop();
@@ -281,11 +297,35 @@ export class SidecarManager implements Service {
     const db = getDb();
     const result = db.run('DELETE FROM sidecars WHERE id = ? AND status = ?', [id, 'enrolled']);
     if (result.changes > 0) {
+      // Sever any LIVE session too - deleting the row alone only blocks the
+      // next connect, and a revoked-but-connected sidecar would keep routing
+      // RPCs indefinitely (stolen-device scenario).
+      this.handleSidecarDisconnect(id);
       this.connected.delete(id);
       console.log(`[SidecarManager] Revoked and removed sidecar ${id}`);
       return true;
     }
     return false;
+  }
+
+  /**
+   * Disconnect any live session whose enrollment row is gone. Covers
+   * revocations the daemon cannot observe directly: `jarvis revoke` runs in
+   * a SEPARATE process and deletes the row in the shared (WAL) DB, so the
+   * daemon re-checks periodically. Runs every 30s from start(); public so
+   * tests (and ops surfaces) can force a sweep.
+   */
+  sweepRevokedConnections(): number {
+    let severed = 0;
+    for (const id of [...this.sidecarConnections.keys()]) {
+      if (!this.isEnrolled(id)) {
+        console.log(`[SidecarManager] Severing revoked sidecar session: ${id}`);
+        this.handleSidecarDisconnect(id);
+        this.connected.delete(id);
+        severed++;
+      }
+    }
+    return severed;
   }
 
   /** Check if a sidecar ID is enrolled (not revoked) */

--- a/src/sidecar/revocation-sweep.test.ts
+++ b/src/sidecar/revocation-sweep.test.ts
@@ -1,0 +1,79 @@
+import { test, expect, describe, beforeEach, afterEach } from 'bun:test';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { initDatabase, closeDb, getDb } from '../vault/schema.ts';
+import { SidecarManager } from './manager.ts';
+import { enrollDevice } from './enrollment.ts';
+
+let dataDir: string;
+let manager: SidecarManager;
+
+function fakeConnection() {
+  const state = { closed: false };
+  return {
+    state,
+    conn: { close: () => { state.closed = true; } },
+  };
+}
+
+/** Wire a fake live session into the manager's private connection map. */
+function attachFake(m: SidecarManager, sid: string) {
+  const { state, conn } = fakeConnection();
+  (m as unknown as { sidecarConnections: Map<string, unknown> }).sidecarConnections.set(sid, conn);
+  return state;
+}
+
+function liveCount(m: SidecarManager): number {
+  return (m as unknown as { sidecarConnections: Map<string, unknown> }).sidecarConnections.size;
+}
+
+describe('revocation severs live sessions (review finding)', () => {
+  beforeEach(async () => {
+    dataDir = await mkdtemp(join(tmpdir(), 'jarvis-revoke-'));
+    initDatabase(':memory:');
+    manager = new SidecarManager(dataDir);
+  });
+
+  afterEach(async () => {
+    closeDb();
+    await rm(dataDir, { recursive: true, force: true });
+  });
+
+  test('sweep leaves enrolled sessions alone', async () => {
+    const { sidecar } = await enrollDevice(dataDir, 'u1.vps1.usejarvis.host', 'desktop-A', {
+      onExisting: 'upsert',
+    });
+    const state = attachFake(manager, sidecar.id);
+
+    expect(manager.sweepRevokedConnections()).toBe(0);
+    expect(state.closed).toBe(false);
+    expect(liveCount(manager)).toBe(1);
+  });
+
+  test('CLI-style revocation (row deleted by another process) is severed by the sweep', async () => {
+    const { sidecar } = await enrollDevice(dataDir, 'u1.vps1.usejarvis.host', 'desktop-A', {
+      onExisting: 'upsert',
+    });
+    const state = attachFake(manager, sidecar.id);
+
+    // What `jarvis revoke` does from its own process: delete the row.
+    getDb().run('DELETE FROM sidecars WHERE id = ?', [sidecar.id]);
+
+    expect(manager.sweepRevokedConnections()).toBe(1);
+    expect(state.closed).toBe(true);
+    expect(liveCount(manager)).toBe(0);
+  });
+
+  test('dashboard revokeSidecar disconnects the live session immediately', async () => {
+    const { sidecar } = await enrollDevice(dataDir, 'u1.vps1.usejarvis.host', 'desktop-A', {
+      onExisting: 'upsert',
+    });
+    const state = attachFake(manager, sidecar.id);
+
+    expect(manager.revokeSidecar(sidecar.id)).toBe(true);
+    expect(state.closed).toBe(true);
+    expect(liveCount(manager)).toBe(0);
+    expect(manager.isEnrolled(sidecar.id)).toBe(false);
+  });
+});

--- a/src/sidecar/timezone-report.test.ts
+++ b/src/sidecar/timezone-report.test.ts
@@ -64,3 +64,45 @@ describe('sidecar timezone reporting', () => {
     expect(row.timezone).toBe('Europe/Rome');
   });
 });
+
+describe('timezone validation (review finding: untrusted sidecar input)', () => {
+  beforeEach(async () => {
+    dataDir = await mkdtemp(join(tmpdir(), 'jarvis-tzval-'));
+    initDatabase(':memory:');
+    manager = new SidecarManager(dataDir);
+  });
+
+  afterEach(async () => {
+    closeDb();
+    await rm(dataDir, { recursive: true, force: true });
+  });
+
+  test('a hostile timezone string is never persisted (YAML-injection path)', async () => {
+    const { sidecar } = await enrollDevice(dataDir, 'u1.vps1.usejarvis.host', 'desktop-A', {
+      onExisting: 'upsert',
+    });
+    manager.registerConnection(connected(sidecar.id, 'Etc/UTC"\ninjected_key: true\n#'));
+
+    const row = getDb().query('SELECT timezone FROM sidecars WHERE id = ?').get(sidecar.id) as {
+      timezone: string | null;
+    };
+    expect(row.timezone).toBeNull();
+  });
+
+  test('sanitizeIanaTimezone accepts real zones, rejects shapes that are not zones', async () => {
+    const { sanitizeIanaTimezone } = await import('./manager.ts');
+    expect(sanitizeIanaTimezone('Europe/Rome')).toBe('Europe/Rome');
+    expect(sanitizeIanaTimezone('America/Argentina/Buenos_Aires')).toBe('America/Argentina/Buenos_Aires');
+    expect(sanitizeIanaTimezone('Etc/GMT+12')).toBe('Etc/GMT+12');
+    expect(sanitizeIanaTimezone('UTC')).toBe('UTC');
+    expect(sanitizeIanaTimezone(' Europe/Rome ')).toBe('Europe/Rome');
+
+    expect(sanitizeIanaTimezone(undefined)).toBeUndefined();
+    expect(sanitizeIanaTimezone('')).toBeUndefined();
+    expect(sanitizeIanaTimezone('not a zone')).toBeUndefined();
+    expect(sanitizeIanaTimezone('/etc/passwd')).toBeUndefined();
+    expect(sanitizeIanaTimezone('a/b/c/d')).toBeUndefined();
+    expect(sanitizeIanaTimezone('A'.repeat(65))).toBeUndefined();
+    expect(sanitizeIanaTimezone('Europe/Rome\nevil: true')).toBeUndefined();
+  });
+});

--- a/src/sidecar/timezone-report.test.ts
+++ b/src/sidecar/timezone-report.test.ts
@@ -1,0 +1,66 @@
+import { test, expect, describe, beforeEach, afterEach } from 'bun:test';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { initDatabase, closeDb, getDb } from '../vault/schema.ts';
+import { SidecarManager } from './manager.ts';
+import { enrollDevice } from './enrollment.ts';
+import type { ConnectedSidecar } from './types.ts';
+
+let dataDir: string;
+let manager: SidecarManager;
+
+function connected(sid: string, timezone?: string): ConnectedSidecar {
+  return {
+    id: sid,
+    name: 'desktop-A',
+    hostname: 'desktop-A',
+    os: 'linux',
+    platform: 'amd64',
+    version: '1.0.0',
+    updateStatus: 'ok' as ConnectedSidecar['updateStatus'],
+    capabilities: [],
+    unavailableCapabilities: [],
+    timezone,
+    connectedAt: new Date(),
+  };
+}
+
+describe('sidecar timezone reporting', () => {
+  beforeEach(async () => {
+    dataDir = await mkdtemp(join(tmpdir(), 'jarvis-tz-'));
+    initDatabase(':memory:');
+    manager = new SidecarManager(dataDir);
+  });
+
+  afterEach(async () => {
+    closeDb();
+    await rm(dataDir, { recursive: true, force: true });
+  });
+
+  test('register persists the reported IANA timezone on the device row', async () => {
+    const { sidecar } = await enrollDevice(dataDir, 'u1.vps1.usejarvis.host', 'desktop-A', {
+      onExisting: 'upsert',
+    });
+    manager.registerConnection(connected(sidecar.id, 'Europe/Rome'));
+
+    const row = getDb().query('SELECT timezone FROM sidecars WHERE id = ?').get(sidecar.id) as {
+      timezone: string | null;
+    };
+    expect(row.timezone).toBe('Europe/Rome');
+  });
+
+  test('a re-register WITHOUT a timezone keeps the previously reported one (COALESCE)', async () => {
+    const { sidecar } = await enrollDevice(dataDir, 'u1.vps1.usejarvis.host', 'desktop-A', {
+      onExisting: 'upsert',
+    });
+    manager.registerConnection(connected(sidecar.id, 'Europe/Rome'));
+    // Old sidecar build (or detection failure) reports nothing.
+    manager.registerConnection(connected(sidecar.id, undefined));
+
+    const row = getDb().query('SELECT timezone FROM sidecars WHERE id = ?').get(sidecar.id) as {
+      timezone: string | null;
+    };
+    expect(row.timezone).toBe('Europe/Rome');
+  });
+});

--- a/src/sidecar/types.ts
+++ b/src/sidecar/types.ts
@@ -45,6 +45,8 @@ export interface SidecarRecord {
   capabilities: string | null;
   /** Sidecar's own semver, reported on register ("dev" for local builds) */
   version: string | null;
+  /** IANA timezone reported on register (null = unknown/old sidecar) */
+  timezone: string | null;
 }
 
 /** JWT claims for a sidecar enrollment token */
@@ -104,6 +106,8 @@ export interface ConnectedSidecar {
   updateStatus: SidecarUpdateStatus;
   capabilities: SidecarCapability[];
   unavailableCapabilities: UnavailableCapability[];
+  /** IANA timezone reported on register ("" = unknown) */
+  timezone?: string;
   connectedAt: Date;
 }
 

--- a/src/vault/schema.ts
+++ b/src/vault/schema.ts
@@ -674,6 +674,9 @@ function createTables(db: Database): void {
   // Sidecar's own (brain-decoupled) version, reported on register. Added later;
   // ALTER in try/catch is the migration pattern used throughout this file.
   try { db.run('ALTER TABLE sidecars ADD COLUMN version TEXT'); } catch { /* already present */ }
+  // IANA timezone reported by the sidecar on register (hosted brains run on
+  // UTC VPSs; the hosting server reads this for follow-the-night scheduling).
+  try { db.run('ALTER TABLE sidecars ADD COLUMN timezone TEXT'); } catch { /* already present */ }
 
   // Settings table: key-value store for dashboard-managed configuration
   db.run(`

--- a/src/vault/schema.ts
+++ b/src/vault/schema.ts
@@ -35,9 +35,12 @@ export function closeDb(): void {
 /**
  * Initialize the SQLite database with all required tables
  * @param dbPath - Path to the database file. Defaults to :memory: for testing
+ * @param opts.quiet - Suppress the stdout init log. CLIs whose stdout is
+ *   machine-readable (jarvis enroll/sidecars/revoke) set this so the token
+ *   or JSON is the ONLY thing on stdout.
  * @returns Database instance
  */
-export function initDatabase(dbPath: string = ":memory:"): Database {
+export function initDatabase(dbPath: string = ":memory:", opts?: { quiet?: boolean }): Database {
   try {
     // Close existing connection if any
     closeDb();
@@ -54,7 +57,7 @@ export function initDatabase(dbPath: string = ":memory:"): Database {
     // Create all tables
     createTables(dbInstance);
 
-    console.log(`Database initialized at: ${dbPath}`);
+    if (!opts?.quiet) console.log(`Database initialized at: ${dbPath}`);
     return dbInstance;
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);


### PR DESCRIPTION
Ten commits across the brain (TS) and sidecar (Go), one feature per commit with a review-fix pass on each half. Each change keeps both the existing and the new behavior working, selected by config.

## What ships

**Config is split into a system file and a user DB.** `config.yaml` is now a read-only SYSTEM config holding network/system keys (`daemon.*`, `auth`, `google`). All user-chosen sections (personality, voice, stt/tts, authority, channels, onboarding, heartbeat, cron, goals, ...) live in the vault DB settings store, edited from the dashboard. `saveConfig` is removed, so the brain never writes `config.yaml`. A file that still carries user sections is imported into the DB once, then re-imported only when the file value actually changes, so a dashboard edit is never clobbered by a stale file.

**`browser.local: false`** disables the local Chrome entirely. `launchChrome` and `BrowserController.connect()` are the enforcement choke points, so no CDP port opens and nothing attaches to a pre-existing listener; browser tools route to a connected sidecar instead.

**`daemon.listen: unix:/path.sock`** binds a unix-domain socket instead of a TCP port. The socket is born `0660` via umask (no post-bind window), verified fail-closed, and unlinked on graceful exit via a `process.on('exit')` handler as well as ordered shutdown. A malformed listen spec is fatal rather than silently falling back to TCP, and `jarvis stop` is pid-only in this mode so it never kills an unrelated process on the default port.

**`jarvis enroll` / `jarvis sidecars list` / `jarvis revoke` CLIs.** Standalone commands that mint and store the enrollment JWT without the daemon running. Enroll is an idempotent upsert by device name (same sid, fresh jti; `--rotate` invalidates prior tokens); the token prints clean on stdout, `--json` for scripting. Revocation severs live sessions, not just future connects. The enrollment core is extracted into a shared module used by both the CLI and the daemon.

**JWT-only access by default.** The shared `auth.token` and `JARVIS_AUTH_TOKEN` are removed; every non-public route requires an enrolled-device access token. The single escape hatch is `auth.insecure_open_access: true`, which logs a loud warning while enabled. Setup flow without a sidecar: enable the flag, finish setup, remove it once a device is enrolled.

**`timezone` (IANA) system-config key.** Every cron in the process (system morning/evening/hourly, workflow triggers, goal windows) evaluates its wall-clock time in the configured zone, DST-safe.

**Sidecar hosted onboarding + timezone reporting.** With no token configured, the sidecar opens a hosted-first connect window and completes a nonce handshake long-poll to receive its JWT; the token flows Go <-> server only, never through page JS, with a "paste your enrollment token" link to the classic self-host form. `submitToken` is gated to the local form so a remote page loaded in the webview cannot enroll the sidecar to a foreign brain. The sidecar reports its machine timezone (TZ env / `/etc/localtime` / Windows `tzutil` + CLDR map) on register; the brain stores it and exposes it through `jarvis sidecars list --json`. The connect origin is pinned to `app.usejarvis.dev`; `JARVIS_HOSTED_URL` / `hosted_base_url` overrides are honored only in `-tags jarvisdebug` builds.

## Breaking changes

- `config.yaml` no longer carries user settings. They move to the DB on first boot (auto-imported from an existing file) and are edited from the dashboard afterward. Editing a user section in the file still works and re-applies on restart.
- `auth.token` and `JARVIS_AUTH_TOKEN` are gone; access is JWT-only. To open the dashboard for first-time setup without a sidecar, set `auth.insecure_open_access: true` and remove it once a device is enrolled. A config still carrying `auth.token` logs a one-line deprecation warning.

## Testing

- Full TS suite green (1562 tests) and the Go sidecar package green; typecheck clean.
- New coverage per feature: config import/change-tracking, the browser choke points, unix-socket bind/perms/no-TCP/pid-only-stop/exit-cleanup, enroll upsert/rotate/revoke-sweep, JWT-only gate + escape hatch, cron DST transitions across zones, the Go handshake client (register/poll/terminal-vs-transient/cancel), the `submitToken` gate, and timezone detection + brain-side validation.
- Manually exercised against a live brain in a sandbox: enroll/upsert/rotate/revoke, config->DB import with the file left untouched, `browser.local` disable, unix-socket serve + `0660` + no-TCP + graceful socket cleanup, JWT-only 401 vs open access, and cron timezone reflected in real goal-cron next-run timestamps.

## Commits

- Move user-owned config sections to the DB settings store; `config.yaml` becomes read-only system config
- Add `browser.local` config flag: never launch local Chrome, browser actions use the sidecar browser
- Support `daemon.listen` unix socket: bind a unix domain socket instead of TCP when configured
- Add standalone `jarvis enroll`/`sidecars`/`revoke` CLIs; extract a shared enrollment module with upsert-by-name
- JWT-only access by default: drop the shared auth token, add the `auth.insecure_open_access` setup escape hatch
- Evaluate crons in the configured IANA timezone
- Address review findings: unix-mode stop safety, DST day-skip, browser connect guard, revocation sweep, change-tracked config import, socket perms, `--rotate`
- Sidecar: hosted-first connect window with handshake nonce long-poll, report IANA timezone on register
- Fix sidecar review findings: gate `submitToken` to the local form, rate-limit pending re-polls, validate reported timezone, bake shell errors into the document, ctx-check dispatches
- Unlink the unix socket on graceful process exit, not only via ordered `stop()`