### PR TITLE
ci(sync): auto-run tests on the weekly catalog PR

### DIFF
--- a/.github/workflows/sync-pieces-catalog.yml
+++ b/.github/workflows/sync-pieces-catalog.yml
@@ -46,6 +46,8 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      # Needed by the "Trigger tests" step to dispatch test.yml on the PR branch.
+      actions: write
     steps:
       - uses: actions/checkout@v5
 
@@ -95,3 +97,17 @@ jobs:
             pieces-catalog
             dependencies
           delete-branch: true
+
+      # PRs authored by github-actions[bot] with GITHUB_TOKEN don't get their
+      # `pull_request` CI started automatically -- the runs sit "awaiting
+      # approval" until a maintainer clicks through. GitHub's suppression rule
+      # explicitly exempts workflow_dispatch, so kick the test workflow at the
+      # PR branch ourselves; its check runs attach to the same head commit and
+      # show up on the PR. (Alternative if this ever breaks: create the PR with
+      # a fine-grained PAT via the `token:` input above, which makes CI trigger
+      # natively.)
+      - name: Trigger tests on the PR branch
+        if: steps.sync.outputs.has_changes == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run test.yml --ref chore/sync-pieces-catalog -R "$GITHUB_REPOSITORY"


### PR DESCRIPTION
## Why

When the weekly catalog sync opens its auto-PR, the `Tests` workflow runs are created but sit **"awaiting approval"** until a maintainer clicks through — the PR is authored by `github-actions[bot]` with the workflow's own `GITHUB_TOKEN`, which has no write access, so GitHub holds its `pull_request` runs (this happened on #288).

## What

GitHub's event-suppression rule for `GITHUB_TOKEN` explicitly exempts `workflow_dispatch`, and `test.yml` already declares that trigger. So after creating/updating the PR, the sync job now dispatches `test.yml` at `chore/sync-pieces-catalog` directly. The check runs (`test`, `sidecar-build`, `ocr-helper`) attach to the same head commit and appear on the PR with no manual approval. Adds `actions: write` to the job permissions for the dispatch.

No secrets or repo-settings changes needed. If we ever want the native trigger instead (and no approval banner at all), the alternative is a fine-grained PAT in the `token:` input of create-pull-request — noted in a comment.
