### PR TITLE
fix(ui): theme settings dropdowns

### DIFF
--- a/ui/src/v2/rooms/settings/SettingsRoom.css
+++ b/ui/src/v2/rooms/settings/SettingsRoom.css
@@ -249,7 +249,60 @@
   line-height: var(--lh-body);
 }
 
-.v2-set__select { cursor: pointer; }
+.v2-set__select {
+  -webkit-appearance: none;
+  appearance: none;
+  cursor: pointer;
+  padding-right: 36px;
+  background-color: var(--raise);
+  background-image:
+    linear-gradient(45deg, transparent 50%, var(--ink-3) 50%),
+    linear-gradient(135deg, var(--ink-3) 50%, transparent 50%);
+  background-position:
+    calc(100% - 15px) 50%,
+    calc(100% - 10px) 50%;
+  background-repeat: no-repeat;
+  background-size: 5px 5px;
+  border-radius: var(--corner-sm);
+  box-shadow: var(--sh-sm);
+  color-scheme: light;
+  transition:
+    background-color var(--dur-fast) var(--ease-out),
+    border-color var(--dur-fast) var(--ease-out),
+    box-shadow var(--dur-fast) var(--ease-out);
+}
+
+:root[data-theme="dark"] .v2-set__select,
+.dk .v2-set__select {
+  color-scheme: dark;
+}
+
+.v2-set__select:hover:not(:disabled) {
+  background-color: var(--paper-3);
+  border-color: var(--ink-3);
+}
+
+.v2-set__select:disabled {
+  background-color: var(--paper-3);
+  color: var(--ink-3);
+  cursor: not-allowed;
+  opacity: 0.65;
+}
+
+.v2-set__select option,
+.v2-set__select optgroup {
+  background: var(--raise);
+  color: var(--ink);
+  font-family: var(--font-sans);
+}
+
+@media (forced-colors: active) {
+  .v2-set__select {
+    appearance: auto;
+    background-image: none;
+    padding-right: 12px;
+  }
+}
 
 .v2-set__input:focus,
 .v2-set__textarea:focus,
@@ -777,4 +830,3 @@
 .v2-set__tab[data-active="true"] { border-radius: 7px 2px 7px 7px; }
 .v2-set__stat-value, .v2-set__section-title { font-family: var(--sans); font-weight: 700; letter-spacing: -0.015em; }
 .v2-set :focus-visible { outline-color: var(--speak); }
-

--- a/ui/src/v2/rooms/settings/SettingsRoom.css
+++ b/ui/src/v2/rooms/settings/SettingsRoom.css
@@ -232,9 +232,10 @@
 .v2-set__select {
   width: 100%;
   padding: 8px 12px;
-  background: var(--paper);
+  background: var(--raise);
   border: 1px solid var(--rule);
-  border-radius: var(--r-1);
+  border-radius: var(--corner-sm);
+  box-shadow: var(--sh-sm);
   font-family: var(--font-sans);
   font-size: var(--text-sm);
   color: var(--ink);
@@ -254,22 +255,18 @@
   appearance: none;
   cursor: pointer;
   padding-right: 36px;
-  background-color: var(--raise);
   background-image:
-    linear-gradient(45deg, transparent 50%, var(--ink-3) 50%),
-    linear-gradient(135deg, var(--ink-3) 50%, transparent 50%);
+    linear-gradient(45deg, transparent 50%, var(--ink3) 50%),
+    linear-gradient(135deg, var(--ink3) 50%, transparent 50%);
   background-position:
     calc(100% - 15px) 50%,
     calc(100% - 10px) 50%;
   background-repeat: no-repeat;
   background-size: 5px 5px;
-  border-radius: var(--corner-sm);
-  box-shadow: var(--sh-sm);
   color-scheme: light;
   transition:
     background-color var(--dur-fast) var(--ease-out),
-    border-color var(--dur-fast) var(--ease-out),
-    box-shadow var(--dur-fast) var(--ease-out);
+    border-color var(--dur-fast) var(--ease-out);
 }
 
 :root[data-theme="dark"] .v2-set__select,
@@ -278,15 +275,14 @@
 }
 
 .v2-set__select:hover:not(:disabled) {
-  background-color: var(--paper-3);
-  border-color: var(--ink-3);
+  background-color: var(--panel2);
+  border-color: var(--ink3);
 }
 
 .v2-set__select:disabled {
-  background-color: var(--paper-3);
-  color: var(--ink-3);
+  background-color: var(--panel2);
+  color: var(--ink2);
   cursor: not-allowed;
-  opacity: 0.65;
 }
 
 .v2-set__select option,
@@ -836,3 +832,4 @@
 .v2-set__tab[data-active="true"] { border-radius: 7px 2px 7px 7px; }
 .v2-set__stat-value, .v2-set__section-title { font-family: var(--sans); font-weight: 700; letter-spacing: -0.015em; }
 .v2-set :focus-visible { outline-color: var(--speak); }
+

--- a/ui/src/v2/rooms/settings/SettingsRoom.css
+++ b/ui/src/v2/rooms/settings/SettingsRoom.css
@@ -298,9 +298,15 @@
 
 @media (forced-colors: active) {
   .v2-set__select {
+    -webkit-appearance: auto;
     appearance: auto;
-    background-image: none;
+    background: Canvas;
+    border-radius: 0;
+    box-shadow: none;
+    color: CanvasText;
+    color-scheme: normal;
     padding-right: 12px;
+    transition: none;
   }
 }
 


### PR DESCRIPTION
## Problem

Settings dropdowns currently rely on each operating system native select presentation. Their corners, fill, shadow, arrow, hover state, and dark-mode popup can look unrelated to the Jarvis Monochrome Lab theme, especially on macOS and Windows.

## What changed

- replace the browser-rendered select arrow with a CSS chevron built from theme-aware gradients
- use the Jarvis raised surface, asymmetric small corner, border, shadow, typography, and spacing tokens
- add a subtle themed hover state
- add an explicit disabled state with the correct cursor and muted tokens
- theme option and option-group text/backgrounds
- set the native popup color scheme to match Jarvis light or dark mode
- restore the operating-system select treatment in Windows High Contrast / forced-colors mode

## Coverage

The shared `.v2-set__select` class is used by Settings dropdowns in:

- General
- LLM providers and model routing
- Channels, STT, and TTS
- Voice

Because the change lives on the shared Settings control class, these selectors stay visually consistent without duplicating styles across tabs.

## User-visible behavior

Settings selects now match adjacent Jarvis controls in both light and dark themes. The arrow remains readable as theme colors change, hover and disabled states are clear, and the opened native option menu uses the matching light/dark color scheme where the platform supports it.

## Accessibility

- existing labels, keyboard behavior, and native select semantics are unchanged
- focus continues to use the Jarvis speaking-blue focus ring
- disabled controls retain readable text and a non-interactive cursor
- forced-colors mode restores the native arrow and removes the decorative background so system colors remain authoritative

## Scope boundaries

- CSS only; no settings state or API changes
- no mobile layout changes
- no custom JavaScript listbox or changed keyboard interaction
- no restyling outside the Settings room

## Verification

- full pre-commit suite — 1,826 passed, 22 skipped, 0 failed
- `bunx tsc --noEmit`
- `bun run build:ui`
- `git diff --check`

## Risk and rollback

The change retains native `select` elements and only alters their presentation. Forced-colors users receive the native control appearance. Reverting the single stylesheet commit restores the prior operating-system presentation with no data impact.