### PR TITLE
docs(sidecar): rewrite setup and troubleshooting guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ JARVIS is not a chatbot with tools. It is a persistent daemon that sees your scr
     - [Removing JARVIS](#removing-jarvis)
   - [🖥️ Sidecar Setup](#️-sidecar-setup)
     - [1. Install the sidecar](#1-install-the-sidecar)
-    - [2. Enroll in the dashboard](#2-enroll-in-the-dashboard)
-    - [3. Run the sidecar](#3-run-the-sidecar)
+    - [2. Start the sidecar](#2-start-the-sidecar)
+    - [3. Connect the device](#3-connect-the-device)
   - [🧠 Core Capabilities](#-core-capabilities)
   - [⚙️ Configuration](#️-configuration)
   - [🏗️ Architecture](#️-architecture)
@@ -259,26 +259,32 @@ This means you can run the daemon on an always-on server and still interact with
 bun install -g @usejarvis/sidecar
 ```
 
-**Or download the binary** from [GitHub Releases](https://github.com/vierisid/jarvis/releases) for your platform (macOS, Linux, Windows).
+**Or download a Sidecar archive** from [GitHub Releases](https://github.com/vierisid/jarvis/releases) for your platform (macOS, Linux, Windows). Sidecar archives are attached when a Jarvis release includes a new Sidecar build, and their filenames contain the independent Sidecar version.
 
-### 2. Enroll in the dashboard
+### 2. Start the sidecar
 
-1. Open the JARVIS dashboard at `http://localhost:3142`
-2. Go to **Settings** → **Sidecar**
-3. Enter a friendly name for this machine (e.g. "work laptop") and click **Enroll**
-4. Click **Copy** to copy the token command
-
-### 3. Run the sidecar
-
-Just start it:
+Start it with no arguments:
 
 ```bash
 jarvis
 ```
 
-The first time it runs unconfigured, a small **setup window** pops up asking for
-the enrollment token — paste the token you copied and click **Connect**. The
-sidecar saves it locally (`~/.jarvis/sidecar.yaml`) and connects.
+The first time it runs unconfigured, a local **Connect window** opens. Hosted
+users finish signing in through the system browser and enrollment completes
+automatically.
+
+### 3. Connect the device
+
+For a self-hosted brain:
+
+1. Configure `daemon.brain_domain` or `JARVIS_BRAIN_DOMAIN` with an origin this machine can reach.
+2. Open the dashboard and go to **Settings** → **Sidecar**, or run `jarvis enroll "work-laptop"` on the brain.
+3. Choose **Self-hosting? Paste your enrollment token** in the Sidecar Connect window.
+4. Paste the raw enrollment token and click **Connect**.
+
+The Sidecar verifies the token against its brain before saving it to
+`~/.jarvis/sidecar.yaml`. An invalid token or unreachable brain does not replace
+the saved configuration.
 
 Prefer the terminal / a headless box? Pass the token on the CLI instead (no
 window):
@@ -287,13 +293,15 @@ window):
 jarvis --token <your-token>
 ```
 
-Either way, subsequent runs are just `jarvis` (the saved token is reused).
+Either way, subsequent runs are just `jarvis` (the saved token is reused). See
+the [complete Sidecar guide](sidecar/README.md) for platform prerequisites,
+permissions, local settings, logs, and troubleshooting.
 
 Once connected, the sidecar appears as online in the Settings page where you can configure its capabilities (terminal, filesystem, desktop, browser, clipboard, screenshot, awareness, file watch, processes, notifications). The host-sensing observers (clipboard, file watch, process monitor, desktop notifications) run inside the sidecar on your machine and stream to the brain - the brain no longer observes its own host.
 
 ### Versioning & updates
 
-The sidecar is versioned **independently of the brain** (`bun update -g @usejarvis/sidecar`, or grab a newer binary from [GitHub Releases](https://github.com/vierisid/jarvis/releases) -- the `sidecar-vX.Y.Z` releases). Run `jarvis --version` to see what you have.
+The sidecar is versioned **independently of the brain** (`bun update -g @usejarvis/sidecar`, or grab a newer archive from a [GitHub Release](https://github.com/vierisid/jarvis/releases) that includes Sidecar assets). It is published through npm without separate `sidecar-v*` Git tags. Run `jarvis --version` to see what you have.
 
 On connect, the brain checks the sidecar's version against its compatibility floors and surfaces the result in **Settings -> Sidecar**:
 

--- a/sidecar/README.md
+++ b/sidecar/README.md
@@ -1,100 +1,266 @@
-# Sidecar
+# Jarvis Sidecar
 
-A Go client that connects to the JARVIS brain over WebSocket and exposes local machine capabilities (terminal, filesystem, clipboard, screenshots, etc.) as RPC handlers.
+The Sidecar is the desktop client that gives a Jarvis brain access to a
+machine's browser, terminal, filesystem, clipboard, screenshots, windows, and
+ambient-awareness signals. It runs on the machine being controlled and keeps
+one authenticated WebSocket connection to the brain.
 
-## Building
+The brain and Sidecar may run on the same machine, but the common setup is an
+always-on brain with one or more Sidecars on laptops and desktops.
 
-```bash
-go build -o jarvis-sidecar .
-```
+## Supported platforms
 
-Cross-compile for other platforms:
-
-```bash
-GOOS=darwin  go build -o jarvis-sidecar-macos .
-GOOS=windows go build -o jarvis-sidecar.exe .
-```
-
-### Panel service prerequisites (Phase 2 ambient UX)
-
-The sidecar can spawn native panel windows (frameless, always-on-top, transparent, click-through) via `github.com/webview/webview_go`. This requires a system webview runtime per platform:
-
-| Platform | Runtime | Install |
+| Platform | Distributed build | Desktop runtime |
 |---|---|---|
-| Windows 11 | WebView2 (Edge Chromium) | Pre-installed on Win11; on Win10 see [WebView2 runtime](https://developer.microsoft.com/microsoft-edge/webview2/) |
-| macOS | WKWebView | Pre-installed (system) |
-| Linux | WebKitGTK 4.1 | see "Linux setup" below |
+| macOS 11+ | Apple silicon and Intel | WKWebView, provided by macOS |
+| Windows 10/11 | x64 | WebView2; the Sidecar offers to install it when absent |
+| Linux | x64 and arm64 | WebKitGTK 4.1 plus the desktop tools listed below |
 
-#### Linux setup (Ubuntu 22.04/24.04 + WSL)
+The npm wrapper selects the correct platform package automatically.
+
+## Install
+
+The recommended install is:
 
 ```bash
-sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev build-essential pkg-config
+bun install -g @usejarvis/sidecar
+jarvis --version
+```
 
-# webview_go's cgo line hardcodes pkg-config name webkit2gtk-4.0, but Noble
-# only ships 4.1. Symlink the .pc files so build-time pkg-config resolves
-# (the webview.h runtime loader already prefers libwebkit2gtk-4.1.so).
+Release archives are also attached to Jarvis GitHub releases when that release
+contains a new Sidecar build. Archive names include the independent Sidecar
+version and target platform, for example
+`jarvis-v0.9.1-darwin-arm64.tar.gz`.
+
+On macOS, native notifications, URL-based enrollment, the menu-bar identity,
+and permission prompts depend on running inside a `Jarvis.app` bundle. See
+[macOS packaging](packaging/macos/README.md) when assembling a local build; a
+raw binary can still be enrolled from the terminal with `--token`.
+
+## Connect a device
+
+### Hosted Jarvis
+
+Run the Sidecar with no arguments:
+
+```bash
+jarvis
+```
+
+On first launch, the local Connect window opens the usejarvis sign-in page in
+the system browser. Finish signing in there; the Connect window receives,
+verifies, and stores the enrollment token automatically.
+
+### Self-hosted brain
+
+First ensure the brain advertises an origin this device can reach. For a remote
+brain, set `daemon.brain_domain` or `JARVIS_BRAIN_DOMAIN` before enrolling.
+See [Self-hosting](../docs/SELF_HOSTING.md) for LAN, TLS, reverse-proxy, and
+WebSocket examples.
+
+Create a device from either:
+
+- Dashboard: **Settings -> Sidecar -> Enroll**
+- Brain CLI: `jarvis enroll "work-laptop"`
+
+Enrollment tokens are shown once. Treat them like passwords.
+
+Start the Sidecar, choose **Self-hosting? Paste your enrollment token** in the
+Connect window, and paste the raw JWT. For a headless machine, pass it directly:
+
+```bash
+jarvis --token <enrollment-jwt>
+```
+
+Before saving a token, the Sidecar contacts the brain named by the token and
+requests an access token. Invalid tokens, wrong brain URLs, unreachable brains,
+and non-Jarvis servers are rejected without changing the saved configuration.
+After enrollment, later launches only need:
+
+```bash
+jarvis
+```
+
+For the token format, verification flow, rotation, and revocation model, see
+[Sidecar authentication](../docs/sidecar/SIDECAR_AUTHENTICATION.md).
+
+## Normal operation
+
+- Windows and macOS run a tray/menu-bar application. Its menu opens Chat, local
+  Sidecar Settings, logs, and other Jarvis surfaces.
+- Linux currently runs in the foreground without a tray. Keep it under the
+  desktop session's service manager if it should stay running.
+- The Sidecar reconnects automatically when the brain is temporarily
+  unavailable.
+- The brain reports the device as online under **Settings -> Sidecar** and
+  shows unavailable capabilities discovered during startup preflight.
+- Capability changes made from the dashboard are hot-applied and reported back
+  to the brain.
+
+Stop a foreground Sidecar with `Ctrl+C`. On Windows or macOS, use **Close**
+from the tray/menu-bar menu.
+
+## Local settings and files
+
+| Item | Location |
+|---|---|
+| Configuration | `~/.jarvis/sidecar.yaml` |
+| Logs | `~/.jarvis/sidecar.log` |
+| Captures (default) | `~/.jarvis/captures/` |
+
+On Windows, `~` means `%USERPROFILE%`. The configuration directory is
+created with owner-only permissions where the platform supports them, and the
+token-bearing configuration file is written with mode `0600` on Unix.
+
+The local Settings window on Windows and macOS controls:
+
+- enrollment token replacement
+- launch at login
+- ethereal Pebble behavior and idle delay
+- anonymous Sidecar telemetry
+
+The dashboard's Sidecar editor controls capabilities and operational limits
+such as blocked commands, blocked paths, file-size limits, browser settings,
+and awareness intervals.
+
+Telemetry is independent from brain telemetry. Disable it in the local
+Settings window, set `telemetry.enabled: false` in `sidecar.yaml`, or launch
+with `JARVIS_SIDECAR_TELEMETRY=0`. See [Telemetry](../docs/TELEMETRY.md).
+
+## Platform requirements
+
+### Windows
+
+- WebView2 is required for the Connect window, Pebble, and native Jarvis
+  panels. Windows 11 normally includes it; the Sidecar prompts to install the
+  runtime when it is missing.
+- PowerShell is used for clipboard and screenshot fallbacks.
+- A Chromium-based browser is required for browser automation. Jarvis detects
+  the default browser first, then known Chrome, Edge, Brave, and Chromium
+  installs.
+
+### macOS
+
+Grant permissions in **System Settings -> Privacy & Security** when requested:
+
+- Microphone for voice and wake word
+- Screen Recording for screen awareness
+- Accessibility for global hotkeys and desktop automation
+- Notifications for Sidecar notifications
+
+Run the bundled application rather than moving only its inner binary. A locally
+built unsigned app can be tested, but distributed builds should be signed and
+notarized.
+
+### Linux
+
+Install the webview and desktop helpers. On Ubuntu 22.04/24.04:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y \
+  libwebkit2gtk-4.1-dev libgtk-3-dev build-essential pkg-config \
+  xclip xsel scrot xdotool dbus
+```
+
+The Sidecar accepts any one of `scrot`, ImageMagick `import`, or
+`gnome-screenshot` for screenshots. Clipboard support needs `xclip` or
+`xsel`. Window awareness and desktop automation need `xdotool`.
+`DISPLAY` or `WAYLAND_DISPLAY` must be present.
+
+On Ubuntu releases whose webview package only ships a
+`webkit2gtk-4.1.pc` pkg-config file, local builds may need 4.0 compatibility
+links:
+
+```bash
 sudo ln -sf /usr/lib/x86_64-linux-gnu/pkgconfig/webkit2gtk-4.1.pc \
-            /usr/lib/x86_64-linux-gnu/pkgconfig/webkit2gtk-4.0.pc
+  /usr/lib/x86_64-linux-gnu/pkgconfig/webkit2gtk-4.0.pc
 sudo ln -sf /usr/lib/x86_64-linux-gnu/pkgconfig/javascriptcoregtk-4.1.pc \
-            /usr/lib/x86_64-linux-gnu/pkgconfig/javascriptcoregtk-4.0.pc
+  /usr/lib/x86_64-linux-gnu/pkgconfig/javascriptcoregtk-4.0.pc
 ```
 
-WSL note: WebKitGTK runs but the panel window appears on the WSL X server, not Windows directly. For real-world dev/test, build for Windows and run natively on Win11.
+Adjust the architecture-specific pkg-config directory when building on arm64.
+Under WSL, Linux GUI windows use the WSL display server; for normal Windows
+desktop automation, run the Windows Sidecar natively.
 
-Cross-compilation with cgo: the panel service uses cgo, so cross-compiling needs the target's webview headers available. For Windows builds from Linux, the simplest path is to build natively on Windows; for macOS, build on a Mac.
+## Troubleshooting
 
-## Usage
+### The setup window does not open
+
+- Check `~/.jarvis/sidecar.log`.
+- On Windows, install or repair WebView2.
+- On Linux, install WebKitGTK and confirm a desktop display variable is set.
+- A headless device can enroll with `jarvis --token <jwt>`.
+
+### The token is rejected or the brain is unreachable
+
+1. Inspect `daemon.brain_domain` or `JARVIS_BRAIN_DOMAIN` on the brain.
+2. From the Sidecar machine, verify that origin resolves and that its
+   `/api/sidecars/.well-known/jwks.json` endpoint is reachable.
+3. Confirm the reverse proxy allows WebSocket upgrades on
+   `/sidecar/connect`.
+4. Re-enroll after correcting the origin. Existing tokens retain the URLs they
+   were issued with.
+
+### A capability is unavailable
+
+The Sidecar runs platform preflight checks before registering. The dashboard
+shows the resulting reason, and the log contains the same startup details.
+Install the named helper or grant the requested operating-system permission,
+then restart the Sidecar.
+
+### The brain says an update is required
+
+The brain enforces minimum and recommended Sidecar versions:
+
+- **OK**: compatible
+- **Update available**: compatible, but a newer Sidecar is recommended
+- **Update required**: connection refused until the Sidecar is updated
+
+Update npm installs with:
 
 ```bash
-# First run — enroll with a token from the brain
-./jarvis-sidecar --token <jwt>
-
-# Subsequent runs — uses saved token
-./jarvis-sidecar
+bun update -g @usejarvis/sidecar
 ```
 
-## File Structure
+The Sidecar version comes from `sidecar/VERSION` and is independent of the
+brain version. It is published through npm without a separate
+`sidecar-v*` Git tag.
 
-### Core
+## Development
 
-| File | Purpose |
-|---|---|
-| `main.go` | Entry point, flag parsing, signal handling |
-| `config.go` | YAML config loading/saving (`~/.jarvis/sidecar.yaml`) |
-| `types.go` | Shared types: capabilities, RPC messages, config structs |
-| `client.go` | WebSocket client, reconnect loop, preflight integration |
-| `handlers.go` | RPC handler registry (terminal, filesystem, clipboard, screenshot, config, system info) |
-| `observers.go` | Background observers (clipboard polling, screen capture, window tracking) |
-
-### Platform-specific (build tags)
-
-Go build constraints (`//go:build linux`, etc.) ensure only the correct OS file is compiled. All three files export the same function signatures:
-
-| Function | Linux | macOS | Windows |
-|---|---|---|---|
-| `platformClipboardRead()` | xclip | pbpaste | powershell Get-Clipboard |
-| `platformClipboardWrite()` | xclip | pbcopy | powershell Set-Clipboard |
-| `platformCaptureScreen()` | scrot / import / gnome-screenshot | screencapture | powershell System.Windows.Forms |
-| `platformDefaultShell()` | `"sh"` | `"sh"` | `"cmd.exe"` |
-| `platformGetActiveWindow()` | xdotool + ps | osascript (System Events) | powershell Get-Process |
-
-Files: `platform_linux.go`, `platform_darwin.go`, `platform_windows.go`
-
-### Preflight checks (build tags)
-
-Before registering handlers, the client validates that required system tools are present. Each capability maps to a check function that returns `""` (available) or a reason string (unavailable).
-
-| File | Checks |
-|---|---|
-| `preflight.go` | `CheckCapabilities()` orchestrator (platform-independent) |
-| `preflight_linux.go` | xclip/xsel, scrot/import/gnome-screenshot, xdotool, Chrome, DISPLAY/WAYLAND_DISPLAY |
-| `preflight_darwin.go` | pbpaste, screencapture, osascript, Chrome |
-| `preflight_windows.go` | powershell, cmd.exe, Chrome |
-
-Unavailable capabilities are reported to the brain in the `register` and `capabilities_update` messages so the dashboard can show warnings and the routing layer can return clear errors.
-
-## Tests
+The Sidecar uses cgo for native webviews and overlays. Build it on the target
+operating system so the compiler can use that platform's UI SDK:
 
 ```bash
+cd sidecar
 go test ./...
+go vet ./...
+make build
 ```
+
+Additional targets:
+
+```bash
+make build-ocr-helper  # macOS Vision OCR helper; requires swiftc
+make app-macos         # assemble dist/macos/Jarvis.app
+make build-test        # sidecartest build with platform diagnostics
+```
+
+`GOOS=... go build` alone is not sufficient for release cross-compilation
+because the native UI code requires cgo, headers, libraries, and a compatible
+toolchain. The release workflow uses native or target-capable runners for each
+platform.
+
+The main implementation areas are:
+
+| Area | Files |
+|---|---|
+| Startup, configuration, reconnect | `main.go`, `config.go`, `client.go` |
+| Enrollment and token verification | `hosted*.go`, `deeplink*.go`, `verify_token.go` |
+| RPC capabilities | `handlers.go`, `browser*.go`, `desktop_*.go`, `ocr_*.go` |
+| Ambient UI | `pebble*.go`, `sub_pebble*.go`, `panels*.go` |
+| Native shell | `tray_*.go`, `settings_window.go`, `log_viewer.go` |
+| Platform checks | `preflight*.go`, `platform_*.go` |
+
+Protocol details live in [Sidecar protocol](../docs/sidecar/SIDECAR_PROTOCOL.md).

--- a/sidecar/README.md
+++ b/sidecar/README.md
@@ -48,8 +48,8 @@ jarvis
 ```
 
 On first launch, the local Connect window opens the usejarvis sign-in page in
-the system browser. Finish signing in there; the Connect window receives,
-verifies, and stores the enrollment token automatically.
+the system browser. Finish signing in there; the Connect window receives the
+enrollment token from the hosted handshake and stores it automatically.
 
 ### Self-hosted brain
 


### PR DESCRIPTION
## Problem

The Sidecar documentation describes an older token-only first run, suggests release cross-compilation with plain `GOOS`, and points users at separate `sidecar-v*` releases that do not exist. It also lacks one place that explains hosted versus self-hosted enrollment, desktop runtime requirements, permissions, local files/settings, update states, and common failure recovery.

Those gaps make the current Connect window and platform packages harder to install and troubleshoot.

## What changed

### Root setup guide

- update the table of contents and Sidecar steps to match the current first-run order
- document the hosted browser handshake
- document the self-hosted token path through Dashboard or `jarvis enroll`
- explain that tokens are verified before `sidecar.yaml` is changed
- link to the complete Sidecar guide
- correct the release model: independent Sidecar versions published through npm, with assets attached to applicable Jarvis releases and no separate `sidecar-v*` tags

### Complete Sidecar guide

Rewrite `sidecar/README.md` around operator tasks:

- supported platforms and distributed architectures
- npm and release-archive installation
- hosted and self-hosted device connection
- headless `--token` enrollment
- normal tray/menu-bar/Linux foreground behavior
- config, log, and capture paths
- ownership/permission handling for the token-bearing config
- local versus dashboard-managed settings
- independent Sidecar telemetry controls
- Windows WebView2, browser, and PowerShell requirements
- macOS bundle and Privacy & Security permissions
- Linux WebKitGTK and desktop helper packages
- WSL behavior
- token, webview, capability, and version troubleshooting
- target-native cgo build requirements and development commands
- implementation-area and protocol references

## Important corrections

- remove the obsolete claim that first run only opens a token form
- remove misleading `GOOS=darwin/windows go build` release instructions; native UI code requires cgo toolchains and target SDKs
- remove references to separate `sidecar-vX.Y.Z` GitHub releases
- distinguish the independently versioned Sidecar from the brain release version
- document that wrong-origin enrollment tokens must be reissued after `brain_domain` is fixed

## Scope boundaries

- documentation only
- no Sidecar runtime, enrollment, packaging, or telemetry behavior changes
- no attempt to change the macOS token input implementation; that is a separate PR
- no Windows Pebble performance changes

## Verification

- all new relative Markdown links resolve
- full pre-commit suite — 1,826 passed, 22 skipped, 0 failed
- `bunx tsc --noEmit`
- `git diff --check`

## Risk and rollback

There is no runtime impact. Reverting this PR restores the previous documentation only.