### PR TITLE
fix(sync): carry forward catalog entries on transient npm failures instead of removing them

### DIFF
--- a/.github/workflows/sync-pieces-catalog.yml
+++ b/.github/workflows/sync-pieces-catalog.yml
@@ -4,6 +4,9 @@
 #   1. `bun run scripts/sync-pieces-catalog.ts` -- walks the activepieces
 #      monorepo at the pinned SHA, queries npm for the latest version of
 #      every piece, and writes `src/workflows/pieces-library/catalog-generated.ts`.
+#      Transient npm failures (429/5xx) carry the previous entry forward
+#      instead of dropping the piece; if npm fails for >10% of pieces the
+#      script exits non-zero and this job fails without opening a PR.
 #      It also diffs against the committed catalog and emits two step outputs:
 #      `verdict` (safe | review) and `has_changes` (whether any entry moved).
 #   2. `bun test` and `tsc --noEmit` -- the catalog tests in
@@ -35,6 +38,11 @@ on:
 jobs:
   sync:
     runs-on: ubuntu-latest
+    # A healthy run finishes in a few minutes. The ceiling guards the
+    # pathological case where npm throttles every request with a long
+    # Retry-After: better to kill the job than burn hours of runner time
+    # (the >10% transient-failure abort usually fires long before this).
+    timeout-minutes: 30
     permissions:
       contents: write
       pull-requests: write

--- a/scripts/lib/catalog-diff.test.ts
+++ b/scripts/lib/catalog-diff.test.ts
@@ -165,6 +165,67 @@ describe("renderReport", () => {
     expect(markdown).toContain("MIT' injected");
   });
 
