### PR TITLE
sidecar: verify manually-entered enrollment tokens against the brain before saving them

### DIFF
--- a/docs/sidecar/SIDECAR_AUTHENTICATION.md
+++ b/docs/sidecar/SIDECAR_AUTHENTICATION.md
@@ -139,7 +139,7 @@ If those claims point at the wrong domain, an old ingress, or a host unreachable
 
 ### Step 3: User Copies Token to Sidecar
 
-`jarvis enroll` prints the JWT to the terminal. The user pastes it into the sidecar's token form (the desktop app asks for it on first run; it is also accepted in Settings), which stores it in the sidecar configuration at `~/.jarvis/sidecar.yaml`.
+`jarvis enroll` prints the JWT to the terminal. The user pastes it into the sidecar's token form (the desktop app asks for it on first run; it is also accepted in Settings, and headlessly via `--token`). Before the token is stored, the sidecar verifies it against the brain it names by requesting an access token (`POST {brain}/sidecar/token` with the enrollment JWT as bearer): an unreachable brain URL, a rejected token, and a server that isn't a Jarvis brain each produce a distinct inline error, and nothing is saved. Only a token the brain accepted is written to the sidecar configuration at `~/.jarvis/sidecar.yaml`.
 
 ### Step 4: Sidecar Verifies Token
 

