### PR TITLE
sidecar: receive self-host enrollment tokens from the connect page via jarvis:// deep link

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,9 @@ jobs:
   # The sidecar is a cgo program (webview_go + GTK overlays). The local
   # pre-commit hook does NOT run Go, so this is the only automated guard that
   # the sidecar still builds. Linux native + Windows mingw cross-build cover the
-  # two toolchains verifiable on a Linux runner; darwin builds on release.
+  # two toolchains verifiable on a Linux runner; darwin compiles in its own
+  # macos job below (previously it first compiled inside the RELEASE workflow,
+  # so an ObjC error failed a release instead of the PR).
   sidecar-build:
     runs-on: ubuntu-latest
     steps:
@@ -73,6 +75,27 @@ jobs:
           set -euo pipefail
           export CGO_CFLAGS="-I$(pwd)/include" CGO_CXXFLAGS="-I$(pwd)/include"
           go build -o /tmp/jarvis-sidecar.exe .
+
+  # Compile gate for the darwin cgo files (deeplink_darwin.go, the *_darwin
+  # bridges): build tags hide them from the linux job, so without this their
+  # first compile happens on a release runner. Build + vet only — the UI
+  # can't run on a headless runner and the logic tests are covered on linux.
+  sidecar-build-darwin:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: sidecar/go.mod
+          cache-dependency-path: sidecar/go.sum
+      - name: Build + vet (darwin, cgo)
+        working-directory: sidecar
+        env:
+          CGO_ENABLED: "1"
+        run: |
+          set -euo pipefail
+          go vet ./...
+          go build ./...
 
   # NOTE: the sidecar VERSION-bump PR gate is intentionally OFF during the
   # current development phase — the sidecar is frozen at sidecar/VERSION = 0.1.0