+  test("carried-forward pieces render the stale section and summary row", () => {
+    const a = [entry({ id: "gmail" }), entry({ id: "spotify", latestVersion: "0.4.4" })];
+    const { verdict, markdown } = renderReport(diffCatalogs(a, a, meta), {
+      ...reportOpts,
+      carriedForward: [{ id: "spotify", version: "0.4.4" }],
+    });
+    expect(markdown).toContain("| Carried forward (stale) | 1 |");
+    expect(markdown).toContain("### Stale entries (carried forward)");
+    expect(markdown).toContain("`spotify` -- kept at `0.4.4`");
+    // On an unchanged SHA a carried-forward entry produces no diff, so it
+    // must not flip the verdict on its own.
+    expect(verdict).toBe("safe");
+  });
+
+  test("a long carried-forward list collapses into a details block", () => {
+    const carried = Array.from({ length: 20 }, (_, i) => ({
+      id: `piece-${String(i).padStart(2, "0")}`,
+      version: "1.0.0",
+    }));
+    const a = carried.map((c) => entry({ id: c.id }));
+    const { markdown } = renderReport(diffCatalogs(a, a, meta), {
+      ...reportOpts,
+      carriedForward: carried,
+    });
+    expect(markdown).toContain("<details><summary>Show 20 carried-forward pieces</summary>");
+    expect(markdown).toContain("| Carried forward (stale) | 20 |");
+  });
+
+  test("a backtick in a carried-forward version can't break out of the code span", () => {
+    const a = [entry({ id: "gmail" })];
+    const { markdown } = renderReport(diffCatalogs(a, a, meta), {
+      ...reportOpts,
+      carriedForward: [{ id: "gmail", version: "1.0.0` injected" }],
+    });
+    expect(markdown).not.toContain("1.0.0` injected");
+    expect(markdown).toContain("1.0.0' injected");
+  });
+
+  test("carried-forward alone does not make the diff a change", () => {
+    const a = [entry({ id: "spotify" })];
+    expect(hasChanges(diffCatalogs(a, a, meta))).toBe(false);
+  });
+
+  test("no carriedForward option renders neither section nor summary row", () => {
+    const a = [entry({ id: "gmail" })];
+    const oldE = [entry({ id: "gmail", latestVersion: "0.9.0" })];
+    const { markdown } = renderReport(diffCatalogs(oldE, a, meta), reportOpts);
+    expect(markdown).not.toContain("Carried forward");
+    expect(markdown).not.toContain("Stale entries");
+  });
+
+  test("empty carriedForward list renders neither section nor summary row", () => {
+    const a = [entry({ id: "gmail" })];
+    const { markdown } = renderReport(diffCatalogs(a, a, meta), {
+      ...reportOpts,
+      carriedForward: [],
+    });
+    expect(markdown).not.toContain("Carried forward");
+    expect(markdown).not.toContain("Stale entries");
+  });
+
   test("no em dashes or fancy arrows leak into the body", () => {
     const oldE = [entry({ id: "gmail", latestVersion: "1.0.0", licenseSpdx: "MIT" })];
     const newE = [

--- a/scripts/lib/catalog-diff.ts
+++ b/scripts/lib/catalog-diff.ts
@@ -154,6 +154,17 @@ export interface ReportOptions {
   fileLabel: string;
   /** Resolve an id to its 1-based line in the generated file, or null. */
   lineOf: (id: string) => number | null;
+  /**
+   * Pieces whose npm lookup failed transiently this run, so the previously
+   * committed latestVersion was reused (metadata still comes from the pinned
+   * SHA, like every other entry). On a routine run -- SHA unchanged -- the
+   * whole entry is therefore identical to the previous catalog and produces
+   * no diff; on a SHA-bump run metadata changes surface in their own diff
+   * sections as usual. Carried-forward status itself never affects the
+   * verdict; the reviewer just needs to know these versions may lag npm
+   * until the next successful run.
+   */
+  carriedForward?: Array<{ id: string; version: string }>;
 }
 
 /** Collapse a list into a `<details>` block once it gets long. */
@@ -224,6 +235,10 @@ export function renderReport(
   p(`| Version bumps | ${diff.versionChanged.length} |`);
   p(`| License changes | ${diff.licenseChanged.length} |`);
   p(`| Other metadata | ${diff.otherChanged.length} |`);
+  const carried = opts.carriedForward ?? [];
+  if (carried.length > 0) {
+    p(`| Carried forward (stale) | ${carried.length} |`);
+  }
   p();
 
   if (diff.shaChanged) {
@@ -257,13 +272,41 @@ export function renderReport(
     p("### Removed pieces");
     p();
     p(
-      "A piece leaving the catalog means it was unpublished from npm (or the npm " +
-        "retry budget was exhausted during sync). Confirm this is intentional and " +
-        "not a transient failure:",
+      "A piece leaving the catalog means npm answered 404 for its latest release " +
+        "(unpublished upstream), or the piece left the monorepo at the pinned SHA " +
+        "(renamed or deleted -- a rename shows up as one removal plus one addition). " +
+        "Transient npm failures do NOT remove pieces; those are carried forward and " +
+        "listed separately. Confirm each removal is intentional:",
     );
     p();
     for (const e of diff.removed) {
       p(`- \`${e.id}\` -- was \`${e.npmPackage}\``);
+    }
+    p();
+  }
+
+  if (carried.length > 0) {
+    p("### Stale entries (carried forward)");
+    p();
+    p(
+      "npm could not be reached for these pieces during this run (rate limit or " +
+        "outage), so each kept its previously committed version instead of being " +
+        "removed; the next successful sync catches them up. Any metadata change " +
+        "from the pinned SHA still appears in the sections above. Listed for " +
+        "transparency -- staleness alone needs no action:",
+    );
+    p();
+    const rows = carried.map(
+      (c) => `- \`${codeSafe(c.id)}\` -- kept at \`${codeSafe(c.version)}\``,
+    );
+    if (rows.length > COLLAPSE_THRESHOLD) {
+      p(`<details><summary>Show ${rows.length} carried-forward pieces</summary>`);
+      p();
+      for (const r of rows) p(r);
+      p();
+      p("</details>");
+    } else {
+      for (const r of rows) p(r);
     }
     p();
   }

--- a/scripts/lib/npm-latest.test.ts
+++ b/scripts/lib/npm-latest.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, test } from "bun:test";
+import {
+  createNpmClient,
+  resolveVersion,
+  NPM_MAX_ATTEMPTS,
+  NPM_RETRY_AFTER_MAX_MS,
+  type NpmFetchResult,
+} from "./npm-latest";
+
+/**
+ * Fake clock: `sleep` advances time instantly and records every wait, so
+ * cooldown behavior is fully deterministic and the tests finish in ms.
+ */
+function fakeClock() {
+  let t = 0;
+  const sleeps: number[] = [];
+  return {
+    now: () => t,
+    sleep: (ms: number) => {
+      sleeps.push(ms);
+      t += ms;
+      return Promise.resolve();
+    },
+    sleeps,
+  };
+}
+
+function res(status: number, body = "{}", headers: Record<string, string> = {}): Response {
+  return new Response(body, { status, headers });
+}
+
+/** Build a client whose fetch pops responses (or throws Errors) off a queue. */
+function clientWith(queue: Array<Response | Error>) {
+  const clock = fakeClock();
+  const calls: string[] = [];
+  const client = createNpmClient({
+    fetch: ((url: string) => {
+      calls.push(url);
+      const next = queue.shift();
+      if (!next) throw new Error("fetch queue exhausted");
+      if (next instanceof Error) return Promise.reject(next);
+      return Promise.resolve(next);
+    }) as unknown as typeof fetch,
+    sleep: clock.sleep,
+    now: clock.now,
+    random: () => 0, // no jitter -- deterministic waits
+  });
+  return { client, calls, sleeps: clock.sleeps };
+}
+
+describe("fetchLatest", () => {
+  test("200 resolves ok with the version", async () => {
+    const { client, calls } = clientWith([res(200, JSON.stringify({ version: "1.2.3" }))]);
+    const r = await client.fetchLatest("@activepieces/piece-spotify");
+    expect(r).toEqual({ kind: "ok", version: "1.2.3" });
+    expect(calls).toEqual(["https://registry.npmjs.org/@activepieces/piece-spotify/latest"]);
+  });
+
+  test("404 resolves not-published without retrying", async () => {
+    const { client, calls } = clientWith([res(404)]);
+    const r = await client.fetchLatest("@activepieces/piece-unreleased");
+    expect(r).toEqual({ kind: "not-published" });
+    expect(calls).toHaveLength(1);
+  });
+
+  test("persistent 429 exhausts the budget and resolves transient (not not-published)", async () => {
+    const { client, calls } = clientWith(
+      Array.from({ length: NPM_MAX_ATTEMPTS }, () => res(429)),
+    );
+    const r = await client.fetchLatest("@activepieces/piece-spotify");
+    expect(r).toEqual({ kind: "transient", error: "HTTP 429" });
+    expect(calls).toHaveLength(NPM_MAX_ATTEMPTS);
+  });
+
+  test("429 then 200 recovers", async () => {
+    const { client } = clientWith([res(429), res(200, JSON.stringify({ version: "2.0.0" }))]);
+    const r = await client.fetchLatest("@activepieces/piece-slack");
+    expect(r).toEqual({ kind: "ok", version: "2.0.0" });
+  });
+
+  test("5xx then 200 recovers", async () => {
+    const { client } = clientWith([res(503), res(200, JSON.stringify({ version: "3.0.0" }))]);
+    const r = await client.fetchLatest("@activepieces/piece-github");
+    expect(r).toEqual({ kind: "ok", version: "3.0.0" });
+  });
+
+  test("network error then 200 recovers", async () => {
+    const { client } = clientWith([
+      new Error("connection reset"),
+      res(200, JSON.stringify({ version: "4.0.0" })),
+    ]);
+    const r = await client.fetchLatest("@activepieces/piece-gmail");
+    expect(r).toEqual({ kind: "ok", version: "4.0.0" });
+  });
+
+  test("429 Retry-After is honoured beyond the 10s generic cap", async () => {
+    const { client, sleeps } = clientWith([
+      res(429, "", { "retry-after": "45" }),
+      res(200, JSON.stringify({ version: "1.0.0" })),
+    ]);
+    await client.fetchLatest("@activepieces/piece-spotify");
+    expect(Math.max(...sleeps)).toBe(45_000);
+  });
+
+  test("429 Retry-After is capped at NPM_RETRY_AFTER_MAX_MS", async () => {
+    const { client, sleeps } = clientWith([
+      res(429, "", { "retry-after": "600" }),
+      res(200, JSON.stringify({ version: "1.0.0" })),
+    ]);
+    await client.fetchLatest("@activepieces/piece-spotify");
+    expect(Math.max(...sleeps)).toBe(NPM_RETRY_AFTER_MAX_MS);
+  });
+
+  test("a 429 pauses subsequent requests on the same client (fleet cooldown)", async () => {
+    const { client, sleeps } = clientWith([
+      res(429, "", { "retry-after": "30" }),
+      res(200, JSON.stringify({ version: "1.0.0" })),
+      // Second package: served instantly, but only after the cooldown passed.
+      res(200, JSON.stringify({ version: "2.0.0" })),
+    ]);
+    await client.fetchLatest("@activepieces/piece-a");
+    const sleepsBefore = sleeps.length;
+    const r = await client.fetchLatest("@activepieces/piece-b");
+    expect(r).toEqual({ kind: "ok", version: "2.0.0" });
+    // The first call's own retry sleep consumed the cooldown on the fake
+    // clock, so the second call must NOT have had to wait again...
+    expect(sleeps.length).toBe(sleepsBefore);
+  });
+
+  test("cooldown makes a later caller wait out the rate-limit window", async () => {
+    // Piece A's LAST attempt gets a 429 with a long Retry-After: the cooldown
+    // is extended but A itself never sleeps it off (no retries left). Piece B
+    // must then wait the full window before its first request.
+    const clock = fakeClock();
+    const queues = new Map<string, Array<Response>>([
+      [
+        "https://registry.npmjs.org/@activepieces/piece-a/latest",
+        [
+          ...Array.from({ length: NPM_MAX_ATTEMPTS - 1 }, () => res(429)),
+          res(429, "", { "retry-after": "30" }),
+        ],
+      ],
+      [
+        "https://registry.npmjs.org/@activepieces/piece-b/latest",
+        [res(200, JSON.stringify({ version: "9.9.9" }))],
+      ],
+    ]);
+    const requestTimes: Array<{ url: string; t: number }> = [];
+    const client = createNpmClient({
+      fetch: ((url: string) => {
+        requestTimes.push({ url, t: clock.now() });
+        return Promise.resolve(queues.get(url)!.shift()!);
+      }) as unknown as typeof fetch,
+      sleep: clock.sleep,
+      now: clock.now,
+      random: () => 0,
+    });
+
+    const a = await client.fetchLatest("@activepieces/piece-a");
+    expect(a.kind).toBe("transient");
+    const cooldownSetAt = clock.now();
+
+    const b = await client.fetchLatest("@activepieces/piece-b");
+    expect(b).toEqual({ kind: "ok", version: "9.9.9" });
+    const bRequest = requestTimes.find((r) => r.url.includes("piece-b"))!;
+    expect(bRequest.t).toBeGreaterThanOrEqual(cooldownSetAt + 30_000);
+  });
+});
+
+describe("resolveVersion", () => {
+  const transient: NpmFetchResult = { kind: "transient", error: "HTTP 429" };
+
+  test("ok uses the npm version", () => {
+    expect(resolveVersion({ kind: "ok", version: "1.2.3" }, "1.0.0")).toEqual({
+      action: "use",
+      version: "1.2.3",
+    });
+  });
+
+  test("404 skips as non-transient even when a previous entry exists", () => {
+    expect(resolveVersion({ kind: "not-published" }, "1.0.0")).toEqual({
+      action: "skip",
+      reason: "no npm release (404)",
+      transient: false,
+    });
+  });
+
+  // The PR #285 regression: a rate-limited run must carry the piece forward,
+  // never remove it.
+  test("transient failure with a previous entry carries the old version forward", () => {
+    expect(resolveVersion(transient, "0.4.4")).toEqual({
+      action: "carry-forward",
+      version: "0.4.4",
+    });
+  });
+
+  test("transient failure with no previous entry skips and is flagged transient", () => {
+    const r = resolveVersion(transient, null);
+    expect(r.action).toBe("skip");
+    if (r.action === "skip") {
+      expect(r.transient).toBe(true);
+      expect(r.reason).toContain("HTTP 429");
+    }
+  });
+});

--- a/scripts/lib/npm-latest.ts
+++ b/scripts/lib/npm-latest.ts
@@ -1,0 +1,181 @@
+/**
+ * npm "latest version" lookups for the pieces-catalog sync: retry with
+ * backoff, a fleet-wide 429 cooldown, and a tri-state result so callers can
+ * tell "not published" (deterministic 404) apart from "npm wouldn't answer"
+ * (transient). Extracted from `scripts/sync-pieces-catalog.ts` so the
+ * classification logic -- whose conflation of the two cases caused 64 false
+ * catalog removals in PR #285 -- stays unit-testable with an injected fetch.
+ */
+
+export type NpmFetchResult =
+  | { kind: "ok"; version: string }
+  /** Deterministic 404 -- the package has no published release. */
+  | { kind: "not-published" }
+  /** 429 / 5xx / network failure on every attempt. Says nothing about the package. */
+  | { kind: "transient"; error: string };
+
+/**
+ * How many times to attempt an npm registry GET before giving up. The sync
+ * fires ~650 unauthenticated GETs from a shared CI IP, so transient 429s /
+ * 5xx / connection resets are expected -- retrying absorbs them. A package
+ * whose retry budget is still exhausted resolves `transient`, never a skip.
+ */
+export const NPM_MAX_ATTEMPTS = 4;
+/** Base backoff in ms. Grows exponentially per attempt (500, 1000, 2000...). */
+export const NPM_BACKOFF_BASE_MS = 500;
+/** Cap on a single wait for non-429 failures (5xx, network). */
+export const NPM_BACKOFF_MAX_MS = 10_000;
+/**
+ * Higher Retry-After cap for 429s specifically. npm's rate-limit window is
+ * per-minute; a 10s cap made every retry land inside the same window (the
+ * root cause of the PR #285 false removals). Waiting the window out is cheap
+ * relative to a weekly batch job.
+ */
+export const NPM_RETRY_AFTER_MAX_MS = 60_000;
+/** Per-request timeout so one hung connection can't stall a whole batch. */
+export const NPM_FETCH_TIMEOUT_MS = 30_000;
+/**
+ * Max random extra wait after a fleet cooldown ends, so the workers don't
+ * all fire into the fresh rate-limit window on the same millisecond.
+ */
+const COOLDOWN_WAKE_JITTER_MS = 250;
+
+export interface NpmClientDeps {
+  /** HTTP implementation; injectable for tests. Defaults to global fetch. */
+  fetch?: typeof fetch;
+  /** Sleep implementation; injectable so tests can run on a fake clock. */
+  sleep?: (ms: number) => Promise<void>;
+  /** Clock; injectable so tests can run deterministically. */
+  now?: () => number;
+  /** Randomness source for jitter; injectable for determinism. */
+  random?: () => number;
+}
+
+export interface NpmClient {
+  fetchLatest(pkg: string): Promise<NpmFetchResult>;
+}
+
+/**
+ * Create a client whose 429 cooldown is shared across every `fetchLatest`
+ * call: when any request is rate-limited, ALL callers pause until the window
+ * passes -- otherwise concurrent workers keep burning their retry budgets
+ * inside the same rate-limit window and fail together.
+ */
+export function createNpmClient(deps: NpmClientDeps = {}): NpmClient {
+  const fetchImpl = deps.fetch ?? fetch;
+  const sleep = deps.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
+  const now = deps.now ?? Date.now;
+  const random = deps.random ?? Math.random;
+
+  /** Timestamp before which no request may be sent. Extended on every 429. */
+  let pauseUntil = 0;
+
+  async function awaitCooldown(): Promise<void> {
+    let waited = false;
+    for (let wait = pauseUntil - now(); wait > 0; wait = pauseUntil - now()) {
+      waited = true;
+      await sleep(wait);
+    }
+    // Stagger the wake-up so the fleet doesn't burst into the fresh window.
+    if (waited) await sleep(Math.floor(random() * COOLDOWN_WAKE_JITTER_MS));
+  }
+
+  function extendCooldown(ms: number): void {
+    pauseUntil = Math.max(pauseUntil, now() + ms);
+  }
+
+  function backoffMs(attempt: number): number {
+    const jitter = Math.floor(random() * NPM_BACKOFF_BASE_MS);
+    return NPM_BACKOFF_BASE_MS * 2 ** (attempt - 1) + jitter;
+  }
+
+  async function fetchLatest(pkg: string): Promise<NpmFetchResult> {
+    const url = `https://registry.npmjs.org/${pkg}/latest`;
+    let lastError = "";
+    for (let attempt = 1; attempt <= NPM_MAX_ATTEMPTS; attempt++) {
+      await awaitCooldown();
+      let waitMs = 0;
+      try {
+        const res = await fetchImpl(url, { signal: AbortSignal.timeout(NPM_FETCH_TIMEOUT_MS) });
+        // A genuine 404 means the package has no npm release -- deterministic,
+        // not worth retrying.
+        if (res.status === 404) return { kind: "not-published" };
+        if (res.ok) {
+          const info = (await res.json()) as { version: string };
+          return { kind: "ok", version: info.version };
+        }
+        // 429 (rate limit) / 5xx / anything else non-OK -- transient. Honour
+        // Retry-After when the server sends it, otherwise back off.
+        lastError = `HTTP ${res.status}`;
+        const serverDelayMs = retryAfterMs(res);
+        if (res.status === 429) {
+          // Rate limiting is a per-IP verdict, not a per-package one, so pause
+          // the whole fleet (even on the last attempt -- it helps the packages
+          // still in flight) and allow the longer Retry-After cap.
+          waitMs = Math.min(serverDelayMs ?? backoffMs(attempt), NPM_RETRY_AFTER_MAX_MS);
+          extendCooldown(waitMs);
+        } else {
+          waitMs = Math.min(serverDelayMs ?? backoffMs(attempt), NPM_BACKOFF_MAX_MS);
+        }
+      } catch (e) {
+        // Network-level failure (DNS, reset, timeout) -- transient.
+        lastError = (e as Error).message;
+        waitMs = Math.min(backoffMs(attempt), NPM_BACKOFF_MAX_MS);
+      }
+      if (attempt < NPM_MAX_ATTEMPTS) await sleep(waitMs);
+    }
+    // Exhausted retries. Soft-fail so one persistently unreachable package
+    // doesn't abort the whole sync; the caller decides what to do with it.
+    console.warn(
+      `[warn] npm fetch failed for ${pkg} after ${NPM_MAX_ATTEMPTS} attempts: ${lastError}`,
+    );
+    return { kind: "transient", error: lastError };
+  }
+
+  return { fetchLatest };
+}
+
+/**
+ * Parse a `Retry-After` header (RFC 7231: delay-seconds form only -- npm
+ * sends integer seconds). Returns ms, or null when absent/unparseable.
+ */
+function retryAfterMs(res: Response): number | null {
+  const raw = res.headers.get("retry-after");
+  if (!raw) return null;
+  const secs = Number(raw.trim());
+  return Number.isFinite(secs) && secs >= 0 ? secs * 1000 : null;
+}
+
+export type VersionResolution =
+  /** npm answered: use its latest version. */
+  | { action: "use"; version: string }
+  /** npm unreachable but the piece shipped before: keep the previous version. */
+  | { action: "carry-forward"; version: string }
+  /** Drop the piece this run. `transient: false` means a real 404. */
+  | { action: "skip"; reason: string; transient: boolean };
+
+/**
+ * Decide what a piece's catalog entry should do given the npm lookup outcome
+ * and the version the previously committed catalog knew (null when the piece
+ * is new). The invariant this encodes -- and the regression PR #285 exposed:
+ * a transient npm failure must NEVER remove an already-shipped piece.
+ */
+export function resolveVersion(
+  result: NpmFetchResult,
+  previousVersion: string | null,
+): VersionResolution {
+  switch (result.kind) {
+    case "ok":
+      return { action: "use", version: result.version };
+    case "not-published":
+      return { action: "skip", reason: "no npm release (404)", transient: false };
+    case "transient":
+      return previousVersion !== null
+        ? { action: "carry-forward", version: previousVersion }
+        : {
+            action: "skip",
+            reason: `npm unreachable (${result.error}) and no previous entry to carry forward`,
+            transient: true,
+          };
+  }
+}

--- a/scripts/sync-pieces-catalog.ts
+++ b/scripts/sync-pieces-catalog.ts
@@ -17,7 +17,15 @@
  *   2. List every directory under packages/pieces/community/.
  *   3. For each piece, read its package.json (name, description, license).
  *   4. Query the npm registry for the latest published version.
- *      Pieces with no npm release are skipped (still in development).
+ *      Pieces npm answers 404 for are skipped (still in development, or
+ *      genuinely unpublished). Transient failures (429 / 5xx / network) that
+ *      survive the retry budget do NOT drop the piece: its previously
+ *      committed latestVersion is carried forward (metadata still comes from
+ *      the pinned SHA), so a rate-limited CI run can never masquerade as a
+ *      mass unpublish. If more than MAX_TRANSIENT_FRACTION of pieces fail
+ *      transiently the whole run aborts instead of shipping a mostly-stale
+ *      catalog. Retry / cooldown / classification logic lives in
+ *      scripts/lib/npm-latest.ts (unit-tested).
  *   5. Build a sorted entry list and write catalog-generated.ts.
  *   6. With --report <path> (or env CATALOG_REPORT_PATH): diff against the
  *      previously-committed catalog and write a markdown PR body that calls out
@@ -56,6 +64,7 @@ import {
   hasChanges,
   type GeneratedEntryLike,
 } from "./lib/catalog-diff";
+import { createNpmClient, resolveVersion } from "./lib/npm-latest";
 
 /**
  * Activepieces commit walked when generating the list. Keep this in sync
@@ -70,10 +79,6 @@ const PINNED_SHA = "d04e6807c485ecd788a72af0d04abffba78563c7";
 const REPO_URL = "https://github.com/activepieces/activepieces.git";
 const WORK_DIR = join(tmpdir(), `jarvis-pieces-sync-${PINNED_SHA.slice(0, 12)}`);
 const OUT_FILE = resolve(import.meta.dir, "../src/workflows/pieces-library/catalog-generated.ts");
-
-interface NpmInfo {
-  version: string;
-}
 
 interface PieceMetadata {
   id: string;
@@ -94,6 +99,12 @@ async function main(): Promise<void> {
   info(`Mode:       ${checkOnly ? "check-only (no write)" : "write"}`);
   if (reportPath) info(`PR report:  ${reportPath}`);
 
+  // Previous generation, loaded before anything can overwrite the file. Used
+  // both to carry entries forward across transient npm failures and (with
+  // --report) to diff for the PR body.
+  const previous = await readPreviousGeneration();
+  const previousById = new Map((previous?.entries ?? []).map((e) => [e.id, e]));
+
   // 1. Sparse-clone packages/pieces/community.
   ensureWorkdir();
   sparseClone(verbose);
@@ -110,16 +121,38 @@ async function main(): Promise<void> {
 
   // 3+4. Read package.json + cross-check npm in parallel.
   const found: PieceMetadata[] = [];
+  const carriedForward: Array<{ id: string; version: string }> = [];
   const skipped: Array<{ id: string; reason: string }> = [];
+  let transientFailures = 0;
   const npmConcurrency = 8;
   for (let i = 0; i < pieceDirs.length; i += npmConcurrency) {
     const batch = pieceDirs.slice(i, i + npmConcurrency);
     const results = await Promise.all(
-      batch.map((dir) => extractPiece(dir, verbose)),
+      batch.map((dir) => extractPiece(dir, verbose, previousById)),
     );
     for (const r of results) {
-      if (r.kind === "ok") found.push(r.entry);
-      else skipped.push({ id: r.id, reason: r.reason });
+      if (r.kind === "ok") {
+        found.push(r.entry);
+      } else if (r.kind === "carried-forward") {
+        found.push(r.entry);
+        carriedForward.push({ id: r.entry.id, version: r.entry.latestVersion });
+        transientFailures++;
+      } else {
+        skipped.push({ id: r.id, reason: r.reason });
+        if (r.transient) transientFailures++;
+      }
+    }
+    // If npm fails transiently for a large slice of the catalog the registry
+    // is down or hard-throttling us. Carrying that many entries forward would
+    // ship a mostly-stale catalog while looking like a routine refresh --
+    // abort (checked per batch so a dead registry fails in minutes, not after
+    // grinding through every remaining retry) and let the next scheduled run
+    // try again instead.
+    if (transientFailures > pieceDirs.length * MAX_TRANSIENT_FRACTION) {
+      fatal(
+        `npm failed transiently for ${transientFailures} of ${pieceDirs.length} pieces ` +
+          `(> ${MAX_TRANSIENT_FRACTION * 100}%) -- registry down or rate-limited, aborting`,
+      );
     }
   }
 
@@ -127,17 +160,18 @@ async function main(): Promise<void> {
   found.sort((a, b) => a.id.localeCompare(b.id));
 
   info(`Pieces resolved on npm: ${found.length}`);
+  if (carriedForward.length > 0) {
+    info(`  of which carried forward on transient npm failure: ${carriedForward.length}`);
+  }
   info(`Pieces skipped:         ${skipped.length}`);
   if (verbose && skipped.length > 0) {
     for (const s of skipped) console.log(`  - ${s.id}: ${s.reason}`);
   }
 
-  // 5. Render + (optionally) analyse the diff for the auto-PR body. Read the
-  // previous generation BEFORE the file is overwritten below.
+  // 5. Render + (optionally) analyse the diff for the auto-PR body.
   const rendered = renderCatalogFile(found);
   if (reportPath) {
-    const previous = await readPreviousGeneration();
-    await writePrReport(reportPath, previous, found, rendered);
+    await writePrReport(reportPath, previous, found, rendered, carriedForward);
   }
 
   if (checkOnly) {
@@ -182,9 +216,15 @@ function sparseClone(verbose: boolean): void {
 
 type ExtractResult =
   | { kind: "ok"; entry: PieceMetadata }
-  | { kind: "skip"; id: string; reason: string };
+  /** npm was unreachable; the previously committed latestVersion is reused. */
+  | { kind: "carried-forward"; entry: PieceMetadata }
+  | { kind: "skip"; id: string; reason: string; transient?: boolean };
 
-async function extractPiece(dir: string, verbose: boolean): Promise<ExtractResult> {
+async function extractPiece(
+  dir: string,
+  verbose: boolean,
+  previousById: Map<string, GeneratedEntryLike>,
+): Promise<ExtractResult> {
   const dirName = dir.split("/").pop()!;
   const pkgPath = join(dir, "package.json");
   if (!existsSync(pkgPath)) {
@@ -209,93 +249,55 @@ async function extractPiece(dir: string, verbose: boolean): Promise<ExtractResul
   if (!/^[a-z][a-z0-9-]*$/.test(id)) {
     return { kind: "skip", id, reason: "id fails [a-z][a-z0-9-]* regex" };
   }
-  // Cross-check npm. Pieces in the monorepo but not on npm are still
-  // under development and we don't want to ship a catalog entry that
-  // would 404 on install.
-  const latest = await fetchNpmLatest(pkg.name);
-  if (!latest) {
-    return { kind: "skip", id, reason: "no npm release" };
-  }
   const license = typeof pkg.license === "string"
     ? pkg.license
     : (pkg.license?.type ?? "");
   // Some pieces don't set `displayName`; fall back to a capitalised id.
   const displayName = pkg.displayName ?? humanise(id);
-  if (verbose) console.log(`  ✓ ${id} (${latest.version})`);
-  return {
-    kind: "ok",
-    entry: {
-      id,
-      npmPackage: pkg.name,
-      displayName,
-      description: pkg.description ?? "",
-      licenseSpdx: license,
-      latestVersion: latest.version,
-    },
-  };
-}
+  const meta = (latestVersion: string): PieceMetadata => ({
+    id,
+    npmPackage: pkg.name!,
+    displayName,
+    description: pkg.description ?? "",
+    licenseSpdx: license,
+    latestVersion,
+  });
 
-/**
- * How many times to attempt an npm registry GET before giving up. The sync
- * fires ~300 unauthenticated GETs from a shared CI IP, so transient 429s /
- * 5xx / connection resets are expected -- retrying absorbs them instead of
- * silently dropping a piece (which trips the "every VERIFIED id materializes"
- * catalog invariant when the dropped piece happens to be verified).
- */
-const NPM_MAX_ATTEMPTS = 4;
-/** Base backoff in ms. Grows exponentially per attempt (500, 1000, 2000...). */
-const NPM_BACKOFF_BASE_MS = 500;
-/** Cap on a single backoff wait so a large Retry-After can't stall the run. */
-const NPM_BACKOFF_MAX_MS = 10_000;
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-/**
- * Parse a `Retry-After` header (RFC 7231: delay-seconds form only -- npm
- * sends integer seconds). Returns ms, or null when absent/unparseable.
- */
-function retryAfterMs(res: Response): number | null {
-  const raw = res.headers.get("retry-after");
-  if (!raw) return null;
-  const secs = Number(raw.trim());
-  return Number.isFinite(secs) && secs >= 0 ? secs * 1000 : null;
-}
-
-async function fetchNpmLatest(pkg: string): Promise<NpmInfo | null> {
-  const url = `https://registry.npmjs.org/${pkg}/latest`;
-  let lastError = "";
-  for (let attempt = 1; attempt <= NPM_MAX_ATTEMPTS; attempt++) {
-    let serverDelayMs: number | null = null;
-    try {
-      const res = await fetch(url);
-      // A genuine 404 means the piece has no npm release -- deterministic,
-      // not worth retrying. Skip it.
-      if (res.status === 404) return null;
-      if (res.ok) return (await res.json()) as NpmInfo;
-      // 429 (rate limit) / 5xx / anything else non-OK -- transient. Honour
-      // Retry-After when the server sends it, otherwise back off.
-      lastError = `HTTP ${res.status}`;
-      serverDelayMs = retryAfterMs(res);
-    } catch (e) {
-      // Network-level failure (DNS, reset, timeout) -- transient.
-      lastError = (e as Error).message;
-    }
-    if (attempt < NPM_MAX_ATTEMPTS) {
-      const backoff = NPM_BACKOFF_BASE_MS * 2 ** (attempt - 1);
-      const jitter = Math.floor(Math.random() * NPM_BACKOFF_BASE_MS);
-      const waitMs = Math.min(serverDelayMs ?? backoff + jitter, NPM_BACKOFF_MAX_MS);
-      await sleep(waitMs);
-    }
+  // Cross-check npm. Pieces in the monorepo but not on npm are still
+  // under development and we don't want to ship a catalog entry that
+  // would 404 on install.
+  const latest = await npm.fetchLatest(pkg.name);
+  const resolution = resolveVersion(latest, previousById.get(id)?.latestVersion ?? null);
+  switch (resolution.action) {
+    case "use":
+      if (verbose) console.log(`  ✓ ${id} (${resolution.version})`);
+      return { kind: "ok", entry: meta(resolution.version) };
+    case "carry-forward":
+      // npm wouldn't answer. That says nothing about the piece itself, so keep
+      // the version the last successful sync knew; it catches up next run.
+      console.warn(
+        `[warn] carrying forward ${id} at ${resolution.version} (npm unreachable: ${
+          latest.kind === "transient" ? latest.error : "unknown"
+        })`,
+      );
+      return { kind: "carried-forward", entry: meta(resolution.version) };
+    case "skip":
+      return { kind: "skip", id, reason: resolution.reason, transient: resolution.transient };
   }
-  // Exhausted retries. Soft-fail so one persistently broken package doesn't
-  // abort the whole sync; the piece is skipped this run and picked up next.
-  console.warn(
-    `[warn] npm fetch failed for ${pkg} after ${NPM_MAX_ATTEMPTS} attempts: ${lastError}`,
-  );
-  return null;
 }
+
+/**
+ * Abort the run when more than this fraction of pieces fail transiently --
+ * at that point the registry is down (or throttling so hard the results are
+ * meaningless) and a catalog refresh would be mostly carried-forward noise.
+ */
+const MAX_TRANSIENT_FRACTION = 0.1;
+
+/**
+ * Shared npm client: retry with backoff, fleet-wide 429 cooldown, tri-state
+ * result. Lives in scripts/lib/npm-latest.ts so it stays unit-tested.
+ */
+const npm = createNpmClient();
 
 function humanise(id: string): string {
   return id
@@ -447,6 +449,7 @@ async function writePrReport(
   previous: PreviousGeneration | null,
   found: PieceMetadata[],
   rendered: string,
+  carriedForward: Array<{ id: string; version: string }>,
 ): Promise<void> {
   const diff = diffCatalogs(previous?.entries ?? [], toGeneratedEntries(found), {
     oldSha: previous?.sha ?? "",
@@ -458,6 +461,7 @@ async function writePrReport(
     generatedAt: new Date().toISOString().slice(0, 10),
     fileLabel: "src/workflows/pieces-library/catalog-generated.ts",
     lineOf: (id) => lineIndex.get(id) ?? null,
+    carriedForward,
   });
 
   mkdirSync(dirname(reportPath), { recursive: true });


### PR DESCRIPTION
## Why

Auto-PR #285 proposed removing 64 pieces from the catalog — including `spotify`, `shopify`, `whatsapp`, `twitter`, `figma`. None of them were actually unpublished: the CI run was rate-limited by the npm registry (the run logs show `HTTP 429` for exactly those 64 packages), the 4-attempt retry budget was exhausted, and `fetchNpmLatest` returned the same `null` for "exhausted retries" as for a genuine 404 — so the sync silently dropped live pieces. Two design flaws made this near-inevitable:

- the backoff was capped at 10s while npm's rate-limit window is per-minute, so every retry landed inside the same throttled window;
- 8 concurrent workers each burned their own retry budget independently once throttling started.

PR #285 has been closed. This PR makes that failure mode impossible.

## What changed

1. **Tri-state npm lookup** (`scripts/lib/npm-latest.ts`, extracted from the sync script so it is unit-testable with an injected fetch): `ok` / `not-published` (deterministic 404) / `transient` (429/5xx/network after all retries). The two failure kinds can no longer be conflated.
2. **Fleet-wide 429 cooldown**: any rate-limited response pauses *all* workers until the window passes, honoring `Retry-After` up to 60s for 429s (other failures keep the 10s cap), with wake-up jitter so the fleet doesn't burst into the fresh window. Requests also get a 30s `AbortSignal.timeout` so a hung connection can't stall a batch.
3. **Carry-forward instead of removal**: a piece whose npm lookup fails transiently keeps its previously committed `latestVersion` (metadata still comes from the pinned SHA). A transient failure can never remove an already-shipped piece — only a real 404 (or the piece leaving the monorepo at a SHA bump) can. New pieces with no previous entry are still skipped until npm answers.
4. **Fail-safe threshold**: if transient failures exceed 10% of pieces, the run aborts (checked per batch, so a dead registry fails in minutes) — the workflow fails and no PR opens, instead of shipping a mostly-stale catalog. The job also got `timeout-minutes: 30`.
5. **Reviewer-facing report**: the auto-PR body now shows a "Stale entries (carried forward)" section plus a summary-table row, and the removed-pieces wording explains that removals now mean real unpublishes or upstream renames/deletions — never transient failures. Carried-forward entries don't flip the verdict (on an unchanged SHA they produce no diff at all).

## Tests

- `scripts/lib/npm-latest.test.ts` (new): retry classification (404 vs exhausted 429), recovery paths, `Retry-After` honored to 45s / capped at 60s, fleet-cooldown behavior on a deterministic fake clock, and the direct regression test: *transient failure + existing entry → carry-forward, never removal*.
- `scripts/lib/catalog-diff.test.ts`: stale section + summary row rendering, collapse path, backtick injection, verdict neutrality, no-op when the list is empty/absent.
- `tsc --noEmit`, `check-no-ee-imports`, and the full catalog test suite pass; a real end-to-end sync run resolved 656/656 pieces with verdict "safe" and zero skips.