--- a/sidecar/account_window.go
+++ b/sidecar/account_window.go
@@ -70,7 +70,7 @@ func (c *SidecarClient) runAccountWindow() {
 	base := resolveHostedBaseURL(c.config.HostedBaseURL)
 	c.mu.Unlock()
 
-	runLocalWebview("JARVIS — Account", 920, 720, webview.HintNone, func(w webview.WebView) {
+	runLocalWebview("JARVIS — Account", 920, 720, webview.HintNone, func(w webview.WebView) func() {
 		w.SetHtml(accountShellHTML)
 		// Dispatch rather than a direct call: the dispatch queue runs after
 		// SetHtml's string navigation has been issued, so the shell is the
@@ -78,5 +78,6 @@ func (c *SidecarClient) runAccountWindow() {
 		// navigations racing in the engine. If the shell still loses the
 		// race, the reveal's timeout fallback covers us as before.
 		w.Dispatch(func() { w.Navigate(base + "/account") })
+		return nil
 	})
 }

--- a/sidecar/client.go
+++ b/sidecar/client.go
@@ -267,6 +267,15 @@ func (c *SidecarClient) editConfig(fn func(cfg *SidecarConfig)) error {
 	return SaveConfig(c.config)
 }
 
+// BrainOverride returns the config's manual brain-URL override (lock-protected;
+// "" when unset). Used by the settings window's token check so a pasted token
+// is verified against the URL the client will actually dial.
+func (c *SidecarClient) BrainOverride() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.config.Brain
+}
+
 // Preferences returns a copy of the current preferences (lock-protected).
 func (c *SidecarClient) Preferences() PreferencesConfig {
 	c.mu.Lock()

--- a/sidecar/hosted.go
+++ b/sidecar/hosted.go
@@ -57,7 +57,8 @@ func resolveHostedBaseURLWith(overrideAllowed bool, cfgValue, envValue string) s
 // the gate, any page in the Clerk/Stripe redirect chain could silently
 // enroll this sidecar to an attacker-controlled brain (enrollment JWTs are
 // self-describing via their brain/jwks claims). accept receives a
-// structurally valid JWT and closes the window.
+// structurally valid JWT; the caller then verifies it against its brain
+// (verify_token.go) and closes the window only on success.
 func submitTokenHandler(isActive func() bool, accept func(token string)) func(string) error {
 	return func(raw string) error {
 		if !isActive() {

--- a/sidecar/hosted_test.go
+++ b/sidecar/hosted_test.go
@@ -92,13 +92,7 @@ func fakeHandshakeServer(t *testing.T, poll func(n int, w http.ResponseWriter)) 
 // A structurally valid unsigned-looking JWT for DecodeJWTPayload.
 func testJWT(t *testing.T) string {
 	t.Helper()
-	header := `{"alg":"ES256"}`
-	payload := `{"sid":"s1","name":"desktop","brain":"wss://x/sidecar/connect","jwks":"https://x/jwks.json","iat":1}`
-	enc := func(s string) string {
-		return strings.TrimRight(strings.NewReplacer("+", "-", "/", "_").Replace(
-			base64StdNoPad(s)), "=")
-	}
-	return enc(header) + "." + enc(payload) + ".sig"
+	return enrollJWT(t, "wss://x/sidecar/connect")
 }
 
 func base64StdNoPad(s string) string {

--- a/sidecar/hosted_window.go
+++ b/sidecar/hosted_window.go
@@ -177,6 +177,13 @@ func runFirstRunWindow(cfg *SidecarConfig) (string, error) {
 	defer handshakeWG.Wait()
 	defer cancel()
 
+	// Brain-check of a pasted token, on its own context: chooseSelfHost cancels
+	// ctx to stop the hosted handshake, but a verification started afterwards
+	// must keep running. Cancelled before the WaitGroup join (LIFO with the
+	// defers above) so closing the window never blocks on a slow probe.
+	verifyCtx, verifyCancel := context.WithCancel(context.Background())
+	defer verifyCancel()
+
 	// Unlike the main-thread-only locals below, this is written by the handshake
 	// goroutine and read after Run() returns, so it needs real synchronisation.
 	// It deliberately does NOT live behind a Dispatch closure: see the capture
@@ -194,6 +201,11 @@ func runFirstRunWindow(cfg *SidecarConfig) (string, error) {
 	// All reads/writes happen on the webview main thread (bindings and
 	// Dispatch closures both run there), so a plain bool is race-free.
 	selfHostFormActive := false
+
+	// True while a pasted token is being verified against its brain; gates
+	// submitToken so a second paste can't race the in-flight check. Main-thread
+	// only, like selfHostFormActive.
+	verifyInFlight := false
 
 	// Connect page URL for the CURRENT handshake nonce, and a guard against
 	// overlapping handshakes (double-clicked "Try again"). Main-thread only,
@@ -232,10 +244,34 @@ func runFirstRunWindow(cfg *SidecarConfig) (string, error) {
 	}
 
 	if err := w.Bind("submitToken", submitTokenHandler(
-		func() bool { return selfHostFormActive },
+		func() bool { return selfHostFormActive && !verifyInFlight },
 		func(tok string) {
-			token = tok
-			w.Terminate()
+			// Structurally valid — now prove it works against the brain it
+			// names before it is persisted. A wrong-URL token used to be saved
+			// blind: the window closed and the only trace of the failure was
+			// the reconnect loop in the log. The form shows "checking" while
+			// this runs; the verdict lands via window.__tokenVerdict, and
+			// success closes the window as before.
+			verifyInFlight = true
+			handshakeWG.Add(1)
+			go func() {
+				defer handshakeWG.Done()
+				verr := verifyBrainToken(verifyCtx, tok, cfg.Brain)
+				w.Dispatch(func() {
+					if torndown.Load() || verifyCtx.Err() != nil {
+						return
+					}
+					verifyInFlight = false
+					if verr != nil {
+						w.Eval("window.__tokenVerdict && window.__tokenVerdict('" + jsEscape(verr.Error()) + "')")
+						return
+					}
+					tokenMu.Lock()
+					token = tok
+					tokenMu.Unlock()
+					w.Terminate()
+				})
+			}()
 		},
 	)); err != nil {
 		return "", fmt.Errorf("bind setup handler: %w", err)
@@ -436,6 +472,7 @@ func runFirstRunWindow(cfg *SidecarConfig) (string, error) {
 	// otherwise be dropped on the floor. Both calls are idempotent, so the
 	// deferred cancel/Wait stay as backstops for the early-return paths.
 	cancel()
+	verifyCancel()
 	handshakeWG.Wait()
 	tokenMu.Lock()
 	defer tokenMu.Unlock()

--- a/sidecar/local_webview_darwin.go
+++ b/sidecar/local_webview_darwin.go
@@ -19,8 +19,12 @@ import (
 // until the window closes, then destroy it on the main thread.
 //
 // build receives the webview and should register bindings and set the page
-// (SetHtml/Navigate); it runs on the main thread.
-func runLocalWebview(title string, width, height int, hint webview.Hint, build func(webview.WebView)) {
+// (SetHtml/Navigate); it runs on the main thread. It may return a cleanup
+// (nil if none) that runs after the window closes — the join point for any
+// goroutine a binding spawned. On macOS the engine is leaked, not freed (see
+// below), so a late Dispatch is not a use-after-free; the join still bounds
+// the goroutine's lifetime to the window's.
+func runLocalWebview(title string, width, height int, hint webview.Hint, build func(webview.WebView) (cleanup func())) {
 	runtime.LockOSThread()
 	wv := webview.New(false)
 	if wv == nil {
@@ -30,11 +34,12 @@ func runLocalWebview(title string, width, height int, hint webview.Hint, build f
 
 	closed := make(chan struct{})
 	var stopReveal func()
+	var cleanup func()
 	uiSync(wv, func() { // synchronous: stopReveal is assigned before watchWindowClose can fire
 		wv.SetTitle(title)
 		wv.SetSize(width, height, hint)
 		stopReveal = revealWebviewOnLoad(wv)
-		build(wv)
+		cleanup = build(wv)
 		watchWindowClose(wv.Window(), func() {
 			// Stopping HERE (main thread), not after <-closed: AppKit releases
 			// the window on close, and a reveal closure already queued on the
@@ -47,6 +52,9 @@ func runLocalWebview(title string, width, height int, hint webview.Hint, build f
 	})
 
 	<-closed
+	if cleanup != nil {
+		cleanup()
+	}
 	// Intentionally do NOT wv.Destroy() here. Under the tray's shared loop the
 	// window closes via AppKit, but webview's own on_window_will_close ->
 	// dispatch(on_window_destroyed) callback still references the engine.

--- a/sidecar/local_webview_other.go
+++ b/sidecar/local_webview_other.go
@@ -13,8 +13,11 @@ import (
 // platforms where each window owns its own goroutine and event loop
 // (Windows/Linux). This goroutine creates, configures, runs, and tears the
 // window down. The reveal-on-load hook is installed here (before build, per
-// its contract); build registers bindings and sets the page before Run().
-func runLocalWebview(title string, width, height int, hint webview.Hint, build func(webview.WebView)) {
+// its contract); build registers bindings and sets the page before Run(), and
+// may return a cleanup (nil if none) that runs after the loop exits but
+// BEFORE the engine is freed — the join point for any goroutine a binding
+// spawned, so a pending Dispatch can never land on a dangling pointer.
+func runLocalWebview(title string, width, height int, hint webview.Hint, build func(webview.WebView) (cleanup func())) {
 	runtime.LockOSThread()
 	wv := webview.New(false)
 	if wv == nil {
@@ -29,6 +32,10 @@ func runLocalWebview(title string, width, height int, hint webview.Hint, build f
 	// must join the timeout goroutine BEFORE the engine is freed, or its
 	// pending Dispatch lands on a dangling pointer.
 	defer stop()
-	build(wv)
+	if cleanup := build(wv); cleanup != nil {
+		// LIFO again: binding goroutines join first, then the reveal timer,
+		// then the engine is freed.
+		defer cleanup()
+	}
 	wv.Run()
 }

--- a/sidecar/log_viewer.go
+++ b/sidecar/log_viewer.go
@@ -23,7 +23,7 @@ func (c *SidecarClient) OpenLogViewer() {
 }
 
 func runLogViewer(logPath string) {
-	runLocalWebview("JARVIS — Logs", 900, 600, webview.HintNone, func(w webview.WebView) {
+	runLocalWebview("JARVIS — Logs", 900, 600, webview.HintNone, func(w webview.WebView) func() {
 
 		// loadLogs returns the current log file contents.
 		_ = w.Bind("loadLogs", func() string {
@@ -50,6 +50,7 @@ func runLogViewer(logPath string) {
 		})
 
 		w.SetHtml(logViewerHTML)
+		return nil
 	})
 }
 

--- a/sidecar/main.go
+++ b/sidecar/main.go
@@ -68,11 +68,28 @@ Usage:
 	}
 
 	if *token != "" {
-		cfg.Token = *token
+		// Same contract as the setup/settings forms (verify_token.go): prove
+		// the token works against the brain it names BEFORE persisting it. A
+		// wrong-URL token used to be saved blind and fail invisibly in the
+		// reconnect loop. Errors go to stderr as well as the log — --token is
+		// typically run from a terminal, and logs already go to the file.
+		tok := trimToken(*token)
+		if err := verifyBrainToken(context.Background(), tok, cfg.Brain); err != nil {
+			log.Printf("[sidecar] enrollment token check failed: %v", err)
+			fmt.Fprintf(os.Stderr, "Error: %v\nThe token was not saved.\n", err)
+			// The Windows build is a GUI-subsystem binary — stderr goes
+			// nowhere — so surface the failure in a native message box there
+			// (MessageBoxW blocks until dismissed). Elsewhere this logs
+			// (Linux) or no-ops before exit (macOS, no run loop yet); the
+			// stderr line above covers those terminals.
+			platformShowAlert("JARVIS Sidecar", fmt.Sprintf("%v\n\nThe token was not saved.", err))
+			os.Exit(1)
+		}
+		cfg.Token = tok
 		if err := SaveConfig(cfg); err != nil {
 			log.Fatalf("[sidecar] Failed to save config: %v", err)
 		}
-		log.Println("[sidecar] Token saved to config")
+		log.Println("[sidecar] Token verified with the brain and saved to config")
 	}
 
 	// Reconcile OS autostart with the saved preference: re-register with the

--- a/sidecar/settings_window.go
+++ b/sidecar/settings_window.go
@@ -8,8 +8,12 @@ package main
 // (brand_css.go).
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"log"
+	"sync"
+	"sync/atomic"
 
 	webview "github.com/webview/webview_go"
 )
@@ -44,7 +48,17 @@ func connStateString(s int32) string {
 }
 
 func (c *SidecarClient) runSettingsWindow() {
-	runLocalWebview("JARVIS — Sidecar Settings", 520, 560, webview.HintNone, func(w webview.WebView) {
+	runLocalWebview("JARVIS — Sidecar Settings", 520, 560, webview.HintNone, func(w webview.WebView) func() {
+		// Lifecycle plumbing for the async token check (bindings run on the
+		// webview main thread, so the network probe must not run inline —
+		// it would freeze the window for up to the probe timeout).
+		// verifyCtx aborts an in-flight probe when the window closes; the
+		// returned cleanup joins the goroutine before the engine is freed;
+		// torndown stops its Dispatch closure from touching a dead document.
+		verifyCtx, verifyCancel := context.WithCancel(context.Background())
+		var verifyWG sync.WaitGroup
+		var torndown atomic.Bool
+		var checkInFlight atomic.Bool
 
 		// getState returns the live connection status + current preferences.
 		_ = w.Bind("getState", func() settingsState {
@@ -61,8 +75,12 @@ func (c *SidecarClient) runSettingsWindow() {
 			return st
 		})
 
-		// saveToken validates + persists a new enrollment token. It applies on the
-		// next reconnect attempt; a restart guarantees a clean reconnect.
+		// saveToken checks + persists a new enrollment token. A malformed paste
+		// rejects the promise immediately; a well-formed one resolves it with
+		// the brain check STARTED (the page shows "checking") and the verdict —
+		// saved, or why not — lands async via window.__tokenVerdict. Only a
+		// token the brain accepted is written to the config; it applies on the
+		// next reconnect attempt, and a restart guarantees a clean reconnect.
 		_ = w.Bind("saveToken", func(raw string) error {
 			raw = trimToken(raw)
 			if raw == "" {
@@ -71,10 +89,35 @@ func (c *SidecarClient) runSettingsWindow() {
 			if _, err := DecodeJWTPayload(raw); err != nil {
 				return fmt.Errorf("That doesn't look like a valid token. Copy the full token printed by 'jarvis enroll'.")
 			}
-			if err := c.editConfig(func(cfg *SidecarConfig) { cfg.Token = raw }); err != nil {
-				return fmt.Errorf("Could not save the token: %v", err)
+			if !checkInFlight.CompareAndSwap(false, true) {
+				return fmt.Errorf("A token check is already running.")
 			}
-			log.Printf("[settings] enrollment token updated")
+			verifyWG.Add(1)
+			go func() {
+				defer verifyWG.Done()
+				defer checkInFlight.Store(false)
+				verr := verifyBrainToken(verifyCtx, raw, c.BrainOverride())
+				if verr == nil {
+					if err := c.editConfig(func(cfg *SidecarConfig) { cfg.Token = raw }); err != nil {
+						verr = fmt.Errorf("Could not save the token: %v", err)
+					} else {
+						log.Printf("[settings] enrollment token verified with the brain and updated")
+					}
+				}
+				if errors.Is(verr, context.Canceled) {
+					return // window closed mid-check; no document to report to
+				}
+				msg := ""
+				if verr != nil {
+					msg = verr.Error()
+				}
+				w.Dispatch(func() {
+					if torndown.Load() {
+						return
+					}
+					w.Eval("window.__tokenVerdict && window.__tokenVerdict('" + jsEscape(msg) + "')")
+				})
+			}()
 			return nil
 		})
 
@@ -132,6 +175,11 @@ func (c *SidecarClient) runSettingsWindow() {
 		})
 
 		w.SetHtml(settingsWindowHTML)
+		return func() {
+			torndown.Store(true)
+			verifyCancel()
+			verifyWG.Wait()
+		}
 	})
 }
 
@@ -302,7 +350,14 @@ const settingsWindowHTML = `<!doctype html>
     setInterval(pollStatus, 2000);
   }
 
+  // True from Save-click until the async verdict lands; suppresses the
+  // input-driven button reset so typing during a check can't re-enable Save,
+  // and remembers what was submitted so the verdict never wipes newer input.
+  var tokenChecking = false;
+  var submittedTok = '';
+
   function resetTokenButton() {
+    if (tokenChecking) return;
     var btn = document.getElementById('saveTok');
     if (btn.textContent !== 'Save token') {
       btn.textContent = 'Save token';
@@ -329,25 +384,46 @@ const settingsWindowHTML = `<!doctype html>
 
   // Note: the JS handler must NOT be named the same as the Go binding
   // (window.saveToken) — a same-named top-level function shadows the binding.
+  // The promise resolving means the brain check STARTED; the verdict (saved,
+  // or why not) arrives async via __tokenVerdict below.
   async function doSaveToken() {
     var btn = document.getElementById('saveTok');
     var msg = document.getElementById('tokMsg');
     var tok = document.getElementById('tok');
     msg.className = 'msg'; msg.textContent = '';
     btn.disabled = true;
+    tokenChecking = true;
+    submittedTok = tok.value;
     try {
       await window.saveToken(tok.value);
-      msg.className = 'msg ok';
-      msg.textContent = 'Saved — restart to reconnect with the new token.';
-      tok.value = '';
-      // Morph Save -> Restart for a one-click apply.
-      btn.textContent = 'Restart Jarvis';
-      btn.onclick = doRestart;
+      msg.textContent = 'Checking the token with your brain…';
     } catch (e) {
+      tokenChecking = false;
       msg.className = 'msg err';
       msg.textContent = (e && e.message) ? e.message : String(e);
+      btn.disabled = false;
     }
+  }
+
+  window.__tokenVerdict = function (errMsg) {
+    var btn = document.getElementById('saveTok');
+    var msg = document.getElementById('tokMsg');
+    var tok = document.getElementById('tok');
+    tokenChecking = false;
     btn.disabled = false;
+    if (errMsg) {
+      msg.className = 'msg err';
+      msg.textContent = errMsg;
+      return;
+    }
+    msg.className = 'msg ok';
+    msg.textContent = 'Saved — restart to reconnect with the new token.';
+    // Only clear what was actually saved — never a newer token typed while
+    // the check was running.
+    if (tok.value === submittedTok) tok.value = '';
+    // Morph Save -> Restart for a one-click apply.
+    btn.textContent = 'Restart Jarvis';
+    btn.onclick = doRestart;
   }
 
   async function togglePref(el) {

--- a/sidecar/setup_window.go
+++ b/sidecar/setup_window.go
@@ -9,14 +9,19 @@ package main
 // local HTML in the shared Monochrome Lab brand (brand_css.go).
 //
 // Flow: main() calls runSetupWindow() when cfg.Token == ""; the window blocks
-// until the user submits a valid-looking token (closing the window cancels).
-// The token is validated only as a well-formed JWT here — the brain still does
-// the real cryptographic verification on connect.
+// until the user submits a working token (closing the window cancels). The
+// submit is two-stage: a malformed JWT rejects the submitToken promise
+// immediately, and a well-formed one is then verified against the brain it
+// names (verify_token.go) while the form shows a checking state — the verdict
+// arrives via window.__tokenVerdict, and only a token the brain accepted is
+// saved and closes the window.
 
 // setupWindowHTML is the self-host first-run form, Monochrome Lab
 // (brand_css.go): a centered raised card with the signature corner.
 // `window.submitToken(value)` is the Go binding installed below; it rejects with
-// a message when the token is empty/malformed so the form can show it inline.
+// a message when the token is empty/malformed so the form can show it inline,
+// and resolves when the brain check has STARTED (not passed) — the async
+// verdict lands in window.__tokenVerdict with an empty message on success.
 const setupWindowHTML = `<!doctype html>
 <html>
 <head>
@@ -51,6 +56,7 @@ const setupWindowHTML = `<!doctype html>
   .hint { font-size: 11px; color: var(--faint); margin: 8px 0 0; line-height: 1.5; }
   .row { display: flex; align-items: center; justify-content: space-between; margin-top: 16px; gap: 12px; }
   #err { color: var(--listen-tx); font-size: 12px; line-height: 1.5; min-height: 16px; flex: 1; text-align: left; }
+  #err.checking { color: var(--ink3); }
   button {
     appearance: none; height: 40px; padding: 0 18px; border: 1px solid transparent;
     border-radius: var(--corner-sm); font-family: var(--sans); font-size: 13.5px;
@@ -86,17 +92,29 @@ const setupWindowHTML = `<!doctype html>
   var err = document.getElementById('err');
   var btn = document.getElementById('go');
   async function submit() {
+    if (btn.disabled) return; // Cmd/Ctrl+Enter during an in-flight check
+    err.className = '';
     err.textContent = '';
     btn.disabled = true;
     try {
       await window.submitToken(tok.value);
-      // On success the window closes; nothing more to do.
+      // Structurally valid: Go is now checking it against the brain. The
+      // verdict arrives via __tokenVerdict below; success closes the window.
+      err.className = 'checking';
+      err.textContent = 'Checking the token with your brain…';
     } catch (e) {
       err.textContent = (e && e.message) ? e.message : String(e);
       btn.disabled = false;
       tok.focus();
     }
   }
+  window.__tokenVerdict = function (msg) {
+    if (!msg) return; // verified: the window is closing
+    err.className = '';
+    err.textContent = msg;
+    btn.disabled = false;
+    tok.focus();
+  };
   tok.addEventListener('keydown', function (e) {
     if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') { e.preventDefault(); submit(); }
   });

--- a/sidecar/verify_token.go
+++ b/sidecar/verify_token.go
@@ -1,0 +1,115 @@
+package main
+
+// Pre-save verification of a manually-supplied enrollment token.
+//
+// A pasted token used to be checked only structurally (DecodeJWTPayload),
+// saved, and then the sidecar restarted into its connect loop — so a token
+// that decodes fine but names a wrong/unreachable brain URL produced no UI at
+// all: the setup window closed, the pebble never spawned, and the only trace
+// was an endless reconnect loop in ~/.jarvis/sidecar.log. verifyBrainToken
+// closes that gap: it proves the token actually works against the brain it
+// names BEFORE the token is persisted, by asking that brain to mint an access
+// token (POST /sidecar/token — the same endpoint accessTokenProvider uses once
+// the sidecar runs). The outcome cleanly separates the three failure modes a
+// user can act on: the brain can't be reached, the brain rejected the token,
+// or the URL answers but isn't a Jarvis brain.
+//
+// The hosted-handshake token deliberately does NOT go through this: that JWT
+// is delivered single-use over the long-poll and must be persisted
+// unconditionally (see the capture comment in hosted_window.go).
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// verifyBrainTimeout bounds the whole probe. Long enough for a slow first TLS
+// handshake, short enough that a black-holed address fails while the user is
+// still looking at the "checking" state.
+const verifyBrainTimeout = 12 * time.Second
+
+// verifyBrainToken checks that the enrollment token works against the brain
+// it will actually be used with: claims.Brain, unless the config's brain
+// override replaces it (same precedence as NewSidecarClient). Returns nil when
+// the brain minted an access token for it; otherwise an error whose message is
+// user-ready (shown verbatim in the setup/settings forms and on stderr for
+// --token). A cancelled ctx surfaces as context.Canceled so callers can tell
+// "window closed" from a real verdict.
+func verifyBrainToken(ctx context.Context, raw, brainOverride string) error {
+	claims, err := DecodeJWTPayload(raw)
+	if err != nil {
+		return fmt.Errorf("That doesn't look like a valid token. Copy the full token printed by 'jarvis enroll'.")
+	}
+	brainURL := claims.Brain
+	if override := normalizeBrainOverride(brainOverride); override != "" {
+		brainURL = override
+	}
+	if strings.TrimSpace(brainURL) == "" {
+		return fmt.Errorf("This token doesn't name a brain to connect to. Run 'jarvis enroll \"<device-name>\"' again and paste the fresh token.")
+	}
+	mintURL := deriveMintURL(brainURL)
+	host := hostForDisplay(mintURL)
+
+	ctx, cancel := context.WithTimeout(ctx, verifyBrainTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, mintURL, nil)
+	if err != nil {
+		return fmt.Errorf("This token points at an invalid brain address (%s).", brainURL)
+	}
+	req.Header.Set("Authorization", "Bearer "+raw)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			return context.Canceled
+		}
+		log.Printf("[verify] brain probe %s failed: %v", mintURL, err)
+		return fmt.Errorf("Could not reach the brain at %s. Check that it is running and reachable from this machine, then try again.", host)
+	}
+	defer resp.Body.Close()
+
+	switch {
+	case resp.StatusCode == http.StatusOK:
+		// Fall through to the body check below.
+	case resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden:
+		return fmt.Errorf("The brain at %s rejected this token — it may be revoked or belong to a different brain. Run 'jarvis enroll \"<device-name>\"' again and paste the fresh token.", host)
+	case resp.StatusCode >= 500:
+		// A brain (or its proxy) that is up but erroring is not a wrong URL —
+		// don't steer the user into re-checking their token or address.
+		return fmt.Errorf("The brain at %s answered with a server error (%s). It may be restarting — try again in a moment.", host, resp.Status)
+	default:
+		return fmt.Errorf("The server at %s doesn't look like a Jarvis brain (unexpected response %s).", host, resp.Status)
+	}
+
+	// A 200 alone isn't proof — a captive portal or an unrelated web app can
+	// answer 200 to any path. Require the actual mint response shape.
+	var out struct {
+		AccessToken string `json:"access_token"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&out); err != nil || out.AccessToken == "" {
+		// Cancellation can also land here, aborting the body read mid-decode —
+		// keep the documented contract (window closed ⇒ context.Canceled)
+		// instead of misreporting it as a bad response body.
+		if errors.Is(ctx.Err(), context.Canceled) {
+			return context.Canceled
+		}
+		return fmt.Errorf("The server at %s doesn't look like a Jarvis brain (unexpected response body).", host)
+	}
+	return nil
+}
+
+// hostForDisplay reduces a URL to its host for user-facing messages, falling
+// back to the raw string if it doesn't parse.
+func hostForDisplay(rawURL string) string {
+	if u, err := url.Parse(rawURL); err == nil && u.Host != "" {
+		return u.Host
+	}
+	return rawURL
+}

--- a/sidecar/verify_token_test.go
+++ b/sidecar/verify_token_test.go
@@ -1,0 +1,149 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// enrollJWT builds a structurally valid (unsigned) enrollment JWT whose brain
+// claim points at the given ws(s) URL.
+func enrollJWT(t *testing.T, brain string) string {
+	t.Helper()
+	header := `{"alg":"ES256"}`
+	payload := `{"sid":"s1","name":"desktop","brain":"` + brain + `","jwks":"https://x/jwks.json","iat":1}`
+	enc := func(s string) string {
+		return strings.TrimRight(strings.NewReplacer("+", "-", "/", "_").Replace(base64StdNoPad(s)), "=")
+	}
+	return enc(header) + "." + enc(payload) + ".sig"
+}
+
+// wsURLFor maps an httptest server to the ws:// connect URL a real enrollment
+// token would carry (deriveMintURL maps it back to http://.../sidecar/token).
+func wsURLFor(srv *httptest.Server) string {
+	return "ws://" + strings.TrimPrefix(srv.URL, "http://") + "/sidecar/connect"
+}
+
+func TestVerifyBrainTokenSuccess(t *testing.T) {
+	var gotAuth, gotPath, gotMethod string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotPath = r.URL.Path
+		gotMethod = r.Method
+		_ = json.NewEncoder(w).Encode(map[string]any{"access_token": "at", "expires_in": 600})
+	}))
+	t.Cleanup(srv.Close)
+
+	jwt := enrollJWT(t, wsURLFor(srv))
+	if err := verifyBrainToken(context.Background(), jwt, ""); err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+	if gotMethod != http.MethodPost || gotPath != "/sidecar/token" {
+		t.Fatalf("probe hit %s %s, want POST /sidecar/token", gotMethod, gotPath)
+	}
+	if gotAuth != "Bearer "+jwt {
+		t.Fatalf("enrollment token not sent as bearer: %q", gotAuth)
+	}
+}
+
+func TestVerifyBrainTokenRejected(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	t.Cleanup(srv.Close)
+
+	err := verifyBrainToken(context.Background(), enrollJWT(t, wsURLFor(srv)), "")
+	if err == nil || !strings.Contains(err.Error(), "rejected this token") {
+		t.Fatalf("403 must read as a rejection, got %v", err)
+	}
+}
+
+func TestVerifyBrainTokenUnreachable(t *testing.T) {
+	// A server that existed and is gone: connection refused on a real port.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	dead := wsURLFor(srv)
+	srv.Close()
+
+	err := verifyBrainToken(context.Background(), enrollJWT(t, dead), "")
+	if err == nil || !strings.Contains(err.Error(), "Could not reach the brain") {
+		t.Fatalf("dead endpoint must read as unreachable, got %v", err)
+	}
+}
+
+func TestVerifyBrainTokenServerError(t *testing.T) {
+	// A brain (or proxy) that is up but erroring must not read as a wrong
+	// URL ("doesn't look like a Jarvis brain") — it should invite a retry.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	t.Cleanup(srv.Close)
+
+	err := verifyBrainToken(context.Background(), enrollJWT(t, wsURLFor(srv)), "")
+	if err == nil || !strings.Contains(err.Error(), "server error") {
+		t.Fatalf("5xx must read as a server error, got %v", err)
+	}
+	if strings.Contains(err.Error(), "doesn't look like a Jarvis brain") {
+		t.Fatalf("5xx must not read as not-a-brain: %v", err)
+	}
+}
+
+func TestVerifyBrainTokenNotABrain(t *testing.T) {
+	// Wrong URL that answers: a plain web server 404s the mint path.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(srv.Close)
+	err := verifyBrainToken(context.Background(), enrollJWT(t, wsURLFor(srv)), "")
+	if err == nil || !strings.Contains(err.Error(), "doesn't look like a Jarvis brain") {
+		t.Fatalf("404 must read as not-a-brain, got %v", err)
+	}
+
+	// A captive portal / unrelated app answering 200 to anything must not pass.
+	portal := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("<html>welcome</html>"))
+	}))
+	t.Cleanup(portal.Close)
+	err = verifyBrainToken(context.Background(), enrollJWT(t, wsURLFor(portal)), "")
+	if err == nil || !strings.Contains(err.Error(), "doesn't look like a Jarvis brain") {
+		t.Fatalf("200-with-garbage must read as not-a-brain, got %v", err)
+	}
+}
+
+func TestVerifyBrainTokenOverrideWins(t *testing.T) {
+	// The token names a dead brain, but the config's brain override points at
+	// a live one — verification must probe the override, like the client does.
+	deadSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	dead := wsURLFor(deadSrv)
+	deadSrv.Close()
+
+	live := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"access_token": "at"})
+	}))
+	t.Cleanup(live.Close)
+
+	if err := verifyBrainToken(context.Background(), enrollJWT(t, dead), live.URL); err != nil {
+		t.Fatalf("override should have been probed, got %v", err)
+	}
+}
+
+func TestVerifyBrainTokenGarbageToken(t *testing.T) {
+	err := verifyBrainToken(context.Background(), "not-a-jwt", "")
+	if err == nil || !strings.Contains(err.Error(), "valid token") {
+		t.Fatalf("garbage must fail structurally, got %v", err)
+	}
+}
+
+func TestVerifyBrainTokenCancelled(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	t.Cleanup(srv.Close)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := verifyBrainToken(ctx, enrollJWT(t, wsURLFor(srv)), "")
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("a cancelled check must surface context.Canceled, got %v", err)
+	}
+}


### PR DESCRIPTION
## Problem

A manually-supplied enrollment token was only checked structurally (JWT decode) before being saved and the sidecar (re)started. A well-formed token pointing at a wrong or unreachable brain URL failed invisibly: the setup window closed, the pebble never spawned, and the only trace was an endless reconnect loop in `~/.jarvis/sidecar.log`. The `--token` CLI flag had no validation at all.

## Change

New `verifyBrainToken()` proves a token works against the brain it names **before** it is persisted, by requesting an access token (`POST {brain}/sidecar/token` with the enrollment JWT as bearer — the same endpoint `accessTokenProvider` uses once running, same `brain:` override precedence as the client). It classifies the three actionable failures into distinct user-facing messages: brain unreachable, token rejected (401/403), server error (5xx, "try again"), and "that server isn't a Jarvis brain" (anything else, including a 200 without the mint response shape, so captive portals can't fake a pass).

Wired into all three manual paths, none of which save on failure:

- **First-run self-host form** — shows "Checking the token with your brain…", verdict lands inline via a new `window.__tokenVerdict` hook; only success closes the window and saves. The check runs in a goroutine on a dedicated context (bindings run on the webview UI thread; the window's main ctx is already cancelled once self-host is chosen), joined through the existing WaitGroup/torndown teardown machinery.
- **Settings window** — same async pattern; the existing "Saved — restart" UX now only appears after the brain accepted the token. Typing during a check can't re-enable Save, and the verdict never wipes newer input.
- **`--token` CLI** — verifies before saving, exits 1 with the error on stderr and (on Windows, where the GUI-subsystem binary has no stderr) a native message box.

The hosted-handshake token is deliberately **not** verified: that JWT is delivered single-use over the long-poll and must always be persisted.

Supporting changes: `runLocalWebview` (both platform variants) lets a window's build function return a cleanup hook so binding goroutines are joined before the engine is freed; `BrainOverride()` accessor on the client; Cmd/Ctrl+Enter double-submit guard in the setup form; docs updated.

## Testing

- 9 new unit tests for `verifyBrainToken` (wire contract, all failure classes, override precedence, cancellation semantics).
- `go build`, `go vet`, full sidecar suite green; brain-side suite green via pre-commit (1818 pass).