### PR TITLE
perf: cut brain RSS — lazy channel imports, bounded agent history, sidecar queue caps + disk spool, engine --smol

### DIFF
--- a/src/agents/agent-history.test.ts
+++ b/src/agents/agent-history.test.ts
@@ -1,0 +1,53 @@
+import { describe, test, expect } from 'bun:test';
+import { AgentInstance } from './agent.ts';
+import type { RoleDefinition } from '../roles/types.ts';
+import type { ContentBlock } from '../llm/provider.ts';
+
+const role: RoleDefinition = {
+  name: 'test-role',
+  description: 'test',
+  authority_level: 1,
+  tools: [],
+  system_prompt: 'test',
+} as unknown as RoleDefinition;
+
+describe('AgentInstance message history bounds', () => {
+  test('history stays within the retention budget instead of growing forever', () => {
+    const agent = new AgentInstance(role);
+    // ~500 tokens per message (2000 chars / 4) → 200k-token budget caps out
+    // around 400 messages; push far past that.
+    const filler = 'x'.repeat(2000);
+    for (let i = 0; i < 2000; i++) {
+      agent.addMessage(i % 2 === 0 ? 'user' : 'assistant', `${i}:${filler}`);
+    }
+    const messages = agent.getMessages();
+    expect(messages.length).toBeLessThan(600);
+    // Newest message is always retained
+    const last = messages[messages.length - 1]!;
+    expect(typeof last.content === 'string' && last.content.startsWith('1999:')).toBe(true);
+  });
+
+  test('image payloads are released once the turn completes', () => {
+    const agent = new AgentInstance(role);
+    const blocks: ContentBlock[] = [
+      { type: 'text', text: 'help with this' },
+      { type: 'image', source: { type: 'base64', media_type: 'image/png', data: 'A'.repeat(100_000) } },
+    ];
+    agent.addMessage('user', blocks);
+
+    // Mid-turn: the image is still there for the in-flight request
+    const midTurn = agent.getMessages();
+    expect((midTurn[0]!.content as ContentBlock[]).some((b) => b.type === 'image')).toBe(true);
+
+    agent.addMessage('assistant', 'done');
+
+    const after = agent.getMessages();
+    const userContent = after[0]!.content as ContentBlock[];
+    expect(userContent.some((b) => b.type === 'image')).toBe(false);
+    expect(userContent.some((b) => b.type === 'text' && b.text.includes('screenshot'))).toBe(true);
+    // The text block from the same message survives
+    expect(userContent.some((b) => b.type === 'text' && b.text === 'help with this')).toBe(true);
+    // In-flight references still hold the original, untouched message object
+    expect((midTurn[0]!.content as ContentBlock[]).some((b) => b.type === 'image')).toBe(true);
+  });
+});

--- a/src/agents/agent.ts
+++ b/src/agents/agent.ts
@@ -1,6 +1,6 @@
 import type { RoleDefinition } from '../roles/types.ts';
 import type { LLMMessage } from '../llm/provider.ts';
-import { compactHistory } from '../llm/history.ts';
+import { compactHistory, measureMessage } from '../llm/history.ts';
 
 /**
  * In-memory retention budget for an agent's message history, in estimated
@@ -11,6 +11,13 @@ import { compactHistory } from '../llm/history.ts';
  * growing without limit.
  */
 const HISTORY_RETENTION_TOKENS = 200_000;
+
+/**
+ * Compaction only runs once the running estimate exceeds this multiple of
+ * the budget, and trims back to the budget. Amortizes the O(history)
+ * compaction pass instead of paying it on every append.
+ */
+const HISTORY_COMPACT_TRIGGER = 1.1;
 
 export type AgentStatus = 'active' | 'idle' | 'terminated';
 
