### PR TITLE
feat(#215): deliver all approval requests to external channels, not just urgent

### DIFF
--- a/src/authority/approval-delivery.test.ts
+++ b/src/authority/approval-delivery.test.ts
@@ -8,7 +8,7 @@ import type { ApprovalRequest } from './approval.ts';
 
 function makeRequest(overrides?: Partial<ApprovalRequest>): ApprovalRequest {
   return {
-    id: 'req-1234-5678-abcd',
+    id: '3f2a9b1c-4d5e-4f60-8a7b-9c0d1e2f3a4b',
     agent_id: 'agent-1',
     agent_name: 'Test Agent',
     tool_name: 'execute_command',
@@ -84,6 +84,11 @@ describe('ApprovalDelivery', () => {
     expect(message).toContain(request.tool_name);
     expect(message).toContain(request.agent_name);
     expect(message).toContain(request.reason);
+
+    // The reply command must match the approve/deny regex in
+    // channel-service.ts handleChannelMessage, or replies can't be parsed.
+    const approveLine = message.split('\n').find((line) => line.trim().startsWith('approve '))!;
+    expect(approveLine.trim()).toMatch(/^approve\s+[a-f0-9-]+$/);
   });
 
   test('always pushes to the websocket broadcaster', async () => {
@@ -92,7 +97,7 @@ describe('ApprovalDelivery', () => {
     delivery.setBroadcaster(broadcaster);
 
     const normal = makeRequest({ urgency: 'normal' });
-    const urgent = makeRequest({ id: 'req-urgent-0001', urgency: 'urgent' });
+    const urgent = makeRequest({ id: 'a1b2c3d4-0000-4000-8000-000000000001', urgency: 'urgent' });
     await delivery.deliver(normal);
     await delivery.deliver(urgent);
 

--- a/src/authority/approval-delivery.test.ts
+++ b/src/authority/approval-delivery.test.ts
@@ -1,0 +1,119 @@
+import { test, expect, describe } from 'bun:test';
+import {
+  ApprovalDelivery,
+  type ApprovalBroadcaster,
+  type ChannelSender,
+} from './approval-delivery.ts';
+import type { ApprovalRequest } from './approval.ts';
+
+function makeRequest(overrides?: Partial<ApprovalRequest>): ApprovalRequest {
+  return {
+    id: 'req-1234-5678-abcd',
+    agent_id: 'agent-1',
+    agent_name: 'Test Agent',
+    tool_name: 'execute_command',
+    tool_arguments: '{"command":"ls"}',
+    action_category: 'execute_command',
+    urgency: 'normal',
+    reason: 'Agent wants to run a command',
+    context: '',
+    status: 'pending',
+    execution_mode: 'deferred',
+    decided_at: null,
+    decided_by: null,
+    executed_at: null,
+    execution_result: null,
+    created_at: Date.now(),
+    ...overrides,
+  };
+}
+
+class FakeBroadcaster implements ApprovalBroadcaster {
+  public received: ApprovalRequest[] = [];
+  broadcastApprovalRequest(request: ApprovalRequest): void {
+    this.received.push(request);
+  }
+}
+
+class FakeChannelSender implements ChannelSender {
+  private throwOnSend: Error | null;
+  public sent: string[] = [];
+  constructor(opts?: { throwOnSend?: Error }) {
+    this.throwOnSend = opts?.throwOnSend ?? null;
+  }
+  async broadcastToAll(text: string): Promise<void> {
+    if (this.throwOnSend) throw this.throwOnSend;
+    this.sent.push(text);
+  }
+}
+
+describe('ApprovalDelivery', () => {
+  test('delivers normal-urgency requests to external channels', async () => {
+    const delivery = new ApprovalDelivery();
+    const sender = new FakeChannelSender();
+    delivery.setChannelSender(sender);
+
+    await delivery.deliver(makeRequest({ urgency: 'normal' }));
+
+    expect(sender.sent).toHaveLength(1);
+  });
+
+  test('delivers urgent requests to external channels', async () => {
+    const delivery = new ApprovalDelivery();
+    const sender = new FakeChannelSender();
+    delivery.setChannelSender(sender);
+
+    await delivery.deliver(makeRequest({ urgency: 'urgent' }));
+
+    expect(sender.sent).toHaveLength(1);
+  });
+
+  test('channel message includes the approve/deny reply commands with the short id', async () => {
+    const delivery = new ApprovalDelivery();
+    const sender = new FakeChannelSender();
+    delivery.setChannelSender(sender);
+
+    const request = makeRequest();
+    await delivery.deliver(request);
+
+    const shortId = request.id.slice(0, 8);
+    const message = sender.sent[0]!;
+    expect(message).toContain('[APPROVAL NEEDED]');
+    expect(message).toContain(`approve ${shortId}`);
+    expect(message).toContain(`deny ${shortId}`);
+    expect(message).toContain(request.tool_name);
+    expect(message).toContain(request.agent_name);
+    expect(message).toContain(request.reason);
+  });
+
+  test('always pushes to the websocket broadcaster', async () => {
+    const delivery = new ApprovalDelivery();
+    const broadcaster = new FakeBroadcaster();
+    delivery.setBroadcaster(broadcaster);
+
+    const normal = makeRequest({ urgency: 'normal' });
+    const urgent = makeRequest({ id: 'req-urgent-0001', urgency: 'urgent' });
+    await delivery.deliver(normal);
+    await delivery.deliver(urgent);
+
+    expect(broadcaster.received).toEqual([normal, urgent]);
+  });
+
+  test('a channel send failure does not reject and does not skip the broadcaster', async () => {
+    const delivery = new ApprovalDelivery();
+    const broadcaster = new FakeBroadcaster();
+    const sender = new FakeChannelSender({ throwOnSend: new Error('telegram down') });
+    delivery.setBroadcaster(broadcaster);
+    delivery.setChannelSender(sender);
+
+    await expect(delivery.deliver(makeRequest())).resolves.toBeUndefined();
+    expect(broadcaster.received).toHaveLength(1);
+    expect(sender.sent).toHaveLength(0);
+  });
+
+  test('resolves when no broadcaster or channel sender is wired', async () => {
+    const delivery = new ApprovalDelivery();
+
+    await expect(delivery.deliver(makeRequest())).resolves.toBeUndefined();
+  });
+});

--- a/src/authority/approval-delivery.ts
+++ b/src/authority/approval-delivery.ts
@@ -1,6 +1,6 @@
 /**
  * Approval Delivery — Pushes approval requests to the user through
- * appropriate channels (WebSocket always, Telegram/Discord if urgent).
+ * appropriate channels (WebSocket always, Telegram/Discord too).
  */
 
 import type { ApprovalRequest } from './approval.ts';
@@ -32,8 +32,9 @@ export class ApprovalDelivery {
     // Always push to dashboard via WebSocket
     this.broadcaster?.broadcastApprovalRequest(request);
 
-    // If urgent, also push to Telegram/Discord
-    if (request.urgency === 'urgent' && this.channelSender) {
+    // Always push to Telegram/Discord so users can approve/deny directly
+    // from messaging channels without opening the dashboard.
+    if (this.channelSender) {
       const message = this.formatApprovalMessage(request);
       try {
         await this.channelSender.broadcastToAll(message);

--- a/src/daemon/ws-service.ts
+++ b/src/daemon/ws-service.ts
@@ -525,7 +525,8 @@ export class WebSocketService implements Service {
 
   /**
    * Broadcast an approval request to all connected dashboard clients.
-   * Always pushed via WS; urgent requests are also sent to external channels.
+   * External channel delivery is handled by ApprovalDelivery so messages
+   * are never duplicated.
    */
   broadcastApprovalRequest(request: ApprovalRequest): void {
     const shortId = request.id.slice(0, 8);
@@ -544,14 +545,6 @@ export class WebSocketService implements Service {
       timestamp: Date.now(),
     };
     this.wsServer.broadcast(message);
-
-    // Push urgent approvals to external channels
-    if (request.urgency === 'urgent' && this.channelService) {
-      const text = `[APPROVAL NEEDED] ${request.agent_name} wants to run ${request.tool_name} (${request.action_category}).\nReason: ${request.reason}\nReply: approve ${shortId} / deny ${shortId}`;
-      this.channelService.broadcastToAll(text).catch(err =>
-        console.error('[WSService] Approval channel broadcast error:', err)
-      );
-    }
   }
 
   /**


### PR DESCRIPTION
## Summary

Fixes #215 - Direct approval in channels.

Previously, only `urgent` approval requests (currently only `make_payment` actions) were delivered to Telegram/Discord. All other approvals — browser control, file access, command execution, etc. — only appeared in the web dashboard, forcing users to tab out to approve them.

## Changes

### 1. Remove urgency gate (src/authority/approval-delivery.ts)

The `deliver()` method now sends **every** approval request to external channels (Telegram, Discord), not just `urgent` ones. Users can reply with `approve <id>` / `deny <id>` directly in their messaging app.

### 2. Remove duplicate channel broadcast (src/daemon/ws-service.ts)

`broadcastApprovalRequest()` was independently sending urgent requests to channels. Since `ApprovalDelivery.deliver()` already handles this for all requests (change #1), the channel broadcast in the WS service was removed to avoid duplicate messages.

## Testing

- `bun test src/authority/` - 47 pass, 0 fail