--- a/sidecar/deeplink.go
+++ b/sidecar/deeplink.go
@@ -1,0 +1,201 @@
+package main
+
+// Browser -> sidecar enrollment deep link (the usejarvis free/self-host door).
+//
+// The connect page's "Self-hosted" row hands the pasted enrollment token to
+// THIS machine via `jarvis://enroll?v=1&nonce=<nonce>&token=<jwt>` — the token
+// never transits the usejarvis server (hosting repo ONBOARDING.md pins the
+// contract). The OS launches a fresh process for the URI; that process
+// forwards it over a user-scoped unix socket to the sidecar instance whose
+// first-run window owns the live handshake, then exits. The receiving side
+// (hosted_window.go) accepts the link ONLY when the URI's nonce matches its
+// own live handshake — any web page can fire jarvis:// URIs, but only the
+// real connect page knows the 256-bit nonce — verifies the token against the
+// brain it names (verify_token.go), and reports just the VERDICT back to the
+// server so the page can show success or the reason for rejection.
+//
+// The socket lives under ~/.jarvis (0600; the dir itself is created 0700 by
+// setupLogging BEFORE runFirstRunWindow, which this bind depends on):
+// filesystem-permission-gated IPC, deliberately NOT a TCP port. Go's net
+// package supports AF_UNIX on every platform this sidecar targets (Windows 10
+// 1803+ included), symmetrically for Listen and Dial.
+//
+// ACCEPTED RISK: x-scheme-handler delivery puts the token-bearing URI in the
+// forwarder's argv, which on Linux is world-readable via /proc/<pid>/cmdline
+// for the forwarder's brief lifetime. Same single-user-desktop exposure as
+// `jarvis enroll` printing the token to a terminal; avoiding it entirely
+// needs D-Bus activation (possible follow-up). Mirrored in ONBOARDING.md.
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+const enrollDeepLinkPrefix = "jarvis://enroll"
+
+// Bounds a forwarded URI read: a real one is nonce (43 chars) + a JWT (a few
+// hundred bytes); anything larger is not ours.
+const enrollDeepLinkMaxLen = 16 << 10
+
+func deepLinkSocketPath() string {
+	return filepath.Join(configDir, "enroll.sock")
+}
+
+// parseEnrollDeepLink extracts {nonce, token} from an enroll URI. The token is
+// whitespace-trimmed (a wrapping-terminal paste travels the page -> URL intact,
+// but be lenient anyway); structural JWT validation is the caller's job.
+func parseEnrollDeepLink(raw string) (nonce, token string, err error) {
+	u, perr := url.Parse(strings.TrimSpace(raw))
+	if perr != nil {
+		return "", "", fmt.Errorf("parse enroll deep link: %w", perr)
+	}
+	if u.Scheme != "jarvis" || u.Host != "enroll" {
+		return "", "", fmt.Errorf("not an enroll deep link: %s://%s", u.Scheme, u.Host)
+	}
+	q := u.Query()
+	// Forward-compat gate: today's contract is v=1 (an omitted v is treated as
+	// 1 for leniency); a future bump must not be half-understood.
+	if v := q.Get("v"); v != "" && v != "1" {
+		return "", "", fmt.Errorf("unsupported enroll deep link version %q", v)
+	}
+	nonce = strings.TrimSpace(q.Get("nonce"))
+	token = trimToken(q.Get("token"))
+	if nonce == "" || token == "" {
+		return "", "", fmt.Errorf("enroll deep link missing nonce or token")
+	}
+	return nonce, token, nil
+}
+
+// maybeForwardEnrollLaunch handles the OS launching this process with a
+// jarvis://enroll URI: forward it to the running first-run window and exit —
+// NEVER boot a full second sidecar off a URI launch. Returns false on a
+// normal launch. Must run before maybeForwardProtocolLaunch: the Windows
+// notification forwarder matches any jarvis:// URI and would swallow enroll
+// links into the (tray-less during onboarding) notification path.
+func maybeForwardEnrollLaunch() bool {
+	var uri string
+	for _, a := range os.Args[1:] {
+		if strings.HasPrefix(a, enrollDeepLinkPrefix) {
+			uri = a
+			break
+		}
+	}
+	if uri == "" {
+		return false
+	}
+	if err := forwardEnrollDeepLink(uri); err != nil {
+		// No listener = no first-run window waiting for a token. The connect
+		// page shows a copy-token fallback for exactly this case, so just
+		// leave a trace for the curious.
+		fmt.Fprintf(os.Stderr, "jarvis: no setup window is waiting for a token (%v)\nOpen the Jarvis app, then click Connect on the web page again.\n", err)
+	}
+	return true
+}
+
+// maybeDropProtocolLaunch is the LAST protocol-launch check in main: any
+// jarvis:// URI that neither the enroll forwarder nor the (Windows-only)
+// notification forwarder claimed must still end this process. Registering the
+// scheme on Linux made every jarvis:// URI a launch vector for ANY web page —
+// without this sink, an unrecognized URI would fall through and boot a full
+// second sidecar contending for the mic, hotkeys, and tray.
+func maybeDropProtocolLaunch() bool {
+	for _, a := range os.Args[1:] {
+		if strings.HasPrefix(a, "jarvis://") {
+			fmt.Fprintf(os.Stderr, "jarvis: ignoring unrecognized jarvis:// launch URI\n")
+			return true
+		}
+	}
+	return false
+}
+
+// forwardEnrollDeepLink hands the URI to the listening sidecar and waits for
+// the ack so the write is fully consumed before this process exits.
+func forwardEnrollDeepLink(uri string) error {
+	conn, err := net.DialTimeout("unix", deepLinkSocketPath(), 2*time.Second)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+	_ = conn.SetDeadline(time.Now().Add(5 * time.Second))
+	if _, err := conn.Write([]byte(uri + "\n")); err != nil {
+		return err
+	}
+	ack := make([]byte, 3)
+	_, _ = io.ReadFull(conn, ack)
+	return nil
+}
+
+// deepLinkListener owns the enroll socket for one first-run window session.
+// Close is idempotent, joins in-flight onURI callbacks, and removes the
+// socket — callers rely on "no callback runs after Close returns" to order
+// teardown against the webview's Destroy.
+type deepLinkListener struct {
+	ln     net.Listener
+	wg     sync.WaitGroup
+	closed atomic.Bool
+}
+
+func listenEnrollDeepLinks(onURI func(uri string)) (*deepLinkListener, error) {
+	path := deepLinkSocketPath()
+	// A stale socket from a crashed run refuses the bind; nothing else may own
+	// this path while no first-run window runs.
+	_ = os.Remove(path)
+	ln, err := net.Listen("unix", path)
+	if err != nil {
+		return nil, err
+	}
+	// 0600: same user only (no-op on Windows; the profile dir gates there).
+	_ = os.Chmod(path, 0o600)
+	l := &deepLinkListener{ln: ln}
+	l.wg.Add(1)
+	go func() {
+		defer l.wg.Done()
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return // listener closed
+			}
+			l.wg.Add(1)
+			go func() {
+				defer l.wg.Done()
+				defer conn.Close()
+				_ = conn.SetDeadline(time.Now().Add(5 * time.Second))
+				line, rerr := bufio.NewReader(io.LimitReader(conn, enrollDeepLinkMaxLen)).ReadString('\n')
+				// A read that never reached the newline (truncated writer,
+				// over-limit payload) is not a URI — reject, don't guess.
+				if rerr != nil {
+					log.Printf("[deeplink] dropped unreadable forward: %v", rerr)
+					return
+				}
+				uri := strings.TrimSpace(line)
+				if uri == "" {
+					return
+				}
+				if !l.closed.Load() {
+					onURI(uri)
+				}
+				_, _ = conn.Write([]byte("ok\n"))
+			}()
+		}
+	}()
+	return l, nil
+}
+
+func (l *deepLinkListener) Close() {
+	if l == nil || l.closed.Swap(true) {
+		return
+	}
+	_ = l.ln.Close()
+	l.wg.Wait()
+	_ = os.Remove(deepLinkSocketPath())
+}

--- a/sidecar/deeplink_bridge_darwin.go
+++ b/sidecar/deeplink_bridge_darwin.go
@@ -1,0 +1,33 @@
+//go:build darwin
+
+package main
+
+// C→Go bridge for macOS URL opens (separate file per the cgo //export rule).
+// Runs on the Cocoa main thread when LaunchServices delivers a jarvis:// URL.
+// Enroll links are re-routed through the SAME unix socket the first-run
+// window listens on — one code path owns nonce-gating and serialization on
+// every OS; no listener simply means no setup window is waiting, and the URI
+// is dropped (matching maybeDropProtocolLaunch elsewhere). Off-thread because
+// the forward dials a socket with deadlines and the Cocoa main thread must
+// not block.
+
+import "C"
+
+import (
+	"log"
+	"strings"
+)
+
+//export goHandleURLOpen
+func goHandleURLOpen(curl *C.char) {
+	uri := C.GoString(curl)
+	if !strings.HasPrefix(uri, enrollDeepLinkPrefix) {
+		log.Printf("[deeplink] ignoring non-enroll URL open")
+		return
+	}
+	go func() {
+		if err := forwardEnrollDeepLink(uri); err != nil {
+			log.Printf("[deeplink] URL open dropped: no setup window is waiting (%v)", err)
+		}
+	}()
+}

