### PR TITLE
fix: reliable external channel delivery — retry with backoff, failure alerts, chunk-resume

### DIFF
--- a/src/comms/channels/telegram.test.ts
+++ b/src/comms/channels/telegram.test.ts
@@ -104,4 +104,31 @@ describe('sendMessage chunking', () => {
       globalThis.fetch = originalFetch;
     }
   });
+
+  test('maps a 5xx with a non-JSON body through the status code so it stays retriable', async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () => ({
+      status: 502,
+      json: async () => {
+        throw new SyntaxError('Unexpected token < in JSON');
+      },
+    })) as unknown as typeof fetch;
+
+    try {
+      const adapter = new TelegramAdapter('test-token');
+
+      let thrown: unknown;
+      try {
+        await adapter.sendMessage('chat-1', 'hi');
+      } catch (err) {
+        thrown = err;
+      }
+
+      expect(thrown).toBeInstanceOf(TelegramSendError);
+      expect((thrown as TelegramSendError).status).toBe(502);
+      expect((thrown as TelegramSendError).message).toBe('Telegram API error: HTTP 502');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
 });

--- a/src/comms/channels/telegram.test.ts
+++ b/src/comms/channels/telegram.test.ts
@@ -1,0 +1,65 @@
+import { test, expect, describe } from 'bun:test';
+import { TelegramSendError, telegramErrorFromResponse } from './telegram.ts';
+
+describe('telegramErrorFromResponse', () => {
+  test('returns null for a successful response', () => {
+    expect(telegramErrorFromResponse(200, { ok: true, result: {} })).toBeNull();
+  });
+
+  test('surfaces retry_after as retryAfterMs on 429', () => {
+    const error = telegramErrorFromResponse(429, {
+      ok: false,
+      error_code: 429,
+      description: 'Too Many Requests: retry after 27',
+      parameters: { retry_after: 27 },
+    });
+
+    expect(error).toBeInstanceOf(TelegramSendError);
+    expect(error!.status).toBe(429);
+    expect(error!.retryAfterMs).toBe(27_000);
+    expect(error!.message).toContain('429');
+  });
+
+  test('recognizes a 429 from the body error_code even if the HTTP status differs', () => {
+    const error = telegramErrorFromResponse(200, {
+      ok: false,
+      error_code: 429,
+      description: 'Too Many Requests: retry after 5',
+      parameters: { retry_after: 5 },
+    });
+
+    expect(error!.status).toBe(429);
+    expect(error!.retryAfterMs).toBe(5_000);
+  });
+
+  test('handles a 429 with missing or garbled parameters', () => {
+    const error = telegramErrorFromResponse(429, {
+      ok: false,
+      error_code: 429,
+      description: 'Too Many Requests',
+      parameters: { retry_after: 'soon' },
+    });
+
+    expect(error!.retryAfterMs).toBeUndefined();
+    expect(error!.message).toContain('429');
+  });
+
+  test('returns a plain send error without retryAfterMs for non-429 failures', () => {
+    const error = telegramErrorFromResponse(400, {
+      ok: false,
+      error_code: 400,
+      description: 'Bad Request: chat not found',
+    });
+
+    expect(error!.status).toBe(400);
+    expect(error!.retryAfterMs).toBeUndefined();
+    expect(error!.message).toBe('Telegram API error: Bad Request: chat not found');
+  });
+
+  test('falls back to the HTTP status when the body has no description', () => {
+    const error = telegramErrorFromResponse(502, null);
+
+    expect(error!.status).toBe(502);
+    expect(error!.message).toBe('Telegram API error: HTTP 502');
+  });
+});

--- a/src/comms/channels/telegram.test.ts
+++ b/src/comms/channels/telegram.test.ts
@@ -1,5 +1,5 @@
 import { test, expect, describe } from 'bun:test';
