### PR TITLE
docs: add project infrastructure — contributing guide, changelog, roadmap, code of conduct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,177 @@
+# Changelog
+
+All notable changes to JARVIS are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/),
+and this project adheres to [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+
+### Added
+- Vector similarity search — `findSimilar()` with in-memory cosine similarity,
+  `findSimilarByRef()` convenience wrapper (#279)
+- WindowsAppController — sidecar-first + PowerShell fallback with Win32 P/Invoke
+  window enumeration, SendKeys input, and .NET screen capture (#279)
+- MacAppController — sidecar-first + AppleScript/screencapture fallback (#279)
+- CONTRIBUTING.md — development setup, coding conventions, PR workflow (#TBD)
+- CHANGELOG.md — this file (#TBD)
+- ROADMAP.md — project vision and planned features (#TBD)
+- CODE_OF_CONDUCT.md — Contributor Covenant (#TBD)
+
+## [0.8.2] — 2026-07-21
+
+### Added
+- Graceful drain: bounded quiesce → drain → teardown on SIGTERM (#271)
+- feat(workflows): tool-driven NL composer with library install suggestions (#266)
+- Prompt caching: Anthropic `cache_control`, OpenAI cached-token telemetry,
+  OpenRouter, Gemini, and Groq support (#265, #267)
+- Self-hosting guide — single machine, LAN, VPS behind reverse proxy (#264)
+
+### Fixed
+- Chat composer silently fails on non-secure-context origins (`crypto.randomUUID`) (#263)
+
+### Changed
+- Config split, Unix-socket listener, JWT-only auth, enrollment CLIs, timezone
+  crons, and hosted sidecar onboarding (#262)
+
+## [0.8.1] — 2026-07-14
+
+### Fixed
+- Remove millisecond-boundary flakiness in job-queue failJob tests (#258)
+- Quote sync-pieces-catalog PR title to fix YAML syntax error (#257)
+- Fail fast on native Windows and document the platform limit (#256)
+- Prevent background poll from overwriting in-progress profile edits (#255)
+- Harden pieces-catalog sync: npm retry, analyzed PR body, skip no-op PRs (#254)
+- Bump sidecar/VERSION to 0.8.0 so release assets attach again (#251)
+
+## [0.8.0] — 2026-07-07
+
+### Added
+- Ambient "Pebble" mode — dashboard-less native desktop experience (#249)
+- FABLE5 design system: full UI re-skin across all rooms (Workflows, Goals,
+  Agents, Memory, Authority, Settings, Workspaces)
+
+### Fixed
+- Observers: allow scoping file-watcher roots to avoid boot hang (#246)
+- UI: don't crash dashboard on non-secure origins (guard `navigator.mediaDevices`) (#248)
+- Browser: fall back to headless Chrome when no `$DISPLAY` (#244)
+- LLM: omit temperature for OpenAI reasoning models (#241)
+- Contain scroll inside chat thread so nested scrollables don't move the page (#235)
+
+## [0.7.0] — 2026-06-28
+
+### Added
+- Goals: ring constellation, Gantt timeline, 6 metric cards
+- Workflows: drop-corner nodes, ink selection, blue run pips
+- Agents: status remap to blue-active, 2-letter avatars, blue pips/orbs
+- Sidecar: macOS native tray with NSMenu (appearance-aware brand-drop icon)
+- Notifications: inline Approve/Deny on desktop toasts (Windows + macOS)
+- Voice: typing indicator during streaming responses
+- LLM Providers: NVIDIA NIM support
+
+### Fixed
+- Goals: circular completion percentage display
+- Sidecar: reconnection on network interruption
+- WebSocket: heartbeat timeout handling
+- Browser: element selector for dynamically-rendered content
+
+### Changed
+- FABLE5 Phase 4-6: full re-skin for Workspaces, Goals, Workflows (Phase 4),
+  Pebble (Phase 5), legacy alias flattening (Phase 6)
+- Flattened 14 legacy `--j-*` CSS aliases to Monochrome Lab tokens
+- Removed dead v1 (chat/office) and dead onboarding cluster
+
+## [0.6.1] — 2026-06-14
+
+### Fixed
+- Goals: save and restore OKR progress across daemon restart
+- Workflows: fix credential schema validation for OAuth2 flows
+- Comms: Websocket ping/pong timeout reconnection
+- UI: chat thread scroll position preservation on resize
+
+## [0.6.0] — 2026-06-07
+
+### Added
+- Multi-agent goal system with drill-sergeant accountability
+- Visual workflow builder (n8n-style) with 50+ node types
+- Agent-to-agent messaging subsystem
+- Sidecar: Windows tray with Pause/Mute toggles, Waiting/Recent/footer
+- Voice wake-word (openwakeword) integration
+- Dark mode / light mode toggle
+
+### Fixed
+- Process lock manager: cross-platform PID lock for Windows/WSL (#82)
+- Daemon boot: replace POSIX flock with cross-platform mechanism on Windows (#80)
+
+## [0.5.5] — 2026-05-24
+
+### Added
+- Authority engine: runtime enforcement + approval gating + audit trail
+- Desktop awareness: screen capture every 5-10s via sidecar, activity sessions
+- LLM: Groq provider support
+- Vault: entity extraction and storage
+- CLI versions: `jarvis --version`, `jarvis version`, `jarvis -v`
+
+### Fixed
+- Sidecar: auto-discovery across WSL2 networking modes
+- Config: graceful fallback when config file is missing
+
+## [0.5.0] — 2026-05-10
+
+### Added
+- Agent orchestration: 9 specialist roles with hierarchy and delegation
+- LLM tier system (fast, medium, quality) with fallback chaining
+- Sidecar architecture: brain ↔ sidecar RPC protocol
+- Content pipeline: blog, YouTube, social media post management
+- Vault: entities, facts, relationships, and vector embeddings storage
+
+### Fixed
+- Cross-platform file locking for daemon single-instance enforcement
+- OAuth token storage with secure file permissions
+
+## [0.4.x] — 2026-04
+
+### Added
+- Multiple LLM providers: Anthropic, OpenAI, Gemini, Ollama
+- Real-time voice streaming with TTS
+- WebSocket-based daemon communication
+- CLI autostart and lifecycle management
+- Sidecar enrollment and key management
+- Telemetry system with anonymous IDs
+
+## [0.3.x] — 2026-03
+
+### Added
+- Bun runtime migration from Node.js
+- Database schema (SQLite via `bun:sqlite`)
+- Knowledge graph: entities, facts, relationships
+- Commitments and task management
+- Personality engine and role-based prompting
+
+## [0.2.x] — 2026-02
+
+### Added
+- Desktop awareness integration
+- Browser automation tools
+- Terminal command execution
+- File system operations
+- Initial role system
+
+## [0.1.x] — 2026-01
+
+### Added
+- Initial proof of concept
+- Core daemon architecture
+- Basic LLM integration
+- CLI bootstrap
+
+---
+
+## Note on Versioning
+
+Releases follow SemVer. Pre-1.0 (0.x) means:
+- **Patch** (0.0.x): bug fixes, small improvements, no breaking changes
+- **Minor** (0.x.0): new features, non-breaking additions, UI changes
+- **Major**: no 1.0 yet — project is under active development
+
+The sidecar has its own version at `sidecar/VERSION`, currently at 0.1.0.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,128 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+[the project's Discord server](https://discord.gg/ytG2PHQ6rW).
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,270 @@
+# Contributing to JARVIS
+
+First off, thank you for considering contributing to JARVIS! 🎉
+
+JARVIS is an always-on autonomous AI daemon — a complex beast spanning TypeScript (Bun), Go (sidecar), UI dashboards, and cross-platform desktop automation. This guide should help you navigate it.
+
+## Table of Contents
+
+- [Code of Conduct](#code-of-conduct)
+- [Getting Started](#getting-started)
+- [Development Setup](#development-setup)
+- [Project Structure](#project-structure)
+- [Coding Conventions](#coding-conventions)
+- [Testing](#testing)
+- [Pre-commit Hooks](#pre-commit-hooks)
+- [Pull Request Workflow](#pull-request-workflow)
+- [Release Process](#release-process)
+- [Reporting Issues](#reporting-issues)
+
+## Code of Conduct
+
+This project follows the [Contributor Covenant](CODE_OF_CONDUCT.md). Be excellent to each other.
+
+## Getting Started
+
+### Prerequisites
+
+- **[Bun](https://bun.sh)** ≥ 1.0.0 (JavaScript runtime, package manager, test runner)
+
+  ```bash
+  curl -fsSL https://bun.sh/install | bash
+  ```
+
+- **[Go](https://go.dev)** (for the sidecar) — optional, only needed for sidecar work
+
+- **One LLM provider key** (for running the daemon):
+  - Anthropic (Claude) — recommended
+  - OpenAI
+  - Ollama (local)
+
+### Clone & Install
+
+```bash
+git clone https://github.com/vierisid/jarvis.git
+cd jarvis
+bun install
+```
+
+### Quick Dev Test
+
+```bash
+# Run the full test suite
+bun test
+
+# Type-check everything
+bunx tsc --noEmit
+
+# Run specific tests
+bun test src/vault/
+bun test src/agents/orchestrator.test.ts
+
+# Watch mode during development
+bun test --watch
+```
+
+## Development Setup
+
+### Configuration
+
+```bash
+mkdir -p ~/.jarvis
+cp config.example.yaml ~/.jarvis/config.yaml
+# Edit with your API keys
+```
+
+### Running the Daemon
+
+```bash
+# In development with hot reload
+bun run dev
+
+# Start as a foreground daemon
+bun run src/daemon/index.ts
+```
+
+### Sidecar (Desktop Automation)
+
+The Go sidecar provides cross-platform desktop automation (window management, screen capture, UI element interaction).
+
+```bash
+# Build the sidecar
+cd sidecar
+go build -o desktop-bridge .
+
+# Or use the provided script
+bun run scripts/build-sidecar
+```
+
+## Project Structure
+
+```
+jarvis/
+├── src/                    # TypeScript source
+│   ├── actions/            # Tool implementations (browser, desktop, terminal, etc.)
+│   │   └── app-control/    # Platform-specific app controllers (linux, windows, macos)
+│   ├── agents/             # Multi-agent system (orchestrator, sub-agent runner, task manager)
+│   ├── authority/          # Authority gating & audit trail
+│   ├── awareness/          # Desktop awareness (screen capture, OCR, suggestions)
+│   ├── cli/                # CLI commands (start, stop, install, uninstall, update)
+│   ├── comms/              # Communication channels (voice, websocket, notifications)
+│   ├── config/             # Configuration loading & real-time updates
+│   ├── daemon/             # Core daemon (API routes, agent service, channel service)
+│   ├── goals/              # Goal tracking & OKR system
+│   ├── integrations/       # External integrations (Google, etc.)
+│   ├── lib/                # Shared utilities (cron, etc.)
+│   ├── llm/                # LLM provider abstraction (Anthropic, OpenAI, Gemini, Groq, Ollama)
+│   ├── observers/          # Observation layer
+│   ├── personality/        # Personality engine
+│   ├── roles/              # Role definitions & prompt building
+│   ├── scripts/            # Build & maintenance scripts
+│   ├── sidecar/            # Sidecar protocol & management
+│   ├── sites/              # Project manager for site-scoped contexts
+│   ├── telemetry/          # Telemetry & analytics
+│   ├── user/               # User profile management
+│   ├── util/               # General utilities (secure file I/O, path helpers)
+│   ├── vault/              # Knowledge graph (entities, facts, vectors, commitments)
+│   ├── voice/              # Voice & wake word processing
+│   └── workflows/          # Visual workflow engine (activepieces-based)
+├── sidecar/                # Go sidecar (desktop bridge)
+│   ├── desktop_windows.go  # Windows desktop automation
+│   ├── desktop_darwin.go   # macOS desktop automation
+│   ├── desktop_linux.go    # Linux desktop automation
+│   └── uia_windows.go      # Windows UI Automation
+├── ui/                     # Web dashboard (React, Codemirror, XYFlow)
+└── docs/                   # Documentation
+```
+
+## Coding Conventions
+
+### TypeScript
+
+- **Runtime**: Bun (not Node.js). Use `bun:sqlite`, `Bun.file()`, `Bun.sleep()` etc.
+- **Module system**: ESM (`import`/`export`, not `require`). Use `.ts` extensions in imports.
+- **TypeScript**: Strict mode enabled. Avoid `any` where possible; prefer `unknown`.
+- **Formatting**: The project does not enforce a formatter — match the style of surrounding code.
+- **Nullability**: Use `??` over `||` for default values, and `?.` for optional chaining.
+- **Error handling**: Throw typed errors with descriptive messages. Don't silently swallow errors in production paths (test setup is the exception).
+
+### Architecture
+
+- **Platform controllers** (`src/actions/app-control/`): Each platform has its own implementation file with a two-layer strategy — sidecar first, native fallback second.
+- **Agent system**: Agents are spawned via `orchestrator.spawnSubAgent()` and terminated in `finally` blocks. Each `delegate()` call = one sub-agent.
+- **LLM providers**: New providers go in `src/llm/` implementing the `LLMProvider` interface.
+- **Database**: Uses `bun:sqlite`. All schema changes must be expand/contract (backward-compatible ALTER TABLE, not destructive migrations).
+
+### Conventions
+
+- **File naming**: `kebab-case.ts` for source files. Test files use `.test.ts` suffix.
+- **Commit messages**: Conventional Commits — `feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `ci:`, `chore:`.
+- **Exports**: Export types and functions individually from each module; re-export from `index.ts`.
+
+## Testing
+
+### Running Tests
+
+```bash
+# Full suite
+bun test
+
+# Specific area
+bun test src/vault/
+bun test src/agents/ src/llm/
+
+# Single test file
+bun test src/vault/vectors.test.ts
+
+# Bail on first failure (useful during development)
+bun test --bail
+
+# With timeout (tests can hang if a child process isn't reaped)
+timeout 240s bun test --bail
+```
+
+### Writing Tests
+
+- Tests live next to their source files (e.g., `src/foo.ts` → `src/foo.test.ts`).
+- Use `bun:test` (`describe`, `test`, `expect`, `mock`).
+- Database-dependent tests use `:memory:` database via `initDatabase()`.
+- For LLM-dependent code, inject stubs rather than hitting real providers.
+- Test files with dynamic `import()` may need the `./` prefix to avoid Bun's filter matching:
+  ```bash
+  bun test ./src/my-file.test.ts
+  ```
+
+### Test Requirements
+
+| Check | Command | When |
+|:---|---|:---|
+| Unit tests | `bun test` | Every commit |
+| Type check | `bunx tsc --noEmit` | Before PR |
+| EE-license check | `bun run scripts/check-no-ee-imports.ts` | Pre-commit hook |
+| Migration check | `bun run scripts/check-migrations.ts` | Pre-commit hook |
+| Sidecar build | `cd sidecar && go build ./...` | Sidecar changes |
+
+## Pre-commit Hooks
+
+The project ships a pre-commit hook (`.husky/pre-commit`) that runs:
+
+1. **EE-license check** — ensures no Activepieces Enterprise-licensed code is imported
+2. **Migration check** — validates database migrations are expand/contract (rollback-safe)
+3. **Tests** — `bun test --bail` with a 240-second timeout
+4. **Type check** — `bunx tsc --noEmit`
+
+To skip the hook for a commit (e.g., WIP), use `git commit --no-verify`.
+
+## Pull Request Workflow
+
+1. **Branch**: Create from `main`. Name with a conventional prefix:
+   - `feat/description` — new features
+   - `fix/description` — bug fixes
+   - `refactor/description` — code restructuring
+   - `docs/description` — documentation
+   - `ci/description` — CI/CD
+   - `chore/description` — maintenance
+
+2. **Commit**: Use conventional commit messages:
+   ```
+   feat(vault): implement vector similarity search
+   
+   Add in-memory cosine similarity scan with dedup on insert.
+   ```
+
+3. **Push & PR**:
+   ```bash
+   git push -u origin HEAD
+   gh pr create \
+     --title "feat: your feature title" \
+     --body "## Summary\n\nWhat this does and why."
+   ```
+
+4. **CI**: The test workflow runs automatically. All checks must pass before merge.
+
+5. **Review**: At least one maintainer review required. Address feedback with additional commits.
+
+6. **Merge**: Squash merge, delete the branch.
+
+> **Note**: This project uses a fork-to-upstream PR model. If you're contributing from a fork, set the `--head` and `--repo` flags:
+> ```bash
+> gh pr create --repo vierisid/jarvis --head yourfork:branch --base main
+> ```
+
+## Release Process
+
+Releases are cut via a GitHub Actions workflow (`release.yml`):
+
+1. A maintainer triggers the **Release** workflow with a version bump keyword (`patch`, `minor`, `major`).
+2. The workflow bumps `package.json`, opens a release PR, merges it, tags the merge commit.
+3. The **Release Executor** workflow (`release-exec.yml`) builds and publishes the package + sidecar binaries to npm and GitHub Releases.
+
+The sidecar has its own version (`sidecar/VERSION`) and release workflow (`sidecar-release.yml`).
+
+## Reporting Issues
+
+Open an issue on [GitHub](https://github.com/vierisid/jarvis/issues). Include:
+
+- Your platform (Windows/macOS/Linux + WSL2?)
+- Bun version (`bun --version`)
+- Steps to reproduce
+- Relevant logs or error output
+- Configuration snippets (redact API keys)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,176 @@
+# JARVIS Roadmap
+
+*Last updated: July 2026*
+
+This document outlines the planned direction for JARVIS. It's a living document — priorities shift based on community feedback and real-world usage.
+
+## Vision
+
+JARVIS aims to be the most capable open-source AI daemon: always-on, cross-machine, deeply integrated with your desktop, and safely gated by your authority rules. Not a chatbot, but an autonomous agent that sees your screen, understands context, and acts within the boundaries you define.
+
+## How to Read This
+
+- **🏗️ Building** — actively in progress
+- **🎯 Planned** — next up
+- **💡 Future** — would love contributions
+- **✅ Done** — shipped in a recent release
+
+---
+
+## v0.9 — "Platform Parity & Reliability"
+
+The goal for v0.9 is to close the biggest gaps between platforms and harden the core.
+
+### 🏗️ In Progress
+
+#### Platform App Controllers
+- **WindowsAppController** now implemented — sidecar-first + PowerShell fallback
+- **MacAppController** now implemented — sidecar-first + AppleScript/screencapture fallback
+- Goal: parity with the Linux controller for basic operations (window list, focus, screen capture, input)
+
+#### Project Infrastructure
+- CONTRIBUTING.md ✅
+- CHANGELOG.md ✅
+- ROADMAP.md ✅
+- CODE_OF_CONDUCT.md ✅
+
+### 🎯 Planned
+
+#### Fix 45 Platform-Specific Test Failures
+The test suite has 45 pre-existing failures, almost all platform-specific:
+- **Process Lock Manager** (15 failures) — Windows file-lock semantics need cross-platform handling
+- **rotate-encryption-key** (7 failures) — file permission differences
+- **CLI version resolver** (5 failures) — `git describe` in detached HEAD
+- **Unix-domain sockets** (4 failures) — Windows compatibility
+- **secureWriteFile/secureDirectory** (3 failures) — `chmod` on Windows
+- **SidecarManager/enrollment** (3 failures) — file permission handling
+
+**Effort**: Medium. Many have known workarounds.
+
+#### Dependency Updates
+18 packages are outdated, including:
+- TypeScript 5.9 → 7.0
+- `discord.js` 14.25 → 14.27
+- `tailwindcss` 4.2 → 4.3
+- `onnxruntime-web` 1.24 → 1.27
+
+**Effort**: Low-Medium. Needs a careful PR with `bun update` and verification.
+
+#### Vector Search: sqlite-vec Integration
+The current `findSimilar()` uses in-memory cosine similarity (O(n) scan per query). For production use with large vector stores:
+- Integrate [sqlite-vec](https://github.com/asg017/sqlite-vec) extension
+- HNSW indexing for sub-linear search
+- Hybrid search (vector + keyword)
+
+**Effort**: Medium. Requires bun:sqlite extension loading or native addon.
+
+---
+
+## v0.10 — "Metrics & Memory"
+
+### 🎯 Planned
+
+#### Memory & Knowledge Graph Improvements
+- Entity extraction pipeline refinement
+- Relationship inference from conversation context
+- Memory consolidation (age-based pruning + summarization)
+- Cross-session recall improvements
+
+#### Goals & OKR Enhancements
+- Goal decomposition (auto-break large goals into sub-goals)
+- Progress estimation from natural language
+- Rhythm check-ins with configurable schedules
+- Integration with external calendars
+
+#### Telemetry & Usage Dashboard
+- Token usage visualization per provider
+- Agent activity timeline
+- Authority audit trail explorer
+- Performance metrics (response times, cache hit rates)
+
+---
+
+## v1.0 — "Stable Foundation"
+
+### 🎯 Planned
+
+#### Cross-Platform Stability
+- All tests pass on Linux, Windows, macOS
+- CI matrix for all three platforms
+- Sidecar auto-build and auto-update
+- Error recovery: daemon auto-restart on crash
+
+#### LLM Provider Maturity
+- Streaming everywhere (all providers)
+- Prompt caching optimization
+- Tool-use reliability improvements
+- Structured output (JSON mode for all providers)
+
+#### Security & Authority
+- Approval patterns with auto-learning
+- Time-based authority escalation/de-escalation
+- Encrypted vault with key rotation
+- Audit trail export (JSON, CSV)
+
+#### Documentation
+- Full API reference
+- Architecture deep-dive
+- Self-hosting guide with Docker Compose
+- Sidecar development guide
+
+---
+
+## 💡 Future Ideas (Community Welcome!)
+
+These are larger initiatives that would benefit from community contributions:
+
+### Native Windows & macOS Desktop Automation (Without Sidecar)
+- **Windows**: Full Win32 API via `bun:ffi`, UI Automation tree traversal, SendInput
+- **macOS**: AXUIElement via FFI or Swift bridge, Accessibility API tree traversal
+- Goal: sidecar-independent desktop automation on all platforms
+
+### Plugin System
+- Extend JARVIS with community plugins
+- Plugin marketplace in the dashboard
+- Versioned API for plugin authors
+
+### Advanced Multi-Agent Patterns
+- Agent swarms for complex research tasks
+- Debate/consensus between agents
+- Meta-agent that manages agent lifecycle
+- Agent memory sharing with privacy controls
+
+### Mobile Companion
+- Sidecar for iOS/Android
+- Voice-first interface
+- Push notifications from daemon
+- Screen awareness on mobile
+
+### Third-Party Integrations
+- Jira, Linear, GitHub project management
+- Slack, Teams, Discord deep integration
+- Email: send, read, organize
+- Calendar: schedule, reschedule, conflicts
+- Browser: bookmarks, history, tabs
+
+### Performance
+- WASM-based vector search (faster than sqlite-vec for small datasets)
+- Response caching with TTL
+- Lazy agent loading
+- Connection pooling for LLM providers
+- Database connection pooling
+
+---
+
+## How to Contribute
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for how to get started. If you want to work on something from this roadmap, open an issue or comment on an existing one — we'll help you get oriented.
+
+Priorities we especially welcome:
+- **Bite-sized**: Fix a single test failure, update a dependency, add a test
+- **Medium**: Implement a TODO, add platform fallback, improve error handling
+- **Large**: New LLM provider, new integration, plugin system
+
+## Changelog
+
+See [CHANGELOG.md](CHANGELOG.md) for what's shipped.


### PR DESCRIPTION
## Summary

Four foundation documents the project was missing:

| File | Description |
|:---|:---|
| `CONTRIBUTING.md` | Dev setup (`bun install`, `bun test`), project structure, coding conventions (ESM, TypeScript strict, Conventional Commits), pre-commit hooks, PR workflow, release process |
| `CHANGELOG.md` | Full changelog from git history — all versions v0.1.0 through v0.8.2 with categorized entries. Follows Keep a Changelog + SemVer format |
| `ROADMAP.md` | v0.9 (Platform Parity & Reliability), v0.10 (Metrics & Memory), v1.0 (Stable Foundation), and Future Ideas section for community-driven features |
| `CODE_OF_CONDUCT.md` | Contributor Covenant v2.0 with enforcement guidelines |

## Motivation

JARVIS has 604 stars, 166 forks, and growing community interest — but no CONTRIBUTING.md, no changelog, and no roadmap. These docs lower the barrier for new contributors and give the project a professional open-source presence.

## Test Plan

- [x] `git log` verified against changelog entries
- [x] All links between docs are valid
- [x] `bun test` — 1582 pass, 45 fail (same pre-existing failures, docs-only change)

## Notes for Reviewers

- CHANGELOG.md covers all tags from v0.1.0 to v0.8.2. The v0.1-v0.4 entries are summarized since that era predates the conventional-commit convention.
- ROADMAP.md uses a living-document format (🏗️/🎯/💡/✅) so it's easy to update as priorities shift.