--- a/sidecar/deeplink_darwin.go
+++ b/sidecar/deeplink_darwin.go
@@ -1,0 +1,60 @@
+//go:build darwin
+
+package main
+
+/*
+#cgo CFLAGS: -x objective-c -fobjc-arc
+#cgo LDFLAGS: -framework Cocoa
+
+#import <Cocoa/Cocoa.h>
+
+// macOS URL-open receiver for jarvis:// deep links. Unlike Linux/Windows,
+// LaunchServices never passes the URI in argv: it activates the running app
+// (or launches it) and delivers a kAEGetURL Apple Event. The scheme itself is
+// claimed by the app bundle's Info.plist (CFBundleURLTypes) — this file only
+// installs the handler that RECEIVES the opens.
+
+extern void goHandleURLOpen(const char* url);
+
+@interface JarvisURLHandler : NSObject
+- (void)handleGetURL:(NSAppleEventDescriptor*)event withReply:(NSAppleEventDescriptor*)reply;
+@end
+
+@implementation JarvisURLHandler
+- (void)handleGetURL:(NSAppleEventDescriptor*)event withReply:(NSAppleEventDescriptor*)reply {
+    NSString* s = [[event paramDescriptorForKeyword:keyDirectObject] stringValue];
+    if (s != nil) {
+        goHandleURLOpen([s UTF8String]);
+    }
+}
+@end
+
+static JarvisURLHandler* jarvisURLHandler = nil;
+
+// Installed via the main queue: registration races nothing that matters — a
+// launched-BY-URL process has no first-run window (and thus no live handshake)
+// yet, so an event slipping past before the handler lands would be dropped by
+// the nonce gate anyway. 'GURL'/'GURL' are the classic kInternetEventClass /
+// kAEGetURL four-char codes, spelled literally to avoid the Carbon header.
+static void jarvisInstallURLHandler(void) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if (jarvisURLHandler != nil) {
+            return;
+        }
+        jarvisURLHandler = [[JarvisURLHandler alloc] init];
+        [[NSAppleEventManager sharedAppleEventManager]
+            setEventHandler:jarvisURLHandler
+            andSelector:@selector(handleGetURL:withReply:)
+            forEventClass:'GURL'
+            andEventID:'GURL'];
+    });
+}
+*/
+import "C"
+
+// installURLOpenHandler queues the Apple Event registration onto the Cocoa
+// main queue (drained by whichever loop owns the main thread — the first-run
+// webview during onboarding, [NSApp run] under the tray afterwards).
+func installURLOpenHandler() {
+	C.jarvisInstallURLHandler()
+}

--- a/sidecar/deeplink_darwin.go
+++ b/sidecar/deeplink_darwin.go
@@ -14,7 +14,10 @@ package main
 // claimed by the app bundle's Info.plist (CFBundleURLTypes) — this file only
 // installs the handler that RECEIVES the opens.
 
-extern void goHandleURLOpen(const char* url);
+// char* (not const char*) to match cgo's generated signature exactly — the
+// prototypes live in different TUs so a mismatch would link anyway, but only
+// by accident.
+extern void goHandleURLOpen(char* url);
 
 @interface JarvisURLHandler : NSObject
 - (void)handleGetURL:(NSAppleEventDescriptor*)event withReply:(NSAppleEventDescriptor*)reply;
@@ -24,18 +27,26 @@ extern void goHandleURLOpen(const char* url);
 - (void)handleGetURL:(NSAppleEventDescriptor*)event withReply:(NSAppleEventDescriptor*)reply {
     NSString* s = [[event paramDescriptorForKeyword:keyDirectObject] stringValue];
     if (s != nil) {
-        goHandleURLOpen([s UTF8String]);
+        goHandleURLOpen((char*)[s UTF8String]);
     }
 }
 @end
 
 static JarvisURLHandler* jarvisURLHandler = nil;
 
