### PR TITLE
feat(llm): add OmniRoute provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ JARVIS is not a chatbot with tools. It is a persistent daemon that sees your scr
 | Voice with wake word | No | Yes — streaming TTS + openwakeword |
 | Goal pursuit (OKRs) | No | Yes — drill sergeant accountability |
 | Authority gating | No | Yes — runtime enforcement + audit trail |
-| LLM provider choice | Usually locked to one | 5 providers: Anthropic, OpenAI, Gemini, Ollama, Groq |
+| LLM provider choice | Usually locked to one | Anthropic, OpenAI, Gemini, Ollama, Groq, OpenRouter, OmniRoute, and more |
 
 ---
 

--- a/src/agents/voice-intent-classifier.ts
+++ b/src/agents/voice-intent-classifier.ts
@@ -267,7 +267,7 @@ settings room ("room": "settings"):
    matches "open the LLM tab", "switch to channels", "go to general settings"
 - "read_status" — args: {}
    matches "read the current status", "what's the LLM config", "what's connected"
-- "set_primary_llm" — args: { "provider": "anthropic"|"openai"|"groq"|"gemini"|"ollama"|"openrouter"|"nvidia"|"litellm" }
+- "set_primary_llm" — args: { "provider": "anthropic"|"openai"|"groq"|"gemini"|"ollama"|"openrouter"|"nvidia"|"litellm"|"omniroute" }
    matches "set primary to anthropic", "make openai the default", "switch to ollama"
 - "set_fallback_llm" — args: { "fallback": string[] | string }
    matches "set the fallback chain to openai and ollama", "use openai as fallback"

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -285,7 +285,8 @@ export type LLMProviderKind =
   | 'openrouter'
   | 'nvidia'
   | 'openai_compatible'
-  | 'litellm';
+  | 'litellm'
+  | 'omniroute';
 
 /**
  * Credentials + endpoint for one provider instance. The `kind` field is
@@ -299,7 +300,7 @@ export type LLMProviderEntry = {
   kind?: LLMProviderKind;
   /** API key for cloud providers. */
   api_key?: string;
-  /** Base URL for self-hosted / local providers (ollama, openai-compatible, litellm). */
+  /** Base URL for self-hosted / local providers (ollama, OpenAI-compatible gateways, OmniRoute). */
   base_url?: string;
 };
 

--- a/src/daemon/api-omniroute-models.test.ts
+++ b/src/daemon/api-omniroute-models.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it, beforeEach, afterEach } from 'bun:test';
+import { createApiRoutes, type ApiContext } from './api-routes.ts';
+import type { JarvisConfig, LLMProviderEntry } from '../config/types.ts';
+
+/**
+ * Tests for POST /api/config/llm/omniroute/models.
+ *
+ * The interesting part of this handler is credential/URL resolution: which
+ * base URL the catalog probe hits and - critically - when the stored API key
+ * is allowed to travel with it. A caller-typed base_url must never receive
+ * saved credentials, otherwise any caller who can reach the daemon can point
+ * the probe at their own host and harvest the key from the Authorization
+ * header. We stub global fetch and assert on the exact outgoing request.
+ */
+
+type Handler = (req: Request) => Response | Promise<Response>;
+type MethodHandlers = { GET?: Handler; POST?: Handler };
+
+function getHandler(routes: Record<string, unknown>, path: string, method: 'GET' | 'POST'): Handler {
+  const route = routes[path] as MethodHandlers | undefined;
+  if (!route) throw new Error(`Route ${path} not registered`);
+  const handler = route[method];
+  if (!handler) throw new Error(`Method ${method} not registered for ${path}`);
+  return handler;
+}
+
+function makeCtx(providers: Record<string, LLMProviderEntry>): ApiContext {
+  return {
+    daemonStartedAt: Date.now(),
+    healthMonitor: {} as ApiContext['healthMonitor'],
+    config: { llm: { providers } } as JarvisConfig,
+  } as ApiContext;
+}
+
+function callEndpoint(providers: Record<string, LLMProviderEntry>, body: Record<string, unknown>) {
+  const routes = createApiRoutes(makeCtx(providers));
+  const handler = getHandler(routes, '/api/config/llm/omniroute/models', 'POST');
+  return handler(new Request('http://x/api/config/llm/omniroute/models', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  }));
+}
+
+describe('POST /api/config/llm/omniroute/models', () => {
+  const realFetch = globalThis.fetch;
+  let upstream: { url: string; auth: string | undefined } | null;
+
+  beforeEach(() => {
+    upstream = null;
+    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      const headers = new Headers(init?.headers);
+      upstream = { url: String(input), auth: headers.get('Authorization') ?? undefined };
+      return new Response(JSON.stringify({ data: [{ id: 'auto' }, { id: 'free/gemini' }] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }) as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  it('never attaches the stored key to a caller-supplied base_url', async () => {
+    const res = await callEndpoint(
+      { 'omni-gw': { kind: 'omniroute', base_url: 'http://saved.example/v1', api_key: 'stored-secret' } },
+      { name: 'omni-gw', base_url: 'http://caller.example/v1' },
+    );
+    const body = await res.json() as { ok: boolean };
+    expect(body.ok).toBe(true);
+    expect(upstream!.url.startsWith('http://caller.example/v1')).toBe(true);
+    expect(upstream!.auth).toBeUndefined();
+  });
+
+  it('uses the stored key when the base URL also comes from stored config', async () => {
+    const res = await callEndpoint(
+      { 'omni-gw': { kind: 'omniroute', base_url: 'http://saved.example/v1', api_key: 'stored-secret' } },
+      { name: 'omni-gw' },
+    );
+    const body = await res.json() as { ok: boolean; models: string[] };
+    expect(body.ok).toBe(true);
+    expect(body.models).toEqual(['auto', 'free/gemini']);
+    expect(upstream!.url.startsWith('http://saved.example/v1')).toBe(true);
+    expect(upstream!.auth).toBe('Bearer stored-secret');
+  });
+
+  it('sends a caller-supplied key with a caller-supplied base_url', async () => {
+    const res = await callEndpoint(
+      {},
+      { base_url: 'http://caller.example/v1', api_key: 'typed-key' },
+    );
+    const body = await res.json() as { ok: boolean };
+    expect(body.ok).toBe(true);
+    expect(upstream!.auth).toBe('Bearer typed-key');
+  });
+
+  it('resolves kind as `entry.kind ?? name` like the rest of the system', async () => {
+    // A provider simply named "omniroute" with no explicit kind field.
+    const res = await callEndpoint(
+      { omniroute: { base_url: 'http://saved.example/v1' } },
+      { name: 'omniroute' },
+    );
+    const body = await res.json() as { ok: boolean };
+    expect(body.ok).toBe(true);
+    expect(upstream!.url.startsWith('http://saved.example/v1')).toBe(true);
+  });
+
+  it('discovers a kind-defaulted provider when no name is given', async () => {
+    const res = await callEndpoint(
+      { omniroute: { base_url: 'http://saved.example/v1' } },
+      {},
+    );
+    const body = await res.json() as { ok: boolean };
+    expect(body.ok).toBe(true);
+    expect(upstream!.url.startsWith('http://saved.example/v1')).toBe(true);
+  });
+
+  it('rejects a name that is not an OmniRoute provider', async () => {
+    const res = await callEndpoint(
+      { anthropic: { kind: 'anthropic', api_key: 'sk-x' } },
+      { name: 'anthropic' },
+    );
+    const body = await res.json() as { ok: boolean; error: string };
+    expect(body.ok).toBe(false);
+    expect(body.error).toBe('OmniRoute provider not found');
+    expect(upstream).toBeNull();
+  });
+
+  it('rejects an unknown provider name', async () => {
+    const res = await callEndpoint({}, { name: 'nope' });
+    const body = await res.json() as { ok: boolean; error: string };
+    expect(body.ok).toBe(false);
+    expect(body.error).toBe('OmniRoute provider not found');
+    expect(upstream).toBeNull();
+  });
+
+  it('rejects a non-http(s) base_url', async () => {
+    const res = await callEndpoint({}, { base_url: 'file:///etc/passwd' });
+    const body = await res.json() as { ok: boolean; error: string };
+    expect(body.ok).toBe(false);
+    expect(body.error).toBe('base_url must be an http(s) URL');
+    expect(upstream).toBeNull();
+  });
+
+  it('falls back to the default local URL with no key when nothing is configured', async () => {
+    const res = await callEndpoint({}, {});
+    const body = await res.json() as { ok: boolean };
+    expect(body.ok).toBe(true);
+    expect(upstream!.url.startsWith('http://localhost:20128/v1')).toBe(true);
+    expect(upstream!.auth).toBeUndefined();
+  });
+});

--- a/src/daemon/api-routes.ts
+++ b/src/daemon/api-routes.ts
@@ -1557,10 +1557,13 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
             base_url?: string;
             api_key?: string;
           };
-          const configured = body.name
-            ? ctx.config.llm.providers?.[body.name]
-            : Object.values(ctx.config.llm.providers ?? {}).find((entry) => entry?.kind === 'omniroute');
-          if (body.name && configured?.kind !== 'omniroute') {
+          // Effective kind is `entry.kind ?? name` (see config-binding.ts) -
+          // a provider simply named "omniroute" counts too.
+          const providers = ctx.config.llm.providers ?? {};
+          const providerName = body.name
+            ?? Object.keys(providers).find((name) => (providers[name]?.kind ?? name) === 'omniroute');
+          const configured = providerName ? providers[providerName] : undefined;
+          if (body.name && (!configured || (configured.kind ?? body.name) !== 'omniroute')) {
             return json({ ok: false, error: 'OmniRoute provider not found', models: [] });
           }
           const requestedBaseUrl = body.base_url?.trim();
@@ -1569,11 +1572,13 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
             return json({ ok: false, error: 'base_url must be an http(s) URL', models: [] });
           }
 
+          // Saved credentials only travel to the saved base URL - a caller-typed
+          // base_url never gets the stored key attached.
           const { getSecret } = await import('../vault/keychain.ts');
-          const apiKey = body.api_key
-            || (body.name && !requestedBaseUrl ? getSecret(`llm.provider.${body.name}.api_key`) : null)
-            || configured?.api_key
-            || '';
+          const storedApiKey = requestedBaseUrl
+            ? null
+            : (providerName ? getSecret(`llm.provider.${providerName}.api_key`) : null) || configured?.api_key;
+          const apiKey = body.api_key || storedApiKey || '';
           const { OmniRouteProvider } = await import('../llm/omniroute.ts');
           const models = await new OmniRouteProvider(baseUrl, 'auto', apiKey).listModels();
           return json({ ok: true, models });

--- a/src/daemon/api-routes.ts
+++ b/src/daemon/api-routes.ts
@@ -1563,14 +1563,15 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
           if (body.name && configured?.kind !== 'omniroute') {
             return json({ ok: false, error: 'OmniRoute provider not found', models: [] });
           }
-          const baseUrl = body.base_url?.trim() || configured?.base_url || 'http://localhost:20128/v1';
+          const requestedBaseUrl = body.base_url?.trim();
+          const baseUrl = requestedBaseUrl || configured?.base_url?.trim() || 'http://localhost:20128/v1';
           if (!/^https?:\/\//i.test(baseUrl)) {
             return json({ ok: false, error: 'base_url must be an http(s) URL', models: [] });
           }
 
           const { getSecret } = await import('../vault/keychain.ts');
           const apiKey = body.api_key
-            || (body.name && !body.base_url ? getSecret(`llm.provider.${body.name}.api_key`) : null)
+            || (body.name && !requestedBaseUrl ? getSecret(`llm.provider.${body.name}.api_key`) : null)
             || configured?.api_key
             || '';
           const { OmniRouteProvider } = await import('../llm/omniroute.ts');

--- a/src/daemon/api-routes.ts
+++ b/src/daemon/api-routes.ts
@@ -1546,6 +1546,43 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
       },
     },
 
