### PR TITLE
Sidecar: system-browser SSO, Account window, webview teardown hardening, Monochrome Lab pages

### DIFF
--- a/sidecar/account_window.go
+++ b/sidecar/account_window.go
@@ -1,0 +1,77 @@
+package main
+
+// Account window — a webview onto the HOSTED account page (usejarvis), not a
+// dashboard room: identity (Clerk avatar/profile/sign-out), the current plan,
+// and device management are account-plane data the brain deliberately never
+// holds, so the page is served by app.usejarvis.dev and authenticated by the
+// Clerk session that the hosted onboarding flow established in this same
+// webview runtime. If that session is gone (cleared cookies, platform without
+// webview cookie persistence), the page falls back to Clerk sign-in and
+// returns to /account.
+//
+// SECURITY: this window shows remote content end-to-end (account page, Clerk,
+// Stripe portal redirects), so it registers no bindings beyond the harmless
+// __jarvis_reveal show-window hook that runLocalWebview's reveal helper
+// installs (webview_reveal.go) — same invariant as the hosted connect flow
+// (hosted_window.go). The origin is pinned via resolveHostedBaseURL: release
+// builds always talk to the real origin.
+
+import (
+	webview "github.com/webview/webview_go"
+)
+
+// accountShellHTML is the local first document, shown while the hosted page
+// loads. The window is created hidden and revealed on document load — without
+// a local shell an unreachable origin would keep the window invisible until
+// the reveal timeout, then surface a raw platform error page with no context.
+// Deliberately static (no retry, no bindings): if the remote navigation
+// fails, the platform error page replaces this shell in an already-visible
+// window the user can simply close and reopen.
+const accountShellHTML = `<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<style>
+  body {
+    margin: 0; padding: 40px 36px;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Inter, sans-serif;
+    background: #f5f2eb; color: #1a1a1a;
+  }
+  h1 { font-size: 20px; margin: 0 0 8px; }
+  .sub { font-size: 13px; margin: 0 0 24px; opacity: 0.8; }
+  .spinner {
+    width: 22px; height: 22px; margin: 18px 0;
+    border: 3px solid #cbc3b2; border-top-color: #c23a2a; border-radius: 50%;
+    animation: spin 0.9s linear infinite;
+  }
+  @keyframes spin { to { transform: rotate(360deg); } }
+</style>
+</head>
+<body>
+  <h1>Your account</h1>
+  <p class="sub">Contacting usejarvis&hellip;</p>
+  <div class="spinner"></div>
+</body>
+</html>`
+
+// OpenAccount opens the hosted account page on its own OS-locked goroutine
+// (webview owns its thread, like the settings window / log viewer).
+func (c *SidecarClient) OpenAccount() {
+	go c.runAccountWindow()
+}
+
+func (c *SidecarClient) runAccountWindow() {
+	c.mu.Lock()
+	base := resolveHostedBaseURL(c.config.HostedBaseURL)
+	c.mu.Unlock()
+
+	runLocalWebview("JARVIS — Account", 920, 720, webview.HintNone, func(w webview.WebView) {
+		w.SetHtml(accountShellHTML)
+		// Dispatch rather than a direct call: the dispatch queue runs after
+		// SetHtml's string navigation has been issued, so the shell is the
+		// document on screen while the remote page loads instead of the two
+		// navigations racing in the engine. If the shell still loses the
+		// race, the reveal's timeout fallback covers us as before.
+		w.Dispatch(func() { w.Navigate(base + "/account") })
+	})
+}

--- a/sidecar/account_window.go
+++ b/sidecar/account_window.go
@@ -21,36 +21,41 @@ import (
 )
 
 // accountShellHTML is the local first document, shown while the hosted page
-// loads. The window is created hidden and revealed on document load — without
-// a local shell an unreachable origin would keep the window invisible until
-// the reveal timeout, then surface a raw platform error page with no context.
-// Deliberately static (no retry, no bindings): if the remote navigation
-// fails, the platform error page replaces this shell in an already-visible
-// window the user can simply close and reopen.
+// loads — a Monochrome Lab loading moment (brand_css.go): centered Pebble in
+// the think state under a mono eyebrow. The window is created hidden and
+// revealed on document load — without a local shell an unreachable origin
+// would keep the window invisible until the reveal timeout, then surface a
+// raw platform error page with no context. Deliberately static (no retry, no
+// bindings): if the remote navigation fails, the platform error page replaces
+// this shell in an already-visible window the user can simply close and
+// reopen.
 const accountShellHTML = `<!doctype html>
 <html>
 <head>
 <meta charset="utf-8">
-<style>
-  body {
-    margin: 0; padding: 40px 36px;
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Inter, sans-serif;
-    background: #f5f2eb; color: #1a1a1a;
+<style>` + brandTokensCSS + brandPebbleCSS + `
+  body { min-height: 100vh; display: flex; align-items: center; justify-content: center; }
+  .statusbox { text-align: center; position: relative; }
+  .dropwrap { display: flex; justify-content: center; margin-bottom: 20px; position: relative; }
+  .dropwrap .bbloom { width: 150px; height: 150px; left: 50%; top: 50%; transform: translate(-50%,-52%); }
+  .statephase {
+    font-family: var(--mono); font-size: 10px; letter-spacing: .12em;
+    text-transform: uppercase; color: var(--ink3); margin-bottom: 9px;
   }
-  h1 { font-size: 20px; margin: 0 0 8px; }
-  .sub { font-size: 13px; margin: 0 0 24px; opacity: 0.8; }
-  .spinner {
-    width: 22px; height: 22px; margin: 18px 0;
-    border: 3px solid #cbc3b2; border-top-color: #c23a2a; border-radius: 50%;
-    animation: spin 0.9s linear infinite;
-  }
-  @keyframes spin { to { transform: rotate(360deg); } }
+  h1 { font-size: 19px; font-weight: 700; letter-spacing: -.025em; margin: 0; }
+  .sub { font-size: 12.5px; color: var(--ink3); margin-top: 6px; }
 </style>
 </head>
 <body>
-  <h1>Your account</h1>
-  <p class="sub">Contacting usejarvis&hellip;</p>
-  <div class="spinner"></div>
+  <div class="statusbox">
+    <div class="dropwrap">
+      <span class="bbloom"></span>
+      <span class="bdrop s-think" style="width:64px;height:64px"><span class="in"></span><span class="ring"></span></span>
+    </div>
+    <div class="statephase">Account</div>
+    <h1>Your account</h1>
+    <p class="sub">Contacting usejarvis&hellip;</p>
+  </div>
 </body>
 </html>`
 

--- a/sidecar/brand_css.go
+++ b/sidecar/brand_css.go
@@ -1,0 +1,104 @@
+package main
+
+// Shared Monochrome Lab styling (hosting repo's DESIGN.md, Brand Book III) for
+// the sidecar's LOCAL pages — connect shell, token form, settings, logs, the
+// account loading shell. One source for the token set and the Pebble so the
+// pages can't drift from each other or from the hosted dashboard, which ports
+// the same vocabulary from the design system of record.
+//
+// Tokens mirror the dashboard's tokens.css: neutrals carry the UI, the four
+// state hues are the only chroma (AA `-tx` variants for colored text), dark
+// follows the OS. There is no data-theme toggle on these pages — the OS
+// preference is the only input, hence plain @media blocks.
+//
+// --rule-hi is a sidecar-local extension (hover borders; not in the
+// dashboard's token set — light value inherited from the old settings CSS,
+// dark value chosen between --rule and --faint). If the dashboard ever grows
+// its own --rule-hi, adopt its values.
+
+// brandTokensCSS is the token set + page base. Every local page opens its
+// <style> with this.
+const brandTokensCSS = `
+  :root {
+    color-scheme: light dark;
+    --bg:#FAFBFC; --raise:#FFFFFF; --panel:#EFF2F5; --panel2:#F6F8FA;
+    --rule:#E2E7EC; --rule2:#EDF0F3; --rule-hi:#D2D9E0;
+    --ink:#13161A; --ink2:#535B63; --ink3:#677077; --faint:#9AA2AB;
+    --listen:#E63B2E; --speak:#2D78FF; --hold:#EAA40E; --ok:#2FA45E;
+    --listen-tx:#C2301F; --speak-tx:#1E5FD8; --hold-tx:#8A6206; --ok-tx:#1F7A43;
+    --sh-sm:0 1px 2px rgba(20,30,45,.06),0 1px 1px rgba(20,30,45,.04);
+    --sh-md:0 2px 6px rgba(20,30,45,.06),0 10px 24px -10px rgba(20,30,45,.18);
+    --sans:'Familjen Grotesk', system-ui, -apple-system, "Segoe UI", sans-serif;
+    --mono:'Spline Sans Mono', ui-monospace, "Cascadia Code", Consolas, monospace;
+    --corner:14px 3px 14px 14px; --corner-sm:9px 2px 9px 9px;
+    --ease:cubic-bezier(.2,.7,.2,1);
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg:#121417; --raise:#1A1D22; --panel:#16191E; --panel2:#1E2128;
+      --rule:#272C33; --rule2:#21252B; --rule-hi:#333A43;
+      --ink:#EEF1F4; --ink2:#A4ABB3; --ink3:#8A919A; --faint:#5C636B;
+      --listen-tx:#FF6A5C; --speak-tx:#6FA4FF; --hold-tx:#F0B53C; --ok-tx:#52C97F;
+      --sh-sm:0 1px 2px rgba(0,0,0,.4);
+      --sh-md:0 10px 24px -10px rgba(0,0,0,.6);
+    }
+  }
+  * { box-sizing: border-box; }
+  ::selection { background: rgba(230,59,46,.24); }
+  body {
+    margin: 0; font-family: var(--sans);
+    background: var(--bg); color: var(--ink);
+    -webkit-font-smoothing: antialiased;
+  }
+`
+
+// brandPebbleCSS is the Pebble (the brand's one living object — one per
+// screen), its bloom, and the wordmark. Markup contract:
+//
+//	<span class="bdrop"><span class="in"></span><span class="ring"></span></span>
+//
+// states via s-think / s-done / s-err on .bdrop; size via inline width/height.
+//
+//	<span class="word"><span class="u">use</span>jarvis</span>
+const brandPebbleCSS = `
+  .bdrop {
+    display: block; position: relative;
+    border-radius: 50% 50% 50% 12px; transform: rotate(45deg);
+    background: rgba(255,255,255,.08); border: .5px solid rgba(255,255,255,.5);
+    box-shadow: inset 1.5px 1.5px 1.5px rgba(255,255,255,.9), 0 6px 18px -4px rgba(20,30,45,.3);
+  }
+  @media (prefers-color-scheme: dark) {
+    .bdrop {
+      border-color: rgba(255,255,255,.4);
+      box-shadow: inset 1.5px 1.5px 1.5px rgba(255,255,255,.55), 0 8px 22px -4px rgba(0,0,0,.6);
+    }
+  }
+  .bdrop .in {
+    position: absolute; inset: 0; border-radius: inherit;
+    background: radial-gradient(circle at 50% 40%, #ff6e60, #e63b2e 58%, #b81e16);
+    animation: brS 2.6s var(--ease) infinite;
+  }
+  .bdrop .ring {
+    position: absolute; inset: -2px; border-radius: inherit; opacity: 0;
+    background: conic-gradient(from 0deg, transparent 0 200deg, rgba(255,255,255,.98) 300deg, transparent 360deg);
+    -webkit-mask: radial-gradient(circle, transparent 38%, #000 46%, #000 56%, transparent 64%);
+    mask: radial-gradient(circle, transparent 38%, #000 46%, #000 56%, transparent 64%);
+  }
+  .bdrop.s-think .in { background: radial-gradient(circle at 50% 40%, #fff, #e6eaef 70%); animation: none; }
+  .bdrop.s-think .ring { opacity: .95; animation: spin 3.4s linear infinite; }
+  .bdrop.s-done .in { background: radial-gradient(circle at 50% 40%, #56c98a, #2fa45e 60%, #1f7e45); }
+  .bdrop.s-err .in { animation: brS 1.2s var(--ease) infinite; }
+  @keyframes brS { 0%,100% { opacity:.62; transform: scale(.96); } 50% { opacity:1; transform: scale(1.05); } }
+  @keyframes spin { to { transform: rotate(360deg); } }
+  .bbloom {
+    position: absolute; border-radius: 50%;
+    background: radial-gradient(circle, rgba(230,59,46,.24), transparent 66%);
+    filter: blur(10px); pointer-events: none;
+  }
+  .bbloom.ok { background: radial-gradient(circle, rgba(47,164,94,.26), transparent 66%); }
+  .word { font-weight: 700; letter-spacing: -.045em; color: var(--ink); }
+  .word .u { color: var(--ink3); }
+  @media (prefers-reduced-motion: reduce) {
+    .bdrop .in, .bdrop.s-think .ring { animation: none; }
+  }
+`

