### PR TITLE
feat(vault): in-memory cosine vector similarity with upsert semantics and tests

### DIFF
--- a/src/vault/index.ts
+++ b/src/vault/index.ts
@@ -71,11 +71,13 @@ export {
 } from './observations.ts';
 
 // Re-export vectors module
-export type { VectorRecord } from './vectors.ts';
+export type { VectorRecord, SimilarityMatch } from './vectors.ts';
 export {
   storeVector,
   findSimilar,
+  findSimilarByRef,
   deleteVectors,
+  countVectors,
 } from './vectors.ts';
 
 // Re-export extractor module

--- a/src/vault/vectors.test.ts
+++ b/src/vault/vectors.test.ts
@@ -1,0 +1,186 @@
+import { test, expect, beforeEach, describe } from 'bun:test';
+import { initDatabase } from './schema.ts';
+import {
+  storeVector,
+  findSimilar,
+  findSimilarByRef,
+  deleteVectors,
+  countVectors,
+} from './vectors.ts';
+
+const MODEL = 'test-model';
+
+function vec(...values: number[]): Float32Array {
+  return new Float32Array(values);
+}
+
+describe('vectors', () => {
+  beforeEach(() => {
+    initDatabase(':memory:');
+  });
+
+  describe('storeVector', () => {
+    test('stores and returns the record', () => {
+      const record = storeVector('note', 'n1', vec(1, 2, 3), MODEL);
+      expect(record.ref_type).toBe('note');
+      expect(record.ref_id).toBe('n1');
+      expect(record.model).toBe(MODEL);
+      expect(countVectors()).toBe(1);
+    });
+
+    test('roundtrips embedding values through the BLOB column', () => {
+      storeVector('note', 'n1', vec(0.25, -1.5, 3.75), MODEL);
+      // an identical query vector must score similarity ~1.0
+      const results = findSimilar(vec(0.25, -1.5, 3.75), 10);
+      expect(results.length).toBe(1);
+      expect(results[0]!.similarity).toBeCloseTo(1.0, 5);
+    });
+
+    test('roundtrips an embedding stored as an offset subarray view', () => {
+      const backing = new Float32Array([9, 9, 0.5, -0.5, 2.0, 9]);
+      storeVector('note', 'n1', backing.subarray(2, 5), MODEL);
+      const results = findSimilar(vec(0.5, -0.5, 2.0), 10);
+      expect(results.length).toBe(1);
+      expect(results[0]!.similarity).toBeCloseTo(1.0, 5);
+    });
+
+    test('replaces an existing (ref_type, ref_id, model) embedding', () => {
+      storeVector('note', 'n1', vec(1, 0), MODEL);
+      storeVector('note', 'n1', vec(0, 1), MODEL);
+      expect(countVectors()).toBe(1);
+      const results = findSimilar(vec(0, 1), 10);
+      expect(results[0]!.similarity).toBeCloseTo(1.0, 5);
+    });
+
+    test('keeps embeddings from different models for the same ref', () => {
+      storeVector('note', 'n1', vec(1, 0), 'model-a');
+      storeVector('note', 'n1', vec(0, 1), 'model-b');
+      expect(countVectors()).toBe(2);
+    });
+  });
+
+  describe('findSimilar', () => {
+    test('returns empty array when store is empty', () => {
+      expect(findSimilar(vec(1, 0, 0))).toEqual([]);
+    });
+
+    test('ranks results by cosine similarity descending', () => {
+      storeVector('note', 'identical', vec(1, 0), MODEL);
+      storeVector('note', 'close', vec(1, 0.2), MODEL);
+      storeVector('note', 'orthogonal', vec(0, 1), MODEL);
+
+      const results = findSimilar(vec(1, 0), 10);
+      expect(results.map((r) => r.ref_id)).toEqual(['identical', 'close', 'orthogonal']);
+      expect(results[0]!.similarity).toBeCloseTo(1.0, 5);
+      expect(results[2]!.similarity).toBeCloseTo(0.0, 5);
+    });
+
+    test('respects the limit', () => {
+      for (let i = 0; i < 5; i++) {
+        storeVector('note', `n${i}`, vec(1, i), MODEL);
+      }
+      expect(findSimilar(vec(1, 0), 2).length).toBe(2);
+    });
+
+    test('filters by minScore', () => {
+      storeVector('note', 'same', vec(1, 0), MODEL);
+      storeVector('note', 'opposite', vec(-1, 0), MODEL);
+
+      const results = findSimilar(vec(1, 0), 10, { minScore: 0.5 });
+      expect(results.map((r) => r.ref_id)).toEqual(['same']);
+    });
+
+    test('handles a zero-norm query without NaN', () => {
+      storeVector('note', 'n1', vec(1, 2), MODEL);
+      const results = findSimilar(vec(0, 0), 10);
+      expect(results[0]!.similarity).toBe(0);
+    });
+
+    test('skips candidates whose dimensionality differs from the query', () => {
+      storeVector('note', 'two-dim', vec(1, 0), MODEL);
+      storeVector('note', 'three-dim', vec(1, 0, 0), MODEL);
+
+      const results = findSimilar(vec(1, 0, 0), 10);
+      expect(results.map((r) => r.ref_id)).toEqual(['three-dim']);
+    });
+
+    test('filters candidates by model when asked', () => {
+      storeVector('note', 'a', vec(1, 0), 'model-a');
+      storeVector('note', 'b', vec(1, 0), 'model-b');
+
+      const results = findSimilar(vec(1, 0), 10, { model: 'model-a' });
+      expect(results.map((r) => r.ref_id)).toEqual(['a']);
+      expect(results[0]!.model).toBe('model-a');
+    });
+
+    test('labels each match with its model when scanning across models', () => {
+      storeVector('note', 'n1', vec(1, 0), 'model-a');
+      storeVector('note', 'n1', vec(1, 0), 'model-b');
+
+      const results = findSimilar(vec(1, 0), 10);
+      expect(results.length).toBe(2);
+      expect(results.map((r) => r.model).sort()).toEqual(['model-a', 'model-b']);
+    });
+
+    test('excludes a given ref when asked', () => {
+      storeVector('note', 'n1', vec(1, 0), MODEL);
+      storeVector('note', 'n2', vec(1, 0.1), MODEL);
+
+      const results = findSimilar(vec(1, 0), 10, { exclude: { ref_type: 'note', ref_id: 'n1' } });
+      expect(results.map((r) => r.ref_id)).toEqual(['n2']);
+    });
+  });
+
+  describe('findSimilarByRef', () => {
+    test('returns empty array when the source ref has no embedding', () => {
+      expect(findSimilarByRef('note', 'missing')).toEqual([]);
+    });
+
+    test('finds related refs without returning the source itself', () => {
+      storeVector('note', 'source', vec(1, 0, 0), MODEL);
+      storeVector('note', 'related', vec(0.9, 0.1, 0), MODEL);
+      storeVector('note', 'unrelated', vec(0, 0, 1), MODEL);
+
+      const results = findSimilarByRef('note', 'source', 10);
+      expect(results.map((r) => r.ref_id)).toEqual(['related', 'unrelated']);
+    });
+
+    test('filters the source lookup by model', () => {
+      storeVector('note', 'source', vec(1, 0), 'model-a');
+      storeVector('note', 'source', vec(0, 1), 'model-b');
+      storeVector('note', 'other', vec(0, 1), 'model-b');
+
+      const results = findSimilarByRef('note', 'source', 10, { model: 'model-b' });
+      expect(results[0]!.ref_id).toBe('other');
+      expect(results[0]!.similarity).toBeCloseTo(1.0, 5);
+    });
+
+    test('only scores candidates from the same model as the source embedding', () => {
+      storeVector('note', 'source', vec(1, 0), 'model-a');
+      storeVector('note', 'same-model', vec(1, 0.1), 'model-a');
+      storeVector('note', 'other-model', vec(1, 0), 'model-b');
+
+      const results = findSimilarByRef('note', 'source', 10, { model: 'model-a' });
+      expect(results.map((r) => r.ref_id)).toEqual(['same-model']);
+    });
+
+    test('applies minScore to results', () => {
+      storeVector('note', 'source', vec(1, 0), MODEL);
+      storeVector('note', 'far', vec(-1, 0), MODEL);
+
+      expect(findSimilarByRef('note', 'source', 10, { minScore: 0.5 })).toEqual([]);
+    });
+  });
+
+  describe('deleteVectors', () => {
+    test('removes all embeddings for a ref', () => {
+      storeVector('note', 'n1', vec(1, 0), 'model-a');
+      storeVector('note', 'n1', vec(0, 1), 'model-b');
+      storeVector('note', 'n2', vec(1, 1), 'model-a');
+
+      deleteVectors('note', 'n1');
+      expect(countVectors()).toBe(1);
+      expect(findSimilarByRef('note', 'n1')).toEqual([]);
+    });
+  });
+});