+    // Full OmniRoute catalog: provider models, free routes, automatic routes,
+    // and user-defined combos. POST keeps an onboarding API key out of the URL
+    // and also supports a saved provider by name from Settings.
+    '/api/config/llm/omniroute/models': {
+      POST: async (req: Request) => {
+        try {
+          const body = await req.json() as {
+            name?: string;
+            base_url?: string;
+            api_key?: string;
+          };
+          const configured = body.name
+            ? ctx.config.llm.providers?.[body.name]
+            : Object.values(ctx.config.llm.providers ?? {}).find((entry) => entry?.kind === 'omniroute');
+          if (body.name && configured?.kind !== 'omniroute') {
+            return json({ ok: false, error: 'OmniRoute provider not found', models: [] });
+          }
+          const baseUrl = body.base_url?.trim() || configured?.base_url || 'http://localhost:20128/v1';
+          if (!/^https?:\/\//i.test(baseUrl)) {
+            return json({ ok: false, error: 'base_url must be an http(s) URL', models: [] });
+          }
+
+          const { getSecret } = await import('../vault/keychain.ts');
+          const apiKey = body.api_key
+            || (body.name && !body.base_url ? getSecret(`llm.provider.${body.name}.api_key`) : null)
+            || configured?.api_key
+            || '';
+          const { OmniRouteProvider } = await import('../llm/omniroute.ts');
+          const models = await new OmniRouteProvider(baseUrl, 'auto', apiKey).listModels();
+          return json({ ok: true, models });
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          return json({ ok: false, error: msg, models: [] });
+        }
+      },
+    },
+
     // --- Usage telemetry ---
     /**
      * Filterable LLM usage query. All query params are optional:

--- a/src/daemon/llm-settings.ts
+++ b/src/daemon/llm-settings.ts
@@ -345,7 +345,6 @@ function migrateLegacyDBSettings(config: JarvisConfig): void {
     { kind: 'ollama', secretKey: '', modelKey: 'llm.ollama.model', baseUrlKey: 'llm.ollama.base_url' },
     { kind: 'openai_compatible', secretKey: 'llm.openai_compatible.api_key', modelKey: 'llm.openai_compatible.model', baseUrlKey: 'llm.openai_compatible.base_url' },
     { kind: 'litellm', secretKey: 'llm.litellm.api_key', modelKey: 'llm.litellm.model', baseUrlKey: 'llm.litellm.base_url' },
-    { kind: 'omniroute', secretKey: 'llm.omniroute.api_key', modelKey: 'llm.omniroute.model', baseUrlKey: 'llm.omniroute.base_url' },
   ];
 
   // Capture legacy per-kind models for building model-ref strings later.

--- a/src/daemon/llm-settings.ts
+++ b/src/daemon/llm-settings.ts
@@ -101,6 +101,7 @@ export const AVAILABLE_KINDS: LLMProviderKind[] = [
   'nvidia',
   'openai_compatible',
   'litellm',
+  'omniroute',
 ];
 
 // ── getLLMSettings ───────────────────────────────────────────────────────
@@ -344,6 +345,7 @@ function migrateLegacyDBSettings(config: JarvisConfig): void {
     { kind: 'ollama', secretKey: '', modelKey: 'llm.ollama.model', baseUrlKey: 'llm.ollama.base_url' },
     { kind: 'openai_compatible', secretKey: 'llm.openai_compatible.api_key', modelKey: 'llm.openai_compatible.model', baseUrlKey: 'llm.openai_compatible.base_url' },
     { kind: 'litellm', secretKey: 'llm.litellm.api_key', modelKey: 'llm.litellm.model', baseUrlKey: 'llm.litellm.base_url' },
+    { kind: 'omniroute', secretKey: 'llm.omniroute.api_key', modelKey: 'llm.omniroute.model', baseUrlKey: 'llm.omniroute.base_url' },
   ];
 
   // Capture legacy per-kind models for building model-ref strings later.

--- a/src/llm/README.md
+++ b/src/llm/README.md
@@ -31,6 +31,14 @@ A unified abstraction layer for multiple LLM providers with automatic fallback s
 - **Features**: Local inference, streaming, tool use
 - **API**: http://localhost:11434/api/chat
 
+### 4. OmniRoute
+- **Routes**: Every model, free route, automatic route, and combo returned by the configured gateway
+- **Default route**: `auto`
+- **Features**: Text and multimodal messages, streaming, function/tool calling, live route discovery
+- **Default API**: http://localhost:20128/v1
+
+Jarvis also includes first-class adapters for Groq, Gemini, OpenRouter, NVIDIA NIM, LiteLLM, and generic OpenAI-compatible endpoints.
+
 ## Usage
 
 ### Basic Setup

--- a/src/llm/config-binding.ts
+++ b/src/llm/config-binding.ts
@@ -26,6 +26,7 @@ import { OpenRouterProvider } from './openrouter.ts';
 import { NVIDIAProvider } from './nvidia.ts';
 import { OpenAICompatibleProvider } from './openai-compatible.ts';
 import { LiteLLMProvider } from './litellm.ts';
+import { OmniRouteProvider } from './omniroute.ts';
 
 /**
  * Instantiate a provider class from a single entry. Returns null when the
@@ -90,6 +91,10 @@ export function instantiateProvider(
     case 'litellm':
       if (!entry.base_url) return null;
       provider = new LiteLLMProvider(entry.base_url, undefined, entry.api_key);
+      break;
+    case 'omniroute':
+      if (!entry.base_url) return null;
+      provider = new OmniRouteProvider(entry.base_url, undefined, entry.api_key);
       break;
     default:
       console.warn(`[LLM] Unknown provider kind '${kind}' for '${name}' - skipping.`);

--- a/src/llm/config-binding.ts
+++ b/src/llm/config-binding.ts
@@ -93,8 +93,7 @@ export function instantiateProvider(
       provider = new LiteLLMProvider(entry.base_url, undefined, entry.api_key);
       break;
     case 'omniroute':
-      if (!entry.base_url) return null;
-      provider = new OmniRouteProvider(entry.base_url, undefined, entry.api_key);
+      provider = new OmniRouteProvider(entry.base_url?.trim() || undefined, undefined, entry.api_key);
       break;
     default:
       console.warn(`[LLM] Unknown provider kind '${kind}' for '${name}' - skipping.`);

--- a/src/llm/index.ts
+++ b/src/llm/index.ts
@@ -18,6 +18,7 @@ export { GeminiProvider } from './gemini.ts';
 export { OllamaProvider } from './ollama.ts';
 export { OpenRouterProvider } from './openrouter.ts';
 export { LiteLLMProvider } from './litellm.ts';
+export { OmniRouteProvider } from './omniroute.ts';
 
 // Manager
 export { LLMManager } from './manager.ts';

--- a/src/llm/omniroute.test.ts
+++ b/src/llm/omniroute.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import { OmniRouteProvider } from './omniroute.ts';
+import { instantiateProvider } from './config-binding.ts';
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe('OmniRouteProvider', () => {
+  it('uses the OmniRoute local endpoint by default', () => {
+    const provider = new OmniRouteProvider();
+    expect(provider.name).toBe('omniroute');
+    expect((provider as any).apiUrl).toBe('http://localhost:20128/v1/chat/completions');
+  });
+
+  it('is created by the canonical config binding with its custom provider name', () => {
+    const provider = instantiateProvider('omni-free', {
+      kind: 'omniroute',
+      base_url: 'http://localhost:20128/v1',
+      api_key: 'sk-omni',
+    });
+    expect(provider).toBeInstanceOf(OmniRouteProvider);
+    expect(provider?.name).toBe('omni-free');
+  });
+
+  it('sends OpenAI function tools and parses returned tool calls', async () => {
+    let requestUrl = '';
+    let requestHeaders: Headers | undefined;
+    let requestBody: Record<string, any> = {};
+    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      requestUrl = String(input);
+      requestHeaders = new Headers(init?.headers);
+      requestBody = JSON.parse(String(init?.body));
+      return new Response(JSON.stringify({
+        id: 'chatcmpl-omni',
+        object: 'chat.completion',
+        created: 0,
+        model: 'free-coding-combo',
+        choices: [{
+          index: 0,
+          message: {
+            role: 'assistant',
+            content: null,
+            tool_calls: [{
+              id: 'call_1',
+              type: 'function',
+              function: { name: 'search', arguments: '{"query":"Jarvis"}' },
+            }],
+          },
+          finish_reason: 'tool_calls',
+        }],
+        usage: { prompt_tokens: 12, completion_tokens: 5, total_tokens: 17 },
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+    }) as typeof fetch;
+
+    const provider = new OmniRouteProvider('https://omni.example/v1/', 'auto', 'sk-omni');
+    const result = await provider.chat(
+      [{ role: 'user', content: 'Find Jarvis' }],
+      {
+        model: 'free-coding-combo',
+        tools: [{
+          name: 'search',
+          description: 'Search the web',
+          parameters: { type: 'object', properties: { query: { type: 'string' } } },
+        }],
+      },
+    );
+
+    expect(requestUrl).toBe('https://omni.example/v1/chat/completions');
+    expect(requestHeaders?.get('Authorization')).toBe('Bearer sk-omni');
+    expect(requestBody.model).toBe('free-coding-combo');
+    expect(requestBody.tool_choice).toBe('auto');
+    expect(requestBody.tools[0].function.name).toBe('search');
+    expect(result.tool_calls).toEqual([{ id: 'call_1', name: 'search', arguments: { query: 'Jarvis' } }]);
+    expect(result.finish_reason).toBe('tool_use');
+  });
+
+  it('returns every model and combo route without OpenAI-family filtering', async () => {
+    globalThis.fetch = (async () => new Response(JSON.stringify({
+      object: 'list',
+      data: [
+        { id: 'auto' },
+        { id: 'cc/claude-opus-4-6' },
+        { id: 'free-coding-combo' },
+        { id: 'google/gemini-3-flash' },
+        { id: 'auto' },
+      ],
+    }), { status: 200 })) as unknown as typeof fetch;
+
+    const models = await new OmniRouteProvider(undefined, undefined, 'sk-omni').listModels();
+    expect(models).toEqual([
+      'auto',
+      'cc/claude-opus-4-6',
+      'free-coding-combo',
+      'google/gemini-3-flash',
+    ]);
+  });
+
+  it('assembles streamed tool-call deltas from routed models', async () => {
+    const events = [
+      { id: '1', object: 'chat.completion.chunk', created: 0, model: 'auto', choices: [{ index: 0, delta: { tool_calls: [{ index: 0, id: 'call_stream', type: 'function', function: { name: 'weather', arguments: '{"city"' } }] }, finish_reason: null }] },
+      { id: '1', object: 'chat.completion.chunk', created: 0, model: 'auto', choices: [{ index: 0, delta: { tool_calls: [{ index: 0, function: { arguments: ':"Paris"}' } }] }, finish_reason: 'tool_calls' }] },
+    ];
+    const sse = `${events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join('')}data: [DONE]\n\n`;
+    globalThis.fetch = (async () => new Response(sse, {
+      status: 200,
+      headers: { 'Content-Type': 'text/event-stream' },
+    })) as unknown as typeof fetch;
+
+    const received = [];
+    for await (const event of new OmniRouteProvider().stream(
+      [{ role: 'user', content: 'Weather?' }],
+      { tools: [{ name: 'weather', description: 'Get weather', parameters: { type: 'object' } }] },
+    )) {
+      received.push(event);
+    }
+
+    expect(received).toContainEqual({
+      type: 'tool_call',
+      tool_call: { id: 'call_stream', name: 'weather', arguments: { city: 'Paris' } },
+    });
+    const done = received.find((event) => event.type === 'done');
+    expect(done?.type === 'done' ? done.response.finish_reason : null).toBe('tool_use');
+  });
+});

--- a/src/llm/omniroute.test.ts
+++ b/src/llm/omniroute.test.ts
@@ -25,6 +25,15 @@ describe('OmniRouteProvider', () => {
     expect(provider?.name).toBe('omni-free');
   });
 
+  it('uses the local default when config omits the base URL', () => {
+    const provider = instantiateProvider('omni-local', {
+      kind: 'omniroute',
+      api_key: 'sk-omni',
+    });
+    expect(provider).toBeInstanceOf(OmniRouteProvider);
+    expect((provider as any).apiUrl).toBe('http://localhost:20128/v1/chat/completions');
+  });
+
   it('sends OpenAI function tools and parses returned tool calls', async () => {
     let requestUrl = '';
     let requestHeaders: Headers | undefined;

--- a/src/llm/omniroute.ts
+++ b/src/llm/omniroute.ts
@@ -1,0 +1,55 @@
+import { OpenAIProvider } from './openai.ts';
+
+/**
+ * OmniRoute is an OpenAI-compatible gateway that combines provider models,
+ * subscription-backed routes, free routes, and user-defined routing combos
+ * behind one endpoint. Reusing OpenAIProvider gives it the same multimodal
+ * messages, streaming, and function/tool-call support as Jarvis' OpenAI path.
+ *
+ * OmniRoute's default local API is http://localhost:20128/v1. A remote or
+ * reverse-proxied installation can be supplied through baseUrl instead.
+ */
+export class OmniRouteProvider extends OpenAIProvider {
+  override name = 'omniroute';
+
+  constructor(
+    baseUrl = 'http://localhost:20128/v1',
+    defaultModel = 'auto',
+    apiKey = '',
+  ) {
+    super(apiKey, defaultModel, baseUrl);
+  }
+
+  protected override get errorLabel(): string {
+    return 'OmniRoute';
+  }
+
+  /**
+   * Return the complete live catalog, including OmniRoute combos and routing
+   * aliases. OpenAIProvider intentionally filters its catalog to OpenAI model
+   * families, which is incorrect for a multi-provider gateway.
+   */
+  override async listModels(): Promise<string[]> {
+    const headers: Record<string, string> = {};
+    if (this.apiKey) headers.Authorization = `Bearer ${this.apiKey}`;
+
+    const response = await fetch(this.modelsUrl, { headers });
+    if (!response.ok) {
+      const detail = await response.text().catch(() => '');
+      throw new Error(
+        `OmniRoute API error (${response.status}) while listing routes${detail ? `: ${detail}` : ''}`,
+      );
+    }
+
+    const payload = await response.json() as { data?: Array<{ id?: unknown }> };
+    if (!Array.isArray(payload.data)) {
+      throw new Error('OmniRoute returned an invalid model catalog');
+    }
+
+    return [...new Set(
+      payload.data
+        .map((entry) => entry.id)
+        .filter((id): id is string => typeof id === 'string' && id.length > 0),
+    )].sort((a, b) => a.localeCompare(b));
+  }
+}

