### PR TITLE
fix(llm): recover from Groq model and quota errors

### DIFF
--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -85,7 +85,7 @@ export async function runDoctor(): Promise<void> {
     const { mergeLLMSettingsIntoConfig } = await import('../daemon/llm-settings.ts');
     llmConfig = await loadConfig();
     initDatabase(llmConfig.daemon.db_path);
-    mergeLLMSettingsIntoConfig(llmConfig);
+    mergeLLMSettingsIntoConfig(llmConfig, { persistMigrations: false });
     llmProviderNames = Object.keys(llmConfig.llm.providers ?? {});
   } catch (err) {
     results.push({ name: 'LLM Provider', status: 'fail', message: `Could not load LLM settings: ${String(err).slice(0, 80)}` });

--- a/src/daemon/api-groq-models.test.ts
+++ b/src/daemon/api-groq-models.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { createApiRoutes, type ApiContext } from './api-routes.ts';
+import type { JarvisConfig, LLMProviderEntry } from '../config/types.ts';
+
+type Handler = (req: Request) => Response | Promise<Response>;
+
+function callEndpoint(
+  providers: Record<string, LLMProviderEntry>,
+  body: Record<string, unknown>,
+): Response | Promise<Response> {
+  const ctx = {
+    daemonStartedAt: Date.now(),
+    healthMonitor: {} as ApiContext['healthMonitor'],
+    config: { llm: { providers } } as JarvisConfig,
+  } as ApiContext;
+  const route = createApiRoutes(ctx)['/api/config/llm/groq/models'] as { POST: Handler };
+  return route.POST(new Request('http://x/api/config/llm/groq/models', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  }));
+}
+
+describe('POST /api/config/llm/groq/models', () => {
+  const realFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    globalThis.fetch = (async () => new Response(JSON.stringify({
+      data: [
+        { id: 'openai/gpt-oss-20b' },
+        { id: 'whisper-large-v3' },
+      ],
+    }), { status: 200, headers: { 'Content-Type': 'application/json' } })) as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  it('accepts a legacy synthesized provider whose kind defaults to its name', async () => {
+    const response = await callEndpoint(
+      { groq: {} },
+      { name: 'groq', api_key: 'typed-key' },
+    );
+    const body = await response.json() as { ok: boolean; models: string[] };
+    expect(body.ok).toBe(true);
+    expect(body.models).toEqual(['openai/gpt-oss-20b']);
+  });
+
+  it('discovers a kind-defaulted provider when no name is supplied', async () => {
+    const response = await callEndpoint(
+      { groq: {} },
+      { api_key: 'typed-key' },
+    );
+    const body = await response.json() as { ok: boolean };
+    expect(body.ok).toBe(true);
+  });
+
+  it('rejects a configured provider of another kind', async () => {
+    const response = await callEndpoint(
+      { custom: { kind: 'openai' } },
+      { name: 'custom', api_key: 'typed-key' },
+    );
+    const body = await response.json() as { ok: boolean; error: string; models: string[] };
+    expect(body).toEqual({ ok: false, error: 'Groq provider not found', models: [] });
+  });
+});