--- a/src/vault/vectors.ts
+++ b/src/vault/vectors.ts
@@ -13,23 +13,57 @@ type VectorRow = {
   id: string;
   ref_type: string;
   ref_id: string;
-  embedding: ArrayBuffer;
+  embedding: Uint8Array;
   model: string;
   created_at: number;
 };
 
+export type SimilarityMatch = {
+  ref_type: string;
+  ref_id: string;
+  model: string;
+  similarity: number;
+};
+
 /**
- * Parse vector row from database, converting BLOB to Float32Array
+ * Parse vector row from database, converting BLOB to Float32Array.
+ * bun:sqlite returns BLOBs as Uint8Array; reinterpret the underlying bytes
+ * as float32 values rather than copying byte-by-byte.
  */
+function blobToFloat32(blob: Uint8Array): Float32Array {
+  const { buffer, byteOffset, byteLength } = blob;
+  return new Float32Array(buffer, byteOffset, Math.floor(byteLength / Float32Array.BYTES_PER_ELEMENT));
+}
+
 function parseVector(row: VectorRow): VectorRecord {
   return {
     ...row,
-    embedding: new Float32Array(row.embedding),
+    embedding: blobToFloat32(row.embedding),
   };
 }
 
 /**
- * Store a vector embedding for a reference entity or fact
+ * Compute cosine similarity between two vectors.
+ * Returns a value in [-1, 1] where 1 = identical direction, 0 = orthogonal.
+ */
+function cosineSimilarity(a: Float32Array, b: Float32Array): number {
+  const len = Math.min(a.length, b.length);
+  let dot = 0, normA = 0, normB = 0;
+  for (let i = 0; i < len; i++) {
+    const x = a[i]!;
+    const y = b[i]!;
+    dot += x * y;
+    normA += x * x;
+    normB += y * y;
+  }
+  const denom = Math.sqrt(normA) * Math.sqrt(normB);
+  return denom === 0 ? 0 : dot / denom;
+}
+
+/**
+ * Store a vector embedding for a reference entity or fact.
+ * Upsert semantics: any existing embedding for the same
+ * (ref_type, ref_id, model) triple is replaced atomically.
  */
 export function storeVector(
   ref_type: string,
@@ -41,14 +75,17 @@ export function storeVector(
   const id = generateId();
   const now = Date.now();
 
-  // Convert Float32Array to Buffer for SQLite BLOB storage
-  const buffer = Buffer.from(embedding.buffer);
+  const buffer = Buffer.from(embedding.buffer, embedding.byteOffset, embedding.byteLength);
 
-  const stmt = db.prepare(
-    'INSERT INTO vectors (id, ref_type, ref_id, embedding, model, created_at) VALUES (?, ?, ?, ?, ?, ?)'
-  );
-
-  stmt.run(id, ref_type, ref_id, buffer, model, now);
+  const upsert = db.transaction(() => {
+    db.prepare(
+      'DELETE FROM vectors WHERE ref_type = ? AND ref_id = ? AND model = ?'
+    ).run(ref_type, ref_id, model);
+    db.prepare(
+      'INSERT INTO vectors (id, ref_type, ref_id, embedding, model, created_at) VALUES (?, ?, ?, ?, ?, ?)'
+    ).run(id, ref_type, ref_id, buffer, model, now);
+  });
+  upsert();
 
   return {
     id,
@@ -61,25 +98,119 @@ export function storeVector(
 }
 
 /**
- * Find similar vectors using cosine similarity
+ * Find similar vectors using in-memory cosine similarity.
  *
- * TODO: This is a stub implementation. For production use, integrate sqlite-vec extension
+ * Loads all vectors from the database and compares against the query embedding.
+ * For small-to-medium vector stores (< 100K vectors) this performs well.
+ *
+ * TODO: For production use with larger datasets, integrate sqlite-vec extension
  * which provides optimized vector similarity search with HNSW indexing.
- *
  * See: https://github.com/asg017/sqlite-vec
  *
  * Example with sqlite-vec:
- * SELECT ref_type, ref_id, vec_distance_cosine(embedding, ?) as similarity
- * FROM vectors
- * ORDER BY similarity DESC
- * LIMIT ?
+ *   SELECT ref_type, ref_id, vec_distance_cosine(embedding, ?) as similarity
+ *   FROM vectors
+ *   ORDER BY similarity DESC
+ *   LIMIT ?
+ *
+ * Candidates whose dimensionality differs from the query are skipped —
+ * embeddings from different models are not comparable. Without a model
+ * filter, a ref embedded under several same-dimension models can appear
+ * once per model; the `model` field on each match disambiguates.
+ *
+ * @param embedding - Query embedding vector
+ * @param limit - Maximum number of results to return (default 10)
+ * @param opts.minScore - Minimum cosine similarity threshold (default 0.0)
+ * @param opts.model - Only score embeddings produced by this model
+ * @param opts.exclude - Reference to omit from results (e.g. the query's own ref)
+ * @returns Array of {ref_type, ref_id, model, similarity} sorted by similarity descending
  */
 export function findSimilar(
   embedding: Float32Array,
-  limit: number = 10
-): Array<{ ref_type: string; ref_id: string; similarity: number }> {
-  // TODO: Implement vector similarity search with sqlite-vec extension
-  return [];
+  limit: number = 10,
+  opts?: { minScore?: number; model?: string; exclude?: { ref_type: string; ref_id: string } }
+): SimilarityMatch[] {
+  const db = getDb();
+  const minScore = opts?.minScore ?? 0.0;
+  const exclude = opts?.exclude;
+
+  let query = 'SELECT ref_type, ref_id, embedding, model FROM vectors';
+  const params: string[] = [];
+  if (opts?.model) {
+    query += ' WHERE model = ?';
+    params.push(opts.model);
+  }
+
+  const rows = db.prepare(query).all(...params) as Array<
+    Pick<VectorRow, 'ref_type' | 'ref_id' | 'embedding' | 'model'>
+  >;
+
+  const scored: SimilarityMatch[] = [];
+
+  for (const row of rows) {
+    if (exclude && row.ref_type === exclude.ref_type && row.ref_id === exclude.ref_id) {
+      continue;
+    }
+    const vec = blobToFloat32(row.embedding);
+    if (vec.length !== embedding.length) {
+      continue;
+    }
+    const sim = cosineSimilarity(embedding, vec);
+    if (sim >= minScore) {
+      scored.push({
+        ref_type: row.ref_type,
+        ref_id: row.ref_id,
+        model: row.model,
+        similarity: sim,
+      });
+    }
+  }
+
+  scored.sort((a, b) => b.similarity - a.similarity);
+
+  return scored.slice(0, limit);
+}
+
+/**
+ * Find vectors similar to a given reference entity's embedding.
+ * Convenience wrapper when you have a ref_type + ref_id and want to find
+ * semantically related content. The source reference itself is excluded
+ * from the results, and only candidates from the same model as the source
+ * embedding are scored. When the ref has embeddings from several models and
+ * no model is given, the most recently stored one is used.
+ *
+ * @param ref_type - Reference type to search by
+ * @param ref_id - Reference ID whose embedding to use as query
+ * @param limit - Max results (default 10)
+ * @param opts - Optional settings (model filter, minScore)
+ * @returns Array of {ref_type, ref_id, model, similarity} or empty if source not found
+ */
+export function findSimilarByRef(
+  ref_type: string,
+  ref_id: string,
+  limit: number = 10,
+  opts?: { model?: string; minScore?: number }
+): SimilarityMatch[] {
+  const db = getDb();
+
+  let query = 'SELECT id, ref_type, ref_id, embedding, model, created_at FROM vectors WHERE ref_type = ? AND ref_id = ?';
+  const params: string[] = [ref_type, ref_id];
+
+  if (opts?.model) {
+    query += ' AND model = ?';
+    params.push(opts.model);
+  }
+  query += ' ORDER BY created_at DESC LIMIT 1';
+
+  const sourceRow = db.prepare(query).get(...params) as VectorRow | undefined;
+  if (!sourceRow) return [];
+
+  const queryEmbedding = parseVector(sourceRow).embedding;
+  return findSimilar(queryEmbedding, limit, {
+    minScore: opts?.minScore,
+    model: sourceRow.model,
+    exclude: { ref_type, ref_id },
+  });
 }
 
 /**
@@ -89,4 +220,13 @@ export function deleteVectors(ref_type: string, ref_id: string): void {
   const db = getDb();
   const stmt = db.prepare('DELETE FROM vectors WHERE ref_type = ? AND ref_id = ?');
   stmt.run(ref_type, ref_id);
+}
+
+/**
+ * Count total vectors in the database.
+ */
+export function countVectors(): number {
+  const db = getDb();
+  const row = db.prepare('SELECT COUNT(*) as count FROM vectors').get() as { count: number };
+  return row.count;
 }

--- a/src/workflows/adapters/agent-delegator.ts
+++ b/src/workflows/adapters/agent-delegator.ts
@@ -9,10 +9,9 @@
  *      flows running and returning final messages, even if the "agent" can't
  *      take actions yet. Tool trace is empty.
  *
- *   M7-backed delegator -- TODO. The full version spawns a sub-agent through
- *      AgentTaskManager + assignPersistentAgentTask, polls its task status
- *      until completion, then returns the final message + tool trace. Lands
- *      when M7's task surface is reachable from this adapter.
+ *   M7-backed delegator -- see `m7-agent-delegator.ts` for the full
+ *      implementation (spawns sub-agents through orchestrator.spawnSubAgent,
+ *      runs them through runSubAgent, extracts tool-call trace).
  *
  * The piece-side type doesn't expose a "tool trace" concept beyond an array
  * of `{name, args?, result?}` objects; both impls satisfy the same contract.


### PR DESCRIPTION
Takes the vector-similarity portion of #279 (thanks @yashmagar01) over the finish line, with fixes on top of the original implementation.

## What this does

Replaces the stubbed `findSimilar()` in `src/vault/vectors.ts` with a real in-memory cosine-similarity search, adds `findSimilarByRef()` and `countVectors()`, gives `storeVector()` atomic upsert semantics per `(ref_type, ref_id, model)`, and keeps the honest TODO about migrating to sqlite-vec at scale. Also carries over #279's accurate comment fix in `agent-delegator.ts`.

## Fixes on top of #279

- **Embedding parsing corrupted every vector**: `bun:sqlite` returns BLOBs as `Uint8Array`, and `new Float32Array(uint8Array)` copies byte-by-byte — a stored `[0.25, -1.5, 3.75]` came back as 12 garbage floats. Now reinterprets the underlying buffer.
- `findSimilarByRef` returned the query ref itself as the top result; the source is now excluded.
- Candidates whose dimensionality differs from the query were scored via silent truncation (a 2-dim vector scored 1.0 against a 3-dim query); they're now skipped, and `findSimilar` gained a `model` filter so multi-model stores return sane results (`findSimilarByRef` scores only the source embedding's model).
- The ~20 strict-mode typecheck errors that failed CI on #279.
- Upsert DELETE+INSERT wrapped in a transaction; `Buffer.from` respects `byteOffset`/`byteLength` for subarray views; deterministic source lookup (`ORDER BY created_at DESC`).
- `SimilarityMatch` type exported from the vault barrel, with a `model` field on each match.

## Tests

New `src/vault/vectors.test.ts` — 20 tests: BLOB roundtrip (including offset-subarray views), upsert replacement, multi-model storage, ranking, `limit`/`minScore`, dimension skip, model filtering, self-exclusion, zero-norm queries, deletion. `bunx tsc --noEmit` clean, full suite 1769 pass / 0 fail.

The Windows/macOS controller portion of #279 is intentionally not included — see the review there.
