### PR TITLE
fix(sidecar): restore paste shortcuts on macOS

### DIFF
--- a/sidecar/application_menu_darwin.go
+++ b/sidecar/application_menu_darwin.go
@@ -26,8 +26,11 @@ static void jarvisAddEditCommand(NSMenu* menu, NSString* title, SEL action,
 
 // Identify an existing Edit-equivalent menu by responder-chain actions, not
 // its display title. macOS localizes "Edit", and embedding hosts can choose a
-// different title while still providing the standard commands.
+// different title while still providing the standard commands. All four core
+// commands must be present somewhere in the menu bar — a partial menu (say,
+// copy without paste) must not suppress installing the full set.
 static BOOL jarvisHasEditMenu(NSMenu* mainMenu) {
+    BOOL hasCut = NO, hasCopy = NO, hasPaste = NO, hasSelectAll = NO;
     for (NSMenuItem* item in mainMenu.itemArray) {
         NSMenu* submenu = item.submenu;
         if (submenu == nil) {
@@ -35,13 +38,13 @@ static BOOL jarvisHasEditMenu(NSMenu* mainMenu) {
         }
         for (NSMenuItem* command in submenu.itemArray) {
             SEL action = command.action;
-            if (action == @selector(cut:) || action == @selector(copy:) ||
-                action == @selector(paste:) || action == @selector(selectAll:)) {
-                return YES;
-            }
+            if (action == @selector(cut:)) hasCut = YES;
+            else if (action == @selector(copy:)) hasCopy = YES;
+            else if (action == @selector(paste:)) hasPaste = YES;
+            else if (action == @selector(selectAll:)) hasSelectAll = YES;
         }
     }
-    return NO;
+    return hasCut && hasCopy && hasPaste && hasSelectAll;
 }
 
 static void jarvisInstallApplicationMenusOnMain(void) {
@@ -54,6 +57,18 @@ static void jarvisInstallApplicationMenusOnMain(void) {
     }
     if (jarvisHasEditMenu(mainMenu)) {
         return; // app bundle or another window already supplied one
+    }
+
+    // AppKit renders item 0 of the main menu as the application menu (the bold
+    // app-name menu). The menu bar is visible whenever the activation policy is
+    // Regular — the vendored webview raises it for the first-run window — so
+    // keep a placeholder in slot 0 or the Edit commands would render under the
+    // app name.
+    if (mainMenu.numberOfItems == 0) {
+        NSMenuItem* appRoot = [[NSMenuItem alloc]
+            initWithTitle:@"" action:nil keyEquivalent:@""];
+        appRoot.submenu = [[NSMenu alloc] initWithTitle:@""];
+        [mainMenu addItem:appRoot];
     }
 
     NSMenu* editMenu = [[NSMenu alloc] initWithTitle:@"Edit"];

--- a/sidecar/application_menu_darwin.go
+++ b/sidecar/application_menu_darwin.go
@@ -1,0 +1,82 @@
+//go:build darwin
+
+package main
+
+/*
+#cgo CFLAGS: -x objective-c -fobjc-arc
+#cgo LDFLAGS: -framework Cocoa
+
+#import <Cocoa/Cocoa.h>
+
+// Programmatic AppKit applications do not receive the standard application
+// menu that a storyboard/nib normally creates. WKWebView's editable controls
+// implement cut/copy/paste/select-all through the responder chain, but macOS
+// only turns Command-X/C/V/A into those actions when matching key equivalents
+// exist in NSApp.mainMenu. Without this hidden Edit menu, the first-run token
+// field accepts typing but Command-V appears to do nothing.
+
+static void jarvisAddEditCommand(NSMenu* menu, NSString* title, SEL action,
+                                 NSString* key, NSEventModifierFlags modifiers) {
+    NSMenuItem* item = [[NSMenuItem alloc]
+        initWithTitle:title action:action keyEquivalent:key];
+    item.target = nil; // nil routes the action through the active responder chain
+    item.keyEquivalentModifierMask = modifiers;
+    [menu addItem:item];
+}
+
+static BOOL jarvisHasEditMenu(NSMenu* mainMenu) {
+    for (NSMenuItem* item in mainMenu.itemArray) {
+        if ([item.submenu.title isEqualToString:@"Edit"]) {
+            return YES;
+        }
+    }
+    return NO;
+}
+
+static void jarvisInstallApplicationMenusOnMain(void) {
+    [NSApplication sharedApplication];
+
+    NSMenu* mainMenu = NSApp.mainMenu;
+    if (mainMenu == nil) {
+        mainMenu = [[NSMenu alloc] initWithTitle:@""];
+        NSApp.mainMenu = mainMenu;
+    }
+    if (jarvisHasEditMenu(mainMenu)) {
+        return; // app bundle or another window already supplied one
+    }
+
+    NSMenu* editMenu = [[NSMenu alloc] initWithTitle:@"Edit"];
+    jarvisAddEditCommand(editMenu, @"Undo", @selector(undo:), @"z",
+                         NSEventModifierFlagCommand);
+    jarvisAddEditCommand(editMenu, @"Redo", @selector(redo:), @"z",
+                         NSEventModifierFlagCommand | NSEventModifierFlagShift);
+    [editMenu addItem:[NSMenuItem separatorItem]];
+    jarvisAddEditCommand(editMenu, @"Cut", @selector(cut:), @"x",
+                         NSEventModifierFlagCommand);
+    jarvisAddEditCommand(editMenu, @"Copy", @selector(copy:), @"c",
+                         NSEventModifierFlagCommand);
+    jarvisAddEditCommand(editMenu, @"Paste", @selector(paste:), @"v",
+                         NSEventModifierFlagCommand);
+    jarvisAddEditCommand(editMenu, @"Select All", @selector(selectAll:), @"a",
+                         NSEventModifierFlagCommand);
+
+    NSMenuItem* editRoot = [[NSMenuItem alloc]
+        initWithTitle:@"Edit" action:nil keyEquivalent:@""];
+    editRoot.submenu = editMenu;
+    [mainMenu addItem:editRoot];
+}
+
+static void jarvisInstallApplicationMenus(void) {
+    // Startup calls this before the first Cocoa run loop. Queueing the work
+    // guarantees AppKit mutation happens on the main thread; the block drains
+    // before the asynchronously loaded token form can become interactive.
+    dispatch_async(dispatch_get_main_queue(), ^{
+        jarvisInstallApplicationMenusOnMain();
+    });
+}
+*/
+import "C"
+
+func installApplicationMenus() {
+	C.jarvisInstallApplicationMenus()
+}

--- a/sidecar/application_menu_darwin.go
+++ b/sidecar/application_menu_darwin.go
@@ -24,10 +24,21 @@ static void jarvisAddEditCommand(NSMenu* menu, NSString* title, SEL action,
     [menu addItem:item];
 }
 
+// Identify an existing Edit-equivalent menu by responder-chain actions, not
+// its display title. macOS localizes "Edit", and embedding hosts can choose a
+// different title while still providing the standard commands.
 static BOOL jarvisHasEditMenu(NSMenu* mainMenu) {
     for (NSMenuItem* item in mainMenu.itemArray) {
-        if ([item.submenu.title isEqualToString:@"Edit"]) {
-            return YES;
+        NSMenu* submenu = item.submenu;
+        if (submenu == nil) {
+            continue;
+        }
+        for (NSMenuItem* command in submenu.itemArray) {
+            SEL action = command.action;
+            if (action == @selector(cut:) || action == @selector(copy:) ||
+                action == @selector(paste:) || action == @selector(selectAll:)) {
+                return YES;
+            }
         }
     }
     return NO;
@@ -67,12 +78,10 @@ static void jarvisInstallApplicationMenusOnMain(void) {
 }
 
 static void jarvisInstallApplicationMenus(void) {
-    // Startup calls this before the first Cocoa run loop. Queueing the work
-    // guarantees AppKit mutation happens on the main thread; the block drains
-    // before the asynchronously loaded token form can become interactive.
-    dispatch_async(dispatch_get_main_queue(), ^{
-        jarvisInstallApplicationMenusOnMain();
-    });
+    // tray_darwin.go pins main() to the process's main OS thread in init().
+    // Install synchronously so Command-X/C/V/A exist before startup can create
+    // or focus the first WKWebView token field.
+    jarvisInstallApplicationMenusOnMain();
 }
 */
 import "C"

--- a/sidecar/application_menu_other.go
+++ b/sidecar/application_menu_other.go
@@ -1,0 +1,5 @@
+//go:build !darwin
+
+package main
+
+func installApplicationMenus() {}

--- a/sidecar/main.go
+++ b/sidecar/main.go
@@ -72,6 +72,12 @@ Usage:
 	// macOS needs the .app bundle's Info.plist). Idempotent, best-effort.
 	registerURLSchemeHandler()
 
+	// WKWebView text fields rely on the responder-chain Edit commands for
+	// Command-X/C/V/A. A programmatic macOS app has no main menu by default, so
+	// install those commands before the first-run token field can receive focus.
+	// No-op on other platforms.
+	installApplicationMenus()
+
 	// When relaunched by an in-app restart (settings token change), wait briefly
 	// for the previous instance to exit and release the mic / hotkeys / tray icon
 	// before we grab them.


### PR DESCRIPTION
## Problem

The macOS Sidecar Connect window accepts typed text but Command-V does not paste an enrollment token. The same responder-chain gap can affect editable fields in local Settings and Logs search.

The Sidecar creates its AppKit application and WKWebView windows programmatically. Unlike a storyboard/nib application, that path does not create the standard Edit menu. WKWebView implements paste through the Cocoa responder chain, but NSApplication only translates Command-V into `paste:` when the matching key equivalent exists in its main menu.

## Root cause

This is not a token parser or clipboard-permission problem. The token field has focus and is editable, but the application has no `NSMenuItem` for the native edit selectors:

- `cut:`
- `copy:`
- `paste:`
- `selectAll:`

As a result, Command-V is never dispatched to WKWebView's first responder.

## What changed

- install a small standard Edit menu during Sidecar startup on macOS
- register native Undo, Redo, Cut, Copy, Paste, and Select All selectors
- use nil menu-item targets so AppKit routes commands to the active WKWebView responder
- install the menu synchronously on the main OS thread (pinned by `tray_darwin.go`'s `init`) before the first-run form becomes interactive
- make installation idempotent: skip only when all four core edit commands (cut/copy/paste/select-all) already exist in the menu bar, so a partial existing menu cannot suppress the full set
- keep a placeholder in main-menu slot 0 (AppKit's application-menu position) so the Edit menu renders correctly while the menu bar is visible during the first-run window
- provide a no-op implementation on Linux and Windows to keep the common startup path platform-neutral

The menu bar is visible during the first-run window (the vendored webview raises the activation policy to Regular there) and hidden under the Sidecar's usual accessory policy; the key equivalents participate in NSApplication event dispatch either way.

## User-visible behavior

- Command-V pastes enrollment tokens into the self-hosted Connect form
- Command-C/X/A and Undo/Redo work in editable Sidecar webview fields
- replacing a token through local Sidecar Settings receives the same native editing behavior
- Linux and Windows behavior is unchanged

## Scope boundaries

- no token validation, trimming, persistence, or enrollment changes
- no clipboard reads from JavaScript
- no custom global keyboard hook
- no docs or packaging changes
- no changes to the vendored webview implementation

## Verification

- formatted with Go 1.25 `gofmt`
- full repository pre-commit suite — 1,826 passed, 22 skipped, 0 failed
- `bunx tsc --noEmit`
- `git diff --check`
- the repository macOS CI job provides the target-native cgo build and vet gate

A local `go test ./...` attempt reached cgo setup but could not build the Linux webview dependency because this workspace image lacks `pkg-config`/WebKitGTK. No test failure occurred before that environment prerequisite.

## Risk and rollback

The AppKit mutation is macOS-only, main-threaded, and idempotent. Commands use the standard responder chain instead of directly reading the clipboard, so the active control remains authoritative. Reverting this PR removes the generated Edit menu and restores the prior shortcut behavior.
