### PR TITLE
Settings hot reload: apply DB-backed settings without restarting the daemon

### DIFF
--- a/src/comms/index.ts
+++ b/src/comms/index.ts
@@ -103,6 +103,17 @@ export class ChannelManager {
   }
 
   /**
+   * Remove every registered adapter. Callers must disconnectAll() first —
+   * this only drops the references so a later register/connect cycle starts
+   * from a clean slate. Without it, an adapter for a channel the user just
+   * DISABLED would survive in the map and connectAll() would happily
+   * reconnect it with the old token/allowlist.
+   */
+  unregisterAll(): void {
+    this.channels.clear();
+  }
+
+  /**
    * Get a specific channel adapter by name
    */
   getChannel(name: string): import('./channels/telegram.ts').ChannelAdapter | undefined {

--- a/src/comms/websocket.ts
+++ b/src/comms/websocket.ts
@@ -56,7 +56,12 @@ export type WSMessage = {
       // Emitted when a pending voice confirmation (clarifier / repeat-back)
       // expires from the server-side TTL sweep. Payload: { id: string }.
       // Clients should dismiss the corresponding card from their UI.
-      | 'voice_confirmation_expired';
+      | 'voice_confirmation_expired'
+      // Emitted after DB-backed settings are hot-applied to the running
+      // daemon (per-section apply or POST /api/config/reload / SIGHUP).
+      // Payload: { sections: string[], ok: boolean, errors?: { section, error }[] }
+      // — section names and error strings only, never setting values.
+      | 'settings_applied';
   payload: unknown;
   id?: string;
   priority?: 'urgent' | 'normal' | 'low';

--- a/src/daemon/api-routes.ts
+++ b/src/daemon/api-routes.ts
@@ -159,6 +159,12 @@ export type ApiContext = {
    * show the "Restart Jarvis" fallback banner.
    */
   isPostSetupServicesReady?: () => boolean;
+  /**
+   * Settings hot reload coordinator. Wired by the daemon at boot; runs
+   * per-section appliers so DB-backed settings (channels, STT, Google
+   * observers, ...) apply to the running process without a restart.
+   */
+  settingsReload?: import('./settings-reload.ts').SettingsReloadCoordinator;
 };
 
 // CORS headers — scoped to the dashboard origin, not wildcard
@@ -1309,8 +1315,8 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
           const { mergeSTTConfig, mergeTTSConfig } = await import('./config-merge.ts');
           const fresh = ctx.config;
           if (body.stt) {
-            // Mirrors /api/config/stt POST semantics. STT is consumed at
-            // the next transcription request, so no hot-swap is needed.
+            // Mirrors /api/config/stt POST semantics. The saveUserSection
+            // below triggers the stt hot-reload applier.
             fresh.stt = mergeSTTConfig(fresh.stt, body.stt);
           }
           if (body.tts) {
@@ -1397,6 +1403,23 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
           active_role: config.active_role,
           voice: config.voice ?? { wake_engine: 'openwakeword' },
         });
+      },
+    },
+
+    // Force a full re-read of the DB-backed settings into the running
+    // daemon. Covers edits made outside the process (sqlite3 CLI, another
+    // tool); same path as SIGHUP. In-process saves don't need this — the
+    // saveUserSection choke point already runs the appliers.
+    '/api/config/reload': {
+      POST: async () => {
+        if (!ctx.settingsReload) return error('Settings hot reload not available', 503);
+        try {
+          const result = await ctx.settingsReload.reloadAll();
+          return json({ ok: result.errors.length === 0, ...result });
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          return error(`Settings reload failed: ${msg}`, 500);
+        }
       },
     },
 
@@ -1898,6 +1921,12 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
           const auth = new GoogleAuth(googleConfig.client_id, googleConfig.client_secret);
           await auth.exchangeCode(code);
 
