### PR TITLE
Shared runtime artifacts: prebuilt engine, pieces catalog and metadata cache paths

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -23,6 +23,17 @@ daemon:
 # browser:
 #   local: false
 
+# The workflow runtime can use READY-MADE artifacts instead of building its
+# own: a dir of prebuilt engine bundles (<hash>/main.js), a ready-made pieces
+# catalog (usable without installing; your own installs shadow it), and a
+# prebuilt piece-metadata cache file. Paths may contain ${version}, expanded
+# from the JARVIS_VERSION env var, for machines that keep artifacts per
+# installed version. Omit any of them and jarvis does that work itself.
+# workflows:
+#   engine_dir: /opt/jarvis-engine/${version}
+#   pieces_dir: /opt/jarvis-pieces/${version}
+#   piece_metadata_cache: /opt/jarvis-cache/${version}/piece-metadata.json
+
 # Authentication — JWT-only by DEFAULT. The dashboard, API, and WebSocket
 # require a token from an enrolled device. Correct setup order:
 #   1. jarvis enroll "my-desktop"     (prints the device's enrollment token)

--- a/scripts/build-shared-runtime.ts
+++ b/scripts/build-shared-runtime.ts
@@ -1,0 +1,188 @@
+#!/usr/bin/env bun
+/**
+ * CLI: build EVERY per-version shared runtime artifact for multi-tenant
+ * hosting, in one pass (the VPS's install-version wrapper calls this from the
+ * freshly installed tree, with HOME pointed at a scratch dir):
+ *
+ *   <out>/engine/<hash>/main.js(+.map,.meta.json)   read-only shared bundle
+ *                                                   (JARVIS_ENGINE_CACHE_ROOT)
+ *   <out>/pieces/{package.json,bun.lock,node_modules/}
+ *                                                   full community catalog
+ *                                                   (JARVIS_SHARED_PIECES_DIR)
+ *   <out>/piece-metadata.json                       prebuilt per-entry cache
+ *                                                   (JARVIS_PIECE_METADATA_CACHE)
+ *
+ * The caller controls delta-efficiency via the environment: a persistent
+ * BUN_INSTALL_CACHE_DIR makes unchanged packages hardlink instead of
+ * download, and seeding <out>/pieces/bun.lock from the PREVIOUS version
+ * (--seed-lock) keeps unchanged catalog ranges pinned so only genuinely
+ * changed pieces resolve anew. Setting BUN_RUNTIME_TRANSPILER_CACHE_PATH
+ * while this runs warms the transpiler cache for every piece SDK the
+ * metadata extraction imports.
+ *
+ * Usage:
+ *   bun run scripts/build-shared-runtime.ts --out /tmp/shared-runtime
+ *     [--pieces N]           only the first N catalog entries (dev/CI smoke)
+ *     [--seed-lock PATH]     previous version's pieces bun.lock
+ *
+ * Exit 0 with a JSON summary on stdout (including per-piece extraction
+ * failures — the CALLER decides how many failures are acceptable); exit 1
+ * only when the build itself cannot complete.
+ */
+
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { cpSync, copyFileSync, existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { buildEngineBundle, ENGINE_BUILD_PATHS } from "../src/workflows/runner/engine-runtime/build";
+import { buildAllJarvisPieces } from "../src/workflows/runner/engine-runtime/build-pieces";
+import { EngineRuntime } from "../src/workflows/runner/engine-runtime/engine-runtime";
+import { SandboxApi } from "../src/workflows/sandbox-api/server";
+import { CredentialResolver } from "../src/workflows/credentials/adapter";
+import { CATALOG } from "../src/workflows/pieces-library/catalog";
+import {
+  buildPieceCatalog,
+  computeCatalogCacheKey,
+} from "../src/workflows/runtime/piece-catalog";
+
+function flagValue(flag: string): string | null {
+  const i = process.argv.indexOf(flag);
+  return i >= 0 ? (process.argv[i + 1] ?? null) : null;
+}
+
+const outArg = flagValue("--out");
+if (!outArg) {
+  console.error("usage: build-shared-runtime --out <dir> [--pieces N] [--seed-lock PATH]");
+  process.exit(1);
+}
+const out = resolve(outArg);
+const piecesLimit = flagValue("--pieces") ? Number(flagValue("--pieces")) : null;
+if (piecesLimit !== null && (!Number.isInteger(piecesLimit) || piecesLimit < 0)) {
+  console.error(`invalid --pieces: ${flagValue("--pieces")}`);
+  process.exit(1);
+}
+const seedLock = flagValue("--seed-lock");
+// --summary: the machine-readable contract. Builder stdout is NOT JSON-clean
+// (engine children's stdout is forwarded with a prefix), so callers that need
+// the summary read the file, never the stream.
+const summaryPath = flagValue("--summary");
+
+// Refuse a dirty output dir: stale artifacts from a previous run (a different
+// catalog subset, an older engine hash) would be swept into the shared tree.
+if (existsSync(out) && readdirSync(out).length > 0) {
+  console.error(`--out ${out} exists and is not empty — pass a fresh directory`);
+  process.exit(1);
+}
+
+const t0 = Date.now();
+const log = (m: string) => console.error(`[shared-runtime] ${m}`);
+
+// 1. Vendored jarvis pieces must be compiled before metadata extraction (they
+// normally ship prebuilt; on a source checkout this builds them).
+await buildAllJarvisPieces();
+
+// 2. Engine bundle -> <out>/engine/<hash>/ (the whole content-addressed dir,
+// so instances resolve it by the same hash they compute from the install).
+// force: a build must always BE a build — without it a stray
+// JARVIS_ENGINE_CACHE_ROOT in the builder's env would turn this into a copy
+// of a pre-existing, unverified bundle.
+const bundle = await buildEngineBundle({ force: true });
+const engineOutDir = resolve(out, "engine", bundle.hash);
+mkdirSync(engineOutDir, { recursive: true });
+cpSync(bundle.bundleDir, engineOutDir, { recursive: true });
+// Content manifest: the dir NAME is a hash of build INPUTS, not of main.js —
+// consumers verify the sha256 of the bytes they are about to execute.
+const mainBytes = readFileSync(resolve(engineOutDir, "main.js"));
+writeFileSync(
+  resolve(engineOutDir, "main.js.sha256"),
+  createHash("sha256").update(mainBytes).digest("hex") + "\n",
+);
+log(`engine bundle ${bundle.hash} -> ${engineOutDir}`);
+
+// 3. Full pieces catalog install. The synthesized package.json is the SAME
+// shape the per-user installer writes, just spanning the whole catalog; the
+// versionRange already carries any VERSION_PIN override.
+const catalog = piecesLimit !== null ? CATALOG.slice(0, piecesLimit) : CATALOG;
+const piecesDir = resolve(out, "pieces");
+mkdirSync(piecesDir, { recursive: true });
+const deps: Record<string, string> = {};
+for (const entry of catalog) deps[entry.npmPackage] = entry.versionRange;
+writeFileSync(
+  resolve(piecesDir, "package.json"),
+  JSON.stringify(
+    {
+      name: "jarvis-shared-pieces",
+      private: true,
+      description: "Shared community-pieces catalog (generated by build-shared-runtime)",
+      dependencies: deps,
+    },
+    null,
+    2,
+  ) + "\n",
+);
+if (seedLock && existsSync(seedLock)) {
+  copyFileSync(seedLock, resolve(piecesDir, "bun.lock"));
+  log(`seeded bun.lock from ${seedLock}`);
+}
+log(`installing ${catalog.length} pieces (bun cache: ${process.env.BUN_INSTALL_CACHE_DIR ?? "default"})`);
+// --ignore-scripts: bun's DEFAULT-trusted list (~370 names incl. esbuild,
+// sharp, better-sqlite3) would otherwise run lifecycle scripts from whatever
+// npm serves — the exact npm-account-controlled-code threat install-version
+// refuses for the brain package itself. A piece whose native dep genuinely
+// needs a build step fails extraction VISIBLY (failures[]) instead.
+// process.execPath: never resolve the interpreter via PATH in a build.
+const install = spawnSync(process.execPath, ["install", "--silent", "--ignore-scripts"], {
+  cwd: piecesDir,
+  stdio: ["ignore", "inherit", "inherit"],
+});
+if (install.status !== 0) {
+  console.error(`bun install failed (exit ${install.status})`);
+  process.exit(1);
+}
+
+// 4. Metadata extraction for the WHOLE tree (vendored + shared catalog),
+// written as the per-entry cache instances mount read-only. No overall
+// deadline: this is a build machine, not a tenant boot — completeness wins.
+const api = new SandboxApi({ services: { credentialResolver: new CredentialResolver() } });
+await api.start({ host: "127.0.0.1", port: 0 });
+// customPiecesPaths mirrors engine-bootstrap: the ENGINE resolves piece
+// modules through these roots (each root's node_modules), independent of the
+// discovery walk below — without the pieces dir here every community piece
+// extraction dies with INTERNAL_ERROR.
+const runtime = new EngineRuntime({
+  api,
+  bundlePath: bundle.bundlePath,
+  pool: false,
+  customPiecesPaths: [resolve(ENGINE_BUILD_PATHS.VENDOR_PACKAGES, "pieces"), piecesDir],
+});
+const pieceRoots = [
+  resolve(ENGINE_BUILD_PATHS.VENDOR_PACKAGES, "pieces/jarvis"),
+  resolve(piecesDir, "node_modules/@activepieces"),
+];
+const cacheFile = resolve(out, "piece-metadata.json");
+const { catalog: built, failures } = await buildPieceCatalog({
+  runtime,
+  pieceRoots,
+  cacheFile,
+  cacheKey: computeCatalogCacheKey({ bundlePath: bundle.bundlePath }),
+  pieceTimeoutMs: 30_000,
+  overallTimeoutMs: 6 * 60 * 60 * 1000,
+  reporter: (m) => log(m),
+});
+await runtime.shutdown();
+await api.stop();
+
+// 5. Machine-readable summary — written to --summary when given (stdout is
+// best-effort only; engine-child passthrough can interleave with it).
+const summary =
+  JSON.stringify({
+    out,
+    engineHash: bundle.hash,
+    pieces: catalog.length,
+    extracted: built.list().length,
+    failures: failures.map((f) => ({ piece: `${f.pieceName}@${f.pieceVersion}`, reason: f.reason })),
+    cacheFile,
+    elapsedMs: Date.now() - t0,
+  });
+if (summaryPath) writeFileSync(resolve(summaryPath), summary + "\n");
+console.log(summary);

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -22,6 +22,26 @@ describe('Config Loader', () => {
     await rm(TEST_CONFIG_DIR, { recursive: true, force: true });
   });
 
+  test('workflows SYSTEM path keys survive the user-section discard; user fields do not', async () => {
+    // A hosted/system config carries only the ready-made artifact paths;
+    // any user-tunable workflow fields in the FILE have no authority (they
+    // live in the DB) — but the paths are file-owned and must survive.
+    const yaml = `
+workflows:
+  enabled: false
+  engine_dir: /opt/jarvis-engine/\${version}
+  pieces_dir: /srv/pieces
+  piece_metadata_cache: /srv/piece-metadata.json
+`;
+    await Bun.write(TEST_CONFIG_PATH, yaml);
+    const loaded = await loadConfig(TEST_CONFIG_PATH);
+    expect(loaded.workflows?.engine_dir).toBe('/opt/jarvis-engine/\${version}');
+    expect(loaded.workflows?.pieces_dir).toBe('/srv/pieces');
+    expect(loaded.workflows?.piece_metadata_cache).toBe('/srv/piece-metadata.json');
+    // The file's `enabled: false` was discarded with the user section.
+    expect(loaded.workflows?.enabled).toBeUndefined();
+  });
+
   test('returns default config when file does not exist', async () => {
     const config = await loadConfig('/tmp/nonexistent-config.yaml');
     // Paths should be tilde-expanded, but all other fields match defaults

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -2,7 +2,7 @@ import YAML from 'yaml';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 import type { JarvisConfig } from './types.ts';
-import { DEFAULT_CONFIG, USER_OWNED_SECTIONS } from './types.ts';
+import { DEFAULT_CONFIG, USER_OWNED_SECTIONS, WORKFLOW_SYSTEM_KEYS } from './types.ts';
 
 function expandTilde(filepath: string): string {
   if (filepath.startsWith('~/')) {
@@ -150,10 +150,31 @@ export async function loadConfig(configPath?: string): Promise<JarvisConfig> {
   // daemon after the DB merge.
   for (const section of USER_OWNED_SECTIONS) {
     const def = (DEFAULT_CONFIG as Record<string, unknown>)[section];
+    // `workflows` is user-owned EXCEPT its system path keys (ready-made
+    // artifact locations a deployment writes into the file): those survive
+    // the discard, and user-settings' merge keeps them file-authoritative.
+    let preserved: Record<string, unknown> | null = null;
+    if (section === "workflows") {
+      const current = (config as Record<string, unknown>)[section];
+      if (current && typeof current === "object") {
+        for (const key of WORKFLOW_SYSTEM_KEYS) {
+          const v = (current as Record<string, unknown>)[key];
+          if (typeof v === "string" && v.trim()) {
+            (preserved ??= {})[key] = v;
+          }
+        }
+      }
+    }
     if (def === undefined) {
       delete (config as Record<string, unknown>)[section];
     } else {
       (config as Record<string, unknown>)[section] = structuredClone(def);
+    }
+    if (preserved) {
+      (config as Record<string, unknown>)[section] = {
+        ...((config as Record<string, unknown>)[section] as object | undefined),
+        ...preserved,
+      };
     }
   }
   applyEnvOverrides(config); // env wins over the discard (e.g. JARVIS_WAKE_ENGINE)

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -189,6 +189,26 @@ export type WorkflowConfig = {
    * a user-owned section, so fleet operators tune via env instead).
    */
   engineIdleTtlMs?: number;
+  /**
+   * Where the workflow runtime finds READY-MADE artifacts instead of
+   * building/installing its own. All optional; each path may contain a
+   * `${version}` placeholder expanded from the `JARVIS_VERSION` env var
+   * (useful when one machine keeps artifacts per installed version). Any
+   * unset/missing path just means jarvis does the work itself, as usual.
+   * The JARVIS_ENGINE_CACHE_ROOT / JARVIS_SHARED_PIECES_DIR /
+   * JARVIS_PIECE_METADATA_CACHE env vars are honored as fallbacks; config
+   * wins when both are set.
+   */
+  /** Dir holding prebuilt engine bundles as `<hash>/main.js` — consulted
+   * before building into `~/.jarvis/cache/engine`. */
+  engine_dir?: string;
+  /** Dir with a ready-made pieces catalog (`node_modules/@activepieces/...`).
+   * Pieces here are usable without installing; a piece installed via the
+   * Library into `~/.jarvis/pieces` shadows the copy found here. */
+  pieces_dir?: string;
+  /** A prebuilt piece-metadata cache FILE (the per-entry JSON the catalog
+   * builder writes) — boots skip extraction for every piece it covers. */
+  piece_metadata_cache?: string;
 };
 
 export type GoalConfig = {
@@ -559,3 +579,12 @@ export const USER_OWNED_SECTIONS = [
 ] as const satisfies readonly (keyof JarvisConfig)[];
 
 export type UserOwnedSection = (typeof USER_OWNED_SECTIONS)[number];
+
+/**
+ * The SYSTEM-owned keys of the otherwise user-owned `workflows` section:
+ * ready-made artifact paths a deployment (e.g. a managed host) writes into
+ * config.yaml. The FILE wins for these — loadConfig preserves them through
+ * the user-section discard and the DB merge re-applies them on top, so a
+ * dashboard save of the user-tunable workflow fields can never strip them.
+ */
+export const WORKFLOW_SYSTEM_KEYS = ["engine_dir", "pieces_dir", "piece_metadata_cache"] as const;

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -68,6 +68,8 @@ import {
 } from "../workflows/runtime/engine-bootstrap.ts";
 import { CredentialResolver } from "../workflows/credentials/adapter.ts";
 import { metadataToCatalogEntry } from "../workflows/runtime/piece-catalog.ts";
+import { sharedPieceVersions } from "../workflows/pieces-library/shared.ts";
+import { resolveSharedRuntimePaths } from "../workflows/runtime/shared-runtime-paths.ts";
 import { DEFAULT_IDS } from "../workflows/db/schema.ts";
 import { apId } from "../workflows/db/ids.ts";
 import { buildSandboxServiceBackends } from "../workflows/runtime/service-backends.ts";
@@ -4050,6 +4052,14 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
         "Workflow credential resolver: registered jarvis:telegram source",
       );
     }
+    // Ready-made workflow-runtime artifact paths (workflows.engine_dir /
+    // pieces_dir / piece_metadata_cache, with ${version} expansion; env vars
+    // as fallback). Resolved ONCE and passed everywhere (bootstrap, Library
+    // routes, uninstall revert) so the whole daemon agrees on the paths.
+    const sharedRuntime = resolveSharedRuntimePaths(jarvisConfig);
+    for (const w of sharedRuntime.warnings) {
+      logWithTimestamp(`[shared-runtime] WARNING: ${w}`);
+    }
     try {
       engineBoot = await bootstrapWorkflowEngine({
         services: {
@@ -4072,6 +4082,9 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
         },
         log: (line) => console.log(`[Daemon] ${line}`),
         engineIdleTtlMs: resolveEngineIdleTtlMs(jarvisConfig.workflows?.engineIdleTtlMs),
+        sharedPiecesDir: sharedRuntime.piecesDir,
+        sharedCacheFile: sharedRuntime.metadataCacheFile,
+        engineCacheRoot: sharedRuntime.engineCacheRoot,
       });
       workflowEngineShutdown = engineBoot.shutdown;
       logWithTimestamp(
@@ -4129,10 +4142,22 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
             kind: "installed" | "uninstalled";
             piece: { npmPackage: string; resolvedVersion: string };
           }) => {
-            if (event.kind === "uninstalled") {
+            // Uninstalling a piece the SHARED catalog also provides reverts
+            // to the shared copy (that's what the next restart would produce
+            // via discoverPieces, and what the Library reports as Included) —
+            // so re-extract at the shared version instead of dropping the
+            // entry and leaving the live catalog disagreeing with the
+            // Library until restart.
+            const sharedVersion =
+              event.kind === "uninstalled"
+                ? sharedPieceVersions(sharedRuntime.piecesDir).get(event.piece.npmPackage)
+                : undefined;
+            if (event.kind === "uninstalled" && sharedVersion === undefined) {
               workflowPieceCatalog.remove(event.piece.npmPackage);
               return;
             }
+            const extractVersion =
+              event.kind === "uninstalled" ? sharedVersion! : event.piece.resolvedVersion;
             // Unique runId per acquire so any future parallel installs
             // (today serialized by the API's library mutex) don't collide on
             // the engine's runId-keyed state.
@@ -4143,7 +4168,7 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
             try {
               const meta = await handle.extractPieceMetadata({
                 pieceName: event.piece.npmPackage,
-                pieceVersion: event.piece.resolvedVersion,
+                pieceVersion: extractVersion,
               });
               workflowPieceCatalog.upsert(metadataToCatalogEntry(meta));
             } finally {
@@ -4158,6 +4183,7 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
         triggerManager,
         credentialResolver,
         ...(workflowPieceCatalog ? { pieceRegistry: workflowPieceCatalog } : {}),
+        sharedPiecesDir: sharedRuntime.piecesDir,
         ...(onPieceLibraryChanged ? { onPieceLibraryChanged } : {}),
         getEventBufferDropped: () => workflowEventBuffer.dropped(),
       }),

--- a/src/daemon/user-settings.test.ts
+++ b/src/daemon/user-settings.test.ts
@@ -26,6 +26,34 @@ describe('user-settings', () => {
     closeDb();
   });
 
+  test('workflows: file-provided SYSTEM path keys win over a saved user section', () => {
+    // A dashboard save of the user-tunable workflow fields (which may carry
+    // stale/absent path keys) must never strip the deployment-written
+    // artifact paths that loadConfig preserved from the FILE.
+    saveUserSection('workflows', {
+      enabled: true,
+      maxConcurrentExecutions: 2,
+      defaultRetries: 0,
+      defaultTimeoutMs: 1000,
+      selfHealEnabled: false,
+      autoSuggestEnabled: false,
+    });
+
+    const config = freshConfig();
+    (config as Record<string, unknown>)['workflows'] = {
+      engine_dir: '/opt/jarvis-engine/${version}',
+      pieces_dir: '/srv/pieces',
+      piece_metadata_cache: '/srv/piece-metadata.json',
+    };
+    mergeUserSettingsIntoConfig(config);
+
+    expect(config.workflows?.enabled).toBe(true);
+    expect(config.workflows?.maxConcurrentExecutions).toBe(2);
+    expect(config.workflows?.engine_dir).toBe('/opt/jarvis-engine/${version}');
+    expect(config.workflows?.pieces_dir).toBe('/srv/pieces');
+    expect(config.workflows?.piece_metadata_cache).toBe('/srv/piece-metadata.json');
+  });
+
   test('save -> merge round-trips a section into the config', () => {
     saveUserSection('stt', { provider: 'groq', groq: { api_key: 'gk-1' } });
     saveUserSection('active_role', 'researcher');

--- a/src/daemon/user-settings.ts
+++ b/src/daemon/user-settings.ts
@@ -23,6 +23,7 @@ import { deepMerge } from '../config/loader.ts';
 import {
   DEFAULT_CONFIG,
   USER_OWNED_SECTIONS,
+  WORKFLOW_SYSTEM_KEYS,
   type JarvisConfig,
   type UserOwnedSection,
 } from '../config/types.ts';
@@ -157,10 +158,27 @@ export function mergeUserSettingsIntoConfig(config: JarvisConfig): void {
     if (stored === undefined) continue;
     const def = (DEFAULT_CONFIG as Record<string, unknown>)[section];
     const target = config as Record<string, unknown>;
+    // `workflows` system path keys are FILE-owned (loadConfig preserved them
+    // through the user-section discard): re-apply them over whatever the DB
+    // row carries, so a dashboard save of the user-tunable workflow fields
+    // can never strip the deployment-written artifact paths.
+    let filePaths: Record<string, unknown> | null = null;
+    if (section === 'workflows') {
+      const current = target[section];
+      if (current && typeof current === 'object') {
+        for (const key of WORKFLOW_SYSTEM_KEYS) {
+          const v = (current as Record<string, unknown>)[key];
+          if (typeof v === 'string' && v.trim()) (filePaths ??= {})[key] = v;
+        }
+      }
+    }
     if (typeof stored === 'object' && stored !== null && !Array.isArray(stored)) {
       target[section] = deepMerge(def !== undefined ? structuredClone(def) : {}, stored);
     } else {
       target[section] = stored;
+    }
+    if (filePaths) {
+      target[section] = { ...(target[section] as object), ...filePaths };
     }
   }
   mergeGoogleSettingsIntoConfig(config);

--- a/src/workflows/api/routes.ts
+++ b/src/workflows/api/routes.ts
@@ -71,6 +71,7 @@ import type { CredentialResolver } from "../credentials/adapter";
 import type { TriggerManager } from "../runner/triggers/manager";
 import type { PieceLookup } from "../runtime/piece-catalog";
 import { CATALOG, findCatalogEntry } from "../pieces-library/catalog";
+import { sharedPieceVersions } from "../pieces-library/shared";
 import {
   installPiece,
   readManifest,
@@ -140,6 +141,12 @@ export interface CreateWorkflowRoutesOptions {
    * picker. Without it, the catalog endpoint returns an empty list.
    */
   pieceRegistry?: PieceLookup;
+  /**
+   * Config-resolved ready-made pieces dir (workflows.pieces_dir, ${version}
+   * expanded). `undefined` falls back to the env var inside
+   * sharedPieceVersions; `null` = definitively none.
+   */
+  sharedPiecesDir?: string | null;
   /**
    * Optional credential resolver. When provided, the connections route can
    * report which `JarvisConnectionSource` adapters are registered (e.g.
@@ -273,8 +280,15 @@ export function createWorkflowRoutes(opts: CreateWorkflowRoutesOptions = {}): Wo
           const installedById = new Map(
             manifest.pieces.map((p) => [p.id, p]),
           );
+          // Shared read-only catalog (multi-tenant hosting): pieces present
+          // there work with NO installation, so the Library reports them as
+          // included (`source: "shared"`). A user install shadows the shared
+          // copy (engine-bootstrap orders roots user-first), so the user's
+          // manifest wins when both exist.
+          const shared = sharedPieceVersions(opts.sharedPiecesDir);
           const entries = CATALOG.map((entry) => {
             const installed = installedById.get(entry.id) ?? null;
+            const sharedVersion = shared.get(entry.npmPackage) ?? null;
             return {
               id: entry.id,
               npmPackage: entry.npmPackage,
@@ -292,8 +306,15 @@ export function createWorkflowRoutes(opts: CreateWorkflowRoutesOptions = {}): Wo
                 ? {
                     resolvedVersion: installed.resolvedVersion,
                     installedAt: installed.installedAt,
+                    source: "user" as const,
                   }
-                : null,
+                : sharedVersion
+                  ? {
+                      resolvedVersion: sharedVersion,
+                      installedAt: 0,
+                      source: "shared" as const,
+                    }
+                  : null,
             };
           });
           return ok({ entries });

--- a/src/workflows/pieces-library/shared.ts
+++ b/src/workflows/pieces-library/shared.ts
@@ -1,0 +1,61 @@
+/**
+ * Read-only SHARED pieces catalog (multi-tenant hosting): a root-owned tree
+ * the host builds once per installed version and exposes via
+ * `JARVIS_SHARED_PIECES_DIR`. Pieces present there are usable by every
+ * instance without installation — the Library shows them as included, and a
+ * user install of the same piece shadows the shared copy (engine-bootstrap
+ * orders the roots user-first).
+ */
+
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+export function sharedPiecesDir(): string | null {
+  const dir = process.env.JARVIS_SHARED_PIECES_DIR?.trim();
+  return dir ? resolve(dir) : null;
+}
+
+const memo = new Map<string, Map<string, string>>();
+
+/**
+ * npmPackage -> version for every piece in the shared tree. `dirArg`
+ * overrides discovery (the daemon passes the config-resolved dir; `null` =
+ * definitely none; `undefined` = fall back to the env var). Memoized per dir
+ * for the process lifetime: the tree is immutable per installed version, and
+ * version changes restart the daemon.
+ */
+export function sharedPieceVersions(dirArg?: string | null): Map<string, string> {
+  const dir = dirArg !== undefined ? (dirArg ? resolve(dirArg) : null) : sharedPiecesDir();
+  const key = dir ?? "";
+  const hit = memo.get(key);
+  if (hit) return hit;
+  const out = new Map<string, string>();
+  if (dir) {
+    const scoped = join(dir, "node_modules", "@activepieces");
+    if (existsSync(scoped)) {
+      for (const ent of readdirSync(scoped, { withFileTypes: true })) {
+        if (!ent.isDirectory() && !ent.isSymbolicLink()) continue;
+        const pkgPath = join(scoped, ent.name, "package.json");
+        try {
+          const pkg = JSON.parse(readFileSync(pkgPath, "utf8")) as {
+            name?: unknown;
+            version?: unknown;
+          };
+          if (typeof pkg.name !== "string" || typeof pkg.version !== "string") continue;
+          // Same convention as discoverPieces: real pieces only.
+          if (!/(^|\/)piece-[a-z0-9][a-z0-9-]*$/.test(pkg.name)) continue;
+          out.set(pkg.name, pkg.version);
+        } catch {
+          // Missing/unreadable package.json: not a piece.
+        }
+      }
+    }
+  }
+  memo.set(key, out);
+  return out;
+}
+
+/** Test seam: drop the memo (the env/dir changed under the test). */
+export function resetSharedPiecesCache(): void {
+  memo.clear();
+}

--- a/src/workflows/runner/engine-runtime/build-pieces.ts
+++ b/src/workflows/runner/engine-runtime/build-pieces.ts
@@ -34,6 +34,8 @@
 import { spawn } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
+  accessSync,
+  constants as fsConstants,
   existsSync,
   mkdirSync,
   readFileSync,
@@ -178,6 +180,21 @@ export async function buildPiece(
 
   // Miss path: stage check first (esbuild presence is required for the
   // actual build below; the cached path above never reaches it).
+  //
+  // Read-only install guard (multi-tenant hosting): the install tree is
+  // root-owned and tenants cannot write dist/. Published versions ship
+  // prebuilt dist/ so the fast-path above normally hits — reaching HERE on a
+  // read-only tree means the version was published without them, which every
+  // instance on the host would rediscover as a raw EACCES mid-boot. Fail
+  // with the actionable message instead.
+  try {
+    accessSync(pieceDir, fsConstants.W_OK);
+  } catch {
+    throw new Error(
+      `piece ${pkg.name} needs a rebuild (missing/stale dist/) but the install tree is read-only — ` +
+        `this version was published without prebuilt piece bundles; republish with 'bun run build:workflows'`,
+    );
+  }
   await ensureStagingInstalled();
   mkdirSync(resolve(distDir, "src"), { recursive: true });
 

--- a/src/workflows/runner/engine-runtime/build.test.ts
+++ b/src/workflows/runner/engine-runtime/build.test.ts
@@ -7,15 +7,60 @@
  * deps and takes a few seconds. CI opts in.
  */
 
-import { test, expect, describe } from "bun:test";
-import { existsSync, statSync } from "node:fs";
+import { test, expect, describe, afterEach } from "bun:test";
+import { existsSync, mkdirSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
 import { spawn } from "node:child_process";
-import { buildEngineBundle, ENGINE_BUILD_PATHS } from "./build";
+import { buildEngineBundle, bundleHash, findCachedBundle, ENGINE_BUILD_PATHS } from "./build";
 
 describe("engine bundle build", () => {
   test("staging dir lives outside the repo", () => {
     expect(ENGINE_BUILD_PATHS.STAGING_DIR.startsWith(ENGINE_BUILD_PATHS.REPO_ROOT)).toBe(false);
     expect(ENGINE_BUILD_PATHS.BUNDLE_ROOT.startsWith(ENGINE_BUILD_PATHS.REPO_ROOT)).toBe(false);
+  });
+
+  describe("shared bundle root (JARVIS_ENGINE_CACHE_ROOT)", () => {
+    afterEach(() => {
+      delete process.env.JARVIS_ENGINE_CACHE_ROOT;
+    });
+
+    test("a prebuilt shared bundle is found WITHOUT any staging dir precondition", async () => {
+      // Multi-tenant hosting seeds the bundle read-only under the shared
+      // root; discovery must not require the per-user 47MB staging install.
+      const root = resolve(tmpdir(), `shared-engine-${Date.now()}`);
+      const hash = bundleHash();
+      const bundleDir = resolve(root, hash);
+      mkdirSync(bundleDir, { recursive: true });
+      writeFileSync(resolve(bundleDir, "main.js"), "// prebuilt");
+      try {
+        process.env.JARVIS_ENGINE_CACHE_ROOT = root;
+        const found = findCachedBundle();
+        expect(found?.hash).toBe(hash);
+        expect(found?.bundlePath).toBe(resolve(bundleDir, "main.js"));
+        // buildEngineBundle short-circuits on it too (no staging install).
+        const built = await buildEngineBundle();
+        expect(built.bundlePath).toBe(resolve(bundleDir, "main.js"));
+      } finally {
+        rmSync(root, { recursive: true, force: true });
+      }
+    });
+
+    test("a shared root with no matching hash falls through to the per-user cache path", () => {
+      const root = resolve(tmpdir(), `shared-engine-miss-${Date.now()}`);
+      mkdirSync(root, { recursive: true });
+      try {
+        process.env.JARVIS_ENGINE_CACHE_ROOT = root;
+        const found = findCachedBundle();
+        // Either the developer machine has a warm per-user cache (found from
+        // BUNDLE_ROOT) or nothing at all — never a hit under the shared root.
+        if (found) {
+          expect(found.bundlePath.startsWith(root)).toBe(false);
+        }
+      } finally {
+        rmSync(root, { recursive: true, force: true });
+      }
+    });
   });
 
   test("vendored engine source exists at the expected path", () => {

--- a/src/workflows/runner/engine-runtime/build.ts
+++ b/src/workflows/runner/engine-runtime/build.ts
@@ -44,6 +44,21 @@ const CACHE_ROOT = resolve(homedir(), ".jarvis/cache");
 const STAGING_DIR = resolve(CACHE_ROOT, "engine-build");
 const BUNDLE_ROOT = resolve(CACHE_ROOT, "engine");
 
+/**
+ * Optional read-only SHARED bundle root (multi-tenant hosting): the host
+ * builds the bundle once per installed version and points every instance at
+ * it via this env var. Consulted before the per-user BUNDLE_ROOT; never
+ * written to — builds always land in the user's own cache, so a shared-root
+ * miss degrades to a local build instead of an EACCES on a root-owned tree.
+ */
+function sharedBundleRoot(explicit?: string | null): string | null {
+  // `undefined` = caller didn't resolve one (env fallback); `null` = the
+  // caller resolved "no shared root" (don't consult the env).
+  if (explicit !== undefined) return explicit ? resolve(explicit) : null;
+  const dir = process.env.JARVIS_ENGINE_CACHE_ROOT?.trim();
+  return dir ? resolve(dir) : null;
+}
+
 /** esbuild version pinned to match what activepieces uses upstream. */
 const ESBUILD_VERSION = "0.24.0";
 
@@ -158,7 +173,9 @@ function buildStagingPackageJson(): string {
       continue;
     }
     if (versionMeetsFloor(declared, floor)) {
-      console.log(
+      // stderr: build tooling stdout may be captured as machine-readable
+      // output (build-shared-runtime's summary) — diagnostics never go there.
+      console.warn(
         `[engine-build] SECURITY_FLOOR '${name}@${floor}' satisfied by upstream '${declared}'; remove entry.`,
       );
       continue;
@@ -270,7 +287,18 @@ export function ensureStagingInstalled(): Promise<void> {
   return stagingInstallInFlight;
 }
 
-export async function buildEngineBundle(opts?: { force?: boolean }): Promise<EngineBundle> {
+export async function buildEngineBundle(opts?: {
+  force?: boolean;
+  sharedRoot?: string | null;
+}): Promise<EngineBundle> {
+  // A shared prebuilt bundle short-circuits the whole build — including the
+  // staging install, which would otherwise cost every tenant a ~47 MB
+  // node_modules just to discover the bundle already exists.
+  if (!opts?.force) {
+    const shared = findSharedBundle(opts?.sharedRoot);
+    if (shared) return shared;
+  }
+
   await ensureStagingInstalled();
 
   const hash = bundleHash();
@@ -333,15 +361,49 @@ export const ENGINE_BUILD_PATHS = {
   BUNDLE_ROOT,
 } as const;
 
+/** The shared-root bundle for the current source hash, if present.
+ *
+ * When the builder shipped a content manifest (main.js.sha256), the bytes we
+ * are about to execute are verified against it — the directory NAME hashes
+ * build inputs, not output, so without this check the store would be
+ * content-addressed in name only. Mismatch/missing-manifest handling: a bad
+ * manifest is a MISS (fall back to the local build), never a crash. */
+function findSharedBundle(sharedRoot?: string | null): EngineBundle | null {
+  const root = sharedBundleRoot(sharedRoot);
+  if (!root) return null;
+  const hash = bundleHash();
+  const bundleDir = resolve(root, hash);
+  const bundlePath = resolve(bundleDir, "main.js");
+  if (!existsSync(bundlePath)) return null;
+  const manifestPath = bundlePath + ".sha256";
+  if (existsSync(manifestPath)) {
+    try {
+      const want = readFileSync(manifestPath, "utf8").trim();
+      const got = createHash("sha256").update(readFileSync(bundlePath)).digest("hex");
+      if (want !== got) return null;
+    } catch {
+      return null;
+    }
+  }
+  return { bundlePath, hash, bundleDir };
+}
+
 /**
- * Locate an already-built engine bundle for the current source state.
- * Returns null if no matching bundle is on disk -- callers can either
+ * Locate an already-built engine bundle for the current source state —
+ * the shared root (if configured) first, then the per-user cache. Returns
+ * null if no matching bundle is on disk -- callers can either
  * `buildEngineBundle()` (slow on cold start) or skip the work entirely.
+ *
+ * Note: NO staging-dir precondition. `bundleHash()` is computed purely from
+ * the install tree + compiled-in constants; the old `STAGING_DIR/package.json`
+ * guard was unsound and forced a pointless per-user staging install before a
+ * prebuilt bundle could even be discovered.
  */
-export function findCachedBundle(): { bundlePath: string; hash: string } | null {
-  // Recompute the hash from current sources; if the staging dir doesn't
-  // exist yet, we have no cached bundle to find.
-  if (!existsSync(resolve(STAGING_DIR, "package.json"))) return null;
+export function findCachedBundle(opts?: {
+  sharedRoot?: string | null;
+}): { bundlePath: string; hash: string } | null {
+  const shared = findSharedBundle(opts?.sharedRoot);
+  if (shared) return { bundlePath: shared.bundlePath, hash: shared.hash };
   const hash = bundleHash();
   const bundlePath = resolve(BUNDLE_ROOT, hash, "main.js");
   return existsSync(bundlePath) ? { bundlePath, hash } : null;

--- a/src/workflows/runner/engine-runtime/spawn.ts
+++ b/src/workflows/runner/engine-runtime/spawn.ts
@@ -68,7 +68,20 @@ export function spawnEngine(opts: SpawnEngineOptions): SpawnedEngine {
   // process.env into the engine because that leaks secrets into a sandboxed
   // process; the engine only needs PATH / HOME / TMPDIR for child-process
   // sandboxing of CODE actions.
-  for (const key of ["PATH", "HOME", "TMPDIR", "LANG", "LC_ALL", "TZ"]) {
+  // BUN_RUNTIME_TRANSPILER_CACHE_PATH: not a secret — forwarding it lets the
+  // engine child hit the host's shared read-only transpiler cache when it
+  // parses large piece SDK files (multi-tenant hosting warms it per version).
+  // Bun is fail-open on an unreadable/unwritable cache dir, so this can never
+  // break a spawn.
+  for (const key of [
+    "PATH",
+    "HOME",
+    "TMPDIR",
+    "LANG",
+    "LC_ALL",
+    "TZ",
+    "BUN_RUNTIME_TRANSPILER_CACHE_PATH",
+  ]) {
     const v = process.env[key];
     if (v !== undefined) env[key] = v;
   }

--- a/src/workflows/runtime/engine-bootstrap.ts
+++ b/src/workflows/runtime/engine-bootstrap.ts
@@ -35,6 +35,7 @@ import {
 import {
   buildPieceCatalog,
   computeCatalogCacheKey,
+  readCachedEntries,
   PieceCatalog,
   type PieceExtractionFailure,
 } from "./piece-catalog";
@@ -70,6 +71,15 @@ export interface BootstrapWorkflowEngineOptions {
    * poolIdleTtlMs). Default: EngineRuntime's own 5-minute default.
    */
   engineIdleTtlMs?: number;
+  /**
+   * Shared-runtime paths, config-resolved by the daemon (see
+   * shared-runtime-paths.ts). `undefined` = fall back to the bare env vars;
+   * `null` = definitively none. config.yaml is the hosting-owned source of
+   * truth; the env vars are the fallback for unmanaged deployments.
+   */
+  sharedPiecesDir?: string | null;
+  sharedCacheFile?: string | null;
+  engineCacheRoot?: string | null;
 }
 
 export interface BootstrapWorkflowEngineResult {
@@ -85,11 +95,11 @@ export interface BootstrapWorkflowEngineResult {
    */
   bundleHash: string;
   /**
-   * Content-hash key used to invalidate the on-disk piece-catalog
-   * cache. Combines the bundle hash with every piece's compiled
-   * output, so any source-level edit forces a fresh extraction. Logged
-   * alongside `bundleHash` so users can confirm cache freshness from
-   * the daemon log alone.
+   * GLOBAL cache-invalidation key for the piece-metadata cache: projection
+   * schema + engine bundle + event-type registry. Per-piece source changes
+   * invalidate their own cache ENTRY (content hash), not this key. Logged
+   * alongside `bundleHash` so users can confirm cache freshness from the
+   * daemon log alone.
    */
   catalogCacheKey: string;
   /** Tear down the SandboxApi server. Call after the worker has stopped. */
@@ -145,10 +155,10 @@ export async function bootstrapWorkflowEngine(
     labelled(
       "bundle-build",
       (async () => {
-        let c = findCachedBundle();
+        let c = findCachedBundle({ sharedRoot: opts.engineCacheRoot });
         if (!c) {
           log("engine bundle not in cache; building (one-time cost ~700ms)");
-          c = await buildEngineBundle();
+          c = await buildEngineBundle({ sharedRoot: opts.engineCacheRoot });
         }
         return c;
       })(),
@@ -171,6 +181,16 @@ export async function bootstrapWorkflowEngine(
   // both at runtime: vendored pieces resolve via the standard upstream
   // layout, user-installed pieces via our patched shared-node_modules
   // shape (see piece-loader.ts).
+  //
+  // JARVIS_SHARED_PIECES_DIR (multi-tenant hosting): a root-owned READ-ONLY
+  // catalog tree built once per installed version. Appended AFTER the user's
+  // own dir so a user-installed piece shadows the shared copy (both the
+  // loader walk and discoverPieces are first-wins). The installer/reconciler
+  // never touch it — they operate solely on `~/.jarvis/pieces`.
+  const sharedPiecesDir =
+    opts.sharedPiecesDir !== undefined
+      ? opts.sharedPiecesDir
+      : process.env.JARVIS_SHARED_PIECES_DIR?.trim() || null;
   const runtime = new EngineRuntime({
     api,
     bundlePath: cached.bundlePath,
@@ -179,6 +199,7 @@ export async function bootstrapWorkflowEngine(
     customPiecesPaths: [
       resolve(ENGINE_BUILD_PATHS.VENDOR_PACKAGES, "pieces"),
       piecesBaseDir(),
+      ...(sharedPiecesDir ? [sharedPiecesDir] : []),
     ],
   });
 
@@ -194,19 +215,45 @@ export async function bootstrapWorkflowEngine(
   const pieceRoots = opts.pieceRoots ?? [
     resolve(ENGINE_BUILD_PATHS.VENDOR_PACKAGES, "pieces/jarvis"),
     resolve(piecesNodeModulesDir(), "@activepieces"),
+    // Shared catalog last: discoverPieces is first-wins, so a user install
+    // of the same piece shadows the shared copy here too.
+    ...(sharedPiecesDir ? [resolve(sharedPiecesDir, "node_modules/@activepieces")] : []),
   ];
-  const cacheKey = computeCatalogCacheKey({
-    bundlePath: cached.bundlePath,
-    pieceRoots,
-  });
+  const cacheKey = computeCatalogCacheKey({ bundlePath: cached.bundlePath });
   const cacheFile = opts.cacheFile ?? DEFAULT_CACHE_FILE;
+  // JARVIS_PIECE_METADATA_CACHE: a READ-ONLY prebuilt metadata cache for the
+  // shared tree (generated at version-install time). With it, first boot is
+  // a cache hit for every shared piece — no 650-piece extraction spike.
+  const sharedCacheFile =
+    opts.sharedCacheFile !== undefined
+      ? opts.sharedCacheFile
+      : process.env.JARVIS_PIECE_METADATA_CACHE?.trim() || null;
+  // A CONFIGURED shared cache that exists but fails the global-key gate means
+  // the host's artifacts don't match this daemon (a bundle rebuilt locally,
+  // or shared artifacts not regenerated for a daemon change). The fallback —
+  // every tenant re-extracting the whole shared catalog — is a fleet-wide
+  // storm, so say so LOUDLY instead of silently filtering to nothing.
+  if (sharedCacheFile && existsSync(sharedCacheFile)) {
+    if (readCachedEntries(sharedCacheFile, cacheKey) === null) {
+      log(
+        `WARNING: shared piece-metadata cache ${sharedCacheFile} does not match this daemon's ` +
+          `catalog key — falling back to per-tenant extraction (were the shared artifacts ` +
+          `rebuilt for this version?)`,
+      );
+    }
+  }
   const t2 = Date.now();
-  const cacheHitBeforeBuild = existsSync(cacheFile);
+  const cacheFilePresent = existsSync(cacheFile);
   const { catalog, failures } = await buildPieceCatalog({
     runtime,
     pieceRoots,
     cacheFile,
     cacheKey,
+    sharedCacheFiles: sharedCacheFile ? [sharedCacheFile] : [],
+    // A shared tree can hold the whole 650-piece catalog; if its prebuilt
+    // cache was rejected (warning above) the default 60s deadline would mark
+    // hundreds of pieces failed. Give the recovery path room instead.
+    ...(sharedPiecesDir ? { overallTimeoutMs: 15 * 60_000 } : {}),
     reporter: (m) => log(m),
   });
   const extractMs = Date.now() - t2;
@@ -214,7 +261,7 @@ export async function bootstrapWorkflowEngine(
     log(`catalog built with ${failures.length} extraction failure(s); pieces still available: ${catalog.list().length} (${extractMs}ms)`);
   } else {
     log(
-      `catalog built (${catalog.list().length} pieces, cache: ${cacheHitBeforeBuild ? "hit" : "miss"}, ${extractMs}ms)`,
+      `catalog built (${catalog.list().length} pieces, cache file ${cacheFilePresent ? "present" : "absent"}, ${extractMs}ms)`,
     );
   }
 

--- a/src/workflows/runtime/piece-catalog.test.ts
+++ b/src/workflows/runtime/piece-catalog.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { resolve } from "node:path";
 import {
@@ -18,8 +18,9 @@ import {
   computeCatalogCacheKey,
   discoverPieces,
   metadataToCatalogEntry,
+  pieceContentHash,
   propsToInputSchema,
-  readCachedCatalog,
+  readCachedEntries,
   type CacheFileShape,
   type PieceLookup,
 } from "./piece-catalog";
@@ -383,56 +384,135 @@ describe("PieceCatalog (unit)", () => {
     }
   });
 
-  test("computeCatalogCacheKey changes when bundle or piece source changes", () => {
+  test("computeCatalogCacheKey tracks the bundle; piece source moves pieceContentHash instead", () => {
     const { path: root, cleanup } = tmp("cache-key");
     const bundlePath = resolve(root, "engine.js");
     writeFileSync(bundlePath, "v1");
-    mkdirSync(resolve(root, "pieces/p/dist/src"), { recursive: true });
+    const pieceDir = resolve(root, "pieces/p");
+    mkdirSync(resolve(pieceDir, "dist/src"), { recursive: true });
     writeFileSync(
-      resolve(root, "pieces/p/package.json"),
+      resolve(pieceDir, "package.json"),
       JSON.stringify({ name: "@scope/piece-p", version: "0.0.1" }),
     );
-    writeFileSync(resolve(root, "pieces/p/dist/src/index.js"), "v1");
+    writeFileSync(resolve(pieceDir, "dist/src/index.js"), "v1");
     try {
-      const k1 = computeCatalogCacheKey({ bundlePath, pieceRoots: [resolve(root, "pieces")] });
-      // Bundle change -> new key.
+      const k1 = computeCatalogCacheKey({ bundlePath });
+      // Bundle change -> new GLOBAL key (invalidates everything).
       writeFileSync(bundlePath, "v2");
-      const k2 = computeCatalogCacheKey({ bundlePath, pieceRoots: [resolve(root, "pieces")] });
+      const k2 = computeCatalogCacheKey({ bundlePath });
       expect(k2).not.toBe(k1);
-      // Piece source change without bundle change -> new key (the bug we fixed in review #2).
-      writeFileSync(resolve(root, "pieces/p/dist/src/index.js"), "edited");
-      const k3 = computeCatalogCacheKey({ bundlePath, pieceRoots: [resolve(root, "pieces")] });
-      expect(k3).not.toBe(k2);
+      // Piece source change is PER-ENTRY now: the global key must NOT move
+      // (that's what keeps one changed piece from invalidating 650 others),
+      // the piece's own content hash must.
+      const h1 = pieceContentHash(pieceDir);
+      writeFileSync(resolve(pieceDir, "dist/src/index.js"), "edited");
+      expect(computeCatalogCacheKey({ bundlePath })).toBe(k2);
+      expect(pieceContentHash(pieceDir)).not.toBe(h1);
     } finally {
       cleanup();
     }
   });
 
-  test("readCachedCatalog returns null when cacheKey doesn't match", () => {
+  test("readCachedEntries: key mismatch, malformed file, and the PRE-per-entry shape all read as a miss", () => {
     const { path: dir, cleanup } = tmp("cache-mismatch");
     const file = resolve(dir, "cache.json");
+    const entry = { name: "p", displayName: "P", description: "", actions: {} };
     const payload: CacheFileShape = {
       cacheKey: "v1",
-      entries: [{ name: "p", displayName: "P", description: "", actions: {} }],
+      pieces: { "p@0.0.1": { contentHash: "h", entry } },
     };
     writeFileSync(file, JSON.stringify(payload));
     try {
-      expect(readCachedCatalog(file, "v1")?.list().length).toBe(1);
-      expect(readCachedCatalog(file, "v2")).toBeNull();
+      expect(readCachedEntries(file, "v1")?.get("p@0.0.1")?.entry.name).toBe("p");
+      expect(readCachedEntries(file, "v2")).toBeNull();
+      expect(readCachedEntries("/no/such/path", "v1")).toBeNull();
+      // Old array-shaped cache (pre-per-entry): a clean one-time miss, not a crash.
+      writeFileSync(file, JSON.stringify({ cacheKey: "v1", entries: [entry] }));
+      expect(readCachedEntries(file, "v1")).toBeNull();
+      writeFileSync(file, "{not json");
+      expect(readCachedEntries(file, "v1")).toBeNull();
     } finally {
       cleanup();
     }
   });
 
-  test("readCachedCatalog returns null when file is missing or malformed", () => {
-    expect(readCachedCatalog("/no/such/path", "v1")).toBeNull();
-    const { path: dir, cleanup } = tmp("cache-bad");
-    const file = resolve(dir, "cache.json");
-    writeFileSync(file, "{not json");
+  test("per-entry cache: shared file serves hits without an engine spawn; only misses extract; user file excludes shared-served entries", async () => {
+    const { path: root, cleanup } = tmp("shared-cache");
+    const { path: cacheDir, cleanup: cleanupCache } = tmp("shared-cache-files");
+    const userFile = resolve(cacheDir, "user.json");
+    const sharedFile = resolve(cacheDir, "shared.json");
+    // Two pieces on disk: "shared" (covered by the shared cache) and "mine"
+    // (a user install the shared cache knows nothing about).
+    for (const [sub, name] of [
+      ["shared", "@scope/piece-shared"],
+      ["mine", "@scope/piece-mine"],
+    ] as const) {
+      mkdirSync(resolve(root, sub), { recursive: true });
+      writeFileSync(
+        resolve(root, sub, "package.json"),
+        JSON.stringify({ name, version: "0.0.1" }),
+      );
+    }
+    const sharedEntry = {
+      name: "@scope/piece-shared", displayName: "Shared", description: "", actions: {},
+    };
+    writeFileSync(
+      sharedFile,
+      JSON.stringify({
+        cacheKey: "v1",
+        pieces: {
+          "@scope/piece-shared@0.0.1": {
+            contentHash: pieceContentHash(resolve(root, "shared")),
+            entry: sharedEntry,
+          },
+        },
+      } satisfies CacheFileShape),
+    );
+    let acquires = 0;
+    const extractedNames: string[] = [];
+    const fakeHandle = {
+      async extractPieceMetadata(o: { pieceName: string }) {
+        extractedNames.push(o.pieceName);
+        return { name: o.pieceName, displayName: "Mine", description: "", actions: {} };
+      },
+      async release() { /* noop */ },
+    } as unknown as EngineHandle;
+    const fakeRuntime = {
+      acquire: async () => (acquires++, fakeHandle),
+    } as unknown as EngineRuntime;
     try {
-      expect(readCachedCatalog(file, "v1")).toBeNull();
+      const { catalog, failures } = await buildPieceCatalog({
+        runtime: fakeRuntime,
+        pieceRoots: [root],
+        cacheFile: userFile,
+        cacheKey: "v1",
+        sharedCacheFiles: [sharedFile],
+        reporter: () => {},
+      });
+      expect(failures).toEqual([]);
+      expect(catalog.list().length).toBe(2);
+      // Only the user's own piece was extracted.
+      expect(extractedNames).toEqual(["@scope/piece-mine"]);
+      expect(acquires).toBe(1);
+      // The user cache holds ONLY the user's piece (shared-served entries are
+      // not copied — per-user files stay small).
+      const written = JSON.parse(readFileSync(userFile, "utf8")) as CacheFileShape;
+      expect(Object.keys(written.pieces)).toEqual(["@scope/piece-mine@0.0.1"]);
+
+      // Second build: everything is a cache hit — the engine is NEVER acquired.
+      const second = await buildPieceCatalog({
+        runtime: fakeRuntime,
+        pieceRoots: [root],
+        cacheFile: userFile,
+        cacheKey: "v1",
+        sharedCacheFiles: [sharedFile],
+        reporter: () => {},
+      });
+      expect(second.catalog.list().length).toBe(2);
+      expect(acquires).toBe(1);
     } finally {
       cleanup();
+      cleanupCache();
     }
   });
 

--- a/src/workflows/runtime/piece-catalog.ts
+++ b/src/workflows/runtime/piece-catalog.ts
@@ -262,18 +262,6 @@ export function discoverPieces(rootDirs: string[]): {
 }
 
 /**
- * Build a deterministic cache-invalidation key from the engine bundle and
- * every piece's compiled `dist/src/index.js`. An edit to any of those forces
- * a catalog rebuild even when the engine bundle is unchanged.
- *
- * We hash content (not mtime+size) because mtime resolution on common
- * filesystems is too coarse to detect successive writes within ~1ms (e.g.
- * dev loops where you edit and rebuild back-to-back, or tests). Reading and
- * hashing each bundle is O(bytes) but only happens at daemon startup and
- * cache-rebuild time -- the on-disk catalog cache absorbs the cost across
- * subsequent boots.
- */
-/**
  * Catalog projection schema version. Mixed into the cache key so any
  * daemon-side change to the projected `PieceCatalogEntry` shape (new
  * fields, reshaped existing fields, anything that `metadataToCatalogEntry`
@@ -306,19 +294,20 @@ export function discoverPieces(rootDirs: string[]): {
  */
 export const CATALOG_SCHEMA_VERSION = "6";
 
-export function computeCatalogCacheKey(opts: {
-  bundlePath: string;
-  pieceRoots: string[];
-}): string {
+/**
+ * GLOBAL cache invalidators only — the projection schema, the engine bundle,
+ * and the event-type registry. Per-piece source changes deliberately do NOT
+ * feed this key anymore: each cached entry carries its own content hash
+ * (`pieceContentHash`), so one changed/added piece invalidates one entry
+ * instead of the whole catalog. That is what makes a large SHARED read-only
+ * cache usable — a user installing a single community piece re-extracts that
+ * piece, not all 650+.
+ */
+export function computeCatalogCacheKey(opts: { bundlePath: string }): string {
   const h = createHash("sha256");
   h.update(`schema\0${CATALOG_SCHEMA_VERSION}\0`);
   h.update("bundle\0");
   hashFileContents(h, opts.bundlePath);
-  const { entries } = discoverPieces(opts.pieceRoots);
-  for (const e of entries) {
-    h.update(`piece\0${e.name}\0${e.version}\0`);
-    hashFileContents(h, resolve(e.dir, "dist/src/index.js"));
-  }
   // Mix in the event-type registry so adding/removing an entry in
   // `WORKFLOW_EVENT_TYPES` invalidates caches automatically. The
   // jarvis-trigger:on_event projection synthesizes its
@@ -339,6 +328,18 @@ export function computeCatalogCacheKey(opts: {
       [...WORKFLOW_EVENT_TYPES].sort((a, b) => a.type.localeCompare(b.type)),
     ),
   );
+  return h.digest("hex");
+}
+
+/**
+ * Per-piece cache validity: the compiled bundle's content hash ("absent" when
+ * there is no dist — npm-published community pieces ship src/index.js only,
+ * which degenerates the check to name@version, exactly what makes one shared
+ * cache file valid for every user of the same shared pieces tree).
+ */
+export function pieceContentHash(dir: string): string {
+  const h = createHash("sha256");
+  hashFileContents(h, resolve(dir, "dist/src/index.js"));
   return h.digest("hex");
 }
 
@@ -372,15 +373,24 @@ export interface BuildCatalogOptions {
   pieceRoots: string[];
   /**
    * Path to the on-disk cache file. When set together with `cacheKey`, the
-   * builder reads from this file if `cacheKey` matches; on miss it extracts
-   * fresh and writes back. Default: no caching.
+   * builder reuses per-piece entries whose content hash still matches and
+   * extracts only the misses, writing the result back. Default: no caching.
    */
   cacheFile?: string;
   /**
-   * Cache invalidation key -- typically `computeCatalogCacheKey({...})`.
-   * Stored alongside the cached entries; mismatch forces a rebuild.
+   * GLOBAL cache invalidation key -- `computeCatalogCacheKey({...})`
+   * (projection schema + engine bundle + event-type registry). Mismatch
+   * invalidates every entry; per-piece changes are handled per entry.
    */
   cacheKey?: string;
+  /**
+   * Additional READ-ONLY cache files consulted for entries the user's own
+   * cache doesn't satisfy (multi-tenant hosting: one prebuilt file for the
+   * shared pieces tree, generated at version-install time). Never written;
+   * entries served from here are not copied into the user's cache file, so
+   * per-user caches stay small (only the user's own installs).
+   */
+  sharedCacheFiles?: string[];
   /** projectId for the synthetic extraction sandbox. Default: DEFAULT_IDS.project. */
   projectId?: string;
   /**
@@ -406,28 +416,65 @@ export interface BuildCatalogResult {
   failures: PieceExtractionFailure[];
 }
 
+export interface CachedPieceEntry {
+  /** `pieceContentHash(dir)` at extraction time; entry valid while it matches. */
+  contentHash: string;
+  entry: PieceCatalogEntry;
+}
+
 export interface CacheFileShape {
+  /** Global invalidators (schema + bundle + event types); see computeCatalogCacheKey. */
   cacheKey: string;
-  entries: PieceCatalogEntry[];
+  /** Keyed by `${name}@${version}`. */
+  pieces: Record<string, CachedPieceEntry>;
 }
 
 /**
- * Read the cache file if `cacheKey` matches; otherwise return null. Exposed
- * separately from the full builder for tests + readability.
+ * Read a cache file's per-piece entry map if its global `cacheKey` matches;
+ * otherwise null. Pre-per-entry cache files (the old `entries[]` array shape)
+ * fail the `pieces` check and read as a full miss — a one-time re-extraction
+ * on upgrade, never a crash. Exposed separately from the full builder for
+ * tests + readability.
  */
-export function readCachedCatalog(
+export function readCachedEntries(
   cacheFile: string,
   cacheKey: string,
-): PieceCatalog | null {
+): Map<string, CachedPieceEntry> | null {
   if (!existsSync(cacheFile)) return null;
+  // Size cap: the whole file is parsed in every tenant process — a runaway
+  // producer must degrade to extraction, not to an OOM at JSON.parse.
+  try {
+    if (statSync(cacheFile).size > 256 * 1024 * 1024) return null;
+  } catch {
+    return null;
+  }
   let cached: CacheFileShape;
   try {
     cached = JSON.parse(readFileSync(cacheFile, "utf8")) as CacheFileShape;
   } catch {
     return null;
   }
-  if (cached.cacheKey !== cacheKey || !Array.isArray(cached.entries)) return null;
-  return new PieceCatalog(cached.entries);
+  if (cached.cacheKey !== cacheKey) return null;
+  if (typeof cached.pieces !== "object" || cached.pieces === null || Array.isArray(cached.pieces)) {
+    return null;
+  }
+  // Validate VALUES, not just the container: a shared cache is a root-supplied
+  // file the tenant can't repair — one null/garbage entry must drop THAT entry
+  // (degrading to extraction for that piece), never crash daemon boot.
+  const out = new Map<string, CachedPieceEntry>();
+  for (const [key, value] of Object.entries(cached.pieces)) {
+    if (
+      value !== null &&
+      typeof value === "object" &&
+      typeof (value as CachedPieceEntry).contentHash === "string" &&
+      (value as CachedPieceEntry).entry !== null &&
+      typeof (value as CachedPieceEntry).entry === "object" &&
+      typeof (value as CachedPieceEntry).entry.name === "string"
+    ) {
+      out.set(key, value as CachedPieceEntry);
+    }
+  }
+  return out;
 }
 
 /**
@@ -448,11 +495,6 @@ export async function buildPieceCatalog(
   const pieceTimeoutMs = opts.pieceTimeoutMs ?? 10_000;
   const overallTimeoutMs = opts.overallTimeoutMs ?? 60_000;
 
-  if (opts.cacheFile && opts.cacheKey) {
-    const fromCache = readCachedCatalog(opts.cacheFile, opts.cacheKey);
-    if (fromCache) return { catalog: fromCache, failures: [] };
-  }
-
   const { entries: discovered, conflicts } = discoverPieces(opts.pieceRoots);
   for (const c of conflicts) {
     reporter(
@@ -460,53 +502,97 @@ export async function buildPieceCatalog(
     );
   }
 
-  const projectId = opts.projectId ?? DEFAULT_IDS.project;
-  const runId = "metadata-extract-" + SandboxRegistry.newSandboxId();
+  // Per-entry cache lookup: the user's own cache first, then any read-only
+  // shared files. Every source is gated on the GLOBAL key (schema + bundle +
+  // event types) and each hit on the piece's own content hash.
+  const userCache =
+    opts.cacheFile && opts.cacheKey ? readCachedEntries(opts.cacheFile, opts.cacheKey) : null;
+  const sharedCaches = (opts.sharedCacheFiles ?? [])
+    .map((f) => (opts.cacheKey ? readCachedEntries(f, opts.cacheKey) : null))
+    .filter((m): m is Map<string, CachedPieceEntry> => m !== null);
 
-  const handle = await opts.runtime.acquire({ runId, projectId });
   const out: PieceCatalogEntry[] = [];
   const failures: PieceExtractionFailure[] = [];
-  const overallDeadline = Date.now() + overallTimeoutMs;
-  try {
-    for (const piece of discovered) {
-      if (Date.now() > overallDeadline) {
-        const pending = discovered.length - out.length - failures.length;
-        if (pending > 0) {
-          reporter(
-            `overall extraction deadline (${overallTimeoutMs}ms) exceeded; ${pending} piece(s) skipped`,
-          );
-          for (const skipped of discovered.slice(out.length + failures.length)) {
-            failures.push({
-              pieceName: skipped.name,
-              pieceVersion: skipped.version,
-              reason: "overall extraction deadline exceeded",
-            });
+  /** Entries the USER cache file should contain after this build (its own
+   * previous hits + fresh extractions; shared-served entries excluded so
+   * per-user files stay small). */
+  const userEntries: Record<string, CachedPieceEntry> = {};
+  const misses: Array<{ piece: PieceDiscoveryEntry; contentHash: string }> = [];
+
+  for (const piece of discovered) {
+    const key = `${piece.name}@${piece.version}`;
+    const contentHash = pieceContentHash(piece.dir);
+    const own = userCache?.get(key);
+    if (own && own.contentHash === contentHash) {
+      out.push(own.entry);
+      userEntries[key] = own;
+      continue;
+    }
+    const shared = sharedCaches
+      .map((m) => m.get(key))
+      .find((e) => e != null && e.contentHash === contentHash);
+    if (shared) {
+      out.push(shared.entry);
+      continue;
+    }
+    misses.push({ piece, contentHash });
+  }
+
+  // Full cache hit: no engine spawn at all (the common warm-boot path — and,
+  // with a prebuilt shared cache, the common FIRST-boot path too).
+  let extracted = 0;
+  if (misses.length > 0) {
+    const projectId = opts.projectId ?? DEFAULT_IDS.project;
+    const runId = "metadata-extract-" + SandboxRegistry.newSandboxId();
+
+    const handle = await opts.runtime.acquire({ runId, projectId });
+    const overallDeadline = Date.now() + overallTimeoutMs;
+    let processed = 0;
+    try {
+      for (const { piece, contentHash } of misses) {
+        if (Date.now() > overallDeadline) {
+          const pending = misses.length - processed;
+          if (pending > 0) {
+            reporter(
+              `overall extraction deadline (${overallTimeoutMs}ms) exceeded; ${pending} piece(s) skipped`,
+            );
+            for (const skipped of misses.slice(processed)) {
+              failures.push({
+                pieceName: skipped.piece.name,
+                pieceVersion: skipped.piece.version,
+                reason: "overall extraction deadline exceeded",
+              });
+            }
           }
+          break;
         }
-        break;
-      }
-      try {
-        const meta = await withTimeout(
-          handle.extractPieceMetadata({
+        processed++;
+        try {
+          const meta = await withTimeout(
+            handle.extractPieceMetadata({
+              pieceName: piece.name,
+              pieceVersion: piece.version,
+            }),
+            pieceTimeoutMs,
+            `extract ${piece.name}@${piece.version} timed out after ${pieceTimeoutMs}ms`,
+          );
+          const entry = metadataToCatalogEntry(meta);
+          out.push(entry);
+          userEntries[`${piece.name}@${piece.version}`] = { contentHash, entry };
+          extracted++;
+        } catch (e) {
+          const reason = e instanceof Error ? e.message : String(e);
+          failures.push({
             pieceName: piece.name,
             pieceVersion: piece.version,
-          }),
-          pieceTimeoutMs,
-          `extract ${piece.name}@${piece.version} timed out after ${pieceTimeoutMs}ms`,
-        );
-        out.push(metadataToCatalogEntry(meta));
-      } catch (e) {
-        const reason = e instanceof Error ? e.message : String(e);
-        failures.push({
-          pieceName: piece.name,
-          pieceVersion: piece.version,
-          reason,
-        });
-        reporter(`extract ${piece.name}@${piece.version} failed: ${reason}`);
+            reason,
+          });
+          reporter(`extract ${piece.name}@${piece.version} failed: ${reason}`);
+        }
       }
+    } finally {
+      await handle.release();
     }
-  } finally {
-    await handle.release();
   }
 
   // Cache write policy: persist the successful entries even when some
@@ -516,11 +602,12 @@ export async function buildPieceCatalog(
   // one was uninstalled. The catalog endpoint already returns only
   // successes (failures are surfaced via the daemon log + audit
   // script), so persisting the partial set is strictly better than
-  // discarding it. We still skip the write when zero pieces succeeded
-  // -- there's nothing useful to cache.
-  if (opts.cacheFile && opts.cacheKey && out.length > 0) {
+  // discarding it. Written only when something was freshly extracted —
+  // a pure cache-hit boot (or a pure shared-cache boot) leaves the
+  // user's file untouched.
+  if (opts.cacheFile && opts.cacheKey && extracted > 0) {
     mkdirSync(dirname(opts.cacheFile), { recursive: true });
-    const payload: CacheFileShape = { cacheKey: opts.cacheKey, entries: out };
+    const payload: CacheFileShape = { cacheKey: opts.cacheKey, pieces: userEntries };
     writeFileSync(opts.cacheFile, JSON.stringify(payload, null, 2) + "\n");
   }
   return { catalog: new PieceCatalog(out), failures };

--- a/src/workflows/runtime/shared-runtime-paths.test.ts
+++ b/src/workflows/runtime/shared-runtime-paths.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from "bun:test";
+import { resolveSharedRuntimePaths } from "./shared-runtime-paths";
+
+describe("resolveSharedRuntimePaths", () => {
+  const wf = (extra: Record<string, string>) =>
+    ({
+      workflows: {
+        enabled: true,
+        maxConcurrentExecutions: 1,
+        defaultRetries: 0,
+        defaultTimeoutMs: 1,
+        selfHealEnabled: false,
+        autoSuggestEnabled: false,
+        ...extra,
+      },
+    }) as Parameters<typeof resolveSharedRuntimePaths>[0];
+
+  test("plain config paths resolve as-is (config wins over env)", () => {
+    const paths = resolveSharedRuntimePaths(
+      wf({
+        engine_dir: "/srv/engine",
+        pieces_dir: "/srv/pieces",
+        piece_metadata_cache: "/srv/piece-metadata.json",
+      }),
+      { JARVIS_SHARED_PIECES_DIR: "/somewhere/else" },
+    );
+    expect(paths.engineCacheRoot).toBe("/srv/engine");
+    expect(paths.piecesDir).toBe("/srv/pieces");
+    expect(paths.metadataCacheFile).toBe("/srv/piece-metadata.json");
+    expect(paths.warnings).toEqual([]);
+  });
+
+  test("${version} placeholder expands from JARVIS_VERSION", () => {
+    const paths = resolveSharedRuntimePaths(
+      wf({
+        engine_dir: "/opt/jarvis-engine/${version}",
+        pieces_dir: "/opt/jarvis-pieces/${version}",
+        piece_metadata_cache: "/opt/jarvis-cache/${version}/piece-metadata.json",
+      }),
+      { JARVIS_VERSION: "1.2.3" },
+    );
+    expect(paths.engineCacheRoot).toBe("/opt/jarvis-engine/1.2.3");
+    expect(paths.piecesDir).toBe("/opt/jarvis-pieces/1.2.3");
+    expect(paths.metadataCacheFile).toBe("/opt/jarvis-cache/1.2.3/piece-metadata.json");
+    expect(paths.warnings).toEqual([]);
+  });
+
+  test("placeholder with an unusable version warns and falls back per path", () => {
+    for (const version of [undefined, "current", "../evil", "bad/slash"]) {
+      const paths = resolveSharedRuntimePaths(
+        wf({
+          engine_dir: "/opt/jarvis-engine/${version}",
+          pieces_dir: "/plain/pieces",
+        }),
+        {
+          ...(version !== undefined ? { JARVIS_VERSION: version } : {}),
+          JARVIS_ENGINE_CACHE_ROOT: "/env/engine",
+        },
+      );
+      // Placeholder path is dropped (env fallback used); plain path is fine.
+      expect(paths.warnings.length).toBe(1);
+      expect(paths.engineCacheRoot).toBe("/env/engine");
+      expect(paths.piecesDir).toBe("/plain/pieces");
+    }
+  });
+
+  test("no config: bare env vars are the fallback; nothing anywhere: all null", () => {
+    const fromEnv = resolveSharedRuntimePaths(
+      {},
+      {
+        JARVIS_ENGINE_CACHE_ROOT: "/env/engine",
+        JARVIS_SHARED_PIECES_DIR: "/env/pieces",
+        JARVIS_PIECE_METADATA_CACHE: "/env/cache/piece-metadata.json",
+      },
+    );
+    expect(fromEnv.engineCacheRoot).toBe("/env/engine");
+    expect(fromEnv.piecesDir).toBe("/env/pieces");
+    expect(fromEnv.metadataCacheFile).toBe("/env/cache/piece-metadata.json");
+
+    expect(resolveSharedRuntimePaths({}, {})).toEqual({
+      engineCacheRoot: null,
+      piecesDir: null,
+      metadataCacheFile: null,
+      warnings: [],
+    });
+  });
+});

--- a/src/workflows/runtime/shared-runtime-paths.ts
+++ b/src/workflows/runtime/shared-runtime-paths.ts
@@ -1,0 +1,71 @@
+/**
+ * Resolve where the workflow runtime finds READY-MADE artifacts (a prebuilt
+ * engine-bundle dir, a ready-made pieces catalog, a prebuilt piece-metadata
+ * cache) instead of building/installing its own.
+ *
+ * Source of truth is the `workflows` config section (`engine_dir`,
+ * `pieces_dir`, `piece_metadata_cache`). Each path may carry a `${version}`
+ * placeholder expanded from the `JARVIS_VERSION` env var — useful when one
+ * machine keeps artifacts per installed version (a multi-tenant host is one
+ * such deployment; a self-hosted instance can just use plain paths). The
+ * bare JARVIS_* env vars are honored as fallbacks; config wins when both
+ * are set. Every consumer treats a null as "no ready-made artifact" and
+ * does the work itself.
+ */
+
+import { resolve } from "node:path";
+import type { JarvisConfig } from "../../config/types";
+
+export interface SharedRuntimePaths {
+  /** Dir containing <hash>/main.js prebuilt engine bundles. */
+  engineCacheRoot: string | null;
+  /** Dir whose node_modules/@activepieces holds a ready-made catalog. */
+  piecesDir: string | null;
+  /** The prebuilt per-entry metadata cache FILE. */
+  metadataCacheFile: string | null;
+  /** Human-readable notes worth logging (e.g. a ${version} placeholder with
+   * no usable JARVIS_VERSION). */
+  warnings: string[];
+}
+
+const VERSION_PLACEHOLDER = "${version}";
+// One path component, no traversal; the literal `current` symlink name is
+// refused — placeholder expansion is for concrete versions only.
+const VERSION_RE = /^[a-z0-9][a-z0-9._-]{0,63}$/;
+
+export function resolveSharedRuntimePaths(
+  cfg: Pick<JarvisConfig, "workflows">,
+  env: Record<string, string | undefined> = process.env,
+): SharedRuntimePaths {
+  const warnings: string[] = [];
+  const wf = cfg.workflows;
+  const version = env.JARVIS_VERSION?.trim() ?? "";
+  const versionOk = VERSION_RE.test(version) && version !== "current" && !version.includes("..");
+
+  const fromEnv = (name: string): string | null => {
+    const v = env[name]?.trim();
+    return v ? resolve(v) : null;
+  };
+
+  /** Config path (with placeholder expansion) or the env fallback. */
+  const resolvePath = (configured: string | undefined, envName: string): string | null => {
+    if (configured?.trim()) {
+      const raw = configured.trim();
+      if (!raw.includes(VERSION_PLACEHOLDER)) return resolve(raw);
+      if (versionOk) return resolve(raw.replaceAll(VERSION_PLACEHOLDER, version));
+      warnings.push(
+        `workflows config path ${JSON.stringify(raw)} uses ${VERSION_PLACEHOLDER} but ` +
+          `JARVIS_VERSION (${JSON.stringify(version)}) is not a usable concrete version — ` +
+          `ignoring it (falling back to ${envName} / self-build)`,
+      );
+    }
+    return fromEnv(envName);
+  };
+
+  return {
+    engineCacheRoot: resolvePath(wf?.engine_dir, "JARVIS_ENGINE_CACHE_ROOT"),
+    piecesDir: resolvePath(wf?.pieces_dir, "JARVIS_SHARED_PIECES_DIR"),
+    metadataCacheFile: resolvePath(wf?.piece_metadata_cache, "JARVIS_PIECE_METADATA_CACHE"),
+    warnings,
+  };
+}

--- a/ui/src/v2/rooms/workflows/LibraryPanel.tsx
+++ b/ui/src/v2/rooms/workflows/LibraryPanel.tsx
@@ -238,12 +238,16 @@ function LibraryRow({
   onUninstall: () => void;
 }): React.ReactElement {
   const isInstalled = entry.installed !== null;
+  // Shared-catalog pieces are managed by the host, not the user: no install
+  // (it already works), no uninstall (the tree is read-only), no update chip
+  // (updates arrive with the host's version upgrades).
+  const isShared = entry.installed?.source === "shared";
   const busy = actionState !== "idle";
   // Compare resolved vs vetted to surface the right hint:
   //   resolved < vetted -> "Update available" (we vetted a newer version)
   //   resolved > vetted -> "Newer than vetted" (user upgraded past our audit)
   //   resolved == vetted -> no chip
-  const versionRel = isInstalled
+  const versionRel = isInstalled && !isShared
     ? compareSemver(entry.installed!.resolvedVersion, entry.vettedVersion)
     : 0;
   const updateAvailable = versionRel < 0;
@@ -254,7 +258,11 @@ function LibraryRow({
       <div className="wf-lib__row-main">
         <div className="wf-lib__row-title">
           <span className="wf-lib__row-name">{entry.displayName}</span>
-          {isInstalled ? (
+          {isShared ? (
+            <Chip tone="ok" title="Included with this Jarvis install — ready to use, nothing to manage">
+              Included {entry.installed!.resolvedVersion}
+            </Chip>
+          ) : isInstalled ? (
             <Chip tone="ok">Installed {entry.installed!.resolvedVersion}</Chip>
           ) : (
             <Chip tone="neutral">{entry.versionRange}</Chip>
@@ -296,7 +304,7 @@ function LibraryRow({
         </div>
       </div>
       <div className="wf-lib__row-actions">
-        {isInstalled ? (
+        {isShared ? null : isInstalled ? (
           <>
             {updateAvailable ? (
               <Button variant="primary" size="sm" onClick={onInstall} disabled={busy}>

--- a/ui/src/v2/rooms/workflows/useLibrary.ts
+++ b/ui/src/v2/rooms/workflows/useLibrary.ts
@@ -35,6 +35,12 @@ export interface LibraryEntry {
   installed: {
     resolvedVersion: string;
     installedAt: number;
+    /**
+     * "user"   -- installed into ~/.jarvis/pieces by this user.
+     * "shared" -- included in the host's read-only shared catalog: usable
+     *             with no install, not uninstallable (installedAt is 0).
+     */
+    source: "user" | "shared";
   } | null;
 }
 


### PR DESCRIPTION
## What

Lets a deployment point the workflow runtime at **ready-made artifacts** instead of building/installing per user. Any install benefits (read-only/immutable deployments, machines with many instances); nothing changes when the new settings are absent.

### Config surface

Three optional fields under the existing `workflows` section — direct paths, each supporting a `${version}` placeholder expanded from the `JARVIS_VERSION` env var for machines that keep artifacts per installed version:

```yaml
workflows:
  engine_dir: /opt/jarvis-engine/${version}          # prebuilt engine bundles, <hash>/main.js
  pieces_dir: /opt/jarvis-pieces/${version}          # ready-made pieces catalog
  piece_metadata_cache: /opt/jarvis-cache/${version}/piece-metadata.json
```

`JARVIS_ENGINE_CACHE_ROOT` / `JARVIS_SHARED_PIECES_DIR` / `JARVIS_PIECE_METADATA_CACHE` env vars remain as fallbacks; config wins. The three keys are file-owned system settings: they survive the user-section discard in `loadConfig` and a dashboard save of the user-tunable workflow fields can never strip them.

### Engine bundle

- A configured engine dir is consulted before `~/.jarvis/cache/engine`; bundles carry a `main.js.sha256` manifest that is verified before execution (mismatch = miss, fall back to a local build).
- Removed the staging-dir guard in `findCachedBundle()` — it was unsound (`bundleHash()` has no staging dependency) and forced a ~47MB per-user `bun install` just to discover an existing bundle.

### Pieces catalog

- The shared dir is appended **after** the user's own `~/.jarvis/pieces` everywhere (loader walk + discovery are first-wins), so user installs shadow the shared copy; the installer/reconciler never touch the shared tree.
- The Library marks shared pieces as **Included** (no install/uninstall buttons); uninstalling a user copy that shadows a shared piece reverts the live catalog to the shared version without a restart.

### Piece-metadata cache

- Restructured from one global cache key to **per-entry**: the global key covers the projection schema + engine bundle + event-type registry; each entry carries its own content hash. A read-only shared cache file is merged under the user's own cache, so installing one piece re-extracts one piece — not the whole catalog.
- Full cache hits never spawn an engine; a configured-but-mismatching shared cache logs a loud warning and gets a longer extraction deadline instead of silently mass-failing; hostile/oversized/malformed cache files degrade per entry rather than crashing boot.

### Builder

`scripts/build-shared-runtime.ts` produces all artifacts in one pass for a given install tree: engine bundle (+manifest), the full community catalog (`bun install --ignore-scripts`, honoring a seeded lockfile for delta builds), and the prebuilt metadata cache. `--out`, `--summary <file>` (stdout is not JSON-clean by design), `--pieces N` for smoke runs, `--seed-lock` for cross-version delta efficiency.

### Hardening

- Read-only install trees missing prebuilt piece `dist/` fail with an actionable message instead of a raw `EACCES` mid-boot.
- The engine child's curated env now forwards `BUN_RUNTIME_TRANSPILER_CACHE_PATH` (bun is fail-open on unreadable caches).

## Behavior without any of this configured

Identical to before — every new path degrades to "jarvis does the work itself".

## Tests

Full suite green (1810+). New coverage: engine cache-root resolution (shared hit, miss fallback), pieces shadowing, per-entry cache merge (shared hit without engine spawn, user file excluding shared-served entries, old cache shape as clean miss), config-path resolution (placeholder expansion, bad-version fallback, env fallback), config survival through `loadConfig` → user-settings merge, and the builder smoke-tested end-to-end.