### PR TITLE
feat(ui): make settings usable on mobile

### DIFF
--- a/ui/src/v2/rooms/RoomShell.tsx
+++ b/ui/src/v2/rooms/RoomShell.tsx
@@ -36,6 +36,8 @@ export interface RoomShellAction {
 
 export interface RoomShellProps {
   title: string;
+  /** Optional hook for room-specific responsive/layout styling. */
+  className?: string;
   /** Optional breadcrumb fragments shown above the title (e.g. ["Memory"]). */
   breadcrumb?: string[];
   /** Optional short subtitle / count line ("5 workflows · 4 active"). */
@@ -58,6 +60,7 @@ export interface RoomShellProps {
  */
 export function RoomShell({
   title,
+  className,
   breadcrumb,
   subtitle,
   actions = [],
@@ -162,7 +165,12 @@ export function RoomShell({
   const leadingGhosts = actions.slice(0, Math.max(0, actions.length - 1));
 
   return (
-    <div className="v2-room-overlay" role="dialog" aria-modal="true" aria-label={title}>
+    <div
+      className={["v2-room-overlay", className].filter(Boolean).join(" ")}
+      role="dialog"
+      aria-modal="true"
+      aria-label={title}
+    >
       <div
         className="v2-room"
         ref={rootRef}

--- a/ui/src/v2/rooms/settings/SettingsRoom.css
+++ b/ui/src/v2/rooms/settings/SettingsRoom.css
@@ -778,3 +778,272 @@
 .v2-set__stat-value, .v2-set__section-title { font-family: var(--sans); font-weight: 700; letter-spacing: -0.015em; }
 .v2-set :focus-visible { outline-color: var(--speak); }
 
+/* ── Phone layout ──
+   Settings is control-dense, so the mobile treatment prioritizes usable
+   touch targets and one-dimensional flows over preserving the desktop grid. */
+
+@media (max-width: 720px) {
+  .v2-room-overlay--settings {
+    inset: 0;
+  }
+
+  .v2-room-overlay--settings .v2-room__header {
+    grid-template-columns: 44px minmax(0, 1fr) 44px;
+    gap: var(--s-2);
+    min-height: 56px;
+    padding:
+      max(var(--s-2), env(safe-area-inset-top))
+      max(var(--s-2), env(safe-area-inset-right))
+      var(--s-2)
+      max(var(--s-2), env(safe-area-inset-left));
+  }
+
+  .v2-room-overlay--settings .v2-room__header-left,
+  .v2-room-overlay--settings .v2-room__header-right {
+    min-width: 44px;
+  }
+
+  .v2-room-overlay--settings .v2-room__header-right {
+    justify-content: flex-end;
+  }
+
+  .v2-room-overlay--settings .v2-room__back,
+  .v2-room-overlay--settings .v2-room__close {
+    width: 44px;
+    height: 44px;
+    margin: 0;
+    padding: 0;
+    justify-content: center;
+  }
+
+  .v2-room-overlay--settings .v2-room__back > span,
+  .v2-room-overlay--settings .v2-room__breadcrumb,
+  .v2-room-overlay--settings .v2-room__subtitle {
+    display: none;
+  }
+
+  .v2-room-overlay--settings .v2-room__title {
+    font-size: var(--text-lg);
+  }
+
+  .v2-room-overlay--settings .v2-room__body,
+  .v2-set {
+    min-width: 0;
+    max-width: 100%;
+    overflow: hidden;
+  }
+
+  .v2-set__stats {
+    display: flex;
+    gap: var(--s-2);
+    padding: var(--s-3) var(--s-3) var(--s-2);
+    overflow-x: auto;
+    overscroll-behavior-inline: contain;
+    scroll-snap-type: inline proximity;
+    scrollbar-width: none;
+  }
+
+  .v2-set__stats::-webkit-scrollbar,
+  .v2-set__tabs::-webkit-scrollbar {
+    display: none;
+  }
+
+  .v2-set__stat {
+    flex: 0 0 116px;
+    min-height: 68px;
+    padding: var(--s-2) var(--s-3);
+    scroll-snap-align: start;
+  }
+
+  .v2-set__stat-value {
+    font-size: var(--text-lg);
+  }
+
+  .v2-set__tabs {
+    gap: var(--s-1);
+    padding: 0 var(--s-3);
+    overflow-x: auto;
+    overscroll-behavior-inline: contain;
+    scroll-padding-inline: var(--s-3);
+    scrollbar-width: none;
+  }
+
+  .v2-set__tab {
+    min-height: 44px;
+    padding: var(--s-2) var(--s-3);
+    scroll-margin-inline: var(--s-3);
+    touch-action: manipulation;
+  }
+
+  .v2-set__body {
+    overscroll-behavior-y: contain;
+    padding:
+      var(--s-3)
+      max(var(--s-3), env(safe-area-inset-right))
+      max(var(--s-8), env(safe-area-inset-bottom))
+      max(var(--s-3), env(safe-area-inset-left));
+  }
+
+  .v2-set__section {
+    gap: var(--s-3);
+    margin-bottom: var(--s-3);
+    padding: var(--s-3);
+  }
+
+  .v2-set__section-head {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .v2-set__section-head > .v2-set__btn {
+    align-self: stretch;
+  }
+
+  .v2-set__row {
+    align-items: stretch;
+    flex-direction: column;
+    min-width: 0;
+  }
+
+  .v2-set__row-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--s-2);
+    width: 100%;
+    min-height: 44px;
+    padding: var(--s-2) 0;
+    border: 0;
+    background: transparent;
+    color: var(--ink);
+    font: inherit;
+    text-align: left;
+  }
+
+  .v2-set__row-name {
+    min-width: 0;
+    overflow-wrap: anywhere;
+  }
+
+  .v2-set__row-state {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--s-1);
+    flex: 0 0 auto;
+  }
+
+  .v2-set__row-body {
+    width: 100%;
+    min-width: 0;
+  }
+
+  .v2-set__input,
+  .v2-set__textarea,
+  .v2-set__select {
+    min-height: 44px;
+    font-size: 16px;
+  }
+
+  .v2-set__btn {
+    min-height: 44px;
+    padding: 8px 14px;
+    touch-action: manipulation;
+  }
+
+  .v2-set__toggle {
+    width: 44px;
+    height: 26px;
+    border-radius: 13px;
+    touch-action: manipulation;
+  }
+
+  .v2-set__toggle::after {
+    width: 22px;
+    height: 22px;
+  }
+
+  .v2-set__toggle[data-checked="true"]::after {
+    left: 20px;
+  }
+
+  .v2-set__toggle-row {
+    min-height: 44px;
+  }
+
+  .v2-set__mode {
+    grid-template-columns: 1fr;
+  }
+
+  .v2-set__mode-card {
+    min-height: 72px;
+  }
+
+  .v2-set__provider-actions,
+  .v2-set__row-actions,
+  .v2-set__sidecar-actions,
+  .v2-set__dialog-foot {
+    display: grid !important;
+    grid-template-columns: 1fr;
+    gap: var(--s-2) !important;
+    width: 100%;
+  }
+
+  .v2-set__provider-actions-spacer {
+    display: none;
+  }
+
+  .v2-set__provider-actions .v2-set__btn,
+  .v2-set__row-actions .v2-set__btn,
+  .v2-set__sidecar-actions .v2-set__btn,
+  .v2-set__dialog-foot .v2-set__btn {
+    width: 100%;
+    margin-left: 0 !important;
+  }
+
+  .v2-set__sidecar {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .v2-set__sidecar-meta {
+    overflow-wrap: anywhere;
+  }
+
+  .v2-set__code--block {
+    max-width: 100%;
+    overflow-x: auto;
+  }
+
+  .v2-set__toast {
+    position: fixed;
+    right: max(var(--s-3), env(safe-area-inset-right));
+    bottom: max(var(--s-3), env(safe-area-inset-bottom));
+    left: max(var(--s-3), env(safe-area-inset-left));
+    max-width: none;
+  }
+
+  .v2-set__overlay {
+    align-items: flex-end;
+    padding: 0;
+  }
+
+  .v2-set__dialog {
+    max-width: none;
+    max-height: calc(100dvh - max(24px, env(safe-area-inset-top)));
+    border-right: 0;
+    border-bottom: 0;
+    border-left: 0;
+    border-radius: var(--r-2) var(--r-2) 0 0;
+  }
+
+  .v2-set__dialog-head,
+  .v2-set__dialog-body,
+  .v2-set__dialog-foot {
+    padding-right: max(var(--s-3), env(safe-area-inset-right));
+    padding-left: max(var(--s-3), env(safe-area-inset-left));
+  }
+
+  .v2-set__dialog-foot {
+    padding-bottom: max(var(--s-3), env(safe-area-inset-bottom));
+  }
+}

--- a/ui/src/v2/rooms/settings/SettingsRoom.css
+++ b/ui/src/v2/rooms/settings/SettingsRoom.css
@@ -460,6 +460,16 @@
 
 .v2-set__provider-actions-spacer { flex: 1; }
 
+.v2-set__row-actions {
+  display: flex;
+  gap: var(--s-2);
+  margin-top: var(--s-3);
+}
+
+.v2-set__btn--push-end {
+  margin-left: auto;
+}
+
 .v2-set__test-result {
   font-family: var(--font-mono);
   font-size: var(--text-xs);
@@ -982,9 +992,9 @@
   .v2-set__row-actions,
   .v2-set__sidecar-actions,
   .v2-set__dialog-foot {
-    display: grid !important;
+    display: grid;
     grid-template-columns: 1fr;
-    gap: var(--s-2) !important;
+    gap: var(--s-2);
     width: 100%;
   }
 
@@ -997,7 +1007,10 @@
   .v2-set__sidecar-actions .v2-set__btn,
   .v2-set__dialog-foot .v2-set__btn {
     width: 100%;
-    margin-left: 0 !important;
+  }
+
+  .v2-set__btn--push-end {
+    margin-left: 0;
   }
 
   .v2-set__sidecar {
@@ -1029,6 +1042,7 @@
 
   .v2-set__dialog {
     max-width: none;
+    max-height: calc(100vh - max(24px, env(safe-area-inset-top)));
     max-height: calc(100dvh - max(24px, env(safe-area-inset-top)));
     border-right: 0;
     border-bottom: 0;

--- a/ui/src/v2/rooms/settings/SettingsRoom.tsx
+++ b/ui/src/v2/rooms/settings/SettingsRoom.tsx
@@ -73,6 +73,22 @@ export function SettingsRoomBody({ mode }: { mode: RoomBodyMode }) {
     return () => window.clearTimeout(id);
   }, [toast]);
 
+  // A phone-width tab strip cannot show every settings section at once.
+  // Keep the active tab visible after taps, keyboard navigation, and voice
+  // actions without moving the vertically scrolling settings panel.
+  useEffect(() => {
+    const activeTab = tabsApi.tablistRef.current?.querySelector<HTMLElement>(
+      `[data-roving-tab="${tab}"]`,
+    );
+    if (!activeTab) return;
+    const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    activeTab.scrollIntoView({
+      behavior: reduceMotion ? "auto" : "smooth",
+      block: "nearest",
+      inline: "center",
+    });
+  }, [tab, tabsApi.tablistRef]);
+
   // ── Settings hot-apply results (daemon `settings_applied` broadcast) ──
   // Applies can finish AFTER a save request returned (debounced channel
   // restarts, SIGHUP / POST /api/config/reload): surface those outcomes
@@ -401,7 +417,12 @@ export function SettingsRoomBody({ mode }: { mode: RoomBodyMode }) {
 
 export function SettingsRoom() {
   return (
-    <RoomShell title="Settings" subtitle="providers · channels · integrations · sidecar" breadcrumb={["Settings"]}>
+    <RoomShell
+      title="Settings"
+      subtitle="providers · channels · integrations · sidecar"
+      breadcrumb={["Settings"]}
+      className="v2-room-overlay--settings"
+    >
       <SettingsRoomBody mode="expanded" />
     </RoomShell>
   );

--- a/ui/src/v2/rooms/settings/SettingsRoom.tsx
+++ b/ui/src/v2/rooms/settings/SettingsRoom.tsx
@@ -75,17 +75,23 @@ export function SettingsRoomBody({ mode }: { mode: RoomBodyMode }) {
 
   // A phone-width tab strip cannot show every settings section at once.
   // Keep the active tab visible after taps, keyboard navigation, and voice
-  // actions without moving the vertically scrolling settings panel.
+  // actions by scrolling the strip itself, never the surrounding panel.
   useEffect(() => {
-    const activeTab = tabsApi.tablistRef.current?.querySelector<HTMLElement>(
+    const tablist = tabsApi.tablistRef.current;
+    const activeTab = tablist?.querySelector<HTMLElement>(
       `[data-roving-tab="${tab}"]`,
     );
-    if (!activeTab) return;
+    if (!tablist || !activeTab || tablist.scrollWidth <= tablist.clientWidth) return;
+    const stripRect = tablist.getBoundingClientRect();
+    const tabRect = activeTab.getBoundingClientRect();
+    const maxLeft = tablist.scrollWidth - tablist.clientWidth;
+    const centeredLeft = tablist.scrollLeft
+      + tabRect.left - stripRect.left
+      - (tablist.clientWidth - tabRect.width) / 2;
     const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
-    activeTab.scrollIntoView({
+    tablist.scrollTo({
+      left: Math.max(0, Math.min(centeredLeft, maxLeft)),
       behavior: reduceMotion ? "auto" : "smooth",
-      block: "nearest",
-      inline: "center",
     });
   }, [tab, tabsApi.tablistRef]);
 

--- a/ui/src/v2/rooms/settings/tabs/LLMTab.tsx
+++ b/ui/src/v2/rooms/settings/tabs/LLMTab.tsx
@@ -367,7 +367,7 @@ function ProviderRow({
             </div>
           )}
 
-          <div className="v2-set__row-actions" style={{ display: "flex", gap: "var(--s-2)", marginTop: "var(--s-3)" }}>
+          <div className="v2-set__row-actions">
             <button
               type="button"
               className="v2-set__btn"
@@ -405,8 +405,7 @@ function ProviderRow({
             </button>
             <button
               type="button"
-              className="v2-set__btn v2-set__btn--danger"
-              style={{ marginLeft: "auto" }}
+              className="v2-set__btn v2-set__btn--danger v2-set__btn--push-end"
               onClick={async () => {
                 if (!await confirmDialog(`Remove provider '${name}'? This deletes the stored API key.`)) return;
                 const r = await data.removeProvider(name);
@@ -511,7 +510,7 @@ function NewProviderRow({
           </div>
         )}
 
-        <div className="v2-set__row-actions" style={{ display: "flex", gap: "var(--s-2)", marginTop: "var(--s-3)" }}>
+        <div className="v2-set__row-actions">
           <button type="button" className="v2-set__btn" onClick={onDone}>
             Cancel
           </button>


### PR DESCRIPTION
## Problem

The Settings room is designed around desktop-width grids and pointer-sized controls. On a phone, the persistent voice rail reduces the usable width, the room header and stat cards consume too much space, action rows can overflow, form controls are small touch targets, and enrollment dialogs do not account for mobile safe areas.

This makes it difficult to control providers, channels, integrations, and sidecars from a phone.

## What changed

### Full-width mobile room

- give `RoomShell` an optional class hook for room-specific layout behavior
- open Settings edge-to-edge below 720px instead of reserving desktop voice-rail space
- compact the Settings header to a centered title with 44px back and close controls
- remove phone-only breadcrumb/subtitle clutter while preserving it on desktop

### Navigation and status

- turn the four status cards into a compact horizontal, scroll-snapping strip
- keep all eight settings tabs horizontally scrollable with hidden scrollbars
- automatically center the selected tab after a tap, keyboard action, or voice-driven tab change
- respect `prefers-reduced-motion` when bringing the active tab into view

### Touch and form behavior

- use at least 44px targets for tabs, buttons, switches, back/close controls, inputs, and selects
- use 16px form text on phones to prevent automatic iOS input zoom
- stack dense setting rows and two-column mode choices into single-column flows
- stack provider, sidecar, row, and dialog actions so they do not overflow
- keep long provider names, metadata, and code values contained within the viewport

### Mobile overlays

- present Settings dialogs as bottom sheets
- constrain sheets with dynamic viewport units
- add safe-area-aware header, content, action, toast, and bottom padding
- contain horizontal and vertical overscroll within the relevant Settings surface

## User-visible behavior

At phone widths, Settings uses the entire viewport and every configuration control remains reachable without horizontal page scrolling. Summary cards and section tabs can be swiped horizontally, while the selected tab is kept in view automatically. Editing and enrollment actions become thumb-friendly stacked controls.

Desktop Settings behavior is unchanged.

## Accessibility

- existing WAI-ARIA tab semantics and roving keyboard navigation are preserved
- touch targets meet the common 44px minimum
- active-tab scrolling honors reduced-motion preferences
- dialogs retain their existing dialog semantics and focus handling

## Scope boundaries

- no settings data model or daemon API changes
- no dropdown restyling; that remains a separate theme PR
- no provider-specific behavior changes
- no changes to the global desktop voice rail
- responsive full-width behavior is scoped to the Settings room through the new class hook

## Verification

- full pre-commit suite — 1,826 passed, 22 skipped, 0 failed
- `bunx tsc --noEmit`
- `bun run build:ui`
- `git diff --check`

## Risk and rollback

The responsive rules are gated behind `max-width: 720px` and the Settings-specific room class. The only shared component change is an optional CSS class prop with no behavior change for existing callers. Reverting this PR restores the prior phone layout without changing saved settings.