### PR TITLE
fix(#119): inject user profile into conv-tier prompts and prevent ghost extraction entities

### DIFF
--- a/src/agents/conv/conv-orchestrator.test.ts
+++ b/src/agents/conv/conv-orchestrator.test.ts
@@ -248,6 +248,34 @@ describe('ConvOrchestrator', () => {
     expect(captured[0]![2]!.content).not.toBe(captured[1]![2]!.content);
   });
 
+  it('omits the profile block when userProfile is not provided', async () => {
+    const captured: LLMMessage[][] = [];
+    class CapturingProvider extends MockProvider {
+      override async chat(messages: LLMMessage[], opts?: LLMOptions): Promise<LLMResponse> {
+        captured.push(messages);
+        return super.chat(messages, opts);
+      }
+    }
+    const provider = new CapturingProvider([textResponse('Hi!')]);
+    const llm = makeManager(provider);
+    const runner = async () => ({ kind: 'completed' as const, text: '', conversation: [] });
+    const dispatcher = new TaskDispatcher(llm, registry, runner as never);
+    const conv = new ConvOrchestrator(llm, registry, dispatcher, 'TestBot.');
+
+    await conv.processTurn('Hi', { userIdentity: 'Name: Alice' });
+    const messages = captured[0]!;
+    // No profile block: the dynamic system prompt sits directly after the
+    // static persona, and it alone carries the identity.
+    expect(messages[0]!.cache).toBe(true);
+    expect(messages[1]!.role).toBe('system');
+    expect(messages[1]!.cache).toBeUndefined();
+    expect(String(messages[1]!.content)).toContain('Alice');
+    expect(messages[2]!.role).toBe('user');
+    for (const m of messages) {
+      expect(String(m.content)).not.toContain('User Profile');
+    }
+  });
+
   it('omits the dynamic system message entirely when there is no dynamic context', async () => {
     const captured: LLMMessage[][] = [];
     class CapturingProvider extends MockProvider {

--- a/src/agents/conv/conv-orchestrator.test.ts
+++ b/src/agents/conv/conv-orchestrator.test.ts
@@ -207,6 +207,47 @@ describe('ConvOrchestrator', () => {
     expect(captured[0]![1]!.content).not.toBe(captured[1]![1]!.content);
   });
 
+  it('renders the user profile as a cache-marked system block between static and dynamic', async () => {
+    const captured: LLMMessage[][] = [];
+    class CapturingProvider extends MockProvider {
+      override async chat(messages: LLMMessage[], opts?: LLMOptions): Promise<LLMResponse> {
+        captured.push(messages);
+        return super.chat(messages, opts);
+      }
+    }
+    const provider = new CapturingProvider([textResponse('Hi!'), textResponse('Hello again!')]);
+    const llm = makeManager(provider);
+    const runner = async () => ({ kind: 'completed' as const, text: '', conversation: [] });
+    const dispatcher = new TaskDispatcher(llm, registry, runner as never);
+    const conv = new ConvOrchestrator(llm, registry, dispatcher, 'TestBot persona.');
+
+    const profileBlock = '# User Profile\n- Preferred name: Alice';
+    await conv.processTurn('Hi', { userIdentity: 'Name: Alice', userProfile: profileBlock, ambientFacts: 'Weather: sunny' });
+    await conv.processTurn('Hi again', { userIdentity: 'Name: Alice', userProfile: profileBlock, ambientFacts: 'Weather: rainy' });
+
+    expect(captured).toHaveLength(2);
+    for (const messages of captured) {
+      // message[0]: static persona, cache-marked; profile stays out of it
+      expect(messages[0]!.role).toBe('system');
+      expect(messages[0]!.cache).toBe(true);
+      expect(String(messages[0]!.content)).not.toContain('User Profile');
+      // message[1]: profile block, cache-marked (provider puts the single
+      // breakpoint on the LAST marked block, caching persona + profile)
+      expect(messages[1]!.role).toBe('system');
+      expect(messages[1]!.cache).toBe(true);
+      expect(String(messages[1]!.content)).toBe(profileBlock);
+      // message[2]: dynamic system prompt, NOT cache-marked
+      expect(messages[2]!.role).toBe('system');
+      expect(messages[2]!.cache).toBeUndefined();
+      expect(String(messages[2]!.content)).toContain('Weather');
+    }
+    // Cached prefix (persona + profile) must be byte-identical across turns
+    // while the dynamic block changes.
+    expect(captured[0]![0]!.content).toBe(captured[1]![0]!.content);
+    expect(captured[0]![1]!.content).toBe(captured[1]![1]!.content);
+    expect(captured[0]![2]!.content).not.toBe(captured[1]![2]!.content);
+  });
+
   it('omits the dynamic system message entirely when there is no dynamic context', async () => {
     const captured: LLMMessage[][] = [];
     class CapturingProvider extends MockProvider {

--- a/src/agents/conv/conv-orchestrator.ts
+++ b/src/agents/conv/conv-orchestrator.ts
@@ -31,6 +31,13 @@ const MAX_CONV_ITERATIONS = 8;
 export type ConvSystemContext = {
   /** User persona (name, timezone, role, etc.) - short identity block. */
   userIdentity?: string;
+  /**
+   * Full user profile block (wizard answers + interview facts). Rendered as
+   * its own cache-marked system message, so it MUST be byte-stable across
+   * turns - keep anything volatile (local time, task state) in userIdentity
+   * or ambientFacts instead.
+   */
+  userProfile?: string;
   /** Last N dialogue turns from the persistent conversation - verbatim. */
   recentDialogue?: LLMMessage[];
   /** Optional extra grounding the conv LLM should always see (e.g., active commitments count). */
@@ -106,17 +113,19 @@ export class ConvOrchestrator {
     context: ConvSystemContext,
     onTaskEvent?: (event: ConvTaskEvent) => void,
   ): AsyncGenerator<ConvStreamEvent> {
-    // Two system messages split at the prompt-cache boundary: the static
-    // persona/instructions prefix is byte-stable across turns (marked
-    // `cache: true` so Anthropic can serve it from cache), while task state
-    // and user identity change every turn and follow unmarked. Note: at
-    // ~1500 tokens the static block may sit below some models' minimum
-    // cacheable prefix and silently not cache - harmless (no premium is
-    // charged); the provider's last-message breakpoint still caches
-    // system + dialogue as one growing prefix.
+    // System messages split at the prompt-cache boundary: the static
+    // persona/instructions prefix and the user profile block are byte-stable
+    // across turns (both marked `cache: true`; the provider places the single
+    // breakpoint on the LAST marked block, so persona + profile cache as one
+    // prefix), while task state and user identity change every turn and
+    // follow unmarked. Note: at ~1500 tokens the static block may sit below
+    // some models' minimum cacheable prefix and silently not cache -
+    // harmless (no premium is charged); the provider's last-message
+    // breakpoint still caches system + dialogue as one growing prefix.
     const dynamicPrompt = this.buildDynamicSystemPrompt(context);
     const messages: LLMMessage[] = [
       { role: 'system', content: this.buildStaticSystemPrompt(), cache: true },
+      ...(context.userProfile ? [{ role: 'system', content: context.userProfile, cache: true } satisfies LLMMessage] : []),
       ...(dynamicPrompt ? [{ role: 'system', content: dynamicPrompt } satisfies LLMMessage] : []),
       ...(context.recentDialogue ?? []),
       { role: 'user', content: userMessage },

--- a/src/daemon/agent-service.ts
+++ b/src/daemon/agent-service.ts
@@ -349,6 +349,7 @@ export class AgentService implements Service, IAgentService {
       let fullText = '';
       try {
         const identity = self.buildUserIdentityBlock();
+        const userProfile = self.buildUserProfileBlock();
         const recentDialogue = await self.loadRecentDialogue(channel);
         const ambient = self.buildAmbientFactsBlock(text);
 
@@ -359,6 +360,7 @@ export class AgentService implements Service, IAgentService {
 
         for await (const event of self.convOrchestrator.streamTurn(text, {
           userIdentity: identity,
+          userProfile,
           recentDialogue,
           ambientFacts: ambient,
         }, taskListener)) {
@@ -516,6 +518,7 @@ export class AgentService implements Service, IAgentService {
       text,
       {
         userIdentity: identity,
+        userProfile: this.buildUserProfileBlock(),
         recentDialogue,
         ambientFacts: this.buildAmbientFactsBlock(text),
       },
@@ -554,29 +557,32 @@ export class AgentService implements Service, IAgentService {
     }
   }
 
-  /** User identity + full profile the conv LLM sees in every turn. */
+  /** One-line identity facts the conv LLM sees in every turn. */
   private buildUserIdentityBlock(): string {
     const parts: string[] = [];
     const name = this.config.user?.name;
     if (name) parts.push(`Name: ${name}`);
     parts.push(`Local time: ${new Date().toLocaleString()}`);
+    return parts.join('. ');
+  }
 
-    // Inject the full user profile (wizard answers + interview facts) so the
-    // conv LLM has the same rich context about the user that the classic path
-    // injects via buildPromptContext -> formatUserProfileForPrompt.
+  /**
+   * Full user profile (wizard answers + interview facts) for the conv LLM,
+   * giving it the same rich context about the user that the classic path
+   * injects via buildPromptContext -> formatUserProfileForPrompt. Rendered
+   * as its own cache-marked system block, so it stays out of the volatile
+   * identity line - keep anything that changes per turn out of here.
+   */
+  private buildUserProfileBlock(): string | undefined {
     try {
       const profile = getUserProfile();
       const profileContext = formatUserProfileForPrompt(profile);
-      if (profileContext) {
-        parts.push('');
-        parts.push('## User Profile');
-        parts.push(profileContext);
-      }
+      if (!profileContext) return undefined;
+      return `# User Profile\n${profileContext}`;
     } catch (err) {
-      console.warn('[AgentService] Error loading user profile for conv identity:', err);
+      console.warn('[AgentService] Error loading user profile for conv prompt:', err);
+      return undefined;
     }
-
-    return parts.join('\n');
   }
 
   /**

--- a/src/daemon/agent-service.ts
+++ b/src/daemon/agent-service.ts
@@ -554,13 +554,29 @@ export class AgentService implements Service, IAgentService {
     }
   }
 
-  /** One-line identity facts the conv LLM sees in every turn. */
+  /** User identity + full profile the conv LLM sees in every turn. */
   private buildUserIdentityBlock(): string {
     const parts: string[] = [];
     const name = this.config.user?.name;
     if (name) parts.push(`Name: ${name}`);
     parts.push(`Local time: ${new Date().toLocaleString()}`);
-    return parts.join('. ');
+
+    // Inject the full user profile (wizard answers + interview facts) so the
+    // conv LLM has the same rich context about the user that the classic path
+    // injects via buildPromptContext -> formatUserProfileForPrompt.
+    try {
+      const profile = getUserProfile();
+      const profileContext = formatUserProfileForPrompt(profile);
+      if (profileContext) {
+        parts.push('');
+        parts.push('## User Profile');
+        parts.push(profileContext);
+      }
+    } catch (err) {
+      console.warn('[AgentService] Error loading user profile for conv identity:', err);
+    }
+
+    return parts.join('\n');
   }
 
   /**

--- a/src/vault/entities.ts
+++ b/src/vault/entities.ts
@@ -95,6 +95,7 @@ export function findEntities(query: {
   type?: EntityType;
   name?: string;
   nameContains?: string;
+  source?: string;
 }): Entity[] {
   const db = getDb();
   const conditions: string[] = [];
@@ -103,6 +104,11 @@ export function findEntities(query: {
   if (query.type) {
     conditions.push('type = ?');
     params.push(query.type);
+  }
+
+  if (query.source) {
+    conditions.push('source = ?');
+    params.push(query.source);
   }
 
   if (query.name) {

--- a/src/vault/extractor.test.ts
+++ b/src/vault/extractor.test.ts
@@ -426,10 +426,12 @@ describe('Vault Extractor', () => {
         entities: [
           { name: 'Boss', type: 'person', properties: { is_current_user: true } },
           { name: 'Speaker', type: 'person', properties: { is_user: 'true' } },
+          { name: 'Narrator', type: 'person', properties: { is_current_user: 'True' } },
         ],
         facts: [
           { subject: 'Boss', predicate: 'role_is', object: 'engineer', confidence: 1.0 },
           { subject: 'Speaker', predicate: 'city_is', object: 'Milan', confidence: 1.0 },
+          { subject: 'Narrator', predicate: 'age_is', object: '30', confidence: 1.0 },
         ],
         relationships: [],
         commitments: [],
@@ -437,9 +439,11 @@ describe('Vault Extractor', () => {
 
       expect(findEntities({ name: 'Boss' })).toHaveLength(0);
       expect(findEntities({ name: 'Speaker' })).toHaveLength(0);
+      expect(findEntities({ name: 'Narrator' })).toHaveLength(0);
       const predicates = findFacts({ subject_id: profileId }).map(f => f.predicate);
       expect(predicates).toContain('role_is');
       expect(predicates).toContain('city_is');
+      expect(predicates).toContain('age_is');
     });
 
     test('prefers the profile entity even when a newer same-name duplicate exists', async () => {

--- a/src/vault/extractor.test.ts
+++ b/src/vault/extractor.test.ts
@@ -6,8 +6,10 @@ import {
   extractAndStore,
   type ExtractionResult,
 } from './extractor.ts';
-import { findEntities } from './entities.ts';
+import { createEntity, findEntities } from './entities.ts';
 import { findFacts } from './facts.ts';
+import { getDb } from './schema.ts';
+import { saveUserProfile, USER_PROFILE_VAULT_SOURCE } from './user-profile.ts';
 import { findRelationships } from './relationships.ts';
 import { findCommitments } from './commitments.ts';
 import type { LLMProvider, LLMMessage, LLMOptions, LLMResponse } from '../llm/provider.ts';
@@ -363,6 +365,132 @@ describe('Vault Extractor', () => {
       // Entity should not be created
       const entities = findEntities({});
       expect(entities).toHaveLength(0);
+    });
+  });
+
+  describe('extractAndStore user profile dedup', () => {
+    /** Provider whose chat() always returns the given extraction JSON. */
+    function extractionProvider(extraction: ExtractionResult): LLMProvider {
+      return {
+        name: 'mock',
+        async chat(): Promise<LLMResponse> {
+          return {
+            content: JSON.stringify(extraction),
+            tool_calls: [],
+            usage: { input_tokens: 100, output_tokens: 50 },
+            model: 'mock-model',
+            finish_reason: 'stop',
+          };
+        },
+        async *stream() {
+          yield { type: 'done', response: {} as any };
+        },
+        async listModels() {
+          return ['mock-model'];
+        },
+      };
+    }
+
+    function runExtraction(extraction: ExtractionResult) {
+      return extractAndStore('Test', 'Test', makeManager(extractionProvider(extraction)));
+    }
+
+    function profileEntityId(): string {
+      const profile = findEntities({ source: USER_PROFILE_VAULT_SOURCE });
+      expect(profile).toHaveLength(1);
+      return profile[0]!.id;
+    }
+
+    test('maps extracted entity sharing the profile name to the profile entity', async () => {
+      saveUserProfile({ preferred_name: 'Alice' });
+      const profileId = profileEntityId();
+
+      await runExtraction({
+        entities: [{ name: 'alice', type: 'person' }],
+        facts: [{ subject: 'alice', predicate: 'likes', object: 'espresso', confidence: 1.0 }],
+        relationships: [],
+        commitments: [],
+      });
+
+      // No duplicate entity; the fact lands on the profile entity.
+      expect(findEntities({ nameContains: 'lice' })).toHaveLength(1);
+      const facts = findFacts({ subject_id: profileId });
+      expect(facts.some(f => f.predicate === 'likes')).toBe(true);
+    });
+
+    test('maps entities flagged is_current_user/is_user (boolean or string) to the profile entity', async () => {
+      saveUserProfile({ preferred_name: 'Alice' });
+      const profileId = profileEntityId();
+
+      await runExtraction({
+        entities: [
+          { name: 'Boss', type: 'person', properties: { is_current_user: true } },
+          { name: 'Speaker', type: 'person', properties: { is_user: 'true' } },
+        ],
+        facts: [
+          { subject: 'Boss', predicate: 'role_is', object: 'engineer', confidence: 1.0 },
+          { subject: 'Speaker', predicate: 'city_is', object: 'Milan', confidence: 1.0 },
+        ],
+        relationships: [],
+        commitments: [],
+      });
+
+      expect(findEntities({ name: 'Boss' })).toHaveLength(0);
+      expect(findEntities({ name: 'Speaker' })).toHaveLength(0);
+      const predicates = findFacts({ subject_id: profileId }).map(f => f.predicate);
+      expect(predicates).toContain('role_is');
+      expect(predicates).toContain('city_is');
+    });
+
+    test('prefers the profile entity even when a newer same-name duplicate exists', async () => {
+      saveUserProfile({ preferred_name: 'Alice' });
+      const profileId = profileEntityId();
+
+      // Ghost duplicate from before the dedup fix, updated more recently than
+      // the profile entity - the buggy lookup (all entities, updated_at DESC)
+      // would pick this one.
+      const ghost = createEntity('person', 'Alice', undefined, 'llm_extraction');
+      getDb().prepare('UPDATE entities SET updated_at = ? WHERE id = ?')
+        .run(Date.now() + 60_000, ghost.id);
+
+      await runExtraction({
+        entities: [{ name: 'Alice', type: 'person' }],
+        facts: [{ subject: 'Alice', predicate: 'likes', object: 'espresso', confidence: 1.0 }],
+        relationships: [],
+        commitments: [],
+      });
+
+      const facts = findFacts({ subject_id: profileId });
+      expect(facts.some(f => f.predicate === 'likes')).toBe(true);
+      expect(findFacts({ subject_id: ghost.id })).toHaveLength(0);
+    });
+
+    test('drops user-representing entities when no profile exists instead of creating ghosts', async () => {
+      await runExtraction({
+        entities: [{ name: 'User', type: 'person', properties: { is_current_user: true } }],
+        facts: [{ subject: 'User', predicate: 'name_is_unknown', object: 'true', confidence: 1.0 }],
+        relationships: [],
+        commitments: [],
+      });
+
+      expect(findEntities({})).toHaveLength(0);
+      expect(findFacts({})).toHaveLength(0);
+    });
+
+    test('still creates unrelated entities normally alongside a profile', async () => {
+      saveUserProfile({ preferred_name: 'Alice' });
+
+      await runExtraction({
+        entities: [{ name: 'Bob', type: 'person' }],
+        facts: [{ subject: 'Bob', predicate: 'email_is', object: 'bob@example.com', confidence: 1.0 }],
+        relationships: [],
+        commitments: [],
+      });
+
+      const bobs = findEntities({ name: 'Bob' });
+      expect(bobs).toHaveLength(1);
+      expect(bobs[0]!.source).toBe('llm_extraction');
+      expect(findFacts({ subject_id: bobs[0]!.id })).toHaveLength(1);
     });
   });
 });

--- a/src/vault/extractor.ts
+++ b/src/vault/extractor.ts
@@ -1,8 +1,9 @@
 import type { LLMManager } from '../llm/manager.ts';
-import { createEntity, findEntities } from './entities.ts';
+import { createEntity, findEntities, type Entity } from './entities.ts';
 import { createFact } from './facts.ts';
 import { createRelationship } from './relationships.ts';
 import { createCommitment } from './commitments.ts';
+import { USER_PROFILE_VAULT_SOURCE } from './user-profile.ts';
 
 export type ExtractionResult = {
   entities: Array<{ name: string; type: string; properties?: Record<string, unknown> }>;
@@ -165,6 +166,17 @@ export async function extractAndStore(
     // Store entities
     const entityMap = new Map<string, string>(); // name -> id
 
+    // Look up the existing user profile entity (if any) so extraction doesn't
+    // create a duplicate "User" entity that shadows the real profile. The user
+    // profile is set via the onboarding wizard with source='user_profile' and
+    // always takes precedence over any LLM extraction about "the user".
+    const profileEntities = findEntities({}) as Entity[];
+    const profileEntityNames = new Set(
+      profileEntities
+        .filter(e => e.source === USER_PROFILE_VAULT_SOURCE)
+        .map(e => e.name.toLowerCase())
+    );
+
     for (const entityData of extraction.entities) {
       const { name, type, properties } = entityData;
 
@@ -172,6 +184,34 @@ export async function extractAndStore(
       if (!isValidEntityType(type)) {
         console.warn(`Invalid entity type: ${type}, skipping entity ${name}`);
         continue;
+      }
+
+      // Skip extraction entities that shadow the user's own profile identity.
+      // This prevents the "User" ghost entity problem where the LLM extracts
+      // "name_is_unknown: true" facts about a generic "User" entity when it
+      // can't answer profile questions, creating confusion in the vault.
+      const nameLower = name.toLowerCase();
+      if (profileEntityNames.has(nameLower)) {
+        // Re-use the profile entity ID instead of creating a duplicate
+        const profileEntity = profileEntities.find(e => e.name.toLowerCase() === nameLower);
+        if (profileEntity) {
+          entityMap.set(name, profileEntity.id);
+          continue;
+        }
+      }
+
+      // Also skip entities whose properties mark them as representing the
+      // user identity (extraction sometimes sets is_current_user or is_user).
+      if (properties) {
+        const props = properties as Record<string, unknown>;
+        if (props.is_current_user === true || props.is_user === true) {
+          // Try to map to the real profile entity instead
+          const profileEntity = profileEntities.find(e => e.source === USER_PROFILE_VAULT_SOURCE);
+          if (profileEntity) {
+            entityMap.set(name, profileEntity.id);
+            continue;
+          }
+        }
       }
 
       // Check if entity already exists

--- a/src/vault/extractor.ts
+++ b/src/vault/extractor.ts
@@ -139,7 +139,7 @@ const GENERIC_USER_NAMES = new Set(['user', 'the user', 'current user', 'unknown
  */
 function representsUser(name: string, properties?: Record<string, unknown>): boolean {
   if (GENERIC_USER_NAMES.has(name.toLowerCase())) return true;
-  const flag = (v: unknown) => v === true || v === 'true';
+  const flag = (v: unknown) => v === true || (typeof v === 'string' && v.toLowerCase() === 'true');
   return flag(properties?.is_current_user) || flag(properties?.is_user);
 }
 
@@ -185,8 +185,10 @@ export async function extractAndStore(
     // profile is set via the onboarding wizard with source='user_profile' and
     // always takes precedence over any LLM extraction about "the user".
     const profileEntities = findEntities({ source: USER_PROFILE_VAULT_SOURCE });
+    // Reversed so on a name collision the newest entity (first in the
+    // updated_at DESC result) wins, matching the profileEntities[0] fallback.
     const profileIdByName = new Map(
-      profileEntities.map(e => [e.name.toLowerCase(), e.id])
+      [...profileEntities].reverse().map(e => [e.name.toLowerCase(), e.id] as const)
     );
 
     for (const entityData of extraction.entities) {

--- a/src/vault/extractor.ts
+++ b/src/vault/extractor.ts
@@ -1,5 +1,5 @@
 import type { LLMManager } from '../llm/manager.ts';
-import { createEntity, findEntities, type Entity } from './entities.ts';
+import { createEntity, findEntities } from './entities.ts';
 import { createFact } from './facts.ts';
 import { createRelationship } from './relationships.ts';
 import { createCommitment } from './commitments.ts';
@@ -129,6 +129,20 @@ function isValidEntityType(type: string): type is 'person' | 'project' | 'tool' 
   return ['person', 'project', 'tool', 'place', 'concept', 'event'].includes(type);
 }
 
+/** Placeholder names the extraction LLM uses for the user when it has no real name. */
+const GENERIC_USER_NAMES = new Set(['user', 'the user', 'current user', 'unknown user']);
+
+/**
+ * Whether an extracted entity stands for the user themselves rather than a
+ * distinct person: flagged via is_current_user/is_user (boolean or string,
+ * extraction output is loosely typed) or named with a generic placeholder.
+ */
+function representsUser(name: string, properties?: Record<string, unknown>): boolean {
+  if (GENERIC_USER_NAMES.has(name.toLowerCase())) return true;
+  const flag = (v: unknown) => v === true || v === 'true';
+  return flag(properties?.is_current_user) || flag(properties?.is_user);
+}
+
 /**
  * High-level: extract and store in vault
  */
@@ -166,15 +180,13 @@ export async function extractAndStore(
     // Store entities
     const entityMap = new Map<string, string>(); // name -> id
 
-    // Look up the existing user profile entity (if any) so extraction doesn't
+    // Look up the existing user profile entities (if any) so extraction doesn't
     // create a duplicate "User" entity that shadows the real profile. The user
     // profile is set via the onboarding wizard with source='user_profile' and
     // always takes precedence over any LLM extraction about "the user".
-    const profileEntities = findEntities({}) as Entity[];
-    const profileEntityNames = new Set(
-      profileEntities
-        .filter(e => e.source === USER_PROFILE_VAULT_SOURCE)
-        .map(e => e.name.toLowerCase())
+    const profileEntities = findEntities({ source: USER_PROFILE_VAULT_SOURCE });
+    const profileIdByName = new Map(
+      profileEntities.map(e => [e.name.toLowerCase(), e.id])
     );
 
     for (const entityData of extraction.entities) {
@@ -191,27 +203,26 @@ export async function extractAndStore(
       // "name_is_unknown: true" facts about a generic "User" entity when it
       // can't answer profile questions, creating confusion in the vault.
       const nameLower = name.toLowerCase();
-      if (profileEntityNames.has(nameLower)) {
+      const profileId = profileIdByName.get(nameLower);
+      if (profileId) {
         // Re-use the profile entity ID instead of creating a duplicate
-        const profileEntity = profileEntities.find(e => e.name.toLowerCase() === nameLower);
-        if (profileEntity) {
-          entityMap.set(name, profileEntity.id);
-          continue;
-        }
+        entityMap.set(name, profileId);
+        continue;
       }
 
-      // Also skip entities whose properties mark them as representing the
-      // user identity (extraction sometimes sets is_current_user or is_user).
-      if (properties) {
-        const props = properties as Record<string, unknown>;
-        if (props.is_current_user === true || props.is_user === true) {
-          // Try to map to the real profile entity instead
-          const profileEntity = profileEntities.find(e => e.source === USER_PROFILE_VAULT_SOURCE);
-          if (profileEntity) {
-            entityMap.set(name, profileEntity.id);
-            continue;
-          }
+      // Also catch entities that represent the user without sharing the
+      // profile name: extraction sometimes sets is_current_user/is_user
+      // (as boolean or string) or falls back to a generic placeholder name.
+      if (representsUser(name, properties)) {
+        if (profileEntities.length > 0) {
+          // Map to the real profile entity instead of creating a duplicate
+          entityMap.set(name, profileEntities[0]!.id);
+        } else {
+          // No profile to map to (wizard skipped): don't create a ghost
+          // entity. Its facts are dropped by the subject-lookup below.
+          console.warn(`Skipping user-representing entity "${name}": no user profile exists`);
         }
+        continue;
       }
 
       // Check if entity already exists


### PR DESCRIPTION
## Summary

Fixes #119 - Memory/profile not injected into chat prompts.

## Changes

### 1. Conv-tier profile injection (src/daemon/agent-service.ts)

`buildUserIdentityBlock()` previously returned only "Name: {name}. Local time: ...". The conv-tier LLM had zero awareness of the user's profile despite all data being stored in the vault.

Fix: Now calls `getUserProfile()` + `formatUserProfileForPrompt()` and appends the full profile block (wizard answers + interview facts) to the identity block. Both `streamMessageConv()` and `handleMessageConv()` get this automatically since they both call `buildUserIdentityBlock()`.

### 2. Ghost entity deduplication (src/vault/extractor.ts)

When the agent couldn't answer profile questions, the LLM extraction pipeline repeatedly created a second "User" entity with `name_is_unknown: true` facts. This polluted the vault and confused retrieval.

Fix: Before creating extraction entities, lookup existing user profile entities (`source='user_profile'`). Entities that:
- Share a name with the user's profile entity, OR
- Have `is_current_user: true` or `is_user: true` properties

...are mapped to the real profile entity ID instead of creating duplicates.

## Testing

- `bun test src/vault/` - 41 pass, 0 fail
- `bun test src/user/` - 4 pass, 0 fail
- `bun test src/vault/extractor.test.ts` - 12 pass, 0 fail
- All pre-existing failures (17 in `pid.test.ts`) are the known Windows flock limitation, unrelated.