--- a/src/daemon/api-routes.ts
+++ b/src/daemon/api-routes.ts
@@ -1635,15 +1635,16 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
       POST: async (req: Request) => {
         try {
           const body = await req.json() as { name?: string; api_key?: string };
-          const configured = body.name
-            ? ctx.config.llm.providers?.[body.name]
-            : Object.values(ctx.config.llm.providers ?? {}).find((entry) => entry?.kind === 'groq');
-          if (body.name && configured?.kind !== 'groq') {
+          const providers = ctx.config.llm.providers ?? {};
+          const providerName = body.name
+            ?? Object.keys(providers).find((name) => (providers[name]?.kind ?? name) === 'groq');
+          const configured = providerName ? providers[providerName] : undefined;
+          if (body.name && (!configured || (configured.kind ?? body.name) !== 'groq')) {
             return json({ ok: false, error: 'Groq provider not found', models: [] });
           }
           const { getSecret } = await import('../vault/keychain.ts');
           const apiKey = body.api_key
-            || (body.name ? getSecret(`llm.provider.${body.name}.api_key`) : null)
+            || (providerName ? getSecret(`llm.provider.${providerName}.api_key`) : null)
             || configured?.api_key
             || '';
           if (!apiKey) return json({ ok: false, error: 'Groq API key required', models: [] });

--- a/src/daemon/api-routes.ts
+++ b/src/daemon/api-routes.ts
@@ -1630,6 +1630,34 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
       },
     },
 
+    // Keep Groq's changing model catalog out of hard-coded UI lists.
+    '/api/config/llm/groq/models': {
+      POST: async (req: Request) => {
+        try {
+          const body = await req.json() as { name?: string; api_key?: string };
+          const configured = body.name
+            ? ctx.config.llm.providers?.[body.name]
+            : Object.values(ctx.config.llm.providers ?? {}).find((entry) => entry?.kind === 'groq');
+          if (body.name && configured?.kind !== 'groq') {
+            return json({ ok: false, error: 'Groq provider not found', models: [] });
+          }
+          const { getSecret } = await import('../vault/keychain.ts');
+          const apiKey = body.api_key
+            || (body.name ? getSecret(`llm.provider.${body.name}.api_key`) : null)
+            || configured?.api_key
+            || '';
+          if (!apiKey) return json({ ok: false, error: 'Groq API key required', models: [] });
+
+          const { GroqProvider } = await import('../llm/groq.ts');
+          const models = await new GroqProvider(apiKey).listModels();
+          return json({ ok: true, models });
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          return json({ ok: false, error: msg, models: [] });
+        }
+      },
+    },
+
     // --- Usage telemetry ---
     /**
      * Filterable LLM usage query. All query params are optional:

--- a/src/daemon/llm-settings.test.ts
+++ b/src/daemon/llm-settings.test.ts
@@ -21,4 +21,16 @@ describe('LLM settings model migrations', () => {
     expect(getSetting('llm.default')).toBe('groq:openai/gpt-oss-120b');
     expect(getSetting('llm.tiers.medium')).toBe('groq:openai/gpt-oss-20b');
   });
+
+  it('can hydrate repaired references without mutating settings', () => {
+    initDatabase(':memory:');
+    setSetting('llm.providers', JSON.stringify({ groq: { kind: 'groq' } }));
+    setSetting('llm.default', 'groq:deepseek-r1-distill-llama-70b');
+    const config = structuredClone(DEFAULT_CONFIG);
+
+    mergeLLMSettingsIntoConfig(config, { persistMigrations: false });
+
+    expect(config.llm.default).toBe('groq:openai/gpt-oss-120b');
+    expect(getSetting('llm.default')).toBe('groq:deepseek-r1-distill-llama-70b');
+  });
 });

--- a/src/daemon/llm-settings.test.ts
+++ b/src/daemon/llm-settings.test.ts
@@ -1,0 +1,24 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import { initDatabase, closeDb } from '../vault/schema.ts';
+import { getSetting, setSetting } from '../vault/settings.ts';
+import { DEFAULT_CONFIG } from '../config/types.ts';
+import { mergeLLMSettingsIntoConfig } from './llm-settings.ts';
+
+afterEach(() => closeDb());
+
+describe('LLM settings model migrations', () => {
+  it('replaces saved decommissioned Groq IDs and persists the repair', () => {
+    initDatabase(':memory:');
+    setSetting('llm.providers', JSON.stringify({ groq: { kind: 'groq' } }));
+    setSetting('llm.default', 'groq:deepseek-r1-distill-llama-70b');
+    setSetting('llm.tiers.medium', 'groq:llama-3.1-8b-instant');
+    const config = structuredClone(DEFAULT_CONFIG);
+
+    mergeLLMSettingsIntoConfig(config);
+
+    expect(config.llm.default).toBe('groq:openai/gpt-oss-120b');
+    expect(config.llm.tiers?.medium).toBe('groq:openai/gpt-oss-20b');
+    expect(getSetting('llm.default')).toBe('groq:openai/gpt-oss-120b');
+    expect(getSetting('llm.tiers.medium')).toBe('groq:openai/gpt-oss-20b');
+  });
+});

--- a/src/daemon/llm-settings.ts
+++ b/src/daemon/llm-settings.ts
@@ -26,6 +26,7 @@ import {
   configureLLMTiers,
 } from '../llm/config-binding.ts';
 import { isAnthropicCustomBaseUrl } from '../llm/anthropic.ts';
+import { GROQ_DEPRECATED_MODEL_REPLACEMENTS } from '../llm/groq-models.ts';
 
 // ── DB keys ──────────────────────────────────────────────────────────────
 const SETTING_PROVIDERS = 'llm.providers';
@@ -307,7 +308,10 @@ export function stripSecretsFromProviders(
  * pre-rework installs and migrates them in-memory so users upgrading don't
  * lose their saved credentials.
  */
-export function mergeLLMSettingsIntoConfig(config: JarvisConfig): void {
+export function mergeLLMSettingsIntoConfig(
+  config: JarvisConfig,
+  options: { persistMigrations?: boolean } = {},
+): void {
   // Replace, don't merge: the DB is authoritative for every LLM setting.
   config.llm.providers = {};
   config.llm.tiers = {};
@@ -352,7 +356,7 @@ export function mergeLLMSettingsIntoConfig(config: JarvisConfig): void {
   // are present and no new-shape providers exist for them. This is the
   // upgrade path for installs that pre-date the provider/model split.
   migrateLegacyDBSettings(config);
-  migrateDeprecatedGroqModels(config);
+  migrateDeprecatedGroqModels(config, options.persistMigrations !== false);
 
   // 3. Pull API keys from the keychain into provider entries. We do NOT
   // surface them in `config.llm.providers.<name>.api_key` (that would risk
@@ -372,13 +376,7 @@ export function mergeLLMSettingsIntoConfig(config: JarvisConfig): void {
 }
 
 /** Replace known retired Groq IDs before runtime starts. */
-function migrateDeprecatedGroqModels(config: JarvisConfig): void {
-  const replacements: Record<string, string> = {
-    'deepseek-r1-distill-llama-70b': 'openai/gpt-oss-120b',
-    'llama-3.3-70b-versatile': 'openai/gpt-oss-120b',
-    'llama-3.1-8b-instant': 'openai/gpt-oss-20b',
-    'qwen/qwen3-32b': 'openai/gpt-oss-120b',
-  };
+function migrateDeprecatedGroqModels(config: JarvisConfig, persist = true): void {
   const migrateRef = (ref: string | undefined): string | undefined => {
     if (!ref) return ref;
     const separator = ref.indexOf(':');
@@ -386,7 +384,7 @@ function migrateDeprecatedGroqModels(config: JarvisConfig): void {
     const providerName = ref.slice(0, separator);
     const entry = config.llm.providers?.[providerName];
     if ((entry?.kind ?? providerName) !== 'groq') return ref;
-    const replacement = replacements[ref.slice(separator + 1)];
+    const replacement = GROQ_DEPRECATED_MODEL_REPLACEMENTS[ref.slice(separator + 1)];
     return replacement ? `${providerName}:${replacement}` : ref;
   };
 
@@ -405,6 +403,8 @@ function migrateDeprecatedGroqModels(config: JarvisConfig): void {
     }
   }
   if (!changed) return;
+
+  if (!persist) return;
 
   setSetting(SETTING_DEFAULT, config.llm.default ?? '');
   setSetting(SETTING_TIER_CONVERSATION, config.llm.tiers?.conversation ?? '');

--- a/src/daemon/llm-settings.ts
+++ b/src/daemon/llm-settings.ts
@@ -253,6 +253,9 @@ export function saveLLMSettings(
     }
   }
 
+  // Repair old Groq references before the updated providers are reloaded.
+  migrateDeprecatedGroqModels(config);
+
   // Persist non-secret state to DB. CRITICAL: strip api_key from every
   // provider entry before serializing - the in-memory entries carry secrets
   // injected from the keychain (see mergeLLMSettingsIntoConfig), and the
@@ -349,6 +352,7 @@ export function mergeLLMSettingsIntoConfig(config: JarvisConfig): void {
   // are present and no new-shape providers exist for them. This is the
   // upgrade path for installs that pre-date the provider/model split.
   migrateLegacyDBSettings(config);
+  migrateDeprecatedGroqModels(config);
 
   // 3. Pull API keys from the keychain into provider entries. We do NOT
   // surface them in `config.llm.providers.<name>.api_key` (that would risk
@@ -365,6 +369,49 @@ export function mergeLLMSettingsIntoConfig(config: JarvisConfig): void {
       config.llm.providers[name] = { ...config.llm.providers[name], api_key: key };
     }
   }
+}
+
+/** Replace known retired Groq IDs before runtime starts. */
+function migrateDeprecatedGroqModels(config: JarvisConfig): void {
+  const replacements: Record<string, string> = {
+    'deepseek-r1-distill-llama-70b': 'openai/gpt-oss-120b',
+    'llama-3.3-70b-versatile': 'openai/gpt-oss-120b',
+    'llama-3.1-8b-instant': 'openai/gpt-oss-20b',
+    'qwen/qwen3-32b': 'openai/gpt-oss-120b',
+  };
+  const migrateRef = (ref: string | undefined): string | undefined => {
+    if (!ref) return ref;
+    const separator = ref.indexOf(':');
+    if (separator <= 0) return ref;
+    const providerName = ref.slice(0, separator);
+    const entry = config.llm.providers?.[providerName];
+    if ((entry?.kind ?? providerName) !== 'groq') return ref;
+    const replacement = replacements[ref.slice(separator + 1)];
+    return replacement ? `${providerName}:${replacement}` : ref;
+  };
+
+  let changed = false;
+  const nextDefault = migrateRef(config.llm.default);
+  if (nextDefault !== config.llm.default) {
+    config.llm.default = nextDefault;
+    changed = true;
+  }
+  for (const tier of ['conversation', 'high', 'medium', 'low'] as const) {
+    const current = config.llm.tiers?.[tier];
+    const next = migrateRef(current);
+    if (next !== current) {
+      if (next) config.llm.tiers![tier] = next;
+      changed = true;
+    }
+  }
+  if (!changed) return;
+
+  setSetting(SETTING_DEFAULT, config.llm.default ?? '');
+  setSetting(SETTING_TIER_CONVERSATION, config.llm.tiers?.conversation ?? '');
+  setSetting(SETTING_TIER_HIGH, config.llm.tiers?.high ?? '');
+  setSetting(SETTING_TIER_MEDIUM, config.llm.tiers?.medium ?? '');
+  setSetting(SETTING_TIER_LOW, config.llm.tiers?.low ?? '');
+  console.log('[LLM] Migrated deprecated Groq model references to supported replacements.');
 }
 
 /**

--- a/src/daemon/llm-settings.ts
+++ b/src/daemon/llm-settings.ts
@@ -255,7 +255,8 @@ export function saveLLMSettings(
   }
 
   // Repair old Groq references before the updated providers are reloaded.
-  migrateDeprecatedGroqModels(config);
+  // No persist: the block below writes default + tiers to the DB anyway.
+  migrateDeprecatedGroqModels(config, false);
 
   // Persist non-secret state to DB. CRITICAL: strip api_key from every
   // provider entry before serializing - the in-memory entries carry secrets

--- a/src/llm/groq-models.ts
+++ b/src/llm/groq-models.ts
@@ -1,4 +1,8 @@
-/** Retired Groq chat models and the supported defaults that replace them. */
+/**
+ * Retired Groq chat models and the supported defaults that replace them.
+ * Replacements are capability-matched (70b-class -> gpt-oss-120b, small ->
+ * gpt-oss-20b); the provider-wide default stays gpt-oss-20b (cheap tier).
+ */
 export const GROQ_DEPRECATED_MODEL_REPLACEMENTS: Readonly<Record<string, string>> = {
   'deepseek-r1-distill-llama-70b': 'openai/gpt-oss-120b',
   'llama-3.3-70b-versatile': 'openai/gpt-oss-120b',

--- a/src/llm/groq-models.ts
+++ b/src/llm/groq-models.ts
@@ -1,0 +1,13 @@
+/** Retired Groq chat models and the supported defaults that replace them. */
+export const GROQ_DEPRECATED_MODEL_REPLACEMENTS: Readonly<Record<string, string>> = {
+  'deepseek-r1-distill-llama-70b': 'openai/gpt-oss-120b',
+  'llama-3.3-70b-versatile': 'openai/gpt-oss-120b',
+  'llama-3.1-8b-instant': 'openai/gpt-oss-20b',
+  'qwen/qwen3-32b': 'openai/gpt-oss-120b',
+  'meta-llama/llama-4-scout-17b-16e-instruct': 'openai/gpt-oss-20b',
+  'meta-llama/llama-4-maverick-17b-128e-instruct': 'openai/gpt-oss-120b',
+};
+
+export function isDeprecatedGroqModel(id: string): boolean {
+  return Object.hasOwn(GROQ_DEPRECATED_MODEL_REPLACEMENTS, id);
+}

--- a/src/llm/groq-models.ts
+++ b/src/llm/groq-models.ts
@@ -2,6 +2,12 @@
  * Retired Groq chat models and the supported defaults that replace them.
  * Replacements are capability-matched (70b-class -> gpt-oss-120b, small ->
  * gpt-oss-20b); the provider-wide default stays gpt-oss-20b (cheap tier).
+ *
+ * Scope: repairing saved "provider:model" references and keeping the offline
+ * fallback suggestions current — the two places we have to guess because the
+ * account cannot be asked. It must NOT filter a live /models response: those
+ * are per-account, and a committed-spend contract keeps serving IDs that are
+ * retired for everyone else.
  */
 export const GROQ_DEPRECATED_MODEL_REPLACEMENTS: Readonly<Record<string, string>> = {
   'deepseek-r1-distill-llama-70b': 'openai/gpt-oss-120b',
@@ -11,7 +17,3 @@ export const GROQ_DEPRECATED_MODEL_REPLACEMENTS: Readonly<Record<string, string>
   'meta-llama/llama-4-scout-17b-16e-instruct': 'openai/gpt-oss-20b',
   'meta-llama/llama-4-maverick-17b-128e-instruct': 'openai/gpt-oss-120b',
 };
-
-export function isDeprecatedGroqModel(id: string): boolean {
-  return Object.hasOwn(GROQ_DEPRECATED_MODEL_REPLACEMENTS, id);
-}

--- a/src/llm/groq.ts
+++ b/src/llm/groq.ts
@@ -8,6 +8,7 @@ import type {
   LLMToolCall,
 } from './provider.ts';
 import { classifyHttpStatus, LLMProviderError } from './provider.ts';
+import { isDeprecatedGroqModel } from './groq-models.ts';
 type GroqContentPart =
   | { type: 'text'; text: string }
   | { type: 'image_url'; image_url: { url: string } };
@@ -87,18 +88,9 @@ type GroqStreamChunk = {
   }>;
 };
 
-const GROQ_DEPRECATED_CHAT_MODELS = new Set([
-  'deepseek-r1-distill-llama-70b',
-  'llama-3.3-70b-versatile',
-  'llama-3.1-8b-instant',
-  'qwen/qwen3-32b',
-  'meta-llama/llama-4-scout-17b-16e-instruct',
-  'meta-llama/llama-4-maverick-17b-128e-instruct',
-]);
-
 /** Models suitable for Jarvis chat + local function calling. */
 export function isGroqJarvisModel(id: string): boolean {
-  if (GROQ_DEPRECATED_CHAT_MODELS.has(id)) return false;
+  if (isDeprecatedGroqModel(id)) return false;
   // These active catalog entries use audio/moderation endpoints, or (for
   // Compound) reject user-provided local tools.
   return !/(whisper|orpheus|prompt-guard|safeguard|^groq\/compound)/i.test(id);
@@ -155,12 +147,11 @@ export class GroqProvider implements LLMProvider {
   private apiKey: string;
   private defaultModel: string;
   private apiUrl = 'https://api.groq.com/openai/v1/chat/completions';
-  // Groq's free/developer limits are token-per-minute constrained. Keep a
-  // single request comfortably below the common 8K TPM ceiling so normal
-  // output still has headroom instead of triggering a guaranteed 429.
-  private static readonly SAFE_PROMPT_CHAR_BUDGET = 16_000;
+  // Keep enough context for paid accounts. Free-tier quota failures carry a
+  // typed rate-limit error and are handled by the manager's retry/failover.
+  private static readonly SAFE_PROMPT_CHAR_BUDGET = 24_000;
   private static readonly SAFE_TOOL_OVERHEAD_CHARS = 8_000;
-  private static readonly RETRY_PROMPT_CHAR_BUDGET = 8_000;
+  private static readonly RETRY_PROMPT_CHAR_BUDGET = 12_000;
   private static readonly MAX_SYSTEM_MESSAGE_CHARS = 8_000;
   private static readonly MAX_USER_MESSAGE_CHARS = 3_500;
   private static readonly MAX_ASSISTANT_MESSAGE_CHARS = 3_500;

--- a/src/llm/groq.ts
+++ b/src/llm/groq.ts
@@ -91,9 +91,10 @@ type GroqStreamChunk = {
 /** Models suitable for Jarvis chat + local function calling. */
 export function isGroqJarvisModel(id: string): boolean {
   if (isDeprecatedGroqModel(id)) return false;
-  // These active catalog entries use audio/moderation endpoints, or (for
-  // Compound) reject user-provided local tools.
-  return !/(whisper|orpheus|prompt-guard|safeguard|^groq\/compound)/i.test(id);
+  // These active catalog entries use audio (whisper/orpheus/tts), moderation
+  // (guard), or embedding endpoints, or (for Compound) reject user-provided
+  // local tools.
+  return !/(whisper|orpheus|playai|tts|guard|embed|^groq\/compound)/i.test(id);
 }
 
 /**
@@ -200,12 +201,12 @@ export class GroqProvider implements LLMProvider {
     if (!response.ok) {
       const errorText = await response.text();
       if (!this.isRequestTooLargeError(response.status, errorText)) {
+        const retryAfterMs = this.retryAfterMs(response);
         yield {
           type: 'error',
           error: `Groq API error (${response.status}): ${errorText}`,
           code: classifyHttpStatus(response.status),
-          ...(this.retryAfterMs(response) !== undefined
-            ? { retry_after_ms: this.retryAfterMs(response) } : {}),
+          ...(retryAfterMs !== undefined ? { retry_after_ms: retryAfterMs } : {}),
         };
         return;
       }
@@ -219,12 +220,12 @@ export class GroqProvider implements LLMProvider {
       );
       if (!response.ok) {
         const retryError = await response.text();
+        const retryAfterMs = this.retryAfterMs(response);
         yield {
           type: 'error',
           error: `Groq API error after retry (${response.status}): ${retryError}`,
           code: classifyHttpStatus(response.status),
-          ...(this.retryAfterMs(response) !== undefined
-            ? { retry_after_ms: this.retryAfterMs(response) } : {}),
+          ...(retryAfterMs !== undefined ? { retry_after_ms: retryAfterMs } : {}),
         };
         return;
       }

--- a/src/llm/groq.ts
+++ b/src/llm/groq.ts
@@ -7,7 +7,7 @@ import type {
   LLMTool,
   LLMToolCall,
 } from './provider.ts';
-import { classifyHttpStatus } from './provider.ts';
+import { classifyHttpStatus, LLMProviderError } from './provider.ts';
 type GroqContentPart =
   | { type: 'text'; text: string }
   | { type: 'image_url'; image_url: { url: string } };
@@ -87,6 +87,23 @@ type GroqStreamChunk = {
   }>;
 };
 
+const GROQ_DEPRECATED_CHAT_MODELS = new Set([
+  'deepseek-r1-distill-llama-70b',
+  'llama-3.3-70b-versatile',
+  'llama-3.1-8b-instant',
+  'qwen/qwen3-32b',
+  'meta-llama/llama-4-scout-17b-16e-instruct',
+  'meta-llama/llama-4-maverick-17b-128e-instruct',
+]);
+
+/** Models suitable for Jarvis chat + local function calling. */
+export function isGroqJarvisModel(id: string): boolean {
+  if (GROQ_DEPRECATED_CHAT_MODELS.has(id)) return false;
+  // These active catalog entries use audio/moderation endpoints, or (for
+  // Compound) reject user-provided local tools.
+  return !/(whisper|orpheus|prompt-guard|safeguard|^groq\/compound)/i.test(id);
+}
+
 /**
  * Groq strict-validates tool call arguments server-side against the
  * tool's JSON Schema. The Llama/Kimi/etc. models it hosts have a
@@ -138,16 +155,19 @@ export class GroqProvider implements LLMProvider {
   private apiKey: string;
   private defaultModel: string;
   private apiUrl = 'https://api.groq.com/openai/v1/chat/completions';
-  private static readonly SAFE_PROMPT_CHAR_BUDGET = 24_000;
+  // Groq's free/developer limits are token-per-minute constrained. Keep a
+  // single request comfortably below the common 8K TPM ceiling so normal
+  // output still has headroom instead of triggering a guaranteed 429.
+  private static readonly SAFE_PROMPT_CHAR_BUDGET = 16_000;
   private static readonly SAFE_TOOL_OVERHEAD_CHARS = 8_000;
-  private static readonly RETRY_PROMPT_CHAR_BUDGET = 12_000;
+  private static readonly RETRY_PROMPT_CHAR_BUDGET = 8_000;
   private static readonly MAX_SYSTEM_MESSAGE_CHARS = 8_000;
   private static readonly MAX_USER_MESSAGE_CHARS = 3_500;
   private static readonly MAX_ASSISTANT_MESSAGE_CHARS = 3_500;
   private static readonly MAX_TOOL_MESSAGE_CHARS = 2_000;
   private static readonly MIN_RECENT_MESSAGES = 6;
 
-  constructor(apiKey: string, defaultModel = 'llama-3.3-70b-versatile') {
+  constructor(apiKey: string, defaultModel = 'openai/gpt-oss-20b') {
     this.apiKey = apiKey;
     this.defaultModel = defaultModel;
   }
@@ -160,14 +180,14 @@ export class GroqProvider implements LLMProvider {
     if (!response.ok) {
       const errorText = await response.text();
       if (!this.isRequestTooLargeError(response.status, errorText)) {
-        throw new Error(`Groq API error (${response.status}): ${errorText}`);
+        throw this.httpError(response, errorText);
       }
       response = await this.sendRequest(
         this.buildRequestBody(messages, options, false, GroqProvider.RETRY_PROMPT_CHAR_BUDGET)
       );
       if (!response.ok) {
         const retryError = await response.text();
-        throw new Error(`Groq API error after retry (${response.status}): ${retryError}`);
+        throw this.httpError(response, retryError);
       }
     }
 
@@ -193,6 +213,8 @@ export class GroqProvider implements LLMProvider {
           type: 'error',
           error: `Groq API error (${response.status}): ${errorText}`,
           code: classifyHttpStatus(response.status),
+          ...(this.retryAfterMs(response) !== undefined
+            ? { retry_after_ms: this.retryAfterMs(response) } : {}),
         };
         return;
       }
@@ -210,6 +232,8 @@ export class GroqProvider implements LLMProvider {
           type: 'error',
           error: `Groq API error after retry (${response.status}): ${retryError}`,
           code: classifyHttpStatus(response.status),
+          ...(this.retryAfterMs(response) !== undefined
+            ? { retry_after_ms: this.retryAfterMs(response) } : {}),
         };
         return;
       }
@@ -333,13 +357,12 @@ export class GroqProvider implements LLMProvider {
       }
 
       const data = await response.json() as { data: Array<{ id: string }> };
-      return data.data.map(m => m.id).sort();
+      return data.data.map(m => m.id).filter(isGroqJarvisModel).sort();
     } catch (_err) {
       return [
-        'llama-3.3-70b-versatile',
-        'llama-3.1-8b-instant',
-        'qwen/qwen3-32b',
-        'deepseek-r1-distill-llama-70b',
+        'openai/gpt-oss-20b',
+        'openai/gpt-oss-120b',
+        'qwen/qwen3.6-27b',
       ];
     }
   }
@@ -377,6 +400,23 @@ export class GroqProvider implements LLMProvider {
       },
       body: JSON.stringify(body),
     });
+  }
+
+  private retryAfterMs(response: Response): number | undefined {
+    const raw = response.headers.get('retry-after');
+    if (!raw) return undefined;
+    const seconds = Number(raw);
+    if (Number.isFinite(seconds) && seconds >= 0) return Math.ceil(seconds * 1000);
+    const dateMs = Date.parse(raw);
+    return Number.isFinite(dateMs) ? Math.max(0, dateMs - Date.now()) : undefined;
+  }
+
+  private httpError(response: Response, detail: string): LLMProviderError {
+    return new LLMProviderError(
+      `Groq API error (${response.status}): ${detail}`,
+      classifyHttpStatus(response.status),
+      this.retryAfterMs(response),
+    );
   }
 
   private convertMessages(messages: LLMMessage[]): GroqMessage[] {

--- a/src/llm/groq.ts
+++ b/src/llm/groq.ts
@@ -8,7 +8,6 @@ import type {
   LLMToolCall,
 } from './provider.ts';
 import { classifyHttpStatus, LLMProviderError } from './provider.ts';
-import { isDeprecatedGroqModel } from './groq-models.ts';
 type GroqContentPart =
   | { type: 'text'; text: string }
   | { type: 'image_url'; image_url: { url: string } };
@@ -88,10 +87,18 @@ type GroqStreamChunk = {
   }>;
 };
 
-/** Models suitable for Jarvis chat + local function calling. */
+/**
+ * Models suitable for Jarvis chat + local function calling.
+ *
+ * Route shape only — deliberately NOT filtered against the deprecation map
+ * (see groq-models.ts). /models is answered per account, and Groq keeps
+ * serving retired IDs to committed-spend contracts past the public shutdown
+ * date. Hiding those would drop a model the account still owns, and since
+ * boot migration has already rewritten the saved reference, this picker is
+ * the only way back to it. The account's own catalog is the authority.
+ */
 export function isGroqJarvisModel(id: string): boolean {
-  if (isDeprecatedGroqModel(id)) return false;
-  // These active catalog entries use audio (whisper/orpheus/tts), moderation
+  // These catalog entries use audio (whisper/orpheus/tts), moderation
   // (guard), or embedding endpoints, or (for Compound) reject user-provided
   // local tools.
   return !/(whisper|orpheus|playai|tts|guard|embed|^groq\/compound)/i.test(id);

--- a/src/llm/manager.ts
+++ b/src/llm/manager.ts
@@ -6,7 +6,7 @@ import type {
   LLMStreamEvent,
   LLMErrorCode,
 } from './provider.ts';
-import { classifyErrorString } from './provider.ts';
+import { classifyErrorString, LLMProviderError } from './provider.ts';
 import {
   type Tier,
   type TierAssignment,
@@ -24,6 +24,8 @@ export class LLMManager {
   private tierMap: TierMap = {};
   private static readonly MAX_RETRIES_PER_PROVIDER = 3;
   private static readonly REQUEST_TIMEOUT_MS = 90000; // 90 second timeout for LLM calls
+  /** Never park an interactive request for a very long quota reset. */
+  private static readonly MAX_RETRY_AFTER_MS = 60000;
   private static readonly isDebugging = process.env.JARVIS_LOG_LEVEL === 'debug' || process.env.DEBUG_LLM === 'true';
 
   constructor() {}
@@ -171,6 +173,10 @@ export class LLMManager {
   private shouldRetry(error: unknown): boolean {
     if (!(error instanceof Error)) return false;
 
+    if (error instanceof LLMProviderError) {
+      return this.shouldRetryCode(error.code);
+    }
+
     const msg = error.message.toLowerCase();
     // Retry on network/timeout errors, not on auth/validation errors
     return msg.includes('timeout') ||
@@ -180,6 +186,18 @@ export class LLMManager {
       msg.includes('temporarily unavailable') ||
       msg.includes('429') ||  // rate limit
       msg.includes('503');    // service unavailable
+  }
+
+  private shouldRetryCode(code: LLMErrorCode | undefined): boolean {
+    return code === 'rate_limit' || code === 'network' || code === 'server';
+  }
+
+  /** Honor provider Retry-After; oversized waits should fail over immediately. */
+  private async waitForRetry(retryAfterMs: number | undefined): Promise<boolean> {
+    if (retryAfterMs === undefined || retryAfterMs <= 0) return true;
+    if (retryAfterMs > LLMManager.MAX_RETRY_AFTER_MS) return false;
+    await new Promise<void>((resolve) => setTimeout(resolve, retryAfterMs));
+    return true;
   }
 
   /**
@@ -205,6 +223,35 @@ export class LLMManager {
   }
 
   /**
+   * Ordered failover candidates for a tier. Besides configured tier models,
+   * include each provider's current default. That lets a provider recover
+   * from a model decommission (for example an old Groq model saved in the DB)
+   * without requiring the dashboard to load first.
+   */
+  private tierCandidates(tier: Tier): Array<{ resolution: TierResolution; provider: LLMProvider }> {
+    const first = this.resolveTierOrThrow(tier);
+    const out = [first];
+    const seen = new Set([`${first.provider.name}\u0000${first.resolution.assignment.model ?? ''}`]);
+    const add = (resolution: TierResolution) => {
+      const provider = this.providers.get(resolution.assignment.provider);
+      if (!provider) return;
+      const key = `${provider.name}\u0000${resolution.assignment.model ?? ''}`;
+      if (seen.has(key)) return;
+      seen.add(key);
+      out.push({ resolution, provider });
+    };
+
+    for (const candidateTier of TIERS) {
+      const assignment = this.tierMap[candidateTier];
+      if (assignment) add({ tier: candidateTier, assignment });
+    }
+    for (const provider of this.providers.values()) {
+      add({ tier, assignment: { provider: provider.name } });
+    }
+    return out;
+  }
+
+  /**
    * Tier-aware chat. Routes to the resolved provider for the requested tier,
    * records usage labeled by subsystem.
    */
@@ -214,41 +261,46 @@ export class LLMManager {
     messages: LLMMessage[],
     options?: LLMOptions,
   ): Promise<LLMResponse> {
-    const { resolution, provider } = this.resolveTierOrThrow(tier);
-    const model = options?.model ?? resolution.assignment.model;
-    const mergedOptions: LLMOptions = { ...options, ...(model ? { model } : {}) };
-
-    const started = Date.now();
-    try {
-      const response = await this.invokeWithRetry(provider, messages, mergedOptions);
-      recordUsage({
-        tier,
-        resolved_tier: resolution.tier,
-        subsystem,
-        provider: provider.name,
-        model: response.model || model || '',
-        input_tokens: response.usage?.input_tokens ?? 0,
-        output_tokens: response.usage?.output_tokens ?? 0,
-        cache_read_input_tokens: response.usage?.cache_read_input_tokens ?? 0,
-        cache_creation_input_tokens: response.usage?.cache_creation_input_tokens ?? 0,
-        latency_ms: Date.now() - started,
-      });
-      return response;
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      recordUsage({
-        tier,
-        resolved_tier: resolution.tier,
-        subsystem,
-        provider: provider.name,
-        model: model || '',
-        input_tokens: 0,
-        output_tokens: 0,
-        latency_ms: Date.now() - started,
-        error_code: classifyErrorString(msg),
-      });
-      throw err;
+    const failures: string[] = [];
+    let lastFailureCode: LLMErrorCode = 'unknown';
+    const exhaustedProviders = new Set<string>();
+    const candidates = this.tierCandidates(tier);
+    for (let candidateIndex = 0; candidateIndex < candidates.length; candidateIndex++) {
+      const { resolution, provider } = candidates[candidateIndex]!;
+      if (exhaustedProviders.has(provider.name)) continue;
+      const model = candidateIndex === 0
+        ? options?.model ?? resolution.assignment.model
+        : resolution.assignment.model;
+      const mergedOptions: LLMOptions = { ...options };
+      if (model) mergedOptions.model = model;
+      else delete mergedOptions.model;
+      const started = Date.now();
+      try {
+        const response = await this.invokeWithRetry(provider, messages, mergedOptions);
+        recordUsage({
+          tier, resolved_tier: resolution.tier, subsystem, provider: provider.name,
+          model: response.model || model || '',
+          input_tokens: response.usage?.input_tokens ?? 0,
+          output_tokens: response.usage?.output_tokens ?? 0,
+          cache_read_input_tokens: response.usage?.cache_read_input_tokens ?? 0,
+          cache_creation_input_tokens: response.usage?.cache_creation_input_tokens ?? 0,
+          latency_ms: Date.now() - started,
+        });
+        return response;
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        const code = err instanceof LLMProviderError ? err.code : classifyErrorString(msg);
+        lastFailureCode = code;
+        if (code === 'rate_limit' || code === 'auth') exhaustedProviders.add(provider.name);
+        failures.push(msg);
+        recordUsage({
+          tier, resolved_tier: resolution.tier, subsystem, provider: provider.name,
+          model: model || '', input_tokens: 0, output_tokens: 0,
+          latency_ms: Date.now() - started, error_code: code,
+        });
+      }
     }
+    throw new LLMProviderError(failures.join('\n\n'), lastFailureCode);
   }
 
   /**
@@ -260,45 +312,66 @@ export class LLMManager {
     messages: LLMMessage[],
     options?: LLMOptions,
   ): AsyncIterable<LLMStreamEvent> {
-    const { resolution, provider } = this.resolveTierOrThrow(tier);
-    const model = options?.model ?? resolution.assignment.model;
-    const mergedOptions: LLMOptions = { ...options, ...(model ? { model } : {}) };
+    const failures: Array<Extract<LLMStreamEvent, { type: 'error' }>> = [];
+    const exhaustedProviders = new Set<string>();
+    const candidates = this.tierCandidates(tier);
+    for (let candidateIndex = 0; candidateIndex < candidates.length; candidateIndex++) {
+      const { resolution, provider } = candidates[candidateIndex]!;
+      if (exhaustedProviders.has(provider.name)) continue;
+      const model = candidateIndex === 0
+        ? options?.model ?? resolution.assignment.model
+        : resolution.assignment.model;
+      const mergedOptions: LLMOptions = { ...options };
+      if (model) mergedOptions.model = model;
+      else delete mergedOptions.model;
+      const started = Date.now();
+      let finalResponse: LLMResponse | null = null;
+      let terminalError: Extract<LLMStreamEvent, { type: 'error' }> | null = null;
+      let emittedContent = false;
 
-    const started = Date.now();
-    let finalResponse: LLMResponse | null = null;
-    let errored: string | null = null;
-
-    try {
       for await (const event of this.streamWithRetry(provider, messages, mergedOptions)) {
         if (event.type === 'done') finalResponse = event.response;
-        if (event.type === 'error') errored = event.error;
+        if (event.type === 'text' || event.type === 'tool_call') emittedContent = true;
+        if (event.type === 'error') {
+          terminalError = event;
+          continue; // hold it while a clean failover is still possible
+        }
         yield event;
       }
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      errored = msg;
-      throw err;
-    } finally {
+
       recordUsage({
-        tier,
-        resolved_tier: resolution.tier,
-        subsystem,
-        provider: provider.name,
+        tier, resolved_tier: resolution.tier, subsystem, provider: provider.name,
         model: finalResponse?.model || model || '',
         input_tokens: finalResponse?.usage?.input_tokens ?? 0,
         output_tokens: finalResponse?.usage?.output_tokens ?? 0,
         cache_read_input_tokens: finalResponse?.usage?.cache_read_input_tokens ?? 0,
         cache_creation_input_tokens: finalResponse?.usage?.cache_creation_input_tokens ?? 0,
         latency_ms: Date.now() - started,
-        error_code: errored ? classifyErrorString(errored) : undefined,
+        error_code: terminalError?.code,
       });
+
+      if (!terminalError) return;
+      if (emittedContent) {
+        yield terminalError;
+        return;
+      }
+      if (terminalError.code === 'rate_limit' || terminalError.code === 'auth') {
+        exhaustedProviders.add(provider.name);
+      }
+      failures.push(terminalError);
     }
+
+    const error = failures.map((event) => event.error).join('\n\n');
+    yield {
+      type: 'error',
+      error,
+      code: failures.at(-1)?.code ?? classifyErrorString(error),
+    };
   }
 
   /**
-   * Single-provider chat with retry. Used by tier-aware paths after the tier
-   * has resolved to a concrete provider. No legacy fallback chain logic - tier
-   * fall-up replaces it.
+   * Single-provider chat with retry. Tier-aware callers layer model/provider
+   * failover around this method after local retries are exhausted.
    */
   private async invokeWithRetry(
     provider: LLMProvider,
@@ -306,6 +379,8 @@ export class LLMManager {
     options?: LLMOptions,
   ): Promise<LLMResponse> {
     const errors: string[] = [];
+    let lastCode: LLMErrorCode = 'unknown';
+    let lastRetryAfterMs: number | undefined;
     for (let attempt = 1; attempt <= LLMManager.MAX_RETRIES_PER_PROVIDER; attempt++) {
       try {
         const result = await this.withTimeout(provider.chat(messages, options), provider.name);
@@ -316,14 +391,22 @@ export class LLMManager {
       } catch (err) {
         const errorMsg = err instanceof Error ? err.message : String(err);
         errors.push(`attempt ${attempt}: ${errorMsg}`);
+        lastCode = err instanceof LLMProviderError ? err.code : classifyErrorString(errorMsg);
+        lastRetryAfterMs = err instanceof LLMProviderError ? err.retryAfterMs : undefined;
         const shouldRetry = this.shouldRetry(err);
         console.error(
           `[LLM] Provider ${provider.name} failed (attempt ${attempt}/${LLMManager.MAX_RETRIES_PER_PROVIDER})${!shouldRetry ? ' [no retry]' : ''}: ${errorMsg}`
         );
-        if (!shouldRetry) break;
+        if (!shouldRetry || attempt === LLMManager.MAX_RETRIES_PER_PROVIDER) break;
+        const retryAfterMs = err instanceof LLMProviderError ? err.retryAfterMs : undefined;
+        if (!await this.waitForRetry(retryAfterMs)) break;
       }
     }
-    throw new Error(this.formatFailure(provider.name, errors));
+    throw new LLMProviderError(
+      this.formatFailure(provider.name, errors),
+      lastCode,
+      lastRetryAfterMs,
+    );
   }
 
   private async *streamWithRetry(
@@ -335,6 +418,8 @@ export class LLMManager {
     let lastErrorCode: LLMErrorCode | undefined;
     for (let attempt = 1; attempt <= LLMManager.MAX_RETRIES_PER_PROVIDER; attempt++) {
       let emittedContent = false;
+      let retryableEvent = true;
+      let eventRetryAfterMs: number | undefined;
       try {
         let hasError = false;
         for await (const event of provider.stream(messages, options)) {
@@ -342,6 +427,8 @@ export class LLMManager {
             hasError = true;
             errors.push(`attempt ${attempt}: ${event.error}`);
             lastErrorCode = event.code ?? classifyErrorString(event.error);
+            retryableEvent = this.shouldRetryCode(lastErrorCode);
+            eventRetryAfterMs = event.retry_after_ms;
             console.error(
               `[LLM] Provider ${provider.name} stream error (attempt ${attempt}/${LLMManager.MAX_RETRIES_PER_PROVIDER}): ${event.error}`
             );
@@ -361,6 +448,8 @@ export class LLMManager {
           yield event;
         }
         if (!hasError) return;
+        if (!retryableEvent || attempt === LLMManager.MAX_RETRIES_PER_PROVIDER) break;
+        if (!await this.waitForRetry(eventRetryAfterMs)) break;
       } catch (err) {
         const errorMsg = err instanceof Error ? err.message : String(err);
         errors.push(`attempt ${attempt}: ${errorMsg}`);
@@ -377,7 +466,9 @@ export class LLMManager {
           };
           return;
         }
-        if (!shouldRetry) break;
+        if (!shouldRetry || attempt === LLMManager.MAX_RETRIES_PER_PROVIDER) break;
+        const retryAfterMs = err instanceof LLMProviderError ? err.retryAfterMs : undefined;
+        if (!await this.waitForRetry(retryAfterMs)) break;
       }
     }
     yield {
@@ -426,6 +517,8 @@ export class LLMManager {
           );
 
           if (!shouldRetry) break;
+          const retryAfterMs = err instanceof LLMProviderError ? err.retryAfterMs : undefined;
+          if (attempt < LLMManager.MAX_RETRIES_PER_PROVIDER && !await this.waitForRetry(retryAfterMs)) break;
         }
       }
 
@@ -472,6 +565,8 @@ export class LLMManager {
       const errors: string[] = [];
       for (let attempt = 1; attempt <= LLMManager.MAX_RETRIES_PER_PROVIDER; attempt++) {
         let emittedContent = false;
+        let retryableEvent = true;
+        let eventRetryAfterMs: number | undefined;
         try {
           let hasError = false;
           for await (const event of provider.stream(messages, options)) {
@@ -479,6 +574,8 @@ export class LLMManager {
               hasError = true;
               errors.push(`attempt ${attempt}: ${event.error}`);
               lastErrorCode = event.code ?? classifyErrorString(event.error);
+              retryableEvent = this.shouldRetryCode(lastErrorCode);
+              eventRetryAfterMs = event.retry_after_ms;
               console.error(
                 `[LLM] Provider ${providerName} stream error (attempt ${attempt}/${LLMManager.MAX_RETRIES_PER_PROVIDER}): ${event.error}`
               );
@@ -501,6 +598,8 @@ export class LLMManager {
           if (!hasError) {
             return;
           }
+          if (!retryableEvent || attempt === LLMManager.MAX_RETRIES_PER_PROVIDER) break;
+          if (!await this.waitForRetry(eventRetryAfterMs)) break;
         } catch (err) {
           const errorMsg = err instanceof Error ? err.message : String(err);
           errors.push(`attempt ${attempt}: ${errorMsg}`);
@@ -520,7 +619,9 @@ export class LLMManager {
             return;
           }
 
-          if (!shouldRetry) break;
+          if (!shouldRetry || attempt === LLMManager.MAX_RETRIES_PER_PROVIDER) break;
+          const retryAfterMs = err instanceof LLMProviderError ? err.retryAfterMs : undefined;
+          if (!await this.waitForRetry(retryAfterMs)) break;
         }
       }
 

--- a/src/llm/manager.ts
+++ b/src/llm/manager.ts
@@ -347,7 +347,8 @@ export class LLMManager {
         cache_read_input_tokens: finalResponse?.usage?.cache_read_input_tokens ?? 0,
         cache_creation_input_tokens: finalResponse?.usage?.cache_creation_input_tokens ?? 0,
         latency_ms: Date.now() - started,
-        error_code: terminalError?.code,
+        error_code: terminalError?.code
+          ?? (terminalError ? classifyErrorString(terminalError.error) : undefined),
       });
 
       if (!terminalError) return;
@@ -362,10 +363,14 @@ export class LLMManager {
     }
 
     const error = failures.map((event) => event.error).join('\n\n');
+    const finalFailure = failures.at(-1);
     yield {
       type: 'error',
       error,
-      code: failures.at(-1)?.code ?? classifyErrorString(error),
+      code: finalFailure?.code ?? classifyErrorString(error),
+      ...(finalFailure?.retry_after_ms !== undefined
+        ? { retry_after_ms: finalFailure.retry_after_ms }
+        : {}),
     };
   }
 
@@ -416,6 +421,7 @@ export class LLMManager {
   ): AsyncIterable<LLMStreamEvent> {
     const errors: string[] = [];
     let lastErrorCode: LLMErrorCode | undefined;
+    let lastRetryAfterMs: number | undefined;
     for (let attempt = 1; attempt <= LLMManager.MAX_RETRIES_PER_PROVIDER; attempt++) {
       let emittedContent = false;
       let retryableEvent = true;
@@ -429,6 +435,7 @@ export class LLMManager {
             lastErrorCode = event.code ?? classifyErrorString(event.error);
             retryableEvent = this.shouldRetryCode(lastErrorCode);
             eventRetryAfterMs = event.retry_after_ms;
+            lastRetryAfterMs = event.retry_after_ms;
             console.error(
               `[LLM] Provider ${provider.name} stream error (attempt ${attempt}/${LLMManager.MAX_RETRIES_PER_PROVIDER}): ${event.error}`
             );
@@ -437,6 +444,7 @@ export class LLMManager {
                 type: 'error',
                 error: this.formatFailure(provider.name, errors),
                 code: lastErrorCode,
+                ...(lastRetryAfterMs !== undefined ? { retry_after_ms: lastRetryAfterMs } : {}),
               };
               return;
             }
@@ -454,6 +462,8 @@ export class LLMManager {
         const errorMsg = err instanceof Error ? err.message : String(err);
         errors.push(`attempt ${attempt}: ${errorMsg}`);
         lastErrorCode = classifyErrorString(errorMsg);
+        const retryAfterMs = err instanceof LLMProviderError ? err.retryAfterMs : undefined;
+        lastRetryAfterMs = retryAfterMs;
         const shouldRetry = this.shouldRetry(err);
         console.error(
           `[LLM] Provider ${provider.name} stream failed (attempt ${attempt}/${LLMManager.MAX_RETRIES_PER_PROVIDER})${!shouldRetry ? ' [no retry]' : ''}: ${errorMsg}`
@@ -463,11 +473,11 @@ export class LLMManager {
             type: 'error',
             error: this.formatFailure(provider.name, errors),
             code: lastErrorCode,
+            ...(lastRetryAfterMs !== undefined ? { retry_after_ms: lastRetryAfterMs } : {}),
           };
           return;
         }
         if (!shouldRetry || attempt === LLMManager.MAX_RETRIES_PER_PROVIDER) break;
-        const retryAfterMs = err instanceof LLMProviderError ? err.retryAfterMs : undefined;
         if (!await this.waitForRetry(retryAfterMs)) break;
       }
     }
@@ -475,6 +485,7 @@ export class LLMManager {
       type: 'error',
       error: this.formatFailure(provider.name, errors),
       code: lastErrorCode ?? classifyErrorString(errors.join('\n')),
+      ...(lastRetryAfterMs !== undefined ? { retry_after_ms: lastRetryAfterMs } : {}),
     };
   }
 
@@ -554,6 +565,7 @@ export class LLMManager {
     // Legacy multi-provider fallback stream (no tier map configured).
     const failures: string[] = [];
     let lastErrorCode: LLMErrorCode | undefined;
+    let lastRetryAfterMs: number | undefined;
 
     for (const providerName of this.getProviderSequence()) {
       const provider = this.providers.get(providerName);
@@ -576,6 +588,7 @@ export class LLMManager {
               lastErrorCode = event.code ?? classifyErrorString(event.error);
               retryableEvent = this.shouldRetryCode(lastErrorCode);
               eventRetryAfterMs = event.retry_after_ms;
+              lastRetryAfterMs = event.retry_after_ms;
               console.error(
                 `[LLM] Provider ${providerName} stream error (attempt ${attempt}/${LLMManager.MAX_RETRIES_PER_PROVIDER}): ${event.error}`
               );
@@ -584,6 +597,7 @@ export class LLMManager {
                   type: 'error',
                   error: this.formatFailure(providerName, errors),
                   code: lastErrorCode,
+                  ...(lastRetryAfterMs !== undefined ? { retry_after_ms: lastRetryAfterMs } : {}),
                 };
                 return;
               }
@@ -604,6 +618,8 @@ export class LLMManager {
           const errorMsg = err instanceof Error ? err.message : String(err);
           errors.push(`attempt ${attempt}: ${errorMsg}`);
           lastErrorCode = classifyErrorString(errorMsg);
+          const retryAfterMs = err instanceof LLMProviderError ? err.retryAfterMs : undefined;
+          lastRetryAfterMs = retryAfterMs;
 
           const shouldRetry = this.shouldRetry(err);
           console.error(
@@ -615,12 +631,12 @@ export class LLMManager {
               type: 'error',
               error: this.formatFailure(providerName, errors),
               code: lastErrorCode,
+              ...(lastRetryAfterMs !== undefined ? { retry_after_ms: lastRetryAfterMs } : {}),
             };
             return;
           }
 
           if (!shouldRetry || attempt === LLMManager.MAX_RETRIES_PER_PROVIDER) break;
-          const retryAfterMs = err instanceof LLMProviderError ? err.retryAfterMs : undefined;
           if (!await this.waitForRetry(retryAfterMs)) break;
         }
       }
@@ -633,6 +649,7 @@ export class LLMManager {
       type: 'error',
       error: aggregated,
       code: lastErrorCode ?? classifyErrorString(aggregated),
+      ...(lastRetryAfterMs !== undefined ? { retry_after_ms: lastRetryAfterMs } : {}),
     };
   }
 }

--- a/src/llm/manager.ts
+++ b/src/llm/manager.ts
@@ -13,6 +13,7 @@ import {
   type TierMap,
   type TierResolution,
   TIERS,
+  TIER_FALLBACK,
   resolveTier,
 } from './tiers.ts';
 import { recordUsage } from './usage.ts';
@@ -198,10 +199,15 @@ export class LLMManager {
    * when the selected model is unavailable or the provider has no quota.
    */
   private shouldFailOver(code: LLMErrorCode | undefined, message: string): boolean {
-    if (code === 'rate_limit' || code === 'not_found') return true;
-    if (code !== 'bad_request') return false;
+    if (code === 'rate_limit') return true;
+    if (code !== 'bad_request' && code !== 'not_found') return false;
+
+    // A bare 404 can mean a bad endpoint or missing non-model resource. Only
+    // cross the provider boundary when the upstream error identifies model
+    // availability as the problem.
     return /\bmodel(?:[_ -](?:decommissioned|not[_ -]found|unsupported|unavailable|retired))\b/i.test(message)
-      || /\b(?:decommissioned|retired)\b.*\bmodel\b/i.test(message);
+      || /\bmodel\b.{0,160}\b(?:decommissioned|not found|does not exist|unsupported|unavailable|retired)\b/i.test(message)
+      || /\b(?:decommissioned|retired)\b.{0,160}\bmodel\b/i.test(message);
   }
 
   /** Honor provider Retry-After; oversized waits should fail over immediately. */
@@ -259,7 +265,10 @@ export class LLMManager {
     add({ tier: first.resolution.tier, assignment: { provider: first.provider.name } });
 
     const mapped: TierResolution[] = [];
-    for (const candidateTier of TIERS) {
+    // Respect the same explicit cost/routing boundary as normal tier
+    // resolution. In particular, task/background tiers never spill into the
+    // conversation tier merely because it happens to be configured.
+    for (const candidateTier of [tier, ...TIER_FALLBACK[tier]]) {
       const assignment = this.tierMap[candidateTier];
       if (assignment) mapped.push({ tier: candidateTier, assignment });
     }
@@ -451,7 +460,7 @@ export class LLMManager {
         );
         if (!shouldRetry || attempt === LLMManager.MAX_RETRIES_PER_PROVIDER) break;
         const retryAfterMs = err instanceof LLMProviderError ? err.retryAfterMs : undefined;
-        if (failFastOnRateLimit && lastCode === 'rate_limit' && retryAfterMs !== undefined) break;
+        if (failFastOnRateLimit && lastCode === 'rate_limit') break;
         if (!await this.waitForRetry(retryAfterMs)) break;
       }
     }
@@ -506,7 +515,7 @@ export class LLMManager {
         }
         if (!hasError) return;
         if (!retryableEvent || attempt === LLMManager.MAX_RETRIES_PER_PROVIDER) break;
-        if (failFastOnRateLimit && lastErrorCode === 'rate_limit' && eventRetryAfterMs !== undefined) break;
+        if (failFastOnRateLimit && lastErrorCode === 'rate_limit') break;
         if (!await this.waitForRetry(eventRetryAfterMs)) break;
       } catch (err) {
         const errorMsg = err instanceof Error ? err.message : String(err);
@@ -528,7 +537,7 @@ export class LLMManager {
           return;
         }
         if (!shouldRetry || attempt === LLMManager.MAX_RETRIES_PER_PROVIDER) break;
-        if (failFastOnRateLimit && lastErrorCode === 'rate_limit' && retryAfterMs !== undefined) break;
+        if (failFastOnRateLimit && lastErrorCode === 'rate_limit') break;
         if (!await this.waitForRetry(retryAfterMs)) break;
       }
     }

--- a/src/llm/manager.ts
+++ b/src/llm/manager.ts
@@ -192,6 +192,18 @@ export class LLMManager {
     return code === 'rate_limit' || code === 'network' || code === 'server';
   }
 
+  /**
+   * Tier failover is intentionally narrower than a provider-local retry.
+   * Sending the same conversation to another provider is only appropriate
+   * when the selected model is unavailable or the provider has no quota.
+   */
+  private shouldFailOver(code: LLMErrorCode | undefined, message: string): boolean {
+    if (code === 'rate_limit' || code === 'not_found') return true;
+    if (code !== 'bad_request') return false;
+    return /\bmodel(?:[_ -](?:decommissioned|not[_ -]found|unsupported|unavailable|retired))\b/i.test(message)
+      || /\b(?:decommissioned|retired)\b.*\bmodel\b/i.test(message);
+  }
+
   /** Honor provider Retry-After; oversized waits should fail over immediately. */
   private async waitForRetry(retryAfterMs: number | undefined): Promise<boolean> {
     if (retryAfterMs === undefined || retryAfterMs <= 0) return true;
@@ -223,10 +235,11 @@ export class LLMManager {
   }
 
   /**
-   * Ordered failover candidates for a tier. Besides configured tier models,
-   * include each provider's current default. That lets a provider recover
-   * from a model decommission (for example an old Groq model saved in the DB)
-   * without requiring the dashboard to load first.
+   * Ordered failover candidates for a tier. Only explicitly tier-mapped
+   * providers are eligible: merely configuring a provider does not authorize
+   * the router to send conversation content to it. Each mapped provider's
+   * default follows its assigned model so a retired model can recover without
+   * waiting for the dashboard to refresh the saved setting.
    */
   private tierCandidates(tier: Tier): Array<{ resolution: TierResolution; provider: LLMProvider }> {
     const first = this.resolveTierOrThrow(tier);
@@ -241,12 +254,18 @@ export class LLMManager {
       out.push({ resolution, provider });
     };
 
+    // Recover the resolved provider's own default before crossing a provider
+    // boundary (and potentially a cost boundary).
+    add({ tier: first.resolution.tier, assignment: { provider: first.provider.name } });
+
+    const mapped: TierResolution[] = [];
     for (const candidateTier of TIERS) {
       const assignment = this.tierMap[candidateTier];
-      if (assignment) add({ tier: candidateTier, assignment });
+      if (assignment) mapped.push({ tier: candidateTier, assignment });
     }
-    for (const provider of this.providers.values()) {
-      add({ tier, assignment: { provider: provider.name } });
+    for (const resolution of mapped) {
+      add(resolution);
+      add({ tier: resolution.tier, assignment: { provider: resolution.assignment.provider } });
     }
     return out;
   }
@@ -263,6 +282,7 @@ export class LLMManager {
   ): Promise<LLMResponse> {
     const failures: string[] = [];
     let lastFailureCode: LLMErrorCode = 'unknown';
+    let lastRetryAfterMs: number | undefined;
     const exhaustedProviders = new Set<string>();
     const candidates = this.tierCandidates(tier);
     for (let candidateIndex = 0; candidateIndex < candidates.length; candidateIndex++) {
@@ -275,8 +295,17 @@ export class LLMManager {
       if (model) mergedOptions.model = model;
       else delete mergedOptions.model;
       const started = Date.now();
+      const hasAlternativeProvider = candidates
+        .slice(candidateIndex + 1)
+        .some((candidate) => candidate.provider.name !== provider.name
+          && !exhaustedProviders.has(candidate.provider.name));
       try {
-        const response = await this.invokeWithRetry(provider, messages, mergedOptions);
+        const response = await this.invokeWithRetry(
+          provider,
+          messages,
+          mergedOptions,
+          hasAlternativeProvider,
+        );
         recordUsage({
           tier, resolved_tier: resolution.tier, subsystem, provider: provider.name,
           model: response.model || model || '',
@@ -291,16 +320,19 @@ export class LLMManager {
         const msg = err instanceof Error ? err.message : String(err);
         const code = err instanceof LLMProviderError ? err.code : classifyErrorString(msg);
         lastFailureCode = code;
-        if (code === 'rate_limit' || code === 'auth') exhaustedProviders.add(provider.name);
+        const retryAfterMs = err instanceof LLMProviderError ? err.retryAfterMs : undefined;
+        if (retryAfterMs !== undefined) lastRetryAfterMs = retryAfterMs;
         failures.push(msg);
         recordUsage({
           tier, resolved_tier: resolution.tier, subsystem, provider: provider.name,
           model: model || '', input_tokens: 0, output_tokens: 0,
           latency_ms: Date.now() - started, error_code: code,
         });
+        if (!this.shouldFailOver(code, msg)) throw err;
+        if (code === 'rate_limit') exhaustedProviders.add(provider.name);
       }
     }
-    throw new LLMProviderError(failures.join('\n\n'), lastFailureCode);
+    throw new LLMProviderError(failures.join('\n\n'), lastFailureCode, lastRetryAfterMs);
   }
 
   /**
@@ -328,8 +360,17 @@ export class LLMManager {
       let finalResponse: LLMResponse | null = null;
       let terminalError: Extract<LLMStreamEvent, { type: 'error' }> | null = null;
       let emittedContent = false;
+      const hasAlternativeProvider = candidates
+        .slice(candidateIndex + 1)
+        .some((candidate) => candidate.provider.name !== provider.name
+          && !exhaustedProviders.has(candidate.provider.name));
 
-      for await (const event of this.streamWithRetry(provider, messages, mergedOptions)) {
+      for await (const event of this.streamWithRetry(
+        provider,
+        messages,
+        mergedOptions,
+        hasAlternativeProvider,
+      )) {
         if (event.type === 'done') finalResponse = event.response;
         if (event.type === 'text' || event.type === 'tool_call') emittedContent = true;
         if (event.type === 'error') {
@@ -356,7 +397,12 @@ export class LLMManager {
         yield terminalError;
         return;
       }
-      if (terminalError.code === 'rate_limit' || terminalError.code === 'auth') {
+      const terminalCode = terminalError.code ?? classifyErrorString(terminalError.error);
+      if (!this.shouldFailOver(terminalCode, terminalError.error)) {
+        yield terminalError;
+        return;
+      }
+      if (terminalCode === 'rate_limit') {
         exhaustedProviders.add(provider.name);
       }
       failures.push(terminalError);
@@ -382,6 +428,7 @@ export class LLMManager {
     provider: LLMProvider,
     messages: LLMMessage[],
     options?: LLMOptions,
+    failFastOnRateLimit = false,
   ): Promise<LLMResponse> {
     const errors: string[] = [];
     let lastCode: LLMErrorCode = 'unknown';
@@ -404,6 +451,7 @@ export class LLMManager {
         );
         if (!shouldRetry || attempt === LLMManager.MAX_RETRIES_PER_PROVIDER) break;
         const retryAfterMs = err instanceof LLMProviderError ? err.retryAfterMs : undefined;
+        if (failFastOnRateLimit && lastCode === 'rate_limit' && retryAfterMs !== undefined) break;
         if (!await this.waitForRetry(retryAfterMs)) break;
       }
     }
@@ -418,6 +466,7 @@ export class LLMManager {
     provider: LLMProvider,
     messages: LLMMessage[],
     options?: LLMOptions,
+    failFastOnRateLimit = false,
   ): AsyncIterable<LLMStreamEvent> {
     const errors: string[] = [];
     let lastErrorCode: LLMErrorCode | undefined;
@@ -457,11 +506,12 @@ export class LLMManager {
         }
         if (!hasError) return;
         if (!retryableEvent || attempt === LLMManager.MAX_RETRIES_PER_PROVIDER) break;
+        if (failFastOnRateLimit && lastErrorCode === 'rate_limit' && eventRetryAfterMs !== undefined) break;
         if (!await this.waitForRetry(eventRetryAfterMs)) break;
       } catch (err) {
         const errorMsg = err instanceof Error ? err.message : String(err);
         errors.push(`attempt ${attempt}: ${errorMsg}`);
-        lastErrorCode = classifyErrorString(errorMsg);
+        lastErrorCode = err instanceof LLMProviderError ? err.code : classifyErrorString(errorMsg);
         const retryAfterMs = err instanceof LLMProviderError ? err.retryAfterMs : undefined;
         lastRetryAfterMs = retryAfterMs;
         const shouldRetry = this.shouldRetry(err);
@@ -478,6 +528,7 @@ export class LLMManager {
           return;
         }
         if (!shouldRetry || attempt === LLMManager.MAX_RETRIES_PER_PROVIDER) break;
+        if (failFastOnRateLimit && lastErrorCode === 'rate_limit' && retryAfterMs !== undefined) break;
         if (!await this.waitForRetry(retryAfterMs)) break;
       }
     }
@@ -617,7 +668,7 @@ export class LLMManager {
         } catch (err) {
           const errorMsg = err instanceof Error ? err.message : String(err);
           errors.push(`attempt ${attempt}: ${errorMsg}`);
-          lastErrorCode = classifyErrorString(errorMsg);
+          lastErrorCode = err instanceof LLMProviderError ? err.code : classifyErrorString(errorMsg);
           const retryAfterMs = err instanceof LLMProviderError ? err.retryAfterMs : undefined;
           lastRetryAfterMs = retryAfterMs;
 

--- a/src/llm/manager.ts
+++ b/src/llm/manager.ts
@@ -25,7 +25,10 @@ export class LLMManager {
   private tierMap: TierMap = {};
   private static readonly MAX_RETRIES_PER_PROVIDER = 3;
   private static readonly REQUEST_TIMEOUT_MS = 90000; // 90 second timeout for LLM calls
-  /** Never park an interactive request for a very long quota reset. */
+  /**
+   * Never park an interactive request for a very long quota reset. Applies
+   * cumulatively across one provider's attempts (see waitForRetry).
+   */
   private static readonly MAX_RETRY_AFTER_MS = 60000;
   private static readonly isDebugging = process.env.JARVIS_LOG_LEVEL === 'debug' || process.env.DEBUG_LLM === 'true';
 
@@ -210,12 +213,25 @@ export class LLMManager {
       || /\b(?:decommissioned|retired)\b.{0,160}\bmodel\b/i.test(message);
   }
 
-  /** Honor provider Retry-After; oversized waits should fail over immediately. */
-  private async waitForRetry(retryAfterMs: number | undefined): Promise<boolean> {
+  /**
+   * Honor provider Retry-After. The budget is shared across one provider's
+   * attempts, so stacked Retry-After sleeps can never park a request for
+   * longer than MAX_RETRY_AFTER_MS in total. Returns false when the wait
+   * would overrun what remains — the caller stops retrying and fails over.
+   */
+  private async waitForRetry(
+    retryAfterMs: number | undefined,
+    budget: { remainingMs: number },
+  ): Promise<boolean> {
     if (retryAfterMs === undefined || retryAfterMs <= 0) return true;
-    if (retryAfterMs > LLMManager.MAX_RETRY_AFTER_MS) return false;
+    if (retryAfterMs > budget.remainingMs) return false;
+    budget.remainingMs -= retryAfterMs;
     await new Promise<void>((resolve) => setTimeout(resolve, retryAfterMs));
     return true;
+  }
+
+  private newRetryBudget(): { remainingMs: number } {
+    return { remainingMs: LLMManager.MAX_RETRY_AFTER_MS };
   }
 
   /**
@@ -374,32 +390,36 @@ export class LLMManager {
         .some((candidate) => candidate.provider.name !== provider.name
           && !exhaustedProviders.has(candidate.provider.name));
 
-      for await (const event of this.streamWithRetry(
-        provider,
-        messages,
-        mergedOptions,
-        hasAlternativeProvider,
-      )) {
-        if (event.type === 'done') finalResponse = event.response;
-        if (event.type === 'text' || event.type === 'tool_call') emittedContent = true;
-        if (event.type === 'error') {
-          terminalError = event;
-          continue; // hold it while a clean failover is still possible
+      try {
+        for await (const event of this.streamWithRetry(
+          provider,
+          messages,
+          mergedOptions,
+          hasAlternativeProvider,
+        )) {
+          if (event.type === 'done') finalResponse = event.response;
+          if (event.type === 'text' || event.type === 'tool_call') emittedContent = true;
+          if (event.type === 'error') {
+            terminalError = event;
+            continue; // hold it while a clean failover is still possible
+          }
+          yield event;
         }
-        yield event;
+      } finally {
+        // Runs even when the consumer stops iterating mid-stream (client
+        // disconnect / stop) so partial calls still land in telemetry.
+        recordUsage({
+          tier, resolved_tier: resolution.tier, subsystem, provider: provider.name,
+          model: finalResponse?.model || model || '',
+          input_tokens: finalResponse?.usage?.input_tokens ?? 0,
+          output_tokens: finalResponse?.usage?.output_tokens ?? 0,
+          cache_read_input_tokens: finalResponse?.usage?.cache_read_input_tokens ?? 0,
+          cache_creation_input_tokens: finalResponse?.usage?.cache_creation_input_tokens ?? 0,
+          latency_ms: Date.now() - started,
+          error_code: terminalError?.code
+            ?? (terminalError ? classifyErrorString(terminalError.error) : undefined),
+        });
       }
-
-      recordUsage({
-        tier, resolved_tier: resolution.tier, subsystem, provider: provider.name,
-        model: finalResponse?.model || model || '',
-        input_tokens: finalResponse?.usage?.input_tokens ?? 0,
-        output_tokens: finalResponse?.usage?.output_tokens ?? 0,
-        cache_read_input_tokens: finalResponse?.usage?.cache_read_input_tokens ?? 0,
-        cache_creation_input_tokens: finalResponse?.usage?.cache_creation_input_tokens ?? 0,
-        latency_ms: Date.now() - started,
-        error_code: terminalError?.code
-          ?? (terminalError ? classifyErrorString(terminalError.error) : undefined),
-      });
 
       if (!terminalError) return;
       if (emittedContent) {
@@ -442,6 +462,7 @@ export class LLMManager {
     const errors: string[] = [];
     let lastCode: LLMErrorCode = 'unknown';
     let lastRetryAfterMs: number | undefined;
+    const retryBudget = this.newRetryBudget();
     for (let attempt = 1; attempt <= LLMManager.MAX_RETRIES_PER_PROVIDER; attempt++) {
       try {
         const result = await this.withTimeout(provider.chat(messages, options), provider.name);
@@ -461,7 +482,7 @@ export class LLMManager {
         if (!shouldRetry || attempt === LLMManager.MAX_RETRIES_PER_PROVIDER) break;
         const retryAfterMs = err instanceof LLMProviderError ? err.retryAfterMs : undefined;
         if (failFastOnRateLimit && lastCode === 'rate_limit') break;
-        if (!await this.waitForRetry(retryAfterMs)) break;
+        if (!await this.waitForRetry(retryAfterMs, retryBudget)) break;
       }
     }
     throw new LLMProviderError(
@@ -480,6 +501,7 @@ export class LLMManager {
     const errors: string[] = [];
     let lastErrorCode: LLMErrorCode | undefined;
     let lastRetryAfterMs: number | undefined;
+    const retryBudget = this.newRetryBudget();
     for (let attempt = 1; attempt <= LLMManager.MAX_RETRIES_PER_PROVIDER; attempt++) {
       let emittedContent = false;
       let retryableEvent = true;
@@ -516,7 +538,7 @@ export class LLMManager {
         if (!hasError) return;
         if (!retryableEvent || attempt === LLMManager.MAX_RETRIES_PER_PROVIDER) break;
         if (failFastOnRateLimit && lastErrorCode === 'rate_limit') break;
-        if (!await this.waitForRetry(eventRetryAfterMs)) break;
+        if (!await this.waitForRetry(eventRetryAfterMs, retryBudget)) break;
       } catch (err) {
         const errorMsg = err instanceof Error ? err.message : String(err);
         errors.push(`attempt ${attempt}: ${errorMsg}`);
@@ -538,7 +560,7 @@ export class LLMManager {
         }
         if (!shouldRetry || attempt === LLMManager.MAX_RETRIES_PER_PROVIDER) break;
         if (failFastOnRateLimit && lastErrorCode === 'rate_limit') break;
-        if (!await this.waitForRetry(retryAfterMs)) break;
+        if (!await this.waitForRetry(retryAfterMs, retryBudget)) break;
       }
     }
     yield {
@@ -571,6 +593,7 @@ export class LLMManager {
       }
 
       const errors: string[] = [];
+      const retryBudget = this.newRetryBudget();
       for (let attempt = 1; attempt <= LLMManager.MAX_RETRIES_PER_PROVIDER; attempt++) {
         try {
           const result = await this.withTimeout(provider.chat(messages, options), providerName);
@@ -589,7 +612,7 @@ export class LLMManager {
 
           if (!shouldRetry) break;
           const retryAfterMs = err instanceof LLMProviderError ? err.retryAfterMs : undefined;
-          if (attempt < LLMManager.MAX_RETRIES_PER_PROVIDER && !await this.waitForRetry(retryAfterMs)) break;
+          if (attempt < LLMManager.MAX_RETRIES_PER_PROVIDER && !await this.waitForRetry(retryAfterMs, retryBudget)) break;
         }
       }
 
@@ -635,6 +658,7 @@ export class LLMManager {
       }
 
       const errors: string[] = [];
+      const retryBudget = this.newRetryBudget();
       for (let attempt = 1; attempt <= LLMManager.MAX_RETRIES_PER_PROVIDER; attempt++) {
         let emittedContent = false;
         let retryableEvent = true;
@@ -673,7 +697,7 @@ export class LLMManager {
             return;
           }
           if (!retryableEvent || attempt === LLMManager.MAX_RETRIES_PER_PROVIDER) break;
-          if (!await this.waitForRetry(eventRetryAfterMs)) break;
+          if (!await this.waitForRetry(eventRetryAfterMs, retryBudget)) break;
         } catch (err) {
           const errorMsg = err instanceof Error ? err.message : String(err);
           errors.push(`attempt ${attempt}: ${errorMsg}`);
@@ -697,7 +721,7 @@ export class LLMManager {
           }
 
           if (!shouldRetry || attempt === LLMManager.MAX_RETRIES_PER_PROVIDER) break;
-          if (!await this.waitForRetry(retryAfterMs)) break;
+          if (!await this.waitForRetry(retryAfterMs, retryBudget)) break;
         }
       }
 

--- a/src/llm/provider.test.ts
+++ b/src/llm/provider.test.ts
@@ -1,13 +1,13 @@
 import { test, expect, describe, beforeEach, afterEach, mock } from 'bun:test';
 import { AnthropicProvider } from './anthropic.ts';
 import { OpenAIProvider, modelRejectsCustomTemperature } from './openai.ts';
-import { GroqProvider, relaxOptionalFieldsToNullable } from './groq.ts';
+import { GroqProvider, isGroqJarvisModel, relaxOptionalFieldsToNullable } from './groq.ts';
 import { OllamaProvider } from './ollama.ts';
 import { OpenRouterProvider } from './openrouter.ts';
 import { NVIDIAProvider } from './nvidia.ts';
 import { LiteLLMProvider } from './litellm.ts';
 import { LLMManager } from './manager.ts';
-import { guardImageSize, classifyHttpStatus, classifyErrorString, type LLMMessage, type ContentBlock } from './provider.ts';
+import { guardImageSize, classifyHttpStatus, classifyErrorString, LLMProviderError, type LLMMessage, type ContentBlock } from './provider.ts';
 import { isToolResult, type ToolResult } from '../actions/tools/registry.ts';
 
 describe('LLM Provider Types', () => {
@@ -211,6 +211,97 @@ describe('LLMManager', () => {
     expect(events.some((event) => event.type === 'done')).toBe(true);
     expect(events.some((event) => event.type === 'error')).toBe(false);
   });
+
+  test('does not retry a permanent streamed 400 before falling back', async () => {
+    const manager = new LLMManager();
+    let badCalls = 0;
+    const bad = {
+      name: 'bad',
+      listModels: async () => [],
+      async chat() { throw new Error('unused'); },
+      async *stream() {
+        badCalls++;
+        yield { type: 'error' as const, error: 'Groq API error (400): model_decommissioned', code: 'bad_request' as const };
+      },
+    };
+    const good = {
+      name: 'good',
+      listModels: async () => ['current'],
+      async chat() { throw new Error('unused'); },
+      async *stream() {
+        yield { type: 'text' as const, text: 'recovered' };
+        yield { type: 'done' as const, response: {
+          content: 'recovered', tool_calls: [], usage: { input_tokens: 1, output_tokens: 1 },
+          model: 'current', finish_reason: 'stop' as const,
+        } };
+      },
+    };
+    manager.registerProvider(bad);
+    manager.registerProvider(good);
+    manager.setFallbackChain(['good']);
+
+    const events = [];
+    for await (const event of manager.stream(sampleMessages)) events.push(event);
+    expect(badCalls).toBe(1);
+    expect(events.some((event) => event.type === 'text' && event.text === 'recovered')).toBe(true);
+  });
+
+  test('tier routing recovers a decommissioned saved model with the provider default', async () => {
+    const manager = new LLMManager();
+    const seenModels: Array<string | undefined> = [];
+    const groq = {
+      name: 'groq',
+      listModels: async () => ['openai/gpt-oss-20b'],
+      async chat(_messages: LLMMessage[], options?: { model?: string }) {
+        seenModels.push(options?.model);
+        if (options?.model === 'deepseek-r1-distill-llama-70b') {
+          throw new LLMProviderError('Groq API error (400): model_decommissioned', 'bad_request');
+        }
+        return {
+          content: 'current model ok', tool_calls: [], usage: { input_tokens: 1, output_tokens: 1 },
+          model: 'openai/gpt-oss-20b', finish_reason: 'stop' as const,
+        };
+      },
+      async *stream() { /* not used */ },
+    };
+    manager.registerProvider(groq);
+    manager.setTierMap({ medium: { provider: 'groq', model: 'deepseek-r1-distill-llama-70b' } });
+
+    const response = await manager.chatTier('medium', 'test', sampleMessages);
+    expect(response.content).toBe('current model ok');
+    expect(seenModels).toEqual(['deepseek-r1-distill-llama-70b', undefined]);
+  });
+
+  test('tier routing skips a rate-limited provider and fails over immediately', async () => {
+    const manager = new LLMManager();
+    let groqCalls = 0;
+    const groq = {
+      name: 'groq', listModels: async () => ['openai/gpt-oss-20b'],
+      async chat() {
+        groqCalls++;
+        throw new LLMProviderError('Groq API error (429): rate limit', 'rate_limit', 120_000);
+      },
+      async *stream() { /* not used */ },
+    };
+    const fallback = {
+      name: 'openai', listModels: async () => ['gpt-5-mini'],
+      async chat() { return {
+        content: 'provider fallback', tool_calls: [], usage: { input_tokens: 1, output_tokens: 1 },
+        model: 'gpt-5-mini', finish_reason: 'stop' as const,
+      }; },
+      async *stream() { /* not used */ },
+    };
+    manager.registerProvider(groq);
+    manager.registerProvider(fallback);
+    manager.setTierMap({
+      medium: { provider: 'groq', model: 'openai/gpt-oss-20b' },
+      high: { provider: 'openai', model: 'gpt-5-mini' },
+    });
+
+    const response = await manager.chatTier('medium', 'test', sampleMessages);
+    expect(response.content).toBe('provider fallback');
+    expect(groqCalls).toBe(1);
+  });
 });
 
 describe('Message Types', () => {
@@ -293,7 +384,7 @@ describe('Default Models', () => {
 
   test('GroqProvider has correct default model', () => {
     const provider = new GroqProvider('test-key') as any;
-    expect(provider.defaultModel).toBe('llama-3.3-70b-versatile');
+    expect(provider.defaultModel).toBe('openai/gpt-oss-20b');
   });
 
   test('OpenRouterProvider has correct default model', () => {
@@ -536,6 +627,14 @@ describe('Groq request shaping', () => {
     expect(out.properties.nested.properties.optional_inner.type).toEqual(['number', 'null']);
   });
 
+  test('live catalog filtering excludes decommissioned and non-chat routes', () => {
+    expect(isGroqJarvisModel('openai/gpt-oss-20b')).toBe(true);
+    expect(isGroqJarvisModel('qwen/qwen3.6-27b')).toBe(true);
+    expect(isGroqJarvisModel('deepseek-r1-distill-llama-70b')).toBe(false);
+    expect(isGroqJarvisModel('whisper-large-v3')).toBe(false);
+    expect(isGroqJarvisModel('groq/compound')).toBe(false);
+  });
+
   test('GroqProvider relaxes optional tool params to accept null before sending', async () => {
     const provider = new GroqProvider('test-key') as any;
     await provider.chat(
@@ -694,6 +793,23 @@ describe('Groq request shaping', () => {
     expect(response.content).toContain('retry ok');
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(JSON.stringify(secondBody).length).toBeLessThan(JSON.stringify(firstBody).length);
+  });
+
+  test('GroqProvider preserves Retry-After on 429 errors', async () => {
+    globalThis.fetch = mock(async () => new Response(
+      JSON.stringify({ error: { message: 'rate limit exceeded' } }),
+      { status: 429, headers: { 'retry-after': '2.5' } },
+    )) as unknown as typeof fetch;
+
+    const provider = new GroqProvider('test-key');
+    try {
+      await provider.chat([{ role: 'user', content: 'hi' }]);
+      throw new Error('expected Groq to reject');
+    } catch (error) {
+      expect(error).toBeInstanceOf(LLMProviderError);
+      expect((error as LLMProviderError).code).toBe('rate_limit');
+      expect((error as LLMProviderError).retryAfterMs).toBe(2500);
+    }
   });
 
   test('GroqProvider compaction never orphans a tool message from its assistant tool_call', async () => {

--- a/src/llm/provider.test.ts
+++ b/src/llm/provider.test.ts
@@ -8,6 +8,8 @@ import { NVIDIAProvider } from './nvidia.ts';
 import { LiteLLMProvider } from './litellm.ts';
 import { LLMManager } from './manager.ts';
 import { guardImageSize, classifyHttpStatus, classifyErrorString, LLMProviderError, type LLMMessage, type ContentBlock } from './provider.ts';
+import { setUsageDatabase } from './usage.ts';
+import { initDatabase, closeDb } from '../vault/schema.ts';
 import { isToolResult, type ToolResult } from '../actions/tools/registry.ts';
 
 describe('LLM Provider Types', () => {
@@ -636,6 +638,51 @@ describe('LLMManager', () => {
       retry_after_ms: 120_000,
     });
   });
+
+  test('Retry-After sleeps draw down a shared per-provider budget', async () => {
+    const manager = new LLMManager() as unknown as {
+      waitForRetry(retryAfterMs: number | undefined, budget: { remainingMs: number }): Promise<boolean>;
+    };
+    const budget = { remainingMs: 100 };
+    expect(await manager.waitForRetry(60, budget)).toBe(true);
+    expect(budget.remainingMs).toBe(40);
+    // A second wait that would overrun the remaining budget fails over
+    // instead of stacking sleeps past the cap.
+    expect(await manager.waitForRetry(60, budget)).toBe(false);
+    // No Retry-After: retry immediately without drawing down the budget.
+    expect(await manager.waitForRetry(undefined, budget)).toBe(true);
+    expect(budget.remainingMs).toBe(40);
+  });
+
+  test('tier streaming records usage when the consumer stops mid-stream', async () => {
+    closeDb();
+    const db = initDatabase(':memory:');
+    setUsageDatabase(() => db);
+    try {
+      const manager = new LLMManager();
+      const streamer = {
+        name: 'streamer', listModels: async () => ['model-a'],
+        async chat(): Promise<never> { throw new Error('not used'); },
+        async *stream() {
+          yield { type: 'text' as const, text: 'first chunk' };
+          yield { type: 'text' as const, text: 'never consumed' };
+        },
+      };
+      manager.registerProvider(streamer);
+      manager.setTierMap({ medium: { provider: 'streamer', model: 'model-a' } });
+
+      for await (const event of manager.streamTier('medium', 'abort-test', sampleMessages)) {
+        if (event.type === 'text') break; // consumer disconnects mid-stream
+      }
+
+      const rows = db.query('SELECT provider, subsystem FROM llm_usage').all() as
+        Array<{ provider: string; subsystem: string }>;
+      expect(rows).toEqual([{ provider: 'streamer', subsystem: 'abort-test' }]);
+    } finally {
+      setUsageDatabase(() => null);
+      closeDb();
+    }
+  });
 });
 
 describe('Message Types', () => {
@@ -967,6 +1014,8 @@ describe('Groq request shaping', () => {
     expect(isGroqJarvisModel('deepseek-r1-distill-llama-70b')).toBe(false);
     expect(isGroqJarvisModel('whisper-large-v3')).toBe(false);
     expect(isGroqJarvisModel('groq/compound')).toBe(false);
+    expect(isGroqJarvisModel('meta-llama/llama-guard-4-12b')).toBe(false);
+    expect(isGroqJarvisModel('playai-tts')).toBe(false);
   });
 
   test('GroqProvider relaxes optional tool params to accept null before sending', async () => {
@@ -1353,6 +1402,10 @@ describe('classifyHttpStatus', () => {
     expect(classifyHttpStatus(502)).toBe('network');
     expect(classifyHttpStatus(503)).toBe('network');
     expect(classifyHttpStatus(504)).toBe('network');
+  });
+
+  test('non-standard 498 (gateway upstream expiry) → network (transient)', () => {
+    expect(classifyHttpStatus(498)).toBe('network');
   });
 
   test('other 5xx → server', () => {

--- a/src/llm/provider.test.ts
+++ b/src/llm/provider.test.ts
@@ -303,6 +303,183 @@ describe('LLMManager', () => {
     expect(groqCalls).toBe(1);
   });
 
+  test('tier routing does not send content to providers that have no tier assignment', async () => {
+    const manager = new LLMManager();
+    let unmappedCalls = 0;
+    const mapped = {
+      name: 'mapped', listModels: async () => ['retired'],
+      async chat() { throw new LLMProviderError('model_not_found', 'not_found'); },
+      async *stream() { /* not used */ },
+    };
+    const unmapped = {
+      name: 'unmapped', listModels: async () => ['available'],
+      async chat() {
+        unmappedCalls++;
+        return {
+          content: 'must not run', tool_calls: [], usage: { input_tokens: 1, output_tokens: 1 },
+          model: 'available', finish_reason: 'stop' as const,
+        };
+      },
+      async *stream() { /* not used */ },
+    };
+    manager.registerProvider(mapped);
+    manager.registerProvider(unmapped);
+    manager.setTierMap({ medium: { provider: 'mapped', model: 'retired' } });
+
+    await expect(manager.chatTier('medium', 'test', sampleMessages)).rejects.toBeInstanceOf(LLMProviderError);
+    expect(unmappedCalls).toBe(0);
+  });
+
+  test('tier routing does not fail over malformed requests', async () => {
+    const manager = new LLMManager();
+    let fallbackCalls = 0;
+    const malformed = {
+      name: 'malformed', listModels: async () => ['model-a'],
+      async chat() { throw new LLMProviderError('invalid tool schema', 'bad_request'); },
+      async *stream() { /* not used */ },
+    };
+    const fallback = {
+      name: 'fallback', listModels: async () => ['model-b'],
+      async chat() {
+        fallbackCalls++;
+        return {
+          content: 'must not run', tool_calls: [], usage: { input_tokens: 1, output_tokens: 1 },
+          model: 'model-b', finish_reason: 'stop' as const,
+        };
+      },
+      async *stream() { /* not used */ },
+    };
+    manager.registerProvider(malformed);
+    manager.registerProvider(fallback);
+    manager.setTierMap({
+      medium: { provider: 'malformed', model: 'model-a' },
+      high: { provider: 'fallback', model: 'model-b' },
+    });
+
+    await expect(manager.chatTier('medium', 'test', sampleMessages)).rejects.toMatchObject({
+      code: 'bad_request',
+    });
+    expect(fallbackCalls).toBe(0);
+  });
+
+  test('tier routing fails over before a short Retry-After sleep', async () => {
+    const manager = new LLMManager();
+    let limitedCalls = 0;
+    const limited = {
+      name: 'limited', listModels: async () => ['model-a'],
+      async chat() {
+        limitedCalls++;
+        throw new LLMProviderError('quota exhausted', 'rate_limit', 30_000);
+      },
+      async *stream() { /* not used */ },
+    };
+    const fallback = {
+      name: 'fallback', listModels: async () => ['model-b'],
+      async chat() { return {
+        content: 'immediate fallback', tool_calls: [], usage: { input_tokens: 1, output_tokens: 1 },
+        model: 'model-b', finish_reason: 'stop' as const,
+      }; },
+      async *stream() { /* not used */ },
+    };
+    manager.registerProvider(limited);
+    manager.registerProvider(fallback);
+    manager.setTierMap({
+      medium: { provider: 'limited', model: 'model-a' },
+      high: { provider: 'fallback', model: 'model-b' },
+    });
+
+    const started = Date.now();
+    const response = await manager.chatTier('medium', 'test', sampleMessages);
+    expect(response.content).toBe('immediate fallback');
+    expect(limitedCalls).toBe(1);
+    expect(Date.now() - started).toBeLessThan(1_000);
+  });
+
+  test('tier chat preserves Retry-After when every candidate is exhausted', async () => {
+    const manager = new LLMManager();
+    const groq = {
+      name: 'groq', listModels: async () => ['openai/gpt-oss-20b'],
+      async chat() { throw new LLMProviderError('quota exhausted', 'rate_limit', 120_000); },
+      async *stream() { /* not used */ },
+    };
+    manager.registerProvider(groq);
+    manager.setTierMap({ medium: { provider: 'groq', model: 'openai/gpt-oss-20b' } });
+
+    await expect(manager.chatTier('medium', 'test', sampleMessages)).rejects.toMatchObject({
+      code: 'rate_limit',
+      retryAfterMs: 120_000,
+    });
+  });
+
+  test('tier streaming preserves typed codes from thrown provider errors', async () => {
+    const manager = new LLMManager();
+    let fallbackCalls = 0;
+    const primary = {
+      name: 'primary', listModels: async () => ['model-a'],
+      async chat() { throw new Error('not used'); },
+      async *stream() { throw new LLMProviderError('opaque failure', 'auth'); },
+    };
+    const fallback = {
+      name: 'fallback', listModels: async () => ['model-b'],
+      async chat() { throw new Error('not used'); },
+      async *stream() { fallbackCalls++; },
+    };
+    manager.registerProvider(primary);
+    manager.registerProvider(fallback);
+    manager.setTierMap({
+      medium: { provider: 'primary', model: 'model-a' },
+      high: { provider: 'fallback', model: 'model-b' },
+    });
+
+    const events = [];
+    for await (const event of manager.streamTier('medium', 'test', sampleMessages)) events.push(event);
+    expect(events.at(-1)).toMatchObject({ type: 'error', code: 'auth' });
+    expect(fallbackCalls).toBe(0);
+  });
+
+  test('tier streaming fails over before a short Retry-After sleep', async () => {
+    const manager = new LLMManager();
+    let limitedCalls = 0;
+    const limited = {
+      name: 'limited', listModels: async () => ['model-a'],
+      async chat() { throw new Error('not used'); },
+      async *stream() {
+        limitedCalls++;
+        yield {
+          type: 'error' as const,
+          error: 'quota exhausted',
+          code: 'rate_limit' as const,
+          retry_after_ms: 30_000,
+        };
+      },
+    };
+    const fallback = {
+      name: 'fallback', listModels: async () => ['model-b'],
+      async chat() { throw new Error('not used'); },
+      async *stream() {
+        yield { type: 'text' as const, text: 'immediate fallback' };
+        yield { type: 'done' as const, response: {
+          content: 'immediate fallback', tool_calls: [], usage: { input_tokens: 1, output_tokens: 1 },
+          model: 'model-b', finish_reason: 'stop' as const,
+        } };
+      },
+    };
+    manager.registerProvider(limited);
+    manager.registerProvider(fallback);
+    manager.setTierMap({
+      medium: { provider: 'limited', model: 'model-a' },
+      high: { provider: 'fallback', model: 'model-b' },
+    });
+
+    const started = Date.now();
+    const events = [];
+    for await (const event of manager.streamTier('medium', 'test', sampleMessages)) events.push(event);
+    expect(events.some((event) => event.type === 'text' && event.text === 'immediate fallback')).toBe(true);
+    expect(events.some((event) => event.type === 'error')).toBe(false);
+    expect(limitedCalls).toBe(1);
+    expect(Date.now() - started).toBeLessThan(1_000);
+  });
+
   test('tier streaming preserves Retry-After when every candidate is exhausted', async () => {
     const manager = new LLMManager();
     const groq = {

--- a/src/llm/provider.test.ts
+++ b/src/llm/provider.test.ts
@@ -1008,14 +1008,27 @@ describe('Groq request shaping', () => {
     expect(out.properties.nested.properties.optional_inner.type).toEqual(['number', 'null']);
   });
 
-  test('live catalog filtering excludes decommissioned and non-chat routes', () => {
+  test('live catalog filtering excludes non-chat routes', () => {
     expect(isGroqJarvisModel('openai/gpt-oss-20b')).toBe(true);
     expect(isGroqJarvisModel('qwen/qwen3.6-27b')).toBe(true);
-    expect(isGroqJarvisModel('deepseek-r1-distill-llama-70b')).toBe(false);
+    expect(isGroqJarvisModel('minimaxai/minimax-m2.7')).toBe(true);
     expect(isGroqJarvisModel('whisper-large-v3')).toBe(false);
+    expect(isGroqJarvisModel('canopylabs/orpheus-v1-english')).toBe(false);
     expect(isGroqJarvisModel('groq/compound')).toBe(false);
+    expect(isGroqJarvisModel('groq/compound-mini')).toBe(false);
     expect(isGroqJarvisModel('meta-llama/llama-guard-4-12b')).toBe(false);
+    expect(isGroqJarvisModel('openai/gpt-oss-safeguard-20b')).toBe(false);
     expect(isGroqJarvisModel('playai-tts')).toBe(false);
+  });
+
+  // Groq answers /models per account: a committed-spend contract keeps
+  // serving IDs that are retired on the free and developer tiers. Since boot
+  // migration has already rewritten the saved reference, filtering these out
+  // of the picker would leave no way back to a model the account still owns.
+  test('live catalog keeps deprecated models the account can still reach', () => {
+    expect(isGroqJarvisModel('llama-3.3-70b-versatile')).toBe(true);
+    expect(isGroqJarvisModel('llama-3.1-8b-instant')).toBe(true);
+    expect(isGroqJarvisModel('deepseek-r1-distill-llama-70b')).toBe(true);
   });
 
   test('GroqProvider relaxes optional tool params to accept null before sending', async () => {

--- a/src/llm/provider.test.ts
+++ b/src/llm/provider.test.ts
@@ -302,6 +302,33 @@ describe('LLMManager', () => {
     expect(response.content).toBe('provider fallback');
     expect(groqCalls).toBe(1);
   });
+
+  test('tier streaming preserves Retry-After when every candidate is exhausted', async () => {
+    const manager = new LLMManager();
+    const groq = {
+      name: 'groq', listModels: async () => ['openai/gpt-oss-20b'],
+      async chat() { throw new Error('not used'); },
+      async *stream() {
+        yield {
+          type: 'error' as const,
+          error: 'Groq API error (429): rate limit',
+          code: 'rate_limit' as const,
+          retry_after_ms: 120_000,
+        };
+      },
+    };
+    manager.registerProvider(groq);
+    manager.setTierMap({ medium: { provider: 'groq', model: 'openai/gpt-oss-20b' } });
+
+    const events = [];
+    for await (const event of manager.streamTier('medium', 'test', sampleMessages)) events.push(event);
+
+    expect(events.at(-1)).toMatchObject({
+      type: 'error',
+      code: 'rate_limit',
+      retry_after_ms: 120_000,
+    });
+  });
 });
 
 describe('Message Types', () => {

--- a/src/llm/provider.test.ts
+++ b/src/llm/provider.test.ts
@@ -330,6 +330,37 @@ describe('LLMManager', () => {
     expect(unmappedCalls).toBe(0);
   });
 
+  test('background tier failover never crosses into the conversation tier', async () => {
+    const manager = new LLMManager();
+    let conversationCalls = 0;
+    const background = {
+      name: 'background', listModels: async () => ['retired'],
+      async chat() { throw new LLMProviderError('model_not_found', 'not_found'); },
+      async *stream() { /* not used */ },
+    };
+    const conversation = {
+      name: 'conversation', listModels: async () => ['expensive'],
+      async chat() {
+        conversationCalls++;
+        return {
+          content: 'must not run', tool_calls: [], usage: { input_tokens: 1, output_tokens: 1 },
+          model: 'expensive', finish_reason: 'stop' as const,
+        };
+      },
+      async *stream() { /* not used */ },
+    };
+    manager.registerProvider(background);
+    manager.registerProvider(conversation);
+    manager.setTierMap({
+      low: { provider: 'background', model: 'retired' },
+      conversation: { provider: 'conversation', model: 'expensive' },
+    });
+
+    await expect(manager.chatTier('low', 'background-test', sampleMessages))
+      .rejects.toBeInstanceOf(LLMProviderError);
+    expect(conversationCalls).toBe(0);
+  });
+
   test('tier routing does not fail over malformed requests', async () => {
     const manager = new LLMManager();
     let fallbackCalls = 0;
@@ -358,6 +389,38 @@ describe('LLMManager', () => {
 
     await expect(manager.chatTier('medium', 'test', sampleMessages)).rejects.toMatchObject({
       code: 'bad_request',
+    });
+    expect(fallbackCalls).toBe(0);
+  });
+
+  test('tier routing does not treat an unrelated 404 as model failover', async () => {
+    const manager = new LLMManager();
+    let fallbackCalls = 0;
+    const missingEndpoint = {
+      name: 'missing-endpoint', listModels: async () => ['model-a'],
+      async chat() { throw new LLMProviderError('POST /chat route not found', 'not_found'); },
+      async *stream() { /* not used */ },
+    };
+    const fallback = {
+      name: 'fallback', listModels: async () => ['model-b'],
+      async chat() {
+        fallbackCalls++;
+        return {
+          content: 'must not run', tool_calls: [], usage: { input_tokens: 1, output_tokens: 1 },
+          model: 'model-b', finish_reason: 'stop' as const,
+        };
+      },
+      async *stream() { /* not used */ },
+    };
+    manager.registerProvider(missingEndpoint);
+    manager.registerProvider(fallback);
+    manager.setTierMap({
+      medium: { provider: 'missing-endpoint', model: 'model-a' },
+      high: { provider: 'fallback', model: 'model-b' },
+    });
+
+    await expect(manager.chatTier('medium', 'test', sampleMessages)).rejects.toMatchObject({
+      code: 'not_found',
     });
     expect(fallbackCalls).toBe(0);
   });
@@ -393,6 +456,37 @@ describe('LLMManager', () => {
     expect(response.content).toBe('immediate fallback');
     expect(limitedCalls).toBe(1);
     expect(Date.now() - started).toBeLessThan(1_000);
+  });
+
+  test('tier routing fails over immediately on quota errors without Retry-After', async () => {
+    const manager = new LLMManager();
+    let limitedCalls = 0;
+    const limited = {
+      name: 'limited', listModels: async () => ['model-a'],
+      async chat() {
+        limitedCalls++;
+        throw new LLMProviderError('quota exhausted', 'rate_limit');
+      },
+      async *stream() { /* not used */ },
+    };
+    const fallback = {
+      name: 'fallback', listModels: async () => ['model-b'],
+      async chat() { return {
+        content: 'immediate fallback', tool_calls: [], usage: { input_tokens: 1, output_tokens: 1 },
+        model: 'model-b', finish_reason: 'stop' as const,
+      }; },
+      async *stream() { /* not used */ },
+    };
+    manager.registerProvider(limited);
+    manager.registerProvider(fallback);
+    manager.setTierMap({
+      medium: { provider: 'limited', model: 'model-a' },
+      high: { provider: 'fallback', model: 'model-b' },
+    });
+
+    const response = await manager.chatTier('medium', 'test', sampleMessages);
+    expect(response.content).toBe('immediate fallback');
+    expect(limitedCalls).toBe(1);
   });
 
   test('tier chat preserves Retry-After when every candidate is exhausted', async () => {
@@ -478,6 +572,42 @@ describe('LLMManager', () => {
     expect(events.some((event) => event.type === 'error')).toBe(false);
     expect(limitedCalls).toBe(1);
     expect(Date.now() - started).toBeLessThan(1_000);
+  });
+
+  test('tier streaming fails over immediately on quota errors without Retry-After', async () => {
+    const manager = new LLMManager();
+    let limitedCalls = 0;
+    const limited = {
+      name: 'limited', listModels: async () => ['model-a'],
+      async chat() { throw new Error('not used'); },
+      async *stream() {
+        limitedCalls++;
+        yield { type: 'error' as const, error: 'quota exhausted', code: 'rate_limit' as const };
+      },
+    };
+    const fallback = {
+      name: 'fallback', listModels: async () => ['model-b'],
+      async chat() { throw new Error('not used'); },
+      async *stream() {
+        yield { type: 'text' as const, text: 'immediate fallback' };
+        yield { type: 'done' as const, response: {
+          content: 'immediate fallback', tool_calls: [], usage: { input_tokens: 1, output_tokens: 1 },
+          model: 'model-b', finish_reason: 'stop' as const,
+        } };
+      },
+    };
+    manager.registerProvider(limited);
+    manager.registerProvider(fallback);
+    manager.setTierMap({
+      medium: { provider: 'limited', model: 'model-a' },
+      high: { provider: 'fallback', model: 'model-b' },
+    });
+
+    const events = [];
+    for await (const event of manager.streamTier('medium', 'test', sampleMessages)) events.push(event);
+    expect(events.some((event) => event.type === 'text' && event.text === 'immediate fallback')).toBe(true);
+    expect(events.some((event) => event.type === 'error')).toBe(false);
+    expect(limitedCalls).toBe(1);
   });
 
   test('tier streaming preserves Retry-After when every candidate is exhausted', async () => {

--- a/src/llm/provider.ts
+++ b/src/llm/provider.ts
@@ -63,7 +63,19 @@ export type LLMStreamEvent =
   | { type: 'text'; text: string; segmentEnd?: boolean }
   | { type: 'tool_call'; tool_call: LLMToolCall }
   | { type: 'done'; response: LLMResponse }
-  | { type: 'error'; error: string; code?: LLMErrorCode };
+  | { type: 'error'; error: string; code?: LLMErrorCode; retry_after_ms?: number };
+
+/** HTTP-aware provider failure used to carry Retry-After into the router. */
+export class LLMProviderError extends Error {
+  constructor(
+    message: string,
+    readonly code: LLMErrorCode,
+    readonly retryAfterMs?: number,
+  ) {
+    super(message);
+    this.name = 'LLMProviderError';
+  }
+}
 
 /**
  * Map an HTTP status code returned by a provider to a canonical error code.
@@ -73,6 +85,7 @@ export type LLMStreamEvent =
 export function classifyHttpStatus(status: number): LLMErrorCode {
   if (status === 401 || status === 403) return 'auth';
   if (status === 429) return 'rate_limit';
+  if (status === 498) return 'network';
   if (status === 404) return 'not_found';
   if (status === 400 || status === 422) return 'bad_request';
   if (status === 502 || status === 503 || status === 504) return 'network';

--- a/src/llm/provider.ts
+++ b/src/llm/provider.ts
@@ -85,6 +85,8 @@ export class LLMProviderError extends Error {
 export function classifyHttpStatus(status: number): LLMErrorCode {
   if (status === 401 || status === 403) return 'auth';
   if (status === 429) return 'rate_limit';
+  // Some OpenAI-compatible gateways use non-standard 498 for an upstream
+  // connection/token expiry and expect clients to retry it as a network fault.
   if (status === 498) return 'network';
   if (status === 404) return 'not_found';
   if (status === 400 || status === 422) return 'bad_request';

--- a/src/llm/test.ts
+++ b/src/llm/test.ts
@@ -24,7 +24,7 @@ async function testProviders() {
   // uses at runtime.
   const db = initDatabase(config.daemon.db_path);
   setUsageDatabase(() => db);
-  mergeLLMSettingsIntoConfig(config);
+  mergeLLMSettingsIntoConfig(config, { persistMigrations: false });
 
   const manager = new LLMManager();
   const hasProvider = registerLLMProviders(manager, config.llm.providers ?? {}, {

--- a/ui/src/v2/onboarding/OnboardingWizard.tsx
+++ b/ui/src/v2/onboarding/OnboardingWizard.tsx
@@ -290,7 +290,11 @@ export function OnboardingWizard({
   const [groqModels, setGroqModels] = useState<string[] | null>(null);
   const [groqLoading, setGroqLoading] = useState(false);
   useEffect(() => {
-    if (provId !== "groq" || !apiKey) return;
+    if (provId !== "groq" || !apiKey) {
+      setGroqModels(null); // drop a catalog fetched with a previous key
+      setGroqLoading(false); // a cancelled in-flight fetch never clears this
+      return;
+    }
     let cancelled = false;
     setGroqLoading(true);
     const timer = window.setTimeout(() => {

--- a/ui/src/v2/onboarding/OnboardingWizard.tsx
+++ b/ui/src/v2/onboarding/OnboardingWizard.tsx
@@ -48,7 +48,7 @@ const PROVIDERS: Provider[] = [
   { id: "jarvis", name: "Jarvis AI", abbr: "JA", kind: "no key", soon: true, noConfig: true },
   { id: "anthropic", name: "Anthropic", abbr: "A", kind: "API key", needsKey: true, optionalBaseUrl: true, keyLabel: "API key", urlLabel: "Custom endpoint URL", urlPh: "https://gateway.example.com", models: ["claude-fable-5", "claude-opus-4-8", "claude-sonnet-5", "claude-haiku-4-5-20251001"], hint: "Enable the custom endpoint option to use ANTHROPIC_BASE_URL and ANTHROPIC_AUTH_TOKEN-style authentication." },
   { id: "openai", name: "OpenAI", abbr: "O", kind: "API key", needsKey: true, models: ["gpt-5.5", "gpt-5.5-pro", "gpt-5.4", "gpt-5-mini", "o4-mini"] },
-  { id: "groq", name: "Groq", abbr: "G", kind: "API key", needsKey: true, models: ["llama-3.3-70b-versatile", "llama-3.1-8b-instant"] },
+  { id: "groq", name: "Groq", abbr: "G", kind: "API key", needsKey: true, models: ["openai/gpt-oss-20b", "openai/gpt-oss-120b", "qwen/qwen3.6-27b"], hint: "Loads the current model catalog from Groq so decommissioned models are never suggested." },
   { id: "gemini", name: "Gemini", abbr: "Ge", kind: "API key", needsKey: true, models: ["gemini-3.1-pro-preview", "gemini-3-flash-preview", "gemini-2.5-pro"] },
   { id: "ollama", name: "Ollama", abbr: "Ol", kind: "local", needsBaseUrl: true, urlLabel: "Ollama base URL", urlPh: "http://localhost:11434", models: ["llama3.1", "llama3.2", "mistral", "qwen2.5"] },
   { id: "openrouter", name: "OpenRouter", abbr: "OR", kind: "API key", needsKey: true, models: ["anthropic/claude-opus-4", "openai/gpt-5.4", "google/gemini-2.5-pro"] },
@@ -286,6 +286,33 @@ export function OnboardingWizard({
     if (provId !== "omniroute" || !omniRouteModels?.length) return;
     if (!omniRouteModels.includes(model)) setModel(omniRouteModels.includes("auto") ? "auto" : omniRouteModels[0]!);
   }, [omniRouteModels, provId]); // model intentionally snaps when the catalog arrives
+
+  const [groqModels, setGroqModels] = useState<string[] | null>(null);
+  const [groqLoading, setGroqLoading] = useState(false);
+  useEffect(() => {
+    if (provId !== "groq" || !apiKey) return;
+    let cancelled = false;
+    setGroqLoading(true);
+    const timer = window.setTimeout(() => {
+      fetch("/api/config/llm/groq/models", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ api_key: apiKey }),
+      })
+        .then((r) => r.json())
+        .then((d: { ok: boolean; models?: string[] }) => {
+          if (!cancelled) setGroqModels(d.ok && d.models ? d.models : []);
+        })
+        .catch(() => { if (!cancelled) setGroqModels([]); })
+        .finally(() => { if (!cancelled) setGroqLoading(false); });
+    }, 400);
+    return () => { cancelled = true; window.clearTimeout(timer); };
+  }, [provId, apiKey]);
+
+  useEffect(() => {
+    if (provId !== "groq" || !groqModels?.length) return;
+    if (!groqModels.includes(model)) setModel(groqModels.includes("openai/gpt-oss-20b") ? "openai/gpt-oss-20b" : groqModels[0]!);
+  }, [groqModels, provId]);
 
   // The Google OAuth poll outlives the click handler — keep its id in a ref so
   // finishing/unmounting the wizard stops it (it ran for up to 5 min after).
@@ -811,9 +838,11 @@ export function OnboardingWizard({
       ? ollamaModels
       : provId === "omniroute" && omniRouteModels && omniRouteModels.length > 0
         ? omniRouteModels
-        : customAnthropic
-          ? (discoveredModels ?? [])
-          : (prov.models ?? []);
+        : provId === "groq" && groqModels && groqModels.length > 0
+          ? groqModels
+          : customAnthropic
+            ? (discoveredModels ?? [])
+            : (prov.models ?? []);
     return (
       <>
         {prov.optionalBaseUrl && (
@@ -844,6 +873,8 @@ export function OnboardingWizard({
         {provId === "ollama" && !ollamaLoading && ollamaModels?.length === 0 && <div className="obw-hint">Could not reach Ollama at this URL — showing suggestions instead. Make sure Ollama is running (models must include their tag, e.g. llama3.1:8b).</div>}
         {provId === "omniroute" && omniRouteLoading && <div className="obw-hint">Loading every OmniRoute model and combo…</div>}
         {provId === "omniroute" && !omniRouteLoading && omniRouteModels?.length === 0 && <div className="obw-hint">Could not read this OmniRoute catalog. Check the URL and API key; you can still test the auto route.</div>}
+        {provId === "groq" && groqLoading && <div className="obw-hint">Loading currently supported Groq models…</div>}
+        {provId === "groq" && !groqLoading && groqModels?.length === 0 && <div className="obw-hint">Could not read Groq’s live catalog — showing current fallback models.</div>}
         <div className="obw-testrow">
           <button className="obw-btn obw-btn-ghost sm" disabled={test.status === "testing"} onClick={runTest}>{test.status === "testing" ? "Testing…" : "Test connection"}</button>
           {test.status === "ok" && <span className="obw-testres ok"><span className="dot" />Connected · {test.msg}</span>}

--- a/ui/src/v2/onboarding/OnboardingWizard.tsx
+++ b/ui/src/v2/onboarding/OnboardingWizard.tsx
@@ -312,7 +312,7 @@ export function OnboardingWizard({
   useEffect(() => {
     if (provId !== "groq" || !groqModels?.length) return;
     if (!groqModels.includes(model)) setModel(groqModels.includes("openai/gpt-oss-20b") ? "openai/gpt-oss-20b" : groqModels[0]!);
-  }, [groqModels, provId]);
+  }, [groqModels, model, provId]);
 
   // The Google OAuth poll outlives the click handler — keep its id in a ref so
   // finishing/unmounting the wizard stops it (it ran for up to 5 min after).

--- a/ui/src/v2/rooms/settings/tabs/LLMTab.tsx
+++ b/ui/src/v2/rooms/settings/tabs/LLMTab.tsx
@@ -48,10 +48,9 @@ const MODELS_BY_KIND: Record<LLMProviderKind, string[]> = {
     "o4-mini",
   ],
   groq: [
-    "llama-3.3-70b-versatile",
-    "llama-3.1-8b-instant",
-    "qwen/qwen3-32b",
-    "deepseek-r1-distill-llama-70b",
+    "openai/gpt-oss-20b",
+    "openai/gpt-oss-120b",
+    "qwen/qwen3.6-27b",
   ],
   gemini: [
     "gemini-3.1-pro-preview",
@@ -1000,7 +999,7 @@ function providerModels(
   // The curated list is untagged guesswork, so prefer the real catalog when
   // the daemon could read it; fall back to the guesses when it could not.
   if (entry.kind === "ollama" && live && live.length > 0) return live;
-  if (entry.kind === "omniroute" && providerCatalogs[name]?.length) {
+  if ((entry.kind === "omniroute" || entry.kind === "groq") && providerCatalogs[name]?.length) {
     return providerCatalogs[name]!;
   }
   return MODELS_BY_KIND[entry.kind] ?? [];
@@ -1036,9 +1035,10 @@ function useLiveProviderCatalogs(
   providers: Record<string, LLMConfigProviderView>,
 ): Record<string, string[]> {
   const targets = Object.entries(providers)
-    .filter(([, entry]) => entry.kind === "omniroute")
+    .filter(([, entry]) => entry.kind === "omniroute" || (entry.kind === "groq" && entry.has_api_key))
     .map(([name, entry]) => ({
       name,
+      kind: entry.kind,
       baseUrl: entry.base_url?.trim() || "http://localhost:20128/v1",
       hasApiKey: entry.has_api_key,
     }))
@@ -1055,7 +1055,8 @@ function useLiveProviderCatalogs(
     let cancelled = false;
     Promise.all(names.map(async (name) => {
       try {
-        const response = await fetch('/api/config/llm/omniroute/models', {
+        const kind = providers[name]!.kind;
+        const response = await fetch(`/api/config/llm/${kind}/models`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ name }),

--- a/ui/src/v2/rooms/settings/tabs/LLMTab.tsx
+++ b/ui/src/v2/rooms/settings/tabs/LLMTab.tsx
@@ -1044,18 +1044,20 @@ function useLiveProviderCatalogs(
     }))
     .sort((a, b) => a.name.localeCompare(b.name));
   const signature = JSON.stringify(targets);
-  const names = targets.map((target) => target.name);
   const [catalogs, setCatalogs] = useState<Record<string, string[]>>({});
 
   useEffect(() => {
-    if (names.length === 0) {
+    if (targets.length === 0) {
       setCatalogs({});
       return;
     }
     let cancelled = false;
-    Promise.all(names.map(async (name) => {
+    Promise.all(targets.map(async ({ name, kind }) => {
       try {
-        const response = await fetch('/api/config/llm/groq/models', {
+        const endpoint = kind === "groq"
+          ? '/api/config/llm/groq/models'
+          : '/api/config/llm/omniroute/models';
+        const response = await fetch(endpoint, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ name }),
@@ -1069,7 +1071,7 @@ function useLiveProviderCatalogs(
       if (!cancelled) setCatalogs(Object.fromEntries(entries));
     });
     return () => { cancelled = true; };
-  }, [signature]); // names are represented by the stable signature
+  }, [signature]); // targets are represented by the stable signature
 
   return catalogs;
 }

--- a/ui/src/v2/rooms/settings/tabs/LLMTab.tsx
+++ b/ui/src/v2/rooms/settings/tabs/LLMTab.tsx
@@ -1055,8 +1055,7 @@ function useLiveProviderCatalogs(
     let cancelled = false;
     Promise.all(names.map(async (name) => {
       try {
-        const kind = providers[name]!.kind;
-        const response = await fetch(`/api/config/llm/${kind}/models`, {
+        const response = await fetch('/api/config/llm/groq/models', {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ name }),


### PR DESCRIPTION
## Problem

Groq requests can fail for two separate reasons that currently surface as generic chat failures:

1. Saved/default model IDs can point at models Groq has retired. `llama-3.3-70b-versatile` and `llama-3.1-8b-instant` shut down on 2026-08-16 for free and developer tiers, and both are shipped as defaults today.
2. Free-tier requests can exceed request or token limits, and the router may keep retrying a permanent failure instead of moving to a usable model/provider.

That combination leaves existing installations stuck on discontinued defaults and makes free Groq accounts spend retries on requests that cannot succeed.

## What changed

### Supported model selection

- replace retired Groq defaults with supported GPT-OSS defaults
- migrate deprecated Groq model references when settings are loaded or saved
- persist repaired settings so the migration does not repeat on every startup — only from the daemon, which owns the settings DB; `jarvis doctor` and `llm test` hydrate read-only
- expose an authenticated daemon endpoint for Groq model discovery, resolving the provider kind as `entry.kind ?? name` so legacy entries synthesized by the migration are found
- populate onboarding and settings selectors from the live Groq catalog while retaining safe fallbacks

The live catalog is filtered by route shape only (audio, moderation, embedding, and Compound entries are dropped), never against the deprecation map: `/models` is answered per account, and a committed-spend contract keeps serving IDs that are retired for everyone else. Since boot migration has already rewritten the saved reference, the picker is the only way back to such a model.

### Safer Groq failures

- classify permanent 400-level failures so they are not retried as transient errors
- carry Retry-After out of Groq responses on a typed `LLMProviderError`

### Recovery and failover

- try the remaining configured models in a tier when the selected model is unavailable
- fail over to another configured provider when Groq is quota-limited
- carry the most relevant retry delay through streamed and aggregated errors
- keep error telemetry classified even when a streamed provider error omits a code, and record it when the consumer disconnects mid-stream

Failover is deliberately narrower than a provider-local retry. Candidates are only providers explicitly mapped to the requested tier and its documented fall-up chain — configuring a provider does not authorize the router to send conversation content to it, and a background tier never spills into `conversation`. Crossing a provider boundary requires a quota error or an error that names model availability; a malformed request fails on the first provider instead of being replayed to every candidate.

Retry-After is honored against a cumulative 60s budget shared across one provider's attempts, so stacked delays cannot park an interactive request. When another candidate provider exists, the router fails over immediately rather than sleeping at all.

## User-visible behavior

- existing discontinued Groq selections are repaired automatically
- model selectors show the chat models available to the authenticated Groq account
- a bad model does not prevent another model in the same tier from being tried
- an exhausted Groq free tier can fall back to another configured provider
- a fully exhausted account still requires another configured provider; this PR does not bypass provider quotas

## Scope boundaries

- no new provider is added
- Groq request-size budgets are unchanged; oversized-history compaction behaves as it did before
- no unrelated settings layout or theme changes are included
- no account credentials are logged or returned by the catalog endpoint

## Verification

- `bun test` — 2,057 passed, 18 skipped, 0 failed
- `bunx tsc --noEmit`
- `bun run build:ui`

Coverage includes deprecated-model migration and read-only hydration, the catalog endpoint's kind resolution (including legacy entries with no `kind` field), permanent-error retry behavior, tier recovery, tier-boundary containment, rate-limit failover, Retry-After propagation and budget draw-down, and mid-stream telemetry.

## Risk and rollback

The main behavioral change is broader failover after a provider/model failure. Failover remains limited to providers the user has mapped to the tier being served. Reverting this PR restores the previous defaults and router behavior; the settings migration rewrites saved model references in place, so a revert leaves the repaired references as-is rather than restoring the retired IDs.