-import { TelegramSendError, telegramErrorFromResponse } from './telegram.ts';
+import { TelegramAdapter, TelegramSendError, telegramErrorFromResponse } from './telegram.ts';
 
 describe('telegramErrorFromResponse', () => {
   test('returns null for a successful response', () => {
@@ -61,5 +61,47 @@ describe('telegramErrorFromResponse', () => {
 
     expect(error!.status).toBe(502);
     expect(error!.message).toBe('Telegram API error: HTTP 502');
+  });
+});
+
+describe('sendMessage chunking', () => {
+  test('tags a mid-chunk failure with the unsent remainder for resumable retries', async () => {
+    const originalFetch = globalThis.fetch;
+    let calls = 0;
+    globalThis.fetch = (async () => {
+      calls++;
+      if (calls === 1) {
+        return { status: 200, json: async () => ({ ok: true }) };
+      }
+      return {
+        status: 429,
+        json: async () => ({
+          ok: false,
+          error_code: 429,
+          description: 'Too Many Requests: retry after 3',
+          parameters: { retry_after: 3 },
+        }),
+      };
+    }) as unknown as typeof fetch;
+
+    try {
+      const adapter = new TelegramAdapter('test-token');
+      // 5000 chars with no newlines splits into a 4096 chunk and a 904 chunk.
+      const text = 'a'.repeat(5000);
+
+      let thrown: unknown;
+      try {
+        await adapter.sendMessage('chat-1', text);
+      } catch (err) {
+        thrown = err;
+      }
+
+      expect(thrown).toBeInstanceOf(TelegramSendError);
+      const sendError = thrown as TelegramSendError & { remainingText?: string };
+      expect(sendError.retryAfterMs).toBe(3_000);
+      expect(sendError.remainingText).toBe('a'.repeat(904));
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 });

--- a/src/comms/channels/telegram.ts
+++ b/src/comms/channels/telegram.ts
@@ -20,6 +20,39 @@ export interface ChannelAdapter {
   isConnected(): boolean;
 }
 
+export class TelegramSendError extends Error {
+  readonly status?: number;
+  readonly retryAfterMs?: number;
+
+  constructor(message: string, opts?: { status?: number; retryAfterMs?: number }) {
+    super(message);
+    this.name = 'TelegramSendError';
+    this.status = opts?.status;
+    this.retryAfterMs = opts?.retryAfterMs;
+  }
+}
+
+/**
+ * Map a Telegram sendMessage HTTP response to an error, or null on success.
+ * On 429 the retry_after from the response body (seconds) is surfaced as
+ * retryAfterMs, and the message always contains "429" so string-based
+ * transient-error classification still works after the error is stringified.
+ */
+export function telegramErrorFromResponse(status: number, body: unknown): TelegramSendError | null {
+  const data = body as { ok?: boolean; error_code?: number; description?: string; parameters?: { retry_after?: unknown } } | null;
+  if (data?.ok === true) return null;
+
+  const description = data?.description ?? `HTTP ${status}`;
+  if (status === 429 || data?.error_code === 429) {
+    const retryAfter = data?.parameters?.retry_after;
+    const retryAfterMs = typeof retryAfter === 'number' && Number.isFinite(retryAfter)
+      ? retryAfter * 1000
+      : undefined;
+    return new TelegramSendError(`Telegram API error 429: ${description}`, { status: 429, retryAfterMs });
+  }
+  return new TelegramSendError(`Telegram API error: ${description}`, { status });
+}
+
 type TelegramUpdate = {
   update_id: number;
   message?: {
@@ -133,13 +166,16 @@ export class TelegramAdapter implements ChannelAdapter {
         if (!data.ok) {
           // Retry without Markdown if parsing failed
           if (data.description?.includes('parse')) {
-            await fetchWithTimeout(`${this.baseUrl}/sendMessage`, {
+            const fallback = await fetchWithTimeout(`${this.baseUrl}/sendMessage`, {
               method: 'POST',
               headers: { 'Content-Type': 'application/json' },
               body: JSON.stringify({ chat_id: chatId, text: chunk }),
             }, 15_000);
+            const fallbackError = telegramErrorFromResponse(fallback.status, await fallback.json());
+            if (fallbackError) throw fallbackError;
           } else {
-            throw new Error(`Telegram API error: ${data.description}`);
+            const error = telegramErrorFromResponse(response.status, data);
+            if (error) throw error;
           }
         }
       } catch (error) {

--- a/src/comms/channels/telegram.ts
+++ b/src/comms/channels/telegram.ts
@@ -162,17 +162,19 @@ export class TelegramAdapter implements ChannelAdapter {
           }),
         }, 15_000);
 
-        const data = await response.json() as any;
+        // A proxy/outage 5xx can carry a non-JSON body; map it through the
+        // status code instead of letting the parse error escape unclassified.
+        const data = await response.json().catch(() => null) as any;
 
-        if (!data.ok) {
+        if (!data?.ok) {
           // Retry without Markdown if parsing failed
-          if (data.description?.includes('parse')) {
+          if (data?.description?.includes('parse')) {
             const fallback = await fetchWithTimeout(`${this.baseUrl}/sendMessage`, {
               method: 'POST',
               headers: { 'Content-Type': 'application/json' },
               body: JSON.stringify({ chat_id: chatId, text: chunk }),
             }, 15_000);
-            const fallbackError = telegramErrorFromResponse(fallback.status, await fallback.json());
+            const fallbackError = telegramErrorFromResponse(fallback.status, await fallback.json().catch(() => null));
             if (fallbackError) throw fallbackError;
           } else {
             const error = telegramErrorFromResponse(response.status, data);

--- a/src/comms/channels/telegram.ts
+++ b/src/comms/channels/telegram.ts
@@ -149,7 +149,8 @@ export class TelegramAdapter implements ChannelAdapter {
   async sendMessage(chatId: string, text: string): Promise<void> {
     // Telegram has a 4096 char limit per message
     const chunks = splitText(text, 4096);
-    for (const chunk of chunks) {
+    for (let i = 0; i < chunks.length; i++) {
+      const chunk = chunks[i]!;
       try {
         const response = await fetchWithTimeout(`${this.baseUrl}/sendMessage`, {
           method: 'POST',
@@ -179,6 +180,12 @@ export class TelegramAdapter implements ChannelAdapter {
           }
         }
       } catch (error) {
+        // Tag the error with the not-yet-sent portion (splitText is lossless,
+        // so the slices concatenate back exactly) so a retrying caller can
+        // resume from the failed chunk instead of duplicating sent ones.
+        if (error instanceof Error && i > 0) {
+          (error as Error & { remainingText?: string }).remainingText = chunks.slice(i).join('');
+        }
         console.error('[TelegramAdapter] Error sending message:', error);
         throw error;
       }

--- a/src/daemon/channel-service.test.ts
+++ b/src/daemon/channel-service.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, expect, test } from "bun:test";
-import { routePerChannel, type ChannelRouterServices } from "./channel-service";
+import { routePerChannel, sendWithRetry, type ChannelRouterServices } from "./channel-service";
 import type { ChannelAdapter, ChannelMessage } from "../comms/channels/telegram";
 
 class FakeAdapter implements ChannelAdapter {
@@ -138,5 +138,122 @@ describe("routePerChannel", () => {
     }));
     expect(res.delivered).toEqual(["telegram"]);
     expect(tg.sent).toHaveLength(1);
+  });
+});
+
+/** Adapter that fails with each scripted error in turn, then succeeds. */
+class ScriptedAdapter {
+  name = "scripted";
+  public sent: Array<{ to: string; text: string }> = [];
+  constructor(private failures: unknown[]) {}
+
+  async sendMessage(to: string, text: string): Promise<void> {
+    const failure = this.failures.shift();
+    if (failure) throw failure;
+    this.sent.push({ to, text });
+  }
+}
+
+function makeSleepRecorder(): { sleeps: number[]; sleep: (ms: number) => Promise<void> } {
+  const sleeps: number[] = [];
+  return {
+    sleeps,
+    sleep: async (ms: number) => {
+      sleeps.push(ms);
+    },
+  };
+}
+
+function rateLimitError(retryAfterMs?: number): Error & { retryAfterMs?: number } {
+  const err = new Error("Telegram API error 429: Too Many Requests") as Error & { retryAfterMs?: number };
+  if (retryAfterMs !== undefined) err.retryAfterMs = retryAfterMs;
+  return err;
+}
+
+describe("sendWithRetry", () => {
+  test("first-try success makes one attempt and never sleeps", async () => {
+    const adapter = new ScriptedAdapter([]);
+    const { sleeps, sleep } = makeSleepRecorder();
+
+    const res = await sendWithRetry(adapter, "user", "hi", { sleep });
+
+    expect(res).toEqual({ ok: true, attempts: 1 });
+    expect(adapter.sent).toEqual([{ to: "user", text: "hi" }]);
+    expect(sleeps).toEqual([]);
+  });
+
+  test("retries transient failures with exponential backoff", async () => {
+    const adapter = new ScriptedAdapter([rateLimitError(), rateLimitError()]);
+    const { sleeps, sleep } = makeSleepRecorder();
+
+    const res = await sendWithRetry(adapter, "user", "hi", { sleep, baseDelayMs: 2_000 });
+
+    expect(res).toEqual({ ok: true, attempts: 3 });
+    expect(sleeps).toEqual([2_000, 4_000]);
+  });
+
+  test("an explicit retryAfterMs larger than the backoff wins", async () => {
+    const adapter = new ScriptedAdapter([rateLimitError(7_000)]);
+    const { sleeps, sleep } = makeSleepRecorder();
+
+    const res = await sendWithRetry(adapter, "user", "hi", { sleep, baseDelayMs: 2_000 });
+
+    expect(res).toEqual({ ok: true, attempts: 2 });
+    expect(sleeps).toEqual([7_000]);
+  });
+
+  test("a retryAfterMs smaller than the backoff loses to the backoff", async () => {
+    const adapter = new ScriptedAdapter([rateLimitError(500)]);
+    const { sleeps, sleep } = makeSleepRecorder();
+
+    const res = await sendWithRetry(adapter, "user", "hi", { sleep, baseDelayMs: 2_000 });
+
+    expect(res).toEqual({ ok: true, attempts: 2 });
+    expect(sleeps).toEqual([2_000]);
+  });
+
+  test("non-transient errors are not retried", async () => {
+    const adapter = new ScriptedAdapter([new Error("Telegram API error: Bad Request: chat not found")]);
+    const { sleeps, sleep } = makeSleepRecorder();
+
+    const res = await sendWithRetry(adapter, "user", "hi", { sleep });
+
+    expect(res).toEqual({ ok: false, attempts: 1, error: "Telegram API error: Bad Request: chat not found" });
+    expect(sleeps).toEqual([]);
+    expect(adapter.sent).toEqual([]);
+  });
+
+  test("fails immediately when the provider demands a wait beyond the budget", async () => {
+    const adapter = new ScriptedAdapter([rateLimitError(120_000)]);
+    const { sleeps, sleep } = makeSleepRecorder();
+
+    const res = await sendWithRetry(adapter, "user", "hi", { sleep, budgetMs: 60_000 });
+
+    expect(res.ok).toBe(false);
+    expect(res.attempts).toBe(1);
+    expect(sleeps).toEqual([]);
+  });
+
+  test("gives up after maxAttempts on persistent transient failure", async () => {
+    const adapter = new ScriptedAdapter([
+      rateLimitError(), rateLimitError(), rateLimitError(), rateLimitError(),
+    ]);
+    const { sleeps, sleep } = makeSleepRecorder();
+
+    const res = await sendWithRetry(adapter, "user", "hi", { sleep, maxAttempts: 4, baseDelayMs: 2_000 });
+
+    expect(res.ok).toBe(false);
+    expect(res.attempts).toBe(4);
+    expect(sleeps).toEqual([2_000, 4_000, 8_000]);
+  });
+
+  test("caps a single wait at maxDelayMs even when retryAfterMs asks for more", async () => {
+    const adapter = new ScriptedAdapter([rateLimitError(45_000)]);
+    const { sleeps, sleep } = makeSleepRecorder();
+
+    const res = await sendWithRetry(adapter, "user", "hi", { sleep, maxDelayMs: 30_000 });
+
+    expect(res).toEqual({ ok: true, attempts: 2 });
+    expect(sleeps).toEqual([30_000]);
   });
 });

--- a/src/daemon/channel-service.test.ts
+++ b/src/daemon/channel-service.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, expect, test } from "bun:test";
-import { routePerChannel, sendWithRetry, type ChannelRouterServices } from "./channel-service";
+import { ChannelService, routePerChannel, sendWithRetry, type ChannelRouterServices } from "./channel-service";
 import type { ChannelAdapter, ChannelMessage } from "../comms/channels/telegram";
 
 class FakeAdapter implements ChannelAdapter {
@@ -314,5 +314,80 @@ describe("sendWithRetry", () => {
 
     expect(res).toEqual({ ok: true, attempts: 2 });
     expect(sleeps).toEqual([2_000]);
+  });
+
+  test("resumes from the error's remainingText instead of resending sent chunks", async () => {
+    class ResumeAdapter {
+      name = "resume";
+      public sent: string[] = [];
+      private calls = 0;
+      async sendMessage(_to: string, text: string): Promise<void> {
+        this.calls++;
+        if (this.calls === 1) {
+          const err = rateLimitError() as Error & { remainingText?: string };
+          err.remainingText = "tail";
+          throw err;
+        }
+        this.sent.push(text);
+      }
+    }
+    const adapter = new ResumeAdapter();
+    const { sleep } = makeSleepRecorder();
+
+    const res = await sendWithRetry(adapter, "user", "head-and-tail", { sleep });
+
+    expect(res).toEqual({ ok: true, attempts: 2 });
+    expect(adapter.sent).toEqual(["tail"]);
+  });
+});
+
+describe("delivery failure handler", () => {
+  function makeService(adapter: ChannelAdapter): ChannelService {
+    // Constructor only stores deps and creates the manager; the live
+    // agent/STT stack is needed only by start(), which we don't call.
+    const svc = new ChannelService({} as never, {} as never);
+    svc.getManager().register(adapter);
+    return svc;
+  }
+
+  test("notifies the handler when a send exhausts its retries", async () => {
+    const failing = new FakeAdapter({
+      connected: true,
+      throwOnSend: new Error("Telegram API error: Bad Request: chat not found"),
+    });
+    const svc = makeService(failing);
+    const failures: Array<{ channel: string; attempts: number; error: string }> = [];
+    svc.setDeliveryFailureHandler((f) => failures.push(f));
+
+    await svc.sendToChannel("fake", "user", "hi");
+
+    expect(failures).toEqual([
+      { channel: "fake", attempts: 1, error: "Telegram API error: Bad Request: chat not found" },
+    ]);
+  });
+
+  test("does not notify the handler on success", async () => {
+    const healthy = new FakeAdapter({ connected: true });
+    const svc = makeService(healthy);
+    const failures: unknown[] = [];
+    svc.setDeliveryFailureHandler((f) => failures.push(f));
+
+    await svc.sendToChannel("fake", "user", "hi");
+
+    expect(failures).toEqual([]);
+    expect(healthy.sent).toEqual([{ to: "user", text: "hi" }]);
+  });
+
+  test("a throwing handler does not break the send path", async () => {
+    const failing = new FakeAdapter({
+      connected: true,
+      throwOnSend: new Error("Telegram API error: Bad Request: chat not found"),
+    });
+    const svc = makeService(failing);
+    svc.setDeliveryFailureHandler(() => {
+      throw new Error("handler boom");
+    });
+
+    await expect(svc.sendToChannel("fake", "user", "hi")).resolves.toBeUndefined();
   });
 });

--- a/src/daemon/channel-service.test.ts
+++ b/src/daemon/channel-service.test.ts
@@ -7,6 +7,8 @@
 import { describe, expect, test } from "bun:test";
 import { ChannelService, routePerChannel, sendWithRetry, type ChannelRouterServices } from "./channel-service";
 import type { ChannelAdapter, ChannelMessage } from "../comms/channels/telegram";
+import { initDatabase } from "../vault/schema";
+import { setSetting } from "../vault/settings";
 
 class FakeAdapter implements ChannelAdapter {
   name = "fake";
@@ -339,6 +341,25 @@ describe("sendWithRetry", () => {
     expect(res).toEqual({ ok: true, attempts: 2 });
     expect(adapter.sent).toEqual(["tail"]);
   });
+
+  test("resends the full text when the error carries no remainingText", async () => {
+    class RecordingAdapter {
+      name = "recording";
+      public sent: string[] = [];
+      private failures = 1;
+      async sendMessage(_to: string, text: string): Promise<void> {
+        if (this.failures-- > 0) throw rateLimitError();
+        this.sent.push(text);
+      }
+    }
+    const adapter = new RecordingAdapter();
+    const { sleep } = makeSleepRecorder();
+
+    const res = await sendWithRetry(adapter, "user", "full message", { sleep });
+
+    expect(res).toEqual({ ok: true, attempts: 2 });
+    expect(adapter.sent).toEqual(["full message"]);
+  });
 });
 
 describe("delivery failure handler", () => {
@@ -349,6 +370,28 @@ describe("delivery failure handler", () => {
     svc.getManager().register(adapter);
     return svc;
   }
+
+  test("broadcastToAll notifies the handler when a channel exhausts its retries", async () => {
+    // broadcastToAll needs a last-known recipient, which is only loaded from
+    // the settings table during start() — seed it through an in-memory vault.
+    initDatabase(":memory:");
+    setSetting("channel.lastRecipient.fake", "user-1");
+    const svc = new ChannelService({} as never, {} as never);
+    await svc.start();
+    const failing = new FakeAdapter({
+      connected: true,
+      throwOnSend: new Error("Telegram API error: Bad Request: chat not found"),
+    });
+    svc.getManager().register(failing);
+    const failures: Array<{ channel: string; attempts: number; error: string }> = [];
+    svc.setDeliveryFailureHandler((f) => failures.push(f));
+
+    await svc.broadcastToAll("hi");
+
+    expect(failures).toEqual([
+      { channel: "fake", attempts: 1, error: "Telegram API error: Bad Request: chat not found" },
+    ]);
+  });
 
   test("notifies the handler when a send exhausts its retries", async () => {
     const failing = new FakeAdapter({

--- a/src/daemon/channel-service.test.ts
+++ b/src/daemon/channel-service.test.ts
@@ -247,13 +247,72 @@ describe("sendWithRetry", () => {
     expect(sleeps).toEqual([2_000, 4_000, 8_000]);
   });
 
-  test("caps a single wait at maxDelayMs even when retryAfterMs asks for more", async () => {
+  test("honors an explicit retryAfterMs beyond the per-wait cap when it fits the budget", async () => {
+    // Sleeping only the capped 30s would retry inside Telegram's stated
+    // penalty window and burn an attempt on a guaranteed 429.
     const adapter = new ScriptedAdapter([rateLimitError(45_000)]);
     const { sleeps, sleep } = makeSleepRecorder();
 
-    const res = await sendWithRetry(adapter, "user", "hi", { sleep, maxDelayMs: 30_000 });
+    const res = await sendWithRetry(adapter, "user", "hi", { sleep, maxDelayMs: 30_000, budgetMs: 60_000 });
 
     expect(res).toEqual({ ok: true, attempts: 2 });
-    expect(sleeps).toEqual([30_000]);
+    expect(sleeps).toEqual([45_000]);
+  });
+
+  test("caps the synthetic backoff at maxDelayMs", async () => {
+    const adapter = new ScriptedAdapter([rateLimitError(), rateLimitError()]);
+    const { sleeps, sleep } = makeSleepRecorder();
+
+    const res = await sendWithRetry(adapter, "user", "hi", { sleep, baseDelayMs: 20_000, maxDelayMs: 30_000 });
+
+    expect(res).toEqual({ ok: true, attempts: 3 });
+    expect(sleeps).toEqual([20_000, 30_000]);
+  });
+
+  test("depletes the budget across attempts, counting elapsed wall-clock time", async () => {
+    const adapter = new ScriptedAdapter([rateLimitError(), rateLimitError(), rateLimitError()]);
+    let clock = 0;
+    const sleeps: number[] = [];
+    const sleep = async (ms: number) => {
+      sleeps.push(ms);
+      clock += ms;
+    };
+
+    const res = await sendWithRetry(adapter, "user", "hi", {
+      sleep,
+      now: () => clock,
+      baseDelayMs: 2_000,
+      budgetMs: 10_000,
+    });
+
+    // Backoff wants 2s, 4s, then 8s — but after 6s of sleeping only 4s of
+    // budget remains, so the third retry fails fast instead of sleeping.
+    expect(res.ok).toBe(false);
+    expect(res.attempts).toBe(3);
+    expect(sleeps).toEqual([2_000, 4_000]);
+  });
+
+  test("retries a fetch timeout (AbortError)", async () => {
+    const abortError = new Error("The operation was aborted.");
+    abortError.name = "AbortError";
+    const adapter = new ScriptedAdapter([abortError]);
+    const { sleeps, sleep } = makeSleepRecorder();
+
+    const res = await sendWithRetry(adapter, "user", "hi", { sleep, baseDelayMs: 2_000 });
+
+    expect(res).toEqual({ ok: true, attempts: 2 });
+    expect(sleeps).toEqual([2_000]);
+  });
+
+  test("retries connection-level failures identified by error code", async () => {
+    const connError = new Error("Unable to connect") as Error & { code?: string };
+    connError.code = "ConnectionRefused";
+    const adapter = new ScriptedAdapter([connError]);
+    const { sleeps, sleep } = makeSleepRecorder();
+
+    const res = await sendWithRetry(adapter, "user", "hi", { sleep, baseDelayMs: 2_000 });
+
+    expect(res).toEqual({ ok: true, attempts: 2 });
+    expect(sleeps).toEqual([2_000]);
   });
 });

--- a/src/daemon/channel-service.ts
+++ b/src/daemon/channel-service.ts
@@ -351,6 +351,7 @@ export interface SendRetryOptions {
   maxDelayMs?: number;
   budgetMs?: number;
   sleep?: (ms: number) => Promise<void>;
+  now?: () => number;
   isTransient?: (err: unknown) => boolean;
 }
 
@@ -358,20 +359,42 @@ export type SendRetryResult =
   | { ok: true; attempts: number }
   | { ok: false; attempts: number; error: string };
 
+/** Runtime error codes for connection-level failures (Node + Bun spellings). */
+const TRANSIENT_ERROR_CODES = new Set([
+  'ECONNREFUSED', 'ECONNRESET', 'ENOTFOUND', 'ETIMEDOUT', 'EPIPE', 'EAI_AGAIN',
+  'ConnectionRefused', 'ConnectionClosed', 'FailedToOpenSocket',
+]);
+
 function defaultIsTransient(err: unknown): boolean {
   // An explicit retry-after from the provider always means "try again",
   // regardless of how the error message is worded.
   if (typeof (err as { retryAfterMs?: unknown })?.retryAfterMs === 'number') return true;
+  if (err instanceof Error) {
+    // AbortError is fetchWithTimeout's timeout. Retrying a timed-out send can
+    // duplicate a message that was actually delivered (Telegram has no
+    // idempotency key) — accepted: a duplicate beats a silently dropped
+    // approval request.
+    if (err.name === 'AbortError' || err.name === 'TimeoutError') return true;
+    const errCode = (err as { code?: unknown }).code;
+    if (typeof errCode === 'string' && TRANSIENT_ERROR_CODES.has(errCode)) return true;
+  }
   const code = classifyErrorString(err instanceof Error ? err.message : String(err));
   return code === 'rate_limit' || code === 'network' || code === 'server';
 }
 
 /**
  * Send a message through an adapter, retrying transient failures (rate
- * limits, network errors) with exponential backoff. Honors an explicit
- * retryAfterMs on the thrown error (e.g. Telegram 429 retry_after) when it
- * exceeds the backoff. Never sleeps past the total budget: if the required
- * wait doesn't fit, it fails immediately instead of stalling the caller.
+ * limits, network errors, timeouts) with exponential backoff. An explicit
+ * retryAfterMs on the thrown error (e.g. Telegram 429 retry_after) is
+ * honored even beyond the per-wait cap, which only bounds the synthetic
+ * backoff. The budget is a wall-clock deadline covering sleeps and attempt
+ * duration: if the required wait doesn't fit before the deadline, it fails
+ * immediately instead of stalling the caller.
+ *
+ * Note: retrying re-runs the adapter's whole sendMessage, so a multi-chunk
+ * (>4096 char) text that fails mid-way resends its leading chunks. Discord
+ * rarely gets here at all — discord.js queues 429s internally, and the
+ * adapter's own errors (not connected, invalid channel) are non-transient.
  */
 export async function sendWithRetry(
   adapter: Pick<ChannelAdapter, 'name' | 'sendMessage'>,
@@ -383,8 +406,9 @@ export async function sendWithRetry(
   const baseDelayMs = opts?.baseDelayMs ?? SEND_RETRY_BASE_DELAY_MS;
   const maxDelayMs = opts?.maxDelayMs ?? SEND_RETRY_MAX_DELAY_MS;
   const sleep = opts?.sleep ?? ((ms: number) => Bun.sleep(ms));
+  const now = opts?.now ?? Date.now;
   const isTransient = opts?.isTransient ?? defaultIsTransient;
-  let budgetMs = opts?.budgetMs ?? SEND_RETRY_BUDGET_MS;
+  const deadline = now() + (opts?.budgetMs ?? SEND_RETRY_BUDGET_MS);
 
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     try {
@@ -397,18 +421,14 @@ export async function sendWithRetry(
       }
 
       const retryAfterMs = (err as { retryAfterMs?: unknown }).retryAfterMs;
-      const backoff = baseDelayMs * Math.pow(2, attempt - 1);
-      const desired = Math.max(typeof retryAfterMs === 'number' ? retryAfterMs : 0, backoff);
-      // Compare the uncapped wait against the budget: if the provider demands
-      // more time than we can afford, fail now instead of stalling the caller.
-      if (desired > budgetMs) {
+      const backoff = Math.min(maxDelayMs, baseDelayMs * Math.pow(2, attempt - 1));
+      const delay = Math.max(typeof retryAfterMs === 'number' ? retryAfterMs : 0, backoff);
+      if (now() + delay > deadline) {
         return { ok: false, attempts: attempt, error: message };
       }
-      const delay = Math.min(maxDelayMs, desired);
 
       console.warn(`[ChannelService] Send to ${adapter.name} failed (attempt ${attempt}/${maxAttempts}), retrying in ${delay}ms: ${message}`);
       await sleep(delay);
-      budgetMs -= delay;
     }
   }
   // Unreachable: the loop always returns on the last attempt.

--- a/src/daemon/channel-service.ts
+++ b/src/daemon/channel-service.ts
@@ -26,6 +26,8 @@ const LAST_RECIPIENT_PREFIX = 'channel.lastRecipient.';
 
 export type ApprovalCommandHandler = (action: 'approve' | 'deny', shortId: string, channel: string) => Promise<string>;
 
+export type DeliveryFailureHandler = (failure: { channel: string; attempts: number; error: string }) => void;
+
 export class ChannelService implements Service {
   name = 'channels';
   private _status: ServiceStatus = 'stopped';
@@ -42,6 +44,8 @@ export class ChannelService implements Service {
   private lastRecipients = new Map<string, string>();
   /** Handler for approval commands (approve/deny) from external channels */
   private approvalHandler: ApprovalCommandHandler | null = null;
+  /** Notified when a send has exhausted its retries (e.g. to alert the dashboard). */
+  private deliveryFailureHandler: DeliveryFailureHandler | null = null;
 
   constructor(config: JarvisConfig, agentService: AgentService) {
     this.config = config;
@@ -51,6 +55,19 @@ export class ChannelService implements Service {
 
   setApprovalHandler(handler: ApprovalCommandHandler): void {
     this.approvalHandler = handler;
+  }
+
+  setDeliveryFailureHandler(handler: DeliveryFailureHandler): void {
+    this.deliveryFailureHandler = handler;
+  }
+
+  private reportDeliveryFailure(channel: string, result: { attempts: number; error: string }): void {
+    console.error(`[ChannelService] Failed to send to ${channel} after ${result.attempts} attempt(s): ${result.error}`);
+    try {
+      this.deliveryFailureHandler?.({ channel, attempts: result.attempts, error: result.error });
+    } catch (err) {
+      console.error('[ChannelService] Delivery failure handler threw:', err);
+    }
   }
 
   async start(): Promise<void> {
@@ -147,7 +164,7 @@ export class ChannelService implements Service {
     }
     const result = await sendWithRetry(adapter, recipientId, text);
     if (!result.ok) {
-      console.error(`[ChannelService] Failed to send to ${channelName} after ${result.attempts} attempt(s): ${result.error}`);
+      this.reportDeliveryFailure(channelName, result);
     }
   }
 
@@ -173,7 +190,7 @@ export class ChannelService implements Service {
       sends.push(
         sendWithRetry(adapter, lastRecipient, text).then((result) => {
           if (!result.ok) {
-            console.error(`[ChannelService] Broadcast to ${name} failed after ${result.attempts} attempt(s): ${result.error}`);
+            this.reportDeliveryFailure(name, result);
           }
         }),
       );
@@ -391,10 +408,12 @@ function defaultIsTransient(err: unknown): boolean {
  * duration: if the required wait doesn't fit before the deadline, it fails
  * immediately instead of stalling the caller.
  *
- * Note: retrying re-runs the adapter's whole sendMessage, so a multi-chunk
- * (>4096 char) text that fails mid-way resends its leading chunks. Discord
- * rarely gets here at all — discord.js queues 429s internally, and the
- * adapter's own errors (not connected, invalid channel) are non-transient.
+ * If a thrown error carries a remainingText string (set by adapters whose
+ * sendMessage chunks long texts and fails mid-way), retries resume with
+ * only the unsent portion instead of duplicating already-sent chunks.
+ * Discord rarely gets here at all — discord.js queues 429s internally, and
+ * the adapter's own errors (not connected, invalid channel) are
+ * non-transient.
  */
 export async function sendWithRetry(
   adapter: Pick<ChannelAdapter, 'name' | 'sendMessage'>,
@@ -409,15 +428,20 @@ export async function sendWithRetry(
   const now = opts?.now ?? Date.now;
   const isTransient = opts?.isTransient ?? defaultIsTransient;
   const deadline = now() + (opts?.budgetMs ?? SEND_RETRY_BUDGET_MS);
+  let currentText = text;
 
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     try {
-      await adapter.sendMessage(recipient, text);
+      await adapter.sendMessage(recipient, currentText);
       return { ok: true, attempts: attempt };
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       if (attempt === maxAttempts || !isTransient(err)) {
         return { ok: false, attempts: attempt, error: message };
+      }
+      const remaining = (err as { remainingText?: unknown }).remainingText;
+      if (typeof remaining === 'string' && remaining.length > 0) {
+        currentText = remaining;
       }
 
       const retryAfterMs = (err as { retryAfterMs?: unknown }).retryAfterMs;

--- a/src/daemon/channel-service.ts
+++ b/src/daemon/channel-service.ts
@@ -19,6 +19,7 @@ import { DiscordAdapter } from '../comms/channels/discord.ts';
 import { createSTTProvider } from '../comms/voice.ts';
 import { getOrCreateConversation, addMessage } from '../vault/conversations.ts';
 import { getSettingsByPrefix, setSetting } from '../vault/settings.ts';
+import { classifyErrorString } from '../llm/provider.ts';
 
 /** Settings-table key prefix for persisted per-channel broadcast recipients. */
 const LAST_RECIPIENT_PREFIX = 'channel.lastRecipient.';
@@ -144,10 +145,9 @@ export class ChannelService implements Service {
       console.warn(`[ChannelService] Cannot send to ${channelName}: not connected`);
       return;
     }
-    try {
-      await adapter.sendMessage(recipientId, text);
-    } catch (err) {
-      console.error(`[ChannelService] Failed to send to ${channelName}:`, err);
+    const result = await sendWithRetry(adapter, recipientId, text);
+    if (!result.ok) {
+      console.error(`[ChannelService] Failed to send to ${channelName} after ${result.attempts} attempt(s): ${result.error}`);
     }
   }
 
@@ -156,6 +156,10 @@ export class ChannelService implements Service {
    * Uses the last known recipient per channel (from most recent inbound message).
    */
   async broadcastToAll(text: string): Promise<void> {
+    // Channels are sent concurrently so one channel's retry backoff can't
+    // delay delivery of a time-boxed message (e.g. an approval request) to
+    // the others.
+    const sends: Promise<void>[] = [];
     for (const name of this.manager.listChannels()) {
       const adapter = this.manager.getChannel(name);
       if (!adapter?.isConnected()) continue;
@@ -166,12 +170,15 @@ export class ChannelService implements Service {
         continue;
       }
 
-      try {
-        await adapter.sendMessage(lastRecipient, text);
-      } catch (err) {
-        console.error(`[ChannelService] Broadcast to ${name} failed:`, err);
-      }
+      sends.push(
+        sendWithRetry(adapter, lastRecipient, text).then((result) => {
+          if (!result.ok) {
+            console.error(`[ChannelService] Broadcast to ${name} failed after ${result.attempts} attempt(s): ${result.error}`);
+          }
+        }),
+      );
     }
+    await Promise.allSettled(sends);
   }
 
   /**
@@ -325,4 +332,85 @@ export async function routePerChannel(
     }
   }
   return { delivered, failed };
+}
+
+export const SEND_RETRY_MAX_ATTEMPTS = 4;
+export const SEND_RETRY_BASE_DELAY_MS = 2_000;
+/** Cap on a single wait, even when the provider asks for more. */
+export const SEND_RETRY_MAX_DELAY_MS = 30_000;
+/**
+ * Total sleep budget across all retries. Kept well under the 2-minute
+ * orchestrator approval window so a retried approval message still leaves
+ * the user time to reply.
+ */
+export const SEND_RETRY_BUDGET_MS = 60_000;
+
+export interface SendRetryOptions {
+  maxAttempts?: number;
+  baseDelayMs?: number;
+  maxDelayMs?: number;
+  budgetMs?: number;
+  sleep?: (ms: number) => Promise<void>;
+  isTransient?: (err: unknown) => boolean;
+}
+
+export type SendRetryResult =
+  | { ok: true; attempts: number }
+  | { ok: false; attempts: number; error: string };
+
+function defaultIsTransient(err: unknown): boolean {
+  // An explicit retry-after from the provider always means "try again",
+  // regardless of how the error message is worded.
+  if (typeof (err as { retryAfterMs?: unknown })?.retryAfterMs === 'number') return true;
+  const code = classifyErrorString(err instanceof Error ? err.message : String(err));
+  return code === 'rate_limit' || code === 'network' || code === 'server';
+}
+
+/**
+ * Send a message through an adapter, retrying transient failures (rate
+ * limits, network errors) with exponential backoff. Honors an explicit
+ * retryAfterMs on the thrown error (e.g. Telegram 429 retry_after) when it
+ * exceeds the backoff. Never sleeps past the total budget: if the required
+ * wait doesn't fit, it fails immediately instead of stalling the caller.
+ */
+export async function sendWithRetry(
+  adapter: Pick<ChannelAdapter, 'name' | 'sendMessage'>,
+  recipient: string,
+  text: string,
+  opts?: SendRetryOptions,
+): Promise<SendRetryResult> {
+  const maxAttempts = opts?.maxAttempts ?? SEND_RETRY_MAX_ATTEMPTS;
+  const baseDelayMs = opts?.baseDelayMs ?? SEND_RETRY_BASE_DELAY_MS;
+  const maxDelayMs = opts?.maxDelayMs ?? SEND_RETRY_MAX_DELAY_MS;
+  const sleep = opts?.sleep ?? ((ms: number) => Bun.sleep(ms));
+  const isTransient = opts?.isTransient ?? defaultIsTransient;
+  let budgetMs = opts?.budgetMs ?? SEND_RETRY_BUDGET_MS;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      await adapter.sendMessage(recipient, text);
+      return { ok: true, attempts: attempt };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (attempt === maxAttempts || !isTransient(err)) {
+        return { ok: false, attempts: attempt, error: message };
+      }
+
+      const retryAfterMs = (err as { retryAfterMs?: unknown }).retryAfterMs;
+      const backoff = baseDelayMs * Math.pow(2, attempt - 1);
+      const desired = Math.max(typeof retryAfterMs === 'number' ? retryAfterMs : 0, backoff);
+      // Compare the uncapped wait against the budget: if the provider demands
+      // more time than we can afford, fail now instead of stalling the caller.
+      if (desired > budgetMs) {
+        return { ok: false, attempts: attempt, error: message };
+      }
+      const delay = Math.min(maxDelayMs, desired);
+
+      console.warn(`[ChannelService] Send to ${adapter.name} failed (attempt ${attempt}/${maxAttempts}), retrying in ${delay}ms: ${message}`);
+      await sleep(delay);
+      budgetMs -= delay;
+    }
+  }
+  // Unreachable: the loop always returns on the last attempt.
+  return { ok: false, attempts: maxAttempts, error: 'unreachable' };
 }

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -3843,6 +3843,15 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
     }
     approvalDelivery.setBroadcaster(wsService);
     approvalDelivery.setChannelSender(channelService);
+    channelService.setDeliveryFailureHandler(({ channel, attempts, error }) => {
+      // 'normal', not 'urgent': urgent notifications are echoed back to
+      // external channels, which would loop the failure into the channel
+      // that just failed. The dashboard is the fallback the user still has.
+      wsService.broadcastNotification(
+        `Could not deliver message to ${channel} after ${attempts} attempt(s): ${error}`,
+        'normal',
+      );
+    });
     deferredExecutor.setResultCallback((requestId, request, result) => {
       // Notify via WS and channels that an approved action was executed.
       // Skip for intent-only approvals — they have no deferred execution.


### PR DESCRIPTION
## Problem

Follow-up to the #274 review. Since #274 routes **every** approval request through `ChannelService.broadcastToAll`, channel delivery became load-bearing — but sends were best-effort in the worst way:

- `broadcastToAll` and `sendToChannel` caught errors and only `console.error`'d them.
- The Telegram adapter never inspected `response.status`, so a 429's `parameters.retry_after` was discarded entirely (Telegram throttles bots at ~20 msg/min per chat).
- A silently dropped approval message meant the request just expired (the orchestrator waits 2 minutes, the approval tool 5) with the user never knowing it existed.

## Changes

### Telegram adapter (`src/comms/channels/telegram.ts`)
- New `TelegramSendError` carrying `status` and `retryAfterMs`, built by the pure helper `telegramErrorFromResponse(status, body)`; `sendMessage` now surfaces 429 `retry_after` instead of discarding it.
- A 5xx with a non-JSON body (e.g. an HTML error page from a proxy during an outage) maps through the status code instead of escaping as an unclassifiable `SyntaxError`, so it stays retriable.
- Fixes a latent bug: the no-Markdown fallback send resolved as success without checking its own response.
- Mid-chunk failures on long (>4096 char) messages are tagged with `remainingText` (the unsent remainder — `splitText` is lossless), enabling resumable retries.

### Retry engine (`src/daemon/channel-service.ts`)
- New exported `sendWithRetry(adapter, recipient, text, opts)`:
  - Retries transient failures: rate limit / network / server (classified via the existing `classifyErrorString`), plus fetch timeouts (`AbortError`) and connection-level error codes (`ECONNREFUSED`, `ConnectionRefused`, …).
  - Exponential backoff 2s → 4s → 8s, 4 attempts; the per-wait cap (30s) bounds only the synthetic backoff — an explicit `retry_after` is honored beyond it when it fits the budget, since retrying inside the provider's stated penalty window guarantees another 429.
  - Wall-clock deadline budget (60s, injectable clock): sleeps **and** attempt duration count, so a retried approval always lands inside the 2-minute reply window; a demanded wait that doesn't fit fails fast instead of stalling.
  - Resumes from `remainingText` when present, so retries don't duplicate already-delivered chunks.
  - Deliberate trade-off: a timed-out send may have actually been delivered, so retrying timeouts can duplicate a message (Telegram has no idempotency key) — a duplicate ping beats a silently expired approval.
- `broadcastToAll` sends to channels **concurrently**, so one channel's backoff can't delay a time-boxed approval on another. Signatures unchanged — no ripple into `approval-delivery.ts` or `ws-service.ts` (no conflicts with #274).
- `tryBroadcastToChannels`/`routePerChannel` intentionally unchanged: they already report failures to callers; opting workflows into retry latency is a separate decision.

### Failure visibility (`src/daemon/channel-service.ts`, `src/daemon/index.ts`)
- New `setDeliveryFailureHandler`: fired when a send exhausts its retries; a throwing handler can't break the send path.
- Wired to the existing `wsService.broadcastNotification` so the dashboard — the fallback channel the user still has — shows "Could not deliver message to telegram after 4 attempt(s): …". Uses `normal` priority deliberately: `urgent` notifications echo back to external channels, which would loop the failure into the channel that just failed.

## Tests

28 new tests, all deterministic (injected sleep/clock, no real waits):

- `telegramErrorFromResponse`: success, 429 with/without valid `retry_after`, body-level `error_code` 429, non-429 failures, missing body.
- `sendWithRetry`: backoff progression, `retry_after` vs backoff/cap precedence in both directions, non-transient short-circuit, budget fail-fast, wall-clock budget depletion across attempts, attempt exhaustion, `AbortError` and connection-code retry, `remainingText` resume, full resend when no `remainingText` is present.
- Failure handler: notified on exhaustion (both the `sendToChannel` and concurrent `broadcastToAll` paths), silent on success, throwing handler tolerated (real `ChannelService` instance + fake adapter).
- Adapter chunking (stubbed `fetch`): a second-chunk 429 surfaces both `retryAfterMs` and the exact unsent remainder; a non-JSON 502 body surfaces a retriable `HTTP 502` error.

Full suite: 1671 pass / 0 fail. `tsc --noEmit` clean.