### PR TITLE
app-control: real Windows/macOS controllers — sidecar-first with injection-safe native fallbacks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,6 +97,29 @@ jobs:
           go vet ./...
           go build ./...
 
+  # The desktop-automation fallback scripts can't be exercised from the linux
+  # job: bun test's pwsh check covers desktop.ps1, but AppleScript terminology
+  # bugs (dictionary terms shadowing variables) only surface on a real macOS
+  # interpreter at runtime — osacompile alone won't catch them, hence the
+  # event-free `probe` command.
+  applescript-check:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Compile + probe desktop.applescript
+        run: |
+          set -euo pipefail
+          SCRIPT=src/actions/app-control/scripts/desktop.applescript
+          osacompile -o /tmp/desktop-syntax-check.scpt "$SCRIPT"
+          OUT=$(osascript "$SCRIPT" probe)
+          echo "probe: $OUT"
+          test "$OUT" = "mods=2;code=36"
+          # Unknown commands must fail loudly (stderr + non-zero exit)
+          if osascript "$SCRIPT" no-such-command 2>/dev/null; then
+            echo "expected non-zero exit for unknown command" >&2
+            exit 1
+          fi
+
   # NOTE: the sidecar VERSION-bump PR gate is intentionally OFF during the
   # current development phase — the sidecar is frozen at sidecar/VERSION = 0.1.0
   # and ships as a single version, so per-change bumps aren't wanted. Reinstate a

--- a/src/actions/README.md
+++ b/src/actions/README.md
@@ -9,8 +9,9 @@ src/actions/
 ├── app-control/      # Cross-platform application control
 │   ├── interface.ts  # Common interface & platform factory
 │   ├── linux.ts      # Linux/X11 implementation
-│   ├── windows.ts    # Windows stub (UI Automation)
-│   └── macos.ts      # macOS stub (AXUIElement)
+│   ├── windows.ts    # Windows: sidecar-first + PowerShell fallback
+│   ├── macos.ts      # macOS: sidecar-first + AppleScript fallback
+│   └── scripts/      # Fixed script assets (desktop.ps1, desktop.applescript)
 ├── browser/          # Chrome DevTools Protocol
 │   ├── cdp.ts        # CDP client implementation
 │   └── session.ts    # Browser session management
@@ -60,9 +61,10 @@ Uses X11 tools (xdotool, xprop, wmctrl, ImageMagick):
 - Geometry and property inspection
 
 **Status:**
-- ✅ Linux: Fully implemented
-- ⏳ Windows: Stub (needs UI Automation API)
-- ⏳ macOS: Stub (needs AXUIElement API)
+- ✅ Linux: Fully implemented (X11 tools)
+- ✅ Windows: Sidecar-first (desktop-bridge, full UI Automation); PowerShell/Win32 fallback for windows, input, screenshots
+- ✅ macOS: Sidecar-first; AppleScript/screencapture fallback for windows, input, screenshots
+- ⏳ UI element trees (getWindowTree) require the sidecar on Windows/macOS
 
 ### Browser Control
 

--- a/src/actions/app-control/interface.test.ts
+++ b/src/actions/app-control/interface.test.ts
@@ -1,0 +1,10 @@
+import { test, expect, describe } from 'bun:test';
+import { getAppController } from './interface.ts';
+
+describe('getAppController', () => {
+  test('returns the same instance across calls', () => {
+    // Regression (review): a fresh controller per tool call reset the sidecar
+    // probe backoff and leaked one sidecar TCP connection per invocation.
+    expect(getAppController()).toBe(getAppController());
+  });
+});

--- a/src/actions/app-control/interface.ts
+++ b/src/actions/app-control/interface.ts
@@ -36,7 +36,18 @@ export interface AppController {
   dragElement?(from: UIElement, to: UIElement): Promise<void>;
 }
 
