### PR TITLE
fix: chat composer silently fails on non-secure-context origins (crypto.randomUUID)

### DIFF
--- a/ui/src/components/office/AgentBuilderView.tsx
+++ b/ui/src/components/office/AgentBuilderView.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
+import { uuid } from "../../lib/uuid";
 
 type SpecialistInfo = {
   id: string;
@@ -219,7 +220,7 @@ export default function AgentBuilderView({ specialists }: { specialists?: Specia
 
   const addNode = (type: BuilderNodeType) => {
     const preset = NODE_PRESETS[type];
-    const id = `node-${crypto.randomUUID()}`;
+    const id = `node-${uuid()}`;
     const idx = nodes.length;
     const specialistId = type === "specialist" ? specialistOptions[0]!.id : preset.config.connector;
     const specialistName = type === "specialist" ? specialistOptions[0]!.name : preset.title;
@@ -274,7 +275,7 @@ export default function AgentBuilderView({ specialists }: { specialists?: Specia
     if (!selectedNode) return;
     const duplicate: BuilderNode = {
       ...selectedNode,
-      id: `node-${crypto.randomUUID()}`,
+      id: `node-${uuid()}`,
       x: Math.min(selectedNode.x + 40, CANVAS_WIDTH - NODE_WIDTH - 24),
       y: Math.min(selectedNode.y + 40, CANVAS_HEIGHT - NODE_HEIGHT - 24),
       title: `${selectedNode.title} Copy`,
@@ -295,7 +296,7 @@ export default function AgentBuilderView({ specialists }: { specialists?: Specia
     if (from === to) return;
     const exists = edges.some((edge) => edge.from === from && edge.to === to);
     if (exists) return;
-    const id = `edge-${crypto.randomUUID()}`;
+    const id = `edge-${uuid()}`;
     setEdges((prev) => [...prev, { id, from, to, label: "flow" }]);
     setSelectedNodeId(null);
     setSelectedEdgeId(id);

--- a/ui/src/hooks/useVoice.ts
+++ b/ui/src/hooks/useVoice.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { RealtimeVoiceController } from "../lib/RealtimeVoiceController";
+import { uuid } from "../lib/uuid";
 
 const SPEECH_WAKE_INTERRUPT_COMMANDS = new Set([
   "stop",
@@ -1059,7 +1060,7 @@ export function useVoice({ wsRef, wakeWordEnabled = true, wakeEngine = "openwake
     const currentRoom = getCurrentRoom?.() ?? "home";
 
     if (browserText) {
-      const requestId = crypto.randomUUID();
+      const requestId = uuid();
       ws.send(JSON.stringify({
         type: "voice_text",
         payload: { requestId, text: browserText, currentRoom },
@@ -1076,7 +1077,7 @@ export function useVoice({ wsRef, wakeWordEnabled = true, wakeEngine = "openwake
       return;
     }
 
-    const requestId = crypto.randomUUID();
+    const requestId = uuid();
     const wavBuffer = encodeWav(pcmChunksRef.current, sampleRateRef.current);
 
     // Signal start

--- a/ui/src/hooks/useWebSocket.ts
+++ b/ui/src/hooks/useWebSocket.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from "react";
+import { uuid } from "../lib/uuid";
 
 export type MessageRole = "user" | "assistant" | "system";
 
@@ -179,7 +180,7 @@ type SidecarEventPayload = {
 function createSidecarNotice(payload: SidecarEventPayload, timestamp?: number): ChatMessage & { notice?: SystemNotice } {
   const reason = payload.event?.reason?.trim();
   const notice: SystemNotice = {
-    id: crypto.randomUUID(),
+    id: uuid(),
     title: "Sidecar offline",
     text: reason
       ? `Jarvis sidecar disconnected: ${reason}. Dashboard features may be delayed until it reconnects.`
@@ -188,7 +189,7 @@ function createSidecarNotice(payload: SidecarEventPayload, timestamp?: number): 
   };
 
   return {
-    id: crypto.randomUUID(),
+    id: uuid(),
     role: "system",
     content: notice.text,
     timestamp: timestamp ?? Date.now(),
@@ -505,7 +506,7 @@ export function useWebSocket() {
             setMessages((prev) => [
               ...prev,
               {
-                id: crypto.randomUUID(),
+                id: uuid(),
                 role: "system" as MessageRole,
                 content: msg.payload.message,
                 timestamp: msg.timestamp,
@@ -523,7 +524,7 @@ export function useWebSocket() {
             setMessages((prev) => [
               ...prev,
               {
-                id: crypto.randomUUID(),
+                id: uuid(),
                 role: (msg.payload.role === "assistant" ? "assistant" : "user") as MessageRole,
                 content: msg.payload.text,
                 timestamp: msg.timestamp,
@@ -546,7 +547,7 @@ export function useWebSocket() {
           setMessages((prev) => [
             ...prev,
             {
-              id: msg.id ?? crypto.randomUUID(),
+              id: msg.id ?? uuid(),
               role: "user" as MessageRole,
               content: msg.payload.text,
               timestamp: msg.timestamp,
@@ -571,7 +572,7 @@ export function useWebSocket() {
       setMessages((prev) => [
         ...prev,
         {
-          id: crypto.randomUUID(),
+          id: uuid(),
           role: "system" as MessageRole,
           content: msg.payload.text,
           timestamp: msg.timestamp,
@@ -592,7 +593,7 @@ export function useWebSocket() {
 
         // Add to agent activity feed
         const activityEvent: AgentActivityEvent = {
-          id: crypto.randomUUID(),
+          id: uuid(),
           agentName: msg.payload.agentName,
           agentId: msg.payload.agentId,
           eventType: msg.payload.type,
@@ -635,7 +636,7 @@ export function useWebSocket() {
 
         if (!streamIdRef.current) {
           // Start a new assistant message
-          const id = crypto.randomUUID();
+          const id = uuid();
           streamIdRef.current = id;
           setMessages((prev) => [
             ...prev,
@@ -700,7 +701,7 @@ export function useWebSocket() {
         setMessages((prev) => [
           ...prev,
           {
-            id: crypto.randomUUID(),
+            id: uuid(),
             role: "system" as MessageRole,
             content: String(wfEvent.data.message),
             timestamp: wfEvent.timestamp,
@@ -752,7 +753,7 @@ export function useWebSocket() {
         setMessages((prev) => [
           ...prev,
           {
-            id: msg.id ?? crypto.randomUUID(),
+            id: msg.id ?? uuid(),
             role: "assistant",
             content: String(payload.text),
             timestamp: msg.timestamp,
@@ -921,7 +922,7 @@ export function useWebSocket() {
       setMessages((prev) => [
         ...prev,
         {
-          id: crypto.randomUUID(),
+          id: uuid(),
           role: "system",
           content,
           detail,
@@ -948,7 +949,7 @@ export function useWebSocket() {
     (text: string, options?: { projectId?: string; currentRoom?: string }) => {
       if (!wsRef.current || wsRef.current.readyState !== WebSocket.OPEN) return;
 
-      const id = crypto.randomUUID();
+      const id = uuid();
 
       // Add user message to local state
       setMessages((prev) => [
@@ -979,7 +980,21 @@ export function useWebSocket() {
         id,
         timestamp: Date.now(),
       };
-      wsRef.current.send(JSON.stringify(msg));
+      try {
+        wsRef.current.send(JSON.stringify(msg));
+      } catch (err) {
+        // Never fail a submit silently (issue #260): surface a notice so the
+        // composer doesn't look alive while nothing reaches the daemon.
+        console.error("Failed to send chat message:", err);
+        pendingChatIdsRef.current.delete(id);
+        const notice: SystemNotice = {
+          id: uuid(),
+          title: "Message not sent",
+          text: `Could not send your message: ${err instanceof Error ? err.message : String(err)}`,
+          level: "warning",
+        };
+        setNotices((prev) => [notice, ...prev.filter((item) => item.text !== notice.text)].slice(0, 3));
+      }
     },
     []
   );

--- a/ui/src/lib/RealtimeVoiceController.ts
+++ b/ui/src/lib/RealtimeVoiceController.ts
@@ -12,6 +12,7 @@
  */
 
 import { floatTo16BitPCM, pcm16ToFloat32, resampleFloat32 } from "./pcm.ts";
+import { uuid } from "./uuid.ts";
 
 const REALTIME_SAMPLE_RATE = 24000; // OpenAI realtime minimum.
 const CAPTURE_WORKLET_URL = "/audio/pcm-capture-processor.js";
@@ -70,7 +71,7 @@ export class RealtimeVoiceController {
       this.source = this.captureCtx.createMediaStreamSource(this.stream);
       this.worklet = new AudioWorkletNode(this.captureCtx, "pcm-capture-processor");
 
-      this.requestId = crypto.randomUUID();
+      this.requestId = uuid();
       ws.send(
         JSON.stringify({
           type: "voice_start",

--- a/ui/src/lib/uuid.test.ts
+++ b/ui/src/lib/uuid.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+import { uuid, uuidV4FromRandomValues } from "./uuid";
+
+const V4_SHAPE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+describe("uuid", () => {
+  test("returns a v4 UUID", () => {
+    expect(uuid()).toMatch(V4_SHAPE);
+  });
+
+  test("fallback builds well-formed v4 UUIDs (version and variant bits)", () => {
+    for (let i = 0; i < 200; i++) {
+      expect(uuidV4FromRandomValues()).toMatch(V4_SHAPE);
+    }
+  });
+
+  test("fallback does not collide across many draws", () => {
+    const seen = new Set<string>();
+    for (let i = 0; i < 10_000; i++) seen.add(uuidV4FromRandomValues());
+    expect(seen.size).toBe(10_000);
+  });
+});

--- a/ui/src/lib/uuid.ts
+++ b/ui/src/lib/uuid.ts
@@ -1,0 +1,23 @@
+/**
+ * UUID v4 that works in non-secure contexts.
+ *
+ * crypto.randomUUID is gated behind secure contexts (HTTPS or localhost), so
+ * on a dashboard served over plain HTTP from a LAN IP it simply doesn't exist
+ * and calling it throws (issue #260). crypto.getRandomValues has no such
+ * gate, so fall back to building the v4 by hand from it.
+ */
+export function uuid(): string {
+  if (typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  return uuidV4FromRandomValues();
+}
+
+/** Fallback path, exported for direct testing (randomUUID exists under bun). */
+export function uuidV4FromRandomValues(): string {
+  const bytes = crypto.getRandomValues(new Uint8Array(16));
+  bytes[6] = (bytes[6]! & 0x0f) | 0x40; // version 4
+  bytes[8] = (bytes[8]! & 0x3f) | 0x80; // variant 10xx
+  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}

--- a/ui/src/v2/rooms/settings/tabs/SidecarTab.tsx
+++ b/ui/src/v2/rooms/settings/tabs/SidecarTab.tsx
@@ -42,6 +42,12 @@ export function SidecarTab({
 
   const copyToken = () => {
     if (!enrollResult) return;
+    // navigator.clipboard is undefined outside secure contexts (plain-HTTP
+    // LAN dashboards), which would throw synchronously and skip the toast.
+    if (!navigator.clipboard) {
+      onToast("Clipboard unavailable over HTTP — select the token manually.", "warn");
+      return;
+    }
     navigator.clipboard.writeText(enrollResult.token).then(
       () => onToast("Token copied to clipboard.", "ok"),
       () => onToast("Copy failed — select manually.", "warn"),


### PR DESCRIPTION
Fixes #260.

When the dashboard is served over plain HTTP from a non-localhost origin
(e.g. http://192.168.x.x:3142), Chrome does not expose crypto.randomUUID
because it is gated behind secure contexts. The composer's send handler
called it unconditionally, threw a TypeError before ws.send(), and the
submit died with no user-facing feedback. The same unconditional call
existed in the incoming-message handlers, so receiving messages (including
the sidecar-offline notice) would crash on these origins too.

Changes:

- Add ui/src/lib/uuid.ts: uses crypto.randomUUID when available, otherwise
  builds a v4 UUID from crypto.getRandomValues, which is not secure-context
  gated. I deliberately did not use the Math.random polyfill suggested in
  the issue: these IDs correlate chat requests with incoming error frames,
  so collision resistance matters.
- Replace all 19 unconditional crypto.randomUUID() calls in ui/src
  (useWebSocket.ts, useVoice.ts, RealtimeVoiceController.ts,
  AgentBuilderView.tsx) with the helper. overlay.html is left as is since
  the awareness overlay always loads from localhost/file, both secure
  contexts.
- Fix the "silently" half of the report: sendMessage now wraps ws.send in
  try/catch and pushes a visible "Message not sent" system notice instead
  of dead-buttoning the composer if any future secure-context-gated API
  throws in the send path.
- Guard navigator.clipboard in SidecarTab.copyToken: it is undefined on
  non-secure origins, so the "copy token" button in the new sidecar
  enrollment flow threw synchronously and even its failure toast never
  fired. It now shows a "select the token manually" toast.
- Add ui/src/lib/uuid.test.ts covering v4 shape (version/variant bits) and
  collision-freeness of the fallback across 10k draws.

Verified by running uuid() under a crypto object stripped of randomUUID
(what Chrome exposes on plain-HTTP LAN origins): distinct, well-formed v4
UUIDs. Full test suite passes (1562 pass, 0 fail), tsc clean, UI bundle
builds.