### PR TITLE
docs: add self-hosting guide (single machine, LAN, VPS behind a reverse proxy)

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,8 @@ Local development builds report `dev` and are never blocked.
 
 JARVIS stores its system configuration at `~/.jarvis/config.yaml`; user-level settings live in its database and are managed from the dashboard. Access is **JWT-only by default**: run `jarvis enroll "<device-name>"` and paste the printed token into the sidecar (desktop app), which connects and gives you the dashboard. Setting up without a sidecar? Temporarily add `auth:\n  insecure_open_access: true` to config.yaml, open `http://localhost:3142` after `jarvis start` for the guided setup, then **remove the flag** once your device is enrolled. The Settings room lets you tweak channels, personality, and authority later.
 
+Running the brain on another machine — a home server, a LAN box, or a VPS with a domain? Read [docs/SELF_HOSTING.md](docs/SELF_HOSTING.md) for the reverse-proxy setup, `brain_domain`, device enrollment across machines, and what plain-HTTP access does and doesn't support.
+
 ```yaml
 daemon:
   port: 3142
@@ -429,6 +431,7 @@ bun run db:init         # Initialize or reset the database
 General:
 
 - [config.example.yaml](config.example.yaml) — Full configuration reference
+- [docs/SELF_HOSTING.md](docs/SELF_HOSTING.md) — Deploying the brain: single machine, LAN, or VPS behind a reverse proxy
 - [docs/LLM_PROVIDERS.md](docs/LLM_PROVIDERS.md) — LLM provider configuration and routing
 - [docs/VAULT_EXTRACTOR.md](docs/VAULT_EXTRACTOR.md) — Memory and knowledge vault
 - [docs/PERSONALITY_ENGINE.md](docs/PERSONALITY_ENGINE.md) — Personality and role system

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -10,6 +10,18 @@ daemon:
   # can actually reach, not localhost or a private/container-only hostname.
   # Env override: JARVIS_BRAIN_DOMAIN="https://brain.example.com"
   # brain_domain: "https://brain.example.com"
+  # Bind a unix domain socket INSTEAD of a TCP port (for a reverse proxy on
+  # the same host). When set, nothing listens on TCP. See docs/SELF_HOSTING.md.
+  # listen: "unix:/run/jarvis/jarvis.sock"
+
+# IANA timezone for cron triggers and morning/evening routines. Set this when
+# the server clock is not your local time (e.g. a UTC-hosted VPS).
+# timezone: "Europe/Rome"
+
+# Set local: false on headless servers (no display): the brain never launches
+# a local Chromium; browser actions route to a connected sidecar's browser.
+# browser:
+#   local: false
 
 # Authentication — JWT-only by DEFAULT. The dashboard, API, and WebSocket
 # require a token from an enrolled device. Correct setup order:

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -1,0 +1,267 @@
+# Self-Hosting Guide
+
+How to run the Jarvis brain yourself and connect to it securely. This covers
+the three common deployment shapes:
+
+1. [Single machine](#1-single-machine) - brain and browser on the same computer
+2. [Home LAN](#2-home-lan) - brain on one machine, accessed from others via IP
+3. [VPS with a domain](#3-vps-with-a-domain) - brain on a public server behind a reverse proxy
+
+Read [How connections work](#how-connections-work) first if you want the model
+in your head; skip straight to your scenario if you just want it running.
+
+## How connections work
+
+Two facts drive every decision below:
+
+**The brain never terminates TLS itself.** The daemon serves plain HTTP on
+`daemon.port` (default 3142), or a unix domain socket if `daemon.listen` is
+set. If you want HTTPS - and for anything beyond a single machine you do -
+you put a reverse proxy (Caddy, nginx, traefik) in front. The daemon honors
+`X-Forwarded-Proto`, so cookies and redirects behave correctly behind a
+proxy.
+
+**Access is JWT-only by default.** There is no shared password or token. You
+enroll devices:
+
+```
+jarvis enroll "my-desktop"
+```
+
+This mints a long-lived enrollment token (ES256 JWT) and prints it. The
+enrollment token is accepted on exactly two endpoints: `/sidecar/connect`
+(the sidecar WebSocket) and `POST /sidecar/token`, which exchanges it for a
+short-lived access token (10 minutes). Everything else - dashboard, API,
+`/ws` - requires an access token. The desktop sidecar app handles this
+automatically: paste the enrollment token into it once, and it connects,
+re-mints access tokens as needed, and opens dashboard panels that are already
+authenticated.
+
+The only public (unauthenticated) routes are `/health`, `/sidecar/connect`,
+the JWKS endpoint (`/api/sidecars/.well-known/jwks.json`), and
+`/api/webhooks/*`.
+
+Device management runs without the daemon (the CLIs open the database
+directly), so you can manage devices over SSH:
+
+```
+jarvis enroll "<name>"            # mint (or re-mint) a device token
+jarvis enroll "<name>" --rotate   # re-enroll AND invalidate all previous tokens
+jarvis sidecars list [--json]     # list enrolled devices
+jarvis revoke <sid>               # revoke a device
+```
+
+Revoking takes effect within ~30 seconds on a running daemon (it sweeps and
+severs live sessions of revoked devices), and immediately for new
+connections and token mints.
+
+### The URL baked into enrollment tokens
+
+`jarvis enroll` embeds the brain's address into the token - that is where the
+sidecar will connect. It comes from `daemon.brain_domain` in `config.yaml`
+(env override: `JARVIS_BRAIN_DOMAIN`). If unset, tokens point at
+`localhost:<port>` and only work for sidecars on the same machine; the CLI
+warns when this happens.
+
+The scheme rules are secure by default:
+
+- A full URL is respected: `https://jarvis.example.com` gives `wss`,
+  `http://192.168.1.10:3142` gives plain `ws`.
+- A bare host is assumed **secure** (`wss`/`https`) unless it is a loopback
+  address (`localhost`, `127.0.0.1`, `[::1]`).
+
+The consequence: a bare LAN IP like `192.168.1.10:3142` produces a `wss://`
+URL, and the sidecar will fail its TLS handshake against the plain-HTTP
+daemon. Plaintext to anything that is not loopback must be spelled out with
+an explicit `http://` prefix. It is never inferred, so a public brain can't
+silently downgrade to sending tokens in the clear.
+
+### First-time setup escape hatch
+
+Enrollment normally happens from a working dashboard or the CLI. If you are
+setting up without a sidecar and need the dashboard open before any device
+exists, `config.yaml` accepts:
+
+```yaml
+auth:
+  insecure_open_access: true
+```
+
+While this is on, **anyone who can reach the daemon can use your Jarvis** -
+the daemon logs a loud warning on every boot. Use it on a machine that is
+not exposed (or reachable only via localhost/SSH tunnel), enroll your first
+device, then remove the flag and restart. It can only be enabled by editing
+the file on the server; nothing in the dashboard or API can turn it on.
+
+## 1. Single machine
+
+The simplest case, and the only one that needs no TLS at all.
+
+```
+jarvis start
+jarvis enroll "my-desktop"    # paste the token into the desktop sidecar app
+```
+
+Browsers treat `localhost` as a secure context, so the dashboard at
+`http://localhost:3142` gets microphone access (voice, wake word), clipboard,
+and every other gated API without a certificate. Enrollment recognizes
+loopback and mints plain `ws://localhost:3142` tokens. Everything works.
+
+## 2. Home LAN
+
+Brain on one machine (say `192.168.1.10`), dashboard and sidecars on others.
+
+Set the brain address so tokens point somewhere reachable, with an explicit
+`http://` since there is no TLS on the LAN:
+
+```yaml
+daemon:
+  brain_domain: "http://192.168.1.10:3142"
+```
+
+Then enroll each device and paste the token into its sidecar. Remember:
+without the explicit `http://`, a bare `192.168.1.10:3142` is treated as
+secure and the sidecar will try `wss://` and fail to connect.
+
+### What works over plain HTTP on a LAN
+
+Auth works: the login cookie is intentionally not marked `Secure` on plain
+HTTP, so the token flow functions. Chat, tools, workflows - all fine.
+Sending tokens in cleartext across your own LAN is the accepted tradeoff
+here; don't do it on a network you don't trust.
+
+What does NOT work from a `http://192.168.x.x` dashboard is anything the
+browser gates behind secure contexts. That is browser policy and cannot be
+polyfilled:
+
+- **No microphone**: voice input and wake word are unavailable.
+- **Clipboard**: copy buttons fall back to select-and-copy manually.
+
+### Getting the full experience on a LAN
+
+Any of these turns the dashboard into a secure context (and lets enrollment
+default to `wss`):
+
+- **SSH tunnel / port-forward**: `ssh -L 3142:localhost:3142 user@192.168.1.10`,
+  then browse `http://localhost:3142`. Zero config, since localhost is a
+  secure context.
+- **Tailscale**: install it on the machines and use `tailscale cert` /
+  Tailscale Serve for automatic HTTPS between your own devices.
+- **Local CA**: run Caddy with its internal CA (or mkcert) on the brain
+  machine and trust the certificate on your client devices.
+
+## 3. VPS with a domain
+
+The production shape: a reverse proxy owns ports 80/443 and TLS, the daemon
+listens privately behind it.
+
+`~/.jarvis/config.yaml` on the VPS:
+
+```yaml
+daemon:
+  port: 3142                                    # bound behind the proxy
+  brain_domain: "https://jarvis.example.com"    # what goes into device tokens
+```
+
+Caddy makes the proxy a two-liner (automatic Let's Encrypt certificates,
+WebSocket support out of the box):
+
+```
+jarvis.example.com {
+    reverse_proxy 127.0.0.1:3142
+}
+```
+
+nginx needs the WebSocket upgrade and forwarded-proto headers spelled out:
+
+```nginx
+server {
+    listen 443 ssl;
+    server_name jarvis.example.com;
+    # ssl_certificate / ssl_certificate_key ...
+
+    location / {
+        proxy_pass http://127.0.0.1:3142;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 300s;
+    }
+}
+```
+
+Make sure port 3142 is not directly reachable from the internet (bind
+firewall rules accordingly, or use the unix socket below and skip TCP
+entirely). If you expose it raw, the failure mode is at least the safe one:
+tokens enrolled against the `https://` domain use `wss` and will refuse to
+connect over plain HTTP - but the dashboard would be reachable in cleartext,
+so don't.
+
+Then, over SSH on the VPS:
+
+```
+jarvis enroll "my-laptop"
+```
+
+Because `brain_domain` is an `https://` URL, the token carries
+`wss://jarvis.example.com/sidecar/connect`. Paste it into the sidecar on
+your laptop and everything - dashboard included - flows through TLS. The
+dashboard is a secure context, so voice and all other features work.
+
+### Unix socket instead of a TCP port
+
+If the proxy runs on the same host, you can remove the TCP listener
+entirely:
+
+```yaml
+daemon:
+  listen: "unix:/run/jarvis/jarvis.sock"
+```
+
+```
+jarvis.example.com {
+    reverse_proxy unix//run/jarvis/jarvis.sock
+}
+```
+
+The daemon binds only the socket (created mode 0660, so put the proxy user
+in your group), and nothing on the machine can reach it over TCP.
+
+### Headless servers and the browser
+
+A VPS usually has no display. Set:
+
+```yaml
+browser:
+  local: false
+```
+
+and the brain will never try to launch a local Chromium; browser actions
+route to a connected sidecar's browser (your desktop) instead.
+
+### Timezone
+
+A VPS typically runs on UTC. Set your IANA timezone so cron triggers and
+morning/evening routines fire at your wall-clock time:
+
+```yaml
+timezone: "Europe/Rome"
+```
+
+## Quick reference
+
+| | Single machine | LAN via IP | VPS + domain |
+|---|---|---|---|
+| TLS needed | no | no (with tradeoffs) | yes, via reverse proxy |
+| `brain_domain` | not needed | `http://<ip>:3142` (explicit scheme) | `https://your.domain` |
+| Voice / mic in dashboard | yes | no (secure-context gated) | yes |
+| Tokens on the wire | loopback only | cleartext on your LAN | encrypted |
+| Sidecar URL in tokens | `ws://localhost:3142` | `ws://<ip>:3142` | `wss://your.domain` |
+
+## Health checks
+
+`GET /health` is unauthenticated and safe to point uptime monitors at. It
+works over the unix socket too, e.g.
+`curl --unix-socket /run/jarvis/jarvis.sock http://localhost/health`.


### PR DESCRIPTION
There was no documentation for running the brain anywhere other than
localhost. After the JWT-only auth and connection changes, self-hosters
have real setup decisions to make (reverse proxy, brain_domain, token
scheme rules) and at least one non-obvious failure mode, so this writes
it all down.

Adds docs/SELF_HOSTING.md covering the three deployment shapes:

- Single machine: no TLS needed, localhost is a secure context,
  everything works out of the box.
- Home LAN via IP: requires brain_domain with an EXPLICIT http:// scheme.
  A bare LAN IP is classified as secure, gets wss:// baked into the
  enrollment token, and the sidecar fails its TLS handshake against the
  plain-HTTP daemon with no obvious hint. This is the failure that would
  otherwise land as "sidecar won't connect" support requests. Also
  documents what plain HTTP does and doesn't support: auth and chat work
  (the cookie deliberately drops the Secure flag on HTTP), but the
  browser gates mic/voice and clipboard behind secure contexts, plus
  three ways around it (SSH tunnel, Tailscale, local CA).
- VPS with a domain: reverse proxy examples (Caddy two-liner, nginx with
  WebSocket upgrade and X-Forwarded-Proto headers), firewalling the raw
  port, the daemon.listen unix-socket variant, browser.local: false for
  headless servers, and the timezone key for UTC hosts.

Plus a "How connections work" section explaining the auth model in one
place: enrollment JWT vs 10-minute access tokens, which routes are
public, the enroll/sidecars/revoke CLIs (including --rotate and the ~30s
revocation sweep for live sessions), and the insecure_open_access escape
hatch with its caveats.

Also:

- README: link the guide from the Configuration section and the docs list.
- config.example.yaml: document daemon.listen, timezone, and
  browser.local, which the guide relies on but were missing from the
  config reference.