--- a/ui/src/v2/onboarding/OnboardingWizard.tsx
+++ b/ui/src/v2/onboarding/OnboardingWizard.tsx
@@ -40,7 +40,7 @@ const Glyph = ({ k }: { k: string }) => <span dangerouslySetInnerHTML={{ __html:
 /* — providers (backend kind ids); model lists per the design — */
 type Provider = {
   id: string; name: string; abbr: string; kind: string; reco?: boolean; soon?: boolean;
-  noConfig?: boolean; needsKey?: boolean; needsBaseUrl?: boolean; freeModel?: boolean;
+  noConfig?: boolean; needsKey?: boolean; keyOptional?: boolean; needsBaseUrl?: boolean; freeModel?: boolean;
   urlLabel?: string; urlPh?: string; models?: string[]; hint?: string;
 };
 const PROVIDERS: Provider[] = [
@@ -54,7 +54,7 @@ const PROVIDERS: Provider[] = [
   { id: "nvidia", name: "NVIDIA NIM", abbr: "N", kind: "API key", needsKey: true, models: ["meta/llama-3.3-70b-instruct"], hint: "Live model catalog loads from your NVIDIA account." },
   { id: "openai_compatible", name: "OpenAI-compatible", abbr: "C", kind: "self-hosted", needsBaseUrl: true, freeModel: true, urlLabel: "Base URL", urlPh: "http://localhost:8080/v1", hint: "Any server that speaks /v1/chat/completions: llama.cpp, vLLM, LM Studio, TGI. Include the /v1 suffix." },
   { id: "litellm", name: "LiteLLM", abbr: "L", kind: "proxy", needsBaseUrl: true, freeModel: true, urlLabel: "LiteLLM proxy URL", urlPh: "http://localhost:4000/v1", hint: "The model below must match an alias defined on your proxy." },
-  { id: "omniroute", name: "OmniRoute", abbr: "Om", kind: "gateway", needsKey: true, needsBaseUrl: true, urlLabel: "OmniRoute API URL", urlPh: "http://localhost:20128/v1", models: ["auto"], hint: "Loads every route and combo from your OmniRoute instance. Tool calls and streaming are supported through its OpenAI-compatible API." },
+  { id: "omniroute", name: "OmniRoute", abbr: "Om", kind: "gateway", needsKey: true, keyOptional: true, needsBaseUrl: true, urlLabel: "OmniRoute API URL", urlPh: "http://localhost:20128/v1", models: ["auto"], hint: "Loads every route and combo from your OmniRoute instance. Tool calls and streaming are supported through its OpenAI-compatible API." },
 ];
 
 const EDGE_VOICES = [
@@ -173,10 +173,13 @@ export function OnboardingWizard({
   // Reset the ElevenLabs test whenever the key changes or the provider flips.
   useEffect(() => { setTtsTest({ status: "idle" }); }, [elevenKey, tts]);
 
+  // Restore the URL last typed for each provider instead of clobbering it
+  // with the default every time the user toggles between providers.
+  const urlByProvider = useRef<Record<string, string>>({});
   useEffect(() => {
     const p = PROVIDERS.find((x) => x.id === provId)!;
     setModel(p.models?.[0] ?? "");
-    if (provId === "omniroute") setBaseUrl("http://localhost:20128/v1");
+    setBaseUrl(urlByProvider.current[provId] ?? (provId === "omniroute" ? "http://localhost:20128/v1" : ""));
     setTest({ status: "idle" });
   }, [provId]);
 
@@ -231,14 +234,17 @@ export function OnboardingWizard({
   const [omniRouteModels, setOmniRouteModels] = useState<string[] | null>(null);
   const [omniRouteLoading, setOmniRouteLoading] = useState(false);
   useEffect(() => {
-    if (provId !== "omniroute" || !baseUrl.trim() || !apiKey) return;
+    if (provId !== "omniroute") return;
+    // No URL to probe: also drop a catalog fetched with earlier inputs so a
+    // stale list doesn't linger on screen.
+    if (!baseUrl.trim()) { setOmniRouteModels(null); return; }
     let cancelled = false;
     setOmniRouteLoading(true);
     const timer = window.setTimeout(() => {
       fetch("/api/config/llm/omniroute/models", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ base_url: baseUrl.trim(), api_key: apiKey }),
+        body: JSON.stringify({ base_url: baseUrl.trim(), ...(apiKey ? { api_key: apiKey } : {}) }),
       })
         .then((r) => r.json())
         .then((d: { ok: boolean; models?: string[] }) => {
@@ -272,7 +278,10 @@ export function OnboardingWizard({
     setTest({ status: "testing" });
     try {
       const body: Record<string, unknown> = { provider: provId, model };
-      if (prov.needsKey) { if (!apiKey) { setTest({ status: "err", msg: "Enter an API key first." }); return; } body.api_key = apiKey; }
+      if (prov.needsKey) {
+        if (!apiKey && !prov.keyOptional) { setTest({ status: "err", msg: "Enter an API key first." }); return; }
+        if (apiKey) body.api_key = apiKey;
+      }
       if (prov.needsBaseUrl) { if (!baseUrl.trim()) { setTest({ status: "err", msg: "Enter a base URL first." }); return; } body.base_url = baseUrl.trim(); }
       if ((provId === "openai_compatible" || provId === "litellm") && apiKey) body.api_key = apiKey;
       const r = await fetch("/api/config/llm/test", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(body) });
@@ -748,8 +757,8 @@ export function OnboardingWizard({
         : (prov.models ?? []);
     return (
       <>
-        {prov.needsBaseUrl && <div className="obw-field"><label>{prov.urlLabel}</label><input className="obw-inp" placeholder={prov.urlPh} value={baseUrl} onChange={(e) => setBaseUrl(e.target.value)} /></div>}
-        {prov.needsKey && <div className="obw-field"><label>API key</label><input className="obw-inp" type="password" placeholder="paste your key" value={apiKey} onChange={(e) => setApiKey(e.target.value)} /></div>}
+        {prov.needsBaseUrl && <div className="obw-field"><label>{prov.urlLabel}</label><input className="obw-inp" placeholder={prov.urlPh} value={baseUrl} onChange={(e) => { urlByProvider.current[provId] = e.target.value; setBaseUrl(e.target.value); }} /></div>}
+        {prov.needsKey && <div className="obw-field"><label>API key{prov.keyOptional ? " (optional)" : ""}</label><input className="obw-inp" type="password" placeholder="paste your key" value={apiKey} onChange={(e) => setApiKey(e.target.value)} /></div>}
         {prov.freeModel
           ? <div className="obw-field"><label>Model</label><input className="obw-inp" placeholder="model id" value={model} onChange={(e) => setModel(e.target.value)} /></div>
           : <div className="obw-field"><label>Model</label><select className="obw-inp" value={model} onChange={(e) => setModel(e.target.value)}>{pickerModels.map((m) => <option key={m} value={m}>{m}</option>)}</select></div>}

--- a/ui/src/v2/onboarding/OnboardingWizard.tsx
+++ b/ui/src/v2/onboarding/OnboardingWizard.tsx
@@ -54,6 +54,7 @@ const PROVIDERS: Provider[] = [
   { id: "nvidia", name: "NVIDIA NIM", abbr: "N", kind: "API key", needsKey: true, models: ["meta/llama-3.3-70b-instruct"], hint: "Live model catalog loads from your NVIDIA account." },
   { id: "openai_compatible", name: "OpenAI-compatible", abbr: "C", kind: "self-hosted", needsBaseUrl: true, freeModel: true, urlLabel: "Base URL", urlPh: "http://localhost:8080/v1", hint: "Any server that speaks /v1/chat/completions: llama.cpp, vLLM, LM Studio, TGI. Include the /v1 suffix." },
   { id: "litellm", name: "LiteLLM", abbr: "L", kind: "proxy", needsBaseUrl: true, freeModel: true, urlLabel: "LiteLLM proxy URL", urlPh: "http://localhost:4000/v1", hint: "The model below must match an alias defined on your proxy." },
+  { id: "omniroute", name: "OmniRoute", abbr: "Om", kind: "gateway", needsKey: true, needsBaseUrl: true, urlLabel: "OmniRoute API URL", urlPh: "http://localhost:20128/v1", models: ["auto"], hint: "Loads every route and combo from your OmniRoute instance. Tool calls and streaming are supported through its OpenAI-compatible API." },
 ];
 
 const EDGE_VOICES = [
@@ -175,6 +176,7 @@ export function OnboardingWizard({
   useEffect(() => {
     const p = PROVIDERS.find((x) => x.id === provId)!;
     setModel(p.models?.[0] ?? "");
+    if (provId === "omniroute") setBaseUrl("http://localhost:20128/v1");
     setTest({ status: "idle" });
   }, [provId]);
 
@@ -222,6 +224,36 @@ export function OnboardingWizard({
       setModel(sameFamily ?? ollamaModels[0]!);
     }
   }, [ollamaModels, provId]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // OmniRoute's catalog is installation-specific: it includes configured
+  // providers, free routes, and custom combos. Read it live instead of
+  // shipping a stale shortlist. The key travels in a POST body, never a URL.
+  const [omniRouteModels, setOmniRouteModels] = useState<string[] | null>(null);
+  const [omniRouteLoading, setOmniRouteLoading] = useState(false);
+  useEffect(() => {
+    if (provId !== "omniroute" || !baseUrl.trim() || !apiKey) return;
+    let cancelled = false;
+    setOmniRouteLoading(true);
+    const timer = window.setTimeout(() => {
+      fetch("/api/config/llm/omniroute/models", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ base_url: baseUrl.trim(), api_key: apiKey }),
+      })
+        .then((r) => r.json())
+        .then((d: { ok: boolean; models?: string[] }) => {
+          if (!cancelled) setOmniRouteModels(d.ok && d.models ? d.models : []);
+        })
+        .catch(() => { if (!cancelled) setOmniRouteModels([]); })
+        .finally(() => { if (!cancelled) setOmniRouteLoading(false); });
+    }, 400);
+    return () => { cancelled = true; window.clearTimeout(timer); };
+  }, [provId, baseUrl, apiKey]);
+
+  useEffect(() => {
+    if (provId !== "omniroute" || !omniRouteModels?.length) return;
+    if (!omniRouteModels.includes(model)) setModel(omniRouteModels.includes("auto") ? "auto" : omniRouteModels[0]!);
+  }, [omniRouteModels, provId]); // model intentionally snaps when the catalog arrives
 
   // The Google OAuth poll outlives the click handler — keep its id in a ref so
   // finishing/unmounting the wizard stops it (it ran for up to 5 min after).
@@ -709,7 +741,11 @@ export function OnboardingWizard({
   function renderProvDetail() {
     if (prov.noConfig) return <div className="obw-testres ok" style={{ fontSize: 12 }}><span className="dot" />Jarvis AI is included with your plan. Nothing to configure.</div>;
     // The live Ollama catalog when we have one, the curated list otherwise.
-    const pickerModels = provId === "ollama" && ollamaModels && ollamaModels.length > 0 ? ollamaModels : (prov.models ?? []);
+    const pickerModels = provId === "ollama" && ollamaModels && ollamaModels.length > 0
+      ? ollamaModels
+      : provId === "omniroute" && omniRouteModels && omniRouteModels.length > 0
+        ? omniRouteModels
+        : (prov.models ?? []);
     return (
       <>
         {prov.needsBaseUrl && <div className="obw-field"><label>{prov.urlLabel}</label><input className="obw-inp" placeholder={prov.urlPh} value={baseUrl} onChange={(e) => setBaseUrl(e.target.value)} /></div>}
@@ -719,6 +755,8 @@ export function OnboardingWizard({
           : <div className="obw-field"><label>Model</label><select className="obw-inp" value={model} onChange={(e) => setModel(e.target.value)}>{pickerModels.map((m) => <option key={m} value={m}>{m}</option>)}</select></div>}
         {provId === "ollama" && ollamaLoading && <div className="obw-hint">Reading installed models from Ollama…</div>}
         {provId === "ollama" && !ollamaLoading && ollamaModels?.length === 0 && <div className="obw-hint">Could not reach Ollama at this URL — showing suggestions instead. Make sure Ollama is running (models must include their tag, e.g. llama3.1:8b).</div>}
+        {provId === "omniroute" && omniRouteLoading && <div className="obw-hint">Loading every OmniRoute model and combo…</div>}
+        {provId === "omniroute" && !omniRouteLoading && omniRouteModels?.length === 0 && <div className="obw-hint">Could not read this OmniRoute catalog. Check the URL and API key; you can still test the auto route.</div>}
         <div className="obw-testrow">
           <button className="obw-btn obw-btn-ghost sm" disabled={test.status === "testing"} onClick={runTest}>{test.status === "testing" ? "Testing…" : "Test connection"}</button>
           {test.status === "ok" && <span className="obw-testres ok"><span className="dot" />Connected · {test.msg}</span>}

--- a/ui/src/v2/rooms/settings/tabs/LLMTab.tsx
+++ b/ui/src/v2/rooms/settings/tabs/LLMTab.tsx
@@ -6,6 +6,7 @@ import {
   KEY_BASED_KINDS,
   LLM_PROVIDER_KIND_LABELS,
   LLM_PROVIDER_KINDS,
+  OPTIONAL_KEY_KINDS,
   URL_BASED_KINDS,
   type LLMConfigProviderView,
   type LLMProviderKind,
@@ -315,7 +316,8 @@ function ProviderRow({
 }) {
   const usesUrl = URL_BASED_KINDS.has(entry.kind);
   const usesKey = KEY_BASED_KINDS.has(entry.kind);
-  const configured = (!usesUrl || !!entry.base_url?.trim()) && (!usesKey || entry.has_api_key);
+  const needsKey = usesKey && !OPTIONAL_KEY_KINDS.has(entry.kind);
+  const configured = (!usesUrl || !!entry.base_url?.trim()) && (!needsKey || entry.has_api_key);
 
   const [apiKey, setApiKey] = useState("");
   const [baseUrl, setBaseUrl] = useState(entry.base_url ?? "");
@@ -354,7 +356,7 @@ function ProviderRow({
         <div className="v2-set__row-body">
           {usesKey && (
             <div className="v2-set__field">
-              <label className="v2-set__field-label">API key</label>
+              <label className="v2-set__field-label">API key{needsKey ? "" : " (optional)"}</label>
               <input
                 type="password"
                 className="v2-set__input"
@@ -457,6 +459,7 @@ function NewProviderRow({
 
   const usesUrl = URL_BASED_KINDS.has(kind);
   const usesKey = KEY_BASED_KINDS.has(kind);
+  const needsKey = usesKey && !OPTIONAL_KEY_KINDS.has(kind);
   // Suggest name = kind unless user typed something
   const effectiveName = name.trim() || kind;
   const duplicate = existing.includes(effectiveName);
@@ -503,7 +506,7 @@ function NewProviderRow({
 
         {usesKey && (
           <div className="v2-set__field">
-            <label className="v2-set__field-label">API key</label>
+            <label className="v2-set__field-label">API key{needsKey ? "" : " (optional)"}</label>
             <input
               type="password"
               className="v2-set__input"
@@ -532,7 +535,7 @@ function NewProviderRow({
           <button
             type="button"
             className="v2-set__btn v2-set__btn--primary"
-            disabled={saving || duplicate || (usesKey && !apiKey) || (usesUrl && !baseUrl)}
+            disabled={saving || duplicate || (needsKey && !apiKey) || (usesUrl && !baseUrl)}
             onClick={async () => {
               setSaving(true);
               const input: { kind: LLMProviderKind; api_key?: string; base_url?: string } = { kind };

--- a/ui/src/v2/rooms/settings/tabs/LLMTab.tsx
+++ b/ui/src/v2/rooms/settings/tabs/LLMTab.tsx
@@ -17,7 +17,8 @@ import {
 /**
  * Curated model lists per provider class. Each key is a kind (not a name)
  * so multiple instances of the same kind share the same dropdown. Empty
- * arrays mean "type any model id" (openai_compatible / litellm proxies).
+ * arrays mean "type any model id" (OpenAI-compatible gateways). OmniRoute's
+ * routes are loaded live because its catalog includes user-defined combos.
  */
 const MODELS_BY_KIND: Record<LLMProviderKind, string[]> = {
   anthropic: [
@@ -86,6 +87,14 @@ const MODELS_BY_KIND: Record<LLMProviderKind, string[]> = {
   ],
   openai_compatible: [],
   litellm: [],
+  omniroute: [],
+};
+
+const DEFAULT_BASE_URLS: Partial<Record<LLMProviderKind, string>> = {
+  ollama: "http://localhost:11434",
+  openai_compatible: "http://localhost:8080/v1",
+  litellm: "http://localhost:4000/v1",
+  omniroute: "http://localhost:20128/v1",
 };
 
 /**
@@ -123,6 +132,7 @@ export function LLMTab({
   const ollamaModels = useOllamaModels(
     Object.values(llm?.providers ?? {}).some((p) => p.kind === "ollama"),
   );
+  const providerCatalogs = useLiveProviderCatalogs(llm?.providers ?? {});
 
   if (!llm) return <div className="v2-set__empty">Loading LLM config...</div>;
 
@@ -176,9 +186,9 @@ export function LLMTab({
       </section>
 
       {mode === "single" ? (
-        <SingleModelSection data={data} onToast={onToast} ollamaModels={ollamaModels} />
+        <SingleModelSection data={data} onToast={onToast} ollamaModels={ollamaModels} providerCatalogs={providerCatalogs} />
       ) : (
-        <MultiTierSection data={data} onToast={onToast} ollamaModels={ollamaModels} />
+        <MultiTierSection data={data} onToast={onToast} ollamaModels={ollamaModels} providerCatalogs={providerCatalogs} />
       )}
     </div>
   );
@@ -305,7 +315,7 @@ function ProviderRow({
 }) {
   const usesUrl = URL_BASED_KINDS.has(entry.kind);
   const usesKey = KEY_BASED_KINDS.has(entry.kind);
-  const configured = usesUrl ? !!entry.base_url : entry.has_api_key;
+  const configured = (!usesUrl || !!entry.base_url) && (!usesKey || entry.has_api_key);
 
   const [apiKey, setApiKey] = useState("");
   const [baseUrl, setBaseUrl] = useState(entry.base_url ?? "");
@@ -360,7 +370,7 @@ function ProviderRow({
               <input
                 type="text"
                 className="v2-set__input"
-                placeholder="http://localhost:11434"
+                placeholder={DEFAULT_BASE_URLS[entry.kind] ?? "https://gateway.example/v1"}
                 value={baseUrl}
                 onChange={(e) => setBaseUrl(e.target.value)}
               />
@@ -459,7 +469,11 @@ function NewProviderRow({
           <select
             className="v2-set__select"
             value={kind}
-            onChange={(e) => setKind(e.target.value as LLMProviderKind)}
+            onChange={(e) => {
+              const next = e.target.value as LLMProviderKind;
+              setKind(next);
+              setBaseUrl(DEFAULT_BASE_URLS[next] ?? "");
+            }}
           >
             {LLM_PROVIDER_KINDS.map((k) => (
               <option key={k} value={k}>
@@ -504,7 +518,7 @@ function NewProviderRow({
             <input
               type="text"
               className="v2-set__input"
-              placeholder="http://localhost:11434"
+              placeholder={DEFAULT_BASE_URLS[kind] ?? "https://gateway.example/v1"}
               value={baseUrl}
               onChange={(e) => setBaseUrl(e.target.value)}
             />
@@ -544,10 +558,12 @@ function SingleModelSection({
   data,
   onToast,
   ollamaModels,
+  providerCatalogs,
 }: {
   data: SettingsHook;
   onToast: (text: string, tone?: "ok" | "warn") => void;
   ollamaModels: string[] | null;
+  providerCatalogs: Record<string, string[]>;
 }) {
   const llm = data.llm!;
 
@@ -567,6 +583,7 @@ function SingleModelSection({
         value={llm.default}
         providers={llm.providers}
         ollamaModels={ollamaModels}
+        providerCatalogs={providerCatalogs}
         onChange={async (ref) => {
           const r = await data.setDefaultModel(ref);
           onToast(r.message, r.ok ? "ok" : "warn");
@@ -582,10 +599,12 @@ function MultiTierSection({
   data,
   onToast,
   ollamaModels,
+  providerCatalogs,
 }: {
   data: SettingsHook;
   onToast: (text: string, tone?: "ok" | "warn") => void;
   ollamaModels: string[] | null;
+  providerCatalogs: Record<string, string[]>;
 }) {
   const llm = data.llm!;
 
@@ -633,6 +652,7 @@ function MultiTierSection({
             value={llm.tiers[t.id]}
             providers={llm.providers}
             ollamaModels={ollamaModels}
+            providerCatalogs={providerCatalogs}
             allowClear
             onChange={async (ref) => {
               const r = await data.setTierModel(t.id, ref);
@@ -652,6 +672,7 @@ function MultiTierSection({
           value={llm.default}
           providers={llm.providers}
           ollamaModels={ollamaModels}
+          providerCatalogs={providerCatalogs}
           allowClear
           onChange={async (ref) => {
             const r = await data.setDefaultModel(ref);
@@ -671,6 +692,7 @@ function ModelSelector({
   value,
   providers,
   ollamaModels,
+  providerCatalogs,
   allowClear,
   onChange,
 }: {
@@ -680,6 +702,8 @@ function ModelSelector({
   providers: Record<string, LLMConfigProviderView>;
   /** Installed Ollama models, fetched once by LLMTab and shared here. */
   ollamaModels: string[] | null;
+  /** Live model/route catalogs keyed by configured provider name. */
+  providerCatalogs: Record<string, string[]>;
   allowClear?: boolean;
   onChange: (ref: string | null) => void;
 }) {
@@ -691,7 +715,7 @@ function ModelSelector({
   );
   const [selectedModel, setSelectedModel] = useState<string>(parsed?.model ?? "");
   const [customModel, setCustomModel] = useState<string>(
-    parsed?.model && !providerModels(providers, parsed.provider, ollamaModels).includes(parsed.model)
+    parsed?.model && !providerModels(providers, parsed.provider, ollamaModels, providerCatalogs).includes(parsed.model)
       ? parsed.model
       : "",
   );
@@ -700,7 +724,7 @@ function ModelSelector({
   useEffect(() => {
     if (parsed) {
       setSelectedProvider(parsed.provider);
-      const known = providerModels(providers, parsed.provider, ollamaModels);
+      const known = providerModels(providers, parsed.provider, ollamaModels, providerCatalogs);
       if (known.includes(parsed.model)) {
         setSelectedModel(parsed.model);
         setCustomModel("");
@@ -718,9 +742,9 @@ function ModelSelector({
     // `ollamaModels` participates: until the live catalog lands, a tagged id
     // looks unknown and would be parked in the custom field. Re-run when it
     // arrives so the dropdown snaps to the real entry.
-  }, [value, ollamaModels]);
+  }, [value, ollamaModels, providerCatalogs]);
 
-  const models = providerModels(providers, selectedProvider, ollamaModels);
+  const models = providerModels(providers, selectedProvider, ollamaModels, providerCatalogs);
   const usesCustomOnly = models.length === 0;
   const effectiveModel = selectedModel === "__custom__" ? customModel.trim() : selectedModel;
 
@@ -753,7 +777,7 @@ function ModelSelector({
             const next = e.target.value;
             setSelectedProvider(next);
             // Reset model when provider changes - the model list is now different.
-            const nextModels = providerModels(providers, next, ollamaModels);
+            const nextModels = providerModels(providers, next, ollamaModels, providerCatalogs);
             const defaultModel = nextModels[0] ?? "__custom__";
             setSelectedModel(defaultModel);
             setCustomModel("");
@@ -835,6 +859,7 @@ function providerModels(
   providers: Record<string, LLMConfigProviderView>,
   name: string,
   live?: string[] | null,
+  providerCatalogs: Record<string, string[]> = {},
 ): string[] {
   const entry = providers[name];
   if (!entry) return [];
@@ -842,6 +867,9 @@ function providerModels(
   // The curated list is untagged guesswork, so prefer the real catalog when
   // the daemon could read it; fall back to the guesses when it could not.
   if (entry.kind === "ollama" && live && live.length > 0) return live;
+  if (entry.kind === "omniroute" && providerCatalogs[name]?.length) {
+    return providerCatalogs[name]!;
+  }
   return MODELS_BY_KIND[entry.kind] ?? [];
 }
 
@@ -868,4 +896,43 @@ function useOllamaModels(enabled: boolean): string[] | null {
     };
   }, [enabled]);
   return models;
+}
+
+/** Load volatile catalogs for gateways/providers whose IDs change frequently. */
+function useLiveProviderCatalogs(
+  providers: Record<string, LLMConfigProviderView>,
+): Record<string, string[]> {
+  const names = Object.entries(providers)
+    .filter(([, entry]) => entry.kind === "omniroute" && !!entry.base_url)
+    .map(([name]) => name)
+    .sort();
+  const signature = names.join("\u0000");
+  const [catalogs, setCatalogs] = useState<Record<string, string[]>>({});
+
+  useEffect(() => {
+    if (names.length === 0) {
+      setCatalogs({});
+      return;
+    }
+    let cancelled = false;
+    Promise.all(names.map(async (name) => {
+      try {
+        const kind = providers[name]!.kind;
+        const response = await fetch(`/api/config/llm/${kind}/models`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ name }),
+        });
+        const data = await response.json() as { ok: boolean; models?: string[] };
+        return [name, data.ok && data.models ? data.models : []] as const;
+      } catch {
+        return [name, []] as const;
+      }
+    })).then((entries) => {
+      if (!cancelled) setCatalogs(Object.fromEntries(entries));
+    });
+    return () => { cancelled = true; };
+  }, [signature]); // names are represented by the stable signature
+
+  return catalogs;
 }

--- a/ui/src/v2/rooms/settings/tabs/LLMTab.tsx
+++ b/ui/src/v2/rooms/settings/tabs/LLMTab.tsx
@@ -315,7 +315,7 @@ function ProviderRow({
 }) {
   const usesUrl = URL_BASED_KINDS.has(entry.kind);
   const usesKey = KEY_BASED_KINDS.has(entry.kind);
-  const configured = (!usesUrl || !!entry.base_url) && (!usesKey || entry.has_api_key);
+  const configured = (!usesUrl || !!entry.base_url?.trim()) && (!usesKey || entry.has_api_key);
 
   const [apiKey, setApiKey] = useState("");
   const [baseUrl, setBaseUrl] = useState(entry.base_url ?? "");
@@ -902,11 +902,16 @@ function useOllamaModels(enabled: boolean): string[] | null {
 function useLiveProviderCatalogs(
   providers: Record<string, LLMConfigProviderView>,
 ): Record<string, string[]> {
-  const names = Object.entries(providers)
-    .filter(([, entry]) => entry.kind === "omniroute" && !!entry.base_url)
-    .map(([name]) => name)
-    .sort();
-  const signature = names.join("\u0000");
+  const targets = Object.entries(providers)
+    .filter(([, entry]) => entry.kind === "omniroute")
+    .map(([name, entry]) => ({
+      name,
+      baseUrl: entry.base_url?.trim() || "http://localhost:20128/v1",
+      hasApiKey: entry.has_api_key,
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+  const signature = JSON.stringify(targets);
+  const names = targets.map((target) => target.name);
   const [catalogs, setCatalogs] = useState<Record<string, string[]>>({});
 
   useEffect(() => {
@@ -917,8 +922,7 @@ function useLiveProviderCatalogs(
     let cancelled = false;
     Promise.all(names.map(async (name) => {
       try {
-        const kind = providers[name]!.kind;
-        const response = await fetch(`/api/config/llm/${kind}/models`, {
+        const response = await fetch('/api/config/llm/omniroute/models', {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ name }),

--- a/ui/src/v2/rooms/settings/useSettingsData.ts
+++ b/ui/src/v2/rooms/settings/useSettingsData.ts
@@ -16,7 +16,8 @@ export type LLMProviderKind =
   | "openrouter"
   | "nvidia"
   | "openai_compatible"
-  | "litellm";
+  | "litellm"
+  | "omniroute";
 
 export const LLM_PROVIDER_KINDS: readonly LLMProviderKind[] = [
   "anthropic",
@@ -28,6 +29,7 @@ export const LLM_PROVIDER_KINDS: readonly LLMProviderKind[] = [
   "nvidia",
   "openai_compatible",
   "litellm",
+  "omniroute",
 ] as const;
 
 export const LLM_PROVIDER_KIND_LABELS: Record<LLMProviderKind, string> = {
@@ -40,6 +42,7 @@ export const LLM_PROVIDER_KIND_LABELS: Record<LLMProviderKind, string> = {
   nvidia: "NVIDIA NIM",
   openai_compatible: "OpenAI-compatible",
   litellm: "LiteLLM",
+  omniroute: "OmniRoute",
 };
 
 /**
@@ -53,6 +56,7 @@ export const KEY_BASED_KINDS: ReadonlySet<LLMProviderKind> = new Set([
   "gemini",
   "openrouter",
   "nvidia",
+  "omniroute",
 ]);
 
 /** Provider kinds that need a base_url. */
@@ -60,6 +64,7 @@ export const URL_BASED_KINDS: ReadonlySet<LLMProviderKind> = new Set([
   "ollama",
   "openai_compatible",
   "litellm",
+  "omniroute",
 ]);
 
 /** Tier slot identifiers. */
@@ -440,7 +445,9 @@ export function useSettingsData() {
     let providersWithKey = 0;
     if (llm) {
       for (const entry of Object.values(llm.providers ?? {})) {
-        if (URL_BASED_KINDS.has(entry.kind) ? entry.base_url : entry.has_api_key) {
+        const usesUrl = URL_BASED_KINDS.has(entry.kind);
+        const usesKey = KEY_BASED_KINDS.has(entry.kind);
+        if ((!usesUrl || !!entry.base_url) && (!usesKey || entry.has_api_key)) {
           providersWithKey++;
         }
       }

--- a/ui/src/v2/rooms/settings/useSettingsData.ts
+++ b/ui/src/v2/rooms/settings/useSettingsData.ts
@@ -447,7 +447,7 @@ export function useSettingsData() {
       for (const entry of Object.values(llm.providers ?? {})) {
         const usesUrl = URL_BASED_KINDS.has(entry.kind);
         const usesKey = KEY_BASED_KINDS.has(entry.kind);
-        if ((!usesUrl || !!entry.base_url) && (!usesKey || entry.has_api_key)) {
+        if ((!usesUrl || !!entry.base_url?.trim()) && (!usesKey || entry.has_api_key)) {
           providersWithKey++;
         }
       }

--- a/ui/src/v2/rooms/settings/useSettingsData.ts
+++ b/ui/src/v2/rooms/settings/useSettingsData.ts
@@ -59,6 +59,14 @@ export const KEY_BASED_KINDS: ReadonlySet<LLMProviderKind> = new Set([
   "omniroute",
 ]);
 
+/**
+ * Kinds that show a key field but don't require it - local gateway installs
+ * can run without auth (the daemon instantiates them keyless too).
+ */
+export const OPTIONAL_KEY_KINDS: ReadonlySet<LLMProviderKind> = new Set([
+  "omniroute",
+]);
+
 /** Provider kinds that need a base_url. */
 export const URL_BASED_KINDS: ReadonlySet<LLMProviderKind> = new Set([
   "ollama",
@@ -446,8 +454,8 @@ export function useSettingsData() {
     if (llm) {
       for (const entry of Object.values(llm.providers ?? {})) {
         const usesUrl = URL_BASED_KINDS.has(entry.kind);
-        const usesKey = KEY_BASED_KINDS.has(entry.kind);
-        if ((!usesUrl || !!entry.base_url?.trim()) && (!usesKey || entry.has_api_key)) {
+        const needsKey = KEY_BASED_KINDS.has(entry.kind) && !OPTIONAL_KEY_KINDS.has(entry.kind);
+        if ((!usesUrl || !!entry.base_url?.trim()) && (!needsKey || entry.has_api_key)) {
           providersWithKey++;
         }
       }


### PR DESCRIPTION
## Summary

- add OmniRoute as a first-class LLM provider in config, onboarding, and settings
- use OmniRoute’s OpenAI-compatible chat endpoint for multimodal messages, streaming, and tool calls
- load the complete live model catalog, including automatic routes and custom combos
- document the default local endpoint and setup behavior

## Verification

- `bun test src/llm/omniroute.test.ts src/llm/provider.test.ts` (77 passed)
- full pre-commit suite (1,831 passed, 22 skipped, 0 failed)
- `bunx tsc --noEmit`
- `bun run build:ui`