### PR TITLE
Graceful drain: bounded quiesce -> drain -> teardown on SIGTERM

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -4,6 +4,9 @@ set -e
 echo "[pre-commit] Checking for Activepieces EE-licensed code..."
 bun run scripts/check-no-ee-imports.ts
 
+echo "[pre-commit] Checking migrations are expand/contract (rollback-safe)..."
+bun run scripts/check-migrations.ts
+
 # Bound the test step with a wall-clock timeout. A test that spawns the
 # engine subprocess and forgets to reap it can hang `bun test --bail`
 # indefinitely (observed once in late-May 2026, never reproduced). 240s

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,7 @@ jobs:
           bun-version: latest
       - run: bun install
       - run: bun run scripts/check-no-ee-imports.ts
+      - run: bun run scripts/check-migrations.ts
       - run: bun test
       - run: bunx tsc --noEmit
 

--- a/bin/jarvis.ts
+++ b/bin/jarvis.ts
@@ -4,7 +4,8 @@
  *
  * Usage:
  *   jarvis start [--port N] [-d|--detach]   Start the daemon
- *   jarvis stop [--port N]                  Stop the running daemon
+ *   jarvis stop [--port N]                  Stop the running daemon (graceful drain)
+ *   jarvis drain [--port N]                 Graceful drain + stop (finish in-flight work)
  *   jarvis status                           Show daemon status
  *   jarvis uninstall                        Remove JARVIS (detects install method)
  *   jarvis doctor                           Check environment & connectivity
@@ -22,6 +23,7 @@ import { acquireLock, releaseLock, isLocked, getLogPath } from '../src/daemon/pi
 import { c } from '../src/cli/helpers.ts';
 import { ensurePortReleased, getConfiguredPort, resolveStopPort } from '../src/cli/lifecycle.ts';
 import { getInstalledVersion } from '../src/cli/version.ts';
+import { loadConfig } from '../src/config/loader.ts';
 
 const PACKAGE_ROOT = join(import.meta.dir, '..');
 
@@ -134,9 +136,11 @@ async function cmdStart(args: string[]): Promise<void> {
       console.log(c.dim('  Stop it first with: jarvis stop'));
       process.exit(1);
     }
+    // Release the flock on final exit. Do NOT handle SIGINT/SIGTERM here: the
+    // daemon (src/daemon/index.ts) traps them and runs a bounded graceful
+    // DRAIN before exiting. A `process.exit(0)` from the CLI would preempt that
+    // async teardown mid-flight. The OS auto-releases the flock on exit anyway.
     process.on('exit', () => releaseLock());
-    process.on('SIGINT', () => { releaseLock(); process.exit(0); });
-    process.on('SIGTERM', () => { releaseLock(); process.exit(0); });
 
     const { startDaemon } = await import('../src/daemon/index.ts');
     await startDaemon({ port, dataDir, noLocalTools });
@@ -195,7 +199,8 @@ async function cmdStart(args: string[]): Promise<void> {
   }
 }
 