-// Installed via the main queue: registration races nothing that matters — a
-// launched-BY-URL process has no first-run window (and thus no live handshake)
-// yet, so an event slipping past before the handler lands would be dropped by
-// the nonce gate anyway. 'GURL'/'GURL' are the classic kInternetEventClass /
-// kAEGetURL four-char codes, spelled literally to avoid the Carbon header.
+// Installed via the main queue. Ordering, made explicit so nobody re-derives
+// it: on a launched-BY-URL cold start, AppKit delivers the queued launch
+// Apple Event during finishLaunching — at the top of the first run loop —
+// while main-queue blocks drain only once the loop is pumping, so the launch
+// URL is DETERMINISTICALLY dropped, not racily. That is acceptable: a cold
+// start has no live handshake to match anyway, and the app opens into
+// onboarding, where the user's next click on the page arrives normally. It is
+// also a platform asymmetry vs Linux/Windows (maybeDropProtocolLaunch): on
+// macOS a jarvis:// click while the app is closed DOES cold-boot the full
+// app via LaunchServices — behind a browser prompt, into onboarding, so it
+// behaves like opening the app. 'GURL'/'GURL' are the classic
+// kInternetEventClass / kAEGetURL four-char codes, spelled literally to avoid
+// the Carbon header.
 static void jarvisInstallURLHandler(void) {
     dispatch_async(dispatch_get_main_queue(), ^{
         if (jarvisURLHandler != nil) {

--- a/sidecar/deeplink_test.go
+++ b/sidecar/deeplink_test.go
@@ -1,0 +1,181 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestParseEnrollDeepLink(t *testing.T) {
+	t.Run("valid link round-trips nonce and token", func(t *testing.T) {
+		nonce, token, err := parseEnrollDeepLink("jarvis://enroll?v=1&nonce=abc123&token=eyJ.x.y")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if nonce != "abc123" || token != "eyJ.x.y" {
+			t.Fatalf("got nonce=%q token=%q", nonce, token)
+		}
+	})
+
+	t.Run("token whitespace is trimmed", func(t *testing.T) {
+		_, token, err := parseEnrollDeepLink("jarvis://enroll?nonce=n&token=%20%0aeyJ.x.y%0a")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if token != "eyJ.x.y" {
+			t.Fatalf("token not trimmed: %q", token)
+		}
+	})
+
+	t.Run("rejects wrong scheme, wrong host, and missing params", func(t *testing.T) {
+		for _, bad := range []string{
+			"https://enroll?nonce=n&token=t",
+			"jarvis://n?id=x&kind=approval&a=approve", // notification URI namespace
+			"jarvis://enroll?nonce=n",
+			"jarvis://enroll?token=t",
+			"jarvis://enroll",
+		} {
+			if _, _, err := parseEnrollDeepLink(bad); err == nil {
+				t.Fatalf("expected error for %q", bad)
+			}
+		}
+	})
+}
+
+// The forwarder and listener speak over the real unix socket under configDir.
+func TestEnrollDeepLinkSocketRoundTrip(t *testing.T) {
+	orig := configDir
+	configDir = t.TempDir()
+	defer func() { configDir = orig }()
+
+	got := make(chan string, 2)
+	l, err := listenEnrollDeepLinks(func(uri string) { got <- uri })
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer l.Close()
+
+	uri := "jarvis://enroll?v=1&nonce=abc&token=e.f.g"
+	if err := forwardEnrollDeepLink(uri); err != nil {
+		t.Fatalf("forward: %v", err)
+	}
+	select {
+	case u := <-got:
+		if u != uri {
+			t.Fatalf("got %q want %q", u, uri)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("URI never delivered")
+	}
+
+	// Close joins handlers, removes the socket, and further forwards fail —
+	// the "no callback after Close" guarantee teardown depends on.
+	l.Close()
+	l.Close() // idempotent
+	if err := forwardEnrollDeepLink(uri); err == nil {
+		t.Fatal("forward after Close should fail")
+	}
+	if _, err := os.Stat(deepLinkSocketPath()); !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("socket not removed by Close: %v", err)
+	}
+}
+
+func TestMaybeDropProtocolLaunch(t *testing.T) {
+	origArgs := os.Args
+	defer func() { os.Args = origArgs }()
+
+	// Any unclaimed jarvis:// URI ends the process instead of booting a full
+	// sidecar (the Linux scheme registration makes this web-page-reachable).
+	os.Args = []string{"jarvis-sidecar", "jarvis://n?id=x&kind=approval&a=approve"}
+	if !maybeDropProtocolLaunch() {
+		t.Fatal("unrecognized jarvis:// URI must be dropped")
+	}
+	os.Args = []string{"jarvis-sidecar"}
+	if maybeDropProtocolLaunch() {
+		t.Fatal("normal launch must proceed")
+	}
+	os.Args = []string{"jarvis-sidecar", "--token", "abc"}
+	if maybeDropProtocolLaunch() {
+		t.Fatal("flag launch must proceed")
+	}
+}
+
+func TestCapUTF16(t *testing.T) {
+	// Astral runes weigh 2 UTF-16 units: 200 of them exceed a 300-unit cap at
+	// rune 150, and a surrogate pair is never split.
+	astral := strings.Repeat("\U0001D54F", 200)
+	capped := capUTF16(astral, 300)
+	if n := len([]rune(capped)); n != 150 {
+		t.Fatalf("got %d runes, want 150", n)
+	}
+	if got := capUTF16("héllo", 300); got != "héllo" {
+		t.Fatalf("under-limit string mangled: %q", got)
+	}
+	if got := capUTF16("abcdef", 3); got != "abc" {
+		t.Fatalf("BMP cap wrong: %q", got)
+	}
+}
+
+func TestReportSelfHostResult(t *testing.T) {
+	type recorded struct {
+		Nonce string  `json:"nonce"`
+		OK    bool    `json:"ok"`
+		Error *string `json:"error"`
+	}
+	var last atomic.Pointer[recorded]
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/handshake/self-host-result" {
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
+		calls.Add(1)
+		var rec recorded
+		_ = json.NewDecoder(r.Body).Decode(&rec)
+		last.Store(&rec)
+		w.WriteHeader(200)
+		fmt.Fprint(w, `{"applied":true}`)
+	}))
+	defer srv.Close()
+
+	t.Run("success posts ok with no error field", func(t *testing.T) {
+		reportSelfHostResult(context.Background(), srv.URL, "n1", nil)
+		rec := last.Load()
+		if rec == nil || !rec.OK || rec.Nonce != "n1" || rec.Error != nil {
+			t.Fatalf("bad payload: %+v", rec)
+		}
+	})
+
+	t.Run("failure posts the user-ready reason, capped at 300 UTF-16 units", func(t *testing.T) {
+		// UTF-16 units, NOT runes: the server's zod .max(…) counts UTF-16, so
+		// an astral-heavy message must land under ITS cap. 400 astral runes =
+		// 800 units -> capped to 150 runes = 300 units.
+		reportSelfHostResult(context.Background(), srv.URL, "n2", errors.New(strings.Repeat("\U0001D54F", 400)))
+		rec := last.Load()
+		if rec == nil || rec.OK || rec.Error == nil {
+			t.Fatalf("bad payload: %+v", rec)
+		}
+		if n := len([]rune(*rec.Error)); n != 150 {
+			t.Fatalf("error not capped at 300 UTF-16 units: %d runes", n)
+		}
+	})
+
+	t.Run("a cancelled verify is teardown, not a verdict", func(t *testing.T) {
+		before := calls.Load()
+		reportSelfHostResult(context.Background(), srv.URL, "n3", context.Canceled)
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		reportSelfHostResult(ctx, srv.URL, "n3", nil)
+		if calls.Load() != before {
+			t.Fatal("teardown must not report")
+		}
+	})
+}

--- a/sidecar/hosted.go
+++ b/sidecar/hosted.go
@@ -77,6 +77,89 @@ func submitTokenHandler(isActive func() bool, accept func(token string)) func(st
 	}
 }
 