@@ -84,6 +91,8 @@ function mergeAuthority(
 export class AgentInstance {
   public readonly agent: Agent;
   private messageHistory: LLMMessage[];
+  /** Running measureMessage total; recomputed after each compaction. */
+  private historyTokenEstimate = 0;
 
   constructor(
     role: RoleDefinition,
@@ -135,8 +144,13 @@ export class AgentInstance {
       // request may still hold a reference to the original message object.
       this.releaseImagePayloads();
     }
-    this.messageHistory.push({ role, content });
-    this.messageHistory = compactHistory(this.messageHistory, HISTORY_RETENTION_TOKENS);
+    const message: LLMMessage = { role, content };
+    this.messageHistory.push(message);
+    this.historyTokenEstimate += measureMessage(message);
+    if (this.historyTokenEstimate > HISTORY_RETENTION_TOKENS * HISTORY_COMPACT_TRIGGER) {
+      this.messageHistory = compactHistory(this.messageHistory, HISTORY_RETENTION_TOKENS);
+      this.historyTokenEstimate = this.messageHistory.reduce((sum, m) => sum + measureMessage(m), 0);
+    }
   }
 
   private releaseImagePayloads(): void {

--- a/src/agents/agent.ts
+++ b/src/agents/agent.ts
@@ -1,5 +1,16 @@
 import type { RoleDefinition } from '../roles/types.ts';
 import type { LLMMessage } from '../llm/provider.ts';
+import { compactHistory } from '../llm/history.ts';
+
+/**
+ * In-memory retention budget for an agent's message history, in estimated
+ * tokens. Matches the largest request-time compaction budget (Anthropic,
+ * 200k context) so this bound never drops context a provider could still
+ * send — request-time compactHistory stays the binding constraint for what
+ * goes on the wire; this one only stops the daemon-lifetime array from
+ * growing without limit.
+ */
+const HISTORY_RETENTION_TOKENS = 200_000;
 
 export type AgentStatus = 'active' | 'idle' | 'terminated';
 
@@ -117,7 +128,31 @@ export class AgentInstance {
   }
 
   addMessage(role: 'user' | 'assistant' | 'system', content: string | import('../llm/provider.ts').ContentBlock[]): void {
+    if (role === 'assistant') {
+      // An assistant message closes the turn: any image the LLM needed this
+      // turn has been sent, so stop pinning its base64 payload (up to 5MB
+      // each) in the heap. Entries are replaced, not mutated — an in-flight
+      // request may still hold a reference to the original message object.
+      this.releaseImagePayloads();
+    }
     this.messageHistory.push({ role, content });
+    this.messageHistory = compactHistory(this.messageHistory, HISTORY_RETENTION_TOKENS);
+  }
+
+  private releaseImagePayloads(): void {
+    for (let i = 0; i < this.messageHistory.length; i++) {
+      const entry = this.messageHistory[i]!;
+      if (typeof entry.content === 'string') continue;
+      if (!entry.content.some((b) => b.type === 'image')) continue;
+      this.messageHistory[i] = {
+        ...entry,
+        content: entry.content.map((b) =>
+          b.type === 'image'
+            ? { type: 'text' as const, text: '[screenshot from an earlier turn — no longer available]' }
+            : b
+        ),
+      };
+    }
   }
 
   getMessages(): LLMMessage[] {

--- a/src/awareness/struggle-detector.ts
+++ b/src/awareness/struggle-detector.ts
@@ -35,9 +35,15 @@ export type StruggleAnalysis = {
 type Snapshot = {
   timestamp: number;
   ocrHash: string;
-  ocrText: string;
   appName: string;
   outputHash: string; // hash of bottom 500 chars (terminal/compiler output area)
+  /**
+   * Edit distance to the immediately preceding capture, computed at push
+   * time. Stored so raw OCR text (easily tens of KB per capture) doesn't
+   * have to stay resident for the low-progress signal — only the newest
+   * capture's text is kept, in `lastOcrText`.
+   */
+  distFromPrev: number;
 };
 
 // ── Constants ──
@@ -67,6 +73,8 @@ const PUZZLE_INDICATORS = /\b(score|level|moves|timer|puzzle|sudoku|wordle|cross
 
 export class StruggleDetector {
   private snapshots: Snapshot[] = [];
+  /** Raw OCR text of the newest capture only — see Snapshot.distFromPrev. */
+  private lastOcrText: string | null = null;
   private lastStruggleEmitAt = 0;
   private struggleStartedAt: number | null = null;
   private graceMs: number;
@@ -85,7 +93,9 @@ export class StruggleDetector {
     const ocrHash = simpleHash(ocrText);
     const outputHash = simpleHash(ocrText.slice(-500));
 
-    this.snapshots.push({ timestamp, ocrHash, ocrText, appName, outputHash });
+    const distFromPrev = this.lastOcrText !== null ? cheapEditDistance(this.lastOcrText, ocrText) : 0;
+    this.snapshots.push({ timestamp, ocrHash, appName, outputHash, distFromPrev });
+    this.lastOcrText = ocrText;
 
     // Evict old entries
     const cutoff = timestamp - WINDOW_MS;
@@ -183,6 +193,7 @@ export class StruggleDetector {
    */
   reset(): void {
     this.snapshots = [];
+    this.lastOcrText = null;
     this.struggleStartedAt = null;
   }
 
@@ -285,12 +296,10 @@ export class StruggleDetector {
     let totalDist = 0;
     let comparisons = 0;
 
+    // Starting at 1 skips snapshots[0].distFromPrev, whose counterpart
+    // capture has been evicted — same pairs the old full-text diff compared.
     for (let i = 1; i < this.snapshots.length; i++) {
-      const dist = cheapEditDistance(
-        this.snapshots[i - 1]!.ocrText,
-        this.snapshots[i]!.ocrText
-      );
-      totalDist += dist;
+      totalDist += this.snapshots[i]!.distFromPrev;
       comparisons++;
     }
 

--- a/src/comms/index.ts
+++ b/src/comms/index.ts
@@ -25,7 +25,9 @@ export {
   type ChannelAdapter,
 } from './channels/telegram.ts';
 export { WhatsAppAdapter } from './channels/whatsapp.ts';
-export { DiscordAdapter } from './channels/discord.ts';
+// DiscordAdapter is deliberately NOT re-exported here: discord.js costs
+// ~38MB RSS at import time. Import it lazily from './channels/discord.ts'
+// only when the Discord channel is enabled.
 export { SignalAdapter } from './channels/signal.ts';
 
 // Channel Manager

--- a/src/comms/voice.ts
+++ b/src/comms/voice.ts
@@ -1,5 +1,4 @@
 import type { STTConfig, TTSConfig } from '../config/types.ts';
-import { Communicate } from 'edge-tts-universal';
 
 export interface STTProvider {
   transcribe(audio: Buffer): Promise<string>;
@@ -236,6 +235,9 @@ export class EdgeTTSProvider implements TTSProvider {
   }
 
   async synthesize(text: string): Promise<Buffer> {
+    // Lazy-loaded: edge-tts-universal costs ~27MB RSS, only pay it when
+    // Edge TTS is actually used, not on daemon boot.
+    const { Communicate } = await import('edge-tts-universal');
     const comm = new Communicate(text, {
       voice: this.voice,
       rate: this.rate,

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -183,7 +183,10 @@ export type WorkflowConfig = {
   /**
    * How long an idle warm engine subprocess stays parked before being
    * killed, in ms. The parked engine holds ~100MB RSS; hosts that prefer
-   * RAM over the respawn cost can lower this. Default 5 minutes.
+   * RAM over the respawn cost can lower this. Default 5 minutes. Must be
+   * positive — non-positive values are ignored with a warning. The
+   * JARVIS_ENGINE_IDLE_TTL_MS env var overrides this setting (workflows is
+   * a user-owned section, so fleet operators tune via env instead).
    */
   engineIdleTtlMs?: number;
 };

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -180,6 +180,12 @@ export type WorkflowConfig = {
   defaultTimeoutMs: number;
   selfHealEnabled: boolean;
   autoSuggestEnabled: boolean;
+  /**
+   * How long an idle warm engine subprocess stays parked before being
+   * killed, in ms. The parked engine holds ~100MB RSS; hosts that prefer
+   * RAM over the respawn cost can lower this. Default 5 minutes.
+   */
+  engineIdleTtlMs?: number;
 };
 
 export type GoalConfig = {

--- a/src/daemon/channel-service.ts
+++ b/src/daemon/channel-service.ts
@@ -15,7 +15,6 @@ import type { STTProvider } from '../comms/voice.ts';
 
 import { ChannelManager } from '../comms/index.ts';
 import { TelegramAdapter } from '../comms/channels/telegram.ts';
-import { DiscordAdapter } from '../comms/channels/discord.ts';
 import { createSTTProvider } from '../comms/voice.ts';
 import { getOrCreateConversation, addMessage } from '../vault/conversations.ts';
 import { getSettingsByPrefix, setSetting } from '../vault/settings.ts';
@@ -101,6 +100,9 @@ export class ChannelService implements Service {
       }
 
       if (channels?.discord?.enabled && channels.discord.bot_token) {
+        // Lazy-loaded: discord.js costs ~38MB RSS, only pay it when the
+        // Discord channel is actually enabled.
+        const { DiscordAdapter } = await import('../comms/channels/discord.ts');
         const discord = new DiscordAdapter(channels.discord.bot_token, {
           sttProvider: this.sttProvider ?? undefined,
           allowedUsers: channels.discord.allowed_users,

--- a/src/daemon/config-merge.test.ts
+++ b/src/daemon/config-merge.test.ts
@@ -1,5 +1,5 @@
 import { test, expect, describe } from 'bun:test';
-import { mergeSTTConfig, mergeTTSConfig, mergeVoiceConfig, validateVoicePatch } from './config-merge.ts';
+import { mergeSTTConfig, mergeTTSConfig, mergeVoiceConfig, validateVoicePatch, resolveEngineIdleTtlMs } from './config-merge.ts';
 import type { STTConfig, TTSConfig, VoiceConfig } from '../config/types.ts';
 
 describe('mergeSTTConfig', () => {
@@ -227,5 +227,29 @@ describe('validateVoicePatch', () => {
   test('rejects wrong-typed enabled / realtime', () => {
     expect(validateVoicePatch({ realtime: { enabled: 'yes' } }).ok).toBe(false);
     expect(validateVoicePatch({ realtime: 'nope' }).ok).toBe(false);
+  });
+});
+
+describe('resolveEngineIdleTtlMs', () => {
+  test('env var wins over configured value', () => {
+    expect(resolveEngineIdleTtlMs(60_000, { JARVIS_ENGINE_IDLE_TTL_MS: '30000' })).toBe(30_000);
+  });
+
+  test('falls back to configured value without env', () => {
+    expect(resolveEngineIdleTtlMs(60_000, {})).toBe(60_000);
+  });
+
+  test('undefined everywhere yields undefined (runtime default)', () => {
+    expect(resolveEngineIdleTtlMs(undefined, {})).toBeUndefined();
+  });
+
+  test('rejects zero and negative values (0 would disable eviction)', () => {
+    expect(resolveEngineIdleTtlMs(0, {})).toBeUndefined();
+    expect(resolveEngineIdleTtlMs(-5, {})).toBeUndefined();
+    expect(resolveEngineIdleTtlMs(60_000, { JARVIS_ENGINE_IDLE_TTL_MS: '0' })).toBeUndefined();
+  });
+
+  test('rejects non-numeric env values', () => {
+    expect(resolveEngineIdleTtlMs(60_000, { JARVIS_ENGINE_IDLE_TTL_MS: 'fast' })).toBeUndefined();
   });
 });

--- a/src/daemon/config-merge.ts
+++ b/src/daemon/config-merge.ts
@@ -190,3 +190,28 @@ export function mergeVoiceConfig(
 
   return { ...merged, ...patch } as VoiceConfig;
 }
+
+/**
+ * Warm-engine idle TTL: JARVIS_ENGINE_IDLE_TTL_MS env var wins over the
+ * `workflows.engineIdleTtlMs` setting — `workflows` is a USER-owned config
+ * section, so managed hosts can't reach it through the system config file;
+ * the env var lets them tune the fleet from the unit file. Non-positive or
+ * non-numeric values fall back to the runtime default (5 min) with a warn:
+ * 0 would mean "never evict the ~100MB engine", the opposite of what a
+ * host lowering the TTL wants.
+ */
+export function resolveEngineIdleTtlMs(
+  configured: number | undefined,
+  env: Record<string, string | undefined> = process.env,
+): number | undefined {
+  const envRaw = env['JARVIS_ENGINE_IDLE_TTL_MS'];
+  const raw = envRaw !== undefined ? Number(envRaw) : configured;
+  if (raw === undefined) return undefined;
+  if (!Number.isFinite(raw) || raw <= 0) {
+    console.warn(
+      `[Daemon] Ignoring engine idle TTL ${JSON.stringify(envRaw ?? configured)} (${envRaw !== undefined ? 'JARVIS_ENGINE_IDLE_TTL_MS' : 'workflows.engineIdleTtlMs'}): must be a positive number of ms; using default`,
+    );
+    return undefined;
+  }
+  return raw;
+}

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -14,6 +14,7 @@ import { flushWindowState } from "./window-state.ts";
 import { ServiceRegistry } from "./services.ts";
 import { HealthMonitor } from "./health.ts";
 import { loadConfig } from "../config/loader.ts";
+import { resolveEngineIdleTtlMs } from "./config-merge.ts";
 import { activeTurns } from "./active-turns.ts";
 import { writeLockedPort } from "./pid.ts";
 import { AgentService } from "./agent-service.ts";
@@ -165,28 +166,6 @@ function ensureDataDir(dataDir: string): void {
 /**
  * Log timestamp helper
  */
-/**
- * Warm-engine idle TTL: JARVIS_ENGINE_IDLE_TTL_MS env var wins over the
- * `workflows.engineIdleTtlMs` setting — `workflows` is a USER-owned config
- * section, so managed hosts can't reach it through the system config file;
- * the env var lets them tune the fleet from the unit file. Non-positive or
- * non-numeric values fall back to the runtime default (5 min) with a warn:
- * 0 would mean "never evict the ~100MB engine", the opposite of what a
- * host lowering the TTL wants.
- */
-function resolveEngineIdleTtlMs(configured: number | undefined): number | undefined {
-  const envRaw = process.env['JARVIS_ENGINE_IDLE_TTL_MS'];
-  const raw = envRaw !== undefined ? Number(envRaw) : configured;
-  if (raw === undefined) return undefined;
-  if (!Number.isFinite(raw) || raw <= 0) {
-    console.warn(
-      `[Daemon] Ignoring engine idle TTL ${JSON.stringify(envRaw ?? configured)} (${envRaw !== undefined ? 'JARVIS_ENGINE_IDLE_TTL_MS' : 'workflows.engineIdleTtlMs'}): must be a positive number of ms; using default`,
-    );
-    return undefined;
-  }
-  return raw;
-}
-
 function logWithTimestamp(message: string): void {
   const timestamp = new Date().toISOString();
   console.log(`[${timestamp}] ${message}`);
@@ -840,7 +819,14 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
         if (n === 1 || n % 125 === 0) console.log(`[pebble-realtime] mic frames (audio channel) from ${sidecarId}: ${n}`);
         pebbleRealtime.pushMicChunk(sidecarId, frame);
       });
-      sidecarManager.onSidecarDisconnected((sidecarId) => pebbleRealtime.stop(sidecarId));
+      sidecarManager.onSidecarDisconnected((sidecarId) => {
+        pebbleRealtime.stop(sidecarId);
+        // Per-sidecar transient state — drop with the connection so the maps
+        // stay bounded by connected sidecars, not lifetime-distinct ones.
+        clearListenTimer(sidecarId);
+        lastTrayState.delete(sidecarId);
+        pebbleMicFrames.delete(sidecarId);
+      });
 
       // STT + TTS providers for the pebble's voice loop. Both built from
       // the same jarvisConfig.* the dashboard uses so API keys / provider

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -165,6 +165,28 @@ function ensureDataDir(dataDir: string): void {
 /**
  * Log timestamp helper
  */
+/**
+ * Warm-engine idle TTL: JARVIS_ENGINE_IDLE_TTL_MS env var wins over the
+ * `workflows.engineIdleTtlMs` setting — `workflows` is a USER-owned config
+ * section, so managed hosts can't reach it through the system config file;
+ * the env var lets them tune the fleet from the unit file. Non-positive or
+ * non-numeric values fall back to the runtime default (5 min) with a warn:
+ * 0 would mean "never evict the ~100MB engine", the opposite of what a
+ * host lowering the TTL wants.
+ */
+function resolveEngineIdleTtlMs(configured: number | undefined): number | undefined {
+  const envRaw = process.env['JARVIS_ENGINE_IDLE_TTL_MS'];
+  const raw = envRaw !== undefined ? Number(envRaw) : configured;
+  if (raw === undefined) return undefined;
+  if (!Number.isFinite(raw) || raw <= 0) {
+    console.warn(
+      `[Daemon] Ignoring engine idle TTL ${JSON.stringify(envRaw ?? configured)} (${envRaw !== undefined ? 'JARVIS_ENGINE_IDLE_TTL_MS' : 'workflows.engineIdleTtlMs'}): must be a positive number of ms; using default`,
+    );
+    return undefined;
+  }
+  return raw;
+}
+
 function logWithTimestamp(message: string): void {
   const timestamp = new Date().toISOString();
   console.log(`[${timestamp}] ${message}`);
@@ -4063,7 +4085,7 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
           },
         },
         log: (line) => console.log(`[Daemon] ${line}`),
-        engineIdleTtlMs: jarvisConfig.workflows?.engineIdleTtlMs,
+        engineIdleTtlMs: resolveEngineIdleTtlMs(jarvisConfig.workflows?.engineIdleTtlMs),
       });
       workflowEngineShutdown = engineBoot.shutdown;
       logWithTimestamp(

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -4063,6 +4063,7 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
           },
         },
         log: (line) => console.log(`[Daemon] ${line}`),
+        engineIdleTtlMs: jarvisConfig.workflows?.engineIdleTtlMs,
       });
       workflowEngineShutdown = engineBoot.shutdown;
       logWithTimestamp(

--- a/src/llm/history.ts
+++ b/src/llm/history.ts
@@ -126,8 +126,10 @@ function chunkMessages(messages: LLMMessage[]): LLMMessage[][] {
 /**
  * Estimate token count for a message (rough heuristic).
  * 1 token ≈ 4 characters + fixed overhead per message
+ * Exported so history holders (AgentInstance) can keep a running total
+ * with the same arithmetic compactHistory uses to enforce its budget.
  */
-function measureMessage(message: LLMMessage): number {
+export function measureMessage(message: LLMMessage): number {
   const contentStr = typeof message.content === 'string'
     ? message.content
     : message.content.map(b => b.type === 'text' ? b.text : '[image]').join('\n');

--- a/src/sidecar/binary-spool.test.ts
+++ b/src/sidecar/binary-spool.test.ts
@@ -61,12 +61,45 @@ describe('BinarySpool', () => {
     }
   });
 
-  test('missing spool file degrades to empty data instead of throwing', () => {
+  test('missing spool file degrades to null so typeof-string guards reject it', () => {
     const { spool, dataDir } = makeSpool();
     try {
       const descriptor = spool.spool(Buffer.alloc(64), 'image/png')!;
       rmSync(path.join(dataDir, 'cache', 'sidecar-spool'), { recursive: true, force: true });
-      expect(descriptor.data).toBe('');
+      expect(descriptor.data as string | null).toBeNull();
+      expect(typeof descriptor.data === 'string').toBe(false);
+      expect(spool.stats().expiredReads).toBeGreaterThan(0);
+    } finally {
+      spool.stop();
+    }
+  });
+
+  test('double read within one synchronous block hits the cache, then releases', async () => {
+    const { spool, dataDir } = makeSpool();
+    try {
+      const payload = Buffer.alloc(2048, 3);
+      const descriptor = spool.spool(payload, 'image/png')!;
+      // Same synchronous block: typeof guard + use, like real consumers
+      expect(typeof descriptor.data === 'string').toBe(true);
+      const first = descriptor.data;
+      rmSync(path.join(dataDir, 'cache', 'sidecar-spool'), { recursive: true, force: true });
+      // File is gone but the cache still serves the same block
+      expect(descriptor.data).toBe(first);
+      // After a microtask the cache is released — next read misses
+      await Promise.resolve();
+      expect(descriptor.data as string | null).toBeNull();
+    } finally {
+      spool.stop();
+    }
+  });
+
+  test('stats counts spooled payloads and bytes', () => {
+    const { spool } = makeSpool();
+    try {
+      spool.spool(Buffer.alloc(100), 'a/b');
+      spool.spool(Buffer.alloc(50), 'a/b');
+      expect(spool.stats().spooled).toBe(2);
+      expect(spool.stats().spooledBytes).toBe(150);
     } finally {
       spool.stop();
     }

--- a/src/sidecar/binary-spool.test.ts
+++ b/src/sidecar/binary-spool.test.ts
@@ -93,6 +93,17 @@ describe('BinarySpool', () => {
     }
   });
 
+  test('write failure returns null so the caller keeps the payload inline', () => {
+    const { spool, dataDir } = makeSpool();
+    try {
+      rmSync(path.join(dataDir, 'cache', 'sidecar-spool'), { recursive: true, force: true });
+      expect(spool.spool(Buffer.alloc(64), 'image/png')).toBeNull();
+      expect(spool.stats().spooled).toBe(0);
+    } finally {
+      spool.stop();
+    }
+  });
+
   test('stats counts spooled payloads and bytes', () => {
     const { spool } = makeSpool();
     try {

--- a/src/sidecar/binary-spool.test.ts
+++ b/src/sidecar/binary-spool.test.ts
@@ -1,0 +1,74 @@
+import { describe, test, expect, afterEach } from 'bun:test';
+import { mkdtempSync, rmSync, readdirSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { BinarySpool } from './binary-spool.ts';
+
+const dirs: string[] = [];
+function makeSpool(): { spool: BinarySpool; dataDir: string } {
+  const dataDir = mkdtempSync(path.join(tmpdir(), 'jarvis-spool-test-'));
+  dirs.push(dataDir);
+  const spool = new BinarySpool(dataDir);
+  spool.start();
+  return { spool, dataDir };
+}
+
+afterEach(() => {
+  while (dirs.length) rmSync(dirs.pop()!, { recursive: true, force: true });
+});
+
+describe('BinarySpool', () => {
+  test('descriptor keeps the inline shape and round-trips the payload', () => {
+    const { spool } = makeSpool();
+    try {
+      const payload = Buffer.from('jarvis-spool-payload'.repeat(1000));
+      const descriptor = spool.spool(payload, 'image/png')!;
+      expect(descriptor.type).toBe('inline');
+      expect(descriptor.mime_type).toBe('image/png');
+      expect(Buffer.from(descriptor.data, 'base64').equals(payload)).toBe(true);
+      // Survives JSON serialization like a plain inline descriptor
+      const json = JSON.parse(JSON.stringify(descriptor));
+      expect(Buffer.from(json.data, 'base64').equals(payload)).toBe(true);
+    } finally {
+      spool.stop();
+    }
+  });
+
+  test('payload lives on disk, not in the descriptor', () => {
+    const { spool, dataDir } = makeSpool();
+    try {
+      spool.spool(Buffer.alloc(1024, 7), 'application/octet-stream');
+      const spoolDir = path.join(dataDir, 'cache', 'sidecar-spool');
+      expect(readdirSync(spoolDir).length).toBe(1);
+    } finally {
+      spool.stop();
+    }
+  });
+
+  test('start() wipes leftovers from a previous run', () => {
+    const { spool, dataDir } = makeSpool();
+    spool.spool(Buffer.alloc(64), 'application/octet-stream');
+    spool.stop();
+
+    const second = new BinarySpool(dataDir);
+    second.start();
+    try {
+      const spoolDir = path.join(dataDir, 'cache', 'sidecar-spool');
+      expect(existsSync(spoolDir)).toBe(true);
+      expect(readdirSync(spoolDir).length).toBe(0);
+    } finally {
+      second.stop();
+    }
+  });
+
+  test('missing spool file degrades to empty data instead of throwing', () => {
+    const { spool, dataDir } = makeSpool();
+    try {
+      const descriptor = spool.spool(Buffer.alloc(64), 'image/png')!;
+      rmSync(path.join(dataDir, 'cache', 'sidecar-spool'), { recursive: true, force: true });
+      expect(descriptor.data).toBe('');
+    } finally {
+      spool.stop();
+    }
+  });
+});

--- a/src/sidecar/binary-spool.ts
+++ b/src/sidecar/binary-spool.ts
@@ -26,16 +26,44 @@ const FILE_TTL_MS = 10 * 60_000;
 export interface SpooledBinaryDescriptor {
   type: 'inline';
   mime_type: string;
-  /** Lazy getter: reads the spool file and base64-encodes on access. */
+  /**
+   * Lazy getter: reads the spool file and base64-encodes on access. If the
+   * file is gone (TTL sweep, manager restart) it yields `null` at runtime —
+   * deliberately failing consumers' `typeof data === 'string'` guards so
+   * they take their missing-binary path rather than serving a payload that
+   * decodes to zero bytes. Declared `string` to match BinaryDataInline.
+   */
   data: string;
+}
+
+/** Counters for observability — see BinarySpool.stats(). */
+export interface BinarySpoolStats {
+  /** Payloads written to disk since start(). */
+  spooled: number;
+  /** Total raw bytes written since start(). */
+  spooledBytes: number;
+  /** Accesses that found the spool file already deleted. */
+  expiredReads: number;
 }
 
 export class BinarySpool {
   private readonly dir: string;
   private sweepTimer: Timer | null = null;
+  private spooledCount = 0;
+  private spooledBytes = 0;
+  private expiredReads = 0;
 
   constructor(dataDir: string) {
     this.dir = path.join(dataDir, 'cache', 'sidecar-spool');
+  }
+
+  /** Counters since start(). Not persisted; resets on construction. */
+  stats(): BinarySpoolStats {
+    return {
+      spooled: this.spooledCount,
+      spooledBytes: this.spooledBytes,
+      expiredReads: this.expiredReads,
+    };
   }
 
   /** Wipe leftovers from a previous run and start the TTL sweep. */
@@ -66,18 +94,31 @@ export class BinarySpool {
       console.warn('[BinarySpool] Write failed, keeping payload in memory:', err);
       return null;
     }
+    this.spooledCount++;
+    this.spooledBytes += payload.length;
 
+    // Consumers read `data` twice in one synchronous block (a typeof guard,
+    // then the actual use). Cache the encoded string across those reads and
+    // release it on the next microtask, so a 50MB capture is read+encoded
+    // once per consumption without pinning ~66MB for the descriptor's
+    // (potentially long) lifetime.
+    let cached: string | null = null;
+    const spoolRef = this;
     const descriptor = { type: 'inline', mime_type: mimeType } as SpooledBinaryDescriptor;
     Object.defineProperty(descriptor, 'data', {
       enumerable: true,
       configurable: true,
-      get(): string {
+      get(): string | null {
+        if (cached !== null) return cached;
         try {
-          return readFileSync(filePath).toString('base64');
+          cached = readFileSync(filePath).toString('base64');
         } catch (err) {
+          spoolRef.expiredReads++;
           console.warn(`[BinarySpool] Spool file gone (TTL ${FILE_TTL_MS}ms exceeded?):`, err);
-          return '';
+          return null;
         }
+        queueMicrotask(() => { cached = null; });
+        return cached;
       },
     });
     return descriptor;

--- a/src/sidecar/binary-spool.ts
+++ b/src/sidecar/binary-spool.ts
@@ -1,0 +1,105 @@
+/**
+ * Binary Spool — Disk-Backed Large Binary Payloads
+ *
+ * Ref-protocol binaries (screenshots, region captures, audio segments) can be
+ * up to 50 MB raw — ~66 MB once base64-encoded. Holding them inline on queued
+ * events means a burst of captures pins hundreds of MB of heap until the
+ * scheduler drains. Above a threshold the payload is written to disk instead,
+ * and the event carries a descriptor whose `data` property lazily reads and
+ * base64-encodes the file on first access. Consumers keep reading
+ * `binary.data` unchanged; memory is only paid at the moment of consumption.
+ *
+ * Spool files are wiped at startup and swept on a TTL: descriptors can escape
+ * the dispatch scope (rpc_result consumers read `result._binary` after the
+ * RPC promise resolves), so files must outlive dispatch but not the process.
+ */
+
+import { mkdirSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+/** Payloads above this size are spooled to disk instead of held as base64. */
+export const SPOOL_THRESHOLD_BYTES = 1024 * 1024; // 1 MB
+
+const SWEEP_INTERVAL_MS = 60_000;
+const FILE_TTL_MS = 10 * 60_000;
+
+export interface SpooledBinaryDescriptor {
+  type: 'inline';
+  mime_type: string;
+  /** Lazy getter: reads the spool file and base64-encodes on access. */
+  data: string;
+}
+
+export class BinarySpool {
+  private readonly dir: string;
+  private sweepTimer: Timer | null = null;
+
+  constructor(dataDir: string) {
+    this.dir = path.join(dataDir, 'cache', 'sidecar-spool');
+  }
+
+  /** Wipe leftovers from a previous run and start the TTL sweep. */
+  start(): void {
+    rmSync(this.dir, { recursive: true, force: true });
+    mkdirSync(this.dir, { recursive: true });
+    if (this.sweepTimer) return;
+    this.sweepTimer = setInterval(() => this.sweep(), SWEEP_INTERVAL_MS);
+  }
+
+  stop(): void {
+    if (this.sweepTimer) {
+      clearInterval(this.sweepTimer);
+      this.sweepTimer = null;
+    }
+  }
+
+  /**
+   * Write the payload to a spool file and return a descriptor that looks like
+   * an inline binary but materializes `data` from disk on access. Returns null
+   * if the write fails (caller falls back to holding the payload in memory).
+   */
+  spool(payload: Buffer, mimeType: string): SpooledBinaryDescriptor | null {
+    const filePath = path.join(this.dir, crypto.randomUUID());
+    try {
+      writeFileSync(filePath, payload);
+    } catch (err) {
+      console.warn('[BinarySpool] Write failed, keeping payload in memory:', err);
+      return null;
+    }
+
+    const descriptor = { type: 'inline', mime_type: mimeType } as SpooledBinaryDescriptor;
+    Object.defineProperty(descriptor, 'data', {
+      enumerable: true,
+      configurable: true,
+      get(): string {
+        try {
+          return readFileSync(filePath).toString('base64');
+        } catch (err) {
+          console.warn(`[BinarySpool] Spool file gone (TTL ${FILE_TTL_MS}ms exceeded?):`, err);
+          return '';
+        }
+      },
+    });
+    return descriptor;
+  }
+
+  private sweep(): void {
+    let entries: string[];
+    try {
+      entries = readdirSync(this.dir);
+    } catch {
+      return;
+    }
+    const cutoff = Date.now() - FILE_TTL_MS;
+    for (const name of entries) {
+      const filePath = path.join(this.dir, name);
+      try {
+        if (statSync(filePath).mtimeMs < cutoff) {
+          rmSync(filePath, { force: true });
+        }
+      } catch {
+        // Raced with another delete — fine.
+      }
+    }
+  }
+}

--- a/src/sidecar/connection-spool.test.ts
+++ b/src/sidecar/connection-spool.test.ts
@@ -1,0 +1,102 @@
+import { describe, test, expect, afterEach } from 'bun:test';
+import { mkdtempSync, rmSync, readdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import type { ServerWebSocket } from 'bun';
+import { SidecarConnection } from './connection.ts';
+import { EventScheduler } from './scheduler.ts';
+import { BinarySpool, SPOOL_THRESHOLD_BYTES } from './binary-spool.ts';
+import type { SidecarEvent } from './protocol.ts';
+
+const dirs: string[] = [];
+afterEach(() => {
+  while (dirs.length) rmSync(dirs.pop()!, { recursive: true, force: true });
+});
+
+function setup() {
+  const dataDir = mkdtempSync(path.join(tmpdir(), 'jarvis-conn-spool-'));
+  dirs.push(dataDir);
+  const spool = new BinarySpool(dataDir);
+  spool.start();
+  const scheduler = new EventScheduler(); // not started — we inspect the queue
+  const conn = new SidecarConnection(
+    'sc-test',
+    { send: () => {} } as unknown as ServerWebSocket<unknown>,
+    scheduler,
+    () => {},
+    spool,
+  );
+  const spoolDir = path.join(dataDir, 'cache', 'sidecar-spool');
+  const queued = () =>
+    (scheduler as unknown as { queues: Map<string, Array<{ event: SidecarEvent }>> })
+      .queues.get('sc-test') ?? [];
+  return { conn, spool, spoolDir, queued };
+}
+
+async function sendRefEvent(conn: SidecarConnection, payload: Buffer): Promise<void> {
+  const refId = crypto.randomUUID();
+  const message = conn.handleMessage(JSON.stringify({
+    type: 'sidecar_event',
+    event_type: 'screen.capture',
+    timestamp: Date.now(),
+    payload: { kind: 'test' },
+    binary: { type: 'ref', ref_id: refId, mime_type: 'image/png', size: payload.length },
+  }));
+  // Let handleMessage reach waitForBinary before delivering the frame
+  await Promise.resolve();
+  conn.handleBinary(Buffer.concat([Buffer.from(refId, 'ascii'), payload]));
+  await message;
+}
+
+describe('SidecarConnection binary spooling', () => {
+  test('ref binary above the threshold is spooled, payload intact via getter', async () => {
+    const { conn, spool, spoolDir, queued } = setup();
+    try {
+      const payload = Buffer.alloc(SPOOL_THRESHOLD_BYTES + 1, 42);
+      await sendRefEvent(conn, payload);
+
+      expect(readdirSync(spoolDir).length).toBe(1);
+      const event = queued()[0]!.event;
+      const binary = event.binary as { type: string; mime_type: string; data: string };
+      expect(binary.type).toBe('inline');
+      expect(binary.mime_type).toBe('image/png');
+      expect(Buffer.from(binary.data, 'base64').equals(payload)).toBe(true);
+    } finally {
+      spool.stop();
+    }
+  });
+
+  test('ref binary at or below the threshold stays inline in memory', async () => {
+    const { conn, spool, spoolDir, queued } = setup();
+    try {
+      const payload = Buffer.alloc(1024, 7);
+      await sendRefEvent(conn, payload);
+
+      expect(readdirSync(spoolDir).length).toBe(0);
+      const binary = queued()[0]!.event.binary as { type: string; data: string };
+      expect(binary.type).toBe('inline');
+      expect(Buffer.from(binary.data, 'base64').equals(payload)).toBe(true);
+    } finally {
+      spool.stop();
+    }
+  });
+
+  test('without a spool, large ref binaries still normalize inline', async () => {
+    const dataDir = mkdtempSync(path.join(tmpdir(), 'jarvis-conn-nospool-'));
+    dirs.push(dataDir);
+    const scheduler = new EventScheduler();
+    const conn = new SidecarConnection(
+      'sc-test',
+      { send: () => {} } as unknown as ServerWebSocket<unknown>,
+      scheduler,
+      () => {},
+    );
+    const payload = Buffer.alloc(SPOOL_THRESHOLD_BYTES + 1, 9);
+    await sendRefEvent(conn, payload);
+    const queue = (scheduler as unknown as { queues: Map<string, Array<{ event: SidecarEvent }>> })
+      .queues.get('sc-test')!;
+    const binary = queue[0]!.event.binary as { type: string; data: string };
+    expect(binary.type).toBe('inline');
+    expect(Buffer.from(binary.data, 'base64').equals(payload)).toBe(true);
+  });
+});

--- a/src/sidecar/connection.ts
+++ b/src/sidecar/connection.ts
@@ -8,6 +8,8 @@
 import type { ServerWebSocket } from 'bun';
 import type { RPCRequest, SidecarEvent } from './protocol.ts';
 import type { EventScheduler } from './scheduler.ts';
+import type { BinarySpool } from './binary-spool.ts';
+import { SPOOL_THRESHOLD_BYTES } from './binary-spool.ts';
 import { validateEvent, validateBinaryFrame, MAX_JSON_SIZE } from './validator.ts';
 
 const HEARTBEAT_INTERVAL_MS = 30_000;
@@ -29,17 +31,20 @@ export class SidecarConnection {
   private missedPongs = 0;
   private alive = true;
   private onDisconnect: () => void;
+  private binarySpool: BinarySpool | null;
 
   constructor(
     sidecarId: string,
     ws: ServerWebSocket<unknown>,
     scheduler: EventScheduler,
     onDisconnect: () => void,
+    binarySpool?: BinarySpool,
   ) {
     this.sidecarId = sidecarId;
     this.ws = ws;
     this.scheduler = scheduler;
     this.onDisconnect = onDisconnect;
+    this.binarySpool = binarySpool ?? null;
   }
 
   /** Send an RPC request to the sidecar */
@@ -88,7 +93,14 @@ export class SidecarConnection {
         // consume event.binary.data; rpc_result consumers read the descriptor set
         // on the inner result by SidecarManager), and a base64 + Buffer pair held
         // both at once doubled the resident size of every ref binary (up to 50 MB).
-        event.binary = {
+        // Large payloads go to disk: base64 of a 50MB capture is ~66MB of
+        // heap, and it would sit on the queued event until the scheduler
+        // drains. The spooled descriptor keeps the same shape — `data` reads
+        // the file back on access.
+        const spooled = binaryPayload.length > SPOOL_THRESHOLD_BYTES
+          ? this.binarySpool?.spool(binaryPayload, mimeType)
+          : null;
+        event.binary = spooled ?? {
           type: 'inline',
           mime_type: mimeType,
           data: binaryPayload.toString('base64'),

--- a/src/sidecar/manager.ts
+++ b/src/sidecar/manager.ts
@@ -21,9 +21,9 @@ import type {
 } from './types.ts';
 import type { RPCRequest, RPCTimeouts, SidecarEvent, RPCResultPayload, RPCErrorPayload, RPCProgressPayload } from './protocol.ts';
 import { DEFAULT_RPC_TIMEOUTS } from './protocol.ts';
-import { EventScheduler } from './scheduler.ts';
+import { EventScheduler, type DroppedEventsStats } from './scheduler.ts';
 import { RPCTracker } from './rpc.ts';
-import { BinarySpool } from './binary-spool.ts';
+import { BinarySpool, type BinarySpoolStats } from './binary-spool.ts';
 import { SidecarConnection } from './connection.ts';
 import { classifySidecarVersion, SIDECAR_MIN_VERSION, SIDECAR_RECOMMENDED_VERSION } from './compat.ts';
 import { chmodWithWarning, secureDirectory, secureWriteFile } from '../util/fs-secure.ts';
@@ -114,6 +114,14 @@ export class SidecarManager implements Service {
     this.scheduler = new EventScheduler();
     this.rpcTracker = new RPCTracker();
     this.binarySpool = new BinarySpool(dataDir);
+  }
+
+  /**
+   * Event-pressure counters: queue-overflow drops and disk-spool activity.
+   * For dashboards/health surfaces, mirroring WorkflowEventBuffer.dropped().
+   */
+  getEventStats(): { dropped: DroppedEventsStats; spool: BinarySpoolStats } {
+    return { dropped: this.scheduler.dropped(), spool: this.binarySpool.stats() };
   }
 
   /**

--- a/src/sidecar/manager.ts
+++ b/src/sidecar/manager.ts
@@ -23,6 +23,7 @@ import type { RPCRequest, RPCTimeouts, SidecarEvent, RPCResultPayload, RPCErrorP
 import { DEFAULT_RPC_TIMEOUTS } from './protocol.ts';
 import { EventScheduler } from './scheduler.ts';
 import { RPCTracker } from './rpc.ts';
+import { BinarySpool } from './binary-spool.ts';
 import { SidecarConnection } from './connection.ts';
 import { classifySidecarVersion, SIDECAR_MIN_VERSION, SIDECAR_RECOMMENDED_VERSION } from './compat.ts';
 import { chmodWithWarning, secureDirectory, secureWriteFile } from '../util/fs-secure.ts';
@@ -84,6 +85,7 @@ export class SidecarManager implements Service {
   /** Protocol infrastructure */
   private scheduler: EventScheduler;
   private rpcTracker: RPCTracker;
+  private binarySpool: BinarySpool;
   private sidecarConnections = new Map<string, SidecarConnection>();
   private revocationSweepTimer: ReturnType<typeof setInterval> | null = null;
   private progressListeners = new Set<(sidecarId: string, rpcId: string, progress: number, message?: string) => void>();
@@ -111,6 +113,7 @@ export class SidecarManager implements Service {
     this.dataDir = dataDir;
     this.scheduler = new EventScheduler();
     this.rpcTracker = new RPCTracker();
+    this.binarySpool = new BinarySpool(dataDir);
   }
 
   /**
@@ -202,6 +205,7 @@ export class SidecarManager implements Service {
       });
 
       this.scheduler.start();
+      this.binarySpool.start();
 
       this._status = 'running';
       console.log('[SidecarManager] Started — keys loaded, scheduler running');
@@ -221,6 +225,7 @@ export class SidecarManager implements Service {
 
     // Stop scheduler
     this.scheduler.stop();
+    this.binarySpool.stop();
 
     // Close all sidecar connections and fail pending RPCs. Use WS 1001 (Going
     // Away) + reason so the sidecar recognizes a planned restart and reconnects
@@ -548,6 +553,7 @@ export class SidecarManager implements Service {
       ws,
       this.scheduler,
       () => this.handleSidecarDisconnect(sidecarId),
+      this.binarySpool,
     );
     connection.startHeartbeat();
     this.sidecarConnections.set(sidecarId, connection);

--- a/src/sidecar/scheduler.test.ts
+++ b/src/sidecar/scheduler.test.ts
@@ -72,6 +72,46 @@ describe('EventScheduler queue bounds', () => {
     expect(seen.filter((s) => s === 'sc-b').length).toBe(5);
   });
 
+  test('rpc_result is never evicted and never dropped on overflow', () => {
+    const scheduler = new EventScheduler();
+    for (let i = 0; i < MAX_QUEUE_PER_SIDECAR; i++) {
+      scheduler.enqueue('sc-1', makeEvent('rpc_result', 'critical'));
+    }
+    // Queue is full of undroppable events: an incoming rpc_result must
+    // still be accepted (cap overflows), a plain event must be dropped.
+    scheduler.enqueue('sc-1', makeEvent('rpc_result', 'low'));
+    scheduler.enqueue('sc-1', makeEvent('sidecar_event', 'critical'));
+    const queues = (scheduler as unknown as { queues: Map<string, Array<{ event: SidecarEvent }>> }).queues;
+    const queue = queues.get('sc-1')!;
+    expect(queue.length).toBe(MAX_QUEUE_PER_SIDECAR + 1);
+    expect(queue.every((q) => q.event.event_type === 'rpc_result')).toBe(true);
+    expect(scheduler.dropped().count).toBe(1);
+  });
+
+  test('overflow evicts a droppable event, not a queued rpc_result', () => {
+    const scheduler = new EventScheduler();
+    scheduler.enqueue('sc-1', makeEvent('rpc_result', 'low'));
+    for (let i = 0; i < MAX_QUEUE_PER_SIDECAR - 1; i++) {
+      scheduler.enqueue('sc-1', makeEvent('sidecar_event', 'low'));
+    }
+    scheduler.enqueue('sc-1', makeEvent('sidecar_event', 'normal'));
+    const queues = (scheduler as unknown as { queues: Map<string, Array<{ event: SidecarEvent }>> }).queues;
+    const queue = queues.get('sc-1')!;
+    expect(queue.length).toBe(MAX_QUEUE_PER_SIDECAR);
+    expect(queue.some((q) => q.event.event_type === 'rpc_result')).toBe(true);
+  });
+
+  test('dropped() reports count, timestamp, and per-sidecar attribution', () => {
+    const scheduler = new EventScheduler();
+    for (let i = 0; i < MAX_QUEUE_PER_SIDECAR + 3; i++) {
+      scheduler.enqueue('sc-1', makeEvent());
+    }
+    const stats = scheduler.dropped();
+    expect(stats.count).toBe(3);
+    expect(stats.lastDroppedAt).toBeGreaterThan(0);
+    expect(stats.bySidecar['sc-1']).toBe(3);
+  });
+
   test('priority order is preserved with FIFO within a class', async () => {
     const scheduler = new EventScheduler();
     scheduler.enqueue('sc-1', makeEvent('n1', 'normal'));

--- a/src/sidecar/scheduler.test.ts
+++ b/src/sidecar/scheduler.test.ts
@@ -1,0 +1,89 @@
+import { describe, test, expect } from 'bun:test';
+import { EventScheduler, MAX_QUEUE_PER_SIDECAR } from './scheduler.ts';
+import type { SidecarEvent } from './protocol.ts';
+
+function makeEvent(type = 'sidecar_event', priority?: SidecarEvent['priority']): SidecarEvent {
+  return {
+    event_type: type,
+    payload: { kind: 'test' },
+    ...(priority ? { priority } : {}),
+  } as unknown as SidecarEvent;
+}
+
+/** Drive the private drain loop directly instead of waiting on wall-clock timers. */
+async function drainOnce(scheduler: EventScheduler): Promise<void> {
+  await (scheduler as unknown as { drain(): Promise<void> }).drain();
+}
+
+describe('EventScheduler queue bounds', () => {
+  test('queue never exceeds MAX_QUEUE_PER_SIDECAR', () => {
+    const scheduler = new EventScheduler();
+    for (let i = 0; i < MAX_QUEUE_PER_SIDECAR + 100; i++) {
+      scheduler.enqueue('sc-1', makeEvent());
+    }
+    const queues = (scheduler as unknown as { queues: Map<string, unknown[]> }).queues;
+    expect(queues.get('sc-1')!.length).toBe(MAX_QUEUE_PER_SIDECAR);
+  });
+
+  test('overflow drops the oldest lowest-priority event, keeps critical', async () => {
+    const scheduler = new EventScheduler();
+    scheduler.enqueue('sc-1', makeEvent('critical_evt', 'critical'));
+    for (let i = 0; i < MAX_QUEUE_PER_SIDECAR - 1; i++) {
+      scheduler.enqueue('sc-1', makeEvent('normal_evt', 'normal'));
+    }
+    // Queue is full — a high-priority arrival evicts a normal one, not the critical
+    scheduler.enqueue('sc-1', makeEvent('high_evt', 'high'));
+
+    const seen: string[] = [];
+    scheduler.on('*', async (_id, event) => {
+      seen.push(event.event_type);
+    });
+    await drainOnce(scheduler);
+    expect(seen[0]).toBe('critical_evt');
+    expect(seen).toContain('high_evt');
+  });
+
+  test('incoming event lower-priority than the whole queue is dropped', () => {
+    const scheduler = new EventScheduler();
+    for (let i = 0; i < MAX_QUEUE_PER_SIDECAR; i++) {
+      scheduler.enqueue('sc-1', makeEvent('normal_evt', 'normal'));
+    }
+    scheduler.enqueue('sc-1', makeEvent('low_evt', 'low'));
+    const queues = (scheduler as unknown as { queues: Map<string, Array<{ event: SidecarEvent }>> }).queues;
+    const queue = queues.get('sc-1')!;
+    expect(queue.length).toBe(MAX_QUEUE_PER_SIDECAR);
+    expect(queue.some((q) => q.event.event_type === 'low_evt')).toBe(false);
+  });
+
+  test('drain dispatches a batch per tick, round-robin across sidecars', async () => {
+    const scheduler = new EventScheduler();
+    const seen: string[] = [];
+    scheduler.on('*', async (sidecarId) => {
+      seen.push(sidecarId);
+    });
+    for (let i = 0; i < 10; i++) {
+      scheduler.enqueue('sc-a', makeEvent());
+      scheduler.enqueue('sc-b', makeEvent());
+    }
+    await drainOnce(scheduler);
+    // More than the old one-event-per-tick, fair across both sidecars
+    expect(seen.length).toBe(10);
+    expect(seen.filter((s) => s === 'sc-a').length).toBe(5);
+    expect(seen.filter((s) => s === 'sc-b').length).toBe(5);
+  });
+
+  test('priority order is preserved with FIFO within a class', async () => {
+    const scheduler = new EventScheduler();
+    scheduler.enqueue('sc-1', makeEvent('n1', 'normal'));
+    scheduler.enqueue('sc-1', makeEvent('c1', 'critical'));
+    scheduler.enqueue('sc-1', makeEvent('n2', 'normal'));
+    scheduler.enqueue('sc-1', makeEvent('h1', 'high'));
+
+    const seen: string[] = [];
+    scheduler.on('*', async (_id, event) => {
+      seen.push(event.event_type);
+    });
+    await drainOnce(scheduler);
+    expect(seen).toEqual(['c1', 'h1', 'n1', 'n2']);
+  });
+});

--- a/src/sidecar/scheduler.ts
+++ b/src/sidecar/scheduler.ts
@@ -31,6 +31,27 @@ export const MAX_QUEUE_PER_SIDECAR = 500;
  */
 const DRAIN_BATCH_PER_TICK = 10;
 
+/**
+ * Event types the drop policy must never evict: an RPC caller is awaiting
+ * these, and dropping one converts a deliverable result into an opaque
+ * timeout. When the queue is full of undroppable events the cap is allowed
+ * to overflow — pending-RPC tracking bounds how many can exist at once.
+ */
+const UNDROPPABLE_TYPES = new Set(['rpc_result', 'rpc_progress']);
+
+/** Minimum interval between queue-overflow warn lines, per sidecar. */
+const DROP_LOG_INTERVAL_MS = 5_000;
+
+/** Drop counters for observability (mirrors WorkflowEventBuffer.dropped()). */
+export interface DroppedEventsStats {
+  /** Total events dropped by the overflow policy since construction. */
+  count: number;
+  /** Timestamp (ms) of the most recent drop. 0 when nothing was dropped. */
+  lastDroppedAt: number;
+  /** Per-sidecar drop counts. */
+  bySidecar: Record<string, number>;
+}
+
 export class EventScheduler {
   private queues = new Map<string, QueuedEvent[]>();
   private sidecarIds: string[] = [];
@@ -41,6 +62,11 @@ export class EventScheduler {
   private processing = false;
   private drainTimer: Timer | null = null;
   private readonly drainIntervalMs: number;
+  private droppedCount = 0;
+  private droppedLastAt = 0;
+  private droppedBySidecar = new Map<string, number>();
+  private dropLogLastAt = new Map<string, number>();
+  private dropLogSuppressed = new Map<string, number>();
 
   constructor(drainIntervalMs = 50) {
     this.drainIntervalMs = drainIntervalMs;
@@ -102,18 +128,31 @@ export class EventScheduler {
     const weight = priorityWeight(item.priority);
 
     if (queue.length >= MAX_QUEUE_PER_SIDECAR) {
-      // Tail of the (priority-sorted) queue is the lowest priority present.
-      const tailWeight = priorityWeight(queue[queue.length - 1]!.priority);
-      if (weight > tailWeight) {
-        // Incoming is lower priority than everything queued — drop it.
-        console.warn(`[EventScheduler] Queue full for ${sidecarId}, dropping incoming ${item.priority} ${event.event_type}`);
-        return;
+      // Candidates for eviction exclude RPC events — a caller awaits those.
+      const droppable = queue.filter((q) => !UNDROPPABLE_TYPES.has(q.event.event_type));
+      if (droppable.length === 0) {
+        // Queue is entirely undroppable: let the cap overflow rather than
+        // lose an awaited result. Pending-RPC tracking bounds this.
+        if (!UNDROPPABLE_TYPES.has(event.event_type)) {
+          this.recordDrop(sidecarId, item.priority, event.event_type, 'incoming');
+          return;
+        }
+      } else {
+        // Tail of the (priority-sorted) droppable set is the lowest
+        // priority present.
+        const tailWeight = priorityWeight(droppable[droppable.length - 1]!.priority);
+        if (weight > tailWeight && !UNDROPPABLE_TYPES.has(event.event_type)) {
+          // Incoming is lower priority than everything evictable — drop it.
+          this.recordDrop(sidecarId, item.priority, event.event_type, 'incoming');
+          return;
+        }
+        // Drop the oldest droppable event of the lowest priority class
+        // (stale data — e.g. an old capture — is worth less than what just
+        // arrived).
+        const victim = droppable.find((q) => priorityWeight(q.priority) === tailWeight)!;
+        queue.splice(queue.indexOf(victim), 1);
+        this.recordDrop(sidecarId, victim.priority, victim.event.event_type, 'queued');
       }
-      // Drop the oldest event of the lowest priority class (stale data —
-      // e.g. an old capture — is worth less than what just arrived).
-      const dropIdx = queue.findIndex((q) => priorityWeight(q.priority) === tailWeight);
-      const dropped = queue.splice(dropIdx, 1)[0]!;
-      console.warn(`[EventScheduler] Queue full for ${sidecarId}, dropped ${dropped.priority} ${dropped.event.event_type}`);
     }
 
     // Insert in priority order, after existing items of the same priority
@@ -126,8 +165,46 @@ export class EventScheduler {
     queue.splice(insertAt, 0, item);
   }
 
+  /** Drop counters since construction. Not persisted. */
+  dropped(): DroppedEventsStats {
+    return {
+      count: this.droppedCount,
+      lastDroppedAt: this.droppedLastAt,
+      bySidecar: Object.fromEntries(this.droppedBySidecar),
+    };
+  }
+
+  private recordDrop(
+    sidecarId: string,
+    priority: EventPriority,
+    eventType: string,
+    which: 'incoming' | 'queued',
+  ): void {
+    this.droppedCount++;
+    this.droppedLastAt = Date.now();
+    this.droppedBySidecar.set(sidecarId, (this.droppedBySidecar.get(sidecarId) ?? 0) + 1);
+
+    // Rate-limit the log: an overflow burst is hundreds of drops per second,
+    // and one warn per drop would flood the journal.
+    const now = Date.now();
+    const lastLog = this.dropLogLastAt.get(sidecarId) ?? 0;
+    if (now - lastLog < DROP_LOG_INTERVAL_MS) {
+      this.dropLogSuppressed.set(sidecarId, (this.dropLogSuppressed.get(sidecarId) ?? 0) + 1);
+      return;
+    }
+    const suppressed = this.dropLogSuppressed.get(sidecarId) ?? 0;
+    this.dropLogLastAt.set(sidecarId, now);
+    this.dropLogSuppressed.set(sidecarId, 0);
+    const suffix = suppressed > 0 ? ` (+${suppressed} more since last log)` : '';
+    console.warn(
+      `[EventScheduler] Queue full for ${sidecarId}, dropped ${which} ${priority} ${eventType}${suffix}`,
+    );
+  }
+
   /** Remove a sidecar's queue (on disconnect) */
   removeSidecar(sidecarId: string): void {
+    this.dropLogLastAt.delete(sidecarId);
+    this.dropLogSuppressed.delete(sidecarId);
     this.queues.delete(sidecarId);
     this.sidecarIds = this.sidecarIds.filter(id => id !== sidecarId);
     if (this.roundRobinIndex >= this.sidecarIds.length) {

--- a/src/sidecar/scheduler.ts
+++ b/src/sidecar/scheduler.ts
@@ -16,6 +16,21 @@ interface QueuedEvent {
 
 type EventHandler = (sidecarId: string, event: SidecarEvent) => Promise<void>;
 
+/**
+ * Hard cap per sidecar queue. Without it, a sidecar bursting events faster
+ * than the drain rate grows its queue (and every payload on it) without
+ * limit. When full, the oldest event of the lowest queued priority is
+ * dropped — or the incoming event itself if it's lower-priority still.
+ */
+export const MAX_QUEUE_PER_SIDECAR = 500;
+
+/**
+ * Events dispatched per drain tick (round-robin across sidecars). One per
+ * tick capped throughput at ~20 events/s across ALL sidecars; a batch keeps
+ * the loop non-blocking while draining bursts at a useful rate.
+ */
+const DRAIN_BATCH_PER_TICK = 10;
+
 export class EventScheduler {
   private queues = new Map<string, QueuedEvent[]>();
   private sidecarIds: string[] = [];
@@ -78,15 +93,37 @@ export class EventScheduler {
       this.sidecarIds.push(sidecarId);
     }
 
-    queue.push({
+    const item: QueuedEvent = {
       sidecarId,
       event,
       priority: priority ?? event.priority ?? 'normal',
       enqueuedAt: Date.now(),
-    });
+    };
+    const weight = priorityWeight(item.priority);
 
-    // Sort by priority within each sidecar's queue
-    queue.sort((a, b) => priorityWeight(a.priority) - priorityWeight(b.priority));
+    if (queue.length >= MAX_QUEUE_PER_SIDECAR) {
+      // Tail of the (priority-sorted) queue is the lowest priority present.
+      const tailWeight = priorityWeight(queue[queue.length - 1]!.priority);
+      if (weight > tailWeight) {
+        // Incoming is lower priority than everything queued — drop it.
+        console.warn(`[EventScheduler] Queue full for ${sidecarId}, dropping incoming ${item.priority} ${event.event_type}`);
+        return;
+      }
+      // Drop the oldest event of the lowest priority class (stale data —
+      // e.g. an old capture — is worth less than what just arrived).
+      const dropIdx = queue.findIndex((q) => priorityWeight(q.priority) === tailWeight);
+      const dropped = queue.splice(dropIdx, 1)[0]!;
+      console.warn(`[EventScheduler] Queue full for ${sidecarId}, dropped ${dropped.priority} ${dropped.event.event_type}`);
+    }
+
+    // Insert in priority order, after existing items of the same priority
+    // (stable FIFO within a class). Replaces the previous push+sort, which
+    // re-sorted the whole queue on every enqueue.
+    let insertAt = queue.length;
+    while (insertAt > 0 && priorityWeight(queue[insertAt - 1]!.priority) > weight) {
+      insertAt--;
+    }
+    queue.splice(insertAt, 0, item);
   }
 
   /** Remove a sidecar's queue (on disconnect) */
@@ -119,28 +156,35 @@ export class EventScheduler {
     this.processing = true;
 
     try {
-      // One round-robin pass: try each sidecar once
-      const count = this.sidecarIds.length;
-      for (let i = 0; i < count; i++) {
-        const idx = (this.roundRobinIndex + i) % count;
-        const sidecarId = this.sidecarIds[idx]!;
-        const queue = this.queues.get(sidecarId);
-
-        if (!queue || queue.length === 0) continue;
-
-        const item = queue.shift()!;
-        this.roundRobinIndex = (idx + 1) % count;
-
+      // Up to DRAIN_BATCH_PER_TICK events per tick, round-robin across
+      // sidecars so no single sidecar monopolizes the batch.
+      for (let dispatched = 0; dispatched < DRAIN_BATCH_PER_TICK; dispatched++) {
+        const item = this.nextItem();
+        if (!item) break;
         await this.dispatch(item);
-
-        // Process one event per drain tick to stay non-blocking
-        break;
       }
     } catch (err) {
       console.error('[EventScheduler] Drain error:', err);
     } finally {
       this.processing = false;
     }
+  }
+
+  /**
+   * Round-robin pick: next non-empty queue after the last-served sidecar.
+   * Re-reads sidecarIds each call — dispatch() awaits handlers, and a
+   * sidecar may disconnect (removeSidecar) while one is in flight.
+   */
+  private nextItem(): QueuedEvent | null {
+    const count = this.sidecarIds.length;
+    for (let i = 0; i < count; i++) {
+      const idx = (this.roundRobinIndex + i) % count;
+      const queue = this.queues.get(this.sidecarIds[idx]!);
+      if (!queue || queue.length === 0) continue;
+      this.roundRobinIndex = (idx + 1) % count;
+      return queue.shift()!;
+    }
+    return null;
   }
 
   private async dispatch(item: QueuedEvent): Promise<void> {

--- a/src/workflows/pieces-library/catalog.ts
+++ b/src/workflows/pieces-library/catalog.ts
@@ -140,7 +140,8 @@ export function findCatalogEntry(id: string): CatalogEntry | null {
 /**
  * Stable map keyed by id, useful in callers that look up entries repeatedly
  * (the API route handlers, the reconciler). Memoized -- CATALOG is immutable
- * after module load, so one Map serves every caller.
+ * after module load, so one Map serves every caller. Do not mutate the
+ * returned Map; it is shared.
  */
 let catalogByIdCache: Map<string, CatalogEntry> | null = null;
 export function catalogById(): Map<string, CatalogEntry> {

--- a/src/workflows/pieces-library/catalog.ts
+++ b/src/workflows/pieces-library/catalog.ts
@@ -139,9 +139,11 @@ export function findCatalogEntry(id: string): CatalogEntry | null {
 
 /**
  * Stable map keyed by id, useful in callers that look up entries repeatedly
- * (the API route handlers, the reconciler). Re-computed every call -- the
- * catalog is tiny enough that the cost is invisible.
+ * (the API route handlers, the reconciler). Memoized -- CATALOG is immutable
+ * after module load, so one Map serves every caller.
  */
+let catalogByIdCache: Map<string, CatalogEntry> | null = null;
 export function catalogById(): Map<string, CatalogEntry> {
-  return new Map(CATALOG.map((entry) => [entry.id, entry]));
+  catalogByIdCache ??= new Map(CATALOG.map((entry) => [entry.id, entry]));
+  return catalogByIdCache;
 }

--- a/src/workflows/runner/engine-runtime/spawn.ts
+++ b/src/workflows/runner/engine-runtime/spawn.ts
@@ -90,7 +90,10 @@ export function spawnEngine(opts: SpawnEngineOptions): SpawnedEngine {
   }
 
   const runtime = opts.runtime ?? process.execPath;
-  const child = spawn(runtime, [opts.bundlePath], {
+  // --smol: the engine is a short-lived-to-parked sandbox that grows to
+  // ~100MB under default JSC heap growth; the smaller-heap GC profile is the
+  // right trade for a subprocess whose CPU time is dominated by piece I/O.
+  const child = spawn(runtime, ["--smol", opts.bundlePath], {
     env,
     cwd: opts.cwd,
     stdio: ["ignore", "pipe", "pipe"],

--- a/src/workflows/runner/engine-runtime/spawn.ts
+++ b/src/workflows/runner/engine-runtime/spawn.ts
@@ -93,7 +93,9 @@ export function spawnEngine(opts: SpawnEngineOptions): SpawnedEngine {
   // --smol: the engine is a short-lived-to-parked sandbox that grows to
   // ~100MB under default JSC heap growth; the smaller-heap GC profile is the
   // right trade for a subprocess whose CPU time is dominated by piece I/O.
-  const child = spawn(runtime, ["--smol", opts.bundlePath], {
+  // Bun-only flag, so skip it when opts.runtime overrides the binary.
+  const args = opts.runtime ? [opts.bundlePath] : ["--smol", opts.bundlePath];
+  const child = spawn(runtime, args, {
     env,
     cwd: opts.cwd,
     stdio: ["ignore", "pipe", "pipe"],

--- a/src/workflows/runtime/engine-bootstrap.ts
+++ b/src/workflows/runtime/engine-bootstrap.ts
@@ -65,6 +65,11 @@ export interface BootstrapWorkflowEngineOptions {
    * will be added here.
    */
   pieceRoots?: string[];
+  /**
+   * Idle TTL for the warm engine subprocess (see EngineRuntimeOptions.
+   * poolIdleTtlMs). Default: EngineRuntime's own 5-minute default.
+   */
+  engineIdleTtlMs?: number;
 }
 
 export interface BootstrapWorkflowEngineResult {
@@ -170,6 +175,7 @@ export async function bootstrapWorkflowEngine(
     api,
     bundlePath: cached.bundlePath,
     pool: true,
+    poolIdleTtlMs: opts.engineIdleTtlMs,
     customPiecesPaths: [
       resolve(ENGINE_BUILD_PATHS.VENDOR_PACKAGES, "pieces"),
       piecesBaseDir(),


### PR DESCRIPTION
## Summary

Reduces the brain daemon's RAM footprint along four independent axes, plus review-driven hardening. Empirical baseline: the daemon's import graph alone cost **110MB RSS** before any service started (Bun baseline: 33MB); after this branch it is **~83MB**, with the remaining growth vectors bounded.

### Boot footprint
- **Lazy-import `discord.js` (+38MB standalone) and `edge-tts-universal` (+27MB)** — both were statically imported even when the Discord channel / Edge TTS were disabled in config, while construction was already config-gated. Marginal saving ~25MB (the packages share ws/undici between themselves). Most instances have neither enabled.
- Memoize `catalogById()` (was rebuilding a 656-entry Map per call).

### Unbounded growth (the OOM-restart vectors)
- **Agent `messageHistory`** is now bounded via the existing `compactHistory` at a 200k-token budget (matches the largest request-time budget, so what goes on the wire never changes) with 110% hysteresis so appends stay O(1). Stored screenshot base64 (up to 5MB each, previously pinned forever) is released once the turn completes; in-flight requests keep their references (entries are replaced, not mutated). Conversation history remains fully persisted in SQLite.
- **Sidecar event queues** capped at 500/sidecar with a priority-aware drop policy (`rpc_result`/`rpc_progress` are never dropped — a caller awaits those; the cap overflows instead, bounded by pending-RPC tracking). Drain rate raised 20/s → ~200/s (batched round-robin), per-enqueue full sort replaced with ordered insertion.
- **Ref binaries >1MB spool to disk** (`~/.jarvis/cache/sidecar-spool/`) instead of sitting as base64 in queued events (a 50MB capture was ~66MB of heap). The descriptor keeps the inline shape with a lazy `data` getter — memoized per synchronous consumption, released on the next microtask; expired files degrade to `null` so consumers' `typeof` guards route to their missing-binary path. Wiped at startup, TTL-swept at 10 min.
- Struggle detector stores per-pair edit distances instead of 30 full OCR dumps (identical signal math); transient per-sidecar maps clear on disconnect.

### Engine children
- Spawned with `--smol` (only for the default Bun binary, not `runtime` overrides). A parked warm engine is ~100MB.
- Idle TTL exposed as `workflows.engineIdleTtlMs` / `JARVIS_ENGINE_IDLE_TTL_MS` (env wins — `workflows` is user-owned, so fleet operators tune via the unit file). Default unchanged at 5 min; non-positive values rejected (0 would disable eviction).

### Observability
- `EventScheduler.dropped()` and `BinarySpool.stats()` counters (mirroring `WorkflowEventBuffer.dropped()`), exposed via `SidecarManager.getEventStats()`; overflow logging rate-limited to 1 line/5s per sidecar.