+          // The exchange above used a throwaway GoogleAuth that saved the
+          // tokens to disk; nudge the hot-reload applier so the daemon's
+          // long-lived auth re-reads them and the observers start now
+          // (no saveGoogleSettings fires here, so this is explicit).
+          ctx.settingsReload?.sectionChanged('google');
+
           return new Response(
             `<html><body style="font-family:system-ui;text-align:center;padding:60px">
               <h1>JARVIS Google Authorization Complete!</h1>
@@ -2004,7 +2033,16 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
             const { unlinkSync } = await import('node:fs');
             unlinkSync(tokensPath);
           }
-          return json({ ok: true, message: 'Disconnected. Restart JARVIS to deactivate observers.' });
+          // The google applier drops the daemon's in-memory tokens and
+          // restarts the observers, so the disconnect takes effect now.
+          if (!ctx.settingsReload) {
+            return json({ ok: true, message: 'Disconnected. Restart to deactivate observers (hot reload unavailable).' });
+          }
+          const applyErr = await ctx.settingsReload.applyNow('google');
+          if (applyErr) {
+            return json({ ok: false, message: `Disconnected, but deactivating observers failed: ${applyErr.error}` });
+          }
+          return json({ ok: true, message: 'Disconnected. Google observers deactivated.' });
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);
           return error(`Failed to disconnect: ${msg}`, 500);
@@ -2064,7 +2102,14 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
           saveUserSection('channels', freshConfig.channels);
           ctx.config.channels = freshConfig.channels;
 
-          return json({ ok: true, message: 'Channel config saved. Restart JARVIS to apply changes.' });
+          if (!ctx.settingsReload) {
+            return json({ ok: true, message: 'Channel config saved. Restart to apply (hot reload unavailable).' });
+          }
+          const applyErr = await ctx.settingsReload.applyNow('channels');
+          if (applyErr) {
+            return json({ ok: false, message: `Channel config saved, but applying it failed: ${applyErr.error}` });
+          }
+          return json({ ok: true, message: 'Channel config saved and applied.' });
         } catch (err) {
           console.error('[API] Error saving channels config:', err);
           return error('Invalid request body');
@@ -2095,7 +2140,15 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
           freshConfig.stt = mergeSTTConfig(freshConfig.stt, body);
           saveUserSection('stt', freshConfig.stt);
           ctx.config.stt = freshConfig.stt;
-          return json({ ok: true, message: 'STT config saved. Restart JARVIS to apply changes.' });
+
+          if (!ctx.settingsReload) {
+            return json({ ok: true, message: 'STT config saved. Restart to apply (hot reload unavailable).' });
+          }
+          const applyErr = await ctx.settingsReload.applyNow('stt');
+          if (applyErr) {
+            return json({ ok: false, message: `STT config saved, but applying it failed: ${applyErr.error}` });
+          }
+          return json({ ok: true, message: 'STT config saved and applied.' });
         } catch (err) {
           console.error('[API] Error saving STT config:', err);
           return error('Invalid request body');

--- a/src/daemon/channel-service.test.ts
+++ b/src/daemon/channel-service.test.ts
@@ -362,6 +362,27 @@ describe("sendWithRetry", () => {
   });
 });
 
+describe("stop() drops adapters (settings hot reload restart-in-place)", () => {
+  test("a disabled channel's adapter does not survive a stop/start cycle", async () => {
+    initDatabase(":memory:");
+    const svc = new ChannelService({} as never, {} as never);
+    const adapter = new FakeAdapter({ connected: true });
+    svc.getManager().register(adapter);
+
+    await svc.stop();
+
+    // Regression: stop() used to only disconnect, so connectAll() in the
+    // next start() reconnected the stale adapter even though the channel
+    // was disabled in the fresh config.
+    expect(adapter.isConnected()).toBe(false);
+    expect(svc.getManager().listChannels()).toEqual([]);
+
+    // start() with a config that enables no channels stays empty.
+    await svc.start();
+    expect(svc.getManager().listChannels()).toEqual([]);
+  });
+});
+
 describe("delivery failure handler", () => {
   function makeService(adapter: ChannelAdapter): ChannelService {
     // Constructor only stores deps and creates the manager; the live

--- a/src/daemon/channel-service.ts
+++ b/src/daemon/channel-service.ts
@@ -134,6 +134,12 @@ export class ChannelService implements Service {
   async stop(): Promise<void> {
     this._status = 'stopping';
     await this.manager.disconnectAll();
+    // Drop the adapters, not just their connections: start() only registers
+    // adapters for channels that are ENABLED in the current config, so a
+    // stop/start cycle (settings hot reload) must not leave a stale adapter
+    // for a now-disabled channel in the map — connectAll() would reconnect
+    // it with the old token, allowlist, and STT provider.
+    this.manager.unregisterAll();
     this._status = 'stopped';
     console.log('[ChannelService] Stopped');
   }

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -96,6 +96,7 @@ let triggerManager: TriggerManager | null = null;
 let workflowEngineShutdown: (() => Promise<void>) | null = null;
 let systemCron: import('./system-cron.ts').SystemCronService | null = null;
 let timerScheduler: TimerWaitpointScheduler | null = null;
+let settingsReload: import('./settings-reload.ts').SettingsReloadCoordinator | null = null;
 /** Graceful-drain deadline (ms), set from config at boot. Default 75s. */
 let drainDeadlineMs = 75_000;
 
@@ -477,6 +478,16 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
     // 3. Create service registry
     registry = new ServiceRegistry();
 
+    // 3a. Settings hot reload: constructed right after DB hydration so every
+    // later block can register per-section appliers as its targets come into
+    // scope (pebble providers, channels, observers, ...). The choke-point
+    // listener makes EVERY saveUserSection/saveGoogleSettings — HTTP route,
+    // voice intent, pebble toggle — schedule the section's appliers.
+    const { SettingsReloadCoordinator } = await import('./settings-reload.ts');
+    const { setSectionSavedListener } = await import('./user-settings.ts');
+    settingsReload = new SettingsReloadCoordinator(jarvisConfig);
+    setSectionSavedListener((section) => settingsReload?.sectionChanged(section));
+
     // 3b. Anonymous usage telemetry (opt-out). Constructed here so it can be
     //     registered before the LLM-dependent services and counts installs
     //     even while the daemon is still in onboarding/setup mode.
@@ -837,6 +848,24 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
           console.warn('[ambient-ui] failed to init TTS provider:', err);
         }
       }
+
+      // Settings hot reload: rebuild the pebble's providers whenever the
+      // stt/tts sections change (dashboard save, voice command, reloadAll).
+      // The dashboard-side wsService providers have their own appliers in
+      // the main registration block.
+      settingsReload?.registerApplier('stt', async (cfg) => {
+        const { createSTTProvider } = await import('../comms/voice.ts');
+        pebbleSTT = cfg.stt ? createSTTProvider(cfg.stt) : null;
+        console.log(`[ambient-ui] STT provider ${pebbleSTT ? `set to ${cfg.stt?.provider}` : 'cleared'} (settings reload)`);
+      });
+      settingsReload?.registerApplier('tts', async (cfg) => {
+        pebbleTTS = null;
+        if (cfg.tts?.enabled) {
+          const { createTTSProvider } = await import('../comms/voice.ts');
+          pebbleTTS = createTTSProvider(cfg.tts);
+        }
+        console.log(`[ambient-ui] TTS provider ${pebbleTTS ? 'rebuilt' : 'cleared'} (settings reload)`);
+      });
 
       // ttsMimeType maps the configured TTS provider to a MIME hint the
       // sidecar uses when sniffing audio bytes. (The sidecar primarily
@@ -1439,43 +1468,20 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
       // pipeline (capture done → transcribe → think → speak), not timers.
       const audioSessions = new (await import('./audio-sessions.ts')).AudioSessionRegistry();
       audioSessions.attach((cb) => sidecarManager.onEvent(cb));
-      // T20 — voice-driven settings mutation. Patches `jarvisConfig`,
-      // persists via the DB settings store, and rebuilds the live providers so
-      // the next response uses the new setting without a daemon
-      // restart. The user explicitly hit this with "turn off TTS in
-      // the settings" — the panel opened but the toggle didn't flip
-      // because no handler was wired to the request. This closes that
-      // gap. New providers added to `jarvisConfig` (e.g. Groq STT)
-      // become voice-switchable too.
+      // T20 — voice-driven settings mutation. Patches `jarvisConfig` and
+      // persists via the DB settings store; the saveUserSection choke-point
+      // hook then runs the stt/tts appliers (pebble + dashboard providers),
+      // so the next response uses the new setting without a daemon restart.
       const applyTTSEnabled = async (enabled: boolean): Promise<void> => {
         const { saveUserSection } = await import('./user-settings.ts');
         if (!jarvisConfig.tts) jarvisConfig.tts = { enabled, provider: 'edge' };
         else jarvisConfig.tts.enabled = enabled;
         saveUserSection('tts', jarvisConfig.tts);
-        const fresh = { tts: jarvisConfig.tts };
-        // Rebuild the pebble's TTS provider so the next response cycle
-        // either uses the new provider or skips TTS entirely.
-        if (enabled) {
-          try {
-            const { createTTSProvider } = await import('../comms/voice.ts');
-            pebbleTTS = createTTSProvider(fresh.tts);
-            if (pebbleTTS) console.log('[ambient-ui] TTS re-enabled via voice command');
-          } catch (err) {
-            console.warn('[ambient-ui] failed to re-init TTS provider:', err);
-            pebbleTTS = null;
-          }
-        } else {
-          pebbleTTS = null;
-          console.log('[ambient-ui] TTS disabled via voice command');
-        }
-        // Hot-reload dashboard TTS too so the WSService stays in sync.
-        if (wsService && fresh.tts) {
-          try {
-            const { createTTSProvider } = await import('../comms/voice.ts');
-            const provider = createTTSProvider(fresh.tts);
-            if (provider && enabled) wsService.setTTSProvider(provider);
-          } catch { /* dashboard fallback */ }
-        }
+        // Await the applier (vs the save hook's scheduled run) so pebbleTTS
+        // is already rebuilt when the confirmation reply is spoken — "turn
+        // on text to speech" must be audible in the SAME response cycle.
+        await settingsReload?.applyNow('tts');
+        console.log(`[ambient-ui] TTS ${enabled ? 'enabled' : 'disabled'} via voice command`);
       };
 
       const applySTTProvider = async (provider: 'openai' | 'groq' | 'sarvam' | 'local'): Promise<boolean> => {
@@ -1491,14 +1497,10 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
         if (!hasKey) return false;
         jarvisConfig.stt.provider = provider;
         saveUserSection('stt', jarvisConfig.stt);
-        const fresh = { stt: jarvisConfig.stt };
-        try {
-          const { createSTTProvider } = await import('../comms/voice.ts');
-          pebbleSTT = createSTTProvider(fresh.stt);
-          console.log(`[ambient-ui] STT provider switched to ${provider} via voice command`);
-        } catch (err) {
-          console.warn('[ambient-ui] failed to re-init STT provider:', err);
-        }
+        // Deterministic swap: the next transcription must already use the
+        // new provider when we confirm the switch to the user.
+        await settingsReload?.applyNow('stt');
+        console.log(`[ambient-ui] STT provider switched to ${provider} via voice command`);
         return true;
       };
 
@@ -3570,6 +3572,94 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
       }
     });
 
+    // 8f. Settings hot reload: per-section appliers. Everything they need
+    // (wsService, channelService, registry, observers, authority) is in
+    // scope here. Appliers are idempotent — routes that already apply a
+    // change by hand (LLM, TTS) can keep doing so; a second run is harmless.
+    settingsReload.setBroadcast((p) => wsService.broadcastSettingsApplied(p));
+
+    // channels — Telegram/Discord adapters bake tokens (and the STT
+    // provider) into their constructors, so restart-in-place is the apply.
+    // Debounced so back-to-back saves reconnect the bots once.
+    settingsReload.registerApplier('channels', async () => {
+      await registry!.stopService('channels');
+      await registry!.startService('channels');
+    }, { debounceMs: 400 });
+
+    // stt — swap the dashboard voice-input provider; live channel adapters
+    // captured the old provider at construction, so chain a channels
+    // restart when any channel is connected.
+    settingsReload.registerApplier('stt', async (cfg) => {
+      const { createSTTProvider } = await import('../comms/voice.ts');
+      wsService.setSTTProvider(cfg.stt ? createSTTProvider(cfg.stt) : null);
+      if (Object.values(channelService.getChannelStatus()).some(Boolean)) {
+        settingsReload!.sectionChanged('channels');
+      }
+    });
+
+    // tts — same swap the /api/config/tts route already does by hand; this
+    // also covers voice-command toggles and reloadAll, and clears the
+    // provider on disable.
+    settingsReload.registerApplier('tts', async (cfg) => {
+      const { createTTSProvider } = await import('../comms/voice.ts');
+      wsService.setTTSProvider(cfg.tts?.enabled ? createTTSProvider(cfg.tts) : null);
+    });
+
+    // google — refresh the auth (disconnect unlinks the tokens file; the
+    // null-first reload drops the stale in-memory tokens), hand it to the
+    // observers and restart them so EmailSync/CalendarSync re-capture it.
+    let lastGoogleCreds = jarvisConfig.google?.client_id && jarvisConfig.google?.client_secret
+      ? `${jarvisConfig.google.client_id}\n${jarvisConfig.google.client_secret}`
+      : null;
+    settingsReload.registerApplier('google', async (cfg) => {
+      const g = cfg.google;
+      const creds = g?.client_id && g?.client_secret ? `${g.client_id}\n${g.client_secret}` : null;
+      if (!creds) {
+        googleAuth = null;
+      } else if (googleAuth && creds === lastGoogleCreds) {
+        googleAuth.reloadTokensFromDisk();
+      } else {
+        googleAuth = new GoogleAuth(g!.client_id!, g!.client_secret!);
+      }
+      lastGoogleCreds = creds;
+      if (observerService) {
+        observerService.setGoogleAuth(googleAuth);
+        await registry!.stopService('observers');
+        await registry!.startService('observers');
+      }
+    });
+
+    // llm — routes keep their synchronous hotReloadLLMProviders call for an
+    // accurate response; this covers reloadAll/SIGHUP (external DB edits).
+    settingsReload.registerApplier('llm', async (cfg) => {
+      const { hotReloadLLMProviders } = await import('./llm-settings.ts');
+      hotReloadLLMProviders(cfg, agentService.getLLMManager());
+    });
+
+    // authority — keep the engine's construction-time snapshot in sync on a
+    // full reload (mirror of the POST /api/authority/config mapping).
+    // emergency_state is excluded: EmergencyController owns it.
+    settingsReload.registerApplier('authority', async (cfg) => {
+      const a = cfg.authority;
+      if (!a) return;
+      const current = authorityEngine.getConfig();
+      authorityEngine.updateConfig({
+        ...current,
+        default_level: a.default_level ?? current.default_level,
+        governed_categories: (a.governed_categories ?? current.governed_categories) as any,
+        overrides: (a.overrides ?? current.overrides) as any,
+        context_rules: (a.context_rules ?? current.context_rules) as any,
+        learning: a.learning ?? current.learning,
+      });
+    });
+
+    // awareness — the service snapshots its sub-config at construction; the
+    // enabled flag is the one knob with a live setter today.
+    settingsReload.registerApplier('awareness', async (cfg) => {
+      awarenessService?.toggle(cfg.awareness?.enabled !== false);
+    });
+    // voice needs no applier: resolveRealtimeVoice reads live config per call.
+
     // ── Tray menu live data (design: usejarvis-tray §00) ──
     // Push a status snapshot to each connected sidecar every few seconds so the
     // tray menu (read on open) shows pending approvals, pause state, health, and
@@ -3874,6 +3964,7 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
       awarenessService: null as any,
       goalService: undefined,
       sidecarManager,
+      settingsReload,
     };
     setCorsOrigin(jarvisConfig.daemon.port);
 
@@ -3920,11 +4011,15 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
     // matching source; non-prefixed ids fall through to the `app_connection`
     // repo (encrypted at rest).
     const credentialResolver = new CredentialResolver();
-    if (googleAuth) {
+    {
+      // Registered unconditionally with a getter reading the live
+      // `googleAuth` binding: the settings hot-reload google applier
+      // reassigns it (connect mid-run, cred rotation, disconnect), and the
+      // source resolves to null while it's absent/unauthenticated.
       const { JarvisGoogleConnectionSource } = await import(
         "../workflows/credentials/google-source.ts"
       );
-      credentialResolver.register(new JarvisGoogleConnectionSource(googleAuth));
+      credentialResolver.register(new JarvisGoogleConnectionSource(() => googleAuth));
       logWithTimestamp(
         "Workflow credential resolver: registered jarvis:google source",
       );
@@ -4561,7 +4656,16 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
               }
             }
           },
-          googleAuth,
+          // Delegating wrapper (not the instance): the settings hot-reload
+          // google applier reassigns `googleAuth`, and the suggestion engine
+          // holds this reference for the service's whole lifetime.
+          {
+            isAuthenticated: () => googleAuth?.isAuthenticated() ?? false,
+            getAccessToken: () => {
+              if (!googleAuth) return Promise.reject(new Error('Google not configured'));
+              return googleAuth.getAccessToken();
+            },
+          },
           async (sidecarId: string, imagePath: string) => {
             try {
               const result = await sidecarManager.dispatchRPC(sidecarId, 'fetch_capture', { path: imagePath }) as
@@ -4922,6 +5026,26 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
 // Register signal handlers
 process.on('SIGINT', () => handleShutdown('SIGINT'));
 process.on('SIGTERM', () => handleShutdown('SIGTERM'));
+
+// SIGHUP = reload settings from the DB (daemon convention). Covers settings
+// edited outside the daemon process (sqlite3 CLI, hosted control plane);
+// same path as POST /api/config/reload. Registering the handler also stops
+// the default terminate-on-HUP, which is what we want for a daemon.
+if (process.platform !== 'win32') {
+  process.on('SIGHUP', () => {
+    if (!settingsReload) {
+      console.log('[Daemon] SIGHUP received before boot finished — ignoring');
+      return;
+    }
+    console.log('[Daemon] SIGHUP — reloading settings from DB');
+    settingsReload.reloadAll()
+      .then((r) => {
+        const changed = r.changed.length > 0 ? r.changed.join(', ') : 'nothing';
+        console.log(`[Daemon] SIGHUP reload done — changed: ${changed}${r.errors.length ? `, errors: ${r.errors.length}` : ''}`);
+      })
+      .catch((err) => console.error('[Daemon] SIGHUP reload failed:', err));
+  });
+}
 
 // Handle uncaught errors
 process.on('uncaughtException', (error) => {

--- a/src/daemon/observer-service.ts
+++ b/src/daemon/observer-service.ts
@@ -97,6 +97,16 @@ export class ObserverService implements Service {
     this.forwardCallback = cb;
   }
 
+  /**
+   * Swap the Google auth used by the email/calendar observers (settings hot
+   * reload). Takes effect on the next start(): EmailSync/CalendarSync are
+   * constructed there and capture the auth reference, so callers should
+   * stop() + start() the service after swapping.
+   */
+  setGoogleAuth(auth: GoogleAuth | null): void {
+    this.googleAuth = auth;
+  }
+
   async start(): Promise<void> {
     this._status = 'starting';
 

--- a/src/daemon/settings-reload.test.ts
+++ b/src/daemon/settings-reload.test.ts
@@ -1,0 +1,252 @@
+import { test, expect, describe, beforeEach, afterEach } from 'bun:test';
+import { initDatabase, closeDb } from '../vault/schema.ts';
+import { setSetting } from '../vault/settings.ts';
+import { DEFAULT_CONFIG, type JarvisConfig } from '../config/types.ts';
+import { SettingsReloadCoordinator, type SettingsAppliedPayload } from './settings-reload.ts';
+import { ServiceRegistry, type Service, type ServiceStatus } from './services.ts';
+
+function freshConfig(): JarvisConfig {
+  return structuredClone(DEFAULT_CONFIG);
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+describe('settings-reload', () => {
+  beforeEach(() => {
+    initDatabase(':memory:');
+  });
+
+  afterEach(() => {
+    closeDb();
+  });
+
+  test('sectionChanged runs the applier with the live config', async () => {
+    const config = freshConfig();
+    const coordinator = new SettingsReloadCoordinator(config);
+    const seen: string[] = [];
+    coordinator.registerApplier('stt', (cfg) => {
+      seen.push(cfg.stt?.provider ?? 'none');
+    });
+
+    config.stt = { provider: 'groq' };
+    coordinator.sectionChanged('stt');
+    await coordinator.whenIdle();
+
+    expect(seen).toEqual(['groq']);
+  });
+
+  test('multiple appliers per section all run, in registration order', async () => {
+    const coordinator = new SettingsReloadCoordinator(freshConfig());
+    const order: string[] = [];
+    coordinator.registerApplier('tts', () => { order.push('a'); });
+    coordinator.registerApplier('tts', () => { order.push('b'); });
+
+    await coordinator.applyNow('tts');
+    expect(order).toEqual(['a', 'b']);
+  });
+
+  test('sectionChanged with no appliers is a no-op', async () => {
+    const coordinator = new SettingsReloadCoordinator(freshConfig());
+    coordinator.sectionChanged('desktop');
+    await coordinator.whenIdle();
+  });
+
+  test('repeat sectionChanged calls coalesce into one applier run', async () => {
+    const coordinator = new SettingsReloadCoordinator(freshConfig());
+    let runs = 0;
+    coordinator.registerApplier('channels', () => { runs++; }, { debounceMs: 30 });
+
+    coordinator.sectionChanged('channels');
+    coordinator.sectionChanged('channels');
+    coordinator.sectionChanged('channels');
+    await sleep(200);
+
+    expect(runs).toBe(1);
+  });
+
+  test('applyNow cancels a pending debounce so nothing runs twice', async () => {
+    const coordinator = new SettingsReloadCoordinator(freshConfig());
+    let runs = 0;
+    coordinator.registerApplier('channels', () => { runs++; }, { debounceMs: 5_000 });
+
+    coordinator.sectionChanged('channels');
+    const err = await coordinator.applyNow('channels');
+    expect(err).toBeNull();
+    expect(runs).toBe(1);
+
+    // The 5s timer was cancelled — no second run shows up.
+    await sleep(50);
+    expect(runs).toBe(1);
+  });
+
+  test('appliers are serialized: never two in flight at once', async () => {
+    const coordinator = new SettingsReloadCoordinator(freshConfig());
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const slowApplier = async () => {
+      inFlight++;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await sleep(20);
+      inFlight--;
+    };
+    coordinator.registerApplier('stt', slowApplier);
+    coordinator.registerApplier('tts', slowApplier);
+
+    await Promise.all([coordinator.applyNow('stt'), coordinator.applyNow('tts')]);
+    expect(maxInFlight).toBe(1);
+  });
+
+  test('a throwing applier surfaces as ApplyError and does not break other sections', async () => {
+    const coordinator = new SettingsReloadCoordinator(freshConfig());
+    const payloads: SettingsAppliedPayload[] = [];
+    coordinator.setBroadcast((p) => payloads.push(p));
+    coordinator.registerApplier('stt', () => {
+      throw new Error('boom');
+    });
+    let ttsRan = false;
+    coordinator.registerApplier('tts', () => { ttsRan = true; });
+
+    const err = await coordinator.applyNow('stt');
+    expect(err?.section).toBe('stt');
+    expect(err?.error).toBe('boom');
+
+    expect(await coordinator.applyNow('tts')).toBeNull();
+    expect(ttsRan).toBe(true);
+
+    expect(payloads).toHaveLength(2);
+    expect(payloads[0]).toEqual({ sections: ['stt'], ok: false, errors: [{ section: 'stt', error: 'boom' }] });
+    expect(payloads[1]).toEqual({ sections: ['tts'], ok: true, errors: [] });
+  });
+
+  test('a throwing applier does not poison the queue for later applies of the same section', async () => {
+    const coordinator = new SettingsReloadCoordinator(freshConfig());
+    let calls = 0;
+    coordinator.registerApplier('channels', () => {
+      calls++;
+      if (calls === 1) throw new Error('first fails');
+    });
+
+    expect((await coordinator.applyNow('channels'))?.error).toBe('first fails');
+    expect(await coordinator.applyNow('channels')).toBeNull();
+    expect(calls).toBe(2);
+  });
+
+  test('reloadAll picks up an external DB edit and runs only the changed sections', async () => {
+    const config = freshConfig();
+    const coordinator = new SettingsReloadCoordinator(config);
+    const applied: string[] = [];
+    coordinator.registerApplier('stt', () => { applied.push('stt'); });
+    coordinator.registerApplier('tts', () => { applied.push('tts'); });
+
+    // Simulate an edit made OUTSIDE the daemon (sqlite3 CLI): raw row write,
+    // no saveUserSection listener fires.
+    setSetting('cfg.stt', JSON.stringify({ provider: 'sarvam', sarvam: { api_key: 'sk-1' } }));
+
+    const result = await coordinator.reloadAll();
+
+    expect(result.changed).toContain('stt');
+    expect(result.changed).not.toContain('tts');
+    expect(result.applied).toContain('stt');
+    expect(result.errors).toEqual([]);
+    expect(applied).toContain('stt');
+    expect(applied).not.toContain('tts');
+    expect(config.stt?.provider).toBe('sarvam');
+  });
+
+  test('reloadAll is stable: a second run with no DB change reports nothing changed', async () => {
+    const config = freshConfig();
+    const coordinator = new SettingsReloadCoordinator(config);
+    setSetting('cfg.tts', JSON.stringify({ enabled: true, provider: 'edge' }));
+
+    const first = await coordinator.reloadAll();
+    expect(first.changed).toContain('tts');
+
+    const second = await coordinator.reloadAll();
+    expect(second.changed).toEqual([]);
+    expect(second.applied).toEqual([]);
+  });
+
+  test('reloadAll cancels a pending scheduled apply for a changed section', async () => {
+    const config = freshConfig();
+    const coordinator = new SettingsReloadCoordinator(config);
+    let runs = 0;
+    coordinator.registerApplier('stt', () => { runs++; }, { debounceMs: 5_000 });
+
+    setSetting('cfg.stt', JSON.stringify({ provider: 'groq' }));
+    coordinator.sectionChanged('stt'); // scheduled 5s out
+    await coordinator.reloadAll();     // runs the applier itself
+
+    expect(runs).toBe(1);
+    await sleep(50);
+    expect(runs).toBe(1); // debounce timer was cancelled
+  });
+
+  test('reloadAll broadcasts one batch with every changed section', async () => {
+    const config = freshConfig();
+    const coordinator = new SettingsReloadCoordinator(config);
+    const payloads: SettingsAppliedPayload[] = [];
+    coordinator.setBroadcast((p) => payloads.push(p));
+
+    setSetting('cfg.stt', JSON.stringify({ provider: 'groq' }));
+    setSetting('cfg.active_role', JSON.stringify('researcher'));
+    await coordinator.reloadAll();
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]!.sections).toContain('stt');
+    expect(payloads[0]!.sections).toContain('active_role');
+    expect(payloads[0]!.ok).toBe(true);
+  });
+
+  test('channels-style applier: stop-then-start through a real ServiceRegistry', async () => {
+    const calls: string[] = [];
+    let failNextStart = false;
+    let status: ServiceStatus = 'stopped';
+    const stub: Service = {
+      name: 'channels',
+      async start() {
+        calls.push('start');
+        if (failNextStart) {
+          failNextStart = false;
+          throw new Error('connect refused');
+        }
+        status = 'running';
+      },
+      async stop() {
+        calls.push('stop');
+        status = 'stopped';
+      },
+      status: () => status,
+    };
+    const registry = new ServiceRegistry();
+    registry.register(stub);
+    await registry.startService('channels');
+    calls.length = 0;
+
+    const coordinator = new SettingsReloadCoordinator(freshConfig());
+    coordinator.registerApplier('channels', async () => {
+      await registry.stopService('channels');
+      await registry.startService('channels');
+    });
+
+    expect(await coordinator.applyNow('channels')).toBeNull();
+    expect(calls).toEqual(['stop', 'start']);
+
+    // A failed start surfaces as an ApplyError but leaves the queue usable.
+    failNextStart = true;
+    const err = await coordinator.applyNow('channels');
+    expect(err?.error).toBe('connect refused');
+    expect(await coordinator.applyNow('channels')).toBeNull();
+  });
+
+  test('a broken broadcast callback never breaks the apply', async () => {
+    const coordinator = new SettingsReloadCoordinator(freshConfig());
+    coordinator.setBroadcast(() => {
+      throw new Error('ws down');
+    });
+    let ran = false;
+    coordinator.registerApplier('tts', () => { ran = true; });
+
+    expect(await coordinator.applyNow('tts')).toBeNull();
+    expect(ran).toBe(true);
+  });
+});

--- a/src/daemon/settings-reload.ts
+++ b/src/daemon/settings-reload.ts
@@ -1,0 +1,237 @@
+/**
+ * Settings hot reload: applies DB-backed settings to the running daemon
+ * without a restart.
+ *
+ * A per-section registry of async appliers with one serialized apply queue.
+ * Change events fire at the write choke point (user-settings.ts calls the
+ * listener installed via setSectionSavedListener), so every writer — HTTP
+ * routes, voice intents, pebble toggles — triggers the appliers with zero
+ * per-callsite wiring. Routes that want to report the apply outcome call
+ * applyNow(section), which cancels the scheduled run so nothing runs twice.
+ *
+ * reloadAll() re-runs the exact boot hydration (mergeLLMSettingsIntoConfig →
+ * mergeUserSettingsIntoConfig → applyEnvOverrides, same order as
+ * daemon/index.ts, so env still wins), diffs JSON snapshots per section, and
+ * runs appliers for changed sections only. It backs POST /api/config/reload
+ * and SIGHUP, covering settings edited outside the daemon process.
+ *
+ * This is deliberately NOT the workflow event bus: appliers must be
+ * awaitable, must not become workflow trigger types, and must never mirror
+ * into the /v1/jarvis/events/poll buffer.
+ *
+ * Rules for appliers:
+ * - Idempotent: the choke-point hook can fire after a route already applied
+ *   the same change by hand; a double apply must be harmless.
+ * - Never write their own section (saveUserSection from inside an applier
+ *   for that section would loop; coalescing bounds it, but don't).
+ * - Read the live config passed in — events carry section names only, never
+ *   values, so tokens/keys stay out of the event path.
+ *
+ * Sections whose config is re-hydrated but that have no component applier
+ * yet (cron schedules, heartbeat aggressiveness, goals, sites, desktop,
+ * workflows, ...) keep today's behavior: new values are visible to live
+ * config readers, construction-time snapshots stay until restart.
+ *
+ * Known limitation: reloadAll() detects changes to CONFIG SECTIONS only.
+ * State living outside the settings table — e.g. the Google tokens file —
+ * doesn't show up in the diff, so deleting google-tokens.json externally
+ * and sending SIGHUP won't deactivate observers (the in-daemon disconnect
+ * route handles that case via applyNow('google')).
+ */
+
+import { applyEnvOverrides } from '../config/loader.ts';
+import { USER_OWNED_SECTIONS, type JarvisConfig, type UserOwnedSection } from '../config/types.ts';
+import { mergeLLMSettingsIntoConfig } from './llm-settings.ts';
+import { mergeUserSettingsIntoConfig } from './user-settings.ts';
+
+export type ReloadSection = UserOwnedSection | 'llm' | 'google';
+export type SectionApplier = (config: JarvisConfig) => void | Promise<void>;
+
+export interface ApplyError {
+  section: ReloadSection;
+  error: string;
+}
+
+export interface ReloadResult {
+  /** Sections whose config value changed during re-hydration. */
+  changed: ReloadSection[];
+  /** Changed sections that had appliers registered (and were run). */
+  applied: ReloadSection[];
+  errors: ApplyError[];
+}
+
+export interface SettingsAppliedPayload {
+  sections: string[];
+  ok: boolean;
+  errors: ApplyError[];
+}
+
+const RELOAD_SECTIONS: readonly ReloadSection[] = [...USER_OWNED_SECTIONS, 'llm', 'google'];
+
+interface RegisteredApplier {
+  fn: SectionApplier;
+  debounceMs: number;
+}
+
+interface PendingApply {
+  timer: ReturnType<typeof setTimeout>;
+}
+
+export class SettingsReloadCoordinator {
+  private readonly config: JarvisConfig;
+  private readonly appliers = new Map<ReloadSection, RegisteredApplier[]>();
+  private readonly pending = new Map<ReloadSection, PendingApply>();
+  /** Single-flight chain: no two appliers ever run concurrently. */
+  private queue: Promise<unknown> = Promise.resolve();
+  private broadcast: ((payload: SettingsAppliedPayload) => void) | null = null;
+
+  constructor(config: JarvisConfig) {
+    this.config = config;
+  }
+
+  /**
+   * Register an applier for a section. Multiple appliers per section
+   * accumulate and run in registration order. debounceMs delays the
+   * scheduled run after sectionChanged (repeat changes restart the timer);
+   * applyNow bypasses it.
+   */
+  registerApplier(
+    section: ReloadSection,
+    applier: SectionApplier,
+    opts?: { debounceMs?: number },
+  ): void {
+    const list = this.appliers.get(section) ?? [];
+    list.push({ fn: applier, debounceMs: Math.max(0, opts?.debounceMs ?? 0) });
+    this.appliers.set(section, list);
+  }
+
+  /** Called after every apply batch (single-section or reloadAll). */
+  setBroadcast(fn: ((payload: SettingsAppliedPayload) => void) | null): void {
+    this.broadcast = fn;
+  }
+
+  /**
+   * Fire-and-forget: schedule a coalesced apply for the section. No-op when
+   * the section has no appliers. A repeat call while one is pending restarts
+   * the debounce timer — appliers read live config, so latest state wins.
+   */
+  sectionChanged(section: ReloadSection): void {
+    const list = this.appliers.get(section);
+    if (!list || list.length === 0) return;
+
+    const delay = Math.max(...list.map((a) => a.debounceMs));
+    const existing = this.pending.get(section);
+    if (existing) clearTimeout(existing.timer);
+    this.pending.set(section, {
+      timer: setTimeout(() => void this.flush(section), delay),
+    });
+  }
+
+  /**
+   * Cancel any pending debounce for the section and run its appliers now
+   * (still serialized behind in-flight applies). Resolves null on success,
+   * the first ApplyError otherwise. No-op (null) when no appliers exist.
+   */
+  applyNow(section: ReloadSection): Promise<ApplyError | null> {
+    const list = this.appliers.get(section);
+    if (!list || list.length === 0) return Promise.resolve(null);
+    return this.flush(section);
+  }
+
+  /**
+   * Full re-hydrate from DB + env, diff per-section JSON snapshots, run
+   * appliers for changed sections only. Serialized behind other applies.
+   */
+  reloadAll(): Promise<ReloadResult> {
+    return this.enqueue(async () => {
+      const before = new Map<ReloadSection, string>();
+      for (const section of RELOAD_SECTIONS) {
+        before.set(section, this.snapshot(section));
+      }
+
+      // Exact boot hydration order (daemon/index.ts): LLM, then user
+      // sections, then env overrides so a JARVIS_* pin still wins.
+      mergeLLMSettingsIntoConfig(this.config);
+      mergeUserSettingsIntoConfig(this.config);
+      applyEnvOverrides(this.config);
+
+      const changed = RELOAD_SECTIONS.filter((s) => this.snapshot(s) !== before.get(s));
+      const applied: ReloadSection[] = [];
+      const errors: ApplyError[] = [];
+      for (const section of changed) {
+        // A scheduled apply for this section is now redundant (appliers are
+        // idempotent, but no point running twice).
+        this.cancelPending(section);
+        if (!this.appliers.get(section)?.length) continue;
+        applied.push(section);
+        errors.push(...(await this.runAppliers(section)));
+      }
+
+      if (changed.length > 0) {
+        this.emitBroadcast({ sections: [...changed], ok: errors.length === 0, errors });
+      }
+      return { changed, applied, errors };
+    });
+  }
+
+  /** Resolves once every pending debounce has flushed and the queue drained. */
+  async whenIdle(): Promise<void> {
+    while (this.pending.size > 0) {
+      await Promise.all([...this.pending.keys()].map((s) => this.flush(s)));
+    }
+    await this.queue;
+  }
+
+  // ── internals ─────────────────────────────────────────────────────────────
+
+  private snapshot(section: ReloadSection): string {
+    return JSON.stringify((this.config as Record<string, unknown>)[section] ?? null);
+  }
+
+  /** Drop a scheduled apply (reloadAll runs the section's appliers itself). */
+  private cancelPending(section: ReloadSection): void {
+    const entry = this.pending.get(section);
+    if (!entry) return;
+    clearTimeout(entry.timer);
+    this.pending.delete(section);
+  }
+
+  private flush(section: ReloadSection): Promise<ApplyError | null> {
+    this.cancelPending(section);
+
+    return this.enqueue(async () => {
+      const errors = await this.runAppliers(section);
+      this.emitBroadcast({ sections: [section], ok: errors.length === 0, errors });
+      return errors[0] ?? null;
+    });
+  }
+
+  private async runAppliers(section: ReloadSection): Promise<ApplyError[]> {
+    const errors: ApplyError[] = [];
+    for (const { fn } of this.appliers.get(section) ?? []) {
+      try {
+        await fn(this.config);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(`[SettingsReload] Applier for '${section}' failed: ${message}`);
+        errors.push({ section, error: message });
+      }
+    }
+    return errors;
+  }
+
+  /** Chain a job onto the single-flight queue; failures never break the chain. */
+  private enqueue<T>(job: () => Promise<T>): Promise<T> {
+    const run = this.queue.then(job);
+    this.queue = run.catch(() => undefined);
+    return run;
+  }
+
+  private emitBroadcast(payload: SettingsAppliedPayload): void {
+    try {
+      this.broadcast?.(payload);
+    } catch (err) {
+      console.error('[SettingsReload] Broadcast failed:', err);
+    }
+  }
+}

--- a/src/daemon/user-settings.test.ts
+++ b/src/daemon/user-settings.test.ts
@@ -9,6 +9,7 @@ import {
   importLegacyUserSettings,
   mergeUserSettingsIntoConfig,
   saveGoogleSettings,
+  setSectionSavedListener,
 } from './user-settings.ts';
 
 function freshConfig(): JarvisConfig {
@@ -21,6 +22,7 @@ describe('user-settings', () => {
   });
 
   afterEach(() => {
+    setSectionSavedListener(null);
     closeDb();
   });
 
@@ -127,6 +129,45 @@ describe('user-settings', () => {
 
   test('null rawYaml (no config file) imports nothing', () => {
     expect(importLegacyUserSettings(null)).toEqual([]);
+  });
+
+  test('section-saved listener fires AFTER the write, with the section name', () => {
+    const events: string[] = [];
+    setSectionSavedListener((section) => {
+      events.push(section);
+      // The DB write must already be visible when the listener runs.
+      expect(loadUserSection('stt')).toEqual({ provider: 'groq' });
+    });
+
+    saveUserSection('stt', { provider: 'groq' });
+    expect(events).toEqual(['stt']);
+  });
+
+  test("saveGoogleSettings notifies the listener with 'google'", () => {
+    const events: string[] = [];
+    setSectionSavedListener((section) => events.push(section));
+
+    saveGoogleSettings({ client_id: 'id', client_secret: 'secret' });
+    expect(events).toEqual(['google']);
+  });
+
+  test('a throwing listener never fails the save', () => {
+    setSectionSavedListener(() => {
+      throw new Error('listener boom');
+    });
+
+    expect(() => saveUserSection('active_role', 'researcher')).not.toThrow();
+    expect(loadUserSection('active_role')).toBe('researcher');
+  });
+
+  test('setSectionSavedListener(null) detaches', () => {
+    const events: string[] = [];
+    setSectionSavedListener((section) => events.push(section));
+    saveUserSection('active_role', 'a');
+    setSectionSavedListener(null);
+    saveUserSection('active_role', 'b');
+
+    expect(events).toEqual(['active_role']);
   });
 
   test('google: DB is only a fallback - a file-provided client always wins', () => {

--- a/src/daemon/user-settings.ts
+++ b/src/daemon/user-settings.ts
@@ -34,6 +34,30 @@ function settingKey(section: UserOwnedSection): string {
 }
 
 /**
+ * Write choke point for hot reload: every saveUserSection/saveGoogleSettings
+ * notifies this listener AFTER the DB write, so the daemon's
+ * SettingsReloadCoordinator can run the section's appliers regardless of who
+ * saved (HTTP route, voice intent, pebble toggle). The daemon injects it at
+ * boot; tests and CLI tools leave it null. Listener errors never fail the
+ * save.
+ */
+let sectionSavedListener: ((section: UserOwnedSection | 'google') => void) | null = null;
+
+export function setSectionSavedListener(
+  fn: ((section: UserOwnedSection | 'google') => void) | null,
+): void {
+  sectionSavedListener = fn;
+}
+
+function notifySectionSaved(section: UserOwnedSection | 'google'): void {
+  try {
+    sectionSavedListener?.(section);
+  } catch (err) {
+    console.error(`[UserSettings] Section-saved listener failed for '${section}':`, err);
+  }
+}
+
+/**
  * Persist one section to the DB. Callers mutate the in-memory config first,
  * then persist that section — the write is per-section, so there is no
  * load-modify-save race across unrelated sections (which is what the old
@@ -44,6 +68,7 @@ export function saveUserSection<K extends UserOwnedSection>(
   value: JarvisConfig[K],
 ): void {
   setSetting(settingKey(section), JSON.stringify(value ?? null));
+  notifySectionSaved(section);
 }
 
 /** Read one stored section; undefined when absent or unparseable. */
@@ -152,6 +177,7 @@ const GOOGLE_KEY = `${CFG_PREFIX}google`;
 
 export function saveGoogleSettings(value: JarvisConfig['google']): void {
   setSetting(GOOGLE_KEY, JSON.stringify(value ?? null));
+  notifySectionSaved('google');
 }
 
 function mergeGoogleSettingsIntoConfig(config: JarvisConfig): void {

--- a/src/daemon/ws-service.ts
+++ b/src/daemon/ws-service.ts
@@ -242,19 +242,20 @@ export class WebSocketService implements Service {
   }
 
   /**
-   * Set the TTS provider for voice responses.
+   * Set the TTS provider for voice responses. Null clears it (provider
+   * disabled or credentials removed via settings hot reload).
    */
-  setTTSProvider(provider: TTSProvider): void {
+  setTTSProvider(provider: TTSProvider | null): void {
     this.ttsProvider = provider;
-    console.log('[WSService] TTS provider set');
+    console.log(provider ? '[WSService] TTS provider set' : '[WSService] TTS provider cleared');
   }
 
   /**
-   * Set the STT provider for voice input transcription.
+   * Set the STT provider for voice input transcription. Null clears it.
    */
-  setSTTProvider(provider: STTProvider): void {
+  setSTTProvider(provider: STTProvider | null): void {
     this.sttProvider = provider;
-    console.log('[WSService] STT provider set');
+    console.log(provider ? '[WSService] STT provider set' : '[WSService] STT provider cleared');
   }
 
   /**
@@ -688,6 +689,23 @@ export class WebSocketService implements Service {
       timestamp: event.timestamp,
     };
     this.wsServer.broadcast(message);
+  }
+
+  /**
+   * Broadcast that DB-backed settings were hot-applied to the running
+   * daemon. Payload carries section names and error strings only — never
+   * setting values (channel tokens, API keys).
+   */
+  broadcastSettingsApplied(payload: {
+    sections: string[];
+    ok: boolean;
+    errors?: { section: string; error: string }[];
+  }): void {
+    this.wsServer.broadcast({
+      type: 'settings_applied',
+      payload,
+      timestamp: Date.now(),
+    });
   }
 
   /**
@@ -2493,16 +2511,16 @@ function ackForRoomAction(ra: { room: string; action: string; args?: Record<stri
     case 'test_provider':
       return a.provider ? `Testing ${String(a.provider)}.` : `Testing provider.`;
     case 'enable_telegram':
-      return `Enabling Telegram. Restart Jarvis to apply.`;
+      return `Enabling Telegram.`;
     case 'disable_telegram':
-      return `Disabling Telegram. Restart Jarvis to apply.`;
+      return `Disabling Telegram.`;
     case 'enable_discord':
-      return `Enabling Discord. Restart Jarvis to apply.`;
+      return `Enabling Discord.`;
     case 'disable_discord':
-      return `Disabling Discord. Restart Jarvis to apply.`;
+      return `Disabling Discord.`;
     case 'set_stt_provider':
       return a.provider
-        ? `Setting STT to ${String(a.provider)}. Restart Jarvis to apply.`
+        ? `Setting STT to ${String(a.provider)}.`
         : `Updating STT provider.`;
     case 'enable_tts':
       return `Turning on text to speech.`;

--- a/src/integrations/google-auth.ts
+++ b/src/integrations/google-auth.ts
@@ -59,6 +59,18 @@ export class GoogleAuth {
   }
 
   /**
+   * Drop the in-memory tokens and re-read from disk. loadTokens() alone
+   * keeps stale in-memory tokens when the file is gone — this null-first
+   * reset is what makes a dashboard "disconnect" (which unlinks the tokens
+   * file) actually deactivate a running instance without a restart.
+   * Returns whether tokens now exist.
+   */
+  reloadTokensFromDisk(): boolean {
+    this.tokens = null;
+    return this.loadTokens() !== null;
+  }
+
+  /**
    * Save tokens to disk.
    */
   async saveTokens(tokens: GoogleTokens): Promise<void> {

--- a/src/workflows/credentials/google-source.ts
+++ b/src/workflows/credentials/google-source.ts
@@ -26,23 +26,35 @@ export const JARVIS_GOOGLE_PREFIX = "jarvis:google";
 export class JarvisGoogleConnectionSource implements JarvisConnectionSource {
   readonly id = "google";
 
-  constructor(private readonly googleAuth: GoogleAuth) {}
+  private readonly getAuth: () => GoogleAuth | null;
+
+  /**
+   * Accepts either a `GoogleAuth` instance or a getter. The daemon passes a
+   * getter reading its live `googleAuth` binding so settings hot reload
+   * (connecting Google mid-run, rotating the OAuth client) is picked up
+   * without re-registering the source; a bare instance is kept for tests
+   * and simple embedders.
+   */
+  constructor(auth: GoogleAuth | (() => GoogleAuth | null)) {
+    this.getAuth = typeof auth === "function" ? auth : () => auth;
+  }
 
   canResolve(externalId: string): boolean {
     return externalId === JARVIS_GOOGLE_PREFIX || externalId.startsWith(`${JARVIS_GOOGLE_PREFIX}:`);
   }
 
   async resolve(_externalId: string): Promise<ResolvedConnection | null> {
-    if (!this.googleAuth.isAuthenticated()) {
-      // Not yet authenticated -- piece will see "connection not found".
-      // Surface as null (vs throw) so other sources / repo lookups can
-      // still run.
+    const auth = this.getAuth();
+    if (!auth || !auth.isAuthenticated()) {
+      // Not configured or not yet authenticated -- piece will see
+      // "connection not found". Surface as null (vs throw) so other
+      // sources / repo lookups can still run.
       return null;
     }
     // Trigger refresh-if-expired before reading the snapshot so the
     // returned access_token + expiry_date are consistent.
-    const accessToken = await this.googleAuth.getAccessToken();
-    const tokens = this.googleAuth.getTokens();
+    const accessToken = await auth.getAccessToken();
+    const tokens = auth.getTokens();
     return {
       type: "OAUTH2",
       value: {

--- a/ui/src/hooks/useWebSocket.ts
+++ b/ui/src/hooks/useWebSocket.ts
@@ -84,6 +84,18 @@ export type AgentActivityEvent = {
   timestamp: number;
 };
 
+/**
+ * Daemon broadcast after DB-backed settings were hot-applied (per-section
+ * save, POST /api/config/reload, or SIGHUP). Carries section names and
+ * error strings only — never setting values.
+ */
+export type SettingsAppliedEvent = {
+  sections: string[];
+  ok: boolean;
+  errors?: { section: string; error: string }[];
+  timestamp: number;
+};
+
 export type VoiceCallbacks = {
   onTTSBinary: (data: ArrayBuffer) => void;
   /** `containsWake` — true if the TTS sentence about to play contains
@@ -363,6 +375,7 @@ export function useWebSocket() {
   const [workflowEvents, setWorkflowEvents] = useState<WorkflowEvent[]>([]);
   const [goalEvents, setGoalEvents] = useState<GoalEvent[]>([]);
   const [siteEvents, setSiteEvents] = useState<SiteEvent[]>([]);
+  const [settingsEvents, setSettingsEvents] = useState<SettingsAppliedEvent[]>([]);
   const [notices, setNotices] = useState<SystemNotice[]>([]);
   const [approvals, setApprovals] = useState<PendingApproval[]>([]);
   const [clarifiers, setClarifiers] = useState<PendingClarifier[]>([]);
@@ -717,6 +730,10 @@ export function useWebSocket() {
     } else if (msg.type === "site_event") {
       const siteEvent = msg.payload as SiteEvent;
       setSiteEvents((prev) => [...prev.slice(-100), siteEvent]);
+    } else if (msg.type === "settings_applied") {
+      const payload = msg.payload as Omit<SettingsAppliedEvent, "timestamp">;
+      const event: SettingsAppliedEvent = { ...payload, timestamp: msg.timestamp };
+      setSettingsEvents((prev) => [...prev.slice(-20), event]);
     } else if (msg.type === "notification") {
       const payload = msg.payload as {
         source?: string;
@@ -1015,7 +1032,7 @@ export function useWebSocket() {
   }, []);
 
   return {
-    messages, isConnected, sendMessage, taskEvents, contentEvents, agentActivity, workflowEvents, goalEvents, siteEvents, notices, dismissNotice,
+    messages, isConnected, sendMessage, taskEvents, contentEvents, agentActivity, workflowEvents, goalEvents, siteEvents, settingsEvents, notices, dismissNotice,
     approvals,
     clarifiers,
     repeatBacks,

--- a/ui/src/v2/onboarding/OnboardingWizard.tsx
+++ b/ui/src/v2/onboarding/OnboardingWizard.tsx
@@ -376,7 +376,12 @@ export function OnboardingWizard({
     setConnectErr(null);
     try {
       const r = await fetch("/api/config/channels", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ telegram: { bot_token: tgToken.trim(), enabled: true } }) });
-      if (r.ok) { setConnected((c) => new Set(c).add("telegram")); setTgOpen(false); setTgToken(""); }
+      // The route hot-applies the config and can return HTTP 200 with
+      // ok:false when the save succeeded but connecting the bot failed —
+      // treat that as a failure so the wizard doesn't claim "connected".
+      const body = r.ok ? await r.json().catch(() => null) as { ok?: boolean; message?: string } | null : null;
+      if (r.ok && body?.ok !== false) { setConnected((c) => new Set(c).add("telegram")); setTgOpen(false); setTgToken(""); }
+      else if (r.ok) setConnectErr((body?.message || "Telegram token saved, but the bot couldn't connect.").slice(0, 120));
       else setConnectErr(((await r.text().catch(() => "")) || `Couldn't save the Telegram token (HTTP ${r.status}).`).slice(0, 120));
     } catch { setConnectErr("Couldn't reach the daemon to save the Telegram token."); }
     finally { setTgBusy(false); }

