### PR TITLE
fix(sidecar): reduce Windows Pebble cursor overhead

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,6 +76,30 @@ jobs:
           export CGO_CFLAGS="-I$(pwd)/include" CGO_CXXFLAGS="-I$(pwd)/include"
           go build -o /tmp/jarvis-sidecar.exe .
 
+  # The windows-tagged tests (pebble draw-bounds crop invariant) are pure Go
+  # but can only RUN on a Windows runner — the mingw cross-build above only
+  # proves the package compiles. `go test` also compiles every _test.go under
+  # GOOS=windows, which the cross-build (build-only) never checks. Scoped to
+  # the draw-bounds test to keep runtime bounded; the full logic suite is
+  # covered on linux.
+  sidecar-test-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: sidecar/go.mod
+          cache-dependency-path: sidecar/go.sum
+      - name: Run windows-tagged pebble tests (amd64, cgo)
+        working-directory: sidecar
+        shell: bash
+        env:
+          CGO_ENABLED: "1"
+        run: |
+          set -euo pipefail
+          export CGO_CFLAGS="-I$(pwd)/include" CGO_CXXFLAGS="-I$(pwd)/include"
+          go test -run '^TestMainPebbleDrawStaysInsideCrop$' -v .
+
   # Compile gate for the darwin cgo files (deeplink_darwin.go, the *_darwin
   # bridges): build tags hide them from the linux job, so without this their
   # first compile happens on a release runner. Build + vet only — the UI

--- a/sidecar/pebble_draw_bounds_windows_test.go
+++ b/sidecar/pebble_draw_bounds_windows_test.go
@@ -1,0 +1,75 @@
+//go:build windows
+
+package main
+
+import "testing"
+
+// TestMainPebbleDrawStaysInsideCrop guards the invariant the compact layered
+// window relies on: present() clears and uploads only the top-left
+// mainPebbleWindowW × mainPebbleWindowH crop of the 460-px-stride backing
+// buffer, so no main-pebble draw path may ever touch a pixel outside that
+// crop. Anything painted below row mainPebbleWindowH would land in rows that
+// are never cleared; anything right of column mainPebbleWindowW would be
+// silently cropped by UpdateLayeredWindow. Both fail here instead.
+//
+// Renders every state, under every halo/eye/blinded overlay combination,
+// across 240 consecutive frame ticks — the longest animation cycle (idle's
+// 240-frame breathe); consecutive ticks 0..239 also cover every phase of the
+// shorter 75/84/96/120/144-frame cycles.
+func TestMainPebbleDrawStaysInsideCrop(t *testing.T) {
+	states := []PebbleState{
+		PebbleIdle, PebbleListening, PebbleThinking, PebbleSpeaking,
+		PebbleWorking, PebbleAsking, PebbleDone, PebbleMuted,
+	}
+	overlays := []struct {
+		name                   string
+		pointing, eye, blinded bool
+	}{
+		{"plain", false, false, false},
+		{"pointing", true, false, false},
+		{"eye", false, true, false},
+		{"pointing+eye+blinded", true, true, true},
+	}
+	const ticks = 240
+
+	pixels := make([]uint32, pebbleWindowW*pebbleWindowH)
+	for _, ov := range overlays {
+		for _, state := range states {
+			s := &pebbleServiceWindows{}
+			s.pointing.Store(ov.pointing)
+			s.eyeActive.Store(ov.eye)
+			s.blinded.Store(ov.blinded)
+			// Clear only the crop rows each frame, exactly like present().
+			// The draw helpers never write a transparent pixel over a painted
+			// one, so a single out-of-crop write on any tick survives until
+			// the scan below.
+			for tick := uint64(0); tick < ticks; tick++ {
+				for i := range pixels[:pebbleWindowW*mainPebbleWindowH] {
+					pixels[i] = 0
+				}
+				s.frameTick = tick
+				s.drawState(pixels, state, 0)
+				s.drawControllingHalo(pixels)
+				s.drawEyeGlyph(pixels)
+			}
+			if x, y, stray := strayPixelOutsideCrop(pixels); stray {
+				t.Fatalf("state %q overlay %q painted outside the %dx%d crop at (%d,%d) — widen mainPebbleWindowW/H or shrink the visual",
+					state, ov.name, mainPebbleWindowW, mainPebbleWindowH, x, y)
+			}
+		}
+	}
+}
+
+func strayPixelOutsideCrop(pixels []uint32) (int, int, bool) {
+	for y := 0; y < pebbleWindowH; y++ {
+		for x := 0; x < pebbleWindowW; x++ {
+			if x < mainPebbleWindowW && y < mainPebbleWindowH {
+				continue
+			}
+			if pixels[y*pebbleWindowW+x] != 0 {
+				return x, y, true
+			}
+		}
+	}
+	return 0, 0, false
+}

