### PR TITLE
feat(llm): support custom Anthropic endpoints

### DIFF
--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -300,7 +300,7 @@ export type LLMProviderEntry = {
   kind?: LLMProviderKind;
   /** API key for cloud providers. */
   api_key?: string;
-  /** Base URL for self-hosted / local providers (ollama, OpenAI-compatible gateways, OmniRoute). */
+  /** Base URL for local providers and compatible API gateways. */
   base_url?: string;
 };
 

--- a/src/daemon/api-llm-test.test.ts
+++ b/src/daemon/api-llm-test.test.ts
@@ -104,10 +104,45 @@ describe('POST /api/config/llm/test Anthropic endpoint scoping', () => {
     expect(requests.every((request) => request.authorization === 'Bearer fresh-token')).toBe(true);
   });
 
-  it('an explicit empty URL tests official Anthropic instead of the stored gateway', async () => {
+  it('refuses to replay the stored gateway token against the official endpoint', async () => {
     const response = await callEndpoint(
       { 'anthropic-sec-test': { kind: 'anthropic', api_key: 'stored-secret', base_url: 'https://saved.example' } },
       { name: 'anthropic-sec-test', base_url: '' },
+    );
+    const body = await response.json() as { ok: boolean; error: string };
+
+    expect(body.ok).toBe(false);
+    expect(body.error).toContain('requires an explicit api_key');
+    expect(requests).toHaveLength(0);
+  });
+
+  it('refuses to replay the stored token against another provider kind', async () => {
+    const response = await callEndpoint(
+      { 'anthropic-sec-test': { kind: 'anthropic', api_key: 'stored-secret' } },
+      { name: 'anthropic-sec-test', kind: 'omniroute' },
+    );
+    const body = await response.json() as { ok: boolean; error: string };
+
+    expect(body.ok).toBe(false);
+    expect(body.error).toContain('requires an explicit api_key');
+    expect(requests).toHaveLength(0);
+  });
+
+  it('accepts the stored token when the kind is restated unchanged', async () => {
+    const response = await callEndpoint(
+      { 'anthropic-sec-test': { kind: 'anthropic', api_key: 'stored-secret', base_url: 'https://saved.example' } },
+      { name: 'anthropic-sec-test', kind: 'anthropic' },
+    );
+    const body = await response.json() as { ok: boolean };
+
+    expect(body.ok).toBe(true);
+    expect(requests.every((request) => request.url.startsWith('https://saved.example/'))).toBe(true);
+  });
+
+  it('tests the official endpoint after the URL is cleared and a fresh key is supplied', async () => {
+    const response = await callEndpoint(
+      { 'anthropic-sec-test': { kind: 'anthropic', api_key: 'stored-secret', base_url: 'https://saved.example' } },
+      { name: 'anthropic-sec-test', base_url: '', api_key: 'fresh-key' },
     );
     const body = await response.json() as { ok: boolean; models?: string[] };
 
@@ -115,7 +150,7 @@ describe('POST /api/config/llm/test Anthropic endpoint scoping', () => {
     expect(body.models).toBeUndefined();
     expect(requests).toHaveLength(1);
     expect(requests[0]!.url).toBe('https://api.anthropic.com/v1/messages');
-    expect(requests[0]!.apiKey).toBe('stored-secret');
+    expect(requests[0]!.apiKey).toBe('fresh-key');
     expect(requests[0]!.authorization).toBeNull();
   });
 
@@ -153,5 +188,60 @@ describe('POST /api/config/llm/test Anthropic endpoint scoping', () => {
         'anthropic-sec-test': { base_url: 'https://attacker.example' },
       },
     })).toThrow('requires the API key or auth token again');
+  });
+
+  it('also rejects clearing the gateway URL while retaining the stored token', () => {
+    const config = {
+      llm: {
+        providers: {
+          'anthropic-sec-test': { kind: 'anthropic', api_key: 'stored-secret', base_url: 'https://saved.example' },
+        },
+        tiers: {},
+      },
+    } as unknown as JarvisConfig;
+
+    expect(() => saveLLMSettings(config, {
+      providers: {
+        'anthropic-sec-test': { base_url: '' },
+      },
+    })).toThrow('requires the API key or auth token again');
+  });
+
+  it('also rejects switching the provider kind while retaining the stored token', () => {
+    const config = {
+      llm: {
+        providers: {
+          'anthropic-sec-test': { kind: 'anthropic', api_key: 'stored-secret' },
+        },
+        tiers: {},
+      },
+    } as unknown as JarvisConfig;
+
+    expect(() => saveLLMSettings(config, {
+      providers: {
+        'anthropic-sec-test': { kind: 'openai' },
+      },
+    })).toThrow('requires the API key or auth token again');
+  });
+
+  it('validates every provider update before applying any of them', () => {
+    const config = {
+      llm: {
+        providers: {
+          'anthropic-sec-test': { kind: 'anthropic', api_key: 'stored-secret' },
+        },
+        tiers: {},
+      },
+    } as unknown as JarvisConfig;
+
+    expect(() => saveLLMSettings(config, {
+      providers: {
+        innocent: { kind: 'anthropic', base_url: 'https://ok.example', api_key: 'fresh-key' },
+        'anthropic-sec-test': { base_url: 'https://attacker.example' },
+      },
+    })).toThrow('requires the API key or auth token again');
+    // The valid entry listed before the rejected one must not have been
+    // applied to the in-memory config.
+    expect(config.llm.providers?.['innocent']).toBeUndefined();
   });
 });