--- a/ui/src/v2/rooms/settings/SettingsRoom.tsx
+++ b/ui/src/v2/rooms/settings/SettingsRoom.tsx
@@ -1,7 +1,5 @@
 import React, { useCallback, useEffect, useState } from "react";
-import { confirmDialog } from "../../ui/ConfirmDialog";
 import {
-  AlertCircle,
   Bot,
   Cable,
   Cog,
@@ -16,6 +14,7 @@ import { Chip, Icon } from "../../ui";
 import { RoomShell } from "../RoomShell";
 import { useRoomActions } from "../useRoomActionBus";
 import { useRovingTabs } from "../useRovingTabs";
+import { useLiveData } from "../../shell/LiveDataContext";
 import { useSettingsData } from "./useSettingsData";
 import {
   resetOnboarding,
@@ -73,6 +72,26 @@ export function SettingsRoomBody({ mode }: { mode: RoomBodyMode }) {
     const id = window.setTimeout(() => setToast(null), 4500);
     return () => window.clearTimeout(id);
   }, [toast]);
+
+  // ── Settings hot-apply results (daemon `settings_applied` broadcast) ──
+  // Applies can finish AFTER a save request returned (debounced channel
+  // restarts, SIGHUP / POST /api/config/reload): surface those outcomes
+  // here — failures as a toast, and always refetch so the tabs show the
+  // actually-applied state.
+  const { settingsEvents } = useLiveData();
+  const lastApplied = settingsEvents.length > 0 ? settingsEvents[settingsEvents.length - 1]! : null;
+  useEffect(() => {
+    if (!lastApplied) return;
+    if (!lastApplied.ok) {
+      const detail = (lastApplied.errors ?? [])
+        .map((e) => `${e.section}: ${e.error}`)
+        .join("; ");
+      showToast(`Applying settings failed — ${detail || lastApplied.sections.join(", ")}`, "warn");
+    }
+    data.refresh();
+    // Keyed on the event object: useWebSocket appends a new array entry per
+    // broadcast, so this fires exactly once per apply batch.
+  }, [lastApplied]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // ── Voice room actions ──
   useRoomActions("settings", (action, args) => {
@@ -321,42 +340,16 @@ export function SettingsRoomBody({ mode }: { mode: RoomBodyMode }) {
           tone={stats.sidecarsConnected > 0 ? "ok" : "neutral"}
         />
         <StatCard
-          label="Restart"
-          value={stats.restartPending ? "Pending" : "Clean"}
-          sub={stats.restartPending ? "save needs apply" : "all changes live"}
-          tone={stats.restartPending ? "warn" : "ok"}
+          label="Changes"
+          value={lastApplied ? (lastApplied.ok ? "Applied" : "Failed") : "Live"}
+          sub={
+            lastApplied
+              ? `last: ${lastApplied.sections.join(", ")}`
+              : "settings hot-applied"
+          }
+          tone={lastApplied && !lastApplied.ok ? "warn" : "ok"}
         />
       </div>
-
-      {/* Restart banner — only when there's a pending restart-required change */}
-      {stats.restartPending && (
-        <div className="v2-set__banner" role="alert">
-          <Icon icon={AlertCircle} size="sm" />
-          <span>
-            Some recent changes (channels, STT, integrations) only take effect after a daemon restart.
-          </span>
-          <button
-            type="button"
-            className="v2-set__banner-btn"
-            onClick={async () => {
-              if (!await confirmDialog("Restart Jarvis now? Your dashboard will reconnect after a few seconds.")) return;
-              const r = await data.restartDaemon();
-              showToast(r.message, r.ok ? "ok" : "warn");
-            }}
-          >
-            Restart now
-          </button>
-          <button
-            type="button"
-            className="v2-set__banner-dismiss"
-            onClick={() => data.setRestartPending(false)}
-            aria-label="Dismiss"
-            title="Dismiss"
-          >
-            ✕
-          </button>
-        </div>
-      )}
 
       {/* Tab bar */}
       <nav

--- a/ui/src/v2/rooms/settings/tabs/IntegrationsTab.tsx
+++ b/ui/src/v2/rooms/settings/tabs/IntegrationsTab.tsx
@@ -24,7 +24,7 @@ export function IntegrationsTab({
           pollRef.current = null;
         }
         setPhase("idle");
-        onToast("Connected. Restart Jarvis to activate Gmail and Calendar observers.", "ok");
+        onToast("Connected. Gmail and Calendar observers are starting.", "ok");
         data.refresh();
       }
     },
@@ -88,7 +88,7 @@ export function IntegrationsTab({
           pollRef.current = null;
           setPhase("idle");
           onToast(
-            "Connected. Restart Jarvis to activate Gmail and Calendar observers.",
+            "Connected. Gmail and Calendar observers are starting.",
             "ok",
           );
           data.refresh();

--- a/ui/src/v2/rooms/settings/useSettingsData.ts
+++ b/ui/src/v2/rooms/settings/useSettingsData.ts
@@ -290,7 +290,7 @@ export interface UserProfileResponse {
 }
 
 export type ActionResult =
-  | { ok: true; message: string; restartRequired?: boolean }
+  | { ok: true; message: string }
   | { ok: false; message: string };
 
 async function getJson<T>(url: string): Promise<T | null> {
@@ -348,8 +348,8 @@ function preserveRef<T>(prev: T, next: T): T {
  *
  * Polls the 8 read endpoints in parallel every 10s (paused while tab
  * hidden). Exposes lifecycle actions that all return ActionResult so the
- * UI can show a per-action toast and bubble up `restartRequired` to the
- * room-level restart banner.
+ * UI can show a per-action toast. Settings are hot-applied by the daemon
+ * (channels, STT, TTS, Google observers), so no restart tracking.
  *
  * Voice actions land on the same lifecycle methods through the room
  * action bus, so behaviour is identical for clicks vs voice.
@@ -368,7 +368,6 @@ export function useSettingsData() {
   const [google, setGoogle] = useState<GoogleStatus | null>(null);
   const [sidecars, setSidecars] = useState<SidecarInfo[]>([]);
   const [profile, setProfile] = useState<UserProfileResponse | null>(null);
-  const [restartPending, setRestartPending] = useState(false);
   const [loading, setLoading] = useState(true);
   const inFlightRef = useRef(false);
 
@@ -456,9 +455,8 @@ export function useSettingsData() {
       channelsEnabled,
       sidecarsConnected,
       sidecarsTotal: sidecars.length,
-      restartPending,
     };
-  }, [llm, channelCfg, ttsCfg, sidecars, restartPending]);
+  }, [llm, channelCfg, ttsCfg, sidecars]);
 
   // ── LLM actions (hot-reloaded) ──────────────────────────────────────
 
@@ -623,7 +621,7 @@ export function useSettingsData() {
     [],
   );
 
-  // ── Channels (restart required) ─────────────────────────────────────
+  // ── Channels (hot-applied by the daemon) ────────────────────────────
   const setTelegram = useCallback(
     async (input: {
       enabled?: boolean;
@@ -631,14 +629,14 @@ export function useSettingsData() {
       allowed_users?: number[];
     }): Promise<ActionResult> => {
       try {
-        await postJson("/api/config/channels", { telegram: input });
-        setRestartPending(true);
+        const r = await postJson<{ ok: boolean; message: string }>(
+          "/api/config/channels",
+          { telegram: input },
+        );
         await refresh();
-        return {
-          ok: true,
-          message: "Telegram saved. Restart Jarvis to apply.",
-          restartRequired: true,
-        };
+        return r.ok
+          ? { ok: true, message: r.message || "Telegram saved and applied." }
+          : { ok: false, message: r.message || "Failed to apply Telegram config." };
       } catch (err) {
         return { ok: false, message: err instanceof Error ? err.message : "Failed" };
       }
@@ -654,14 +652,14 @@ export function useSettingsData() {
       guild_id?: string;
     }): Promise<ActionResult> => {
       try {
-        await postJson("/api/config/channels", { discord: input });
-        setRestartPending(true);
+        const r = await postJson<{ ok: boolean; message: string }>(
+          "/api/config/channels",
+          { discord: input },
+        );
         await refresh();
-        return {
-          ok: true,
-          message: "Discord saved. Restart Jarvis to apply.",
-          restartRequired: true,
-        };
+        return r.ok
+          ? { ok: true, message: r.message || "Discord saved and applied." }
+          : { ok: false, message: r.message || "Failed to apply Discord config." };
       } catch (err) {
         return { ok: false, message: err instanceof Error ? err.message : "Failed" };
       }
@@ -688,14 +686,14 @@ export function useSettingsData() {
         } else if (extras?.api_key) {
           body[provider] = { api_key: extras.api_key };
         }
-        await postJson("/api/config/stt", body);
-        setRestartPending(true);
+        const r = await postJson<{ ok: boolean; message: string }>(
+          "/api/config/stt",
+          body,
+        );
         await refresh();
-        return {
-          ok: true,
-          message: `STT set to ${provider}. Restart Jarvis to apply.`,
-          restartRequired: true,
-        };
+        return r.ok
+          ? { ok: true, message: r.message || `STT set to ${provider}.` }
+          : { ok: false, message: r.message || "Failed to apply STT config." };
       } catch (err) {
         return { ok: false, message: err instanceof Error ? err.message : "Failed" };
       }
@@ -789,7 +787,6 @@ export function useSettingsData() {
         "/api/system/autostart/restart",
         {},
       );
-      setRestartPending(false);
       // Refetch later — daemon may be down briefly
       window.setTimeout(refresh, 3000);
       return { ok: true, message: r.message || "Restart scheduled." };
@@ -858,14 +855,14 @@ export function useSettingsData() {
 
   const disconnectGoogle = useCallback(async (): Promise<ActionResult> => {
     try {
-      await postJson("/api/auth/google/disconnect", {});
-      setRestartPending(true);
+      const r = await postJson<{ ok: boolean; message: string }>(
+        "/api/auth/google/disconnect",
+        {},
+      );
       await refresh();
-      return {
-        ok: true,
-        message: "Disconnected. Restart Jarvis to deactivate observers.",
-        restartRequired: true,
-      };
+      return r.ok
+        ? { ok: true, message: r.message || "Google disconnected. Observers stopped." }
+        : { ok: false, message: r.message || "Disconnect failed." };
     } catch (err) {
       return { ok: false, message: err instanceof Error ? err.message : "Failed" };
     }
@@ -933,8 +930,6 @@ export function useSettingsData() {
     // derived
     stats,
     loading,
-    restartPending,
-    setRestartPending,
 
     // actions
     refresh,

--- a/ui/src/v2/shell/AppShell.tsx
+++ b/ui/src/v2/shell/AppShell.tsx
@@ -499,6 +499,7 @@ function AppShellLive() {
         taskEvents: live.taskEvents,
         contentEvents: live.contentEvents,
         agentActivity: live.agentActivity,
+        settingsEvents: live.settingsEvents,
         latestAssistantReply,
       }}
     >

--- a/ui/src/v2/shell/LiveDataContext.tsx
+++ b/ui/src/v2/shell/LiveDataContext.tsx
@@ -5,6 +5,7 @@ import type {
   PendingApproval,
   PendingClarifier,
   PendingRepeatBack,
+  SettingsAppliedEvent,
   SystemNotice,
   TaskEvent,
 } from "../../hooks/useWebSocket";
@@ -26,6 +27,13 @@ export interface LiveData {
   taskEvents: TaskEvent[];
   contentEvents: ContentEvent[];
   agentActivity: AgentActivityEvent[];
+  /**
+   * Settings hot-apply results broadcast by the daemon (`settings_applied`).
+   * The Settings Room reads the latest entry for its status card and toasts
+   * failures from applies that finish after the save request returned
+   * (debounced channel restarts, SIGHUP / reload-endpoint runs).
+   */
+  settingsEvents: SettingsAppliedEvent[];
   /**
    * Phase 6.5.5 — most-recent assistant reply, used by the RailReplyPreview
    * so users in a Room can see Jarvis's response without leaving. Null when
@@ -66,5 +74,6 @@ const EMPTY: LiveData = {
   taskEvents: [],
   contentEvents: [],
   agentActivity: [],
+  settingsEvents: [],
   latestAssistantReply: null,
 };

--- a/ui/src/v2/thread/useLiveThread.ts
+++ b/ui/src/v2/thread/useLiveThread.ts
@@ -308,6 +308,8 @@ export function useLiveThread() {
     contentEvents: ws.contentEvents,
     /** Live agent delegation events (drives Logs Room live tail). */
     agentActivity: ws.agentActivity,
+    /** Settings hot-apply results (drives the Settings Room status card + toasts). */
+    settingsEvents: ws.settingsEvents,
     /** Phase 5A: palette pushes synthetic cards into the thread via this. */
     injectCard,
     /** Phase 6.1.5: room-window helpers. */


### PR DESCRIPTION
## What

DB-backed settings (the SQLite `settings` table — `cfg.*`, `llm.*`, google) now apply to the running daemon without a restart. Every "Restart JARVIS to apply changes" message is gone, on the server and in the dashboard.

## How

- **`SettingsReloadCoordinator`** (`src/daemon/settings-reload.ts`): per-section applier registry with a single serialized apply queue, per-section coalescing, and optional debounce. Deliberately not the workflow event bus — apply results are awaitable and settings events never leak into `/v1/jarvis/events/poll`.
- **Write choke point**: `saveUserSection`/`saveGoogleSettings` notify an injectable listener after the DB write, so every writer (HTTP routes, voice intents, pebble toggles, EmergencyController) triggers the appliers with no per-callsite wiring. Routes that report the outcome `await applyNow(section)`.
- **Appliers**: channels (restart-in-place via ServiceRegistry, 400ms debounce), STT (wsService + pebble provider swap, chained channels restart while bots are live), TTS, Google (null-first `reloadTokensFromDisk()` / rebuild on cred change, observers restarted via `setGoogleAuth`), LLM, authority, awareness-enabled.
- **External edits**: `POST /api/config/reload` and SIGHUP re-run the exact boot hydration order (LLM → user sections → env overrides, so `JARVIS_*` still wins), diff per-section JSON snapshots, and apply only what changed.
- **UI**: restart banner / restart-pending plumbing removed; new `settings_applied` WS event drives the Settings room status card, failure toasts, and refetches.

## Review hardening (multi-agent review, all findings fixed)

- `ChannelService.stop()` now drops adapters (`ChannelManager.unregisterAll()`) — previously a *disabled* channel's stale adapter survived the map and `connectAll()` reconnected it with the old token/allowlist (+ regression test).
- `jarvis:google` workflow credential source registers unconditionally with a live getter, and awareness gets a delegating auth wrapper — connecting Google mid-run or rotating creds now reaches both.
- OnboardingWizard handles the new `200 + {ok:false}` apply-failure contract.
- Voice TTS/STT toggles await the applier so the confirmation is spoken with the new provider in the same cycle.
- Routes report "Restart to apply (hot reload unavailable)" instead of "applied" when no coordinator is wired.

## Notes

- `RestartRequiredBanner` is deliberately untouched: it signals post-setup-service construction *failure* (`post_setup_services_ready === false`), a genuine restart case unrelated to settings apply.
- Documented limitation: `reloadAll()` diffs config sections only — an external deletion of the Google tokens file + SIGHUP won't deactivate observers (the disconnect route handles the in-daemon case).
- Sections without component appliers yet (cron schedules, heartbeat aggressiveness, goals, sites, …) re-hydrate into config but running components keep construction-time values — same as before, noted in the coordinator header.

## Testing

- 13 new coordinator tests (coalescing, serialization, error isolation, debounce cancellation, `reloadAll` diff/cancel/broadcast, ServiceRegistry stop/start cycle) + choke-point listener tests + channel-adapter regression test.
- Full suite: 1756 pass / 0 fail. `tsc --noEmit` clean (src + ui). UI bundle builds.