--- a/sidecar/pebble_overlay_windows.go
+++ b/sidecar/pebble_overlay_windows.go
@@ -486,7 +486,10 @@ func (s *pebbleServiceWindows) createRenderSurface() error {
 	}
 
 	oldBitmap, _, _ := procSelectObject.Call(memDC, dib)
-	if oldBitmap == 0 {
+	// SelectObject has two failure sentinels depending on object type:
+	// NULL and HGDI_ERROR ((HGDIOBJ)-1). Never retain HGDI_ERROR as the
+	// bitmap to restore during cleanup or the DIB/DC can leak.
+	if oldBitmap == 0 || oldBitmap == ^uintptr(0) {
 		procDeleteObjectGdi.Call(dib)
 		procDeleteDC.Call(memDC)
 		return fmt.Errorf("SelectObject failed")

--- a/sidecar/pebble_overlay_windows.go
+++ b/sidecar/pebble_overlay_windows.go
@@ -139,6 +139,16 @@ type pebbleServiceWindows struct {
 
 	hwnd uintptr
 
+	// The main cursor pebble owns one reusable software surface for its whole
+	// lifetime. Recreating a 32-bit DIB and memory DC on every 16 ms frame was
+	// needlessly expensive and could make the hardware cursor feel sluggish on
+	// some Windows machines. These handles are created on the overlay thread in
+	// createWindow and released on that same thread in destroyWindow.
+	renderDC        uintptr
+	renderDIB       uintptr
+	renderOldBitmap uintptr
+	renderBits      unsafe.Pointer
+
 	// hotkeyStop / paletteHotkeyStop / paletteMouseHookStop are cleanup
 	// functions for the summon (Ctrl+Space) hotkey, the Ctrl+K palette hotkey,
 	// and the Ctrl+MMB low-level mouse hook respectively. Called on Close.
@@ -319,6 +329,7 @@ func (s *pebbleServiceWindows) Close() error {
 // destroyWindow tears down the layered window. The shared runtime
 // (runPebbleLoop) calls it when the frame loop exits. Implements pebblePlatform.
 func (s *pebbleServiceWindows) destroyWindow() {
+	s.destroyRenderSurface()
 	if s.hwnd != 0 {
 		procDestroyWindow.Call(s.hwnd)
 		s.hwnd = 0
@@ -350,18 +361,19 @@ func (s *pebbleServiceWindows) pumpMessages() {
 
 // ─────────────────────────── Window creation ────────────────────────────────
 
-// Window size and anchor — the window is sized to fit the pebble pill PLUS
-// a bubble that drops below it. Most pixels are alpha=0 (true transparent);
-// only the pebble + bubble paint visible content. The pebble's centre is
-// pinned at (pebbleAnchorX, pebbleAnchorY) within the window, and the
-// window is positioned so that anchor lands at (cursor + offset).
+// The backing-buffer dimensions remain large because the Windows drawing
+// helpers are shared with sub-pebbles and the dormant bubble renderer. The
+// main cursor pebble itself no longer paints a bubble, so its actual layered
+// window is cropped to the visual's bounds. This prevents DWM from moving and
+// blending a mostly-transparent 460x480 surface whenever the cursor moves.
 const (
-	// Window is sized to hold the disc PLUS a generous bubble area that
-	// drops below — large enough for multi-paragraph responses without
-	// ellipsizing. The disc still anchors near the top-left so cursor-
-	// follow math is unchanged from the smaller-window design.
 	pebbleWindowW = 460
 	pebbleWindowH = 480
+
+	// Includes the drop's 2.1x glow, the pointing halo, and the awareness eye
+	// around the (40,28) anchor, with a few pixels of AA breathing room.
+	mainPebbleWindowW = 72
+	mainPebbleWindowH = 64
 	// pebbleAnchorX / pebbleAnchorY are shared in pebble_core.go.
 )
 
@@ -396,8 +408,8 @@ func (s *pebbleServiceWindows) createWindow() error {
 	style := uintptr(pblWsPopup | pblWsVisible)
 	x := int32(0)
 	y := int32(0)
-	w := int32(pebbleWindowW)
-	h := int32(pebbleWindowH)
+	w := int32(mainPebbleWindowW)
+	h := int32(mainPebbleWindowH)
 
 	hwnd, _, err := procCreateWindowExW.Call(
 		exStyle,
@@ -427,7 +439,79 @@ func (s *pebbleServiceWindows) createWindow() error {
 		swpNoMove|swpNoSize|swpNoActivate|swpShowWindow)
 
 	s.hwnd = hwnd
+	if err := s.createRenderSurface(); err != nil {
+		procDestroyWindow.Call(hwnd)
+		s.hwnd = 0
+		return err
+	}
 	return nil
+}
+
+// createRenderSurface allocates the main pebble's memory DC and DIB once.
+// The DIB keeps the shared renderer's 460 px stride, but only the top
+// mainPebbleWindowH rows are cleared, drawn, and presented for this overlay.
+func (s *pebbleServiceWindows) createRenderSurface() error {
+	screenDC, _, _ := procGetDC.Call(0)
+	if screenDC == 0 {
+		return fmt.Errorf("GetDC failed")
+	}
+	defer procReleaseDC.Call(0, screenDC)
+
+	memDC, _, _ := procCreateCompatibleDC.Call(screenDC)
+	if memDC == 0 {
+		return fmt.Errorf("CreateCompatibleDC failed")
+	}
+
+	bi := pblBitmapInfo{
+		Header: pblBitmapInfoHeader{
+			BiSize:        uint32(unsafe.Sizeof(pblBitmapInfoHeader{})),
+			BiWidth:       pebbleWindowW,
+			BiHeight:      -pebbleWindowH,
+			BiPlanes:      1,
+			BiBitCount:    32,
+			BiCompression: 0,
+		},
+	}
+	var bits unsafe.Pointer
+	dib, _, _ := procCreateDIBSection.Call(
+		memDC,
+		uintptr(unsafe.Pointer(&bi)),
+		0, // DIB_RGB_COLORS
+		uintptr(unsafe.Pointer(&bits)),
+		0, 0,
+	)
+	if dib == 0 || bits == nil {
+		procDeleteDC.Call(memDC)
+		return fmt.Errorf("CreateDIBSection failed")
+	}
+
+	oldBitmap, _, _ := procSelectObject.Call(memDC, dib)
+	if oldBitmap == 0 {
+		procDeleteObjectGdi.Call(dib)
+		procDeleteDC.Call(memDC)
+		return fmt.Errorf("SelectObject failed")
+	}
+	s.renderDC = memDC
+	s.renderDIB = dib
+	s.renderOldBitmap = oldBitmap
+	s.renderBits = bits
+	return nil
+}
+
+func (s *pebbleServiceWindows) destroyRenderSurface() {
+	if s.renderDC != 0 && s.renderOldBitmap != 0 {
+		procSelectObject.Call(s.renderDC, s.renderOldBitmap)
+	}
+	if s.renderDIB != 0 {
+		procDeleteObjectGdi.Call(s.renderDIB)
+	}
+	if s.renderDC != 0 {
+		procDeleteDC.Call(s.renderDC)
+	}
+	s.renderDC = 0
+	s.renderDIB = 0
+	s.renderOldBitmap = 0
+	s.renderBits = nil
 }
 
 // pebbleWndProc handles WM_NCHITTEST (disc-only clicks) + WM_LBUTTONDOWN/UP
@@ -573,47 +657,22 @@ func (s *pebbleServiceWindows) present() error {
 	winX := s.renderedX.Load()
 	winY := s.renderedY.Load()
 
-	// Create memory DC + 32-bit DIB
+	if s.renderDC == 0 || s.renderBits == nil {
+		return fmt.Errorf("pebble render surface is not initialized")
+	}
+
+	// Acquire only the desktop DC needed by UpdateLayeredWindow. The memory DC
+	// and DIB are persistent for the overlay's lifetime.
 	screenDC, _, _ := procGetDC.Call(0)
+	if screenDC == 0 {
+		return fmt.Errorf("GetDC failed")
+	}
 	defer procReleaseDC.Call(0, screenDC)
-	memDC, _, _ := procCreateCompatibleDC.Call(screenDC)
-	defer procDeleteDC.Call(memDC)
 
-	bi := pblBitmapInfo{
-		Header: pblBitmapInfoHeader{
-			BiSize:        uint32(unsafe.Sizeof(pblBitmapInfoHeader{})),
-			BiWidth:       pebbleWindowW,
-			BiHeight:      -pebbleWindowH, // top-down
-			BiPlanes:      1,
-			BiBitCount:    32,
-			BiCompression: 0,
-		},
-	}
-	var bits unsafe.Pointer
-	dib, _, _ := procCreateDIBSection.Call(
-		memDC,
-		uintptr(unsafe.Pointer(&bi)),
-		0, // DIB_RGB_COLORS
-		uintptr(unsafe.Pointer(&bits)),
-		0, 0,
-	)
-	if dib == 0 {
-		return fmt.Errorf("CreateDIBSection failed")
-	}
-	// Save the DC's default bitmap and restore it before deleting the DIB.
-	// DeleteObject fails on a bitmap still selected into a DC (and DeleteDC does
-	// NOT free a selected bitmap), so without the restore the DIB and its
-	// full-window pixel buffer leak every frame -> GDI handle/memory exhaustion
-	// within minutes at the 60fps frame loop. defer LIFO ordering puts this
-	// before the procDeleteDC(memDC) defer above, which is required.
-	oldBmp, _, _ := procSelectObject.Call(memDC, dib)
-	defer func() {
-		procSelectObject.Call(memDC, oldBmp)
-		procDeleteObjectGdi.Call(dib)
-	}()
-
-	pixels := unsafe.Slice((*uint32)(bits), pebbleWindowW*pebbleWindowH)
-	for i := range pixels {
+	pixels := unsafe.Slice((*uint32)(s.renderBits), pebbleWindowW*pebbleWindowH)
+	// The main renderer never paints below its compact layered-window crop.
+	// Clear just those rows instead of all 220,800 backing pixels.
+	for i := range pixels[:pebbleWindowW*mainPebbleWindowH] {
 		pixels[i] = 0
 	}
 	state, _ := s.state.Load().(PebbleState)
@@ -649,7 +708,7 @@ func (s *pebbleServiceWindows) present() error {
 		AlphaFormat:         acSrcAlpha,
 	}
 	winPt := pblPoint{X: winX, Y: winY}
-	winSz := pblSize{CX: pebbleWindowW, CY: pebbleWindowH}
+	winSz := pblSize{CX: mainPebbleWindowW, CY: mainPebbleWindowH}
 	srcPt := pblPoint{X: 0, Y: 0}
 
 	r, _, _ := procUpdateLayeredWindow.Call(
@@ -657,7 +716,7 @@ func (s *pebbleServiceWindows) present() error {
 		screenDC,
 		uintptr(unsafe.Pointer(&winPt)),
 		uintptr(unsafe.Pointer(&winSz)),
-		memDC,
+		s.renderDC,
 		uintptr(unsafe.Pointer(&srcPt)),
 		0, // crKey (unused with ULW_ALPHA)
 		uintptr(unsafe.Pointer(&blend)),


### PR DESCRIPTION
## Summary

Fixes the cursor slowdown reported by some Windows users while Pebble follows the pointer.

This PR is intentionally limited to the Windows main Pebble render path. It does not change Groq, providers, settings, docs, macOS behavior, installer localization, or sub-pebbles.

## Root cause

The Windows main Pebble currently renders only a small drop near its `(40, 28)` anchor, but its layered window retained the old `460 x 480` dimensions from the removed cursor-bubble UI.

On every 16 ms frame, it also:

1. acquired a desktop DC,
2. created a compatible memory DC,
3. allocated a `460 x 480` 32-bit DIB,
4. cleared all 220,800 pixels,
5. drew the small Pebble,
6. uploaded and moved the entire mostly-transparent surface through `UpdateLayeredWindow`,
7. destroyed the GDI objects again.

That made cursor-follow motion trigger far more CPU, GDI, memory, and DWM compositor work than the visible overlay requires. On slower or graphics-constrained Windows systems, that work can make the hardware cursor feel delayed.

## What changed

- Keep one memory DC and DIB for the lifetime of the main Pebble window.
- Create and destroy those GDI resources on the overlay's existing thread-affine lifecycle.
- Crop the main layered window and `UpdateLayeredWindow` upload to `72 x 64`.
- Preserve the existing `460`-pixel backing stride so the shared Windows drawing helpers and sub-pebble renderer are untouched.
- Clear only the rows used by the compact main-Pebble crop.
- Retain the existing 60 fps easing and animation cadence.
- Keep the drop, outer glow, pointing halo, awareness eye, hit testing, topmost behavior, and click behavior unchanged.
- Add explicit failure handling for desktop DC, compatible DC, DIB, and bitmap-selection setup.

## Performance impact

- Layered compositor surface: `220,800` pixels -> `4,608` pixels (48x smaller, about 97.9% less).
- Per-frame clear: `220,800` pixels -> `29,440` backing pixels (about 86.7% less).
- Per-frame memory DC and DIB allocation/destruction: removed.

## Scope and compatibility

- Windows main Pebble only.
- Sub-pebbles keep their full backing window because they still support expanded result cards.
- macOS and Linux renderers are unchanged.
- No RPC, settings, state-machine, cursor-follow physics, hotkey, or visual timing changes.
- No schema or migration changes.

## Verification

- `.githooks/pre-commit`
  - 1,826 passed
  - 22 skipped
  - 0 failed
  - TypeScript type-check passed
- `gofmt`
- `git diff --check`
- Attempted local Windows cross-build:
  - cgo-disabled build reaches the vendored WebView package, which intentionally has no non-cgo Windows implementation.
  - cgo-enabled cross-build requires mingw (`gcc` on this Linux host does not support `-mthreads`).
  - The repository's Windows CI job installs mingw and is the authoritative target compile gate for this PR.

## Manual Windows verification checklist

- Move the pointer continuously on an affected Windows machine and confirm the cursor remains responsive with Pebble following.
- Verify idle breathing, listening/speaking color pulses, thinking orbit, asking ring, and working pulse.
- Verify awareness eye and blinded indicator are not clipped.
- Verify `[POINT:...]` movement and controlling halo are not clipped.
- Verify short-click summon, long-press blind toggle, Ctrl+Space, Ctrl+K, and Ctrl+middle-click.
- Leave Pebble running long enough to confirm GDI handles remain stable.

## Risk and rollback

Risk is low and isolated to Windows layered-window resource management and crop bounds. The backing DIB dimensions and drawing stride remain unchanged, which avoids a broad renderer refactor. If a visual is found outside the compact crop, increasing `mainPebbleWindowW/H` is a contained adjustment; reverting this single commit restores the prior path.