--- a/sidecar/brand_pages_dump_test.go
+++ b/sidecar/brand_pages_dump_test.go
@@ -1,0 +1,44 @@
+package main
+
+// Temporary helper: dumps the local pages to JARVIS_PAGE_DUMP_DIR for visual
+// QA in a real browser. Not part of the suite (skips without the env var).
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDumpBrandPages(t *testing.T) {
+	dir := os.Getenv("JARVIS_PAGE_DUMP_DIR")
+	if dir == "" {
+		t.Skip("set JARVIS_PAGE_DUMP_DIR to dump the local pages")
+	}
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	demoURL := "https://app.usejarvis.dev/connect?handshake=3KcshMk_demo_nonce_x8Qw2v0hV5uJ9pTz4rLb6nA1eYdC7fGm"
+	pages := map[string]string{
+		"hosted.html": hostedShellHTML,
+		"hosted-browser.html": strings.Replace(hostedShellHTML, "/*__BOOT__*/",
+			"window.__browserOpened(true, '"+demoURL+"');", 1),
+		"hosted-err.html": hostedShellWithError("Could not reach usejarvis. Check your connection and try again."),
+		"setup.html":      setupWindowHTML,
+		"account.html":    accountShellHTML,
+		"settings.html":   settingsWindowHTML,
+		"logs.html":       logViewerHTML,
+	}
+	for name, html := range pages {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(html), 0644); err != nil {
+			t.Fatal(err)
+		}
+		// Force the dark tokens AND dark UA form controls (color-scheme), so
+		// checkboxes/scrollbars in the dump match a real dark-OS window.
+		dark := strings.ReplaceAll(html, "@media (prefers-color-scheme: dark)", "@media all")
+		dark = strings.Replace(dark, "color-scheme: light dark", "color-scheme: dark", 1)
+		if err := os.WriteFile(filepath.Join(dir, "dark-"+name), []byte(dark), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+}

--- a/sidecar/hosted_window.go
+++ b/sidecar/hosted_window.go
@@ -32,71 +32,86 @@ import (
 )
 
 // hostedShellHTML is the local page shown while the handshake registers (and
-// as the fallback surface for errors). Styled like the token form. The
-// /*__BOOT__*/ placeholder lets hostedShellWithError bake an error into the
-// document itself - an Eval racing a fresh SetHtml can silently lose the
-// message, a baked-in script cannot.
+// as the fallback surface for errors). Monochrome Lab (brand_css.go): a
+// centered status screen whose Pebble mirrors the machine's state — breathing
+// red while contacting usejarvis, white think-ring while sign-in runs in the
+// browser, fast red on error. The /*__BOOT__*/ placeholder lets
+// hostedShellWithError bake an error into the document itself - an Eval
+// racing a fresh SetHtml can silently lose the message, a baked-in script
+// cannot.
 const hostedShellHTML = `<!doctype html>
 <html>
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<style>
-  :root { color-scheme: light; }
-  * { box-sizing: border-box; }
-  body {
-    margin: 0; padding: 40px 36px;
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Inter, sans-serif;
-    background: #f5f2eb; color: #1a1a1a;
-    display: flex; flex-direction: column; min-height: 92vh;
+<style>` + brandTokensCSS + brandPebbleCSS + `
+  body { min-height: 100vh; display: flex; flex-direction: column; padding: 26px 30px; }
+  .bhead .word { font-size: 16px; }
+  .center { flex: 1; display: flex; align-items: center; justify-content: center; }
+  .statusbox { width: 100%; max-width: 380px; text-align: center; position: relative; }
+  .dropwrap { display: flex; justify-content: center; margin-bottom: 20px; position: relative; }
+  .dropwrap .bbloom { width: 150px; height: 150px; left: 50%; top: 50%; transform: translate(-50%,-52%); }
+  .statephase {
+    font-family: var(--mono); font-size: 10px; letter-spacing: .12em;
+    text-transform: uppercase; color: var(--ink3); margin-bottom: 9px;
   }
-  h1 { font-size: 20px; margin: 0 0 8px; }
-  .sub { font-size: 13px; margin: 0 0 24px; opacity: 0.8; line-height: 1.5; }
-  #status { font-size: 13px; color: #6a675f; min-height: 18px; }
-  #err { color: #c23a2a; font-size: 13px; min-height: 18px; margin-top: 6px; }
-  .spinner {
-    width: 22px; height: 22px; margin: 18px 0;
-    border: 3px solid #cbc3b2; border-top-color: #c23a2a; border-radius: 50%;
-    animation: spin 0.9s linear infinite;
-  }
-  @keyframes spin { to { transform: rotate(360deg); } }
-  .footer { margin-top: auto; font-size: 12px; color: #6a675f; }
-  .footer a { color: #c23a2a; cursor: pointer; text-decoration: underline; }
-  #reopen { display: none; margin-top: 6px; font-size: 13px; }
-  #reopen a { color: #c23a2a; cursor: pointer; text-decoration: underline; }
+  h2 { font-size: 19px; font-weight: 700; letter-spacing: -.025em; margin: 0; }
+  #status { font-size: 12.5px; color: var(--ink3); line-height: 1.55; margin-top: 6px; min-height: 18px; }
+  #err { font-size: 12px; color: var(--listen-tx); line-height: 1.5; margin-top: 8px; min-height: 18px; }
+  #reopen { display: none; margin-top: 8px; font-size: 12.5px; }
+  #reopen a { color: var(--listen-tx); cursor: pointer; text-decoration: underline; }
   #url {
-    display: none; margin-top: 10px; padding: 8px 10px;
-    font-family: ui-monospace, Menlo, Consolas, monospace; font-size: 12px;
-    background: #ece8dd; border-radius: 6px; word-break: break-all; user-select: all;
+    display: none; margin-top: 12px; padding: 9px 11px; text-align: left;
+    font-family: var(--mono); font-size: 11px; line-height: 1.5;
+    background: var(--panel2); border: 1px solid var(--rule);
+    border-radius: var(--corner-sm); color: var(--ink2);
+    word-break: break-all; user-select: all;
   }
-  #retry { display: none; margin-top: 12px; }
-  button {
-    appearance: none; border: 0; border-radius: 8px; padding: 9px 16px;
-    background: #c23a2a; color: #fff; font-size: 13px; font-weight: 600; cursor: pointer;
+  #retry { display: none; margin-top: 16px; }
+  .btn {
+    appearance: none; height: 40px; padding: 0 18px; border: 1px solid transparent;
+    border-radius: var(--corner-sm); font-family: var(--sans); font-size: 13.5px;
+    font-weight: 600; cursor: pointer; background: var(--ink); color: var(--bg);
+    transition: filter 150ms var(--ease);
   }
+  .btn:hover { filter: brightness(1.08); }
+  .btn:focus-visible { outline: 2px solid var(--ink2); outline-offset: 2px; }
+  .footer { margin: 0; font-size: 11.5px; color: var(--faint); text-align: center; }
+  .footer a { color: var(--listen-tx); cursor: pointer; text-decoration: underline; }
 </style>
 </head>
 <body>
-  <h1>Connect this device</h1>
-  <p class="sub">Sign in to your usejarvis account to link this machine to your Jarvis.</p>
-  <div class="spinner" id="spin"></div>
-  <div id="status">Contacting usejarvis&hellip;</div>
-  <div id="err"></div>
-  <div id="reopen"><a onclick="window.openConnectPage()">Open the sign-in page again</a></div>
-  <div id="url"></div>
-  <div id="retry"><button onclick="window.retryHosted()">Try again</button></div>
+  <div class="bhead"><span class="word"><span class="u">use</span>jarvis</span></div>
+  <div class="center">
+    <div class="statusbox">
+      <div class="dropwrap">
+        <span class="bbloom" id="bloom"></span>
+        <span class="bdrop" id="drop" style="width:64px;height:64px"><span class="in"></span><span class="ring"></span></span>
+      </div>
+      <div class="statephase" id="phase">Connecting</div>
+      <h2>Connect this device</h2>
+      <div id="status">Contacting usejarvis&hellip;</div>
+      <div id="err"></div>
+      <div id="reopen"><a onclick="window.openConnectPage()">Open the sign-in page again</a></div>
+      <div id="url"></div>
+      <div id="retry"><button class="btn" onclick="window.retryHosted()">Try again</button></div>
+    </div>
+  </div>
   <p class="footer">Self-hosting your own brain? <a onclick="window.chooseSelfHost()">Paste your enrollment token</a></p>
 <script>
   window.__setStatus = function (text) { document.getElementById('status').textContent = text; };
   window.__setError = function (text) {
+    document.getElementById('drop').className = text ? 'bdrop s-err' : 'bdrop';
+    document.getElementById('phase').textContent = text ? 'Setup failed' : 'Connecting';
     document.getElementById('status').textContent = '';
     document.getElementById('err').textContent = text;
-    document.getElementById('spin').style.display = text ? 'none' : '';
     document.getElementById('retry').style.display = text ? 'block' : 'none';
     document.getElementById('reopen').style.display = 'none';
     document.getElementById('url').style.display = 'none';
   };
   window.__browserOpened = function (ok, url) {
+    document.getElementById('drop').className = ok ? 'bdrop s-think' : 'bdrop';
+    document.getElementById('phase').textContent = ok ? 'Waiting for sign-in' : 'Open the link below';
     document.getElementById('status').textContent = ok
       ? 'We opened usejarvis in your browser — finish signing in there. This window will continue on its own.'
       : 'Could not open your browser automatically. Open this link yourself:';

--- a/sidecar/hosted_window.go
+++ b/sidecar/hosted_window.go
@@ -2,19 +2,21 @@ package main
 
 // First-run window, hosted-first (usejarvis).
 //
-// When no token is configured the sidecar starts the handshake and loads the
+// When no token is configured the sidecar starts the handshake and opens the
 // hosted connect page (Clerk login, plan/checkout for a first device) in the
-// webview; a "Self-hosting?" link on the local shell switches to the classic
-// paste-a-token form. The webview's Go binding surface is deliberately
-// minimal - progress/close UX only (`onProgress`, `onComplete`) - the JWT is
-// delivered over the nonce long-poll, never through page JavaScript.
+// SYSTEM browser — not in this webview: the embedded engine drops
+// window.open, so Clerk's Google SSO popup silently no-oped, and Google
+// rejects OAuth from embedded webviews regardless. The webview only ever
+// shows the local shell, which tracks progress while the nonce long-poll
+// waits for the enrollment JWT; a "Self-hosting?" link switches to the
+// classic paste-a-token form. The JWT is delivered over the long-poll, never
+// through page JavaScript.
 //
 // SECURITY: webview bindings are reachable by WHATEVER page the webview is
-// showing, and the hosted flow navigates to remote content (connect page,
-// Clerk, Stripe's checkout redirects). `submitToken` is therefore gated: it
-// only accepts input while the LOCAL token form is the active document
-// (selfHostFormActive), so no remote page can silently enroll this sidecar
-// to an attacker-controlled brain by injecting a self-describing JWT.
+// showing. This window now only ever shows local documents, but `submitToken`
+// stays gated to the LOCAL token form (selfHostFormActive) as defense in
+// depth against a compromised shell document, and `openConnectPage` takes no
+// arguments — it can only launch the Go-held pinned connect URL.
 
 import (
 	"context"
@@ -23,6 +25,8 @@ import (
 	"os"
 	"runtime"
 	"strings"
+	"sync"
+	"sync/atomic"
 
 	webview "github.com/webview/webview_go"
 )
@@ -58,6 +62,13 @@ const hostedShellHTML = `<!doctype html>
   @keyframes spin { to { transform: rotate(360deg); } }
   .footer { margin-top: auto; font-size: 12px; color: #6a675f; }
   .footer a { color: #c23a2a; cursor: pointer; text-decoration: underline; }
+  #reopen { display: none; margin-top: 6px; font-size: 13px; }
+  #reopen a { color: #c23a2a; cursor: pointer; text-decoration: underline; }
+  #url {
+    display: none; margin-top: 10px; padding: 8px 10px;
+    font-family: ui-monospace, Menlo, Consolas, monospace; font-size: 12px;
+    background: #ece8dd; border-radius: 6px; word-break: break-all; user-select: all;
+  }
   #retry { display: none; margin-top: 12px; }
   button {
     appearance: none; border: 0; border-radius: 8px; padding: 9px 16px;
@@ -71,14 +82,28 @@ const hostedShellHTML = `<!doctype html>
   <div class="spinner" id="spin"></div>
   <div id="status">Contacting usejarvis&hellip;</div>
   <div id="err"></div>
+  <div id="reopen"><a onclick="window.openConnectPage()">Open the sign-in page again</a></div>
+  <div id="url"></div>
   <div id="retry"><button onclick="window.retryHosted()">Try again</button></div>
   <p class="footer">Self-hosting your own brain? <a onclick="window.chooseSelfHost()">Paste your enrollment token</a></p>
 <script>
   window.__setStatus = function (text) { document.getElementById('status').textContent = text; };
   window.__setError = function (text) {
+    document.getElementById('status').textContent = '';
     document.getElementById('err').textContent = text;
     document.getElementById('spin').style.display = text ? 'none' : '';
     document.getElementById('retry').style.display = text ? 'block' : 'none';
+    document.getElementById('reopen').style.display = 'none';
+    document.getElementById('url').style.display = 'none';
+  };
+  window.__browserOpened = function (ok, url) {
+    document.getElementById('status').textContent = ok
+      ? 'We opened usejarvis in your browser — finish signing in there. This window will continue on its own.'
+      : 'Could not open your browser automatically. Open this link yourself:';
+    document.getElementById('reopen').style.display = 'block';
+    var u = document.getElementById('url');
+    u.textContent = url;
+    u.style.display = 'block';
   };
   /*__BOOT__*/
 </script>
@@ -110,21 +135,66 @@ func runFirstRunWindow(cfg *SidecarConfig) (string, error) {
 
 	base := resolveHostedBaseURL(cfg.HostedBaseURL)
 	ctx, cancel := context.WithCancel(context.Background())
+	// LIFO sandwich with the deferred Destroy above: on return, cancel() makes
+	// the handshake goroutine's HTTP calls abort promptly, Wait() joins the
+	// goroutine, and only then does Destroy free the engine. The goroutine's
+	// w.Dispatch calls check ctx only INSIDE their closures — without the join,
+	// one concluding at the instant the window closes could Dispatch into a
+	// freed engine (the same hazard class stopReveal closes for the timer).
+	var handshakeWG sync.WaitGroup
+	defer handshakeWG.Wait()
 	defer cancel()
 
+	// Unlike the main-thread-only locals below, this is written by the handshake
+	// goroutine and read after Run() returns, so it needs real synchronisation.
+	// It deliberately does NOT live behind a Dispatch closure: see the capture
+	// site in startHandshake.
+	var tokenMu sync.Mutex
 	var token string
+
+	// The user explicitly clicked "paste your own token". Distinct from ctx,
+	// which the deferred teardown ALSO cancels — so `ctx.Err() != nil` cannot
+	// tell "the user opted out of hosted" from "this function is returning",
+	// and only the former may discard a delivered hosted JWT.
+	var selfHostChosen atomic.Bool
 
 	// True only while the LOCAL paste-a-token form is the active document.
 	// All reads/writes happen on the webview main thread (bindings and
 	// Dispatch closures both run there), so a plain bool is race-free.
 	selfHostFormActive := false
 
+	// Connect page URL for the CURRENT handshake nonce, and a guard against
+	// overlapping handshakes (double-clicked "Try again"). Main-thread only,
+	// like selfHostFormActive/token: bindings and Dispatch closures both run
+	// on the webview main thread, and the pre-Run startHandshake call happens
+	// before the loop starts.
+	connectURL := ""
+	handshakeInFlight := false
+	reopenInFlight := false
+
+	// Set once Run() returns: a SetHtml closure posted by chooseSelfHost or
+	// retryHosted just before the window closed can outlive this loop (GTK
+	// idle sources and the Cocoa main queue both survive loop exit) and drain
+	// in the process's NEXT webview loop, after Destroy has freed this
+	// engine. The ctx guard the other closures use cannot cover
+	// chooseSelfHost — it cancels ctx itself — so those two closures re-check
+	// this flag instead (same pattern as webview_reveal's stopped flag).
+	// Atomic because the later loop may run on a different OS thread.
+	var torndown atomic.Bool
+
 	// Self-host path: swap to the classic token form (its submitToken binding
 	// is installed below and only accepts input while this form is active).
 	if err := w.Bind("chooseSelfHost", func() {
-		cancel() // stop the handshake goroutine; its nonce simply expires
+		selfHostChosen.Store(true) // before cancel(): the ONLY reason to drop a hosted token
+		cancel()                   // stop the handshake goroutine; its nonce simply expires
 		selfHostFormActive = true
-		w.Dispatch(func() { w.SetHtml(setupWindowHTML) })
+		connectURL = "" // openConnectPage goes dormant with the shell
+		w.Dispatch(func() {
+			if torndown.Load() {
+				return
+			}
+			w.SetHtml(setupWindowHTML)
+		})
 	}); err != nil {
 		return "", fmt.Errorf("bind chooseSelfHost: %w", err)
 	}
@@ -139,25 +209,49 @@ func runFirstRunWindow(cfg *SidecarConfig) (string, error) {
 		return "", fmt.Errorf("bind setup handler: %w", err)
 	}
 
-	// Minimal page bindings: progress/close UX ONLY, never token transport
-	// (the connect page shows its own progress; these let it inform the shell
-	// and close the window when its flow ends). Reachable from remote pages,
-	// which is fine: they log, they cannot move credentials.
-	if err := w.Bind("onProgress", func(step string) {
-		log.Printf("[hosted] connect page progress: %s", step)
+	// Fallback for the shell's "open the sign-in page again" link: the
+	// automatic browser launch failed, or the user closed the tab. Takes no
+	// arguments — it can only relaunch the pinned URL Go already holds. The
+	// launch runs off-thread (it waits up to 3s for the launcher's verdict,
+	// which must not stall the UI loop), joined via handshakeWG so it cannot
+	// Dispatch into a freed engine, ctx-guarded like the handshake's closures,
+	// and debounced so a double-click launches one browser, not two.
+	if err := w.Bind("openConnectPage", func() {
+		if connectURL == "" || reopenInFlight {
+			return
+		}
+		reopenInFlight = true
+		url := connectURL
+		handshakeWG.Add(1)
+		go func() {
+			defer handshakeWG.Done()
+			err := openInDefaultBrowser(ctx, url)
+			w.Dispatch(func() { reopenInFlight = false })
+			if err != nil && ctx.Err() == nil {
+				log.Printf("[hosted] reopen browser failed: %v", err)
+				w.Dispatch(func() {
+					// url != connectURL: the document moved on while the
+					// launch was failing (terminal error shell, or a fresh
+					// retry) — don't repaint a dead nonce's URL over it.
+					if ctx.Err() != nil || url != connectURL {
+						return
+					}
+					w.Eval("window.__browserOpened && window.__browserOpened(false, '" + jsEscape(url) + "')")
+				})
+			}
+		}()
 	}); err != nil {
-		return "", fmt.Errorf("bind onProgress: %w", err)
-	}
-	if err := w.Bind("onComplete", func() {
-		// The long-poll delivers the JWT and terminates the window; the page
-		// signaling completion is only a UX hint.
-		log.Printf("[hosted] connect page reports completion")
-	}); err != nil {
-		return "", fmt.Errorf("bind onComplete: %w", err)
+		return "", fmt.Errorf("bind openConnectPage: %w", err)
 	}
 
 	startHandshake := func() {
+		handshakeInFlight = true
+		handshakeWG.Add(1)
 		go func() {
+			defer handshakeWG.Done()
+			// Posted after any final showShellError SetHtml (FIFO), so by the
+			// time "Try again" is clickable the guard is already down.
+			defer w.Dispatch(func() { handshakeInFlight = false })
 			setStatus := func(text string) {
 				w.Dispatch(func() {
 					if ctx.Err() != nil {
@@ -171,6 +265,7 @@ func runFirstRunWindow(cfg *SidecarConfig) (string, error) {
 					if ctx.Err() != nil {
 						return // self-host chosen or window closing: leave the form alone
 					}
+					connectURL = "" // the nonce died with the handshake
 					w.SetHtml(hostedShellWithError(text))
 				})
 			}
@@ -191,19 +286,42 @@ func runFirstRunWindow(cfg *SidecarConfig) (string, error) {
 				return
 			}
 
-			// Hand the webview to the hosted connect page (nonce in the URL;
-			// the page claims it after Clerk login). Re-check ctx INSIDE the
-			// dispatched closure: if the user picked self-host in the gap, a
-			// late Navigate must not yank the token form away.
+			// Sign-in happens in the SYSTEM browser (nonce in the URL; the
+			// connect page claims it after Clerk login) — see the header
+			// comment for why not this webview. The shell stays up as the
+			// progress surface. Re-check ctx INSIDE the dispatched closures:
+			// if the user picked self-host in the gap, a late Eval must not
+			// scribble on the token form.
+			connect := connectPageURL(base, nonce)
 			w.Dispatch(func() {
 				if ctx.Err() != nil {
 					return
 				}
-				w.Navigate(connectPageURL(base, nonce))
+				connectURL = connect
+			})
+			if ctx.Err() != nil {
+				// Self-host chosen or window closed mid-register. Best
+				// effort: a cancel racing the launch below can still open
+				// one stale tab, whose nonce simply expires.
+				return
+			}
+			launched := true
+			if err := openInDefaultBrowser(ctx, connect); err != nil {
+				if ctx.Err() != nil {
+					return
+				}
+				launched = false
+				log.Printf("[hosted] could not open the system browser: %v", err)
+			}
+			w.Dispatch(func() {
+				if ctx.Err() != nil {
+					return
+				}
+				w.Eval(fmt.Sprintf("window.__browserOpened && window.__browserOpened(%t, '%s')", launched, jsEscape(connect)))
 			})
 
 			jwt, err := awaitHandshakeToken(ctx, base, nonce, func(step string) {
-				setStatus(step) // only visible if the shell is still showing
+				setStatus(step) // server-side provisioning hints
 			})
 			if err != nil {
 				if ctx.Err() != nil {
@@ -214,41 +332,79 @@ func runFirstRunWindow(cfg *SidecarConfig) (string, error) {
 				return
 			}
 			log.Printf("[hosted] enrollment token received via handshake")
-			w.Dispatch(func() {
-				// Assigned on the main thread so the read after w.Run()
-				// needs no cross-goroutine ordering argument.
+			// Captured HERE, not inside the Dispatch closure. By the time
+			// awaitHandshakeToken returns, the server has already marked the
+			// handshake delivered — this JWT is SPENT, and the nonce can never
+			// be re-polled. Losing it strands the user with a paid, enrolled
+			// instance and no way to reach it. Seen live on macOS: the token
+			// arrived, the closure never drained, and the window sat open
+			// forever while runFirstRunWindow stayed blocked in Run().
+			//
+			// So the two concerns are separated: keeping the credential is
+			// correctness and happens unconditionally below; closing the window
+			// is UI and stays best-effort in the dispatch.
+			//
+			// Gated on the explicit opt-out rather than ctx — the deferred
+			// teardown cancels ctx too, so a ctx check here would silently
+			// discard a valid token on an ordinary close.
+			if !selfHostChosen.Load() {
+				tokenMu.Lock()
 				token = jwt
-				w.Terminate()
-			})
+				tokenMu.Unlock()
+			}
+			w.Dispatch(func() { w.Terminate() })
 		}()
 	}
 
 	if err := w.Bind("retryHosted", func() {
-		if ctx.Err() != nil {
-			return // self-host already chosen; nothing to retry
+		if ctx.Err() != nil || handshakeInFlight {
+			return // self-host already chosen, or a double-click: one handshake at a time
 		}
 		selfHostFormActive = false
-		w.Dispatch(func() { w.SetHtml(hostedShellHTML) })
+		connectURL = "" // stale nonce; the fresh handshake sets the new URL
+		w.Dispatch(func() {
+			if torndown.Load() {
+				return
+			}
+			w.SetHtml(hostedShellHTML)
+		})
 		startHandshake()
 	}); err != nil {
 		return "", fmt.Errorf("bind retryHosted: %w", err)
 	}
 
-	revealWebviewOnLoad(w)
+	stopReveal := revealWebviewOnLoad(w)
+	// LIFO with the deferred Destroy at the top: joining the reveal-timeout
+	// goroutine before the engine is freed prevents its pending Dispatch from
+	// landing on a dangling pointer if the window closes within the timeout.
+	defer stopReveal()
 	w.SetHtml(hostedShellHTML)
 	startHandshake()
 	w.Run() // blocks until Terminate() or the window is closed
+	torndown.Store(true)
+	// Join the handshake goroutine BEFORE reading the token, rather than
+	// leaving it to the deferred Wait: defers run after the return value is
+	// evaluated, so a token that lands in the instant the window closes would
+	// otherwise be dropped on the floor. Both calls are idempotent, so the
+	// deferred cancel/Wait stay as backstops for the early-return paths.
+	cancel()
+	handshakeWG.Wait()
+	tokenMu.Lock()
+	defer tokenMu.Unlock()
 	return token, nil
 }
 
 // jsEscape makes a Go string safe inside a single-quoted JS string literal.
-// Backslash first, then quotes and line terminators; `<` is escaped so the
+// Backslash first, then quotes and line terminators (including U+2028/U+2029,
+// which pre-ES2019 parsers treat as terminators); `<` is escaped so the
 // literal can also sit inside an inline <script> without closing it.
 func jsEscape(s string) string {
 	s = strings.ReplaceAll(s, `\`, `\\`)
 	s = strings.ReplaceAll(s, `'`, `\'`)
 	s = strings.ReplaceAll(s, "\n", `\n`)
 	s = strings.ReplaceAll(s, "\r", `\r`)
+	s = strings.ReplaceAll(s, "\u2028", `\u2028`)
+	s = strings.ReplaceAll(s, "\u2029", `\u2029`)
 	s = strings.ReplaceAll(s, "<", `\x3c`)
 	return s
 }

--- a/sidecar/local_webview_darwin.go
+++ b/sidecar/local_webview_darwin.go
@@ -29,18 +29,29 @@ func runLocalWebview(title string, width, height int, hint webview.Hint, build f
 	}
 
 	closed := make(chan struct{})
-	uiSync(wv, func() {
+	var stopReveal func()
+	uiSync(wv, func() { // synchronous: stopReveal is assigned before watchWindowClose can fire
 		wv.SetTitle(title)
 		wv.SetSize(width, height, hint)
+		stopReveal = revealWebviewOnLoad(wv)
 		build(wv)
-		watchWindowClose(wv.Window(), func() { close(closed) })
+		watchWindowClose(wv.Window(), func() {
+			// Stopping HERE (main thread), not after <-closed: AppKit releases
+			// the window on close, and a reveal closure already queued on the
+			// main queue would otherwise run against the freed handle before
+			// our goroutine even wakes. Main-queue ordering makes the stop
+			// flag visible to any closure that drains after this callback.
+			stopReveal()
+			close(closed)
+		})
 	})
 
 	<-closed
 	// Intentionally do NOT wv.Destroy() here. Under the tray's shared loop the
-	// window closes via AppKit, but pending callbacks still reference the engine
-	// — webview's own on_window_will_close -> dispatch(on_window_destroyed) and
-	// revealWebviewOnLoad's reveal-timeout goroutine. Destroying now frees the
-	// engine out from under them -> use-after-free crash. We leak the engine
-	// instead (these windows open rarely). TODO: cancellable teardown to reclaim.
+	// window closes via AppKit, but webview's own on_window_will_close ->
+	// dispatch(on_window_destroyed) callback still references the engine.
+	// Destroying now frees the engine out from under it -> use-after-free
+	// crash. We leak the engine instead (these windows open rarely; the reveal
+	// timer, the other dangling reference this leak used to cover, is joined
+	// above). TODO: cancellable teardown to reclaim.
 }

--- a/sidecar/local_webview_other.go
+++ b/sidecar/local_webview_other.go
@@ -12,7 +12,8 @@ import (
 // runLocalWebview hosts a small local-HTML webview window (settings, logs) on
 // platforms where each window owns its own goroutine and event loop
 // (Windows/Linux). This goroutine creates, configures, runs, and tears the
-// window down. build registers bindings and sets the page before Run().
+// window down. The reveal-on-load hook is installed here (before build, per
+// its contract); build registers bindings and sets the page before Run().
 func runLocalWebview(title string, width, height int, hint webview.Hint, build func(webview.WebView)) {
 	runtime.LockOSThread()
 	wv := webview.New(false)
@@ -23,6 +24,11 @@ func runLocalWebview(title string, width, height int, hint webview.Hint, build f
 	defer wv.Destroy()
 	wv.SetTitle(title)
 	wv.SetSize(width, height, hint)
+	stop := revealWebviewOnLoad(wv)
+	// LIFO with the Destroy above: a window closed within the reveal timeout
+	// must join the timeout goroutine BEFORE the engine is freed, or its
+	// pending Dispatch lands on a dangling pointer.
+	defer stop()
 	build(wv)
 	wv.Run()
 }

--- a/sidecar/log_viewer.go
+++ b/sidecar/log_viewer.go
@@ -49,9 +49,6 @@ func runLogViewer(logPath string) {
 			return dst
 		})
 
-		// The vendored webview creates the window hidden (no flash); reveal it once
-		// the page has loaded.
-		revealWebviewOnLoad(w)
 		w.SetHtml(logViewerHTML)
 	})
 }

--- a/sidecar/log_viewer.go
+++ b/sidecar/log_viewer.go
@@ -3,8 +3,8 @@ package main
 // Local log viewer — a small webview window that shows the sidecar's own log
 // file (~/.jarvis/sidecar.log) with search, copy, and export. Entirely local:
 // it is NOT a dashboard room and never talks to the brain. Reuses the webview_go
-// dependency (same as the setup window / panels); the UI is plain HTML, to be
-// branded later.
+// dependency (same as the setup window / panels); the UI is local HTML in the
+// shared Monochrome Lab brand (brand_css.go).
 
 import (
 	"fmt"
@@ -58,25 +58,11 @@ const logViewerHTML = `<!doctype html>
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<style>
-  /* Monochrome Lab (Brand Book III). Force light regardless of OS appearance. */
-  :root {
-    color-scheme: light;
-    --bg:#FAFBFC; --raise:#FFFFFF; --panel:#EFF2F5; --panel2:#F6F8FA;
-    --rule:#E2E7EC; --rule-hi:#D2D9E0;
-    --ink:#13161A; --ink2:#535B63; --ink3:#677077; --faint:#9AA2AB;
-    --speak:#2D78FF;
-    --sans:'Familjen Grotesk', system-ui, -apple-system, "Segoe UI", sans-serif;
-    --mono:'Spline Sans Mono', ui-monospace, "Cascadia Code", Consolas, monospace;
-    --corner-sm: 9px 2px 9px 9px;
-  }
-  * { box-sizing: border-box; }
-  html, body { height: 100%; margin: 0; }
-  body {
-    display: flex; flex-direction: column;
-    font-family: var(--sans); font-size: 13px;
-    background: var(--bg); color: var(--ink);
-  }
+<style>` + brandTokensCSS + `
+  /* Monochrome Lab (Brand Book III) — shared tokens from brand_css.go,
+     dark follows the OS. */
+  html, body { height: 100%; }
+  body { display: flex; flex-direction: column; font-size: 13px; }
   .bar {
     display: flex; align-items: center; gap: 8px; padding: 10px 12px;
     background: var(--raise); border-bottom: 1px solid var(--rule); flex: 0 0 auto;
@@ -104,8 +90,8 @@ const logViewerHTML = `<!doctype html>
     transition: background .12s, border-color .12s, color .12s;
   }
   button:hover { background: var(--panel); color: var(--ink); border-color: var(--rule-hi); }
-  button.primary { background: var(--ink); color: #fff; border-color: var(--ink); }
-  button.primary:hover { background: #272C33; }
+  button.primary { background: var(--ink); color: var(--bg); border-color: var(--ink); }
+  button.primary:hover { filter: brightness(1.08); }
   pre {
     flex: 1 1 auto; margin: 0; padding: 12px 14px; overflow: auto;
     font-family: var(--mono); font-size: 12px; line-height: 1.5;

--- a/sidecar/open_browser.go
+++ b/sidecar/open_browser.go
@@ -1,0 +1,49 @@
+package main
+
+// openInDefaultBrowser hands a URL to the OS default browser. The hosted
+// first-run flow signs the user in there rather than in the embedded webview:
+// the vendored engine has no window.open handling (Clerk's Google SSO popup
+// silently no-ops) and Google rejects OAuth from embedded webviews anyway.
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"runtime"
+	"time"
+)
+
+func openInDefaultBrowser(ctx context.Context, url string) error {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("open", url)
+	case "windows":
+		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", url)
+	default:
+		cmd = exec.Command("xdg-open", url)
+	}
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("open default browser: %w", err)
+	}
+	// A launcher normally hands off and exits immediately; a prompt nonzero
+	// exit means no browser took the URL (xdg-open exits 3 when no handler is
+	// configured). Wait only briefly — xdg-open's generic fallback can stay
+	// alive as long as the browser it spawned, and that is a success — and
+	// abandon the wait on ctx cancel so a closing window is never stalled
+	// behind the verdict. The goroutine keeps waiting in those cases and
+	// reaps the child — no zombies on any path.
+	exited := make(chan error, 1)
+	go func() { exited <- cmd.Wait() }()
+	select {
+	case err := <-exited:
+		if err != nil {
+			return fmt.Errorf("open default browser: %w", err)
+		}
+		return nil
+	case <-time.After(3 * time.Second):
+		return nil // still running: assume it is fronting the browser
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}

--- a/sidecar/panels_runtime.go
+++ b/sidecar/panels_runtime.go
@@ -114,6 +114,32 @@ func (s *panelService) Spawn(spec PanelSpec) (PanelID, error) {
 		runtime.LockOSThread()
 		defer runtime.UnlockOSThread()
 
+		// Windows/Linux own the loop and Destroy the webview after Run()
+		// returns. Declared FIRST so defer LIFO runs it LAST: hotkey teardown,
+		// follower shutdown, close(impl.done), and registry removal all happen
+		// before the engine is freed — with Destroy first (the old order), the
+		// still-registered summon hotkey could Dispatch into freed memory, and
+		// a Close()/reopen could reach the dead entry. The delayShow reveal
+		// timer and the close watcher are joined here too, for the same reason
+		// (same fix as webview_reveal.go's stop). On macOS (shared loop) the
+		// window closes under the tray's [NSApp run], and webview's own
+		// on_window_will_close dispatch still references the engine; destroying
+		// it here frees the engine out from under it -> use-after-free crash.
+		// Leak the engine on macOS instead (panels open rarely; the timer and
+		// watcher are joined either way). TODO: cancellable teardown to
+		// reclaim. wv/stopReveal/stopCloseWatch are populated later; they stay
+		// nil/no-op on the webview.New failure path.
+		var wv webview.WebView
+		stopReveal := func() {}
+		stopCloseWatch := func() {}
+		defer func() {
+			stopCloseWatch()
+			stopReveal()
+			if wv != nil && !panelSharedLoop {
+				wv.Destroy()
+			}
+		}()
+
 		defer s.reg.delete(spec.ID)
 		defer close(impl.done)
 		defer func() {
@@ -130,24 +156,12 @@ func (s *panelService) Spawn(spec PanelSpec) (PanelID, error) {
 
 		log.Printf("[panels] spawn(%s): creating webview", spec.ID)
 		debug := false
-		wv := webview.New(debug)
+		wv = webview.New(debug)
 		if wv == nil {
 			log.Printf("[panels] spawn(%s): webview.New returned nil — WebView2 runtime missing?", spec.ID)
 			close(impl.ready)
 			return
 		}
-		// Windows/Linux own the loop and Destroy the webview safely after Run()
-		// returns. On macOS (shared loop) the window closes under the tray's
-		// [NSApp run], but pending webview callbacks still reference the engine
-		// (the delayShow reveal-timeout goroutine, webview's own
-		// on_window_will_close dispatch); destroying it here frees the engine out
-		// from under them -> use-after-free crash. Leak the engine on macOS
-		// instead (panels open rarely). TODO: cancellable teardown to reclaim.
-		defer func() {
-			if !panelSharedLoop {
-				wv.Destroy()
-			}
-		}()
 		impl.setWV(wv)
 		log.Printf("[panels] spawn(%s): webview created", spec.ID)
 
@@ -256,7 +270,24 @@ func (s *panelService) Spawn(spec PanelSpec) (PanelID, error) {
 				// window (its SetWindowPos uses SWP_SHOWWINDOW for always-on-top).
 				_ = platformSetWindowVisible(earlyHandle, false)
 				var panelShown atomic.Bool
+				var revealStopped atomic.Bool
 				showPanel := func() {
+					if revealStopped.Load() {
+						return // teardown won the race; the handle may be dead
+					}
+					select {
+					case <-impl.uiClosed:
+						// macOS: the window already closed under the shared
+						// loop. uiClosed is closed inside the will-close
+						// notification ON THE MAIN THREAD, so a reveal closure
+						// queued behind it reliably sees this and bails —
+						// otherwise it would re-show and focus the closed
+						// (frameless, registry-deleted) panel as an
+						// unreachable zombie. revealStopped can't cover this:
+						// the spawn goroutine sets it only after it wakes.
+						return
+					default:
+					}
 					if panelShown.CompareAndSwap(false, true) {
 						_ = platformSetWindowVisible(earlyHandle, true)
 						_ = platformFocusWindow(earlyHandle)
@@ -268,12 +299,28 @@ func (s *panelService) Spawn(spec PanelSpec) (PanelID, error) {
 					`if(document.readyState==='complete'){setTimeout(r,120);}` +
 					`else{window.addEventListener('load',function(){setTimeout(r,120);});}}catch(e){}})();`)
 				_ = wv.Bind("__sidecar_panel_ready", func() { showPanel() })
+				// Timeout fallback, cancellable: stopReveal (joined by the defer
+				// above before Destroy) keeps the Dispatch CALL off a freed
+				// engine, and revealStopped keeps an already-queued closure off
+				// a dead window handle (GTK idle sources survive gtk_main_quit).
+				revealDone := make(chan struct{})
+				revealFinished := make(chan struct{})
 				go func() {
-					time.Sleep(6 * time.Second)
-					if wv := impl.loadWV(); wv != nil {
+					defer close(revealFinished)
+					select {
+					case <-time.After(6 * time.Second):
 						wv.Dispatch(func() { showPanel() })
+					case <-revealDone:
 					}
 				}()
+				var stopOnce sync.Once
+				stopReveal = func() {
+					stopOnce.Do(func() {
+						revealStopped.Store(true)
+						close(revealDone)
+					})
+					<-revealFinished
+				}
 			}
 
 			if spec.URL != "" {
@@ -456,11 +503,21 @@ func (s *panelService) Spawn(spec PanelSpec) (PanelID, error) {
 		// panel can't be reopened. Watch the HWND; when it's destroyed, force the
 		// loop to return so cleanup runs. No-op on platforms where
 		// platformWindowAlive can't probe the handle.
+		//
+		// Joined (stopCloseWatch, in the Destroy defer) before the engine is
+		// freed: teardown closes impl.done only AFTER Destroy (defer LIFO), so
+		// the done check alone leaves a gap where a tick could see the window
+		// dead, pass the check, and Dispatch into freed memory.
+		watchStop := make(chan struct{})
+		watchFinished := make(chan struct{})
 		go func() {
+			defer close(watchFinished)
 			t := time.NewTicker(250 * time.Millisecond)
 			defer t.Stop()
 			for {
 				select {
+				case <-watchStop:
+					return // teardown is joining us
 				case <-impl.done:
 					return
 				case <-t.C:
@@ -468,6 +525,8 @@ func (s *panelService) Spawn(spec PanelSpec) (PanelID, error) {
 						continue
 					}
 					select {
+					case <-watchStop:
+						return // teardown is joining us
 					case <-impl.done:
 						return // already tearing down (webview terminated it)
 					default:
@@ -486,6 +545,11 @@ func (s *panelService) Spawn(spec PanelSpec) (PanelID, error) {
 				}
 			}
 		}()
+		var watchOnce sync.Once
+		stopCloseWatch = func() {
+			watchOnce.Do(func() { close(watchStop) })
+			<-watchFinished
+		}
 
 		close(impl.ready)
 		if panelSharedLoop {

--- a/sidecar/settings_window.go
+++ b/sidecar/settings_window.go
@@ -130,9 +130,6 @@ func (c *SidecarClient) runSettingsWindow() {
 			return nil
 		})
 
-		// The vendored webview creates the window hidden (no flash); reveal it once
-		// the page has loaded.
-		revealWebviewOnLoad(w)
 		w.SetHtml(settingsWindowHTML)
 	})
 }

--- a/sidecar/settings_window.go
+++ b/sidecar/settings_window.go
@@ -4,7 +4,8 @@ package main
 // lets the user change the enrollment token, and edit sidecar preferences.
 // Entirely local: it is NOT a dashboard room and never talks to the brain
 // (the old "Settings" entry opened the remote settings room). Mirrors the log
-// viewer pattern; UI is plain HTML, to be branded later.
+// viewer pattern; UI is local HTML in the shared Monochrome Lab brand
+// (brand_css.go).
 
 import (
 	"fmt"
@@ -151,25 +152,13 @@ const settingsWindowHTML = `<!doctype html>
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<style>
-  /* Monochrome Lab (Brand Book III) — sidecar settings. Forced light;
-     row grammar from the room-13 settings design: label + consequence left,
-     control right, inside raised panels with the asymmetric corner. */
-  :root {
-    color-scheme: light;
-    --bg:#FAFBFC; --raise:#FFFFFF; --panel:#EFF2F5; --panel2:#F6F8FA;
-    --rule:#E2E7EC; --rule2:#EDF0F3; --rule-hi:#D2D9E0;
-    --ink:#13161A; --ink2:#535B63; --ink3:#677077; --faint:#9AA2AB;
-    --listen:#E63B2E; --listen-tx:#C2301F; --speak:#2D78FF;
-    --hold:#EAA40E; --ok:#2FA45E; --ok-tx:#1F7A43;
-    --sans:'Familjen Grotesk', system-ui, -apple-system, "Segoe UI", sans-serif;
-    --mono:'Spline Sans Mono', ui-monospace, "Cascadia Code", Consolas, monospace;
-    --corner:14px 3px 14px 14px; --corner-sm:9px 2px 9px 9px; --ease:cubic-bezier(.2,.7,.2,1);
-    --sh-sm:0 1px 2px rgba(20,30,45,.06),0 1px 1px rgba(20,30,45,.04);
-  }
-  * { box-sizing: border-box; }
-  html, body { margin: 0; height: 100%; }
-  body { font-family: var(--sans); background: var(--bg); color: var(--ink); padding: 24px 22px 28px; overflow-y: auto; font-size: 13px; }
+<style>` + brandTokensCSS + `
+  /* Monochrome Lab (Brand Book III) — sidecar settings, shared tokens from
+     brand_css.go (dark follows the OS); row grammar from the room-13 settings
+     design: label + consequence left, control right, inside raised panels
+     with the asymmetric corner. */
+  html, body { height: 100%; }
+  body { padding: 24px 22px 28px; overflow-y: auto; font-size: 13px; }
   h1 { font-size: 19px; font-weight: 650; letter-spacing: -.01em; margin: 0 0 3px; }
   .sub { font-size: 12px; color: var(--ink3); margin: 0 0 18px; }
   .sec { font-family: var(--mono); font-size: 10px; letter-spacing: .1em; text-transform: uppercase; color: var(--ink3); margin: 20px 4px 8px; }
@@ -207,8 +196,8 @@ const settingsWindowHTML = `<!doctype html>
   /* buttons */
   .sbtn { appearance: none; font-family: var(--sans); font-size: 12px; font-weight: 600; padding: 7px 14px; border-radius: var(--corner-sm); border: 1px solid var(--rule); color: var(--ink); background: var(--raise); cursor: pointer; transition: background .12s, border-color .12s; }
   .sbtn:hover { background: var(--panel); border-color: var(--rule-hi); }
-  .sbtn.pri { background: var(--ink); color: #fff; border-color: var(--ink); }
-  .sbtn.pri:hover { background: #272C33; }
+  .sbtn.pri { background: var(--ink); color: var(--bg); border-color: var(--ink); }
+  .sbtn.pri:hover { filter: brightness(1.08); }
   .sbtn:disabled { opacity: .5; cursor: default; }
   /* number input */
   .num { width: 62px; padding: 6px 9px; border: 1px solid var(--rule); border-radius: var(--corner-sm); background: var(--panel2); color: var(--ink); font-family: var(--mono); font-size: 12px; outline: none; text-align: center; }

--- a/sidecar/setup_window.go
+++ b/sidecar/setup_window.go
@@ -5,15 +5,16 @@ package main
 // When the sidecar starts with no token configured, instead of printing an
 // error and exiting we pop up a small native window asking for the enrollment
 // JWT. It reuses the webview_go dependency the panels already pull in, so it is
-// a single cross-platform implementation (Windows / Linux / macOS) and the UI is
-// plain HTML that can be branded later.
+// a single cross-platform implementation (Windows / Linux / macOS); the UI is
+// local HTML in the shared Monochrome Lab brand (brand_css.go).
 //
 // Flow: main() calls runSetupWindow() when cfg.Token == ""; the window blocks
 // until the user submits a valid-looking token (closing the window cancels).
 // The token is validated only as a well-formed JWT here — the brain still does
 // the real cryptographic verification on connect.
 
-// setupWindowHTML is the (intentionally minimal, unbranded) first-run form.
+// setupWindowHTML is the self-host first-run form, Monochrome Lab
+// (brand_css.go): a centered raised card with the signature corner.
 // `window.submitToken(value)` is the Go binding installed below; it rejects with
 // a message when the token is empty/malformed so the form can show it inline.
 const setupWindowHTML = `<!doctype html>
@@ -21,47 +22,63 @@ const setupWindowHTML = `<!doctype html>
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<style>
-  /* Force the sidecar's own light theme regardless of the OS appearance. */
-  :root { color-scheme: light; }
-  * { box-sizing: border-box; }
-  body {
-    margin: 0; padding: 28px;
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Inter, sans-serif;
-    background: #f5f2eb; color: #1a1a1a;
+<style>` + brandTokensCSS + brandPebbleCSS + `
+  body { min-height: 100vh; display: flex; flex-direction: column; padding: 26px 30px; }
+  .bhead .word { font-size: 16px; }
+  .center { flex: 1; display: flex; align-items: center; justify-content: center; }
+  .formbox {
+    width: 100%; max-width: 440px; padding: 24px 24px 20px;
+    background: var(--raise); border: 1px solid var(--rule);
+    border-radius: var(--corner); box-shadow: var(--sh-md);
   }
-  h1 { font-size: 18px; margin: 0 0 6px; }
-  .sub { font-size: 13px; margin: 0 0 18px; opacity: 0.8; line-height: 1.45; }
-  .hint { font-size: 12px; color: #6a675f; margin: 6px 0 16px; }
-  label { font-size: 12px; font-weight: 600; display: block; margin-bottom: 6px; }
+  .eyebrow {
+    font-family: var(--mono); font-size: 10px; letter-spacing: .12em;
+    text-transform: uppercase; color: var(--ink3); margin-bottom: 9px;
+  }
+  h1 { font-size: 19px; font-weight: 700; letter-spacing: -.025em; margin: 0 0 6px; }
+  .sub { font-size: 12.5px; color: var(--ink3); margin: 0 0 18px; line-height: 1.55; }
+  .sub b { color: var(--ink2); font-weight: 600; }
+  label { font-size: 11px; font-weight: 600; color: var(--ink2); display: block; margin-bottom: 7px; }
   textarea {
     width: 100%; height: 110px; resize: none; padding: 10px 12px;
-    font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace; font-size: 12px;
-    border: 1px solid #cbc3b2; border-radius: 8px; background: #fff; color: #1a1a1a;
-    line-height: 1.4;
+    font-family: var(--mono); font-size: 11.5px; line-height: 1.5;
+    border: 1px solid var(--rule); border-radius: var(--corner-sm);
+    background: var(--panel2); color: var(--ink); outline: none;
+    transition: border-color .12s, box-shadow .12s, background .12s;
   }
-  textarea:focus { outline: 2px solid #c23a2a; outline-offset: 1px; border-color: #c23a2a; }
+  textarea::placeholder { color: var(--faint); }
+  textarea:focus { border-color: var(--speak); background: var(--raise); box-shadow: 0 0 0 3px rgba(45,120,255,.14); }
+  .hint { font-size: 11px; color: var(--faint); margin: 8px 0 0; line-height: 1.5; }
   .row { display: flex; align-items: center; justify-content: space-between; margin-top: 16px; gap: 12px; }
-  #err { color: #c23a2a; font-size: 12px; min-height: 16px; flex: 1; }
+  #err { color: var(--listen-tx); font-size: 12px; line-height: 1.5; min-height: 16px; flex: 1; text-align: left; }
   button {
-    appearance: none; border: 0; border-radius: 8px; padding: 10px 18px;
-    background: #c23a2a; color: #fff; font-size: 13px; font-weight: 600; cursor: pointer;
+    appearance: none; height: 40px; padding: 0 18px; border: 1px solid transparent;
+    border-radius: var(--corner-sm); font-family: var(--sans); font-size: 13.5px;
+    font-weight: 600; cursor: pointer; background: var(--ink); color: var(--bg);
+    transition: filter 150ms var(--ease);
   }
-  button:hover { background: #a83120; }
+  button:not(:disabled):hover { filter: brightness(1.08); }
+  button:focus-visible { outline: 2px solid var(--ink2); outline-offset: 2px; }
   button:disabled { opacity: 0.5; cursor: default; }
 </style>
 </head>
 <body>
-  <h1>Connect this machine to JARVIS</h1>
-  <p class="sub">Paste the enrollment token from the dashboard
-    (<b>Settings &rarr; Sidecar &rarr; Enroll</b>). It connects this sidecar to
-    your brain and authenticates it.</p>
-  <label for="tok">Enrollment token</label>
-  <textarea id="tok" placeholder="eyJhbGciOiJFUzI1NiIs..." spellcheck="false" autofocus></textarea>
-  <p class="hint">The token is stored locally at ~/.jarvis/sidecar.yaml. Press Cmd/Ctrl+Enter to connect.</p>
-  <div class="row">
-    <span id="err"></span>
-    <button id="go" onclick="submit()">Connect</button>
+  <div class="bhead"><span class="word"><span class="u">use</span>jarvis</span></div>
+  <div class="center">
+    <div class="formbox">
+      <div class="eyebrow">Self-hosted</div>
+      <h1>Connect this machine to Jarvis</h1>
+      <p class="sub">Paste the enrollment token from the dashboard
+        (<b>Settings &rarr; Sidecar &rarr; Enroll</b>). It connects this sidecar to
+        your brain and authenticates it.</p>
+      <label for="tok">Enrollment token</label>
+      <textarea id="tok" placeholder="eyJhbGciOiJFUzI1NiIs..." spellcheck="false" autofocus></textarea>
+      <p class="hint">The token is stored locally at ~/.jarvis/sidecar.yaml. Press Cmd/Ctrl+Enter to connect.</p>
+      <div class="row">
+        <span id="err"></span>
+        <button id="go" onclick="submit()">Connect</button>
+      </div>
+    </div>
   </div>
 <script>
   var tok = document.getElementById('tok');

--- a/sidecar/third_party/webview_go/JARVIS_PATCH.md
+++ b/sidecar/third_party/webview_go/JARVIS_PATCH.md
@@ -24,8 +24,9 @@ In `libs/webview/include/webview.h`, the win32 `win32_edge_engine` constructor:
 ```
 
 The host (sidecar) now creates the window hidden and reveals it itself once the
-page has loaded — see `revealWebviewOnLoad` (`webview_reveal.go`) for the setup
-window + log viewer, and the inline reveal in `panels_runtime.go` for panels.
+page has loaded — see `revealWebviewOnLoad` (`webview_reveal.go`) for the local
+windows (settings, logs, account) and the hosted first-run window, and the
+inline reveal in `panels_runtime.go` for panels.
 Non-`delayShow` overlay panels are shown immediately.
 
 ## The Cocoa patch (macOS main-thread window creation)

--- a/sidecar/tray_bridge_darwin.go
+++ b/sidecar/tray_bridge_darwin.go
@@ -24,6 +24,13 @@ func goTrayOpenChat() {
 	}
 }
 
+//export goTrayOpenAccount
+func goTrayOpenAccount() {
+	if trayOpenAccountDarwin != nil {
+		go trayOpenAccountDarwin()
+	}
+}
+
 //export goTrayOpenSettings
 func goTrayOpenSettings() {
 	if trayOpenSettingsDarwin != nil {

--- a/sidecar/tray_darwin.go
+++ b/sidecar/tray_darwin.go
@@ -34,6 +34,7 @@ package main
 
 extern void goTrayClose(void);
 extern void goTrayOpenChat(void);
+extern void goTrayOpenAccount(void);
 extern void goTrayOpenSettings(void);
 extern void goTrayOpenLogs(void);
 extern void goTrayPause(void);
@@ -49,6 +50,7 @@ extern void goTrayWaiting(void);
 @interface JarvisTrayTarget : NSObject <NSApplicationDelegate>
 - (void)onClose:(id)sender;
 - (void)onChat:(id)sender;
+- (void)onAccount:(id)sender;
 - (void)onSettings:(id)sender;
 - (void)onLogs:(id)sender;
 - (void)onPause:(id)sender;
@@ -58,6 +60,7 @@ extern void goTrayWaiting(void);
 @implementation JarvisTrayTarget
 - (void)onClose:(id)sender    { (void)sender; goTrayClose(); }
 - (void)onChat:(id)sender     { (void)sender; goTrayOpenChat(); }
+- (void)onAccount:(id)sender  { (void)sender; goTrayOpenAccount(); }
 - (void)onSettings:(id)sender { (void)sender; goTrayOpenSettings(); }
 - (void)onLogs:(id)sender     { (void)sender; goTrayOpenLogs(); }
 - (void)onPause:(id)sender    { (void)sender; goTrayPause(); }
@@ -232,6 +235,7 @@ static void jarvisTrayRebuild(const char* header, int waiting, int paused, int m
         }
 
         jarvisAddItem(menu, @"Open dashboard", @selector(onChat:));
+        jarvisAddItem(menu, @"Account", @selector(onAccount:));
         jarvisAddItem(menu, @"Settings", @selector(onSettings:));
         jarvisAddItem(menu, @"Logs", @selector(onLogs:));
         [menu addItem:[NSMenuItem separatorItem]];
@@ -301,6 +305,7 @@ func init() { runtime.LockOSThread() }
 var (
 	trayOnCloseDarwin      func()
 	trayOpenChatDarwin     func()
+	trayOpenAccountDarwin  func()
 	trayOpenSettingsDarwin func()
 	trayOpenLogsDarwin     func()
 	trayEmitDarwin         func(eventType string, payload map[string]any) // tray → brain (pause/mute)
@@ -388,6 +393,7 @@ func runWithTray(ctx context.Context, cancel context.CancelFunc, client *Sidecar
 	}
 	client.SetShutdown(trayOnCloseDarwin)
 	trayOpenChatDarwin = client.OpenChat
+	trayOpenAccountDarwin = client.OpenAccount
 	trayOpenSettingsDarwin = client.OpenSettings
 	trayOpenLogsDarwin = client.OpenLogViewer
 	trayClientDarwin = client

--- a/sidecar/tray_windows.go
+++ b/sidecar/tray_windows.go
@@ -67,6 +67,7 @@ const (
 	trayMenuWaitingID  = 5
 	trayMenuPauseID    = 6
 	trayMenuMuteID     = 7
+	trayMenuAccountID  = 8
 	// Brand icon resources compiled into rsrc_windows_amd64.syso from jarvis.rc.
 	// ID 2 is also the .exe / taskbar application icon (lowest-numbered group
 	// icon). ID 3 is the vermilion drop shown when the connection drops.
@@ -108,6 +109,7 @@ var (
 	trayOnClose      func()
 	trayConnState    func() int32 // brain-connection state (connConnecting/connConnected/connError)
 	trayOpenChat     func()
+	trayOpenAccount  func()
 	trayOpenSettings func()
 	trayOpenLogs     func()
 	trayEmit         func(eventType string, payload map[string]any) // tray → brain (pause/mute)
@@ -123,6 +125,7 @@ func runWithTray(ctx context.Context, cancel context.CancelFunc, client *Sidecar
 	client.SetShutdown(trayOnClose)
 	trayConnState = client.ConnState
 	trayOpenChat = client.OpenChat
+	trayOpenAccount = client.OpenAccount
 	trayOpenSettings = client.OpenSettings
 	trayOpenLogs = client.OpenLogViewer
 	trayEmit = func(et string, p map[string]any) {
@@ -394,6 +397,7 @@ func showTrayMenu(hwnd uintptr) {
 	// combos we won't hijack globally. A deliberate global "open dashboard"
 	// hotkey would be a separate opt-in, on an uncommon combo.)
 	appendTrayItem(hMenu, "Open dashboard", trayMenuChatID)
+	appendTrayItem(hMenu, "Account", trayMenuAccountID)
 	appendTrayItem(hMenu, "Settings", trayMenuSettingsID)
 	appendTrayItem(hMenu, "Logs", trayMenuLogsID)
 	procAppendMenuW.Call(hMenu, trayMfSeparator, 0, 0)
@@ -426,6 +430,10 @@ func showTrayMenu(hwnd uintptr) {
 	case trayMenuChatID:
 		if trayOpenChat != nil {
 			go trayOpenChat()
+		}
+	case trayMenuAccountID:
+		if trayOpenAccount != nil {
+			go trayOpenAccount()
 		}
 	case trayMenuSettingsID:
 		if trayOpenSettings != nil {

--- a/sidecar/webview_reveal.go
+++ b/sidecar/webview_reveal.go
@@ -4,11 +4,13 @@ package main
 //
 // The vendored webview_go is patched (on Windows) to create its window HIDDEN,
 // so there's no empty-window flash during WebView2 init. Each webview owner is
-// then responsible for revealing the window once its page is ready. This helper
-// does that for the simple local-HTML windows (setup window, log viewer); the
-// panels have their own reveal (with focus) inline in panels_runtime.go.
+// then responsible for revealing the window once its page is ready. This
+// helper does that for the windows runLocalWebview hosts (settings, logs,
+// account) and the hosted first-run window; the panels have their own reveal
+// (with focus) inline in panels_runtime.go.
 
 import (
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -19,10 +21,27 @@ import (
 // short settle for first paint and a timeout fallback so it can never stay
 // stuck hidden). Must be called BEFORE SetHtml/Navigate + Run so the injected
 // script applies to the loaded document.
-func revealWebviewOnLoad(w webview.WebView) {
+//
+// The returned stop func cancels the timeout fallback, WAITS for its
+// goroutine to exit, and flags the reveal dead. The join guarantees no
+// Dispatch CALL can happen after Destroy — the use-after-free a window
+// closed inside the timeout used to hit. The flag covers the residue the
+// join can't: when the timer wins the select race concurrently with stop,
+// the closure is already posted and outlives teardown (GTK idle sources
+// survive gtk_main_quit and run in the process's next main loop; the Cocoa
+// main queue outlives the AppKit-released window), so show() re-checks the
+// flag before touching the handle. Callers MUST invoke stop after the window
+// closes and before Destroy(). stop is idempotent, and never blocks
+// meaningfully: Dispatch is a non-blocking post on every platform, so the
+// goroutine can't wedge between the select firing and finished closing.
+func revealWebviewOnLoad(w webview.WebView) (stop func()) {
 	handle := w.Window()
 	var shown atomic.Bool
+	var stopped atomic.Bool
 	show := func() {
+		if stopped.Load() {
+			return
+		}
 		if shown.CompareAndSwap(false, true) {
 			_ = platformSetWindowVisible(handle, true)
 		}
@@ -31,8 +50,23 @@ func revealWebviewOnLoad(w webview.WebView) {
 		`if(document.readyState==='complete'){setTimeout(r,80);}` +
 		`else{window.addEventListener('load',function(){setTimeout(r,80);});}}catch(e){}})();`)
 	_ = w.Bind("__jarvis_reveal", func() { show() })
+
+	done := make(chan struct{})
+	finished := make(chan struct{})
 	go func() {
-		time.Sleep(5 * time.Second)
-		w.Dispatch(func() { show() })
+		defer close(finished)
+		select {
+		case <-time.After(5 * time.Second):
+			w.Dispatch(func() { show() })
+		case <-done:
+		}
 	}()
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			stopped.Store(true)
+			close(done)
+		})
+		<-finished
+	}
 }


### PR DESCRIPTION
Four commits that overhaul the sidecar's window surfaces end-to-end: fix the broken Google SSO onboarding, make webview teardown memory-safe, add an Account tray entry, and bring every local page onto the brand.

## Google SSO fix + token safety (`28275d7`)

Clicking **Log in with Google** on first-run silently did nothing: the connect page ran inside the embedded webview, whose engine drops `window.open` — Clerk's OAuth popup died in page JS, so no error ever reached the logs (and Google blocks OAuth in embedded webviews anyway).

Sign-in now happens in the **system default browser** (`xdg-open` / `open` / `rundll32`). The webview keeps a local shell showing progress; the enrollment JWT still arrives Go-side over the nonce long-poll, never through page JS. The shell shows the connect URL as copyable text with a re-open link (debounced, no-arg binding, pinned URL only) for when the launcher fails.

Separately, a delivered token can no longer be lost: by the time the long-poll returns, the JWT is spent server-side, yet its survival used to depend on a Dispatch closure draining — seen stalling on macOS, stranding a paid enrolled instance. The token is now captured under a mutex the moment it arrives; closing the window stays best-effort UI. Discarding a hosted JWT is gated on the explicit self-host opt-out (`selfHostChosen`), not on ctx, which ordinary teardown also cancels — and the tail joins the handshake before reading the token. Worst case on the (still unexplained) macOS dispatch stall degrades from "redo checkout" to "close the window manually, setup completes".

## Webview teardown hardening (`ab855d2`)

Closing any local window inside its reveal timeout could Dispatch into a freed engine (GTK idle sources and the Cocoa main queue outlive the loop). `revealWebviewOnLoad` now returns a stop func that cancels **and joins** its timer goroutine before `Destroy`; `runLocalWebview` owns the reveal hook on all platforms; panel teardown runs hotkey/registry cleanup before the engine is freed; the first-run window joins all handshake goroutines and guards its two un-ctx-guardable `SetHtml` closures with a post-`Run()` flag.

## Account window (`35c864c`)

New tray entry opening the hosted account page (avatar, plan, devices, sign-out) in its own webview — remote content end-to-end, so it registers no bindings beyond the reveal hook; origin pinned to `app.usejarvis.dev` in release builds; local shell while the page loads.

## Monochrome Lab on every local page (`55266ca`)

All local pages (connect shell, token form, account shell, settings, logs) now share one brand source (`brand_css.go`): the token set ported value-for-value from the hosting dashboard's `tokens.css`, the Pebble as each screen's one living object mirroring machine state, dark following the OS. Settings/logs drop their forced-light inline token copies. Includes a guarded dump test (`JARVIS_PAGE_DUMP_DIR`) used to QA all seven page states in headless Chromium, light and dark.

## Testing

- `go build`, `go vet`, `go test` clean; pre-commit suite passes on every commit.
- Multiple independent review rounds per commit; all confirmed findings fixed.
- Tested end-to-end with a `-tags jarvisdebug` build against a live hosting stack: browser SSO round-trip, token delivery, retry/self-host paths, account window, all pages in both themes.