+// Cached per process: the Windows/macOS controllers keep sidecar probe
+// backoff state and a live sidecar TCP connection on the instance, so a
+// fresh controller per tool call would re-probe every time and leak sockets.
+let cachedController: AppController | null = null;
+
 export function getAppController(): AppController {
+  if (cachedController) return cachedController;
+  cachedController = createAppController();
+  return cachedController;
+}
+
+function createAppController(): AppController {
   const platform = process.platform;
 
   switch (platform) {

--- a/src/actions/app-control/macos.test.ts
+++ b/src/actions/app-control/macos.test.ts
@@ -1,0 +1,185 @@
+import { test, expect, describe } from 'bun:test';
+import { spawnSync } from 'node:child_process';
+import { existsSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { MacAppController, mapMacKeys } from './macos.ts';
+import type { NativeExec, NativeExecResult } from './native-exec.ts';
+
+const SCRIPT_PATH = join(import.meta.dir, 'scripts', 'desktop.applescript');
+
+type Call = { cmd: string[]; input: string };
+
+function fakeExec(handler: (cmd: string[], input: string) => Partial<NativeExecResult>) {
+  const calls: Call[] = [];
+  const exec: NativeExec = (cmd, input) => {
+    calls.push({ cmd, input });
+    const result = handler(cmd, input);
+    return { status: 0, stdout: '', stderr: '', ...result };
+  };
+  return { exec, calls };
+}
+
+function controller(handler: (cmd: string[], input: string) => Partial<NativeExecResult>) {
+  const { exec, calls } = fakeExec(handler);
+  return { ctrl: new MacAppController({ exec, useSidecar: false }), calls };
+}
+
+// pid, focused, x, y, width, height, className, title
+const windowLine = (pid: number, focused: boolean, title: string) =>
+  `${pid}\t${focused ? '1' : '0'}\t10\t20\t300\t200\tSafari\t${title}`;
+
+describe('mapMacKeys', () => {
+  test('maps named keys to virtual key codes, not keystroke text', () => {
+    // Regression: PR #279 generated `keystroke "return"`, which types the word.
+    expect(mapMacKeys(['Enter'])).toEqual({ modifiers: [], kind: 'code', value: '36' });
+    expect(mapMacKeys(['Tab'])).toEqual({ modifiers: [], kind: 'code', value: '48' });
+    expect(mapMacKeys(['Escape'])).toEqual({ modifiers: [], kind: 'code', value: '53' });
+  });
+
+  test('collects modifiers into a chord', () => {
+    expect(mapMacKeys(['Command', 'A'])).toEqual({ modifiers: ['command'], kind: 'char', value: 'a' });
+    expect(mapMacKeys(['Ctrl', 'Shift', 'Tab'])).toEqual({ modifiers: ['control', 'shift'], kind: 'code', value: '48' });
+    expect(mapMacKeys(['Alt', 'Left'])).toEqual({ modifiers: ['option'], kind: 'code', value: '123' });
+  });
+
+  test('rejects chords without a main key or with several main keys', () => {
+    expect(() => mapMacKeys(['Command'])).toThrow(/no non-modifier key/);
+    expect(() => mapMacKeys(['A', 'B'])).toThrow(/more than one non-modifier key/);
+    expect(() => mapMacKeys(['Widget'])).toThrow(/Unsupported key/);
+  });
+});
+
+describe('MacAppController fallback', () => {
+  test('runs the fixed script asset with the command as an argument', async () => {
+    const { ctrl, calls } = controller(() => ({ stdout: windowLine(42, true, 'Docs') }));
+    await ctrl.getActiveWindow();
+    expect(calls[0]!.cmd.slice(0, 3)).toEqual(['osascript', SCRIPT_PATH, 'get-active-window']);
+  });
+
+  test('getActiveWindow parses the tab-separated line', async () => {
+    const { ctrl } = controller(() => ({ stdout: windowLine(42, true, 'Docs — Draft') }));
+    expect(await ctrl.getActiveWindow()).toEqual({
+      pid: 42,
+      title: 'Docs — Draft',
+      className: 'Safari',
+      bounds: { x: 10, y: 20, width: 300, height: 200 },
+      focused: true,
+    });
+  });
+
+  test('listWindows parses multiple lines and skips malformed ones', async () => {
+    const out = [windowLine(1, true, 'A'), 'garbage', windowLine(2, false, 'B')].join('\n');
+    const { ctrl } = controller(() => ({ stdout: out }));
+    const windows = await ctrl.listWindows();
+    expect(windows.map((w) => w.pid)).toEqual([1, 2]);
+    expect(windows[1]!.focused).toBe(false);
+  });
+
+  test('typeText passes user text as a standalone argv item, unmodified', async () => {
+    // Regression: PR #279 spliced text into AppleScript source.
+    const hostile = `he said "hi" & 'bye' \\ $(reboot) \n newline`;
+    const { ctrl, calls } = controller(() => ({}));
+    await ctrl.typeText(hostile);
+    expect(calls[0]!.cmd).toEqual(['osascript', SCRIPT_PATH, 'type-text', hostile]);
+  });
+
+  test('pressKeys sends mapped chord arguments, never raw AppleScript', async () => {
+    const { ctrl, calls } = controller(() => ({}));
+    await ctrl.pressKeys(['Command', 'Shift', 'Enter']);
+    expect(calls[0]!.cmd).toEqual(['osascript', SCRIPT_PATH, 'press-keys', 'command,shift', 'code', '36']);
+    await ctrl.pressKeys(['Enter']);
+    expect(calls[1]!.cmd).toEqual(['osascript', SCRIPT_PATH, 'press-keys', '-', 'code', '36']);
+  });
+
+  test('clickElement clicks at the element center', async () => {
+    const { ctrl, calls } = controller(() => ({}));
+    await ctrl.clickElement({
+      id: '1', role: 'button', name: 'OK', value: null,
+      bounds: { x: 100, y: 100, width: 51, height: 21 }, children: [], properties: {},
+    });
+    expect(calls[0]!.cmd).toEqual(['osascript', SCRIPT_PATH, 'click-at', '126', '111']);
+  });
+
+  test('captureWindow captures the region of the window matching the pid', async () => {
+    const png = Buffer.from('fake-png');
+    const { ctrl, calls } = controller((cmd) => {
+      if (cmd[0] === 'osascript') return { stdout: windowLine(42, true, 'Docs') };
+      // screencapture: write the "image" to the target file (last arg)
+      writeFileSync(cmd[cmd.length - 1]!, png);
+      return {};
+    });
+    const buffer = await ctrl.captureWindow(42);
+    const capture = calls.find((c) => c.cmd[0] === 'screencapture')!;
+    expect(capture.cmd).toContain('-R');
+    expect(capture.cmd).toContain('10,20,300,200');
+    expect(buffer.equals(png)).toBe(true);
+    // Temp file is cleaned up
+    expect(existsSync(capture.cmd[capture.cmd.length - 1]!)).toBe(false);
+  });
+
+  test('throws with stderr detail when osascript exits non-zero', async () => {
+    // Regression: PR #279 swallowed stderr and returned '' on failure.
+    const { ctrl } = controller(() => ({
+      status: 1,
+      stderr: 'execution error: Can’t get application process whose unix id = 7. (-1728)',
+    }));
+    expect(ctrl.focusWindow(7)).rejects.toThrow(/unix id = 7/);
+  });
+
+  test('launchApp uses open with an argv array, never a shell string', async () => {
+    // Regression: PR #279 built `sh -c` with unescaped executable/args.
+    const { ctrl, calls } = controller(() => ({}));
+    await ctrl.launchApp(`App'; reboot; '`, '--flag "a b"');
+    const cmd = calls[0]!.cmd;
+    expect(cmd[0]).toBe('open');
+    expect(cmd).toEqual(['open', '-a', `App'; reboot; '`, '--args', '--flag', 'a b']);
+  });
+
+  test('closeWindow and getWindowTree without sidecar throw instead of pretending', async () => {
+    const { ctrl } = controller(() => ({}));
+    expect(ctrl.closeWindow(1)).rejects.toThrow(/sidecar/);
+    expect(ctrl.getWindowTree(1)).rejects.toThrow(/sidecar/);
+  });
+});
+
+describe('desktop.applescript script asset', () => {
+  const script = readFileSync(SCRIPT_PATH, 'utf-8');
+
+  test('dispatches through on run argv (no source assembly)', () => {
+    expect(script).toContain('on run argv');
+  });
+
+  test('does not depend on binaries that do not ship with macOS', () => {
+    // Regression: PR #279 relied on cliclick / mouseclick.
+    expect(script).not.toContain('cliclick');
+    expect(script).not.toContain('mouseclick');
+  });
+
+  test('never types key names as literal text', () => {
+    // Regression: PR #279 generated `keystroke "return"`.
+    expect(script).not.toMatch(/keystroke "(return|tab|escape|delete|space)"/);
+    expect(script).toContain('key code (keyValue as integer)');
+  });
+
+  test('coerces numeric window fields to text before concatenation', () => {
+    // Regression: PR #279 concatenated integers with &, producing AppleScript
+    // list concatenation and corrupted window metadata.
+    expect(script).toContain('(procPid as text) & tab');
+    expect(script).toContain('(xPos as text)');
+  });
+
+  const hasOsacompile = spawnSync('which', ['osacompile'], { encoding: 'utf-8', timeout: 10_000 }).status === 0;
+
+  // Only runs on macOS dev machines; proves the script compiles.
+  test.skipIf(!hasOsacompile)('compiles under osacompile', () => {
+    const out = join(tmpdir(), `jarvis-desktop-syntax-${process.pid}.scpt`);
+    try {
+      const result = spawnSync('osacompile', ['-o', out, SCRIPT_PATH], { encoding: 'utf-8', timeout: 60_000 });
+      expect(result.stderr).toBe('');
+      expect(result.status).toBe(0);
+    } finally {
+      try { unlinkSync(out); } catch {}
+    }
+  }, 60_000);
+});

--- a/src/actions/app-control/macos.test.ts
+++ b/src/actions/app-control/macos.test.ts
@@ -136,6 +136,15 @@ describe('MacAppController fallback', () => {
     expect(cmd).toEqual(['open', '-a', `App'; reboot; '`, '--args', '--flag', 'a b']);
   });
 
+  test('launchApp path-fallback keeps the arguments', async () => {
+    // Regression (review): the retry after a failed `open -a` dropped --args.
+    const { ctrl, calls } = controller((cmd) =>
+      cmd[1] === '-a' ? { status: 1, stderr: 'Unable to find application' } : {},
+    );
+    await ctrl.launchApp('/opt/tool.app', '--flag');
+    expect(calls[1]!.cmd).toEqual(['open', '/opt/tool.app', '--args', '--flag']);
+  });
+
   test('closeWindow and getWindowTree without sidecar throw instead of pretending', async () => {
     const { ctrl } = controller(() => ({}));
     expect(ctrl.closeWindow(1)).rejects.toThrow(/sidecar/);
@@ -162,6 +171,23 @@ describe('desktop.applescript script asset', () => {
     expect(script).toContain('key code (keyValue as integer)');
   });
 
+  test('avoids System Events dictionary terms as identifiers in tell blocks', () => {
+    // Regression (review): a pressKeys parameter named `kind` collided with
+    // System Events terminology, breaking every press-keys invocation.
+    expect(script).toContain('on pressKeys(modsCsv, keyKind, keyValue)');
+    expect(script).toContain('set useCode to (keyKind is "code")');
+    // The CI probe command exercises the terminology-sensitive constructs.
+    expect(script).toContain('on probeTerminology()');
+  });
+
+  test('sanitizes tabs/newlines in titles and process names', () => {
+    // Regression (review): un-sanitized fields break the tab-separated,
+    // line-per-window format (the ps1 side already squashed them).
+    expect(script).toContain('on sanitizeField(theValue)');
+    expect(script).toContain('my sanitizeField(winTitle)');
+    expect(script).toContain('my sanitizeField(procName)');
+  });
+
   test('coerces numeric window fields to text before concatenation', () => {
     // Regression: PR #279 concatenated integers with &, producing AppleScript
     // list concatenation and corrupted window metadata.
@@ -171,7 +197,8 @@ describe('desktop.applescript script asset', () => {
 
   const hasOsacompile = spawnSync('which', ['osacompile'], { encoding: 'utf-8', timeout: 10_000 }).status === 0;
 
-  // Only runs on macOS dev machines; proves the script compiles.
+  // Only runs on macOS dev machines; proves the script compiles. CI runs the
+  // same checks in the applescript-check job of test.yml.
   test.skipIf(!hasOsacompile)('compiles under osacompile', () => {
     const out = join(tmpdir(), `jarvis-desktop-syntax-${process.pid}.scpt`);
     try {
@@ -181,5 +208,14 @@ describe('desktop.applescript script asset', () => {
     } finally {
       try { unlinkSync(out); } catch {}
     }
+  }, 60_000);
+
+  // Executes the event-free probe command on the real interpreter, catching
+  // runtime terminology collisions that osacompile accepts.
+  test.skipIf(!hasOsacompile)('terminology probe runs on the real interpreter', () => {
+    const result = spawnSync('osascript', [SCRIPT_PATH, 'probe'], { encoding: 'utf-8', timeout: 60_000 });
+    expect(result.stderr).toBe('');
+    expect(result.stdout.trim()).toBe('mods=2;code=36');
+    expect(result.status).toBe(0);
   }, 60_000);
 });

--- a/src/actions/app-control/macos.ts
+++ b/src/actions/app-control/macos.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import type { AppController, WindowInfo, UIElement } from './interface.ts';
 import type { DesktopController } from './desktop-controller.ts';
 import { defaultExec, runNative, type NativeExec } from './native-exec.ts';
+import { SidecarProbe } from './sidecar-probe.ts';
 
 /**
  * macOS App Controller.
@@ -23,9 +24,6 @@ import { defaultExec, runNative, type NativeExec } from './native-exec.ts';
  */
 
 const SCRIPT_PATH = join(import.meta.dir, 'scripts', 'desktop.applescript');
-
-// How long to wait before re-probing for a sidecar after a failed attempt.
-const SIDECAR_RETRY_MS = 30_000;
 
 const MAC_MODIFIERS: Record<string, string> = {
   command: 'command',
@@ -131,29 +129,15 @@ function parseWindowLine(line: string): WindowInfo | null {
 
 export class MacAppController implements AppController {
   private exec: NativeExec;
-  private useSidecar: boolean;
-  private sidecar: DesktopController | null = null;
-  private sidecarRetryAt = 0;
+  private sidecarProbe: SidecarProbe;
 
   constructor(opts: { exec?: NativeExec; useSidecar?: boolean } = {}) {
     this.exec = opts.exec ?? defaultExec;
-    this.useSidecar = opts.useSidecar ?? true;
+    this.sidecarProbe = new SidecarProbe(opts.useSidecar ?? true);
   }
 
-  private async getSidecar(): Promise<DesktopController | null> {
-    if (!this.useSidecar) return null;
-    if (this.sidecar?.connected) return this.sidecar;
-    if (Date.now() < this.sidecarRetryAt) return null;
-    try {
-      const { DesktopController } = await import('./desktop-controller.ts');
-      const sidecar = this.sidecar ?? new DesktopController();
-      await sidecar.connect();
-      this.sidecar = sidecar;
-      return sidecar;
-    } catch {
-      this.sidecarRetryAt = Date.now() + SIDECAR_RETRY_MS;
-      return null;
-    }
+  private getSidecar(): Promise<DesktopController | null> {
+    return this.sidecarProbe.get();
   }
 
   /**
@@ -260,15 +244,15 @@ export class MacAppController implements AppController {
     if (sc) return sc.launchApp(executable, args);
 
     // `open -a` resolves app names and .app bundles; fall back to opening the
-    // argument as a path. Arguments are passed as an argv array — no shell.
+    // argument as a path. Arguments are passed as an argv array — no shell —
+    // and survive the fallback attempt.
     const extraArgs = parseCommandArgs(args);
+    const argsTail = extraArgs.length > 0 ? ['--args', ...extraArgs] : [];
     try {
-      const openArgs = ['-a', executable];
-      if (extraArgs.length > 0) openArgs.push('--args', ...extraArgs);
-      runNative(this.exec, ['open', ...openArgs], '', `open -a ${executable}`);
+      runNative(this.exec, ['open', '-a', executable, ...argsTail], '', `open -a ${executable}`);
     } catch (appError) {
       try {
-        runNative(this.exec, ['open', executable], '', `open ${executable}`);
+        runNative(this.exec, ['open', executable, ...argsTail], '', `open ${executable}`);
       } catch {
         throw appError;
       }
@@ -286,6 +270,8 @@ export class MacAppController implements AppController {
   }
 }
 
+// Naive splitter (same as linux.ts): whole-token quotes only. Tokens like
+// --flag="a b" are not un-quoted mid-token; acceptable for launch arguments.
 function parseCommandArgs(args?: string): string[] {
   if (!args?.trim()) return [];
   const parts = args.match(/"[^"]*"|'[^']*'|\S+/g) ?? [];

--- a/src/actions/app-control/macos.ts
+++ b/src/actions/app-control/macos.ts
@@ -1,54 +1,293 @@
+import { readFileSync, unlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import type { AppController, WindowInfo, UIElement } from './interface.ts';
+import type { DesktopController } from './desktop-controller.ts';
+import { defaultExec, runNative, type NativeExec } from './native-exec.ts';
+
+/**
+ * macOS App Controller.
+ *
+ * Two-layer implementation:
+ *   1. Desktop sidecar via TCP JSON-RPC — full Accessibility (AXUIElement)
+ *      support when a sidecar speaking the desktop-bridge protocol is running.
+ *   2. AppleScript / screencapture fallback — window listing, focus,
+ *      screenshots, and input simulation through a fixed helper script
+ *      (scripts/desktop.applescript).
+ *
+ * The fallback never assembles AppleScript source from user input: the helper
+ * script ships as an asset with an `on run argv` dispatcher, and all dynamic
+ * values travel as osascript arguments, so arbitrary text cannot escape into
+ * script code. The fallback paths require the Accessibility and Screen
+ * Recording permissions for the process running the daemon.
+ */
+
+const SCRIPT_PATH = join(import.meta.dir, 'scripts', 'desktop.applescript');
+
+// How long to wait before re-probing for a sidecar after a failed attempt.
+const SIDECAR_RETRY_MS = 30_000;
+
+const MAC_MODIFIERS: Record<string, string> = {
+  command: 'command',
+  cmd: 'command',
+  meta: 'command',
+  super: 'command',
+  win: 'command',
+  option: 'option',
+  alt: 'option',
+  control: 'control',
+  ctrl: 'control',
+  shift: 'shift',
+};
+
+/** macOS virtual key codes for keys `keystroke` cannot express. */
+const MAC_KEY_CODES: Record<string, number> = {
+  enter: 36,
+  return: 36,
+  tab: 48,
+  space: 49,
+  backspace: 51,
+  delete: 51,
+  forwarddelete: 117,
+  escape: 53,
+  esc: 53,
+  home: 115,
+  end: 119,
+  pageup: 116,
+  pagedown: 121,
+  left: 123,
+  right: 124,
+  down: 125,
+  up: 126,
+  f1: 122,
+  f2: 120,
+  f3: 99,
+  f4: 118,
+  f5: 96,
+  f6: 97,
+  f7: 98,
+  f8: 100,
+  f9: 101,
+  f10: 109,
+  f11: 103,
+  f12: 111,
+};
+
+export type MacKeyChord = {
+  /** Subset of command/option/control/shift, deduplicated, in input order. */
+  modifiers: string[];
+  /** "code" = numeric virtual key code, "char" = literal keystroke character. */
+  kind: 'code' | 'char';
+  value: string;
+};
+
+/**
+ * Map a key chord like ["Command", "Shift", "S"] to the arguments the
+ * AppleScript helper's press-keys command expects.
+ */
+export function mapMacKeys(keys: string[]): MacKeyChord {
+  const modifiers: string[] = [];
+  let key: string | null = null;
+
+  for (const raw of keys) {
+    const lower = raw.toLowerCase();
+    const modifier = MAC_MODIFIERS[lower];
+    if (modifier) {
+      if (!modifiers.includes(modifier)) modifiers.push(modifier);
+      continue;
+    }
+    if (key !== null) {
+      throw new Error(`Key combination [${keys.join('+')}] has more than one non-modifier key`);
+    }
+    key = raw;
+  }
+
+  if (key === null) {
+    throw new Error(`Key combination [${keys.join('+')}] has no non-modifier key to press`);
+  }
+  const code = MAC_KEY_CODES[key.toLowerCase()];
+  if (code !== undefined) return { modifiers, kind: 'code', value: String(code) };
+  if ([...key].length === 1) return { modifiers, kind: 'char', value: key.toLowerCase() };
+  throw new Error(`Unsupported key "${key}" for the AppleScript fallback`);
+}
+
+// Tab-separated fields emitted by the helper script (title last).
+function parseWindowLine(line: string): WindowInfo | null {
+  const parts = line.split('\t');
+  if (parts.length < 8) return null;
+  return {
+    pid: parseInt(parts[0]!, 10) || 0,
+    title: parts.slice(7).join('\t') || 'Unknown',
+    className: parts[6] || 'Unknown',
+    bounds: {
+      x: parseInt(parts[2]!, 10) || 0,
+      y: parseInt(parts[3]!, 10) || 0,
+      width: parseInt(parts[4]!, 10) || 0,
+      height: parseInt(parts[5]!, 10) || 0,
+    },
+    focused: parts[1] === '1',
+  };
+}
 
 export class MacAppController implements AppController {
-  private notImplemented(method: string): never {
-    throw new Error(
-      `${method} not yet implemented for macOS.\n\n` +
-      `TODO: Implement using one of:\n` +
-      `  - AXUIElement API via N-API native bindings\n` +
-      `  - AppleScript automation\n` +
-      `  - node-mac-automation package\n` +
-      `  - Swift/Objective-C bridge via FFI\n\n` +
-      `Reference:\n` +
-      `  - https://developer.apple.com/documentation/applicationservices/axuielement\n` +
-      `  - https://developer.apple.com/library/archive/documentation/Accessibility/Conceptual/AccessibilityMacOSX/\n` +
-      `  - https://github.com/sveinbjornt/AXElementsTester`
+  private exec: NativeExec;
+  private useSidecar: boolean;
+  private sidecar: DesktopController | null = null;
+  private sidecarRetryAt = 0;
+
+  constructor(opts: { exec?: NativeExec; useSidecar?: boolean } = {}) {
+    this.exec = opts.exec ?? defaultExec;
+    this.useSidecar = opts.useSidecar ?? true;
+  }
+
+  private async getSidecar(): Promise<DesktopController | null> {
+    if (!this.useSidecar) return null;
+    if (this.sidecar?.connected) return this.sidecar;
+    if (Date.now() < this.sidecarRetryAt) return null;
+    try {
+      const { DesktopController } = await import('./desktop-controller.ts');
+      const sidecar = this.sidecar ?? new DesktopController();
+      await sidecar.connect();
+      this.sidecar = sidecar;
+      return sidecar;
+    } catch {
+      this.sidecarRetryAt = Date.now() + SIDECAR_RETRY_MS;
+      return null;
+    }
+  }
+
+  /**
+   * Run a command of the fixed helper script. Dynamic values travel as
+   * osascript arguments — never interpolated into script text.
+   */
+  private runScript(command: string, args: string[] = []): string {
+    const stdout = runNative(
+      this.exec,
+      ['osascript', SCRIPT_PATH, command, ...args],
+      '',
+      `desktop.applescript ${command}`,
     );
+    return stdout.replace(/\n$/, '');
   }
 
   async getActiveWindow(): Promise<WindowInfo> {
-    this.notImplemented('getActiveWindow');
+    const sc = await this.getSidecar();
+    if (sc) return sc.getActiveWindow();
+    const line = this.runScript('get-active-window');
+    const info = parseWindowLine(line);
+    if (!info) throw new Error(`Could not parse active window info: ${line.slice(0, 200)}`);
+    return info;
   }
 
   async getWindowTree(pid: number): Promise<UIElement[]> {
-    this.notImplemented('getWindowTree');
+    const sc = await this.getSidecar();
+    if (sc) return sc.getWindowTree(pid);
+    throw new Error(
+      'UI element traversal on macOS requires the desktop-bridge sidecar. ' +
+      'Build the sidecar and ensure it is running.',
+    );
   }
 
   async listWindows(): Promise<WindowInfo[]> {
-    this.notImplemented('listWindows');
+    const sc = await this.getSidecar();
+    if (sc) return sc.listWindows();
+    const out = this.runScript('list-windows');
+    const windows: WindowInfo[] = [];
+    for (const line of out.split('\n')) {
+      if (!line.trim()) continue;
+      const info = parseWindowLine(line);
+      if (info) windows.push(info);
+    }
+    return windows;
   }
 
   async clickElement(element: UIElement): Promise<void> {
-    this.notImplemented('clickElement');
+    const sc = await this.getSidecar();
+    if (sc) return sc.clickElement(element);
+    const x = Math.round(element.bounds.x + element.bounds.width / 2);
+    const y = Math.round(element.bounds.y + element.bounds.height / 2);
+    this.runScript('click-at', [String(x), String(y)]);
   }
 
   async typeText(text: string): Promise<void> {
-    this.notImplemented('typeText');
+    const sc = await this.getSidecar();
+    if (sc) return sc.typeText(text);
+    this.runScript('type-text', [text]);
   }
 
   async pressKeys(keys: string[]): Promise<void> {
-    this.notImplemented('pressKeys');
+    const sc = await this.getSidecar();
+    if (sc) return sc.pressKeys(keys);
+    const chord = mapMacKeys(keys);
+    this.runScript('press-keys', [chord.modifiers.join(',') || '-', chord.kind, chord.value]);
   }
 
   async captureScreen(): Promise<Buffer> {
-    this.notImplemented('captureScreen');
+    const sc = await this.getSidecar();
+    if (sc) return sc.captureScreen();
+    return this.captureToBuffer(['-x', '-t', 'png']);
   }
 
   async captureWindow(pid: number): Promise<Buffer> {
-    this.notImplemented('captureWindow');
+    const sc = await this.getSidecar();
+    if (sc) return sc.captureWindow(pid);
+    const windows = await this.listWindows();
+    const win = windows.find((w) => w.pid === pid);
+    if (!win) throw new Error(`No window found for PID ${pid}`);
+    const { x, y, width, height } = win.bounds;
+    return this.captureToBuffer(['-x', '-R', `${x},${y},${width},${height}`, '-t', 'png']);
+  }
+
+  private captureToBuffer(captureArgs: string[]): Buffer {
+    const tmpFile = join(tmpdir(), `jarvis-capture-${process.pid}-${Date.now()}.png`);
+    try {
+      runNative(this.exec, ['screencapture', ...captureArgs, tmpFile], '', 'screencapture');
+      return Buffer.from(readFileSync(tmpFile));
+    } finally {
+      try { unlinkSync(tmpFile); } catch {}
+    }
   }
 
   async focusWindow(pid: number): Promise<void> {
-    this.notImplemented('focusWindow');
+    const sc = await this.getSidecar();
+    if (sc) return sc.focusWindow(pid);
+    this.runScript('focus-window', [String(pid)]);
   }
+
+  async launchApp(executable: string, args?: string): Promise<object> {
+    if (!executable.trim()) throw new Error('Executable is required');
+    const sc = await this.getSidecar();
+    if (sc) return sc.launchApp(executable, args);
+
+    // `open -a` resolves app names and .app bundles; fall back to opening the
+    // argument as a path. Arguments are passed as an argv array — no shell.
+    const extraArgs = parseCommandArgs(args);
+    try {
+      const openArgs = ['-a', executable];
+      if (extraArgs.length > 0) openArgs.push('--args', ...extraArgs);
+      runNative(this.exec, ['open', ...openArgs], '', `open -a ${executable}`);
+    } catch (appError) {
+      try {
+        runNative(this.exec, ['open', executable], '', `open ${executable}`);
+      } catch {
+        throw appError;
+      }
+    }
+    return { executable, args: args ?? '' };
+  }
+
+  async closeWindow(pid: number): Promise<void> {
+    const sc = await this.getSidecar();
+    if (sc) return sc.closeWindow(pid);
+    throw new Error(
+      'closeWindow on macOS requires the desktop-bridge sidecar. ' +
+      'Use focusWindow + pressKeys(["Command", "W"]) as a fallback.',
+    );
+  }
+}
+
+function parseCommandArgs(args?: string): string[] {
+  if (!args?.trim()) return [];
+  const parts = args.match(/"[^"]*"|'[^']*'|\S+/g) ?? [];
+  return parts.map((part) => part.replace(/^['"]|['"]$/g, ''));
 }

--- a/src/actions/app-control/native-exec.ts
+++ b/src/actions/app-control/native-exec.ts
@@ -1,0 +1,54 @@
+import { spawnSync } from 'node:child_process';
+
+/**
+ * Minimal synchronous exec used by the Windows/macOS fallback controllers.
+ * Injectable so tests can capture the exact command lines and payloads
+ * without spawning real processes.
+ */
+export type NativeExecResult = {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+  error?: Error;
+};
+
+export type NativeExec = (cmd: string[], input: string) => NativeExecResult;
+
+export const defaultExec: NativeExec = (cmd, input) => {
+  const [file, ...args] = cmd;
+  const result = spawnSync(file!, args, {
+    encoding: 'utf-8',
+    // Always pipe stdin (empty string closes it) so scripts reading
+    // [Console]::In never hang waiting for input.
+    input,
+    timeout: 30_000,
+    // Base64 screenshots can be several MB.
+    maxBuffer: 64 * 1024 * 1024,
+    windowsHide: true,
+  });
+  return {
+    status: result.status,
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+    error: result.error,
+  };
+};
+
+/**
+ * Run a command and return stdout, throwing on spawn failure or non-zero
+ * exit. Fallback scripts report errors on stderr with a non-zero exit code —
+ * they must surface as thrown errors, never as silent no-ops, because the
+ * agent plans its next step based on action outcomes.
+ */
+export function runNative(exec: NativeExec, cmd: string[], input: string, what: string): string {
+  const result = exec(cmd, input);
+  if (result.error) {
+    throw new Error(`${what} failed to start: ${result.error.message}`);
+  }
+  if (result.status !== 0) {
+    const stderr = result.stderr.trim();
+    const exitInfo = result.status === null ? 'was killed (timeout?)' : `exited with code ${result.status}`;
+    throw new Error(`${what} ${exitInfo}${stderr ? `: ${stderr}` : ''}`);
+  }
+  return result.stdout;
+}

--- a/src/actions/app-control/scripts/desktop.applescript
+++ b/src/actions/app-control/scripts/desktop.applescript
@@ -25,11 +25,29 @@ on run argv
 		pressKeys(item 2 of argv, item 3 of argv, item 4 of argv)
 	else if cmd is "click-at" then
 		clickAt((item 2 of argv) as integer, (item 3 of argv) as integer)
+	else if cmd is "probe" then
+		return probeTerminology()
 	else
 		error "Unknown command: " & cmd
 	end if
 	return ""
 end run
+
+-- Replace tabs/newlines with spaces so titles can't break the tab-separated,
+-- line-per-window output format (mirrors Describe() in desktop.ps1).
+on sanitizeField(theValue)
+	if theValue is missing value then return ""
+	set theText to theValue as text
+	set savedDelims to AppleScript's text item delimiters
+	repeat with badChar in {tab, linefeed, return}
+		set AppleScript's text item delimiters to (badChar as text)
+		set theParts to text items of theText
+		set AppleScript's text item delimiters to space
+		set theText to theParts as text
+	end repeat
+	set AppleScript's text item delimiters to savedDelims
+	return theText
+end sanitizeField
 
 on windowLine(procPid, procName, isFocused, win)
 	tell application "System Events"
@@ -39,8 +57,7 @@ on windowLine(procPid, procName, isFocused, win)
 	end tell
 	set focusedText to "0"
 	if isFocused then set focusedText to "1"
-	if winTitle is missing value then set winTitle to ""
-	return (procPid as text) & tab & focusedText & tab & (xPos as text) & tab & (yPos as text) & tab & (winWidth as text) & tab & (winHeight as text) & tab & procName & tab & winTitle
+	return (procPid as text) & tab & focusedText & tab & (xPos as text) & tab & (yPos as text) & tab & (winWidth as text) & tab & (winHeight as text) & tab & my sanitizeField(procName) & tab & my sanitizeField(winTitle)
 end windowLine
 
 on activeWindowLine()
@@ -88,16 +105,23 @@ on typeText(theText)
 end typeText
 
 -- modsCsv: comma-separated subset of command/option/control/shift, or "-".
--- kind: "code" (value is a numeric key code) or "char" (value is a literal
+-- keyKind: "code" (value is a numeric key code) or "char" (value is a literal
 -- character for keystroke). The caller maps key names to codes.
-on pressKeys(modsCsv, kind, keyValue)
+--
+-- NB: identifiers used inside the System Events tell block must not collide
+-- with its dictionary terminology (terms win over variables at compile time
+-- and break silently at runtime — e.g. `kind` is a System Events property).
+-- Terminology-sensitive decisions are therefore computed before the tell,
+-- and the `probe` command exercises this handler's constructs in CI.
+on pressKeys(modsCsv, keyKind, keyValue)
+	set useCode to (keyKind is "code")
 	tell application "System Events"
 		set mods to {}
 		if modsCsv contains "command" then set end of mods to command down
 		if modsCsv contains "option" then set end of mods to option down
 		if modsCsv contains "control" then set end of mods to control down
 		if modsCsv contains "shift" then set end of mods to shift down
-		if kind is "code" then
+		if useCode then
 			if (count of mods) is 0 then
 				key code (keyValue as integer)
 			else
@@ -112,6 +136,23 @@ on pressKeys(modsCsv, kind, keyValue)
 		end if
 	end tell
 end pressKeys
+
+-- Exercises the terminology-sensitive constructs of pressKeys (modifier enum
+-- constants, branch selection, integer coercion) without sending any events,
+-- so CI can catch dictionary/variable collisions on a real macOS interpreter.
+on probeTerminology()
+	set useCode to ("code" is "code")
+	set probedCode to 0
+	tell application "System Events"
+		set mods to {}
+		if "command,shift" contains "command" then set end of mods to command down
+		if "command,shift" contains "option" then set end of mods to option down
+		if "command,shift" contains "control" then set end of mods to control down
+		if "command,shift" contains "shift" then set end of mods to shift down
+		if useCode then set probedCode to ("36" as integer)
+	end tell
+	return "mods=" & ((count of mods) as text) & ";code=" & (probedCode as text)
+end probeTerminology
 
 on clickAt(xPos, yPos)
 	tell application "System Events"

--- a/src/actions/app-control/scripts/desktop.applescript
+++ b/src/actions/app-control/scripts/desktop.applescript
@@ -1,0 +1,122 @@
+-- Jarvis desktop helper — macOS fallback path (no sidecar).
+--
+-- Invoked as:
+--   osascript desktop.applescript <command> [args...]
+--
+-- All user-supplied values arrive as argv items and are never spliced into
+-- script source. osascript reports handler errors on stderr and exits
+-- non-zero, which the caller (macos.ts) turns into thrown errors.
+--
+-- Window lines are tab-separated: pid, focused(1/0), x, y, width, height,
+-- className (process name), title. Title comes last.
+
+on run argv
+	if (count of argv) < 1 then error "Missing command"
+	set cmd to item 1 of argv
+	if cmd is "get-active-window" then
+		return activeWindowLine()
+	else if cmd is "list-windows" then
+		return listWindowLines()
+	else if cmd is "focus-window" then
+		focusPid((item 2 of argv) as integer)
+	else if cmd is "type-text" then
+		typeText(item 2 of argv)
+	else if cmd is "press-keys" then
+		pressKeys(item 2 of argv, item 3 of argv, item 4 of argv)
+	else if cmd is "click-at" then
+		clickAt((item 2 of argv) as integer, (item 3 of argv) as integer)
+	else
+		error "Unknown command: " & cmd
+	end if
+	return ""
+end run
+
+on windowLine(procPid, procName, isFocused, win)
+	tell application "System Events"
+		set winTitle to name of win
+		set {xPos, yPos} to position of win
+		set {winWidth, winHeight} to size of win
+	end tell
+	set focusedText to "0"
+	if isFocused then set focusedText to "1"
+	if winTitle is missing value then set winTitle to ""
+	return (procPid as text) & tab & focusedText & tab & (xPos as text) & tab & (yPos as text) & tab & (winWidth as text) & tab & (winHeight as text) & tab & procName & tab & winTitle
+end windowLine
+
+on activeWindowLine()
+	tell application "System Events"
+		set frontProc to first application process whose frontmost is true
+		set procName to name of frontProc
+		set procPid to unix id of frontProc
+		set wins to windows of frontProc
+		if (count of wins) is 0 then error "Frontmost application has no windows"
+		set win to item 1 of wins
+	end tell
+	return my windowLine(procPid, procName, true, win)
+end activeWindowLine
+
+on listWindowLines()
+	set out to {}
+	tell application "System Events"
+		set frontPid to unix id of (first application process whose frontmost is true)
+		repeat with proc in (application processes whose background only is false)
+			set procPid to unix id of proc
+			set procName to name of proc
+			repeat with win in (windows of proc)
+				try
+					set end of out to my windowLine(procPid, procName, procPid is frontPid, win)
+				end try
+			end repeat
+		end repeat
+	end tell
+	set savedDelims to AppleScript's text item delimiters
+	set AppleScript's text item delimiters to linefeed
+	set joined to out as text
+	set AppleScript's text item delimiters to savedDelims
+	return joined
+end listWindowLines
+
+on focusPid(thePid)
+	tell application "System Events"
+		set targetProc to first application process whose unix id is thePid
+		set frontmost of targetProc to true
+	end tell
+end focusPid
+
+on typeText(theText)
+	tell application "System Events" to keystroke theText
+end typeText
+
+-- modsCsv: comma-separated subset of command/option/control/shift, or "-".
+-- kind: "code" (value is a numeric key code) or "char" (value is a literal
+-- character for keystroke). The caller maps key names to codes.
+on pressKeys(modsCsv, kind, keyValue)
+	tell application "System Events"
+		set mods to {}
+		if modsCsv contains "command" then set end of mods to command down
+		if modsCsv contains "option" then set end of mods to option down
+		if modsCsv contains "control" then set end of mods to control down
+		if modsCsv contains "shift" then set end of mods to shift down
+		if kind is "code" then
+			if (count of mods) is 0 then
+				key code (keyValue as integer)
+			else
+				key code (keyValue as integer) using mods
+			end if
+		else
+			if (count of mods) is 0 then
+				keystroke keyValue
+			else
+				keystroke keyValue using mods
+			end if
+		end if
+	end tell
+end pressKeys
+
+on clickAt(xPos, yPos)
+	tell application "System Events"
+		tell (first application process whose frontmost is true)
+			click at {xPos, yPos}
+		end tell
+	end tell
+end clickAt

--- a/src/actions/app-control/scripts/desktop.ps1
+++ b/src/actions/app-control/scripts/desktop.ps1
@@ -1,0 +1,240 @@
+<#
+  Jarvis desktop helper — Windows fallback path (no sidecar).
+
+  Invoked as:
+    powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -File desktop.ps1 <command>
+
+  The JSON payload (if any) arrives on stdin — never interpolated into script
+  text, so arbitrary user/LLM-derived strings cannot alter the script.
+  Results are written to stdout (JSON or base64); any failure writes a message
+  to stderr and exits non-zero.
+
+  Must stay PowerShell 5.1 compatible: no ternary, no null-coalescing, no
+  pipeline continuation at start-of-line.
+#>
+param(
+  [Parameter(Mandatory = $true, Position = 0)]
+  [string]$Command
+)
+
+$ErrorActionPreference = 'Stop'
+
+Add-Type -TypeDefinition @"
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Text;
+
+public static class JarvisWin32 {
+    [DllImport("user32.dll")] static extern IntPtr GetForegroundWindow();
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)] static extern int GetWindowText(IntPtr hWnd, StringBuilder text, int maxCount);
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)] static extern int GetClassName(IntPtr hWnd, StringBuilder text, int maxCount);
+    [DllImport("user32.dll")] static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint processId);
+    [DllImport("user32.dll")] static extern bool GetWindowRect(IntPtr hWnd, out RECT rect);
+    [DllImport("user32.dll")] static extern bool IsWindowVisible(IntPtr hWnd);
+    [DllImport("user32.dll")] static extern bool IsIconic(IntPtr hWnd);
+    [DllImport("user32.dll")] static extern bool ShowWindow(IntPtr hWnd, int cmdShow);
+    [DllImport("user32.dll")] static extern bool SetForegroundWindow(IntPtr hWnd);
+    [DllImport("user32.dll")] static extern bool AttachThreadInput(uint idAttach, uint idAttachTo, bool attach);
+    [DllImport("kernel32.dll")] static extern uint GetCurrentThreadId();
+    [DllImport("user32.dll")] static extern bool SetCursorPos(int x, int y);
+    [DllImport("user32.dll")] static extern void mouse_event(uint flags, uint dx, uint dy, uint data, UIntPtr extraInfo);
+    [DllImport("user32.dll")] static extern bool PostMessage(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam);
+
+    delegate bool EnumWindowsProc(IntPtr hWnd, IntPtr lParam);
+    [DllImport("user32.dll")] static extern bool EnumWindows(EnumWindowsProc callback, IntPtr lParam);
+
+    const uint MOUSEEVENTF_LEFTDOWN = 0x0002;
+    const uint MOUSEEVENTF_LEFTUP = 0x0004;
+    const uint WM_CLOSE = 0x0010;
+    const int SW_RESTORE = 9;
+
+    struct RECT { public int Left; public int Top; public int Right; public int Bottom; }
+
+    // Fields: pid, focused, x, y, width, height, className, title.
+    // Tab-separated; title comes last and has tabs/newlines squashed.
+    static string Describe(IntPtr hWnd, IntPtr foreground) {
+        StringBuilder title = new StringBuilder(512);
+        GetWindowText(hWnd, title, title.Capacity);
+        StringBuilder cls = new StringBuilder(256);
+        GetClassName(hWnd, cls, cls.Capacity);
+        uint processId;
+        GetWindowThreadProcessId(hWnd, out processId);
+        RECT r;
+        GetWindowRect(hWnd, out r);
+        string safeClass = cls.ToString().Replace("\t", " ").Replace("\r", " ").Replace("\n", " ");
+        string safeTitle = title.ToString().Replace("\t", " ").Replace("\r", " ").Replace("\n", " ");
+        return string.Join("\t", new string[] {
+            processId.ToString(),
+            hWnd == foreground ? "1" : "0",
+            r.Left.ToString(), r.Top.ToString(),
+            (r.Right - r.Left).ToString(), (r.Bottom - r.Top).ToString(),
+            safeClass, safeTitle
+        });
+    }
+
+    public static string ActiveWindow() {
+        IntPtr fg = GetForegroundWindow();
+        if (fg == IntPtr.Zero) throw new InvalidOperationException("No foreground window");
+        return Describe(fg, fg);
+    }
+
+    public static string[] ListWindows() {
+        IntPtr fg = GetForegroundWindow();
+        List<string> lines = new List<string>();
+        EnumWindows(delegate(IntPtr hWnd, IntPtr lParam) {
+            if (!IsWindowVisible(hWnd)) return true;
+            StringBuilder title = new StringBuilder(512);
+            GetWindowText(hWnd, title, title.Capacity);
+            if (title.Length == 0) return true;
+            lines.Add(Describe(hWnd, fg));
+            return true;
+        }, IntPtr.Zero);
+        return lines.ToArray();
+    }
+
+    static IntPtr FindMainWindow(int processId) {
+        IntPtr found = IntPtr.Zero;
+        EnumWindows(delegate(IntPtr hWnd, IntPtr lParam) {
+            if (!IsWindowVisible(hWnd)) return true;
+            uint winPid;
+            GetWindowThreadProcessId(hWnd, out winPid);
+            if (winPid == (uint)processId) { found = hWnd; return false; }
+            return true;
+        }, IntPtr.Zero);
+        return found;
+    }
+
+    public static int[] WindowRect(int processId) {
+        IntPtr hWnd = FindMainWindow(processId);
+        if (hWnd == IntPtr.Zero) throw new InvalidOperationException("No visible window for PID " + processId);
+        RECT r;
+        GetWindowRect(hWnd, out r);
+        return new int[] { r.Left, r.Top, r.Right - r.Left, r.Bottom - r.Top };
+    }
+
+    public static void Focus(int processId) {
+        IntPtr hWnd = FindMainWindow(processId);
+        if (hWnd == IntPtr.Zero) throw new InvalidOperationException("No visible window for PID " + processId);
+        if (IsIconic(hWnd)) ShowWindow(hWnd, SW_RESTORE);
+        if (SetForegroundWindow(hWnd)) return;
+        // Foreground lock: attach to the current foreground thread and retry.
+        uint dummy;
+        uint fgThread = GetWindowThreadProcessId(GetForegroundWindow(), out dummy);
+        uint self = GetCurrentThreadId();
+        AttachThreadInput(self, fgThread, true);
+        bool ok = SetForegroundWindow(hWnd);
+        AttachThreadInput(self, fgThread, false);
+        if (!ok) throw new InvalidOperationException("Could not bring window to foreground for PID " + processId);
+    }
+
+    public static void Close(int processId) {
+        IntPtr hWnd = FindMainWindow(processId);
+        if (hWnd == IntPtr.Zero) throw new InvalidOperationException("No visible window for PID " + processId);
+        if (!PostMessage(hWnd, WM_CLOSE, IntPtr.Zero, IntPtr.Zero)) {
+            throw new InvalidOperationException("PostMessage(WM_CLOSE) failed for PID " + processId);
+        }
+    }
+
+    public static void ClickAt(int x, int y) {
+        if (!SetCursorPos(x, y)) throw new InvalidOperationException("SetCursorPos(" + x + ", " + y + ") failed");
+        mouse_event(MOUSEEVENTF_LEFTDOWN, 0, 0, 0, UIntPtr.Zero);
+        mouse_event(MOUSEEVENTF_LEFTUP, 0, 0, 0, UIntPtr.Zero);
+    }
+}
+"@
+
+function Read-Payload {
+  $raw = [Console]::In.ReadToEnd()
+  if ([string]::IsNullOrWhiteSpace($raw)) { return $null }
+  return ConvertFrom-Json -InputObject $raw
+}
+
+function ConvertFrom-WindowLine {
+  param([string]$Line)
+  $parts = $Line -split "`t", 8
+  return [PSCustomObject]@{
+    pid = [int]$parts[0]
+    focused = ($parts[1] -eq '1')
+    x = [int]$parts[2]
+    y = [int]$parts[3]
+    width = [int]$parts[4]
+    height = [int]$parts[5]
+    className = $parts[6]
+    title = $parts[7]
+  }
+}
+
+function Get-RectCaptureBase64 {
+  param([int]$X, [int]$Y, [int]$Width, [int]$Height)
+  if ($Width -le 0 -or $Height -le 0) { throw "Invalid capture region ${Width}x${Height}" }
+  Add-Type -AssemblyName System.Drawing
+  $bmp = New-Object System.Drawing.Bitmap($Width, $Height)
+  $g = [System.Drawing.Graphics]::FromImage($bmp)
+  try {
+    $g.CopyFromScreen($X, $Y, 0, 0, (New-Object System.Drawing.Size($Width, $Height)))
+    $ms = New-Object System.IO.MemoryStream
+    $bmp.Save($ms, [System.Drawing.Imaging.ImageFormat]::Png)
+    return [Convert]::ToBase64String($ms.ToArray())
+  } finally {
+    $g.Dispose()
+    $bmp.Dispose()
+  }
+}
+
+try {
+  switch ($Command) {
+    'get-active-window' {
+      $win = ConvertFrom-WindowLine -Line ([JarvisWin32]::ActiveWindow())
+      Write-Output (ConvertTo-Json -InputObject $win -Compress)
+    }
+    'list-windows' {
+      $wins = @([JarvisWin32]::ListWindows() | ForEach-Object { ConvertFrom-WindowLine -Line $_ })
+      Write-Output (ConvertTo-Json -InputObject $wins -Compress)
+    }
+    'click-at' {
+      $p = Read-Payload
+      [JarvisWin32]::ClickAt([int]$p.x, [int]$p.y)
+    }
+    'send-keys' {
+      # The SendKeys string is pre-escaped by the caller (see windows.ts).
+      $p = Read-Payload
+      Add-Type -AssemblyName System.Windows.Forms
+      [System.Windows.Forms.SendKeys]::SendWait([string]$p.keys)
+    }
+    'capture-screen' {
+      Add-Type -AssemblyName System.Windows.Forms
+      $b = [System.Windows.Forms.Screen]::PrimaryScreen.Bounds
+      Write-Output (Get-RectCaptureBase64 -X $b.X -Y $b.Y -Width $b.Width -Height $b.Height)
+    }
+    'capture-window' {
+      $p = Read-Payload
+      $r = [JarvisWin32]::WindowRect([int]$p.pid)
+      Write-Output (Get-RectCaptureBase64 -X $r[0] -Y $r[1] -Width $r[2] -Height $r[3])
+    }
+    'focus-window' {
+      $p = Read-Payload
+      [JarvisWin32]::Focus([int]$p.pid)
+    }
+    'close-window' {
+      $p = Read-Payload
+      [JarvisWin32]::Close([int]$p.pid)
+    }
+    'launch-app' {
+      $p = Read-Payload
+      if ([string]::IsNullOrWhiteSpace([string]$p.args)) {
+        $proc = Start-Process -FilePath ([string]$p.executable) -PassThru
+      } else {
+        $proc = Start-Process -FilePath ([string]$p.executable) -ArgumentList ([string]$p.args) -PassThru
+      }
+      Write-Output (ConvertTo-Json -InputObject @{ pid = $proc.Id } -Compress)
+    }
+    default {
+      throw "Unknown command: $Command"
+    }
+  }
+  exit 0
+} catch {
+  [Console]::Error.WriteLine($_.Exception.Message)
+  exit 1
+}

--- a/src/actions/app-control/scripts/desktop.ps1
+++ b/src/actions/app-control/scripts/desktop.ps1
@@ -19,6 +19,12 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
+# Redirected stdout/stderr default to the OEM code page on Windows PowerShell;
+# emit UTF-8 so non-ASCII window titles survive the trip back to Node. The
+# inbound payload is ASCII-safe JSON (see toAsciiJson in windows.ts), so the
+# stdin encoding does not matter.
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+
 Add-Type -TypeDefinition @"
 using System;
 using System.Collections.Generic;
@@ -37,6 +43,7 @@ public static class JarvisWin32 {
     [DllImport("user32.dll")] static extern bool SetForegroundWindow(IntPtr hWnd);
     [DllImport("user32.dll")] static extern bool AttachThreadInput(uint idAttach, uint idAttachTo, bool attach);
     [DllImport("kernel32.dll")] static extern uint GetCurrentThreadId();
+    [DllImport("user32.dll")] static extern bool SetProcessDPIAware();
     [DllImport("user32.dll")] static extern bool SetCursorPos(int x, int y);
     [DllImport("user32.dll")] static extern void mouse_event(uint flags, uint dx, uint dy, uint data, UIntPtr extraInfo);
     [DllImport("user32.dll")] static extern bool PostMessage(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam);
@@ -141,8 +148,19 @@ public static class JarvisWin32 {
         mouse_event(MOUSEEVENTF_LEFTDOWN, 0, 0, 0, UIntPtr.Zero);
         mouse_event(MOUSEEVENTF_LEFTUP, 0, 0, 0, UIntPtr.Zero);
     }
+
+    // Without this, powershell.exe is DPI-virtualized on scaled displays:
+    // window rects, cursor coordinates, and captures come back in scaled
+    // (non-native) pixels.
+    public static void MakeDpiAware() {
+        SetProcessDPIAware();
+    }
 }
 "@
+
+# Best-effort: SetProcessDPIAware never throws on Windows; the catch only
+# fires where user32 is absent (the linux-CI pwsh syntax probe).
+try { [JarvisWin32]::MakeDpiAware() } catch { }
 
 function Read-Payload {
   $raw = [Console]::In.ReadToEnd()
@@ -171,12 +189,14 @@ function Get-RectCaptureBase64 {
   Add-Type -AssemblyName System.Drawing
   $bmp = New-Object System.Drawing.Bitmap($Width, $Height)
   $g = [System.Drawing.Graphics]::FromImage($bmp)
+  $ms = $null
   try {
     $g.CopyFromScreen($X, $Y, 0, 0, (New-Object System.Drawing.Size($Width, $Height)))
     $ms = New-Object System.IO.MemoryStream
     $bmp.Save($ms, [System.Drawing.Imaging.ImageFormat]::Png)
     return [Convert]::ToBase64String($ms.ToArray())
   } finally {
+    if ($null -ne $ms) { $ms.Dispose() }
     $g.Dispose()
     $bmp.Dispose()
   }
@@ -227,7 +247,11 @@ try {
       } else {
         $proc = Start-Process -FilePath ([string]$p.executable) -ArgumentList ([string]$p.args) -PassThru
       }
-      Write-Output (ConvertTo-Json -InputObject @{ pid = $proc.Id } -Compress)
+      # -PassThru returns nothing when the shell reuses an existing process
+      # (documents, URLs) — report pid null rather than failing the launch.
+      $launchedPid = $null
+      if ($null -ne $proc) { $launchedPid = $proc.Id }
+      Write-Output (ConvertTo-Json -InputObject @{ pid = $launchedPid } -Compress)
     }
     default {
       throw "Unknown command: $Command"

--- a/src/actions/app-control/sidecar-probe.ts
+++ b/src/actions/app-control/sidecar-probe.ts
@@ -1,0 +1,37 @@
+import type { DesktopController } from './desktop-controller.ts';
+
+// How long to wait before re-probing for a sidecar after a failed attempt.
+const SIDECAR_RETRY_MS = 30_000;
+
+/**
+ * Lazily connects to the desktop-bridge sidecar, reusing one controller (and
+ * its TCP connection) across calls and backing off after failed probes.
+ *
+ * Meaningful only if the owning controller itself is long-lived —
+ * getAppController() caches controllers per process for exactly that reason.
+ */
+export class SidecarProbe {
+  private enabled: boolean;
+  private sidecar: DesktopController | null = null;
+  private retryAt = 0;
+
+  constructor(enabled: boolean) {
+    this.enabled = enabled;
+  }
+
+  async get(): Promise<DesktopController | null> {
+    if (!this.enabled) return null;
+    if (this.sidecar?.connected) return this.sidecar;
+    if (Date.now() < this.retryAt) return null;
+    try {
+      const { DesktopController } = await import('./desktop-controller.ts');
+      const sidecar = this.sidecar ?? new DesktopController();
+      await sidecar.connect();
+      this.sidecar = sidecar;
+      return sidecar;
+    } catch {
+      this.retryAt = Date.now() + SIDECAR_RETRY_MS;
+      return null;
+    }
+  }
+}

--- a/src/actions/app-control/windows.test.ts
+++ b/src/actions/app-control/windows.test.ts
@@ -2,7 +2,7 @@ import { test, expect, describe } from 'bun:test';
 import { spawnSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { WindowsAppController, escapeSendKeysText, mapKeysToSendKeys } from './windows.ts';
+import { WindowsAppController, escapeSendKeysText, mapKeysToSendKeys, toAsciiJson } from './windows.ts';
 import type { NativeExec, NativeExecResult } from './native-exec.ts';
 
 const SCRIPT_PATH = join(import.meta.dir, 'scripts', 'desktop.ps1');
@@ -63,6 +63,21 @@ describe('mapKeysToSendKeys', () => {
     expect(() => mapKeysToSendKeys(['NotAKey'])).toThrow(/Unsupported key/);
     expect(() => mapKeysToSendKeys(['Control'])).toThrow(/no non-modifier key/);
   });
+
+  test('rejects multiple non-modifier keys, matching macOS/Linux chord semantics', () => {
+    expect(() => mapKeysToSendKeys(['A', 'B'])).toThrow(/more than one non-modifier key/);
+  });
+});
+
+describe('toAsciiJson', () => {
+  test('escapes all non-ASCII characters while round-tripping via JSON', () => {
+    const payload = { keys: 'café — “smart” ünïcode ✓' };
+    const json = toAsciiJson(payload);
+    for (const ch of json) {
+      expect(ch.charCodeAt(0)).toBeLessThan(128);
+    }
+    expect(JSON.parse(json)).toEqual(payload);
+  });
 });
 
 describe('WindowsAppController fallback', () => {
@@ -110,6 +125,18 @@ describe('WindowsAppController fallback', () => {
     expect(call.cmd.join(' ')).not.toContain('Start-Process');
     const payload = JSON.parse(call.input) as { keys: string };
     expect(payload.keys).toBe(escapeSendKeysText(hostile));
+  });
+
+  test('typeText payload is ASCII-safe for the OEM-code-page stdin', async () => {
+    // Regression: powershell.exe decodes redirected stdin with the OEM code
+    // page, so raw UTF-8 payloads arrive as mojibake.
+    const { ctrl, calls } = controller(() => ({}));
+    await ctrl.typeText('café ünïcode ✓');
+    const input = calls[0]!.input;
+    for (const ch of input) {
+      expect(ch.charCodeAt(0)).toBeLessThan(128);
+    }
+    expect((JSON.parse(input) as { keys: string }).keys).toBe('café ünïcode ✓');
   });
 
   test('clickElement clicks at the element center via click-at', async () => {

--- a/src/actions/app-control/windows.test.ts
+++ b/src/actions/app-control/windows.test.ts
@@ -1,0 +1,212 @@
+import { test, expect, describe } from 'bun:test';
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { WindowsAppController, escapeSendKeysText, mapKeysToSendKeys } from './windows.ts';
+import type { NativeExec, NativeExecResult } from './native-exec.ts';
+
+const SCRIPT_PATH = join(import.meta.dir, 'scripts', 'desktop.ps1');
+
+type Call = { cmd: string[]; input: string };
+
+function fakeExec(handler: (cmd: string[], input: string) => Partial<NativeExecResult>) {
+  const calls: Call[] = [];
+  const exec: NativeExec = (cmd, input) => {
+    calls.push({ cmd, input });
+    const result = handler(cmd, input);
+    return { status: 0, stdout: '', stderr: '', ...result };
+  };
+  return { exec, calls };
+}
+
+function controller(handler: (cmd: string[], input: string) => Partial<NativeExecResult>) {
+  const { exec, calls } = fakeExec(handler);
+  return { ctrl: new WindowsAppController({ exec, useSidecar: false }), calls };
+}
+
+describe('escapeSendKeysText', () => {
+  test('escapes SendKeys metacharacters by wrapping in braces', () => {
+    expect(escapeSendKeysText('100%+{cool}')).toBe('100{%}{+}{{}cool{}}');
+    expect(escapeSendKeysText('a^b~c(d)e')).toBe('a{^}b{~}c{(}d{)}e');
+    expect(escapeSendKeysText('[x]')).toBe('{[}x{]}');
+  });
+
+  test('leaves exclamation marks untouched', () => {
+    // Regression: PR #279 replaced "!" with the literal string " Surround EscapeExclamation".
+    expect(escapeSendKeysText('hello world!')).toBe('hello world!');
+  });
+
+  test('converts newlines and tabs to key tokens', () => {
+    expect(escapeSendKeysText('a\nb\r\nc\td')).toBe('a{ENTER}b{ENTER}c{TAB}d');
+  });
+});
+
+describe('mapKeysToSendKeys', () => {
+  test('maps modifier chords', () => {
+    expect(mapKeysToSendKeys(['Control', 'C'])).toBe('^c');
+    expect(mapKeysToSendKeys(['Control', 'Shift', 'S'])).toBe('^+s');
+    expect(mapKeysToSendKeys(['Alt', 'Tab'])).toBe('%{TAB}');
+  });
+
+  test('maps named keys', () => {
+    expect(mapKeysToSendKeys(['Enter'])).toBe('{ENTER}');
+    expect(mapKeysToSendKeys(['Escape'])).toBe('{ESC}');
+    expect(mapKeysToSendKeys(['F5'])).toBe('{F5}');
+  });
+
+  test('escapes special single-character keys', () => {
+    expect(mapKeysToSendKeys(['Control', '+'])).toBe('^{+}');
+  });
+
+  test('rejects the Windows key and unknown keys', () => {
+    expect(() => mapKeysToSendKeys(['Win', 'L'])).toThrow(/sidecar/);
+    expect(() => mapKeysToSendKeys(['NotAKey'])).toThrow(/Unsupported key/);
+    expect(() => mapKeysToSendKeys(['Control'])).toThrow(/no non-modifier key/);
+  });
+});
+
+describe('WindowsAppController fallback', () => {
+  const windowJson = JSON.stringify({
+    pid: 123, focused: true, x: 10, y: 20, width: 300, height: 200,
+    className: 'Chrome_WidgetWin_1', title: 'Docs',
+  });
+
+  test('invokes the fixed script asset by path, never -Command', async () => {
+    const { ctrl, calls } = controller(() => ({ stdout: windowJson }));
+    await ctrl.getActiveWindow();
+    const cmd = calls[0]!.cmd;
+    expect(cmd[0]).toBe('powershell.exe');
+    expect(cmd).toContain('-File');
+    expect(cmd).toContain(SCRIPT_PATH);
+    expect(cmd).toContain('get-active-window');
+    expect(cmd).not.toContain('-Command');
+  });
+
+  test('getActiveWindow parses the script JSON', async () => {
+    const { ctrl } = controller(() => ({ stdout: windowJson }));
+    const win = await ctrl.getActiveWindow();
+    expect(win).toEqual({
+      pid: 123,
+      title: 'Docs',
+      className: 'Chrome_WidgetWin_1',
+      bounds: { x: 10, y: 20, width: 300, height: 200 },
+      focused: true,
+    });
+  });
+
+  test('listWindows handles both array and single-object JSON', async () => {
+    const { ctrl: many } = controller(() => ({ stdout: `[${windowJson},${windowJson}]` }));
+    expect(await many.listWindows()).toHaveLength(2);
+    const { ctrl: one } = controller(() => ({ stdout: windowJson }));
+    expect(await one.listWindows()).toHaveLength(1);
+  });
+
+  test('typeText sends user text only via stdin JSON, never on the command line', async () => {
+    // Regression: PR #279 interpolated text into single-quoted PowerShell.
+    const hostile = `'; Start-Process calc; '$(rm -rf /) "double" \`backtick\``;
+    const { ctrl, calls } = controller(() => ({}));
+    await ctrl.typeText(hostile);
+    const call = calls[0]!;
+    expect(call.cmd.join(' ')).not.toContain('Start-Process');
+    const payload = JSON.parse(call.input) as { keys: string };
+    expect(payload.keys).toBe(escapeSendKeysText(hostile));
+  });
+
+  test('clickElement clicks at the element center via click-at', async () => {
+    // Regression: PR #279 sent SendKeys "{CLICK}", which is not a SendKeys token.
+    const { ctrl, calls } = controller(() => ({}));
+    await ctrl.clickElement({
+      id: '1', role: 'button', name: 'OK', value: null,
+      bounds: { x: 100, y: 100, width: 51, height: 21 }, children: [], properties: {},
+    });
+    expect(calls[0]!.cmd).toContain('click-at');
+    expect(JSON.parse(calls[0]!.input)).toEqual({ x: 126, y: 111 });
+  });
+
+  test('captureWindow passes the pid to the script', async () => {
+    // Regression: PR #279 ignored the pid and always captured the full screen.
+    const png = Buffer.from('fake-png');
+    const { ctrl, calls } = controller(() => ({ stdout: png.toString('base64') }));
+    const buffer = await ctrl.captureWindow(4242);
+    expect(calls[0]!.cmd).toContain('capture-window');
+    expect(JSON.parse(calls[0]!.input)).toEqual({ pid: 4242 });
+    expect(buffer.equals(png)).toBe(true);
+  });
+
+  test('throws with stderr detail when the script exits non-zero', async () => {
+    // Regression: PR #279 swallowed failures and returned empty strings.
+    const { ctrl } = controller(() => ({ status: 1, stderr: 'No visible window for PID 7' }));
+    expect(ctrl.focusWindow(7)).rejects.toThrow(/No visible window for PID 7/);
+  });
+
+  test('throws when the process cannot be spawned', async () => {
+    const { ctrl } = controller(() => ({ status: null, error: new Error('ENOENT') }));
+    expect(ctrl.captureScreen()).rejects.toThrow(/failed to start: ENOENT/);
+  });
+
+  test('launchApp passes executable and args via stdin payload', async () => {
+    const { ctrl, calls } = controller(() => ({ stdout: '{"pid":555}' }));
+    const result = await ctrl.launchApp(`C:\\Program Files\\O'Brien\\app.exe`, '--flag "a b"');
+    expect(calls[0]!.cmd).toContain('launch-app');
+    expect(JSON.parse(calls[0]!.input)).toEqual({
+      executable: `C:\\Program Files\\O'Brien\\app.exe`,
+      args: '--flag "a b"',
+    });
+    expect(result).toEqual({ pid: 555, executable: `C:\\Program Files\\O'Brien\\app.exe`, args: '--flag "a b"' });
+  });
+
+  test('getWindowTree without sidecar throws instead of pretending', async () => {
+    const { ctrl } = controller(() => ({}));
+    expect(ctrl.getWindowTree(1)).rejects.toThrow(/sidecar/);
+  });
+});
+
+describe('desktop.ps1 script asset', () => {
+  const script = readFileSync(SCRIPT_PATH, 'utf-8');
+
+  test('never starts a line with a pipe (PowerShell 5.1 parse error)', () => {
+    // Regression: PR #279 emitted "| ConvertTo-Json" on its own line.
+    expect(script).not.toMatch(/^\s*\|/m);
+  });
+
+  test('never assigns to the read-only $pid automatic variable', () => {
+    expect(script).not.toMatch(/\$pid\s*=/i);
+    expect(script).not.toMatch(/\[ref\]\s*\$pid\b/i);
+  });
+
+  test('does not use SendKeys mouse-click pseudo-tokens', () => {
+    expect(script).not.toContain('{CLICK}');
+  });
+
+  test('keeps System.Drawing out of the compiled C# (needs -ReferencedAssemblies)', () => {
+    // Regression: PR #279 compiled C# referencing System.Drawing/WinForms
+    // without -ReferencedAssemblies. Drawing is only used from PowerShell
+    // after Add-Type -AssemblyName.
+    expect(script).not.toMatch(/using System\.Drawing/);
+    expect(script).not.toMatch(/using System\.Windows\.Forms/);
+    expect(script).toContain('Add-Type -AssemblyName System.Drawing');
+  });
+
+  test('reads payloads from stdin and reports failures on stderr with exit 1', () => {
+    expect(script).toContain('[Console]::In.ReadToEnd()');
+    expect(script).toContain('[Console]::Error.WriteLine');
+    expect(script).toContain('exit 1');
+  });
+
+  const hasPwsh = spawnSync('pwsh', ['-NoProfile', '-Command', '$PSVersionTable.PSVersion.Major'], {
+    encoding: 'utf-8', timeout: 30_000,
+  }).status === 0;
+
+  // pwsh is preinstalled on GitHub ubuntu runners, so this runs in CI.
+  // Executing with an unknown command proves the script parses, the C#
+  // interop block compiles, and the error path exits 1 via stderr.
+  test.skipIf(!hasPwsh)('parses and compiles under pwsh', () => {
+    const result = spawnSync(
+      'pwsh',
+      ['-NoProfile', '-NonInteractive', '-File', SCRIPT_PATH, 'syntax-probe'],
+      { encoding: 'utf-8', input: '', timeout: 120_000 },
+    );
+    expect(result.stderr).toContain('Unknown command: syntax-probe');
+    expect(result.status).toBe(1);
+  }, 120_000);
+});

--- a/src/actions/app-control/windows.ts
+++ b/src/actions/app-control/windows.ts
@@ -2,6 +2,7 @@ import { join } from 'node:path';
 import type { AppController, WindowInfo, UIElement } from './interface.ts';
 import type { DesktopController } from './desktop-controller.ts';
 import { defaultExec, runNative, type NativeExec } from './native-exec.ts';
+import { SidecarProbe } from './sidecar-probe.ts';
 
 /**
  * Windows App Controller.
@@ -18,9 +19,6 @@ import { defaultExec, runNative, type NativeExec } from './native-exec.ts';
  */
 
 const SCRIPT_PATH = join(import.meta.dir, 'scripts', 'desktop.ps1');
-
-// How long to wait before re-probing for a sidecar after a failed attempt.
-const SIDECAR_RETRY_MS = 30_000;
 
 /** SendKeys metacharacters, each escaped by wrapping in braces. */
 const SENDKEYS_SPECIAL = /([+^%~(){}[\]])/g;
@@ -75,15 +73,27 @@ const SENDKEYS_KEYS: Record<string, string> = {
   f10: '{F10}',
   f11: '{F11}',
   f12: '{F12}',
+  f13: '{F13}',
+  f14: '{F14}',
+  f15: '{F15}',
+  f16: '{F16}',
+  printscreen: '{PRTSC}',
+  prtsc: '{PRTSC}',
+  capslock: '{CAPSLOCK}',
+  numlock: '{NUMLOCK}',
+  scrolllock: '{SCROLLLOCK}',
+  help: '{HELP}',
 };
 
 /**
  * Map a key chord like ["Control", "Shift", "S"] to a SendKeys string ("^+s").
- * Throws on keys SendKeys cannot synthesize (e.g. the Windows key).
+ * A chord is modifiers plus exactly one main key — matching the macOS and
+ * Linux controllers. Throws on keys SendKeys cannot synthesize (e.g. the
+ * Windows key).
  */
 export function mapKeysToSendKeys(keys: string[]): string {
   let modifiers = '';
-  const rest: string[] = [];
+  let mainKey: string | null = null;
 
   for (const raw of keys) {
     const lower = raw.toLowerCase();
@@ -95,24 +105,25 @@ export function mapKeysToSendKeys(keys: string[]): string {
     if (lower === 'win' || lower === 'meta' || lower === 'super' || lower === 'command' || lower === 'cmd') {
       throw new Error(`SendKeys cannot press the ${raw} key; Windows-key shortcuts need the desktop sidecar`);
     }
+    if (mainKey !== null) {
+      throw new Error(`Key combination [${keys.join('+')}] has more than one non-modifier key`);
+    }
     const named = SENDKEYS_KEYS[lower];
     if (named) {
-      rest.push(named);
+      mainKey = named;
       continue;
     }
     if ([...raw].length === 1) {
-      rest.push(escapeSendKeysText(raw.toLowerCase()));
+      mainKey = escapeSendKeysText(raw.toLowerCase());
       continue;
     }
     throw new Error(`Unsupported key "${raw}" for the SendKeys fallback`);
   }
 
-  if (rest.length === 0) {
+  if (mainKey === null) {
     throw new Error(`Key combination [${keys.join('+')}] has no non-modifier key to press`);
   }
-  const body = rest.join('');
-  if (modifiers && rest.length > 1) return `${modifiers}(${body})`;
-  return modifiers + body;
+  return modifiers + mainKey;
 }
 
 type ScriptWindow = {
@@ -136,42 +147,41 @@ function toWindowInfo(raw: ScriptWindow): WindowInfo {
   };
 }
 
+/**
+ * powershell.exe decodes redirected stdin with the OEM code page, not UTF-8,
+ * so the payload must be pure ASCII: escape everything past 0x7F as \uXXXX
+ * (valid JSON, decoded back to the original characters by ConvertFrom-Json).
+ */
+export function toAsciiJson(payload: Record<string, unknown>): string {
+  return JSON.stringify(payload).replace(
+    /[\u0080-\uffff]/g,
+    (ch) => `\\u${ch.charCodeAt(0).toString(16).padStart(4, '0')}`,
+  );
+}
+
 export class WindowsAppController implements AppController {
   private exec: NativeExec;
-  private useSidecar: boolean;
-  private sidecar: DesktopController | null = null;
-  private sidecarRetryAt = 0;
+  private sidecarProbe: SidecarProbe;
 
   constructor(opts: { exec?: NativeExec; useSidecar?: boolean } = {}) {
     this.exec = opts.exec ?? defaultExec;
-    this.useSidecar = opts.useSidecar ?? true;
+    this.sidecarProbe = new SidecarProbe(opts.useSidecar ?? true);
   }
 
-  private async getSidecar(): Promise<DesktopController | null> {
-    if (!this.useSidecar) return null;
-    if (this.sidecar?.connected) return this.sidecar;
-    if (Date.now() < this.sidecarRetryAt) return null;
-    try {
-      const { DesktopController } = await import('./desktop-controller.ts');
-      const sidecar = this.sidecar ?? new DesktopController();
-      await sidecar.connect();
-      this.sidecar = sidecar;
-      return sidecar;
-    } catch {
-      this.sidecarRetryAt = Date.now() + SIDECAR_RETRY_MS;
-      return null;
-    }
+  private getSidecar(): Promise<DesktopController | null> {
+    return this.sidecarProbe.get();
   }
 
   /**
    * Run a command of the fixed helper script. The payload travels on stdin
-   * as JSON — never on the command line, never interpolated into script text.
+   * as ASCII-safe JSON — never on the command line, never interpolated into
+   * script text.
    */
   private runScript(command: string, payload?: Record<string, unknown>): string {
     const stdout = runNative(
       this.exec,
       ['powershell.exe', '-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass', '-File', SCRIPT_PATH, command],
-      payload === undefined ? '' : JSON.stringify(payload),
+      payload === undefined ? '' : toAsciiJson(payload),
       `desktop.ps1 ${command}`,
     );
     return stdout.trim();
@@ -256,8 +266,9 @@ export class WindowsAppController implements AppController {
     if (!executable.trim()) throw new Error('Executable is required');
     const sc = await this.getSidecar();
     if (sc) return sc.launchApp(executable, args);
-    const result = this.runScriptJson<{ pid: number }>('launch-app', { executable, args: args ?? '' });
-    return { pid: result.pid, executable, args: args ?? '' };
+    // pid is null when the shell reuses an existing process (documents, URLs).
+    const result = this.runScriptJson<{ pid: number | null }>('launch-app', { executable, args: args ?? '' });
+    return { pid: result.pid ?? null, executable, args: args ?? '' };
   }
 
   async closeWindow(pid: number): Promise<void> {

--- a/src/actions/app-control/windows.ts
+++ b/src/actions/app-control/windows.ts
@@ -1,44 +1,268 @@
+import { join } from 'node:path';
 import type { AppController, WindowInfo, UIElement } from './interface.ts';
+import type { DesktopController } from './desktop-controller.ts';
+import { defaultExec, runNative, type NativeExec } from './native-exec.ts';
 
 /**
- * Windows App Controller — stub.
- * Previously delegated to the C# DesktopController sidecar.
- * TODO: Implement local platform-native commands or route via Go sidecar.
+ * Windows App Controller.
+ *
+ * Two-layer implementation:
+ *   1. Desktop sidecar (desktop-bridge.exe) via TCP JSON-RPC — full Win32/UI
+ *      Automation support when the sidecar is built and running.
+ *   2. PowerShell fallback — window listing, focus, screenshots, and input
+ *      simulation through a fixed helper script (scripts/desktop.ps1).
+ *
+ * The fallback never assembles PowerShell source from user input: the helper
+ * script ships as an asset and all dynamic values travel as a JSON payload on
+ * stdin, so arbitrary text cannot escape into script code.
  */
-export class WindowsAppController implements AppController {
-  async getActiveWindow(): Promise<WindowInfo> {
-    throw new Error('WindowsAppController: Not implemented. Use sidecar desktop tools with a target parameter.');
+
+const SCRIPT_PATH = join(import.meta.dir, 'scripts', 'desktop.ps1');
+
+// How long to wait before re-probing for a sidecar after a failed attempt.
+const SIDECAR_RETRY_MS = 30_000;
+
+/** SendKeys metacharacters, each escaped by wrapping in braces. */
+const SENDKEYS_SPECIAL = /([+^%~(){}[\]])/g;
+
+/**
+ * Escape literal text for [System.Windows.Forms.SendKeys]::SendWait.
+ * Newlines become {ENTER} and tabs {TAB}; everything else is typed verbatim.
+ */
+export function escapeSendKeysText(text: string): string {
+  return text
+    .replace(SENDKEYS_SPECIAL, '{$1}')
+    .replace(/\r\n|\r|\n/g, '{ENTER}')
+    .replace(/\t/g, '{TAB}');
+}
+
+const SENDKEYS_MODIFIERS: Record<string, string> = {
+  control: '^',
+  ctrl: '^',
+  alt: '%',
+  option: '%',
+  shift: '+',
+};
+
+const SENDKEYS_KEYS: Record<string, string> = {
+  enter: '{ENTER}',
+  return: '{ENTER}',
+  tab: '{TAB}',
+  escape: '{ESC}',
+  esc: '{ESC}',
+  backspace: '{BACKSPACE}',
+  delete: '{DELETE}',
+  del: '{DELETE}',
+  insert: '{INSERT}',
+  home: '{HOME}',
+  end: '{END}',
+  pageup: '{PGUP}',
+  pagedown: '{PGDN}',
+  up: '{UP}',
+  down: '{DOWN}',
+  left: '{LEFT}',
+  right: '{RIGHT}',
+  space: ' ',
+  f1: '{F1}',
+  f2: '{F2}',
+  f3: '{F3}',
+  f4: '{F4}',
+  f5: '{F5}',
+  f6: '{F6}',
+  f7: '{F7}',
+  f8: '{F8}',
+  f9: '{F9}',
+  f10: '{F10}',
+  f11: '{F11}',
+  f12: '{F12}',
+};
+
+/**
+ * Map a key chord like ["Control", "Shift", "S"] to a SendKeys string ("^+s").
+ * Throws on keys SendKeys cannot synthesize (e.g. the Windows key).
+ */
+export function mapKeysToSendKeys(keys: string[]): string {
+  let modifiers = '';
+  const rest: string[] = [];
+
+  for (const raw of keys) {
+    const lower = raw.toLowerCase();
+    const modifier = SENDKEYS_MODIFIERS[lower];
+    if (modifier) {
+      if (!modifiers.includes(modifier)) modifiers += modifier;
+      continue;
+    }
+    if (lower === 'win' || lower === 'meta' || lower === 'super' || lower === 'command' || lower === 'cmd') {
+      throw new Error(`SendKeys cannot press the ${raw} key; Windows-key shortcuts need the desktop sidecar`);
+    }
+    const named = SENDKEYS_KEYS[lower];
+    if (named) {
+      rest.push(named);
+      continue;
+    }
+    if ([...raw].length === 1) {
+      rest.push(escapeSendKeysText(raw.toLowerCase()));
+      continue;
+    }
+    throw new Error(`Unsupported key "${raw}" for the SendKeys fallback`);
   }
 
-  async getWindowTree(_pid: number): Promise<UIElement[]> {
-    throw new Error('WindowsAppController: Not implemented. Use sidecar desktop tools with a target parameter.');
+  if (rest.length === 0) {
+    throw new Error(`Key combination [${keys.join('+')}] has no non-modifier key to press`);
+  }
+  const body = rest.join('');
+  if (modifiers && rest.length > 1) return `${modifiers}(${body})`;
+  return modifiers + body;
+}
+
+type ScriptWindow = {
+  pid: number;
+  focused: boolean;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  className: string;
+  title: string;
+};
+
+function toWindowInfo(raw: ScriptWindow): WindowInfo {
+  return {
+    pid: raw.pid,
+    title: raw.title || 'Unknown',
+    className: raw.className || 'Unknown',
+    bounds: { x: raw.x, y: raw.y, width: raw.width, height: raw.height },
+    focused: raw.focused,
+  };
+}
+
+export class WindowsAppController implements AppController {
+  private exec: NativeExec;
+  private useSidecar: boolean;
+  private sidecar: DesktopController | null = null;
+  private sidecarRetryAt = 0;
+
+  constructor(opts: { exec?: NativeExec; useSidecar?: boolean } = {}) {
+    this.exec = opts.exec ?? defaultExec;
+    this.useSidecar = opts.useSidecar ?? true;
+  }
+
+  private async getSidecar(): Promise<DesktopController | null> {
+    if (!this.useSidecar) return null;
+    if (this.sidecar?.connected) return this.sidecar;
+    if (Date.now() < this.sidecarRetryAt) return null;
+    try {
+      const { DesktopController } = await import('./desktop-controller.ts');
+      const sidecar = this.sidecar ?? new DesktopController();
+      await sidecar.connect();
+      this.sidecar = sidecar;
+      return sidecar;
+    } catch {
+      this.sidecarRetryAt = Date.now() + SIDECAR_RETRY_MS;
+      return null;
+    }
+  }
+
+  /**
+   * Run a command of the fixed helper script. The payload travels on stdin
+   * as JSON — never on the command line, never interpolated into script text.
+   */
+  private runScript(command: string, payload?: Record<string, unknown>): string {
+    const stdout = runNative(
+      this.exec,
+      ['powershell.exe', '-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass', '-File', SCRIPT_PATH, command],
+      payload === undefined ? '' : JSON.stringify(payload),
+      `desktop.ps1 ${command}`,
+    );
+    return stdout.trim();
+  }
+
+  private runScriptJson<T>(command: string, payload?: Record<string, unknown>): T {
+    const out = this.runScript(command, payload);
+    if (!out) throw new Error(`desktop.ps1 ${command} produced no output`);
+    try {
+      return JSON.parse(out) as T;
+    } catch {
+      throw new Error(`desktop.ps1 ${command} returned invalid JSON: ${out.slice(0, 200)}`);
+    }
+  }
+
+  async getActiveWindow(): Promise<WindowInfo> {
+    const sc = await this.getSidecar();
+    if (sc) return sc.getActiveWindow();
+    return toWindowInfo(this.runScriptJson<ScriptWindow>('get-active-window'));
+  }
+
+  async getWindowTree(pid: number): Promise<UIElement[]> {
+    const sc = await this.getSidecar();
+    if (sc) return sc.getWindowTree(pid);
+    throw new Error(
+      'UI element traversal on Windows requires the desktop-bridge sidecar. ' +
+      'Build it with: bun run scripts/build-sidecar.ts',
+    );
   }
 
   async listWindows(): Promise<WindowInfo[]> {
-    throw new Error('WindowsAppController: Not implemented. Use sidecar desktop tools with a target parameter.');
+    const sc = await this.getSidecar();
+    if (sc) return sc.listWindows();
+    const result = this.runScriptJson<ScriptWindow[] | ScriptWindow>('list-windows');
+    const windows = Array.isArray(result) ? result : [result];
+    return windows.map(toWindowInfo);
   }
 
-  async clickElement(_element: UIElement): Promise<void> {
-    throw new Error('WindowsAppController: Not implemented. Use sidecar desktop tools with a target parameter.');
+  async clickElement(element: UIElement): Promise<void> {
+    const sc = await this.getSidecar();
+    if (sc) return sc.clickElement(element);
+    const x = Math.round(element.bounds.x + element.bounds.width / 2);
+    const y = Math.round(element.bounds.y + element.bounds.height / 2);
+    this.runScript('click-at', { x, y });
   }
 
-  async typeText(_text: string): Promise<void> {
-    throw new Error('WindowsAppController: Not implemented. Use sidecar desktop tools with a target parameter.');
+  async typeText(text: string): Promise<void> {
+    const sc = await this.getSidecar();
+    if (sc) return sc.typeText(text);
+    this.runScript('send-keys', { keys: escapeSendKeysText(text) });
   }
 
-  async pressKeys(_keys: string[]): Promise<void> {
-    throw new Error('WindowsAppController: Not implemented. Use sidecar desktop tools with a target parameter.');
+  async pressKeys(keys: string[]): Promise<void> {
+    const sc = await this.getSidecar();
+    if (sc) return sc.pressKeys(keys);
+    this.runScript('send-keys', { keys: mapKeysToSendKeys(keys) });
   }
 
   async captureScreen(): Promise<Buffer> {
-    throw new Error('WindowsAppController: Not implemented. Use sidecar desktop tools with a target parameter.');
+    const sc = await this.getSidecar();
+    if (sc) return sc.captureScreen();
+    const base64 = this.runScript('capture-screen');
+    if (!base64) throw new Error('capture-screen produced no image data');
+    return Buffer.from(base64, 'base64');
   }
 
-  async captureWindow(_pid: number): Promise<Buffer> {
-    throw new Error('WindowsAppController: Not implemented. Use sidecar desktop tools with a target parameter.');
+  async captureWindow(pid: number): Promise<Buffer> {
+    const sc = await this.getSidecar();
+    if (sc) return sc.captureWindow(pid);
+    const base64 = this.runScript('capture-window', { pid });
+    if (!base64) throw new Error(`capture-window produced no image data for PID ${pid}`);
+    return Buffer.from(base64, 'base64');
   }
 
-  async focusWindow(_pid: number): Promise<void> {
-    throw new Error('WindowsAppController: Not implemented. Use sidecar desktop tools with a target parameter.');
+  async focusWindow(pid: number): Promise<void> {
+    const sc = await this.getSidecar();
+    if (sc) return sc.focusWindow(pid);
+    this.runScript('focus-window', { pid });
+  }
+
+  async launchApp(executable: string, args?: string): Promise<object> {
+    if (!executable.trim()) throw new Error('Executable is required');
+    const sc = await this.getSidecar();
+    if (sc) return sc.launchApp(executable, args);
+    const result = this.runScriptJson<{ pid: number }>('launch-app', { executable, args: args ?? '' });
+    return { pid: result.pid, executable, args: args ?? '' };
+  }
+
+  async closeWindow(pid: number): Promise<void> {
+    const sc = await this.getSidecar();
+    if (sc) return sc.closeWindow(pid);
+    this.runScript('close-window', { pid });
   }
 }


### PR DESCRIPTION
Completes the app-controller half of #279 (thanks @yashmagar01 for the initial take), rebuilt along the lines requested in the review there. The vector-similarity half already landed via #281.

## What this does

Replaces the throwing `WindowsAppController` / `MacAppController` stubs with two-layer implementations:

1. **Sidecar-first** — desktop-bridge via TCP JSON-RPC when available, with a shared `SidecarProbe` (30s backoff between failed probes, one reused connection).
2. **Native fallback** — window listing/focus, input simulation, screenshots, launch/close through fixed script assets: `scripts/desktop.ps1` (PowerShell 5.1-compatible command dispatcher) and `scripts/desktop.applescript` (`on run argv` dispatcher).

`getWindowTree` (UI element trees) remains sidecar-only on both platforms and says so instead of pretending.

## Design points from the #279 review

- **No script assembly from user text.** The scripts ship as fixed assets; dynamic values travel as ASCII-safe JSON on stdin (Windows) or as `osascript` argv items (macOS). User/LLM-derived text can never escape into script source or a shell — this eliminates the injection bug class rather than patching instances of it.
- **Hard failures, no silent no-ops.** The shared `native-exec.ts` helper throws on spawn failure and non-zero exit with stderr included; both scripts report errors on stderr and exit 1. An agent planning its next step from action outcomes never sees a fake success.
- **Every bug called out in the #279 review is fixed and pinned by a regression test**, including: the lone-line `| ConvertTo-Json` PS 5.1 parse error, `$pid` read-only assignments, the invented SendKeys `{CLICK}` token (real clicks now via `SetCursorPos` + `mouse_event`), `!` mangling in typed text, `captureWindow` ignoring its pid, `keystroke "return"` typing the literal word (named keys now map to `key code` numbers), integer `&` list-concatenation corrupting window metadata, the `cliclick` dependency, `sh -c` launches, and swallowed stderr.
- Also fixed along the way: AppleScript identifiers colliding with System Events dictionary terms (terminology wins over variables at runtime), OEM-code-page corruption of non-ASCII text through `powershell.exe` stdin/stdout, per-call controller instances defeating sidecar backoff and leaking sockets (`getAppController()` now caches per process), DPI-virtualized coordinates on scaled displays, and WM_CLOSE instead of force-killing on `closeWindow`.

## Verification

This was developed on Linux, so in addition to the unit tests (52 new across `windows.test.ts` / `macos.test.ts` / `interface.test.ts`, asserting real command lines and payloads against an injected exec):

- `desktop.ps1` was executed in the `mcr.microsoft.com/powershell` container: parses, the Win32 C# interop compiles, stdin JSON payloads dispatch, non-ASCII survives, failures exit 1 via stderr. A conditional test repeats this wherever `pwsh` exists — including the ubuntu CI runner.
- New `applescript-check` CI job on `macos-latest`: `osacompile` the script, execute its event-free `probe` command on the real interpreter (catches runtime terminology collisions that compilation accepts), and assert unknown commands fail loudly.
- `bun test`: 1872 pass / 0 fail; `bunx tsc --noEmit` clean.

What CI still cannot cover: actually driving a real desktop (keystrokes, clicks, captures) on Windows/macOS hardware. The fallback paths are single commands against a fixed script, so a maintainer can smoke-test directly, e.g. `powershell -NoProfile -File src/actions/app-control/scripts/desktop.ps1 list-windows` or `osascript src/actions/app-control/scripts/desktop.applescript get-active-window`.

Closes #279.