+// reportSelfHostResult posts the verdict of a LOCALLY-verified self-host
+// enroll (jarvis:// deep link) so the connect page can show success or the
+// reason for rejection: {nonce, ok, error?} — the token itself never leaves
+// this machine. Nonce-authed server-side; the error string is user-ready
+// (verify_token.go messages) and the server caps it at 300 chars. Bounded
+// retries: losing the verdict leaves the page waiting on a spinner even
+// though this side already moved on.
+func reportSelfHostResult(ctx context.Context, base, nonce string, verr error) {
+	if ctx.Err() != nil || errors.Is(verr, context.Canceled) {
+		return // window tearing down — not a verdict
+	}
+	payload := map[string]any{"nonce": nonce, "ok": verr == nil}
+	if verr != nil {
+		// Cap in UTF-16 CODE UNITS, not runes — the server's zod .max counts
+		// UTF-16, and a rune-capped astral-plane message (host names ride in
+		// from the token's own claims) would be rejected there, losing the
+		// verdict entirely.
+		payload["error"] = capUTF16(verr.Error(), 300)
+	}
+	body, _ := json.Marshal(payload)
+	for attempt := 1; attempt <= 3; attempt++ {
+		rctx, rcancel := context.WithTimeout(ctx, 10*time.Second)
+		err := postSelfHostResultOnce(rctx, base, body)
+		rcancel()
+		if err == nil {
+			return
+		}
+		log.Printf("[hosted] self-host verdict report failed (attempt %d/3): %v", attempt, err)
+		var pe *permanentReportError
+		if errors.As(err, &pe) {
+			return // a 4xx repeats identically — retrying is noise
+		}
+		select {
+		case <-time.After(2 * time.Second):
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+// capUTF16 truncates s to at most max UTF-16 code units, never splitting a
+// rune (a surrogate pair either fits whole or is dropped).
+func capUTF16(s string, max int) string {
+	units := 0
+	for i, r := range s {
+		w := 1
+		if r > 0xFFFF {
+			w = 2
+		}
+		if units+w > max {
+			return s[:i]
+		}
+		units += w
+	}
+	return s
+}
+
+// permanentReportError marks a server verdict rejection (4xx) that retries
+// cannot fix.
+type permanentReportError struct{ status string }
+
+func (e *permanentReportError) Error() string { return "server returned " + e.status }
+
+func postSelfHostResultOnce(ctx context.Context, base string, body []byte) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, base+"/api/handshake/self-host-result", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	res, err := hostedHTTPClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+	if res.StatusCode >= 400 && res.StatusCode < 500 {
+		return &permanentReportError{status: res.Status}
+	}
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		return fmt.Errorf("server returned %s", res.Status)
+	}
+	return nil
+}
+
 // generateHandshakeNonce returns a 256-bit unguessable correlation id.
 func generateHandshakeNonce() (string, error) {
 	buf := make([]byte, 32)
@@ -148,6 +231,13 @@ type errHandshakeFailed struct{ reason string }
 
 func (e *errHandshakeFailed) Error() string { return e.reason }
 
+// errHandshakeResolvedLocally: the handshake completed with NO token — a
+// self-host verdict resolved it, meaning the deep-link path on THIS machine
+// (or none at all, for a stranger's report) owns the outcome. Not an error to
+// paint on the shell: the deep-link goroutine already accepted the token and
+// is closing the window, or there is nothing for the hosted path to do.
+var errHandshakeResolvedLocally = errors.New("handshake resolved by a local self-host enroll")
+
 func pollHandshakeOnce(ctx context.Context, base, nonce string) (*handshakePollResponse, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, base+"/api/handshake/poll?nonce="+url.QueryEscape(nonce), nil)
 	if err != nil {
@@ -201,6 +291,9 @@ func awaitHandshakeToken(ctx context.Context, base, nonce string, onProgress fun
 
 		switch res.Status {
 		case "complete":
+			if res.Token == "" {
+				return "", errHandshakeResolvedLocally
+			}
 			if _, err := DecodeJWTPayload(res.Token); err != nil {
 				return "", fmt.Errorf("handshake returned an invalid token: %w", err)
 			}

--- a/sidecar/hosted_window.go
+++ b/sidecar/hosted_window.go
@@ -20,6 +20,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -207,6 +208,19 @@ func runFirstRunWindow(cfg *SidecarConfig) (string, error) {
 	// only, like selfHostFormActive.
 	verifyInFlight := false
 
+	// The ACTIVE handshake's nonce (set once registered server-side), read by
+	// the deep-link handler off-thread — a jarvis://enroll link only counts
+	// when it names this exact nonce. Any page can fire deep links; only the
+	// real connect page knows the 256-bit nonce.
+	var nonceMu sync.Mutex
+	currentNonce := ""
+	setNonce := func(n string) { nonceMu.Lock(); currentNonce = n; nonceMu.Unlock() }
+	getNonce := func() string { nonceMu.Lock(); defer nonceMu.Unlock(); return currentNonce }
+
+	// Serializes deep-link verifications (the browser row can be re-clicked
+	// while a probe is in flight; verify_token.go bounds each at ~12s).
+	var deepLinkBusy atomic.Bool
+
 	// Connect page URL for the CURRENT handshake nonce, and a guard against
 	// overlapping handshakes (double-clicked "Try again"). Main-thread only,
 	// like selfHostFormActive/token: bindings and Dispatch closures both run
@@ -370,6 +384,13 @@ func runFirstRunWindow(cfg *SidecarConfig) (string, error) {
 				return
 			}
 
+			// Registered: from here the connect page can hand a self-host
+			// token straight back to us by deep link, keyed by this nonce.
+			// Never cleared on later errors — the page for this nonce may
+			// still be open in the browser, and a deep link doesn't need the
+			// long-poll to be alive; a fresh handshake overwrites it.
+			setNonce(nonce)
+
 			// Sign-in happens in the SYSTEM browser (nonce in the URL; the
 			// connect page claims it after Clerk login) — see the header
 			// comment for why not this webview. The shell stays up as the
@@ -410,6 +431,12 @@ func runFirstRunWindow(cfg *SidecarConfig) (string, error) {
 			if err != nil {
 				if ctx.Err() != nil {
 					return // window closed or self-host chosen
+				}
+				if errors.Is(err, errHandshakeResolvedLocally) {
+					// The deep-link goroutine owns the outcome (it verified,
+					// stored the token, and is closing the window) — painting
+					// an error over its success would be a lie.
+					return
 				}
 				log.Printf("[hosted] handshake failed: %v", err)
 				showShellError("Setup did not complete: " + err.Error())
@@ -457,6 +484,62 @@ func runFirstRunWindow(cfg *SidecarConfig) (string, error) {
 		return "", fmt.Errorf("bind retryHosted: %w", err)
 	}
 
+	// Enrollment deep links (jarvis://enroll — the connect page's free door):
+	// the OS-launched forwarder dials our socket with the URI; nonce-match,
+	// verify against the brain, report ONLY the verdict, and on success take
+	// the token exactly like the hosted path. Listener failure is not fatal —
+	// the page's copy-token fallback and the local paste form both still work.
+	// dl.Close() joins in-flight callbacks; each callback joins its own work
+	// into handshakeWG, so the explicit post-Run teardown below stays ordered:
+	// close listener -> Wait -> read token -> (deferred) Destroy.
+	dl, dlErr := listenEnrollDeepLinks(func(uri string) {
+		nonce, tok, perr := parseEnrollDeepLink(uri)
+		if perr != nil {
+			log.Printf("[hosted] enroll deep link dropped: %v", perr)
+			return
+		}
+		want := getNonce()
+		if want == "" || nonce != want {
+			log.Printf("[hosted] enroll deep link dropped: nonce mismatch")
+			return
+		}
+		if !deepLinkBusy.CompareAndSwap(false, true) {
+			log.Printf("[hosted] enroll deep link dropped: a verification is already running")
+			return
+		}
+		handshakeWG.Add(1)
+		go func() {
+			defer handshakeWG.Done()
+			defer deepLinkBusy.Store(false)
+			if _, derr := DecodeJWTPayload(tok); derr != nil {
+				reportSelfHostResult(verifyCtx, base, nonce, fmt.Errorf("That doesn't look like a valid token. Copy the full token printed by 'jarvis enroll'."))
+				return
+			}
+			verr := verifyBrainToken(verifyCtx, tok, cfg.Brain)
+			// The page is the feedback surface either way: it shows the reason
+			// on failure and flips to "connected" on success.
+			reportSelfHostResult(verifyCtx, base, nonce, verr)
+			if verr != nil {
+				log.Printf("[hosted] deep-linked token rejected: %v", verr)
+				return
+			}
+			log.Printf("[hosted] enrollment token received via deep link and verified")
+			tokenMu.Lock()
+			token = tok
+			tokenMu.Unlock()
+			w.Dispatch(func() {
+				if torndown.Load() {
+					return
+				}
+				w.Terminate()
+			})
+		}()
+	})
+	if dlErr != nil {
+		log.Printf("[hosted] enroll deep-link listener unavailable: %v", dlErr)
+	}
+	defer dl.Close() // idempotent backstop for early returns (nil-safe)
+
 	stopReveal := revealWebviewOnLoad(w)
 	// LIFO with the deferred Destroy at the top: joining the reveal-timeout
 	// goroutine before the engine is freed prevents its pending Dispatch from
@@ -466,6 +549,9 @@ func runFirstRunWindow(cfg *SidecarConfig) (string, error) {
 	startHandshake()
 	w.Run() // blocks until Terminate() or the window is closed
 	torndown.Store(true)
+	// No further deep links, and no callback mid-flight past this line (Close
+	// joins them) — so the Add-into-handshakeWG below cannot race the Wait.
+	dl.Close()
 	// Join the handshake goroutine BEFORE reading the token, rather than
 	// leaving it to the deferred Wait: defers run after the return value is
 	// evaluated, so a token that lands in the instant the window closes would

--- a/sidecar/main.go
+++ b/sidecar/main.go
@@ -12,10 +12,23 @@ import (
 )
 
 func main() {
-	// A notification button was clicked: the OS launched us with a jarvis:// URI.
-	// Forward the action to the already-running sidecar and exit before any heavy
-	// init (so we never boot a second instance that would grab the mic / tray).
+	// The OS launched us with a jarvis:// URI — forward it to the already-running
+	// sidecar and exit before any heavy init (so we never boot a second instance
+	// that would grab the mic / tray). Enroll links (the connect page's self-host
+	// door) are checked FIRST: the Windows notification forwarder below matches
+	// any jarvis:// URI and would swallow them into the tray path, which doesn't
+	// even exist during first-run onboarding.
+	if maybeForwardEnrollLaunch() {
+		return
+	}
+	// A notification button was clicked (Windows protocol activation).
 	if maybeForwardProtocolLaunch() {
+		return
+	}
+	// Any OTHER jarvis:// URI: drop and exit. A URI launch must never boot a
+	// full sidecar — on Linux the scheme registration makes this reachable by
+	// any web page.
+	if maybeDropProtocolLaunch() {
 		return
 	}
 
@@ -53,6 +66,11 @@ Usage:
 	// Register the AUMID + jarvis:// URI scheme notifications need (Windows-only;
 	// no-op elsewhere). Idempotent, cheap, safe to run every launch.
 	setupNotifications()
+
+	// Claim the jarvis:// scheme for enroll deep links where the OS lets a bare
+	// binary do it (Linux desktop entry; Windows rides the registration above;
+	// macOS needs the .app bundle's Info.plist). Idempotent, best-effort.
+	registerURLSchemeHandler()
 
 	// When relaunched by an in-app restart (settings token change), wait briefly
 	// for the previous instance to exit and release the mic / hotkeys / tray icon

--- a/sidecar/packaging/macos/Info.plist
+++ b/sidecar/packaging/macos/Info.plist
@@ -32,5 +32,19 @@
 	<string>Jarvis listens for your voice commands and wake word.</string>
 	<key>NSAppleEventsUsageDescription</key>
 	<string>Jarvis controls the apps you ask it to act in.</string>
+	<!-- jarvis:// deep links (the connect page's self-host enroll handoff).
+	     macOS delivers URL opens to the running app as a kAEGetURL Apple Event,
+	     never argv — the receiving handler lives in deeplink_darwin.go. -->
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>Jarvis Protocol</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>jarvis</string>
+			</array>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/sidecar/scheme_darwin.go
+++ b/sidecar/scheme_darwin.go
@@ -1,0 +1,13 @@
+//go:build darwin
+
+package main
+
+// The jarvis:// scheme itself is claimed by the app bundle's Info.plist
+// (CFBundleURLTypes) — a bare binary cannot register one at runtime. What the
+// PROCESS must do every launch is install the Apple Event handler that
+// receives the opens (deeplink_darwin.go): macOS delivers URL opens to the
+// running app as kAEGetURL, never argv, so the Linux/Windows argv forwarding
+// path never fires here.
+func registerURLSchemeHandler() {
+	installURLOpenHandler()
+}

--- a/sidecar/scheme_linux.go
+++ b/sidecar/scheme_linux.go
@@ -1,0 +1,51 @@
+//go:build linux
+
+package main
+
+// jarvis:// URL-scheme registration, freedesktop flavor: a NoDisplay .desktop
+// entry claiming x-scheme-handler/jarvis, pointed at this binary. Idempotent
+// and best-effort (called every launch, like the Windows registry setup in
+// notify_windows.go — which is why Windows needs nothing here): a moved
+// binary heals its registration on the next run. Browsers route jarvis://
+// links here after xdg-mime records the default.
+
+import (
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+const schemeDesktopFile = "jarvis-sidecar-url.desktop"
+
+func registerURLSchemeHandler() {
+	exe, err := os.Executable()
+	if err != nil {
+		log.Printf("[deeplink] scheme registration skipped: %v", err)
+		return
+	}
+	dir := filepath.Join(homeDir(), ".local", "share", "applications")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		log.Printf("[deeplink] scheme registration skipped: %v", err)
+		return
+	}
+	entry := "[Desktop Entry]\n" +
+		"Type=Application\n" +
+		"Name=Jarvis Sidecar (link handler)\n" +
+		"Comment=Handles jarvis:// links from the usejarvis connect page\n" +
+		"Exec=\"" + exe + "\" %u\n" +
+		"NoDisplay=true\n" +
+		"StartupNotify=false\n" +
+		"MimeType=x-scheme-handler/jarvis;\n"
+	path := filepath.Join(dir, schemeDesktopFile)
+	if old, rerr := os.ReadFile(path); rerr != nil || string(old) != entry {
+		if werr := os.WriteFile(path, []byte(entry), 0o644); werr != nil {
+			log.Printf("[deeplink] scheme registration failed: %v", werr)
+			return
+		}
+	}
+	// Best-effort: some environments lack these tools; the MimeType= line in
+	// the entry still lets desktop databases pick the handler up on rebuild.
+	_ = exec.Command("xdg-mime", "default", schemeDesktopFile, "x-scheme-handler/jarvis").Run()
+	_ = exec.Command("update-desktop-database", dir).Run()
+}

--- a/sidecar/scheme_other.go
+++ b/sidecar/scheme_other.go
@@ -1,12 +1,10 @@
-//go:build !linux
+//go:build !linux && !darwin
 
 package main
 
-// jarvis:// URL-scheme registration, non-Linux:
-//   - Windows: already registered every startup by windowsSetupNotifications
-//     (notify_windows.go writes HKCU\Software\Classes\jarvis -> this exe for
-//     notification protocol activation; enroll links ride the same scheme).
-//   - macOS: a bare binary cannot claim a URL scheme at runtime — the scheme
-//     is declared by the .app bundle's Info.plist (CFBundleURLTypes, scheme
-//     "jarvis"), owned by packaging. Nothing to do here.
+// jarvis:// URL-scheme registration, Windows: already registered every startup
+// by windowsSetupNotifications (notify_windows.go writes
+// HKCU\Software\Classes\jarvis -> this exe for notification protocol
+// activation; enroll links ride the same scheme and arrive via argv, handled
+// by maybeForwardEnrollLaunch). Nothing extra to do.
 func registerURLSchemeHandler() {}

--- a/sidecar/scheme_other.go
+++ b/sidecar/scheme_other.go
@@ -1,0 +1,12 @@
+//go:build !linux
+
+package main
+
+// jarvis:// URL-scheme registration, non-Linux:
+//   - Windows: already registered every startup by windowsSetupNotifications
+//     (notify_windows.go writes HKCU\Software\Classes\jarvis -> this exe for
+//     notification protocol activation; enroll links ride the same scheme).
+//   - macOS: a bare binary cannot claim a URL scheme at runtime — the scheme
+//     is declared by the .app bundle's Info.plist (CFBundleURLTypes, scheme
+//     "jarvis"), owned by packaging. Nothing to do here.
+func registerURLSchemeHandler() {}


### PR DESCRIPTION
## What

The usejarvis connect page's free "Self-hosted" door now hands the pasted enrollment token straight to the local sidecar — it never transits the hosting server (contract pinned in the hosting repo's ONBOARDING.md). This PR implements the receiving end:

- **`deeplink.go`** — `jarvis://enroll?v=1&nonce=<nonce>&token=<jwt>` parsing (strict host match so the notification `jarvis://n` namespace can't be confused, `v` forward-compat gate), the OS-launched forwarder (writes the URI to a 0600 unix socket at `~/.jarvis/enroll.sock` and exits — never boots a second instance), and the session-scoped listener whose `Close()` joins in-flight callbacks so window teardown stays ordered.
- **`hosted_window.go`** — the listener lives inside the first-run window: a link is accepted only when its nonce matches the live handshake (any page can fire deep links; only the real connect page knows the 256-bit nonce), verifications are serialized, and the token goes through the existing `verifyBrainToken` before persisting. On success the token is stored and the window closes into the normal persist-and-restart path.
- **`hosted.go`** — `reportSelfHostResult`: only the verdict `{nonce, ok, error?}` goes to `POST /api/handshake/self-host-result` so the page can show "connected" or the exact rejection reason. Error capped at 300 UTF-16 code units (matching the server's zod cap), bounded retries, no retry on 4xx, and no report on cancelled contexts — teardown is not a verdict. The long-poll treats a token-less completion as "resolved locally" instead of painting an error over the deep-link success.
- **`main.go`** — enroll URIs are checked before the Windows notification forwarder (which matches any `jarvis://` argv), and **any unclaimed `jarvis://` launch is dropped and exits**: registering the scheme on Linux made URI launches reachable by any web page, and one must never boot a duplicate sidecar contending for the mic/hotkeys/tray.
- **`scheme_linux.go` / `scheme_other.go`** — Linux registers a `NoDisplay` desktop entry claiming `x-scheme-handler/jarvis` + `xdg-mime default` (self-healing if the binary moves); Windows already registers the scheme in `notify_windows.go`; macOS needs `CFBundleURLTypes` in the app bundle (packaging follow-up, noted in-code).

## Security notes

- Nonce gate: mismatched or absent-handshake links are dropped; a hostile page cannot know the nonce.
- Verify-before-persist: the same `verifyBrainToken` probe as the local paste form and `--token` (#295), so a wrong/unreachable-brain token is rejected with a user-ready reason instead of saved blind.
- Accepted risk (documented in-code and in the hosting repo docs): scheme-handler delivery puts the token-bearing URI in the forwarder's argv, world-readable via `/proc/<pid>/cmdline` for that process's brief lifetime — same single-user-desktop exposure as `jarvis enroll` printing the token to a terminal. D-Bus activation would close it if ever needed.

## Testing

- `go build ./... && go vet . && go test .` green (new tests: URI parsing incl. namespace/version rejection, socket round-trip with the Close-joins-handlers guarantee, verdict payload/UTF-16 cap/teardown semantics, and the unclaimed-URI drop).
- Verified end-to-end against the local hosting stack: browser row → OS handler → socket forward → verify → verdict → page flips to connected / shows the rejection reason.

## macOS

Included (second commit): `CFBundleURLTypes` in the bundle plist claims the scheme, and a `kAEGetURL` Apple Event handler receives opens — macOS delivers URL opens to the running app as an Apple Event, never argv, so the Linux/Windows forwarding path can't fire there. Enroll links are re-routed through the same `enroll.sock` as the other platforms, keeping nonce-gating and serialization in one code path. A `sidecar-build-darwin` CI job (third commit) now compiles + vets the darwin cgo on `macos-latest` for every push/PR — green on this branch, so the ObjC is compile-verified. **Remaining caveat: runtime behavior (browser prompt → Apple Event → socket → verify) still needs a click-through on a real Mac before merge.**

## Follow-ups

- Windows AF_UNIX smoke test on a real box (Go's unix-socket support there is symmetric but less battle-tested).