--- a/src/daemon/api-llm-test.test.ts
+++ b/src/daemon/api-llm-test.test.ts
@@ -1,0 +1,157 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { createApiRoutes, type ApiContext } from './api-routes.ts';
+import { saveLLMSettings } from './llm-settings.ts';
+import type { JarvisConfig, LLMProviderEntry } from '../config/types.ts';
+
+type Handler = (req: Request) => Response | Promise<Response>;
+type CapturedRequest = {
+  url: string;
+  authorization: string | null;
+  apiKey: string | null;
+  model?: string;
+};
+
+function callEndpoint(
+  providers: Record<string, LLMProviderEntry>,
+  body: Record<string, unknown>,
+): Response | Promise<Response> {
+  const ctx = {
+    daemonStartedAt: Date.now(),
+    healthMonitor: {} as ApiContext['healthMonitor'],
+    config: { llm: { providers } } as JarvisConfig,
+  } as ApiContext;
+  const route = createApiRoutes(ctx)['/api/config/llm/test'] as { POST: Handler };
+  return route.POST(new Request('http://x/api/config/llm/test', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  }));
+}
+
+describe('POST /api/config/llm/test Anthropic endpoint scoping', () => {
+  const realFetch = globalThis.fetch;
+  let requests: CapturedRequest[];
+
+  beforeEach(() => {
+    requests = [];
+    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      const headers = new Headers(init?.headers);
+      const requestBody = init?.body ? JSON.parse(String(init.body)) as { model?: string } : {};
+      const url = String(input);
+      requests.push({
+        url,
+        authorization: headers.get('authorization'),
+        apiKey: headers.get('x-api-key'),
+        model: requestBody.model,
+      });
+      if (url.endsWith('/v1/models')) {
+        return new Response(JSON.stringify({
+          data: [{ id: 'gateway-fast' }, { id: 'gateway-large' }],
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      return new Response(JSON.stringify({
+        id: 'msg_test',
+        type: 'message',
+        role: 'assistant',
+        content: [{ type: 'text', text: 'OK' }],
+        model: requestBody.model ?? 'claude-default',
+        stop_reason: 'end_turn',
+        usage: { input_tokens: 1, output_tokens: 1 },
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+    }) as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  it('never sends a stored token to a caller-supplied URL', async () => {
+    const response = await callEndpoint(
+      { 'anthropic-sec-test': { kind: 'anthropic', api_key: 'stored-secret' } },
+      { name: 'anthropic-sec-test', base_url: 'https://attacker.example' },
+    );
+    const body = await response.json() as { ok: boolean; error: string };
+
+    expect(body.ok).toBe(false);
+    expect(body.error).toContain('requires an explicit api_key');
+    expect(requests).toHaveLength(0);
+  });
+
+  it('uses the stored token with its unchanged stored endpoint', async () => {
+    const response = await callEndpoint(
+      { 'anthropic-sec-test': { kind: 'anthropic', api_key: 'stored-secret', base_url: 'https://saved.example' } },
+      { name: 'anthropic-sec-test' },
+    );
+    const body = await response.json() as { ok: boolean; model: string; models: string[] };
+
+    expect(body.ok).toBe(true);
+    expect(body.model).toBe('gateway-fast');
+    expect(body.models).toEqual(['gateway-fast', 'gateway-large']);
+    expect(requests).toHaveLength(2);
+    expect(requests.every((request) => request.url.startsWith('https://saved.example/'))).toBe(true);
+    expect(requests.every((request) => request.authorization === 'Bearer stored-secret')).toBe(true);
+  });
+
+  it('uses only an explicitly supplied token at a changed endpoint', async () => {
+    const response = await callEndpoint(
+      { 'anthropic-sec-test': { kind: 'anthropic', api_key: 'stored-secret', base_url: 'https://saved.example' } },
+      { name: 'anthropic-sec-test', base_url: 'https://new.example', api_key: 'fresh-token' },
+    );
+    const body = await response.json() as { ok: boolean };
+
+    expect(body.ok).toBe(true);
+    expect(requests.every((request) => request.url.startsWith('https://new.example/'))).toBe(true);
+    expect(requests.every((request) => request.authorization === 'Bearer fresh-token')).toBe(true);
+  });
+
+  it('an explicit empty URL tests official Anthropic instead of the stored gateway', async () => {
+    const response = await callEndpoint(
+      { 'anthropic-sec-test': { kind: 'anthropic', api_key: 'stored-secret', base_url: 'https://saved.example' } },
+      { name: 'anthropic-sec-test', base_url: '' },
+    );
+    const body = await response.json() as { ok: boolean; models?: string[] };
+
+    expect(body.ok).toBe(true);
+    expect(body.models).toBeUndefined();
+    expect(requests).toHaveLength(1);
+    expect(requests[0]!.url).toBe('https://api.anthropic.com/v1/messages');
+    expect(requests[0]!.apiKey).toBe('stored-secret');
+    expect(requests[0]!.authorization).toBeNull();
+  });
+
+  it('does not label curated fallback models as gateway discovery', async () => {
+    globalThis.fetch = (async (input: string | URL | Request) => {
+      requests.push({ url: String(input), authorization: null, apiKey: null });
+      return new Response('not found', { status: 404 });
+    }) as unknown as typeof fetch;
+
+    const response = await callEndpoint(
+      { 'anthropic-sec-test': { kind: 'anthropic', api_key: 'stored-secret', base_url: 'https://saved.example' } },
+      { name: 'anthropic-sec-test' },
+    );
+    const body = await response.json() as { ok: boolean; error: string; models?: string[] };
+
+    expect(body.ok).toBe(false);
+    expect(body.error).toContain('Could not discover any models');
+    expect(body.models).toBeUndefined();
+    expect(requests).toHaveLength(1);
+    expect(requests[0]!.url).toBe('https://saved.example/v1/models');
+  });
+
+  it('also rejects persisting a new endpoint while retaining the stored token', () => {
+    const config = {
+      llm: {
+        providers: {
+          'anthropic-sec-test': { kind: 'anthropic', api_key: 'stored-secret' },
+        },
+        tiers: {},
+      },
+    } as unknown as JarvisConfig;
+
+    expect(() => saveLLMSettings(config, {
+      providers: {
+        'anthropic-sec-test': { base_url: 'https://attacker.example' },
+      },
+    })).toThrow('requires the API key or auth token again');
+  });
+});

--- a/src/daemon/api-routes.ts
+++ b/src/daemon/api-routes.ts
@@ -1484,7 +1484,14 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
     '/api/config/llm/test': {
       POST: async (req: Request) => {
         try {
-          const body = await req.json() as { provider: string; api_key?: string; model?: string; base_url?: string };
+          const body = await req.json() as {
+            name?: string;
+            provider?: string;
+            kind?: import('../config/types.ts').LLMProviderKind;
+            api_key?: string;
+            model?: string;
+            base_url?: string;
+          };
           const { testLLMProvider } = await import('./llm-settings.ts');
           const result = await testLLMProvider(body, ctx.config);
           return json(result);

--- a/src/daemon/llm-settings.ts
+++ b/src/daemon/llm-settings.ts
@@ -447,7 +447,7 @@ export async function testLLMProvider(
     model?: string;
   },
   config: JarvisConfig,
-): Promise<{ ok: boolean; model?: string; error?: string }> {
+): Promise<{ ok: boolean; model?: string; models?: string[]; error?: string }> {
   // Resolve effective name + kind. Legacy `provider` is treated as `name`.
   const name = opts.name ?? opts.provider ?? opts.kind;
   if (!name) return { ok: false, error: 'provider name required' };
@@ -472,11 +472,13 @@ export async function testLLMProvider(
   }
 
   try {
+    const models = await instance.listModels().catch(() => []);
+    const testModel = opts.model || (baseUrl ? models[0] : undefined);
     const resp = await instance.chat(
       [{ role: 'user', content: 'Say OK' }],
-      { max_tokens: 5, ...(opts.model ? { model: opts.model } : {}) },
+      { max_tokens: 5, ...(testModel ? { model: testModel } : {}) },
     );
-    return { ok: true, model: resp.model };
+    return { ok: true, model: resp.model, models };
   } catch (err) {
     return { ok: false, error: err instanceof Error ? err.message : String(err) };
   }

--- a/src/daemon/llm-settings.ts
+++ b/src/daemon/llm-settings.ts
@@ -168,25 +168,47 @@ export function saveLLMSettings(
 
   // Apply provider updates (add / modify / remove).
   if (body.providers) {
-    for (const [name, update] of Object.entries(body.providers)) {
+    const updates = Object.entries(body.providers);
+    // Validate every update before mutating anything: a rejection mid-loop
+    // would otherwise leave earlier entries applied in memory but never
+    // persisted by the setSetting() block at the end of this function.
+    for (const [name, update] of updates) {
+      if (update === null) continue;
+      const existing = config.llm.providers[name] ?? {};
+      const nextBaseUrl = normalizeBaseUrl(update.base_url);
+      const existingBaseUrl = normalizeBaseUrl(existing.base_url);
+      const retainsStoredCredential = update.api_key === undefined
+        && (Boolean(existing.api_key) || hasSecret(keychainKey(name)));
+      // A stored credential is scoped to its saved endpoint in BOTH
+      // directions: it must not follow the provider to a new gateway, and a
+      // gateway token must not be replayed against the official endpoint
+      // after the URL is cleared. Any base_url move requires the credential
+      // again in the same request.
+      if (
+        update.base_url !== undefined
+        && nextBaseUrl !== existingBaseUrl
+        && retainsStoredCredential
+      ) {
+        throw new Error(`Provider '${name}' requires the API key or auth token again when changing base_url`);
+      }
+      // `kind` selects an endpoint just like base_url does — switching it
+      // would replay the stored credential against another provider's API.
+      // (Legacy entries without an explicit kind are keyed by their name.)
+      if (
+        update.kind !== undefined
+        && update.kind !== (existing.kind ?? name)
+        && retainsStoredCredential
+      ) {
+        throw new Error(`Provider '${name}' requires the API key or auth token again when changing kind`);
+      }
+    }
+    for (const [name, update] of updates) {
       if (update === null) {
         delete config.llm.providers[name];
         try { deleteSecret(keychainKey(name)); } catch { /* ignore */ }
         continue;
       }
       const existing = config.llm.providers[name] ?? {};
-      const nextBaseUrl = normalizeBaseUrl(update.base_url);
-      const existingBaseUrl = normalizeBaseUrl(existing.base_url);
-      const retainsStoredCredential = update.api_key === undefined
-        && (Boolean(existing.api_key) || hasSecret(keychainKey(name)));
-      if (
-        update.base_url !== undefined
-        && nextBaseUrl
-        && nextBaseUrl !== existingBaseUrl
-        && retainsStoredCredential
-      ) {
-        throw new Error(`Provider '${name}' requires the API key or auth token again when changing base_url`);
-      }
       const merged: LLMProviderEntry = { ...existing };
       if (update.kind !== undefined) merged.kind = update.kind;
       if (update.base_url !== undefined) merged.base_url = update.base_url;
@@ -480,18 +502,30 @@ export async function testLLMProvider(
   const normalizedRequestedBaseUrl = normalizeBaseUrl(requestedBaseUrl);
   const normalizedConfiguredBaseUrl = normalizeBaseUrl(configuredBaseUrl);
 
-  // A stored credential is scoped to its saved endpoint. Never attach it to
-  // a caller-supplied URL; changing to a new custom endpoint requires the
-  // caller to provide the credential again in the same request. An explicit
-  // empty URL is safe: it switches Anthropic back to its official origin.
+  // A stored credential is scoped to its saved endpoint, in both directions:
+  // never attach it to a caller-supplied URL, and never replay a gateway
+  // token against the official endpoint after the URL is cleared. Moving the
+  // endpoint anywhere requires the credential again in the same request.
   if (
     hasExplicitBaseUrl
-    && requestedBaseUrl
     && normalizedRequestedBaseUrl !== normalizedConfiguredBaseUrl
     && storedApiKey
     && !opts.api_key
   ) {
-    return { ok: false, error: 'A new base_url requires an explicit api_key or auth token' };
+    return { ok: false, error: 'Changing base_url requires an explicit api_key or auth token' };
+  }
+
+  // `kind` selects an endpoint just like base_url does — an overridden kind
+  // would replay the stored credential against another provider's API (some
+  // kinds don't even need a base_url to reach one, e.g. their default
+  // origin). Legacy entries without an explicit kind are keyed by name.
+  if (
+    opts.kind !== undefined
+    && opts.kind !== (configured?.kind ?? name)
+    && storedApiKey
+    && !opts.api_key
+  ) {
+    return { ok: false, error: 'Changing the provider kind requires an explicit api_key or auth token' };
   }
 
   // Resolve credentials: explicit > keychain > config inline. Preserve an
@@ -518,7 +552,7 @@ export async function testLLMProvider(
       if (!models.length) {
         return { ok: false, error: 'Could not discover any models from the custom Anthropic endpoint' };
       }
-      testModel ??= models[0];
+      testModel = models[0];
     }
     const resp = await instance.chat(
       [{ role: 'user', content: 'Say OK' }],

--- a/src/daemon/llm-settings.ts
+++ b/src/daemon/llm-settings.ts
@@ -25,6 +25,7 @@ import {
   atomicReloadProviders,
   configureLLMTiers,
 } from '../llm/config-binding.ts';
+import { isAnthropicCustomBaseUrl } from '../llm/anthropic.ts';
 
 // ── DB keys ──────────────────────────────────────────────────────────────
 const SETTING_PROVIDERS = 'llm.providers';
@@ -39,6 +40,10 @@ const SETTING_PROMPT_CACHE = 'llm.prompt_cache';
 /** Keychain key for a provider's API key, by provider NAME (not kind). */
 function keychainKey(providerName: string): string {
   return `llm.provider.${providerName}.api_key`;
+}
+
+function normalizeBaseUrl(value: string | undefined): string {
+  return value?.trim().replace(/\/+$/, '') ?? '';
 }
 
 // ── Types exposed to the dashboard ───────────────────────────────────────
@@ -170,6 +175,18 @@ export function saveLLMSettings(
         continue;
       }
       const existing = config.llm.providers[name] ?? {};
+      const nextBaseUrl = normalizeBaseUrl(update.base_url);
+      const existingBaseUrl = normalizeBaseUrl(existing.base_url);
+      const retainsStoredCredential = update.api_key === undefined
+        && (Boolean(existing.api_key) || hasSecret(keychainKey(name)));
+      if (
+        update.base_url !== undefined
+        && nextBaseUrl
+        && nextBaseUrl !== existingBaseUrl
+        && retainsStoredCredential
+      ) {
+        throw new Error(`Provider '${name}' requires the API key or auth token again when changing base_url`);
+      }
       const merged: LLMProviderEntry = { ...existing };
       if (update.kind !== undefined) merged.kind = update.kind;
       if (update.base_url !== undefined) merged.base_url = update.base_url;
@@ -456,9 +473,31 @@ export async function testLLMProvider(
   const configured = config.llm.providers?.[name];
   const kind: LLMProviderKind = (opts.kind ?? configured?.kind ?? name) as LLMProviderKind;
 
-  // Resolve credentials: explicit > keychain > config inline.
-  const apiKey = opts.api_key ?? getSecret(keychainKey(name)) ?? configured?.api_key ?? '';
-  const baseUrl = opts.base_url ?? configured?.base_url ?? '';
+  const hasExplicitBaseUrl = Object.hasOwn(opts, 'base_url');
+  const requestedBaseUrl = opts.base_url?.trim() ?? '';
+  const configuredBaseUrl = configured?.base_url?.trim() ?? '';
+  const storedApiKey = getSecret(keychainKey(name)) ?? configured?.api_key ?? '';
+  const normalizedRequestedBaseUrl = normalizeBaseUrl(requestedBaseUrl);
+  const normalizedConfiguredBaseUrl = normalizeBaseUrl(configuredBaseUrl);
+
+  // A stored credential is scoped to its saved endpoint. Never attach it to
+  // a caller-supplied URL; changing to a new custom endpoint requires the
+  // caller to provide the credential again in the same request. An explicit
+  // empty URL is safe: it switches Anthropic back to its official origin.
+  if (
+    hasExplicitBaseUrl
+    && requestedBaseUrl
+    && normalizedRequestedBaseUrl !== normalizedConfiguredBaseUrl
+    && storedApiKey
+    && !opts.api_key
+  ) {
+    return { ok: false, error: 'A new base_url requires an explicit api_key or auth token' };
+  }
+
+  // Resolve credentials: explicit > keychain > config inline. Preserve an
+  // explicit empty base_url instead of falling back to the stored gateway.
+  const apiKey = opts.api_key ?? storedApiKey;
+  const baseUrl = hasExplicitBaseUrl ? requestedBaseUrl : configuredBaseUrl;
 
   const entry: LLMProviderEntry = {
     kind,
@@ -472,13 +511,20 @@ export async function testLLMProvider(
   }
 
   try {
-    const models = await instance.listModels().catch(() => []);
-    const testModel = opts.model || (baseUrl ? models[0] : undefined);
+    let models: string[] | undefined;
+    let testModel = opts.model;
+    if (kind === 'anthropic' && isAnthropicCustomBaseUrl(baseUrl) && !testModel) {
+      models = await instance.listModels().catch(() => []);
+      if (!models.length) {
+        return { ok: false, error: 'Could not discover any models from the custom Anthropic endpoint' };
+      }
+      testModel ??= models[0];
+    }
     const resp = await instance.chat(
       [{ role: 'user', content: 'Say OK' }],
       { max_tokens: 5, ...(testModel ? { model: testModel } : {}) },
     );
-    return { ok: true, model: resp.model, models };
+    return { ok: true, model: testModel ?? resp.model, ...(models ? { models } : {}) };
   } catch (err) {
     return { ok: false, error: err instanceof Error ? err.message : String(err) };
   }

--- a/src/llm/README.md
+++ b/src/llm/README.md
@@ -19,7 +19,7 @@ A unified abstraction layer for multiple LLM providers with automatic fallback s
 - **Features**: Text generation, streaming, tool use
 - **API**: https://api.anthropic.com/v1/messages
 
-Anthropic providers can also use a Claude-compatible gateway. In onboarding or **Settings > LLM**, enter the gateway origin (for example, `https://myrellms.xyz`) as the optional base URL and put the value normally used for `ANTHROPIC_AUTH_TOKEN` in the credential field. Jarvis appends `/v1/messages` and sends the token as `Authorization: Bearer …`.
+Anthropic providers can also use a Claude-compatible gateway. In onboarding or **Settings > LLM**, enable **Use a custom Anthropic endpoint**, enter the gateway origin, and put the value normally used for `ANTHROPIC_AUTH_TOKEN` in the credential field. Jarvis appends `/v1/messages`, sends the token as `Authorization: Bearer …`, and reads available models from `/v1/models` when the gateway supports it.
 
 Leaving the base URL blank keeps the standard Anthropic endpoint and `x-api-key` authentication.
 

--- a/src/llm/README.md
+++ b/src/llm/README.md
@@ -19,6 +19,10 @@ A unified abstraction layer for multiple LLM providers with automatic fallback s
 - **Features**: Text generation, streaming, tool use
 - **API**: https://api.anthropic.com/v1/messages
 
+Anthropic providers can also use a Claude-compatible gateway. In onboarding or **Settings > LLM**, enter the gateway origin (for example, `https://myrellms.xyz`) as the optional base URL and put the value normally used for `ANTHROPIC_AUTH_TOKEN` in the credential field. Jarvis appends `/v1/messages` and sends the token as `Authorization: Bearer …`.
+
+Leaving the base URL blank keeps the standard Anthropic endpoint and `x-api-key` authentication.
+
 ### 2. OpenAI GPT
 - **Models**: GPT-4o, GPT-4 Turbo, GPT-3.5 Turbo
 - **Default**: `gpt-4o`

--- a/src/llm/anthropic.test.ts
+++ b/src/llm/anthropic.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, afterEach } from 'bun:test';
-import { AnthropicProvider } from './anthropic.ts';
+import { AnthropicProvider, anthropicMessagesUrl } from './anthropic.ts';
 import type { LLMMessage, LLMStreamEvent } from './provider.ts';
 
 const originalFetch = globalThis.fetch;
@@ -53,6 +53,51 @@ function countCacheControls(body: CapturedBody): number {
   }
   return n;
 }
+
+describe('AnthropicProvider custom endpoint', () => {
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('normalizes base URLs to the Messages API endpoint', () => {
+    expect(anthropicMessagesUrl('https://myrellms.xyz')).toBe('https://myrellms.xyz/v1/messages');
+    expect(anthropicMessagesUrl('https://myrellms.xyz/v1/')).toBe('https://myrellms.xyz/v1/messages');
+    expect(anthropicMessagesUrl('https://myrellms.xyz/v1/messages')).toBe('https://myrellms.xyz/v1/messages');
+  });
+
+  it('uses bearer authentication for a custom base URL', async () => {
+    let requestUrl = '';
+    let requestHeaders = new Headers();
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      requestUrl = String(input);
+      requestHeaders = new Headers(init?.headers);
+      return new Response(JSON.stringify(anthropicResponse()), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const provider = new AnthropicProvider('custom-token', undefined, {
+      baseUrl: 'https://myrellms.xyz',
+    });
+    await provider.chat([{ role: 'user', content: 'hi' }]);
+
+    expect(requestUrl).toBe('https://myrellms.xyz/v1/messages');
+    expect(requestHeaders.get('authorization')).toBe('Bearer custom-token');
+    expect(requestHeaders.get('x-api-key')).toBeNull();
+    expect(requestHeaders.get('anthropic-version')).toBe('2023-06-01');
+  });
+
+  it('keeps x-api-key authentication on Anthropic by default', async () => {
+    let requestHeaders = new Headers();
+    globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      requestHeaders = new Headers(init?.headers);
+      return new Response(JSON.stringify(anthropicResponse()), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    await new AnthropicProvider('sk-ant-test').chat([{ role: 'user', content: 'hi' }]);
+
+    expect(requestHeaders.get('x-api-key')).toBe('sk-ant-test');
+    expect(requestHeaders.get('authorization')).toBeNull();
+  });
+});
 
 describe('AnthropicProvider cache_control placement', () => {
   afterEach(() => {

--- a/src/llm/anthropic.test.ts
+++ b/src/llm/anthropic.test.ts
@@ -98,6 +98,21 @@ describe('AnthropicProvider custom endpoint', () => {
     expect(requestHeaders.get('authorization')).toBeNull();
   });
 
+  it('keeps x-api-key authentication when the official URL is entered explicitly', async () => {
+    let requestHeaders = new Headers();
+    globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      requestHeaders = new Headers(init?.headers);
+      return new Response(JSON.stringify(anthropicResponse()), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    await new AnthropicProvider('sk-ant-test', undefined, {
+      baseUrl: 'https://api.anthropic.com',
+    }).chat([{ role: 'user', content: 'hi' }]);
+
+    expect(requestHeaders.get('x-api-key')).toBe('sk-ant-test');
+    expect(requestHeaders.get('authorization')).toBeNull();
+  });
+
   it('discovers models from a custom endpoint', async () => {
     let requestUrl = '';
     let requestHeaders = new Headers();

--- a/src/llm/anthropic.test.ts
+++ b/src/llm/anthropic.test.ts
@@ -60,9 +60,9 @@ describe('AnthropicProvider custom endpoint', () => {
   });
 
   it('normalizes base URLs to the Messages API endpoint', () => {
-    expect(anthropicMessagesUrl('https://myrellms.xyz')).toBe('https://myrellms.xyz/v1/messages');
-    expect(anthropicMessagesUrl('https://myrellms.xyz/v1/')).toBe('https://myrellms.xyz/v1/messages');
-    expect(anthropicMessagesUrl('https://myrellms.xyz/v1/messages')).toBe('https://myrellms.xyz/v1/messages');
+    expect(anthropicMessagesUrl('https://gateway.example.com')).toBe('https://gateway.example.com/v1/messages');
+    expect(anthropicMessagesUrl('https://gateway.example.com/v1/')).toBe('https://gateway.example.com/v1/messages');
+    expect(anthropicMessagesUrl('https://gateway.example.com/v1/messages')).toBe('https://gateway.example.com/v1/messages');
   });
 
   it('uses bearer authentication for a custom base URL', async () => {
@@ -75,11 +75,11 @@ describe('AnthropicProvider custom endpoint', () => {
     }) as unknown as typeof fetch;
 
     const provider = new AnthropicProvider('custom-token', undefined, {
-      baseUrl: 'https://myrellms.xyz',
+      baseUrl: 'https://gateway.example.com',
     });
     await provider.chat([{ role: 'user', content: 'hi' }]);
 
-    expect(requestUrl).toBe('https://myrellms.xyz/v1/messages');
+    expect(requestUrl).toBe('https://gateway.example.com/v1/messages');
     expect(requestHeaders.get('authorization')).toBe('Bearer custom-token');
     expect(requestHeaders.get('x-api-key')).toBeNull();
     expect(requestHeaders.get('anthropic-version')).toBe('2023-06-01');
@@ -96,6 +96,26 @@ describe('AnthropicProvider custom endpoint', () => {
 
     expect(requestHeaders.get('x-api-key')).toBe('sk-ant-test');
     expect(requestHeaders.get('authorization')).toBeNull();
+  });
+
+  it('discovers models from a custom endpoint', async () => {
+    let requestUrl = '';
+    let requestHeaders = new Headers();
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      requestUrl = String(input);
+      requestHeaders = new Headers(init?.headers);
+      return new Response(JSON.stringify({
+        data: [{ id: 'claude-custom-large' }, { id: 'claude-custom-fast' }],
+      }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const models = await new AnthropicProvider('custom-token', undefined, {
+      baseUrl: 'https://gateway.example.com',
+    }).listModels();
+
+    expect(requestUrl).toBe('https://gateway.example.com/v1/models');
+    expect(requestHeaders.get('authorization')).toBe('Bearer custom-token');
+    expect(models).toEqual(['claude-custom-fast', 'claude-custom-large']);
   });
 });
 

--- a/src/llm/anthropic.test.ts
+++ b/src/llm/anthropic.test.ts
@@ -130,7 +130,8 @@ describe('AnthropicProvider custom endpoint', () => {
 
     expect(requestUrl).toBe('https://gateway.example.com/v1/models');
     expect(requestHeaders.get('authorization')).toBe('Bearer custom-token');
-    expect(models).toEqual(['claude-custom-fast', 'claude-custom-large']);
+    expect(requestHeaders.get('anthropic-version')).toBe('2023-06-01');
+    expect(models).toEqual(['claude-custom-large', 'claude-custom-fast']);
   });
 });
 

--- a/src/llm/anthropic.ts
+++ b/src/llm/anthropic.ts
@@ -109,21 +109,32 @@ type AnthropicSystemBlock = {
   cache_control?: { type: 'ephemeral' };
 };
 
+export function anthropicMessagesUrl(baseUrl?: string): string {
+  if (!baseUrl?.trim()) return 'https://api.anthropic.com/v1/messages';
+  const normalized = baseUrl.trim().replace(/\/+$/, '');
+  if (normalized.endsWith('/v1/messages')) return normalized;
+  if (normalized.endsWith('/v1')) return `${normalized}/messages`;
+  return `${normalized}/v1/messages`;
+}
+
 export class AnthropicProvider implements LLMProvider {
   name = 'anthropic';
   private apiKey: string;
   private defaultModel: string;
   private promptCache: boolean;
-  private apiUrl = 'https://api.anthropic.com/v1/messages';
+  private apiUrl: string;
+  private bearerAuth: boolean;
 
   constructor(
     apiKey: string,
     defaultModel = 'claude-sonnet-4-5-20250929',
-    opts?: { promptCache?: boolean },
+    opts?: { promptCache?: boolean; baseUrl?: string },
   ) {
     this.apiKey = apiKey;
     this.defaultModel = defaultModel;
     this.promptCache = opts?.promptCache !== false;
+    this.apiUrl = anthropicMessagesUrl(opts?.baseUrl);
+    this.bearerAuth = Boolean(opts?.baseUrl?.trim());
   }
 
   /**
@@ -131,10 +142,11 @@ export class AnthropicProvider implements LLMProvider {
    */
   private async fetchWithRetry(body: string, stream: boolean = false): Promise<Response> {
     const headers: Record<string, string> = {
-      'x-api-key': this.apiKey,
       'anthropic-version': '2023-06-01',
       'content-type': 'application/json',
     };
+    if (this.bearerAuth) headers.authorization = `Bearer ${this.apiKey}`;
+    else headers['x-api-key'] = this.apiKey;
 
     for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
       const response = await fetch(this.apiUrl, {

--- a/src/llm/anthropic.ts
+++ b/src/llm/anthropic.ts
@@ -360,10 +360,7 @@ export class AnthropicProvider implements LLMProvider {
   }
 
   async listModels(): Promise<string[]> {
-    // Anthropic doesn't have a models endpoint, so return known models
-    // (current family first). Keep in sync with the UI model pickers in
-    // ui/src/v2/rooms/settings/tabs/LLMTab.tsx + the onboarding wizard.
-    return [
+    const knownModels = [
       'claude-fable-5',
       'claude-opus-4-8',
       'claude-sonnet-5',
@@ -371,6 +368,21 @@ export class AnthropicProvider implements LLMProvider {
       'claude-sonnet-4-6',
       'claude-haiku-4-5-20251001',
     ];
+    if (!this.bearerAuth) return knownModels;
+
+    try {
+      const response = await fetch(this.apiUrl.replace(/\/messages$/, '/models'), {
+        headers: { authorization: `Bearer ${this.apiKey}` },
+      });
+      if (!response.ok) return knownModels;
+      const payload = await response.json() as { data?: Array<{ id?: unknown }> };
+      const models = payload.data
+        ?.map((entry) => entry.id)
+        .filter((id): id is string => typeof id === 'string' && id.length > 0);
+      return models?.length ? [...new Set(models)].sort() : knownModels;
+    } catch {
+      return knownModels;
+    }
   }
 
   private convertMessages(messages: LLMMessage[]): {

--- a/src/llm/anthropic.ts
+++ b/src/llm/anthropic.ts
@@ -117,6 +117,18 @@ export function anthropicMessagesUrl(baseUrl?: string): string {
   return `${normalized}/v1/messages`;
 }
 
+/** The public Anthropic origin still uses x-api-key even when typed explicitly. */
+export function isAnthropicCustomBaseUrl(baseUrl?: string): boolean {
+  if (!baseUrl?.trim()) return false;
+  try {
+    return new URL(baseUrl.trim()).origin !== 'https://api.anthropic.com';
+  } catch {
+    // Let fetch surface the malformed URL; never treat it as Anthropic's
+    // trusted origin for credential/header selection.
+    return true;
+  }
+}
+
 export class AnthropicProvider implements LLMProvider {
   name = 'anthropic';
   private apiKey: string;
@@ -134,7 +146,7 @@ export class AnthropicProvider implements LLMProvider {
     this.defaultModel = defaultModel;
     this.promptCache = opts?.promptCache !== false;
     this.apiUrl = anthropicMessagesUrl(opts?.baseUrl);
-    this.bearerAuth = Boolean(opts?.baseUrl?.trim());
+    this.bearerAuth = isAnthropicCustomBaseUrl(opts?.baseUrl);
   }
 
   /**
@@ -374,14 +386,14 @@ export class AnthropicProvider implements LLMProvider {
       const response = await fetch(this.apiUrl.replace(/\/messages$/, '/models'), {
         headers: { authorization: `Bearer ${this.apiKey}` },
       });
-      if (!response.ok) return knownModels;
+      if (!response.ok) return [];
       const payload = await response.json() as { data?: Array<{ id?: unknown }> };
       const models = payload.data
         ?.map((entry) => entry.id)
         .filter((id): id is string => typeof id === 'string' && id.length > 0);
-      return models?.length ? [...new Set(models)].sort() : knownModels;
+      return models?.length ? [...new Set(models)].sort() : [];
     } catch {
-      return knownModels;
+      return [];
     }
   }
 

--- a/src/llm/anthropic.ts
+++ b/src/llm/anthropic.ts
@@ -384,14 +384,19 @@ export class AnthropicProvider implements LLMProvider {
 
     try {
       const response = await fetch(this.apiUrl.replace(/\/messages$/, '/models'), {
-        headers: { authorization: `Bearer ${this.apiKey}` },
+        headers: {
+          authorization: `Bearer ${this.apiKey}`,
+          'anthropic-version': '2023-06-01',
+        },
       });
       if (!response.ok) return [];
       const payload = await response.json() as { data?: Array<{ id?: unknown }> };
       const models = payload.data
         ?.map((entry) => entry.id)
         .filter((id): id is string => typeof id === 'string' && id.length > 0);
-      return models?.length ? [...new Set(models)].sort() : [];
+      // Keep the gateway's own ordering: its first entry is the closest
+      // thing to a recommended default we have.
+      return models?.length ? [...new Set(models)] : [];
     } catch {
       return [];
     }

--- a/src/llm/config-binding.ts
+++ b/src/llm/config-binding.ts
@@ -56,6 +56,7 @@ export function instantiateProvider(
       if (!entry.api_key) return null;
       provider = new AnthropicProvider(entry.api_key, undefined, {
         promptCache: globals?.promptCache !== false,
+        baseUrl: entry.base_url,
       });
       break;
     case 'openai':

--- a/ui/src/v2/onboarding/OnboardingWizard.css
+++ b/ui/src/v2/onboarding/OnboardingWizard.css
@@ -143,8 +143,6 @@ select.obw-inp { cursor: pointer; -webkit-appearance: none; appearance: none; }
 .obw-toggle::after { content: ""; position: absolute; top: 2px; left: 2px; width: 15px; height: 15px; border-radius: 50%; background: var(--bg); transition: left 0.15s; }
 .obw-toggle[data-checked="true"] { background: var(--ink); }
 .obw-toggle[data-checked="true"]::after { left: 17px; }
-.obw-models { display: flex; flex-wrap: wrap; gap: 5px; max-height: 92px; margin-top: 9px; overflow: auto; }
-.obw-models span { padding: 3px 7px; border: 1px solid var(--rule); border-radius: 999px; font-family: var(--mono); font-size: 9px; color: var(--ink3); }
 .obw-advlink { display: inline-block; margin-top: 12px; font-size: 11.5px; color: var(--speak); cursor: pointer; font-weight: 500; background: none; border: none; padding: 0; font-family: var(--sans); }
 
 /* permission / integration rows */

--- a/ui/src/v2/onboarding/OnboardingWizard.css
+++ b/ui/src/v2/onboarding/OnboardingWizard.css
@@ -138,6 +138,13 @@ select.obw-inp { cursor: pointer; -webkit-appearance: none; appearance: none; }
 .obw-testres.ok { color: var(--ok); }
 .obw-testres.err { color: var(--listen); }
 .obw-testres .dot { width: 7px; height: 7px; border-radius: 50% 50% 50% 1px; transform: rotate(45deg); background: currentColor; }
+.obw-toggle-row { display: flex; align-items: center; gap: 9px; margin: 0 0 11px; font-size: 12px; color: var(--ink2); cursor: pointer; }
+.obw-toggle { position: relative; width: 34px; height: 19px; flex: 0 0 auto; padding: 0; border: 0; border-radius: 999px; background: var(--rule); cursor: pointer; }
+.obw-toggle::after { content: ""; position: absolute; top: 2px; left: 2px; width: 15px; height: 15px; border-radius: 50%; background: var(--bg); transition: left 0.15s; }
+.obw-toggle[data-checked="true"] { background: var(--ink); }
+.obw-toggle[data-checked="true"]::after { left: 17px; }
+.obw-models { display: flex; flex-wrap: wrap; gap: 5px; max-height: 92px; margin-top: 9px; overflow: auto; }
+.obw-models span { padding: 3px 7px; border: 1px solid var(--rule); border-radius: 999px; font-family: var(--mono); font-size: 9px; color: var(--ink3); }
 .obw-advlink { display: inline-block; margin-top: 12px; font-size: 11.5px; color: var(--speak); cursor: pointer; font-weight: 500; background: none; border: none; padding: 0; font-family: var(--sans); }
 
 /* permission / integration rows */

--- a/ui/src/v2/onboarding/OnboardingWizard.tsx
+++ b/ui/src/v2/onboarding/OnboardingWizard.tsx
@@ -45,7 +45,7 @@ type Provider = {
 };
 const PROVIDERS: Provider[] = [
   { id: "jarvis", name: "Jarvis AI", abbr: "JA", kind: "no key", soon: true, noConfig: true },
-  { id: "anthropic", name: "Anthropic", abbr: "A", kind: "API key", needsKey: true, optionalBaseUrl: true, keyLabel: "API key or auth token", urlLabel: "Custom base URL (optional)", urlPh: "https://myrellms.xyz", models: ["claude-fable-5", "claude-opus-4-8", "claude-sonnet-5", "claude-haiku-4-5-20251001"], hint: "Leave the URL blank for Anthropic. Custom URLs use bearer-token authentication, matching ANTHROPIC_BASE_URL and ANTHROPIC_AUTH_TOKEN." },
+  { id: "anthropic", name: "Anthropic", abbr: "A", kind: "API key", needsKey: true, optionalBaseUrl: true, keyLabel: "API key", urlLabel: "Custom endpoint URL", urlPh: "https://gateway.example.com", models: ["claude-fable-5", "claude-opus-4-8", "claude-sonnet-5", "claude-haiku-4-5-20251001"], hint: "Enable the custom endpoint option to use ANTHROPIC_BASE_URL and ANTHROPIC_AUTH_TOKEN-style authentication." },
   { id: "openai", name: "OpenAI", abbr: "O", kind: "API key", needsKey: true, models: ["gpt-5.5", "gpt-5.5-pro", "gpt-5.4", "gpt-5-mini", "o4-mini"] },
   { id: "groq", name: "Groq", abbr: "G", kind: "API key", needsKey: true, models: ["llama-3.3-70b-versatile", "llama-3.1-8b-instant"] },
   { id: "gemini", name: "Gemini", abbr: "Ge", kind: "API key", needsKey: true, models: ["gemini-3.1-pro-preview", "gemini-3-flash-preview", "gemini-2.5-pro"] },
@@ -104,7 +104,7 @@ const TOUR = [
   { sm: "Authority is your control panel, with a kill-switch. Nothing with real-world impact happens without your yes.", t: "", pos: { left: 130, top: 150 } },
 ];
 
-type TestState = { status: "idle" | "testing" | "ok" | "err"; msg?: string };
+type TestState = { status: "idle" | "testing" | "ok" | "err"; msg?: string; models?: string[] };
 
 export function OnboardingWizard({
   status,
@@ -143,6 +143,7 @@ export function OnboardingWizard({
   const prov = PROVIDERS.find((p) => p.id === provId)!;
   const [apiKey, setApiKey] = useState("");
   const [baseUrl, setBaseUrl] = useState("");
+  const [customEndpoint, setCustomEndpoint] = useState(false);
   const [model, setModel] = useState("");
   const [test, setTest] = useState<TestState>({ status: "idle" });
   // hearing
@@ -179,13 +180,16 @@ export function OnboardingWizard({
   useEffect(() => {
     const p = PROVIDERS.find((x) => x.id === provId)!;
     setModel(p.models?.[0] ?? "");
-    setBaseUrl(urlByProvider.current[provId] ?? (provId === "omniroute" ? "http://localhost:20128/v1" : ""));
+    const nextBaseUrl = urlByProvider.current[provId]
+      ?? (provId === "omniroute" ? "http://localhost:20128/v1" : "");
+    setBaseUrl(nextBaseUrl);
+    setCustomEndpoint(provId === "anthropic" && Boolean(nextBaseUrl));
     setTest({ status: "idle" });
   }, [provId]);
 
   // Same for the brain test: a changed key, base URL, or model invalidates a
   // previous "Connected" verdict.
-  useEffect(() => { setTest((t) => (t.status === "idle" ? t : { status: "idle" })); }, [apiKey, baseUrl, model]);
+  useEffect(() => { setTest((t) => (t.status === "idle" ? t : { status: "idle" })); }, [apiKey, baseUrl, customEndpoint, model]);
 
   // Ollama serves only what the operator pulled, and every id carries a tag
   // ("qwen2.5:3b"). The curated list is untagged guesswork — picking from it
@@ -283,16 +287,19 @@ export function OnboardingWizard({
         if (apiKey) body.api_key = apiKey;
       }
       if (prov.needsBaseUrl) { if (!baseUrl.trim()) { setTest({ status: "err", msg: "Enter a base URL first." }); return; } body.base_url = baseUrl.trim(); }
-      if (prov.optionalBaseUrl && baseUrl.trim()) body.base_url = baseUrl.trim();
+      if (prov.optionalBaseUrl && customEndpoint) {
+        if (!baseUrl.trim()) { setTest({ status: "err", msg: "Enter a custom endpoint URL first." }); return; }
+        body.base_url = baseUrl.trim();
+      }
       if ((provId === "openai_compatible" || provId === "litellm") && apiKey) body.api_key = apiKey;
       const r = await fetch("/api/config/llm/test", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(body) });
-      const data = (await r.json()) as { ok: boolean; model?: string; error?: string };
-      if (data.ok) setTest({ status: "ok", msg: data.model ?? model });
+      const data = (await r.json()) as { ok: boolean; model?: string; models?: string[]; error?: string };
+      if (data.ok) setTest({ status: "ok", msg: data.model ?? model, models: data.models });
       else setTest({ status: "err", msg: data.error ?? "Test failed." });
     } catch (e) {
       setTest({ status: "err", msg: e instanceof Error ? e.message : "Test failed." });
     }
-  }, [provId, model, apiKey, baseUrl, prov]);
+  }, [provId, model, apiKey, baseUrl, customEndpoint, prov]);
 
   const brainReady = !prov.soon && (prov.noConfig || test.status === "ok");
 
@@ -303,7 +310,7 @@ export function OnboardingWizard({
       const entry: Record<string, unknown> = { kind: prov.kind === "no key" ? "jarvis" : provId };
       if (prov.needsKey && apiKey) entry.api_key = apiKey;
       if (prov.needsBaseUrl) entry.base_url = baseUrl.trim();
-      if (prov.optionalBaseUrl && baseUrl.trim()) entry.base_url = baseUrl.trim();
+      if (prov.optionalBaseUrl && customEndpoint && baseUrl.trim()) entry.base_url = baseUrl.trim();
       const llm: Record<string, unknown> = { providers: { [provId]: entry }, default: `${provId}:${model || "default"}` };
 
       const ttsBlock: Record<string, unknown> = { enabled: tts !== "off", provider: tts === "off" ? "edge" : tts };
@@ -323,7 +330,7 @@ export function OnboardingWizard({
     } catch (e) {
       setError(e instanceof Error ? e.message : "Setup failed.");
     } finally { setBusy(false); }
-  }, [prov, provId, apiKey, baseUrl, model, tts, edgeVoice, elevenKey, elevenVoice, elevenModel, stt, sttKey, sttEndpoint]);
+  }, [prov, provId, apiKey, baseUrl, customEndpoint, model, tts, edgeVoice, elevenKey, elevenVoice, elevenModel, stt, sttKey, sttEndpoint]);
 
   const skipAll = useCallback(async () => {
     setBusy(true);
@@ -759,8 +766,25 @@ export function OnboardingWizard({
         : (prov.models ?? []);
     return (
       <>
-        {(prov.needsBaseUrl || prov.optionalBaseUrl) && <div className="obw-field"><label>{prov.urlLabel}</label><input className="obw-inp" placeholder={prov.urlPh} value={baseUrl} onChange={(e) => { urlByProvider.current[provId] = e.target.value; setBaseUrl(e.target.value); }} /></div>}
-        {prov.needsKey && <div className="obw-field"><label>{prov.keyLabel ?? `API key${prov.keyOptional ? " (optional)" : ""}`}</label><input className="obw-inp" type="password" placeholder="paste your key" value={apiKey} onChange={(e) => setApiKey(e.target.value)} /></div>}
+        {prov.optionalBaseUrl && (
+          <label className="obw-toggle-row">
+            <button
+              type="button"
+              className="obw-toggle"
+              data-checked={customEndpoint}
+              aria-checked={customEndpoint}
+              role="switch"
+              onClick={() => {
+                setCustomEndpoint((enabled) => !enabled);
+                urlByProvider.current[provId] = "";
+                setBaseUrl("");
+              }}
+            />
+            <span>Use a custom Anthropic endpoint</span>
+          </label>
+        )}
+        {(prov.needsBaseUrl || (prov.optionalBaseUrl && customEndpoint)) && <div className="obw-field"><label>{prov.urlLabel}</label><input className="obw-inp" placeholder={prov.urlPh} value={baseUrl} onChange={(e) => { urlByProvider.current[provId] = e.target.value; setBaseUrl(e.target.value); }} /></div>}
+        {prov.needsKey && <div className="obw-field"><label>{prov.optionalBaseUrl && customEndpoint ? "Auth token" : (prov.keyLabel ?? `API key${prov.keyOptional ? " (optional)" : ""}`)}</label><input className="obw-inp" type="password" placeholder="paste your key" value={apiKey} onChange={(e) => setApiKey(e.target.value)} /></div>}
         {prov.freeModel
           ? <div className="obw-field"><label>Model</label><input className="obw-inp" placeholder="model id" value={model} onChange={(e) => setModel(e.target.value)} /></div>
           : <div className="obw-field"><label>Model</label><select className="obw-inp" value={model} onChange={(e) => setModel(e.target.value)}>{pickerModels.map((m) => <option key={m} value={m}>{m}</option>)}</select></div>}
@@ -773,6 +797,11 @@ export function OnboardingWizard({
           {test.status === "ok" && <span className="obw-testres ok"><span className="dot" />Connected · {test.msg}</span>}
           {test.status === "err" && <span className="obw-testres err"><span className="dot" />{test.msg}</span>}
         </div>
+        {test.status === "ok" && test.models && test.models.length > 0 && (
+          <div className="obw-models" aria-label="Models discovered">
+            {test.models.map((discoveredModel) => <span key={discoveredModel}>{discoveredModel}</span>)}
+          </div>
+        )}
         {prov.hint && <div className="obw-hint">{prov.hint}</div>}
       </>
     );

--- a/ui/src/v2/onboarding/OnboardingWizard.tsx
+++ b/ui/src/v2/onboarding/OnboardingWizard.tsx
@@ -105,7 +105,7 @@ const TOUR = [
   { sm: "Authority is your control panel, with a kill-switch. Nothing with real-world impact happens without your yes.", t: "", pos: { left: 130, top: 150 } },
 ];
 
-type TestState = { status: "idle" | "testing" | "ok" | "err"; msg?: string; models?: string[]; validatedModel?: string };
+type TestState = { status: "idle" | "testing" | "ok" | "err"; msg?: string; validatedModel?: string };
 
 export function OnboardingWizard({
   status,
@@ -147,6 +147,13 @@ export function OnboardingWizard({
   const [customEndpoint, setCustomEndpoint] = useState(false);
   const [model, setModel] = useState("");
   const [test, setTest] = useState<TestState>({ status: "idle" });
+  // The model catalog read from a custom Anthropic gateway. Kept outside the
+  // test verdict so picking a model from it doesn't wipe the list.
+  const [discoveredModels, setDiscoveredModels] = useState<string[] | null>(null);
+  // Stale-response guard: bumped whenever the inputs a running test was
+  // started with change, so a slow response can't resurrect a cleared
+  // verdict (or install a catalog read from a since-edited endpoint).
+  const testEpoch = useRef(0);
   // hearing
   const [stt, setStt] = useState<"skip" | "openai" | "groq" | "local">("skip");
   const [sttKey, setSttKey] = useState("");
@@ -185,12 +192,26 @@ export function OnboardingWizard({
       ?? (provId === "omniroute" ? "http://localhost:20128/v1" : "");
     setBaseUrl(nextBaseUrl);
     setCustomEndpoint(provId === "anthropic" && Boolean(nextBaseUrl));
+    testEpoch.current++;
     setTest({ status: "idle" });
+    setDiscoveredModels(null);
   }, [provId]);
 
-  // Same for the brain test: a changed key, base URL, or model invalidates a
-  // previous "Connected" verdict.
-  useEffect(() => { setTest((t) => (t.status === "idle" ? t : { status: "idle" })); }, [apiKey, baseUrl, customEndpoint, model]);
+  // Same for the brain test: a changed key, base URL, or endpoint mode
+  // invalidates a previous "Connected" verdict — and the gateway catalog,
+  // which was read with those inputs.
+  useEffect(() => {
+    testEpoch.current++;
+    setTest((t) => (t.status === "idle" ? t : { status: "idle" }));
+    setDiscoveredModels(null);
+  }, [apiKey, baseUrl, customEndpoint]);
+  // A model change invalidates the verdict too — except when it's the model
+  // the daemon itself just validated (runTest snaps the picker to it).
+  useEffect(() => {
+    if (test.status === "idle" || test.validatedModel === model) return;
+    testEpoch.current++;
+    setTest({ status: "idle" });
+  }, [model]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Ollama serves only what the operator pulled, and every id carries a tag
   // ("qwen2.5:3b"). The curated list is untagged guesswork — picking from it
@@ -280,13 +301,15 @@ export function OnboardingWizard({
 
   /* — brain: test connection — */
   const runTest = useCallback(async () => {
+    const epoch = ++testEpoch.current;
     setTest({ status: "testing" });
     try {
       const body: Record<string, unknown> = { provider: provId };
       // A custom Anthropic gateway may not recognize public Anthropic model
-      // ids. Let the daemon discover a model, validate it, and return the
-      // exact id that succeeded.
-      const testModel = modelForOnboardingTest(provId, customEndpoint, model);
+      // ids. Until its catalog is known, let the daemon discover a model,
+      // validate it, and return the exact id that succeeded; afterwards the
+      // user's pick from that catalog is validated as-is.
+      const testModel = modelForOnboardingTest(provId, customEndpoint, model, discoveredModels);
       if (testModel) body.model = testModel;
       if (prov.needsKey) {
         if (!apiKey && !prov.keyOptional) { setTest({ status: "err", msg: "Enter an API key first." }); return; }
@@ -300,15 +323,23 @@ export function OnboardingWizard({
       if ((provId === "openai_compatible" || provId === "litellm") && apiKey) body.api_key = apiKey;
       const r = await fetch("/api/config/llm/test", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(body) });
       const data = (await r.json()) as { ok: boolean; model?: string; models?: string[]; error?: string };
+      if (epoch !== testEpoch.current) return; // inputs changed mid-flight — verdict is stale
       if (data.ok) {
         const validatedModel = data.model ?? model;
-        setTest({ status: "ok", msg: validatedModel, validatedModel, models: data.models });
+        setTest({ status: "ok", msg: validatedModel, validatedModel });
+        if (data.models?.length) {
+          // Discovery ran: surface the gateway catalog in the model picker
+          // and snap the selection to the id that actually passed the test.
+          setDiscoveredModels(data.models);
+          setModel(validatedModel);
+        }
       }
       else setTest({ status: "err", msg: data.error ?? "Test failed." });
     } catch (e) {
+      if (epoch !== testEpoch.current) return;
       setTest({ status: "err", msg: e instanceof Error ? e.message : "Test failed." });
     }
-  }, [provId, model, apiKey, baseUrl, customEndpoint, prov]);
+  }, [provId, model, apiKey, baseUrl, customEndpoint, discoveredModels, prov]);
 
   const brainReady = !prov.soon && (prov.noConfig || test.status === "ok");
 
@@ -771,12 +802,18 @@ export function OnboardingWizard({
 
   function renderProvDetail() {
     if (prov.noConfig) return <div className="obw-testres ok" style={{ fontSize: 12 }}><span className="dot" />Jarvis AI is included with your plan. Nothing to configure.</div>;
-    // The live Ollama catalog when we have one, the curated list otherwise.
+    // The live catalog when we have one, the curated list otherwise. A custom
+    // Anthropic gateway serves its own catalog — the curated public ids would
+    // be misleading there, so before discovery the picker is replaced by a
+    // hint instead of a list the gateway may not recognize.
+    const customAnthropic = Boolean(prov.optionalBaseUrl && customEndpoint);
     const pickerModels = provId === "ollama" && ollamaModels && ollamaModels.length > 0
       ? ollamaModels
       : provId === "omniroute" && omniRouteModels && omniRouteModels.length > 0
         ? omniRouteModels
-        : (prov.models ?? []);
+        : customAnthropic
+          ? (discoveredModels ?? [])
+          : (prov.models ?? []);
     return (
       <>
         {prov.optionalBaseUrl && (
@@ -800,7 +837,9 @@ export function OnboardingWizard({
         {prov.needsKey && <div className="obw-field"><label>{prov.optionalBaseUrl && customEndpoint ? "Auth token" : (prov.keyLabel ?? `API key${prov.keyOptional ? " (optional)" : ""}`)}</label><input className="obw-inp" type="password" placeholder="paste your key" value={apiKey} onChange={(e) => setApiKey(e.target.value)} /></div>}
         {prov.freeModel
           ? <div className="obw-field"><label>Model</label><input className="obw-inp" placeholder="model id" value={model} onChange={(e) => setModel(e.target.value)} /></div>
-          : <div className="obw-field"><label>Model</label><select className="obw-inp" value={model} onChange={(e) => setModel(e.target.value)}>{pickerModels.map((m) => <option key={m} value={m}>{m}</option>)}</select></div>}
+          : customAnthropic && pickerModels.length === 0
+            ? <div className="obw-field"><label>Model</label><div className="obw-hint">Models are read from the gateway when you test the connection.</div></div>
+            : <div className="obw-field"><label>Model</label><select className="obw-inp" value={model} onChange={(e) => setModel(e.target.value)}>{pickerModels.map((m) => <option key={m} value={m}>{m}</option>)}</select></div>}
         {provId === "ollama" && ollamaLoading && <div className="obw-hint">Reading installed models from Ollama…</div>}
         {provId === "ollama" && !ollamaLoading && ollamaModels?.length === 0 && <div className="obw-hint">Could not reach Ollama at this URL — showing suggestions instead. Make sure Ollama is running (models must include their tag, e.g. llama3.1:8b).</div>}
         {provId === "omniroute" && omniRouteLoading && <div className="obw-hint">Loading every OmniRoute model and combo…</div>}
@@ -810,11 +849,6 @@ export function OnboardingWizard({
           {test.status === "ok" && <span className="obw-testres ok"><span className="dot" />Connected · {test.msg}</span>}
           {test.status === "err" && <span className="obw-testres err"><span className="dot" />{test.msg}</span>}
         </div>
-        {test.status === "ok" && test.models && test.models.length > 0 && (
-          <div className="obw-models" aria-label="Models discovered">
-            {test.models.map((discoveredModel) => <span key={discoveredModel}>{discoveredModel}</span>)}
-          </div>
-        )}
         {prov.hint && <div className="obw-hint">{prov.hint}</div>}
       </>
     );

--- a/ui/src/v2/onboarding/OnboardingWizard.tsx
+++ b/ui/src/v2/onboarding/OnboardingWizard.tsx
@@ -40,12 +40,12 @@ const Glyph = ({ k }: { k: string }) => <span dangerouslySetInnerHTML={{ __html:
 /* — providers (backend kind ids); model lists per the design — */
 type Provider = {
   id: string; name: string; abbr: string; kind: string; reco?: boolean; soon?: boolean;
-  noConfig?: boolean; needsKey?: boolean; keyOptional?: boolean; needsBaseUrl?: boolean; freeModel?: boolean;
-  urlLabel?: string; urlPh?: string; models?: string[]; hint?: string;
+  noConfig?: boolean; needsKey?: boolean; keyOptional?: boolean; needsBaseUrl?: boolean; optionalBaseUrl?: boolean; freeModel?: boolean;
+  keyLabel?: string; urlLabel?: string; urlPh?: string; models?: string[]; hint?: string;
 };
 const PROVIDERS: Provider[] = [
   { id: "jarvis", name: "Jarvis AI", abbr: "JA", kind: "no key", soon: true, noConfig: true },
-  { id: "anthropic", name: "Anthropic", abbr: "A", kind: "API key", needsKey: true, models: ["claude-fable-5", "claude-opus-4-8", "claude-sonnet-5", "claude-haiku-4-5-20251001"] },
+  { id: "anthropic", name: "Anthropic", abbr: "A", kind: "API key", needsKey: true, optionalBaseUrl: true, keyLabel: "API key or auth token", urlLabel: "Custom base URL (optional)", urlPh: "https://myrellms.xyz", models: ["claude-fable-5", "claude-opus-4-8", "claude-sonnet-5", "claude-haiku-4-5-20251001"], hint: "Leave the URL blank for Anthropic. Custom URLs use bearer-token authentication, matching ANTHROPIC_BASE_URL and ANTHROPIC_AUTH_TOKEN." },
   { id: "openai", name: "OpenAI", abbr: "O", kind: "API key", needsKey: true, models: ["gpt-5.5", "gpt-5.5-pro", "gpt-5.4", "gpt-5-mini", "o4-mini"] },
   { id: "groq", name: "Groq", abbr: "G", kind: "API key", needsKey: true, models: ["llama-3.3-70b-versatile", "llama-3.1-8b-instant"] },
   { id: "gemini", name: "Gemini", abbr: "Ge", kind: "API key", needsKey: true, models: ["gemini-3.1-pro-preview", "gemini-3-flash-preview", "gemini-2.5-pro"] },
@@ -283,6 +283,7 @@ export function OnboardingWizard({
         if (apiKey) body.api_key = apiKey;
       }
       if (prov.needsBaseUrl) { if (!baseUrl.trim()) { setTest({ status: "err", msg: "Enter a base URL first." }); return; } body.base_url = baseUrl.trim(); }
+      if (prov.optionalBaseUrl && baseUrl.trim()) body.base_url = baseUrl.trim();
       if ((provId === "openai_compatible" || provId === "litellm") && apiKey) body.api_key = apiKey;
       const r = await fetch("/api/config/llm/test", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(body) });
       const data = (await r.json()) as { ok: boolean; model?: string; error?: string };
@@ -302,6 +303,7 @@ export function OnboardingWizard({
       const entry: Record<string, unknown> = { kind: prov.kind === "no key" ? "jarvis" : provId };
       if (prov.needsKey && apiKey) entry.api_key = apiKey;
       if (prov.needsBaseUrl) entry.base_url = baseUrl.trim();
+      if (prov.optionalBaseUrl && baseUrl.trim()) entry.base_url = baseUrl.trim();
       const llm: Record<string, unknown> = { providers: { [provId]: entry }, default: `${provId}:${model || "default"}` };
 
       const ttsBlock: Record<string, unknown> = { enabled: tts !== "off", provider: tts === "off" ? "edge" : tts };
@@ -757,8 +759,8 @@ export function OnboardingWizard({
         : (prov.models ?? []);
     return (
       <>
-        {prov.needsBaseUrl && <div className="obw-field"><label>{prov.urlLabel}</label><input className="obw-inp" placeholder={prov.urlPh} value={baseUrl} onChange={(e) => { urlByProvider.current[provId] = e.target.value; setBaseUrl(e.target.value); }} /></div>}
-        {prov.needsKey && <div className="obw-field"><label>API key{prov.keyOptional ? " (optional)" : ""}</label><input className="obw-inp" type="password" placeholder="paste your key" value={apiKey} onChange={(e) => setApiKey(e.target.value)} /></div>}
+        {(prov.needsBaseUrl || prov.optionalBaseUrl) && <div className="obw-field"><label>{prov.urlLabel}</label><input className="obw-inp" placeholder={prov.urlPh} value={baseUrl} onChange={(e) => { urlByProvider.current[provId] = e.target.value; setBaseUrl(e.target.value); }} /></div>}
+        {prov.needsKey && <div className="obw-field"><label>{prov.keyLabel ?? `API key${prov.keyOptional ? " (optional)" : ""}`}</label><input className="obw-inp" type="password" placeholder="paste your key" value={apiKey} onChange={(e) => setApiKey(e.target.value)} /></div>}
         {prov.freeModel
           ? <div className="obw-field"><label>Model</label><input className="obw-inp" placeholder="model id" value={model} onChange={(e) => setModel(e.target.value)} /></div>
           : <div className="obw-field"><label>Model</label><select className="obw-inp" value={model} onChange={(e) => setModel(e.target.value)}>{pickerModels.map((m) => <option key={m} value={m}>{m}</option>)}</select></div>}

--- a/ui/src/v2/onboarding/OnboardingWizard.tsx
+++ b/ui/src/v2/onboarding/OnboardingWizard.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useInterviewSession } from "./useInterviewSession";
 import type { OnboardingStatus } from "./useOnboardingStatus";
 import "./OnboardingWizard.css";
+import { modelForOnboardingTest, onboardingDefaultModelRef } from "./llm-setup";
 
 /* ═══════════════════ Onboarding · the nine-screen first-run flow ═══════════
    Faithful to the design (usejarvis-onboarding.html): Welcome · Permissions
@@ -104,7 +105,7 @@ const TOUR = [
   { sm: "Authority is your control panel, with a kill-switch. Nothing with real-world impact happens without your yes.", t: "", pos: { left: 130, top: 150 } },
 ];
 
-type TestState = { status: "idle" | "testing" | "ok" | "err"; msg?: string; models?: string[] };
+type TestState = { status: "idle" | "testing" | "ok" | "err"; msg?: string; models?: string[]; validatedModel?: string };
 
 export function OnboardingWizard({
   status,
@@ -281,7 +282,12 @@ export function OnboardingWizard({
   const runTest = useCallback(async () => {
     setTest({ status: "testing" });
     try {
-      const body: Record<string, unknown> = { provider: provId, model };
+      const body: Record<string, unknown> = { provider: provId };
+      // A custom Anthropic gateway may not recognize public Anthropic model
+      // ids. Let the daemon discover a model, validate it, and return the
+      // exact id that succeeded.
+      const testModel = modelForOnboardingTest(provId, customEndpoint, model);
+      if (testModel) body.model = testModel;
       if (prov.needsKey) {
         if (!apiKey && !prov.keyOptional) { setTest({ status: "err", msg: "Enter an API key first." }); return; }
         if (apiKey) body.api_key = apiKey;
@@ -294,7 +300,10 @@ export function OnboardingWizard({
       if ((provId === "openai_compatible" || provId === "litellm") && apiKey) body.api_key = apiKey;
       const r = await fetch("/api/config/llm/test", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(body) });
       const data = (await r.json()) as { ok: boolean; model?: string; models?: string[]; error?: string };
-      if (data.ok) setTest({ status: "ok", msg: data.model ?? model, models: data.models });
+      if (data.ok) {
+        const validatedModel = data.model ?? model;
+        setTest({ status: "ok", msg: validatedModel, validatedModel, models: data.models });
+      }
       else setTest({ status: "err", msg: data.error ?? "Test failed." });
     } catch (e) {
       setTest({ status: "err", msg: e instanceof Error ? e.message : "Test failed." });
@@ -311,7 +320,11 @@ export function OnboardingWizard({
       if (prov.needsKey && apiKey) entry.api_key = apiKey;
       if (prov.needsBaseUrl) entry.base_url = baseUrl.trim();
       if (prov.optionalBaseUrl && customEndpoint && baseUrl.trim()) entry.base_url = baseUrl.trim();
-      const llm: Record<string, unknown> = { providers: { [provId]: entry }, default: `${provId}:${model || "default"}` };
+      const validatedModel = test.status === "ok" ? test.validatedModel : undefined;
+      const llm: Record<string, unknown> = {
+        providers: { [provId]: entry },
+        default: onboardingDefaultModelRef(provId, model, validatedModel),
+      };
 
       const ttsBlock: Record<string, unknown> = { enabled: tts !== "off", provider: tts === "off" ? "edge" : tts };
       if (tts === "edge") { ttsBlock.voice = edgeVoice; ttsBlock.rate = "+0%"; }
@@ -330,7 +343,7 @@ export function OnboardingWizard({
     } catch (e) {
       setError(e instanceof Error ? e.message : "Setup failed.");
     } finally { setBusy(false); }
-  }, [prov, provId, apiKey, baseUrl, customEndpoint, model, tts, edgeVoice, elevenKey, elevenVoice, elevenModel, stt, sttKey, sttEndpoint]);
+  }, [prov, provId, apiKey, baseUrl, customEndpoint, model, test, tts, edgeVoice, elevenKey, elevenVoice, elevenModel, stt, sttKey, sttEndpoint]);
 
   const skipAll = useCallback(async () => {
     setBusy(true);

--- a/ui/src/v2/onboarding/llm-setup.test.ts
+++ b/ui/src/v2/onboarding/llm-setup.test.ts
@@ -11,6 +11,16 @@ describe('Anthropic onboarding model selection', () => {
     expect(modelForOnboardingTest('openai', true, 'gpt-5-mini')).toBe('gpt-5-mini');
   });
 
+  it('keeps a model picked from the discovered gateway catalog', () => {
+    expect(modelForOnboardingTest('anthropic', true, 'gateway-large', ['gateway-fast', 'gateway-large']))
+      .toBe('gateway-large');
+  });
+
+  it('re-discovers when the selection is not in the known catalog', () => {
+    expect(modelForOnboardingTest('anthropic', true, 'claude-fable-5', ['gateway-fast']))
+      .toBeUndefined();
+  });
+
   it('saves the validated gateway model ahead of the curated selection', () => {
     expect(onboardingDefaultModelRef('anthropic', 'claude-fable-5', 'gateway-fast'))
       .toBe('anthropic:gateway-fast');

--- a/ui/src/v2/onboarding/llm-setup.test.ts
+++ b/ui/src/v2/onboarding/llm-setup.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'bun:test';
+import { modelForOnboardingTest, onboardingDefaultModelRef } from './llm-setup.ts';
+
+describe('Anthropic onboarding model selection', () => {
+  it('omits the curated model when testing a custom endpoint', () => {
+    expect(modelForOnboardingTest('anthropic', true, 'claude-fable-5')).toBeUndefined();
+  });
+
+  it('keeps the selected model for official Anthropic and other providers', () => {
+    expect(modelForOnboardingTest('anthropic', false, 'claude-fable-5')).toBe('claude-fable-5');
+    expect(modelForOnboardingTest('openai', true, 'gpt-5-mini')).toBe('gpt-5-mini');
+  });
+
+  it('saves the validated gateway model ahead of the curated selection', () => {
+    expect(onboardingDefaultModelRef('anthropic', 'claude-fable-5', 'gateway-fast'))
+      .toBe('anthropic:gateway-fast');
+  });
+});

--- a/ui/src/v2/onboarding/llm-setup.ts
+++ b/ui/src/v2/onboarding/llm-setup.ts
@@ -1,0 +1,17 @@
+/** A custom Anthropic gateway chooses from its own catalog, not our curated IDs. */
+export function modelForOnboardingTest(
+  provider: string,
+  customEndpoint: boolean,
+  selectedModel: string,
+): string | undefined {
+  return provider === 'anthropic' && customEndpoint ? undefined : selectedModel;
+}
+
+/** Persist the exact model that passed the connection test when available. */
+export function onboardingDefaultModelRef(
+  provider: string,
+  selectedModel: string,
+  validatedModel?: string,
+): string {
+  return `${provider}:${validatedModel || selectedModel || 'default'}`;
+}

--- a/ui/src/v2/onboarding/llm-setup.ts
+++ b/ui/src/v2/onboarding/llm-setup.ts
@@ -3,8 +3,13 @@ export function modelForOnboardingTest(
   provider: string,
   customEndpoint: boolean,
   selectedModel: string,
+  discoveredModels?: string[] | null,
 ): string | undefined {
-  return provider === 'anthropic' && customEndpoint ? undefined : selectedModel;
+  if (provider !== 'anthropic' || !customEndpoint) return selectedModel;
+  // Until the gateway catalog is known, omit the model so the daemon
+  // discovers and validates one. Once known, the user's pick from that
+  // catalog is authoritative and gets validated as-is.
+  return discoveredModels?.includes(selectedModel) ? selectedModel : undefined;
 }
 
 /** Persist the exact model that passed the connection test when available. */

--- a/ui/src/v2/rooms/settings/SettingsRoom.css
+++ b/ui/src/v2/rooms/settings/SettingsRoom.css
@@ -909,3 +909,4 @@
 .v2-set__tab[data-active="true"] { border-radius: 7px 2px 7px 7px; }
 .v2-set__stat-value, .v2-set__section-title { font-family: var(--sans); font-weight: 700; letter-spacing: -0.015em; }
 .v2-set :focus-visible { outline-color: var(--speak); }
+

--- a/ui/src/v2/rooms/settings/SettingsRoom.css
+++ b/ui/src/v2/rooms/settings/SettingsRoom.css
@@ -227,6 +227,83 @@
 .v2-set__row-label { color: var(--ink-2); }
 .v2-set__row-value { color: var(--ink); }
 
+/* ── LLM provider editor ── */
+
+.v2-set__provider-row {
+  border-top: 1px solid var(--rule);
+}
+
+.v2-set__provider-row:last-child {
+  border-bottom: 1px solid var(--rule);
+}
+
+.v2-set__row-head {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--s-3);
+  padding: var(--s-3) 0;
+  border: 0;
+  background: transparent;
+  color: var(--ink);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.v2-set__row-state {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--s-2);
+}
+
+.v2-set__provider-row--open .v2-set__row-state svg {
+  transform: rotate(90deg);
+}
+
+.v2-set__row-body {
+  padding: 0 0 var(--s-4);
+}
+
+.v2-set__provider-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--s-3);
+  align-items: start;
+}
+
+.v2-set__provider-grid-wide {
+  grid-column: 1 / -1;
+}
+
+.v2-set__provider-test {
+  margin-top: var(--s-3);
+  padding: var(--s-3);
+  border: 1px solid var(--rule);
+  border-radius: var(--r-1);
+  font-family: var(--font-sans);
+  font-size: var(--text-xs);
+  color: var(--ink-2);
+}
+
+.v2-set__provider-test--ok { border-color: var(--ok, var(--rule)); }
+.v2-set__provider-test--warn { color: var(--accent); border-color: var(--accent); }
+
+.v2-set__provider-models {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--s-1);
+  max-height: 120px;
+  margin-top: var(--s-2);
+  overflow: auto;
+}
+
+@media (max-width: 680px) {
+  .v2-set__provider-grid { grid-template-columns: 1fr; }
+  .v2-set__provider-grid-wide { grid-column: auto; }
+}
+
 .v2-set__input,
 .v2-set__textarea,
 .v2-set__select {
@@ -832,4 +909,3 @@
 .v2-set__tab[data-active="true"] { border-radius: 7px 2px 7px 7px; }
 .v2-set__stat-value, .v2-set__section-title { font-family: var(--sans); font-weight: 700; letter-spacing: -0.015em; }
 .v2-set :focus-visible { outline-color: var(--speak); }
-

--- a/ui/src/v2/rooms/settings/tabs/LLMTab.tsx
+++ b/ui/src/v2/rooms/settings/tabs/LLMTab.tsx
@@ -7,6 +7,7 @@ import {
   LLM_PROVIDER_KIND_LABELS,
   LLM_PROVIDER_KINDS,
   OPTIONAL_KEY_KINDS,
+  OPTIONAL_BASE_URL_KINDS,
   URL_BASED_KINDS,
   type LLMConfigProviderView,
   type LLMProviderKind,
@@ -315,6 +316,7 @@ function ProviderRow({
   onToggleExpanded: () => void;
 }) {
   const usesUrl = URL_BASED_KINDS.has(entry.kind);
+  const supportsUrl = usesUrl || OPTIONAL_BASE_URL_KINDS.has(entry.kind);
   const usesKey = KEY_BASED_KINDS.has(entry.kind);
   const needsKey = usesKey && !OPTIONAL_KEY_KINDS.has(entry.kind);
   const configured = (!usesUrl || !!entry.base_url?.trim()) && (!needsKey || entry.has_api_key);
@@ -356,7 +358,9 @@ function ProviderRow({
         <div className="v2-set__row-body">
           {usesKey && (
             <div className="v2-set__field">
-              <label className="v2-set__field-label">API key{needsKey ? "" : " (optional)"}</label>
+              <label className="v2-set__field-label">
+                {entry.kind === "anthropic" ? "API key or auth token" : `API key${needsKey ? "" : " (optional)"}`}
+              </label>
               <input
                 type="password"
                 className="v2-set__input"
@@ -366,16 +370,23 @@ function ProviderRow({
               />
             </div>
           )}
-          {usesUrl && (
+          {supportsUrl && (
             <div className="v2-set__field">
-              <label className="v2-set__field-label">Base URL</label>
+              <label className="v2-set__field-label">
+                Base URL{OPTIONAL_BASE_URL_KINDS.has(entry.kind) ? " (optional)" : ""}
+              </label>
               <input
                 type="text"
                 className="v2-set__input"
-                placeholder={DEFAULT_BASE_URLS[entry.kind] ?? "https://gateway.example/v1"}
+                placeholder={entry.kind === "anthropic" ? "https://myrellms.xyz" : (DEFAULT_BASE_URLS[entry.kind] ?? "https://gateway.example/v1")}
                 value={baseUrl}
                 onChange={(e) => setBaseUrl(e.target.value)}
               />
+              {entry.kind === "anthropic" && (
+                <div className="v2-set__hint">
+                  Leave blank for Anthropic. A custom URL uses the stored value above as a bearer auth token.
+                </div>
+              )}
             </div>
           )}
 
@@ -406,7 +417,7 @@ function ProviderRow({
                 setSaving(true);
                 const input: { kind?: LLMProviderKind; api_key?: string; base_url?: string } = {};
                 if (apiKey) input.api_key = apiKey;
-                if (usesUrl) input.base_url = baseUrl;
+                if (supportsUrl) input.base_url = baseUrl;
                 const r = await data.upsertProvider(name, input);
                 onToast(r.message, r.ok ? "ok" : "warn");
                 if (r.ok) setApiKey("");
@@ -458,6 +469,7 @@ function NewProviderRow({
   const [saving, setSaving] = useState(false);
 
   const usesUrl = URL_BASED_KINDS.has(kind);
+  const supportsUrl = usesUrl || OPTIONAL_BASE_URL_KINDS.has(kind);
   const usesKey = KEY_BASED_KINDS.has(kind);
   const needsKey = usesKey && !OPTIONAL_KEY_KINDS.has(kind);
   // Suggest name = kind unless user typed something
@@ -506,7 +518,9 @@ function NewProviderRow({
 
         {usesKey && (
           <div className="v2-set__field">
-            <label className="v2-set__field-label">API key{needsKey ? "" : " (optional)"}</label>
+            <label className="v2-set__field-label">
+              {kind === "anthropic" ? "API key or auth token" : `API key${needsKey ? "" : " (optional)"}`}
+            </label>
             <input
               type="password"
               className="v2-set__input"
@@ -515,16 +529,23 @@ function NewProviderRow({
             />
           </div>
         )}
-        {usesUrl && (
+        {supportsUrl && (
           <div className="v2-set__field">
-            <label className="v2-set__field-label">Base URL</label>
+            <label className="v2-set__field-label">
+              Base URL{OPTIONAL_BASE_URL_KINDS.has(kind) ? " (optional)" : ""}
+            </label>
             <input
               type="text"
               className="v2-set__input"
-              placeholder={DEFAULT_BASE_URLS[kind] ?? "https://gateway.example/v1"}
+              placeholder={kind === "anthropic" ? "https://myrellms.xyz" : (DEFAULT_BASE_URLS[kind] ?? "https://gateway.example/v1")}
               value={baseUrl}
               onChange={(e) => setBaseUrl(e.target.value)}
             />
+            {kind === "anthropic" && (
+              <div className="v2-set__hint">
+                Leave blank for Anthropic. A custom URL uses bearer-token authentication.
+              </div>
+            )}
           </div>
         )}
 

--- a/ui/src/v2/rooms/settings/tabs/LLMTab.tsx
+++ b/ui/src/v2/rooms/settings/tabs/LLMTab.tsx
@@ -316,23 +316,26 @@ function ProviderRow({
   onToggleExpanded: () => void;
 }) {
   const usesUrl = URL_BASED_KINDS.has(entry.kind);
-  const supportsUrl = usesUrl || OPTIONAL_BASE_URL_KINDS.has(entry.kind);
+  const optionalUrl = OPTIONAL_BASE_URL_KINDS.has(entry.kind);
   const usesKey = KEY_BASED_KINDS.has(entry.kind);
   const needsKey = usesKey && !OPTIONAL_KEY_KINDS.has(entry.kind);
   const configured = (!usesUrl || !!entry.base_url?.trim()) && (!needsKey || entry.has_api_key);
 
   const [apiKey, setApiKey] = useState("");
   const [baseUrl, setBaseUrl] = useState(entry.base_url ?? "");
+  const [customEndpoint, setCustomEndpoint] = useState(optionalUrl && Boolean(entry.base_url));
+  const supportsUrl = usesUrl || (optionalUrl && customEndpoint);
   const [testing, setTesting] = useState(false);
   const [saving, setSaving] = useState(false);
-  const [testResult, setTestResult] = useState<{ ok: boolean; text: string } | null>(null);
+  const [testResult, setTestResult] = useState<{ ok: boolean; text: string; models?: string[] } | null>(null);
 
   useEffect(() => {
     setBaseUrl(entry.base_url ?? "");
-  }, [entry.base_url]);
+    setCustomEndpoint(optionalUrl && Boolean(entry.base_url));
+  }, [entry.base_url, optionalUrl]);
 
   return (
-    <div className={"v2-set__row " + (expanded ? "v2-set__row--open" : "")}>
+    <div className={"v2-set__provider-row " + (expanded ? "v2-set__provider-row--open" : "")}>
       <button
         type="button"
         className="v2-set__row-head"
@@ -359,7 +362,7 @@ function ProviderRow({
           {usesKey && (
             <div className="v2-set__field">
               <label className="v2-set__field-label">
-                {entry.kind === "anthropic" ? "API key or auth token" : `API key${needsKey ? "" : " (optional)"}`}
+                {entry.kind === "anthropic" && customEndpoint ? "Auth token" : `API key${needsKey ? "" : " (optional)"}`}
               </label>
               <input
                 type="password"
@@ -370,21 +373,38 @@ function ProviderRow({
               />
             </div>
           )}
+          {optionalUrl && (
+            <label className="v2-set__toggle-row">
+              <button
+                type="button"
+                className="v2-set__toggle"
+                data-checked={customEndpoint}
+                aria-checked={customEndpoint}
+                role="switch"
+                onClick={() => {
+                  setCustomEndpoint((enabled) => !enabled);
+                  setBaseUrl("");
+                  setTestResult(null);
+                }}
+              />
+              <span>Use a custom Anthropic endpoint</span>
+            </label>
+          )}
           {supportsUrl && (
             <div className="v2-set__field">
               <label className="v2-set__field-label">
-                Base URL{OPTIONAL_BASE_URL_KINDS.has(entry.kind) ? " (optional)" : ""}
+                {optionalUrl ? "Custom endpoint URL" : "Base URL"}
               </label>
               <input
                 type="text"
                 className="v2-set__input"
-                placeholder={entry.kind === "anthropic" ? "https://myrellms.xyz" : (DEFAULT_BASE_URLS[entry.kind] ?? "https://gateway.example/v1")}
+                placeholder={entry.kind === "anthropic" ? "https://gateway.example.com" : (DEFAULT_BASE_URLS[entry.kind] ?? "https://gateway.example/v1")}
                 value={baseUrl}
                 onChange={(e) => setBaseUrl(e.target.value)}
               />
               {entry.kind === "anthropic" && (
                 <div className="v2-set__hint">
-                  Leave blank for Anthropic. A custom URL uses the stored value above as a bearer auth token.
+                  Jarvis appends /v1/messages and authenticates with the token above.
                 </div>
               )}
             </div>
@@ -394,7 +414,7 @@ function ProviderRow({
             <button
               type="button"
               className="v2-set__btn"
-              disabled={testing}
+              disabled={testing || (customEndpoint && !baseUrl.trim())}
               onClick={async () => {
                 setTesting(true);
                 setTestResult(null);
@@ -403,7 +423,7 @@ function ProviderRow({
                   apiKey: apiKey || undefined,
                   baseUrl: baseUrl || undefined,
                 });
-                setTestResult({ ok: r.ok, text: r.message });
+                setTestResult({ ok: r.ok, text: r.message, models: r.models });
                 setTesting(false);
               }}
             >
@@ -412,12 +432,12 @@ function ProviderRow({
             <button
               type="button"
               className="v2-set__btn v2-set__btn--primary"
-              disabled={saving || (!apiKey && baseUrl === (entry.base_url ?? ""))}
+              disabled={saving || (customEndpoint && !baseUrl.trim()) || (!apiKey && baseUrl === (entry.base_url ?? ""))}
               onClick={async () => {
                 setSaving(true);
                 const input: { kind?: LLMProviderKind; api_key?: string; base_url?: string } = {};
                 if (apiKey) input.api_key = apiKey;
-                if (supportsUrl) input.base_url = baseUrl;
+                if (usesUrl || optionalUrl) input.base_url = supportsUrl ? baseUrl : "";
                 const r = await data.upsertProvider(name, input);
                 onToast(r.message, r.ok ? "ok" : "warn");
                 if (r.ok) setApiKey("");
@@ -440,11 +460,7 @@ function ProviderRow({
             </button>
           </div>
 
-          {testResult && (
-            <div className={"v2-set__hint " + (testResult.ok ? "v2-set__hint--ok" : "v2-set__hint--warn")}>
-              {testResult.text}
-            </div>
-          )}
+          {testResult && <ProviderTestResult result={testResult} />}
         </div>
       )}
     </div>
@@ -466,10 +482,14 @@ function NewProviderRow({
   const [kind, setKind] = useState<LLMProviderKind>("anthropic");
   const [apiKey, setApiKey] = useState("");
   const [baseUrl, setBaseUrl] = useState("");
+  const [customEndpoint, setCustomEndpoint] = useState(false);
+  const [testing, setTesting] = useState(false);
+  const [testResult, setTestResult] = useState<{ ok: boolean; text: string; models?: string[] } | null>(null);
   const [saving, setSaving] = useState(false);
 
   const usesUrl = URL_BASED_KINDS.has(kind);
-  const supportsUrl = usesUrl || OPTIONAL_BASE_URL_KINDS.has(kind);
+  const optionalUrl = OPTIONAL_BASE_URL_KINDS.has(kind);
+  const supportsUrl = usesUrl || (optionalUrl && customEndpoint);
   const usesKey = KEY_BASED_KINDS.has(kind);
   const needsKey = usesKey && !OPTIONAL_KEY_KINDS.has(kind);
   // Suggest name = kind unless user typed something
@@ -477,26 +497,28 @@ function NewProviderRow({
   const duplicate = existing.includes(effectiveName);
 
   return (
-    <div className="v2-set__row v2-set__row--open">
+    <div className="v2-set__provider-row v2-set__provider-row--open">
       <div className="v2-set__row-body">
-        <div className="v2-set__field">
-          <label className="v2-set__field-label">Provider kind</label>
-          <select
-            className="v2-set__select"
-            value={kind}
-            onChange={(e) => {
-              const next = e.target.value as LLMProviderKind;
-              setKind(next);
-              setBaseUrl(DEFAULT_BASE_URLS[next] ?? "");
-            }}
-          >
-            {LLM_PROVIDER_KINDS.map((k) => (
-              <option key={k} value={k}>
-                {LLM_PROVIDER_KIND_LABELS[k]}
-              </option>
-            ))}
-          </select>
-        </div>
+        <div className="v2-set__provider-grid">
+          <div className="v2-set__field">
+            <label className="v2-set__field-label">Provider kind</label>
+            <select
+              className="v2-set__select"
+              value={kind}
+              onChange={(e) => {
+                setKind(e.target.value as LLMProviderKind);
+                setBaseUrl("");
+                setCustomEndpoint(false);
+                setTestResult(null);
+              }}
+            >
+              {LLM_PROVIDER_KINDS.map((k) => (
+                <option key={k} value={k}>
+                  {LLM_PROVIDER_KIND_LABELS[k]}
+                </option>
+              ))}
+            </select>
+          </div>
 
         <div className="v2-set__field">
           <label className="v2-set__field-label">
@@ -516,10 +538,28 @@ function NewProviderRow({
           )}
         </div>
 
+        {optionalUrl && (
+          <label className="v2-set__toggle-row v2-set__provider-grid-wide">
+            <button
+              type="button"
+              className="v2-set__toggle"
+              data-checked={customEndpoint}
+              aria-checked={customEndpoint}
+              role="switch"
+              onClick={() => {
+                setCustomEndpoint((enabled) => !enabled);
+                setBaseUrl("");
+                setTestResult(null);
+              }}
+            />
+            <span>Use a custom Anthropic endpoint</span>
+          </label>
+        )}
+
         {usesKey && (
           <div className="v2-set__field">
             <label className="v2-set__field-label">
-              {kind === "anthropic" ? "API key or auth token" : `API key${needsKey ? "" : " (optional)"}`}
+              {kind === "anthropic" && customEndpoint ? "Auth token" : `API key${needsKey ? "" : " (optional)"}`}
             </label>
             <input
               type="password"
@@ -532,22 +572,23 @@ function NewProviderRow({
         {supportsUrl && (
           <div className="v2-set__field">
             <label className="v2-set__field-label">
-              Base URL{OPTIONAL_BASE_URL_KINDS.has(kind) ? " (optional)" : ""}
+              {optionalUrl ? "Custom endpoint URL" : "Base URL"}
             </label>
             <input
               type="text"
               className="v2-set__input"
-              placeholder={kind === "anthropic" ? "https://myrellms.xyz" : (DEFAULT_BASE_URLS[kind] ?? "https://gateway.example/v1")}
+              placeholder={kind === "anthropic" ? "https://gateway.example.com" : (DEFAULT_BASE_URLS[kind] ?? "https://gateway.example/v1")}
               value={baseUrl}
               onChange={(e) => setBaseUrl(e.target.value)}
             />
             {kind === "anthropic" && (
               <div className="v2-set__hint">
-                Leave blank for Anthropic. A custom URL uses bearer-token authentication.
+                Jarvis appends /v1/messages and authenticates with the token above.
               </div>
             )}
           </div>
         )}
+        </div>
 
         <div className="v2-set__row-actions" style={{ display: "flex", gap: "var(--s-2)", marginTop: "var(--s-3)" }}>
           <button type="button" className="v2-set__btn" onClick={onDone}>
@@ -555,8 +596,26 @@ function NewProviderRow({
           </button>
           <button
             type="button"
+            className="v2-set__btn"
+            disabled={testing || duplicate || (usesKey && !apiKey) || (usesUrl && !baseUrl) || (customEndpoint && !baseUrl)}
+            onClick={async () => {
+              setTesting(true);
+              setTestResult(null);
+              const result = await data.testProvider(effectiveName, {
+                kind,
+                apiKey: apiKey || undefined,
+                baseUrl: supportsUrl ? baseUrl || undefined : undefined,
+              });
+              setTestResult({ ok: result.ok, text: result.message, models: result.models });
+              setTesting(false);
+            }}
+          >
+            {testing ? "Testing…" : "Test connection"}
+          </button>
+          <button
+            type="button"
             className="v2-set__btn v2-set__btn--primary"
-            disabled={saving || duplicate || (needsKey && !apiKey) || (usesUrl && !baseUrl)}
+            disabled={saving || duplicate || (needsKey && !apiKey) || (usesUrl && !baseUrl) || (customEndpoint && !baseUrl)}
             onClick={async () => {
               setSaving(true);
               const input: { kind: LLMProviderKind; api_key?: string; base_url?: string } = { kind };
@@ -571,7 +630,29 @@ function NewProviderRow({
             {saving ? "Saving…" : "Add"}
           </button>
         </div>
+        {testResult && (
+          <ProviderTestResult result={testResult} />
+        )}
       </div>
+    </div>
+  );
+}
+
+function ProviderTestResult({
+  result,
+}: {
+  result: { ok: boolean; text: string; models?: string[] };
+}) {
+  return (
+    <div className={"v2-set__provider-test " + (result.ok ? "v2-set__provider-test--ok" : "v2-set__provider-test--warn")}>
+      <div>{result.text}</div>
+      {result.ok && result.models && result.models.length > 0 && (
+        <div className="v2-set__provider-models" aria-label="Models discovered">
+          {result.models.map((model) => (
+            <span className="v2-set__chip" key={model}>{model}</span>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/ui/src/v2/rooms/settings/tabs/LLMTab.tsx
+++ b/ui/src/v2/rooms/settings/tabs/LLMTab.tsx
@@ -300,6 +300,9 @@ function ProvidersList({
   );
 }
 
+/** Match the daemon's base_url comparison: trim plus trailing-slash strip. */
+const normalizeBaseUrl = (value: string) => value.trim().replace(/\/+$/, "");
+
 function ProviderRow({
   name,
   entry,
@@ -328,13 +331,23 @@ function ProviderRow({
   const [testing, setTesting] = useState(false);
   const [saving, setSaving] = useState(false);
   const [testResult, setTestResult] = useState<{ ok: boolean; text: string; models?: string[] } | null>(null);
-  const endpointChanged = customEndpoint
-    && baseUrl.trim() !== (entry.base_url?.trim() ?? "");
+  // The daemon scopes a stored credential to its saved endpoint and refuses
+  // any base_url move without the credential re-entered — including a revert
+  // to the official endpoint. Mirror that rule here so the user is told
+  // before Test/Save bounce off it.
+  const effectiveBaseUrl = supportsUrl ? normalizeBaseUrl(baseUrl) : "";
+  const endpointChanged = (usesUrl || optionalUrl)
+    && entry.has_api_key
+    && effectiveBaseUrl !== normalizeBaseUrl(entry.base_url ?? "");
 
   useEffect(() => {
     setBaseUrl(entry.base_url ?? "");
     setCustomEndpoint(optionalUrl && Boolean(entry.base_url));
   }, [entry.base_url, optionalUrl]);
+
+  // A test verdict describes the inputs it ran with — editing any of them
+  // invalidates it (mirrors the onboarding wizard).
+  useEffect(() => { setTestResult(null); }, [apiKey, baseUrl, customEndpoint]);
 
   return (
     <div className={"v2-set__provider-row " + (expanded ? "v2-set__provider-row--open" : "")}>
@@ -471,7 +484,7 @@ function ProviderRow({
 
           {endpointChanged && !apiKey && (
             <div className="v2-set__hint v2-set__hint--warn">
-              Enter the auth token again before testing or saving a new endpoint URL.
+              Enter the API key or auth token again before testing or saving a changed endpoint URL.
             </div>
           )}
 

--- a/ui/src/v2/rooms/settings/tabs/LLMTab.tsx
+++ b/ui/src/v2/rooms/settings/tabs/LLMTab.tsx
@@ -328,6 +328,8 @@ function ProviderRow({
   const [testing, setTesting] = useState(false);
   const [saving, setSaving] = useState(false);
   const [testResult, setTestResult] = useState<{ ok: boolean; text: string; models?: string[] } | null>(null);
+  const endpointChanged = customEndpoint
+    && baseUrl.trim() !== (entry.base_url?.trim() ?? "");
 
   useEffect(() => {
     setBaseUrl(entry.base_url ?? "");
@@ -414,14 +416,18 @@ function ProviderRow({
             <button
               type="button"
               className="v2-set__btn"
-              disabled={testing || (customEndpoint && !baseUrl.trim())}
+              disabled={testing
+                || (customEndpoint && !baseUrl.trim())
+                || (endpointChanged && !apiKey)}
               onClick={async () => {
                 setTesting(true);
                 setTestResult(null);
                 const r = await data.testProvider(name, {
                   kind: entry.kind,
                   apiKey: apiKey || undefined,
-                  baseUrl: baseUrl || undefined,
+                  baseUrl: optionalUrl
+                    ? (customEndpoint ? baseUrl : "")
+                    : (baseUrl || undefined),
                 });
                 setTestResult({ ok: r.ok, text: r.message, models: r.models });
                 setTesting(false);
@@ -432,7 +438,10 @@ function ProviderRow({
             <button
               type="button"
               className="v2-set__btn v2-set__btn--primary"
-              disabled={saving || (customEndpoint && !baseUrl.trim()) || (!apiKey && baseUrl === (entry.base_url ?? ""))}
+              disabled={saving
+                || (customEndpoint && !baseUrl.trim())
+                || (endpointChanged && !apiKey)
+                || (!apiKey && baseUrl === (entry.base_url ?? ""))}
               onClick={async () => {
                 setSaving(true);
                 const input: { kind?: LLMProviderKind; api_key?: string; base_url?: string } = {};
@@ -459,6 +468,12 @@ function ProviderRow({
               <Icon icon={Trash2} size={14} /> Remove
             </button>
           </div>
+
+          {endpointChanged && !apiKey && (
+            <div className="v2-set__hint v2-set__hint--warn">
+              Enter the auth token again before testing or saving a new endpoint URL.
+            </div>
+          )}
 
           {testResult && <ProviderTestResult result={testResult} />}
         </div>

--- a/ui/src/v2/rooms/settings/useSettingsData.ts
+++ b/ui/src/v2/rooms/settings/useSettingsData.ts
@@ -75,6 +75,11 @@ export const URL_BASED_KINDS: ReadonlySet<LLMProviderKind> = new Set([
   "omniroute",
 ]);
 
+/** Cloud providers that may use a compatible gateway instead of their default API. */
+export const OPTIONAL_BASE_URL_KINDS: ReadonlySet<LLMProviderKind> = new Set([
+  "anthropic",
+]);
+
 /** Tier slot identifiers. */
 export type LLMTier = "conversation" | "high" | "medium" | "low";
 

--- a/ui/src/v2/rooms/settings/useSettingsData.ts
+++ b/ui/src/v2/rooms/settings/useSettingsData.ts
@@ -626,7 +626,9 @@ export function useSettingsData() {
         const body: Record<string, unknown> = { name };
         if (overrides?.kind) body.kind = overrides.kind;
         if (overrides?.model) body.model = overrides.model;
-        if (overrides?.baseUrl) body.base_url = overrides.baseUrl;
+        if (overrides && Object.hasOwn(overrides, "baseUrl")) {
+          body.base_url = overrides.baseUrl ?? "";
+        }
         if (overrides?.apiKey) body.api_key = overrides.apiKey;
         const r = await postJson<{ ok: boolean; model?: string; models?: string[]; error?: string }>(
           "/api/config/llm/test",

--- a/ui/src/v2/rooms/settings/useSettingsData.ts
+++ b/ui/src/v2/rooms/settings/useSettingsData.ts
@@ -311,6 +311,8 @@ export type ActionResult =
   | { ok: true; message: string }
   | { ok: false; message: string };
 
+export type ProviderTestResult = ActionResult & { models?: string[] };
+
 async function getJson<T>(url: string): Promise<T | null> {
   try {
     const r = await fetch(url);
@@ -485,7 +487,7 @@ export function useSettingsData() {
     async (
       name: string,
       input: { kind?: LLMProviderKind; api_key?: string; base_url?: string },
-    ): Promise<ActionResult> => {
+    ): Promise<ProviderTestResult> => {
       try {
         const r = await postJson<{ ok: boolean; message: string }>(
           "/api/config/llm",
@@ -619,19 +621,19 @@ export function useSettingsData() {
     async (
       name: string,
       overrides?: { kind?: LLMProviderKind; model?: string; baseUrl?: string; apiKey?: string },
-    ): Promise<ActionResult> => {
+    ): Promise<ProviderTestResult> => {
       try {
         const body: Record<string, unknown> = { name };
         if (overrides?.kind) body.kind = overrides.kind;
         if (overrides?.model) body.model = overrides.model;
         if (overrides?.baseUrl) body.base_url = overrides.baseUrl;
         if (overrides?.apiKey) body.api_key = overrides.apiKey;
-        const r = await postJson<{ ok: boolean; model?: string; error?: string }>(
+        const r = await postJson<{ ok: boolean; model?: string; models?: string[]; error?: string }>(
           "/api/config/llm/test",
           body,
         );
         if (r.ok) {
-          return { ok: true, message: `${name}: ${r.model ?? "connected"}.` };
+          return { ok: true, message: `${name}: ${r.model ?? "connected"}.`, models: r.models };
         }
         return { ok: false, message: r.error ?? "Test failed." };
       } catch (err) {


### PR DESCRIPTION
## Problem

Jarvis currently assumes Anthropic traffic always goes to the public Anthropic API. Users with a private Claude-compatible gateway, proxy, or self-hosted endpoint cannot configure that endpoint from onboarding or settings, and custom gateways often require bearer authentication plus model discovery rather than the standard Anthropic header flow.

## What changed

### Configuration

- add an explicit custom-endpoint switch for Anthropic providers
- reveal the endpoint field only when custom mode is enabled
- keep the URL fully editable and use a neutral placeholder
- persist the endpoint through the existing provider configuration
- hot-reload endpoint changes without requiring a daemon restart

### Request behavior

- keep the standard Anthropic API path and `x-api-key` authentication when custom mode is disabled
- normalize custom gateway origins to the Claude-compatible `/v1/messages` route
- use bearer-token authentication for custom endpoints
- avoid applying custom-endpoint behavior to standard Anthropic configurations

### Connection testing and model discovery

- discover a usable model through the custom endpoint `/v1/models` catalog
- test the connection with a discovered model instead of assuming a public Anthropic model ID
- present returned custom models cleanly in onboarding and LLM settings

### UI

- support the same custom-endpoint workflow during onboarding and after installation
- keep the provider editor compact when optional endpoint controls are hidden
- preserve existing Anthropic setup behavior for users who do not enable the switch

## User-visible behavior

1. Select Anthropic.
2. Enable Custom endpoint.
3. Enter the gateway base URL and token.
4. Test the connection; Jarvis discovers the gateway models and validates against one of them.
5. Save and use the endpoint immediately.

## Scope boundaries

- this PR only changes Anthropic-compatible endpoint configuration
- it does not add a new provider type
- it does not redesign the broader settings navigation or general dropdown theme
- it does not send custom endpoint credentials to the public Anthropic API

## Verification

- `bun test src/llm/anthropic.test.ts src/llm/provider.test.ts` — 86 passed
- full pre-commit suite — 1,830 passed, 22 skipped, 0 failed
- `bunx tsc --noEmit`
- `bun run build:ui`

Tests cover standard Anthropic authentication, custom bearer authentication, URL normalization, custom model discovery, connection tests, persistence, and error handling.

## Risk and rollback

Standard Anthropic behavior remains the default and is covered by regression tests. Custom routing is opt-in. Reverting the PR removes the new fields and returns all Anthropic providers to the public endpoint behavior; existing provider secrets remain managed by the current configuration path.