-async function cmdStop(args: string[] = []): Promise<void> {
+async function cmdStop(args: string[] = [], opts: { verb?: string } = {}): Promise<void> {
+  const verb = opts.verb ?? 'Stopping';
   const pid = isLocked();
 
   // Parse `--port N` for the no-lockfile recovery path. Ignored when the
@@ -237,19 +242,27 @@ async function cmdStop(args: string[] = []): Promise<void> {
     return;
   }
 
-  console.log(c.cyan(`Stopping JARVIS daemon (PID ${pid})...`));
+  console.log(c.cyan(`${verb} JARVIS daemon (PID ${pid})...`));
   try {
     process.kill(pid, 'SIGTERM');
 
-    // Wait up to 5s for graceful shutdown, then SIGKILL
+    // SIGTERM triggers a BOUNDED graceful drain in the daemon (finish in-flight
+    // turns/workflows within the deadline). Poll until it exits -- an idle
+    // daemon exits near-instantly; a busy one drains first. SIGKILL only if it
+    // overruns its own drain deadline (+ margin).
+    const cfg = await loadConfig().catch(() => null);
+    const graceMs = (cfg?.daemon?.drain_deadline_ms ?? 75_000) + 20_000;
+    const deadline = Date.now() + graceMs;
     let alive = true;
-    for (let i = 0; i < 10; i++) {
+    let ticks = 0;
+    while (Date.now() < deadline) {
       await new Promise(resolve => setTimeout(resolve, 500));
       try { process.kill(pid, 0); } catch { alive = false; break; }
+      if (++ticks === 6) console.log(c.dim('  Draining in-flight work...'));
     }
 
     if (alive) {
-      console.log(c.dim('  Process still alive, sending SIGKILL...'));
+      console.log(c.dim('  Drain deadline exceeded, sending SIGKILL...'));
       try { process.kill(pid, 'SIGKILL'); } catch { /* already gone */ }
     }
 
@@ -400,6 +413,10 @@ switch (command) {
     break;
   case 'stop':
     await cmdStop(commandArgs);
+    break;
+  case 'drain':
+    // Same signal as stop (SIGTERM -> bounded graceful drain); clearer label.
+    await cmdStop(commandArgs, { verb: 'Draining' });
     break;
   case 'restart':
     await cmdRestart(commandArgs);

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "build:ui": "bun build ui/index.html ui/pebble.html --outdir ui/dist",
     "test": "bun test",
     "check:no-ee": "bun run scripts/check-no-ee-imports.ts",
+    "check:migrations": "bun run scripts/check-migrations.ts",
     "sync:pieces": "bun run scripts/sync-pieces-catalog.ts",
     "check:pieces": "bun run scripts/sync-pieces-catalog.ts --check",
     "build:workflows": "bun run scripts/build-workflows.ts",

--- a/scripts/check-migrations.test.ts
+++ b/scripts/check-migrations.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+import { contractKind, scanContent, OK_MARKER } from "./check-migrations.ts";
+
+describe("check-migrations contractKind", () => {
+  test("flags contracting DDL", () => {
+    expect(contractKind("db.run('ALTER TABLE t DROP COLUMN c')")).toBe("DROP COLUMN");
+    expect(contractKind("db.run('DROP TABLE t')")).toBe("DROP TABLE");
+    expect(contractKind("db.run('ALTER TABLE t RENAME COLUMN a TO b')")).toBe("RENAME COLUMN");
+    expect(contractKind("db.run('ALTER TABLE t RENAME TO t2')")).toBe("RENAME TABLE");
+    expect(contractKind("db.run('ALTER TABLE t ADD COLUMN c TEXT NOT NULL')")).toBe(
+      "ADD COLUMN NOT NULL without DEFAULT",
+    );
+  });
+
+  test("allows additive DDL", () => {
+    expect(contractKind("db.run('ALTER TABLE t ADD COLUMN c TEXT')")).toBeNull();
+    expect(contractKind("db.run(`ALTER TABLE t ADD COLUMN c TEXT NOT NULL DEFAULT ''`)")).toBeNull();
+    expect(contractKind("db.run('CREATE TABLE IF NOT EXISTS t (id INTEGER)')")).toBeNull();
+    expect(contractKind("db.run('CREATE INDEX IF NOT EXISTS i ON t(c)')")).toBeNull();
+  });
+
+  test("scanContent reports un-acknowledged contracts but honors the marker", () => {
+    const bad = "db.run('ALTER TABLE t DROP COLUMN c')";
+    expect(scanContent("f.ts", bad)).toHaveLength(1);
+    expect(scanContent("f.ts", `${bad} // ${OK_MARKER}: reader gone`)).toHaveLength(0);
+  });
+});

--- a/scripts/check-migrations.test.ts
+++ b/scripts/check-migrations.test.ts
@@ -12,11 +12,24 @@ describe("check-migrations contractKind", () => {
     );
   });
 
+  test("flags a unique index (contracting) but not a plain index", () => {
+    expect(contractKind("db.run('CREATE UNIQUE INDEX u ON t(c)')")).toBe("CREATE UNIQUE INDEX");
+    expect(contractKind("db.run('CREATE INDEX IF NOT EXISTS i ON t(c)')")).toBeNull();
+  });
+
   test("allows additive DDL", () => {
     expect(contractKind("db.run('ALTER TABLE t ADD COLUMN c TEXT')")).toBeNull();
     expect(contractKind("db.run(`ALTER TABLE t ADD COLUMN c TEXT NOT NULL DEFAULT ''`)")).toBeNull();
     expect(contractKind("db.run('CREATE TABLE IF NOT EXISTS t (id INTEGER)')")).toBeNull();
-    expect(contractKind("db.run('CREATE INDEX IF NOT EXISTS i ON t(c)')")).toBeNull();
+  });
+
+  test("comments do not waive or falsely trip detection", () => {
+    // A comment word 'default' must NOT waive a real NOT NULL add.
+    expect(contractKind("db.run('ALTER TABLE t ADD COLUMN c TEXT NOT NULL') // app default")).toBe(
+      "ADD COLUMN NOT NULL without DEFAULT",
+    );
+    // A comment mentioning drop column must NOT be flagged (no real DDL).
+    expect(contractKind("// TODO: drop column legacy_id next release")).toBeNull();
   });
 
   test("scanContent reports un-acknowledged contracts but honors the marker", () => {

--- a/scripts/check-migrations.ts
+++ b/scripts/check-migrations.ts
@@ -39,13 +39,22 @@ interface Violation {
   text: string;
 }
 
+/** Strip line/block comments so a comment word (e.g. "default", or a `// drop
+ *  column later` note) can't waive OR falsely trip the DDL detection. */
+function stripComments(line: string): string {
+  return line.replace(/\/\*.*?\*\//g, "").replace(/\/\/.*$/, "");
+}
+
 /** Classify a DDL line's rollback hazard, or null if additive/safe. */
 export function contractKind(line: string): string | null {
-  const l = line.toLowerCase();
+  const l = stripComments(line).toLowerCase();
   if (/\bdrop\s+column\b/.test(l)) return "DROP COLUMN";
   if (/\bdrop\s+table\b/.test(l)) return "DROP TABLE";
   if (/\brename\s+column\b/.test(l)) return "RENAME COLUMN";
   if (/\brename\s+to\b/.test(l)) return "RENAME TABLE";
+  // A unique index on an existing table rejects the duplicate rows an older
+  // version legally wrote -> contracting (a plain index is additive/fine).
+  if (/\bcreate\s+unique\s+index\b/.test(l)) return "CREATE UNIQUE INDEX";
   // ADD COLUMN ... NOT NULL with no DEFAULT on the same statement.
   if (/\badd\s+column\b/.test(l) && /\bnot\s+null\b/.test(l) && !/\bdefault\b/.test(l)) {
     return "ADD COLUMN NOT NULL without DEFAULT";
@@ -72,7 +81,11 @@ function main(): void {
     try {
       content = readFileSync(join(REPO_ROOT, rel), "utf-8");
     } catch {
-      continue; // file may not exist in every checkout
+      // A listed DDL file that's gone (moved/renamed/typo) must FAIL loudly --
+      // a silent skip is indistinguishable from "scanned + clean" and would
+      // disable the guard. Update DDL_FILES if the schema genuinely moved.
+      console.error(`[check-migrations] DDL file not found: ${rel} (update DDL_FILES if it moved)`);
+      process.exit(1);
     }
     violations.push(...scanContent(rel, content));
   }

--- a/scripts/check-migrations.ts
+++ b/scripts/check-migrations.ts
@@ -1,0 +1,100 @@
+#!/usr/bin/env bun
+/**
+ * Guard: enforce expand/contract migration discipline on the per-instance DB
+ * DDL, so a rolling brain update stays rollback-safe (UPDATES.md).
+ *
+ * Per-instance SQLite migrations run on brain boot (idempotent `ALTER TABLE`
+ * blocks in the scanned files) and are coupled to the code version. During a
+ * rollout the fleet runs TWO versions at once, and a rollback repins an instance
+ * to the PREVIOUS version's code on the NEW version's schema. That only works if
+ * every migration is additive within the rollback window: a new version may only
+ * ADD (nullable columns, new tables) and must still read the old shape; a column
+ * is DROP/renamed only a version LATER, once the readers are out of the window.
+ *
+ * Fails (exit 1) on rollback-hazardous DDL unless the line carries the marker
+ * `expand-contract-ok` (in a comment), which is a human's explicit assertion
+ * that the prior reader is already out of the rollback window:
+ *   1. DROP COLUMN / DROP TABLE / RENAME COLUMN / RENAME TO  -- contracting.
+ *   2. ADD COLUMN ... NOT NULL without a DEFAULT             -- breaks existing
+ *      rows on apply AND old-version inserts that omit the column.
+ *
+ * Run via: `bun run scripts/check-migrations.ts`, the pre-commit hook, and CI.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const REPO_ROOT = new URL("..", import.meta.url).pathname.replace(/\/$/, "");
+
+// Per-instance DB DDL sources (the user data whose shape a rollback depends on).
+const DDL_FILES = ["src/vault/schema.ts", "src/workflows/db/schema.ts"];
+
+/** A line opts out with this marker in a comment (acknowledged as window-safe). */
+export const OK_MARKER = "expand-contract-ok";
+
+interface Violation {
+  file: string;
+  line: number;
+  kind: string;
+  text: string;
+}
+
+/** Classify a DDL line's rollback hazard, or null if additive/safe. */
+export function contractKind(line: string): string | null {
+  const l = line.toLowerCase();
+  if (/\bdrop\s+column\b/.test(l)) return "DROP COLUMN";
+  if (/\bdrop\s+table\b/.test(l)) return "DROP TABLE";
+  if (/\brename\s+column\b/.test(l)) return "RENAME COLUMN";
+  if (/\brename\s+to\b/.test(l)) return "RENAME TABLE";
+  // ADD COLUMN ... NOT NULL with no DEFAULT on the same statement.
+  if (/\badd\s+column\b/.test(l) && /\bnot\s+null\b/.test(l) && !/\bdefault\b/.test(l)) {
+    return "ADD COLUMN NOT NULL without DEFAULT";
+  }
+  return null;
+}
+
+/** Scan a DDL file's text for un-acknowledged contracting DDL. */
+export function scanContent(file: string, content: string): Violation[] {
+  const out: Violation[] = [];
+  content.split("\n").forEach((line, i) => {
+    const kind = contractKind(line);
+    if (!kind) return;
+    if (line.includes(OK_MARKER)) return; // acknowledged as rollback-window-safe
+    out.push({ file, line: i + 1, kind, text: line.trim() });
+  });
+  return out;
+}
+
+function main(): void {
+  const violations: Violation[] = [];
+  for (const rel of DDL_FILES) {
+    let content: string;
+    try {
+      content = readFileSync(join(REPO_ROOT, rel), "utf-8");
+    } catch {
+      continue; // file may not exist in every checkout
+    }
+    violations.push(...scanContent(rel, content));
+  }
+
+  if (violations.length === 0) {
+    console.log("[check-migrations] OK -- no un-acknowledged contracting DDL.");
+    return;
+  }
+
+  console.error("[check-migrations] Rollback-hazardous DDL found (expand/contract):\n");
+  for (const v of violations) {
+    console.error(`  ${v.file}:${v.line}  [${v.kind}]`);
+    console.error(`    ${v.text}`);
+  }
+  console.error(
+    `\nA rollback repins an instance to the PREVIOUS version's code. The above` +
+      `\nchanges would break that version reading the new schema. Either make it` +
+      `\nadditive (keep the old shape this version, contract a version later), or` +
+      `\n-- if the prior reader is already out of the rollback window -- append a` +
+      `\ncomment containing "${OK_MARKER}" to the line to acknowledge it.`,
+  );
+  process.exit(1);
+}
+
+if (import.meta.main) main();

--- a/src/comms/websocket.test.ts
+++ b/src/comms/websocket.test.ts
@@ -50,8 +50,8 @@ test('WebSocketServer - health endpoint', async () => {
 test('WebSocketServer - health reports the JARVIS_VERSION pin', async () => {
   const prev = process.env.JARVIS_VERSION;
   process.env.JARVIS_VERSION = '2026.07.01';
-  server.start();
   try {
+    server.start(); // inside try so a start() throw still restores the env
     const data = (await (await fetch('http://localhost:3143/health')).json()) as any;
     expect(data.version).toBe('2026.07.01');
   } finally {

--- a/src/comms/websocket.test.ts
+++ b/src/comms/websocket.test.ts
@@ -41,8 +41,24 @@ test('WebSocketServer - health endpoint', async () => {
   expect(data.status).toBe('ok');
   expect(data.clients).toBe(0);
   expect(typeof data.uptime).toBe('number');
+  // version reflects the JARVIS_VERSION pin (null when unset, e.g. self-host).
+  expect(data).toHaveProperty('version');
 
   server.stop();
+});
+
+test('WebSocketServer - health reports the JARVIS_VERSION pin', async () => {
+  const prev = process.env.JARVIS_VERSION;
+  process.env.JARVIS_VERSION = '2026.07.01';
+  server.start();
+  try {
+    const data = (await (await fetch('http://localhost:3143/health')).json()) as any;
+    expect(data.version).toBe('2026.07.01');
+  } finally {
+    server.stop();
+    if (prev === undefined) delete process.env.JARVIS_VERSION;
+    else process.env.JARVIS_VERSION = prev;
+  }
 });
 
 test('WebSocketServer - root endpoint returns 404 without static dir', async () => {

--- a/src/comms/websocket.ts
+++ b/src/comms/websocket.ts
@@ -347,10 +347,15 @@ export class WebSocketServer {
           return new Response('WebSocket upgrade failed', { status: 500 });
         }
 
-        // 3. Health check (always public)
+        // 3. Health check (always public). `version` is the pinned release the
+        // process was launched from (systemd sets JARVIS_VERSION from the
+        // per-instance EnvironmentFile); the hosting control plane reads it to
+        // CONFIRM a rolling update actually landed on the target version rather
+        // than trusting the restart. `null` on self-host (no pin).
         if (pathname === '/health') {
           return Response.json({
             status: 'ok',
+            version: process.env.JARVIS_VERSION ?? null,
             uptime: Date.now() - self.startTime,
             clients: self.clients.size,
             timestamp: Date.now(),

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -363,6 +363,14 @@ export type JarvisConfig = {
      * the token is re-issued with a reachable origin.
      */
     brain_domain?: string;
+    /**
+     * Graceful-drain deadline (ms). On SIGTERM the daemon quiesces (stops
+     * accepting new work) and waits up to this long for in-flight agent turns
+     * and workflow runs to reach a safe point before tearing down. Kept UNDER
+     * the supervisor's kill grace (hosted: systemd `TimeoutStopSec=90`) so the
+     * drain finishes before SIGKILL. Default 75s.
+     */
+    drain_deadline_ms?: number;
   };
   auth?: AuthConfig;
   /**

--- a/src/daemon/active-turns.test.ts
+++ b/src/daemon/active-turns.test.ts
@@ -1,45 +1,48 @@
 import { describe, expect, test } from 'bun:test';
-import { activeTurns } from './active-turns.ts';
+import { ActiveTurns } from './active-turns.ts';
 
-// The singleton is shared; each test leaves the count at 0 and re-reads state.
-// (isDraining is monotonic, so the quiesce test runs last.)
+// Use fresh instances (not the process singleton) so tests are order-independent.
 
 describe('ActiveTurns', () => {
   test('begin/end move the in-flight count; end is idempotent', () => {
-    expect(activeTurns.active).toBe(0);
-    const end1 = activeTurns.begin();
-    const end2 = activeTurns.begin();
-    expect(activeTurns.active).toBe(2);
+    const t = new ActiveTurns();
+    expect(t.active).toBe(0);
+    const end1 = t.begin();
+    const end2 = t.begin();
+    expect(t.active).toBe(2);
     end1();
     end1(); // idempotent: no double-decrement
-    expect(activeTurns.active).toBe(1);
+    expect(t.active).toBe(1);
     end2();
-    expect(activeTurns.active).toBe(0);
+    expect(t.active).toBe(0);
   });
 
   test('drain resolves immediately when nothing is in flight', async () => {
-    expect(await activeTurns.drain(1000)).toEqual({ drained: true, remaining: 0 });
+    expect(await new ActiveTurns().drain(1000)).toEqual({ drained: true, remaining: 0 });
   });
 
   test('drain resolves once in-flight turns finish before the deadline', async () => {
-    const end = activeTurns.begin();
-    const drainP = activeTurns.drain(2000);
+    const t = new ActiveTurns();
+    const end = t.begin();
+    const drainP = t.drain(2000);
     setTimeout(end, 10);
     expect(await drainP).toEqual({ drained: true, remaining: 0 });
   });
 
   test('drain reports remaining turns when the deadline is hit', async () => {
-    const end = activeTurns.begin();
-    const result = await activeTurns.drain(20); // shorter than the turn
+    const t = new ActiveTurns();
+    const end = t.begin();
+    const result = await t.drain(20); // shorter than the turn
     expect(result.drained).toBe(false);
     expect(result.remaining).toBe(1);
-    end(); // cleanup
-    expect(activeTurns.active).toBe(0);
+    end();
+    expect(t.active).toBe(0);
   });
 
   test('quiesce flips isDraining (refuses new turns)', () => {
-    expect(activeTurns.isDraining).toBe(false);
-    activeTurns.quiesce();
-    expect(activeTurns.isDraining).toBe(true);
+    const t = new ActiveTurns();
+    expect(t.isDraining).toBe(false);
+    t.quiesce();
+    expect(t.isDraining).toBe(true);
   });
 });

--- a/src/daemon/active-turns.test.ts
+++ b/src/daemon/active-turns.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from 'bun:test';
+import { activeTurns } from './active-turns.ts';
+
+// The singleton is shared; each test leaves the count at 0 and re-reads state.
+// (isDraining is monotonic, so the quiesce test runs last.)
+
+describe('ActiveTurns', () => {
+  test('begin/end move the in-flight count; end is idempotent', () => {
+    expect(activeTurns.active).toBe(0);
+    const end1 = activeTurns.begin();
+    const end2 = activeTurns.begin();
+    expect(activeTurns.active).toBe(2);
+    end1();
+    end1(); // idempotent: no double-decrement
+    expect(activeTurns.active).toBe(1);
+    end2();
+    expect(activeTurns.active).toBe(0);
+  });
+
+  test('drain resolves immediately when nothing is in flight', async () => {
+    expect(await activeTurns.drain(1000)).toEqual({ drained: true, remaining: 0 });
+  });
+
+  test('drain resolves once in-flight turns finish before the deadline', async () => {
+    const end = activeTurns.begin();
+    const drainP = activeTurns.drain(2000);
+    setTimeout(end, 10);
+    expect(await drainP).toEqual({ drained: true, remaining: 0 });
+  });
+
+  test('drain reports remaining turns when the deadline is hit', async () => {
+    const end = activeTurns.begin();
+    const result = await activeTurns.drain(20); // shorter than the turn
+    expect(result.drained).toBe(false);
+    expect(result.remaining).toBe(1);
+    end(); // cleanup
+    expect(activeTurns.active).toBe(0);
+  });
+
+  test('quiesce flips isDraining (refuses new turns)', () => {
+    expect(activeTurns.isDraining).toBe(false);
+    activeTurns.quiesce();
+    expect(activeTurns.isDraining).toBe(true);
+  });
+});

--- a/src/daemon/active-turns.ts
+++ b/src/daemon/active-turns.ts
@@ -9,7 +9,7 @@
  * overruns the deadline is ABANDONED (not checkpointed) — the process exits and
  * the user re-asks. One daemon per process, so a singleton is correct.
  */
-class ActiveTurns {
+export class ActiveTurns {
   private count = 0;
   private draining = false;
   private waiters: Array<() => void> = [];

--- a/src/daemon/active-turns.ts
+++ b/src/daemon/active-turns.ts
@@ -1,0 +1,82 @@
+/**
+ * In-flight primary agent-turn tracker, for graceful drain (UPDATES.md).
+ *
+ * Primary turns (WS chat, background reactions, commitments) are fire-and-forget
+ * and untracked elsewhere, so a drain has nothing to await. This is a tiny
+ * process-wide counter: entry points `begin()` a turn and call the returned
+ * `end` when it settles; the drain `quiesce()`s (new turns are refused) then
+ * `drain(deadline)`s (await the count to zero). Per UPDATES.md a turn that
+ * overruns the deadline is ABANDONED (not checkpointed) — the process exits and
+ * the user re-asks. One daemon per process, so a singleton is correct.
+ */
+class ActiveTurns {
+  private count = 0;
+  private draining = false;
+  private waiters: Array<() => void> = [];
+
+  /** Once draining, new turns should be refused (checked by the entry points). */
+  get isDraining(): boolean {
+    return this.draining;
+  }
+
+  /** Number of turns currently in flight. */
+  get active(): number {
+    return this.count;
+  }
+
+  /** Stop accepting new turns (idempotent). Existing turns keep running. */
+  quiesce(): void {
+    this.draining = true;
+  }
+
+  /**
+   * Mark a turn in-flight. Returns an idempotent `end` to call when it settles
+   * (success OR error) — always call it in a `finally` so a throwing turn can't
+   * leak the count and wedge the drain.
+   */
+  begin(): () => void {
+    this.count += 1;
+    let ended = false;
+    return () => {
+      if (ended) return;
+      ended = true;
+      this.count -= 1;
+      if (this.count === 0) this.flush();
+    };
+  }
+
+  /**
+   * Resolve when no turns are in flight, or after `deadlineMs`. `drained` is
+   * false on timeout (the caller then proceeds to teardown, abandoning them).
+   */
+  drain(deadlineMs: number): Promise<{ drained: boolean; remaining: number }> {
+    if (this.count === 0) return Promise.resolve({ drained: true, remaining: 0 });
+    return new Promise((resolve) => {
+      const timer = setTimeout(
+        () => resolve({ drained: false, remaining: this.count }),
+        deadlineMs,
+      );
+      this.waiters.push(() => {
+        clearTimeout(timer);
+        resolve({ drained: true, remaining: 0 });
+      });
+    });
+  }
+
+  private flush(): void {
+    const waiters = this.waiters;
+    this.waiters = [];
+    for (const w of waiters) w();
+  }
+}
+
+/** Thrown by turn entry points when the daemon is draining (reject new work). */
+export class DrainingError extends Error {
+  constructor() {
+    super('daemon is draining; not accepting new work');
+    this.name = 'DrainingError';
+  }
+}
+
+/** Process-wide singleton (one daemon per process). */
+export const activeTurns = new ActiveTurns();

--- a/src/daemon/agent-service.ts
+++ b/src/daemon/agent-service.ts
@@ -427,27 +427,36 @@ export class AgentService implements Service, IAgentService {
     stream: AsyncIterable<LLMStreamEvent>;
     onComplete: (fullText: string) => Promise<void>;
   } {
-    const systemPrompt = this.buildFullSystemPromptParts(channel, text);
-    if (siteContext) systemPrompt.dynamic += '\n\n' + siteContext;
+    // Same drain gate + in-flight tracking as streamMessage (the pebble image
+    // turn is a real turn — must not start mid-drain or run uncounted).
+    if (activeTurns.isDraining) throw new DrainingError();
+    const endTurn = activeTurns.begin();
+    try {
+      const systemPrompt = this.buildFullSystemPromptParts(channel, text);
+      if (siteContext) systemPrompt.dynamic += '\n\n' + siteContext;
 
-    const content: import('../llm/provider.ts').ContentBlock[] = [
-      { type: 'image', source: { type: 'base64', media_type: mediaType, data: imageBase64 } },
-      { type: 'text', text },
-    ];
-    const stream = this.orchestrator.streamMessage(systemPrompt, content);
+      const content: import('../llm/provider.ts').ContentBlock[] = [
+        { type: 'image', source: { type: 'base64', media_type: mediaType, data: imageBase64 } },
+        { type: 'text', text },
+      ];
+      const stream = this.orchestrator.streamMessage(systemPrompt, content);
 
-    const onComplete = async (fullText: string): Promise<void> => {
-      await Promise.allSettled([
-        this.extractKnowledge(text, fullText).catch((err) =>
-          console.error('[AgentService] Extraction error:', err instanceof Error ? err.message : err)
-        ),
-        this.learnFromInteraction(text, fullText, channel).catch((err) =>
-          console.error('[AgentService] Learning error:', err instanceof Error ? err.message : err)
-        ),
-      ]);
-    };
+      const onComplete = async (fullText: string): Promise<void> => {
+        await Promise.allSettled([
+          this.extractKnowledge(text, fullText).catch((err) =>
+            console.error('[AgentService] Extraction error:', err instanceof Error ? err.message : err)
+          ),
+          this.learnFromInteraction(text, fullText, channel).catch((err) =>
+            console.error('[AgentService] Learning error:', err instanceof Error ? err.message : err)
+          ),
+        ]);
+      };
 
-    return { stream, onComplete };
+      return { stream: trackTurnStream(stream, endTurn), onComplete };
+    } catch (err) {
+      endTurn();
+      throw err;
+    }
   }
 
   /**
@@ -461,7 +470,8 @@ export class AgentService implements Service, IAgentService {
    *     ReAct loop on the medium tier).
    */
   async handleMessage(text: string, channel: string = 'websocket'): Promise<string> {
-    // Background turns (event reactions, commitments, bg-agent) route here.
+    // Non-streaming turn entry (external channels, etc). Background reactions go
+    // through BackgroundAgentService.handleMessage, which is gated separately.
     if (activeTurns.isDraining) throw new DrainingError();
     const endTurn = activeTurns.begin();
     try {

--- a/src/daemon/agent-service.ts
+++ b/src/daemon/agent-service.ts
@@ -14,7 +14,21 @@ import type { RoleDefinition } from '../roles/types.ts';
 import type { PersonalityModel } from '../personality/model.ts';
 
 import { LLMManager } from '../llm/manager.ts';
+import { activeTurns, DrainingError } from './active-turns.ts';
 import { registerLLMProviders, configureLLMTiers } from '../llm/config-binding.ts';
+
+/** Wrap a turn's stream so the in-flight count is released when it settles
+ *  (exhausted, errored, or the consumer breaks). `endTurn` is idempotent. */
+async function* trackTurnStream(
+  inner: AsyncIterable<LLMStreamEvent>,
+  endTurn: () => void,
+): AsyncGenerator<LLMStreamEvent> {
+  try {
+    yield* inner;
+  } finally {
+    endTurn();
+  }
+}
 import { getDb } from '../vault/schema.ts';
 import { AgentOrchestrator } from '../agents/orchestrator.ts';
 import { loadRole } from '../roles/loader.ts';
@@ -271,6 +285,23 @@ export class AgentService implements Service, IAgentService {
     stream: AsyncIterable<LLMStreamEvent>;
     onComplete: (fullText: string) => Promise<void>;
   } {
+    // Refuse new turns once draining; otherwise count this one in-flight so a
+    // graceful drain can await it (released when the tracked stream settles).
+    if (activeTurns.isDraining) throw new DrainingError();
+    const endTurn = activeTurns.begin();
+    try {
+      const inner = this.streamMessageInner(text, channel, siteContext);
+      return { stream: trackTurnStream(inner.stream, endTurn), onComplete: inner.onComplete };
+    } catch (err) {
+      endTurn();
+      throw err;
+    }
+  }
+
+  private streamMessageInner(text: string, channel: string = 'websocket', siteContext?: string): {
+    stream: AsyncIterable<LLMStreamEvent>;
+    onComplete: (fullText: string) => Promise<void>;
+  } {
     if (this.convOrchestrator) {
       return this.streamMessageConv(text, channel);
     }
@@ -430,26 +461,33 @@ export class AgentService implements Service, IAgentService {
    *     ReAct loop on the medium tier).
    */
   async handleMessage(text: string, channel: string = 'websocket'): Promise<string> {
-    let response: string;
+    // Background turns (event reactions, commitments, bg-agent) route here.
+    if (activeTurns.isDraining) throw new DrainingError();
+    const endTurn = activeTurns.begin();
+    try {
+      let response: string;
 
-    if (this.convOrchestrator) {
-      response = await this.handleMessageConv(text, channel);
-    } else {
-      const systemPrompt = this.buildFullSystemPromptParts(channel, text);
-      response = await this.orchestrator.processMessage(systemPrompt, text);
+      if (this.convOrchestrator) {
+        response = await this.handleMessageConv(text, channel);
+      } else {
+        const systemPrompt = this.buildFullSystemPromptParts(channel, text);
+        response = await this.orchestrator.processMessage(systemPrompt, text);
+      }
+
+      // Run extraction and learning in parallel (non-blocking but tracked)
+      Promise.allSettled([
+        this.extractKnowledge(text, response).catch((err) =>
+          console.error('[AgentService] Extraction error:', err instanceof Error ? err.message : err)
+        ),
+        this.learnFromInteraction(text, response, channel).catch((err) =>
+          console.error('[AgentService] Learning error:', err instanceof Error ? err.message : err)
+        ),
+      ]);
+
+      return response;
+    } finally {
+      endTurn();
     }
-
-    // Run extraction and learning in parallel (non-blocking but tracked)
-    Promise.allSettled([
-      this.extractKnowledge(text, response).catch((err) =>
-        console.error('[AgentService] Extraction error:', err instanceof Error ? err.message : err)
-      ),
-      this.learnFromInteraction(text, response, channel).catch((err) =>
-        console.error('[AgentService] Learning error:', err instanceof Error ? err.message : err)
-      ),
-    ]);
-
-    return response;
   }
 
   /**

--- a/src/daemon/background-agent-service.ts
+++ b/src/daemon/background-agent-service.ts
@@ -13,6 +13,7 @@ import { join } from 'node:path';
 import { homedir } from 'node:os';
 import type { Service, ServiceStatus } from './services.ts';
 import type { IAgentService } from './agent-service-interface.ts';
+import { activeTurns } from './active-turns.ts';
 import type { JarvisConfig } from '../config/types.ts';
 import type { RoleDefinition } from '../roles/types.ts';
 import type { LLMManager } from '../llm/manager.ts';
@@ -126,21 +127,29 @@ export class BackgroundAgentService implements Service, IAgentService {
    * Handle a reactive event message (from EventReactor / CommitmentExecutor).
    */
   async handleMessage(text: string, channel: string = 'system'): Promise<string> {
-    // Wait if busy — event reactor already has its own queue, so this is a safety net
-    const waitStart = Date.now();
-    while (this.busy && Date.now() - waitStart < 60_000) {
-      await new Promise(r => setTimeout(r, 1000));
-    }
-
-    this.busy = true;
+    // Don't START a background reaction once draining; count it in-flight
+    // otherwise so the graceful drain awaits it too (same as the primary turns).
+    if (activeTurns.isDraining) return 'skipped: draining';
+    const endTurn = activeTurns.begin();
     try {
-      const systemPrompt = this.buildSystemPromptParts(channel);
-      return await this.orchestrator.processMessage(systemPrompt, text);
-    } catch (err) {
-      console.error('[BackgroundAgent] Message error:', err);
-      return `Error: ${err instanceof Error ? err.message : String(err)}`;
+      // Wait if busy — event reactor already has its own queue, so this is a safety net
+      const waitStart = Date.now();
+      while (this.busy && Date.now() - waitStart < 60_000) {
+        await new Promise(r => setTimeout(r, 1000));
+      }
+
+      this.busy = true;
+      try {
+        const systemPrompt = this.buildSystemPromptParts(channel);
+        return await this.orchestrator.processMessage(systemPrompt, text);
+      } catch (err) {
+        console.error('[BackgroundAgent] Message error:', err);
+        return `Error: ${err instanceof Error ? err.message : String(err)}`;
+      } finally {
+        this.busy = false;
+      }
     } finally {
-      this.busy = false;
+      endTurn();
     }
   }
 

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -163,8 +163,16 @@ function logWithTimestamp(message: string): void {
  */
 async function handleShutdown(signal: string): Promise<void> {
   if (shutdownInProgress) {
-    console.log('\n[Daemon] Force shutdown requested, exiting immediately');
-    process.exit(1);
+    // A repeated SIGNAL means the operator/user wants to force-quit now.
+    if (signal === 'SIGINT' || signal === 'SIGTERM') {
+      console.log('\n[Daemon] Second signal — forcing immediate exit');
+      process.exit(1);
+    }
+    // But an internal error (uncaughtException/unhandledRejection) while we're
+    // already draining -- e.g. a stray rejection from a still-streaming turn --
+    // must NOT abort the drain (that would skip teardown + lose window state).
+    console.warn(`[Daemon] ${signal} during drain (ignored; drain continues)`);
+    return;
   }
 
   shutdownInProgress = true;
@@ -224,6 +232,12 @@ async function handleShutdown(signal: string): Promise<void> {
       triggerManager = null;
     }
 
+    // Begin stopping the workflow worker NOW, unawaited: stop() flips
+    // `running=false` synchronously so it won't claim a FRESH job during the
+    // drain window (which would then get only a sliver of budget and orphan),
+    // while its already-in-flight run keeps going. Awaited, bounded, in phase 3.
+    const workerStopping = workflowWorker ? workflowWorker.stop() : null;
+
     // ---- Phase 2: DRAIN -- await in-flight agent turns up to the deadline ----
     // Per UPDATES.md a turn is NOT checkpointed mid-flight: if it overruns we
     // abandon it (the process exits, the user re-asks). Workflow runs ARE
@@ -256,8 +270,11 @@ async function handleShutdown(signal: string): Promise<void> {
     if (workflowWorker) {
       const wfBudget = Math.max(2000, drainUntil - Date.now());
       const stopped = await Promise.race([
-        workflowWorker.stop().then(() => true),
-        new Promise<boolean>((r) => setTimeout(() => r(false), wfBudget)),
+        (workerStopping ?? Promise.resolve()).then(() => true),
+        new Promise<boolean>((r) => {
+          const t = setTimeout(() => r(false), wfBudget);
+          t.unref?.();
+        }),
       ]);
       if (!stopped) {
         console.log('[Drain] workflow worker over deadline; in-flight run left RUNNING for boot-recovery');
@@ -328,7 +345,15 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
     process.exit(1);
   }
 
-  drainDeadlineMs = jarvisConfig.daemon.drain_deadline_ms ?? 75_000;
+  // Drain budget: default 75s; a non-positive value falls back; cap at 85s so a
+  // misconfig can't push the drain past the supervisor's kill grace (systemd
+  // TimeoutStopSec=90) and get SIGKILLed mid-drain.
+  const configuredDrain = jarvisConfig.daemon.drain_deadline_ms;
+  drainDeadlineMs = configuredDrain && configuredDrain > 0 ? configuredDrain : 75_000;
+  if (drainDeadlineMs > 85_000) {
+    console.warn(`[Daemon] drain_deadline_ms=${drainDeadlineMs} exceeds the safe ceiling; capping at 85000`);
+    drainDeadlineMs = 85_000;
+  }
 
   // Determine data directory: CLI args > config file > default
   const dataDir = userConfig?.dataDir ?? jarvisConfig.daemon.data_dir ?? DEFAULT_DATA_DIR;

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -14,6 +14,7 @@ import { flushWindowState } from "./window-state.ts";
 import { ServiceRegistry } from "./services.ts";
 import { HealthMonitor } from "./health.ts";
 import { loadConfig } from "../config/loader.ts";
+import { activeTurns } from "./active-turns.ts";
 import { writeLockedPort } from "./pid.ts";
 import { AgentService } from "./agent-service.ts";
 import { createObservation } from "../vault/observations.ts";
@@ -41,6 +42,8 @@ import { sendDesktopNotification } from "../comms/desktop-notify.ts";
 import { SidecarManager, buildEnrollmentUrls } from "../sidecar/manager.ts";
 import { ensureWorkflowSchema } from "../workflows/db/index.ts";
 import { Worker as WorkflowWorker } from "../workflows/queue/worker.ts";
+import { recoverOrphanedJobs } from "../workflows/db/repos/job-queue.ts";
+import { TimerWaitpointScheduler } from "../workflows/timer-scheduler.ts";
 import { createRunFlowHandler, RUN_FLOW } from "../workflows/runner/handler.ts";
 import { createWorkflowRoutes } from "../workflows/api/routes.ts";
 import { TriggerManager } from "../workflows/runner/triggers/manager.ts";
@@ -81,6 +84,9 @@ let workflowWorker: WorkflowWorker | null = null;
 let triggerManager: TriggerManager | null = null;
 let workflowEngineShutdown: (() => Promise<void>) | null = null;
 let systemCron: import('./system-cron.ts').SystemCronService | null = null;
+let timerScheduler: TimerWaitpointScheduler | null = null;
+/** Graceful-drain deadline (ms), set from config at boot. Default 75s. */
+let drainDeadlineMs = 75_000;
 
 /**
  * Parse command line arguments
@@ -162,9 +168,25 @@ async function handleShutdown(signal: string): Promise<void> {
   }
 
   shutdownInProgress = true;
-  console.log(`\n[Daemon] Received ${signal}, shutting down gracefully...`);
+  console.log(`\n[Daemon] Received ${signal}, draining gracefully (deadline ${drainDeadlineMs}ms)...`);
 
   try {
+    // One wall-clock budget for the whole drain (turns + workflow), kept under
+    // the supervisor's SIGKILL grace.
+    const drainUntil = Date.now() + drainDeadlineMs;
+
+    // ---- Phase 1: QUIESCE -- stop accepting NEW work; keep in-flight alive ----
+    // New agent turns are refused (agent-service throws DrainingError); stop the
+    // timer/event SOURCES that would spawn turns or workflow jobs. The agent, WS,
+    // sidecar, and workflow worker stay UP so in-flight work can finish + stream.
+    activeTurns.quiesce();
+
+    // Stop the TIMER scheduler so it doesn't enqueue new resume jobs mid-drain.
+    if (timerScheduler) {
+      timerScheduler.stop();
+      timerScheduler = null;
+    }
+
     // Stop system cron (publishes cron.* events on the shared bus)
     if (systemCron) {
       systemCron.stop();
@@ -195,26 +217,51 @@ async function handleShutdown(signal: string): Promise<void> {
       bgAgent = null;
     }
 
-    // Stop health monitor
-    if (healthMonitor) {
-      healthMonitor.stop();
-    }
-
-    // Stop all services (reverse order: websocket -> observers -> agent)
-    if (registry) {
-      await registry.stopAll();
-    }
-
-    // Stop the trigger manager first so no new RUN_FLOW jobs get enqueued
-    // while the worker drains.
+    // Stop the trigger manager so no NEW RUN_FLOW jobs get enqueued while we
+    // drain (in-flight runs already claimed keep going).
     if (triggerManager) {
       await triggerManager.stop();
       triggerManager = null;
     }
 
-    // Stop the workflow worker (drains in-flight jobs, then exits the poll loop)
+    // ---- Phase 2: DRAIN -- await in-flight agent turns up to the deadline ----
+    // Per UPDATES.md a turn is NOT checkpointed mid-flight: if it overruns we
+    // abandon it (the process exits, the user re-asks). Workflow runs ARE
+    // durable (per-step checkpoint + resume), so they're handled in teardown.
+    const active = activeTurns.active;
+    if (active > 0) console.log(`[Drain] waiting for ${active} in-flight turn(s)...`);
+    const { drained, remaining } = await activeTurns.drain(Math.max(0, drainUntil - Date.now()));
+    if (drained) {
+      console.log('[Drain] all in-flight turns completed');
+    } else {
+      console.log(`[Drain] deadline reached; abandoning ${remaining} in-flight turn(s) (user re-asks)`);
+    }
+
+    // ---- Phase 3: TEARDOWN ----
+    // Stop health monitor
+    if (healthMonitor) {
+      healthMonitor.stop();
+    }
+
+    // Stop all services (reverse order: websocket -> observers -> agent). Safe
+    // now: turns are drained, so tearing down the agent/WS drops nothing live.
+    if (registry) {
+      await registry.stopAll();
+    }
+
+    // Stop the workflow worker (drains its in-flight run, then exits the poll
+    // loop) -- but bounded by the remaining budget. If a long run overruns, we
+    // leave it RUNNING; the next boot's recoverOrphanedJobs re-queues it to
+    // resume promptly (workflow state is durable, unlike agent turns).
     if (workflowWorker) {
-      await workflowWorker.stop();
+      const wfBudget = Math.max(2000, drainUntil - Date.now());
+      const stopped = await Promise.race([
+        workflowWorker.stop().then(() => true),
+        new Promise<boolean>((r) => setTimeout(() => r(false), wfBudget)),
+      ]);
+      if (!stopped) {
+        console.log('[Drain] workflow worker over deadline; in-flight run left RUNNING for boot-recovery');
+      }
       workflowWorker = null;
     }
 
@@ -280,6 +327,8 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
     console.error('[Daemon] Fix the YAML syntax in ~/.jarvis/config.yaml or delete it to use defaults.\n');
     process.exit(1);
   }
+
+  drainDeadlineMs = jarvisConfig.daemon.drain_deadline_ms ?? 75_000;
 
   // Determine data directory: CLI args > config file > default
   const dataDir = userConfig?.dataDir ?? jarvisConfig.daemon.data_dir ?? DEFAULT_DATA_DIR;
@@ -3777,11 +3826,20 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
       workflowSandboxApi.setServices(backends);
       logWithTimestamp("Workflow engine service backends wired (llm/tools/notify/context/agent/events/workflows)");
 
+      // Boot recovery: re-queue any run orphaned RUNNING by a prior crash /
+      // over-deadline drain so it resumes NOW, not after the lease lapses.
+      const recovered = recoverOrphanedJobs();
+      if (recovered > 0) logWithTimestamp(`Recovered ${recovered} orphaned workflow job(s) for resume`);
+
       const flowExecutor = new EngineFlowExecutor(workflowEngineRuntime);
       workflowWorker = new WorkflowWorker({
         handlers: { [RUN_FLOW]: createRunFlowHandler({ executor: flowExecutor }) },
       });
       workflowWorker.start();
+
+      // Resume TIMER waitpoints whose delay has elapsed (incl. during downtime).
+      timerScheduler = new TimerWaitpointScheduler();
+      timerScheduler.start();
     } else {
       console.warn("[Daemon] Workflow worker not started -- engine unavailable; queued RUN_FLOW jobs will pile up");
     }

--- a/src/sidecar/connection.ts
+++ b/src/sidecar/connection.ts
@@ -160,8 +160,12 @@ export class SidecarConnection {
     }
   }
 
-  /** Close connection and clean up */
-  close(): void {
+  /**
+   * Close connection and clean up. Pass a WS close code + reason for a graceful
+   * "going away" (1001) on drain, so the sidecar sees a clean planned-restart
+   * signal rather than an ambiguous drop (it reconnects either way).
+   */
+  close(code?: number, reason?: string): void {
     this.stopHeartbeat();
 
     // Reject all pending binary waits
@@ -172,7 +176,8 @@ export class SidecarConnection {
     this.pendingBinary.clear();
 
     try {
-      this.ws.close();
+      if (code !== undefined) this.ws.close(code, reason);
+      else this.ws.close();
     } catch {
       // Already closed
     }

--- a/src/sidecar/manager.ts
+++ b/src/sidecar/manager.ts
@@ -200,10 +200,12 @@ export class SidecarManager implements Service {
     // Stop scheduler
     this.scheduler.stop();
 
-    // Close all sidecar connections and fail pending RPCs
+    // Close all sidecar connections and fail pending RPCs. Use WS 1001 (Going
+    // Away) + reason so the sidecar recognizes a planned restart and reconnects
+    // promptly against the freshly-booted brain (same keys + JWT).
     for (const [id, conn] of this.sidecarConnections) {
       this.rpcTracker.failAll(id, 'manager stopping');
-      conn.close();
+      conn.close(1001, 'server restarting');
     }
     this.sidecarConnections.clear();
 

--- a/src/vault/schema.ts
+++ b/src/vault/schema.ts
@@ -429,8 +429,10 @@ function createTables(db: Database): void {
       created_at INTEGER NOT NULL
     )
   `);
-  // OCR moved to sidecar; thumbnails are no longer generated.
-  try { db.run('ALTER TABLE screen_captures DROP COLUMN thumbnail_path'); } catch { /* already dropped or never present */ }
+  // OCR moved to sidecar; thumbnails are no longer generated. Re-added as a
+  // nullable column below (~line 448) in the same boot, so a rolled-back reader
+  // still finds thumbnail_path.
+  try { db.run('ALTER TABLE screen_captures DROP COLUMN thumbnail_path'); } catch { /* expand-contract-ok: re-added nullable below */ }
   // Track which sidecar owns the capture file so the brain can route
   // fetch_capture RPCs correctly (sidecars may run on different hosts).
   try { db.run('ALTER TABLE screen_captures ADD COLUMN sidecar_id TEXT'); } catch { /* already present */ }

--- a/src/workflows/db/repos/job-queue.ts
+++ b/src/workflows/db/repos/job-queue.ts
@@ -200,10 +200,22 @@ export function getJob<P = Record<string, unknown>>(id: string): Job<P> | null {
  */
 export function recoverOrphanedJobs(): number {
   const ts = nowMs();
-  const res = db().run(
+  const d = db();
+  // Poison guard: a job that already hit its attempt ceiling terminates as
+  // FAILED instead of re-running (and possibly re-crashing the daemon on) its
+  // side-effectful steps in a tight boot loop forever. `claimNextJob` doesn't
+  // check max_attempts, so recovery must.
+  d.run(
+    `UPDATE workflow_job
+     SET status = 'FAILED', last_error = 'orphaned: max attempts exhausted', locked_until = NULL, updated = ?
+     WHERE status = 'RUNNING' AND attempt >= max_attempts`,
+    [ts],
+  );
+  // The rest re-queue for immediate re-claim.
+  const res = d.run(
     `UPDATE workflow_job
      SET status = 'QUEUED', locked_until = NULL, scheduled_at = ?, updated = ?
-     WHERE status = 'RUNNING'`,
+     WHERE status = 'RUNNING' AND attempt < max_attempts`,
     [ts, ts],
   );
   return res.changes;

--- a/src/workflows/db/repos/job-queue.ts
+++ b/src/workflows/db/repos/job-queue.ts
@@ -188,6 +188,27 @@ export function getJob<P = Record<string, unknown>>(id: string): Job<P> | null {
   return row ? rowToJob<P>(row) : null;
 }
 
+/**
+ * Boot-time recovery (UPDATES.md graceful-drain resume). The daemon is
+ * single-process, so any job still `RUNNING` at startup was orphaned by the
+ * previous process's death (crash, or a drain that exceeded its deadline).
+ * Reset such jobs to `QUEUED` with the lease cleared and `scheduled_at=now` so
+ * the worker re-claims them IMMEDIATELY, instead of waiting out the (up to
+ * `leaseMs`, default 5-min) lease lapse. The run re-executes from its last
+ * durable checkpoint. Returns how many jobs were recovered. Must run BEFORE the
+ * worker starts polling.
+ */
+export function recoverOrphanedJobs(): number {
+  const ts = nowMs();
+  const res = db().run(
+    `UPDATE workflow_job
+     SET status = 'QUEUED', locked_until = NULL, scheduled_at = ?, updated = ?
+     WHERE status = 'RUNNING'`,
+    [ts, ts],
+  );
+  return res.changes;
+}
+
 export function completeJob(id: string): void {
   const ts = nowMs();
   const res = db().run(

--- a/src/workflows/db/repos/waitpoint.ts
+++ b/src/workflows/db/repos/waitpoint.ts
@@ -149,6 +149,24 @@ export function listWaitpointsByFlowRun(
     .map(rowToWaitpoint);
 }
 
+/**
+ * Active TIMER waitpoints whose resume time has arrived (`resume_date_time <=
+ * now`). Drives the TIMER scheduler (UPDATES.md) — a delay/wait step whose
+ * timer elapsed (incl. during downtime) has no other resume trigger. ISO-8601
+ * strings sort chronologically, so a lexical `<=` is a time comparison.
+ */
+export function listDueTimerWaitpoints(nowIso: string, limit = 100): Waitpoint[] {
+  return db()
+    .prepare<WaitpointRow, [string, number]>(
+      `SELECT * FROM waitpoint
+       WHERE type = 'TIMER' AND resumed_at IS NULL
+         AND resume_date_time IS NOT NULL AND resume_date_time <= ?
+       ORDER BY resume_date_time ASC LIMIT ?`,
+    )
+    .all(nowIso, limit)
+    .map(rowToWaitpoint);
+}
+
 export function markWaitpointResumed(id: string, now = Date.now()): boolean {
   const r = db()
     .prepare(`UPDATE waitpoint SET resumed_at = ? WHERE id = ? AND resumed_at IS NULL`)

--- a/src/workflows/db/schema.ts
+++ b/src/workflows/db/schema.ts
@@ -40,7 +40,7 @@ const STATEMENTS: string[] = [
   )`,
   `CREATE INDEX IF NOT EXISTS idx_flow_project ON flow(project_id)`,
   `CREATE INDEX IF NOT EXISTS idx_flow_status ON flow(status)`,
-  `CREATE UNIQUE INDEX IF NOT EXISTS uq_flow_external ON flow(project_id, external_id)`,
+  `CREATE UNIQUE INDEX IF NOT EXISTS uq_flow_external ON flow(project_id, external_id)`, // expand-contract-ok: base-schema index (created with the table)
 
   // Engine-managed trigger state lives in `engine_listeners` (JSON array of
   // AppEventListener `{ events, identifierValue }`, returned by upstream's
@@ -123,7 +123,7 @@ const STATEMENTS: string[] = [
   )`,
   `CREATE INDEX IF NOT EXISTS idx_app_connection_project ON app_connection(project_id)`,
   `CREATE INDEX IF NOT EXISTS idx_app_connection_piece ON app_connection(piece_name)`,
-  `CREATE UNIQUE INDEX IF NOT EXISTS uq_app_connection_external ON app_connection(project_id, piece_name, external_id)`,
+  `CREATE UNIQUE INDEX IF NOT EXISTS uq_app_connection_external ON app_connection(project_id, piece_name, external_id)`, // expand-contract-ok: base-schema index (created with the table)
 
   // --- Trigger events: webhook payloads, polling captures, event-bus emissions awaiting flow execution ---
   `CREATE TABLE IF NOT EXISTS trigger_event (
@@ -147,7 +147,7 @@ const STATEMENTS: string[] = [
     created INTEGER NOT NULL,
     updated INTEGER NOT NULL
   )`,
-  `CREATE UNIQUE INDEX IF NOT EXISTS uq_store_entry_project_key ON store_entry(project_id, key)`,
+  `CREATE UNIQUE INDEX IF NOT EXISTS uq_store_entry_project_key ON store_entry(project_id, key)`, // expand-contract-ok: base-schema index (created with the table)
 
   // --- Files passed between steps (file-helper, image-helper, etc.) ---
   `CREATE TABLE IF NOT EXISTS workflow_file (

--- a/src/workflows/queue/queue.test.ts
+++ b/src/workflows/queue/queue.test.ts
@@ -50,6 +50,16 @@ describe("job-queue repo", () => {
     expect(claimNextJob()?.id).toBe(j.id); // immediately re-claimable
   });
 
+  test("recoverOrphanedJobs fails a poison job at the attempt ceiling instead of re-queuing", () => {
+    const poison = enqueue({ jobType: "T", payload: {}, maxAttempts: 1 });
+    claimNextJob(); // poison -> RUNNING, attempt 1 == max_attempts
+    const healthy = enqueue({ jobType: "T", payload: {}, maxAttempts: 3 });
+    claimNextJob(); // healthy -> RUNNING, attempt 1 < max_attempts
+    expect(recoverOrphanedJobs()).toBe(1); // only the healthy one re-queues
+    expect(getJob(poison.id)?.status).toBe("FAILED");
+    expect(getJob(healthy.id)?.status).toBe("QUEUED");
+  });
+
   test("priority + scheduled_at ordering", () => {
     const now = Date.now();
     const a = enqueue({ jobType: "T", payload: {}, priority: 1, scheduledAt: now });

--- a/src/workflows/queue/queue.test.ts
+++ b/src/workflows/queue/queue.test.ts
@@ -8,6 +8,7 @@ import {
   failJob,
   getJob,
   queueStats,
+  recoverOrphanedJobs,
 } from "../db/repos/job-queue";
 import { Worker } from "./worker";
 
@@ -35,6 +36,18 @@ describe("job-queue repo", () => {
 
     completeJob(j.id);
     expect(getJob(j.id)?.status).toBe("SUCCEEDED");
+  });
+
+  test("recoverOrphanedJobs re-queues orphaned RUNNING jobs for immediate re-claim", () => {
+    const j = enqueue({ jobType: "TEST", payload: {} });
+    const claimed = claimNextJob(); // -> RUNNING with a live (future) lease
+    expect(claimed?.id).toBe(j.id);
+    // A normal poll won't re-claim it: the lease hasn't lapsed.
+    expect(claimNextJob()).toBeNull();
+    // Boot recovery treats the orphaned RUNNING job as re-runnable NOW.
+    expect(recoverOrphanedJobs()).toBe(1);
+    expect(getJob(j.id)?.status).toBe("QUEUED");
+    expect(claimNextJob()?.id).toBe(j.id); // immediately re-claimable
   });
 
   test("priority + scheduled_at ordering", () => {

--- a/src/workflows/sandbox-api/routes/waitpoints.ts
+++ b/src/workflows/sandbox-api/routes/waitpoints.ts
@@ -7,8 +7,8 @@
  * `resumeUrl` in step output so external callers can hit it later to wake the
  * flow.
  *
- * The actual resume scheduling (TIMER tick, WEBHOOK route, etc.) is layered on
- * after this commit; today the row is just persisted.
+ * TIMER/DELAY waitpoints are resumed by the TimerWaitpointScheduler; WEBHOOK by
+ * the resume route.
  */
 
 import { createWaitpoint } from "../../db/repos/waitpoint";
@@ -27,11 +27,25 @@ interface CreateWaitpointBody {
   httpRequestId?: string;
 }
 
-const ALLOWED_TYPES: ReadonlySet<WaitpointType> = new Set<WaitpointType>([
-  "WEBHOOK",
-  "TIMER",
-  "MANUAL",
-]);
+// Accepted engine-side waitpoint types. The pieces framework emits `DELAY`
+// (timer-based) + `WEBHOOK`; we also accept `TIMER`/`MANUAL`. `DELAY` is a
+// timer, so it's STORED as `TIMER` — both mean "resume at resume_date_time" and
+// the TIMER scheduler keys off that single type.
+const ACCEPTED_TYPES: ReadonlySet<string> = new Set(["WEBHOOK", "TIMER", "MANUAL", "DELAY"]);
+
+function normalizeType(t: string): WaitpointType {
+  return t === "DELAY" ? "TIMER" : (t as WaitpointType);
+}
+
+// `resume_date_time` is compared LEXICALLY by the scheduler, so it must be
+// canonical ISO-8601 UTC. Delay pieces send either `toISOString()` (delay-until)
+// or `toUTCString()` (delay-for, RFC-1123) — normalize both. An unparseable
+// value drops to undefined rather than persisting a never-due timer.
+function normalizeResumeDateTime(raw?: string): string | undefined {
+  if (!raw) return undefined;
+  const d = new Date(raw);
+  return Number.isNaN(d.getTime()) ? undefined : d.toISOString();
+}
 
 export interface WaitpointRouteDeps {
   /** Public URL prefix used to construct the resumeUrl returned to the engine. */
@@ -48,7 +62,7 @@ export function createWaitpointsRoute(deps: WaitpointRouteDeps): RouteHandler {
     }
     if (!body.flowRunId) return err("missing flowRunId", 400);
     if (!body.stepName) return err("missing stepName", 400);
-    if (!body.type || !ALLOWED_TYPES.has(body.type as WaitpointType)) {
+    if (!body.type || !ACCEPTED_TYPES.has(body.type)) {
       return err(`unsupported waitpoint type ${body.type}`, 400);
     }
     if (body.flowRunId !== ctx.claims.runId) {
@@ -58,9 +72,9 @@ export function createWaitpointsRoute(deps: WaitpointRouteDeps): RouteHandler {
       flowRunId: body.flowRunId,
       projectId: body.projectId ?? ctx.claims.projectId,
       stepName: body.stepName,
-      type: body.type as WaitpointType,
+      type: normalizeType(body.type),
       version: body.version,
-      resumeDateTime: body.resumeDateTime,
+      resumeDateTime: normalizeResumeDateTime(body.resumeDateTime),
       responseToSend: body.responseToSend,
       workerHandlerId: body.workerHandlerId,
       httpRequestId: body.httpRequestId,

--- a/src/workflows/sandbox-api/sandbox-api.test.ts
+++ b/src/workflows/sandbox-api/sandbox-api.test.ts
@@ -15,6 +15,7 @@ import { closeWorkflowDb, initWorkflowDb } from "../db";
 import { _clearStoreForTests } from "../db/repos/store-entry";
 import { createFlow, setPublishedVersion, updateFlowStatus } from "../db/repos/flow";
 import { createDraftVersion, lockVersion } from "../db/repos/flow-version";
+import { getWaitpoint } from "../db/repos/waitpoint";
 
 const sampleIdentity = () => ({
   sandboxId: SandboxRegistry.newSandboxId(),
@@ -643,6 +644,21 @@ describe("SandboxApi routes (B3: files, waitpoints, logs)", () => {
       }),
     });
     expect(r.status).toBe(403);
+  });
+
+  test("POST /v1/waitpoints accepts DELAY (stored as TIMER) and normalizes RFC-1123 -> ISO", async () => {
+    // delay-for pieces send type 'DELAY' with an RFC-1123 (toUTCString) time.
+    const rfc1123 = new Date("2026-07-07T03:00:00Z").toUTCString();
+    const r = await authedFetchForRun("/v1/waitpoints", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ flowRunId: testRunId, stepName: "delay", type: "DELAY", resumeDateTime: rfc1123 }),
+    });
+    expect(r.status).toBe(200);
+    const { waitpointId } = (await r.json()) as { waitpointId: string };
+    const wp = getWaitpoint(waitpointId);
+    expect(wp?.type).toBe("TIMER"); // DELAY mapped so the scheduler finds it
+    expect(wp?.resumeDateTime).toBe("2026-07-07T03:00:00.000Z"); // normalized to ISO for lexical compare
   });
 
   test("POST /v1/waitpoints rejects unsupported type", async () => {

--- a/src/workflows/timer-scheduler.test.ts
+++ b/src/workflows/timer-scheduler.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { closeWorkflowDb, initWorkflowDb } from './db/index';
+import { createFlow } from './db/repos/flow';
+import { createDraftVersion } from './db/repos/flow-version';
+import { createFlowRun, updateRun } from './db/repos/flow-run';
+import { createWaitpoint, getWaitpoint } from './db/repos/waitpoint';
+import { claimNextJob } from './db/repos/job-queue';
+import { TimerWaitpointScheduler } from './timer-scheduler';
+
+beforeEach(() => initWorkflowDb(':memory:'));
+afterEach(() => closeWorkflowDb());
+
+function pausedRun(): string {
+  const flow = createFlow();
+  const v = createDraftVersion({
+    flowId: flow.id,
+    displayName: 'v1',
+    trigger: { name: 'trigger', type: 'EMPTY' },
+  });
+  return createFlowRun({ flowId: flow.id, flowVersionId: v.id, status: 'PAUSED' }).id;
+}
+
+function timerWaitpoint(runId: string, resumeIso: string) {
+  return createWaitpoint({
+    flowRunId: runId,
+    projectId: 'p',
+    stepName: 'wait',
+    type: 'TIMER',
+    resumeDateTime: resumeIso,
+  });
+}
+
+describe('TimerWaitpointScheduler', () => {
+  const sched = new TimerWaitpointScheduler();
+  const now = Date.parse('2026-07-07T03:00:00Z');
+
+  test('resumes a due TIMER waitpoint on a PAUSED run (enqueues one RESUME job)', () => {
+    const runId = pausedRun();
+    timerWaitpoint(runId, new Date(now - 1000).toISOString());
+    expect(sched.tick(now)).toBe(1);
+    const job = claimNextJob<{ executionType: string; runId: string }>();
+    expect(job?.payload.executionType).toBe('RESUME');
+    expect(job?.payload.runId).toBe(runId);
+  });
+
+  test('leaves a not-yet-due timer alone', () => {
+    const runId = pausedRun();
+    timerWaitpoint(runId, new Date(now + 60_000).toISOString());
+    expect(sched.tick(now)).toBe(0);
+    expect(claimNextJob()).toBeNull();
+  });
+
+  test('retires a due timer whose run is no longer PAUSED (no resume enqueued)', () => {
+    const runId = pausedRun();
+    updateRun(runId, { status: 'SUCCEEDED' });
+    const wp = timerWaitpoint(runId, new Date(now - 1000).toISOString());
+    expect(sched.tick(now)).toBe(0);
+    expect(getWaitpoint(wp.id)?.resumedAt).not.toBeNull(); // retired, won't re-scan
+    expect(claimNextJob()).toBeNull();
+  });
+
+  test('a second tick does not double-resume', () => {
+    const runId = pausedRun();
+    timerWaitpoint(runId, new Date(now - 1000).toISOString());
+    expect(sched.tick(now)).toBe(1);
+    expect(sched.tick(now)).toBe(0);
+  });
+});

--- a/src/workflows/timer-scheduler.ts
+++ b/src/workflows/timer-scheduler.ts
@@ -1,0 +1,58 @@
+/**
+ * TIMER-waitpoint scheduler (UPDATES.md graceful-drain resume).
+ *
+ * A workflow `delay`/`wait` step parks the run at PAUSED with a TIMER waitpoint
+ * carrying a `resume_date_time`. WEBHOOK/MANUAL waitpoints resume when their URL
+ * is hit, but a TIMER has no external trigger — so without this tick a timer
+ * that elapses (including entirely during a restart's downtime) never fires.
+ * This periodically finds due TIMER waitpoints and enqueues their RESUME job,
+ * exactly as the resume webhook route does.
+ */
+
+import { enqueue } from './db/repos/job-queue.ts';
+import { getFlowRun } from './db/repos/flow-run.ts';
+import { listDueTimerWaitpoints, markWaitpointResumed } from './db/repos/waitpoint.ts';
+
+export class TimerWaitpointScheduler {
+  private timer: ReturnType<typeof setInterval> | null = null;
+
+  constructor(private readonly intervalMs = 15_000) {}
+
+  start(): void {
+    if (this.timer) return;
+    this.tick(); // fire once now so a due-during-downtime timer resumes at boot
+    this.timer = setInterval(() => this.tick(), this.intervalMs);
+  }
+
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  /** Resume every currently-due TIMER waitpoint. Returns how many were resumed. */
+  tick(now: number = Date.now()): number {
+    let resumed = 0;
+    for (const wp of listDueTimerWaitpoints(new Date(now).toISOString())) {
+      const run = getFlowRun(wp.flowRunId);
+      // Only PAUSED runs are resumable; for anything else, retire the waitpoint
+      // so it isn't re-scanned every tick.
+      if (!run || run.status !== 'PAUSED') {
+        markWaitpointResumed(wp.id, now);
+        continue;
+      }
+      // Claim-then-enqueue: marking resumed first (unique on resumed_at IS NULL)
+      // keeps a double tick from enqueuing the same resume twice.
+      if (!markWaitpointResumed(wp.id, now)) continue;
+      enqueue({
+        jobType: 'RUN_FLOW',
+        payload: { runId: wp.flowRunId, executionType: 'RESUME', resumePayload: {} },
+        flowRunId: wp.flowRunId,
+        maxAttempts: 1, // re-resuming an already-resumed waitpoint would walk past it
+      });
+      resumed++;
+    }
+    return resumed;
+  }
+}

--- a/src/workflows/timer-scheduler.ts
+++ b/src/workflows/timer-scheduler.ts
@@ -9,6 +9,7 @@
  * exactly as the resume webhook route does.
  */
 
+import { getWorkflowDb } from './db/index.ts';
 import { enqueue } from './db/repos/job-queue.ts';
 import { getFlowRun } from './db/repos/flow-run.ts';
 import { listDueTimerWaitpoints, markWaitpointResumed } from './db/repos/waitpoint.ts';
@@ -31,27 +32,48 @@ export class TimerWaitpointScheduler {
     }
   }
 
-  /** Resume every currently-due TIMER waitpoint. Returns how many were resumed. */
+  /**
+   * Resume every currently-due TIMER waitpoint. Returns how many were resumed.
+   * Never throws (runs on a setInterval — a throw would become an
+   * uncaughtException and take the daemon down); per-waitpoint errors are logged
+   * and skipped.
+   */
   tick(now: number = Date.now()): number {
     let resumed = 0;
-    for (const wp of listDueTimerWaitpoints(new Date(now).toISOString())) {
-      const run = getFlowRun(wp.flowRunId);
-      // Only PAUSED runs are resumable; for anything else, retire the waitpoint
-      // so it isn't re-scanned every tick.
-      if (!run || run.status !== 'PAUSED') {
-        markWaitpointResumed(wp.id, now);
-        continue;
+    let due;
+    try {
+      due = listDueTimerWaitpoints(new Date(now).toISOString());
+    } catch (e) {
+      console.error('[TimerScheduler] scan failed:', e);
+      return 0;
+    }
+    for (const wp of due) {
+      try {
+        const run = getFlowRun(wp.flowRunId);
+        // Only PAUSED runs are resumable; for anything else, retire the
+        // waitpoint so it isn't re-scanned every tick.
+        if (!run || run.status !== 'PAUSED') {
+          markWaitpointResumed(wp.id, now);
+          continue;
+        }
+        // Mark-resumed + enqueue ATOMICALLY: a crash between the two would
+        // otherwise leave the waitpoint retired with no RESUME job -> run stuck
+        // PAUSED forever. The unique `WHERE resumed_at IS NULL` also stops a
+        // concurrent tick from double-enqueuing.
+        const enqueued = getWorkflowDb().transaction(() => {
+          if (!markWaitpointResumed(wp.id, now)) return false; // lost the race
+          enqueue({
+            jobType: 'RUN_FLOW',
+            payload: { runId: wp.flowRunId, executionType: 'RESUME', resumePayload: {} },
+            flowRunId: wp.flowRunId,
+            maxAttempts: 1, // re-resuming an already-resumed waitpoint would walk past it
+          });
+          return true;
+        })();
+        if (enqueued) resumed++;
+      } catch (e) {
+        console.error(`[TimerScheduler] resume failed for waitpoint ${wp.id}:`, e);
       }
-      // Claim-then-enqueue: marking resumed first (unique on resumed_at IS NULL)
-      // keeps a double tick from enqueuing the same resume twice.
-      if (!markWaitpointResumed(wp.id, now)) continue;
-      enqueue({
-        jobType: 'RUN_FLOW',
-        payload: { runId: wp.flowRunId, executionType: 'RESUME', resumePayload: {} },
-        flowRunId: wp.flowRunId,
-        maxAttempts: 1, // re-resuming an already-resumed waitpoint would walk past it
-      });
-      resumed++;
     }
     return resumed;
   }


### PR DESCRIPTION
## What

SIGTERM now runs a three-phase shutdown on a single wall-clock budget
(`daemon.drain_deadline_ms`, default 75s, capped at 85s so it always fits under a
supervisor's stop grace) instead of tearing everything down immediately:

1. **Quiesce**: refuse new work. Agent turns are gated by a new `ActiveTurns`
   tracker (new turns throw `DrainingError`, background-agent runs are skipped),
   and every work source stops: system cron, commitments, goals, awareness,
   triggers, and the timer scheduler. The workflow worker stops claiming fresh
   jobs immediately (its in-flight run keeps going). Agent, WS, and sidecar
   connections stay up so in-flight work can finish and stream.
2. **Drain**: await in-flight agent turns up to the deadline. Turns are not
   checkpointed: an overrun turn is abandoned and the user re-asks.
3. **Teardown**: stop services in reverse order, stop the workflow worker bounded
   by the remaining budget (an overrunning run is left RUNNING on purpose), shut
   down the engine, flush window state, close the DB.

## Workflow durability

Workflows resume across restarts and crashes:

- `recoverOrphanedJobs()` at boot re-queues runs left RUNNING by a crash or an
  over-deadline drain, immediately instead of after the 5-minute lease expiry.
  Poison jobs (repeatedly recovered) fail out instead of looping forever.
- New `TimerWaitpointScheduler` resumes delay/wait steps whose timer elapsed,
  including while the daemon was down. Wired to the real delay pieces at the
  waitpoint boundary: `DELAY` is accepted and stored as `TIMER`, and both
  `toISOString()` and RFC-1123 datetimes are normalized to ISO. Mark-resumed +
  enqueue is atomic, and a throwing tick can't kill the scheduler loop.

## Sidecars and CLI

- Sidecar connections get a WS 1001 "going away" close on drain; they already
  auto-reconnect with the same keys/JWT.
- New `jarvis drain` command; `jarvis stop` is drain-aware (polls up to the
  drain deadline instead of a hard 5s) and the racing CLI SIGTERM handler is
  removed so the daemon owns its own shutdown.
- `/health` now reports the `JARVIS_VERSION` the process was launched from, so a
  rolling update can be confirmed against the target version by the caller.

## Migration discipline

New `scripts/check-migrations.ts` (wired into CI and pre-commit) fails on
rollback-hazardous per-instance DDL (DROP/RENAME COLUMN, ADD COLUMN NOT NULL
without DEFAULT, CREATE UNIQUE INDEX) unless the line is annotated
`expand-contract-ok`. This keeps rollback real: the previous version's code must
be able to run on the new schema. Comments are stripped before scanning and a
missing DDL file fails loudly. Existing safe sites are annotated.

## Testing

- New unit tests: `ActiveTurns`, timer scheduler, orphan recovery, waitpoint
  DELAY handling, `/health` version, migration guard.
- Full suite green: 1624 pass / 0 fail (13093 assertions).
