### PR TITLE
feat(i18n): add first-run response language selection

### DIFF
--- a/src/agents/conv/conv-orchestrator.test.ts
+++ b/src/agents/conv/conv-orchestrator.test.ts
@@ -182,7 +182,7 @@ describe('ConvOrchestrator', () => {
     const dispatcher = new TaskDispatcher(llm, registry, runner as never);
     const conv = new ConvOrchestrator(llm, registry, dispatcher, 'TestBot persona.');
 
-    await conv.processTurn('Hi', { userIdentity: 'Name: Alice', ambientFacts: 'Weather: sunny' });
+    await conv.processTurn('Hi', { responseLanguage: 'es', userIdentity: 'Name: Alice', ambientFacts: 'Weather: sunny' });
     await conv.processTurn('Hi again', { userIdentity: 'Name: Alice', ambientFacts: 'Weather: rainy' });
 
     expect(captured).toHaveLength(2);
@@ -198,6 +198,9 @@ describe('ConvOrchestrator', () => {
       expect(messages[1]!.role).toBe('system');
       expect(messages[1]!.cache).toBeUndefined();
       const dynamicText = String(messages[1]!.content);
+      if (messages === captured[0]) {
+        expect(dynamicText).toContain('Use Spanish for every user-facing response.');
+      }
       expect(dynamicText).toContain('Alice');
       expect(dynamicText).toContain('Weather');
     }

--- a/src/agents/conv/conv-orchestrator.ts
+++ b/src/agents/conv/conv-orchestrator.ts
@@ -25,10 +25,14 @@ import { CONV_TOOLS, CONV_TOOL_NAMES } from './conv-tools.ts';
 import { TaskDispatcher } from './task-dispatcher.ts';
 import { TaskRegistry } from './task-registry.ts';
 import type { TaskRecord, TaskRequest, TaskResultEnvelope } from './task-envelope.ts';
+import { buildResponseLanguageInstruction } from '../../config/language.ts';
+import type { JarvisLanguage } from '../../config/types.ts';
 
 const MAX_CONV_ITERATIONS = 8;
 
 export type ConvSystemContext = {
+  /** Live user preference; kept dynamic so a settings change applies now. */
+  responseLanguage?: JarvisLanguage;
   /** User persona (name, timezone, role, etc.) - short identity block. */
   userIdentity?: string;
   /**
@@ -416,6 +420,11 @@ export class ConvOrchestrator {
    */
   private buildDynamicSystemPrompt(context: ConvSystemContext): string {
     const parts: string[] = [];
+
+    if (context.responseLanguage) {
+      parts.push(buildResponseLanguageInstruction(context.responseLanguage));
+      parts.push('');
+    }
 
     if (context.userIdentity) {
       parts.push('# User');

--- a/src/config/language.test.ts
+++ b/src/config/language.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  buildResponseLanguageInstruction,
+  isJarvisLanguage,
+  resolveJarvisLanguage,
+} from './language.ts';
+
+describe('Jarvis response language', () => {
+  test('recognizes only languages the product currently supports', () => {
+    expect(isJarvisLanguage('en')).toBe(true);
+    expect(isJarvisLanguage('es')).toBe(true);
+    expect(isJarvisLanguage('fr')).toBe(false);
+    expect(isJarvisLanguage(null)).toBe(false);
+  });
+
+  test('normalizes BCP 47 locale variants and falls back safely', () => {
+    expect(resolveJarvisLanguage('es-ES')).toBe('es');
+    expect(resolveJarvisLanguage('es_MX')).toBe('es');
+    expect(resolveJarvisLanguage('EN-us')).toBe('en');
+    expect(resolveJarvisLanguage('fr-FR')).toBe('en');
+    expect(resolveJarvisLanguage(undefined)).toBe('en');
+  });
+
+  test('builds a strict single-language response contract', () => {
+    const prompt = buildResponseLanguageInstruction('es');
+    expect(prompt).toContain('Use Spanish for every user-facing response.');
+    expect(prompt).toContain('Stay in Spanish');
+    expect(prompt).toContain('unless the user explicitly asks');
+    expect(prompt).toContain('verbatim quotations may remain');
+  });
+});

--- a/src/config/language.ts
+++ b/src/config/language.ts
@@ -1,0 +1,43 @@
+import type { JarvisLanguage } from './types.ts';
+
+export const DEFAULT_JARVIS_LANGUAGE: JarvisLanguage = 'en';
+
+export const JARVIS_LANGUAGES: Readonly<Record<JarvisLanguage, { name: string; nativeName: string }>> = {
+  en: { name: 'English', nativeName: 'English' },
+  es: { name: 'Spanish', nativeName: 'Español' },
+};
+
+export function isJarvisLanguage(value: unknown): value is JarvisLanguage {
+  return typeof value === 'string' && Object.hasOwn(JARVIS_LANGUAGES, value);
+}
+
+/**
+ * Resolve persisted/browser locale-shaped values to a supported Jarvis
+ * language. Full BCP 47 tags are accepted so `es-ES` and `es-MX` both map to
+ * Spanish; unknown or missing values safely fall back to English.
+ */
+export function resolveJarvisLanguage(value: unknown): JarvisLanguage {
+  if (isJarvisLanguage(value)) return value;
+  if (typeof value === 'string') {
+    const base = value.trim().toLowerCase().split(/[-_]/, 1)[0];
+    if (isJarvisLanguage(base)) return base;
+  }
+  return DEFAULT_JARVIS_LANGUAGE;
+}
+
+/**
+ * High-priority behavioral instruction shared by every user-facing LLM path.
+ * The instruction is written in English because it is control text, while the
+ * selected language names make the output contract unambiguous to the model.
+ */
+export function buildResponseLanguageInstruction(value: unknown): string {
+  const language = resolveJarvisLanguage(value);
+  const label = JARVIS_LANGUAGES[language].name;
+  return [
+    '# Response Language',
+    `Use ${label} for every user-facing response.`,
+    `Stay in ${label} even when system instructions, tool output, source material, or conversation history are in another language.`,
+    'Do not switch languages unless the user explicitly asks you to in their current message.',
+    'Code, identifiers, URLs, proper nouns, and verbatim quotations may remain in their original form.',
+  ].join('\n');
+}

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -233,8 +233,12 @@ export type AuthConfig = {
   insecure_open_access?: boolean;
 };
 
+export type JarvisLanguage = 'en' | 'es';
+
 export type UserConfig = {
   name?: string;
+  /** Default language for every user-facing Jarvis response. */
+  language?: JarvisLanguage;
 };
 
 /**
@@ -451,6 +455,7 @@ export type JarvisConfig = {
 export const DEFAULT_CONFIG: JarvisConfig = {
   user: {
     name: '',
+    language: 'en',
   },
   telemetry: {
     enabled: true,

--- a/src/daemon/agent-service.ts
+++ b/src/daemon/agent-service.ts
@@ -74,6 +74,7 @@ import { TaskDispatcher } from '../agents/conv/task-dispatcher.ts';
 import { DialogueCompactor } from '../agents/conv/dialogue-compactor.ts';
 import type { ConvTaskEvent } from '../agents/conv/conv-orchestrator.ts';
 import { getRecentConversation, getMessages } from '../vault/conversations.ts';
+import { buildResponseLanguageInstruction, resolveJarvisLanguage } from '../config/language.ts';
 
 export class AgentService implements Service, IAgentService {
   name = 'agent';
@@ -358,6 +359,7 @@ export class AgentService implements Service, IAgentService {
         const taskListener = self.convTaskEventListener ?? undefined;
 
         for await (const event of self.convOrchestrator.streamTurn(text, {
+          responseLanguage: resolveJarvisLanguage(self.config.user?.language),
           userIdentity: identity,
           userProfile,
           recentDialogue,
@@ -516,6 +518,7 @@ export class AgentService implements Service, IAgentService {
     const result = await this.convOrchestrator.processTurn(
       text,
       {
+        responseLanguage: resolveJarvisLanguage(this.config.user?.language),
         userIdentity: identity,
         userProfile: this.buildUserProfileBlock(),
         recentDialogue,
@@ -777,6 +780,7 @@ export class AgentService implements Service, IAgentService {
     const traits = (this.config.personality?.core_traits ?? []).slice(0, 6).join(', ');
     return [
       `You are ${name}${userName ? `, ${userName}'s personal AI assistant` : ', a personal AI assistant'}, in a live, real-time voice conversation.`,
+      buildResponseLanguageInstruction(this.config.user?.language),
       'Speak naturally and conversationally, the way a person talks out loud.',
       traits ? `Your character: ${traits}.` : '',
       'You can take real actions with your tools whenever the user asks.',
@@ -838,6 +842,7 @@ export class AgentService implements Service, IAgentService {
 
     const context: PromptContext = {
       userName: this.config.user?.name || undefined,
+      responseLanguage: resolveJarvisLanguage(this.config.user?.language),
       currentTime: new Date().toISOString(),
       availableSpecialists: this.specialistListText || undefined,
       hasSidecars,

--- a/src/daemon/api-routes.ts
+++ b/src/daemon/api-routes.ts
@@ -1462,7 +1462,7 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
               name: next.name ?? '',
               language: resolveJarvisLanguage(next.language),
             },
-            message: 'Language preference saved. New Jarvis responses will use it immediately.',
+            message: 'User settings saved. Changes apply immediately.',
           });
         } catch (err) {
           return errorFromException(err);

--- a/src/daemon/api-routes.ts
+++ b/src/daemon/api-routes.ts
@@ -10,6 +10,7 @@ import { applyApprovalDecision } from './approval-decision.ts';
 import type { AgentService } from './agent-service.ts';
 import type { JarvisConfig } from '../config/types.ts';
 import { resolveRealtimeVoice, DEFAULT_BLOCKED_CATEGORIES } from '../config/realtime.ts';
+import { isJarvisLanguage, resolveJarvisLanguage } from '../config/language.ts';
 import type { EntityType } from '../vault/entities.ts';
 import type { CommitmentPriority, CommitmentStatus } from '../vault/commitments.ts';
 import type { ObservationType } from '../vault/observations.ts';
@@ -997,6 +998,7 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
             tutorial_dismissed: o?.tutorial_dismissed_at != null,
             tutorial_progress_step: o?.tutorial_progress_step ?? null,
             last_reset_at: o?.last_reset_at ?? null,
+            language: resolveJarvisLanguage(ctx.config.user?.language),
             // Boot timestamp + post-setup readiness let the dashboard
             // detect whether the background services (bgAgent, commitment
             // executor, awareness) are actually running. With in-process
@@ -1086,11 +1088,20 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
      * regresses state.
      */
     '/api/onboarding/skip': {
-      POST: async () => {
+      POST: async (req: Request) => {
         try {
+          const body = (await req.json().catch(() => ({}))) as { language?: unknown };
+          if (body.language !== undefined && !isJarvisLanguage(body.language)) {
+            return error('Unsupported language. Choose "en" or "es".', 400);
+          }
           const { saveUserSection } = await import('./user-settings.ts');
           const fresh = ctx.config;
           const now = Date.now();
+          if (body.language !== undefined) {
+            fresh.user = { ...fresh.user, language: body.language };
+            saveUserSection('user', fresh.user);
+            ctx.config.user = fresh.user;
+          }
           fresh.onboarding = {
             ...fresh.onboarding,
             setup_completed_at: fresh.onboarding?.setup_completed_at ?? now,
@@ -1262,6 +1273,7 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
      *
      * Body shape:
      *   {
+     *     user: { language: "en" | "es" },
      *     llm: {
      *       primary: "anthropic" | "openai" | ... ,
      *       <provider>: { api_key?: string, model?: string, base_url?: string }
@@ -1294,10 +1306,17 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
       POST: async (req: Request) => {
         try {
           const body = (await req.json()) as {
+            user?: { language?: unknown };
             llm?: Record<string, unknown>;
             stt?: Record<string, unknown>;
             tts?: Record<string, unknown>;
           };
+
+          // Validate the preference before any provider/settings writes so an
+          // unsupported value cannot leave first-run setup half-applied.
+          if (body.user?.language !== undefined && !isJarvisLanguage(body.user.language)) {
+            return error('Unsupported language. Choose "en" or "es".', 400);
+          }
 
           // 1. LLM settings — same path as /api/config/llm POST.
           if (body.llm && Object.keys(body.llm).length > 0) {
@@ -1314,6 +1333,9 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
           const { saveUserSection } = await import('./user-settings.ts');
           const { mergeSTTConfig, mergeTTSConfig } = await import('./config-merge.ts');
           const fresh = ctx.config;
+          if (body.user?.language !== undefined) {
+            fresh.user = { ...fresh.user, language: body.user.language };
+          }
           if (body.stt) {
             // Mirrors /api/config/stt POST semantics. The saveUserSection
             // below triggers the stt hot-reload applier.
@@ -1333,9 +1355,11 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
           };
           if (body.stt) saveUserSection('stt', fresh.stt);
           if (body.tts) saveUserSection('tts', fresh.tts);
+          if (body.user?.language !== undefined) saveUserSection('user', fresh.user);
           saveUserSection('onboarding', fresh.onboarding);
           if (body.stt) ctx.config.stt = fresh.stt;
           if (body.tts) ctx.config.tts = fresh.tts;
+          if (body.user?.language !== undefined) ctx.config.user = fresh.user;
           ctx.config.onboarding = fresh.onboarding;
 
           // 3. Hot-reload the TTS provider when possible so the post-setup
@@ -1389,6 +1413,10 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
         const config = ctx.config;
         return json({
           daemon: config.daemon,
+          user: {
+            name: config.user?.name ?? '',
+            language: resolveJarvisLanguage(config.user?.language),
+          },
           // LLM config is DB/keychain-managed (dashboard). Report a sanitized
           // canonical summary - provider names, single-LLM default, and the
           // tier map. The dedicated dashboard endpoint is /api/config/llm.
@@ -1403,6 +1431,42 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
           active_role: config.active_role,
           voice: config.voice ?? { wake_engine: 'openwakeword' },
         });
+      },
+    },
+
+    '/api/config/user': {
+      POST: async (req: Request) => {
+        try {
+          const body = (await req.json().catch(() => ({}))) as {
+            name?: unknown;
+            language?: unknown;
+          };
+          if (body.language !== undefined && !isJarvisLanguage(body.language)) {
+            return error('Unsupported language. Choose "en" or "es".', 400);
+          }
+          if (body.name !== undefined && typeof body.name !== 'string') {
+            return error('User name must be a string.', 400);
+          }
+
+          const next = {
+            ...ctx.config.user,
+            ...(typeof body.name === 'string' ? { name: body.name.trim() } : {}),
+            ...(body.language !== undefined ? { language: body.language } : {}),
+          };
+          const { saveUserSection } = await import('./user-settings.ts');
+          ctx.config.user = next;
+          saveUserSection('user', next);
+          return json({
+            ok: true,
+            user: {
+              name: next.name ?? '',
+              language: resolveJarvisLanguage(next.language),
+            },
+            message: 'Language preference saved. New Jarvis responses will use it immediately.',
+          });
+        } catch (err) {
+          return errorFromException(err);
+        }
       },
     },
 
@@ -2296,6 +2360,10 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
           { voice_id: 'en-AU-NatashaNeural', name: 'Natasha (AU Female)', category: 'neural' },
           { voice_id: 'en-US-JennyNeural', name: 'Jenny (US Female)', category: 'neural' },
           { voice_id: 'en-US-DavisNeural', name: 'Davis (US Male)', category: 'neural' },
+          { voice_id: 'es-ES-ElviraNeural', name: 'Elvira (Spain Female)', category: 'neural' },
+          { voice_id: 'es-ES-AlvaroNeural', name: 'Álvaro (Spain Male)', category: 'neural' },
+          { voice_id: 'es-MX-DaliaNeural', name: 'Dalia (Mexico Female)', category: 'neural' },
+          { voice_id: 'es-MX-JorgeNeural', name: 'Jorge (Mexico Male)', category: 'neural' },
         ]);
       },
     },

--- a/src/daemon/background-agent-service.ts
+++ b/src/daemon/background-agent-service.ts
@@ -31,6 +31,7 @@ import { buildSystemPromptParts, type PromptContext, type SystemPromptParts } fr
 import { getDueCommitments, getUpcoming } from '../vault/commitments.ts';
 import { getRecentObservations } from '../vault/observations.ts';
 import { findContent } from '../vault/content-pipeline.ts';
+import { resolveJarvisLanguage } from '../config/language.ts';
 
 const BG_CDP_PORT = 9223;
 const BG_PROFILE_DIR = join(homedir(), '.jarvis', 'browser', 'bg-profile');
@@ -165,6 +166,7 @@ export class BackgroundAgentService implements Service, IAgentService {
 
   private buildPromptContext(): PromptContext {
     const context: PromptContext = {
+      responseLanguage: resolveJarvisLanguage(this.config.user?.language),
       currentTime: new Date().toISOString(),
     };
 

--- a/src/daemon/onboarding-interviewer.test.ts
+++ b/src/daemon/onboarding-interviewer.test.ts
@@ -68,6 +68,13 @@ describe('createInterviewSession', () => {
     expect(session.done).toBe(false);
     expect(session.factsRecorded).toBe(0);
     expect(session.farewell).toBeUndefined();
+    expect(session.language).toBe('en');
+  });
+
+  test('adds the selected language contract to the interviewer prompt', () => {
+    const session = createInterviewSession('es-MX');
+    expect(session.language).toBe('es');
+    expect(session.messages[0]?.content).toContain('Use Spanish for every user-facing response.');
   });
 });
 
@@ -219,5 +226,17 @@ describe('runInterviewTurn — MAX_INTERVIEW_TURNS safeguard', () => {
     expect(session.done).toBe(true);
     expect(result.farewell).toBeDefined();
     expect(result.farewell!.length).toBeGreaterThan(0);
+  });
+
+  test('the turn-cap safeguard respects the selected Spanish language', async () => {
+    const session = createInterviewSession('es');
+    session.turnCount = MAX_INTERVIEW_TURNS;
+    const llm = fakeLLM([]);
+
+    const result = await runInterviewTurn(session, llm, 'una cosa más');
+
+    expect(result.done).toBe(true);
+    expect(result.farewell).toContain('Hemos cubierto bastante');
+    expect(result.farewell).not.toContain("We've covered");
   });
 });

--- a/src/daemon/onboarding-interviewer.ts
+++ b/src/daemon/onboarding-interviewer.ts
@@ -28,6 +28,8 @@
 import type { LLMManager } from '../llm/manager.ts';
 import type { LLMMessage, LLMTool, LLMToolCall } from '../llm/provider.ts';
 import { appendUserProfileFact, markInterviewWrapped } from '../vault/user-profile.ts';
+import { buildResponseLanguageInstruction, resolveJarvisLanguage } from '../config/language.ts';
+import type { JarvisLanguage } from '../config/types.ts';
 
 /** Hard cap on agent turns per session — defends against forget-to-wrap loops. */
 export const MAX_INTERVIEW_TURNS = 30;
@@ -132,16 +134,23 @@ export interface InterviewSession {
   farewell?: string;
   /** Count of facts recorded so far — surfaced to the UI for progress. */
   factsRecorded: number;
+  /** Selected response language, used by safeguards as well as the LLM. */
+  language: JarvisLanguage;
 }
 
-export function createInterviewSession(): InterviewSession {
+export function createInterviewSession(languageValue: unknown = 'en'): InterviewSession {
+  const language = resolveJarvisLanguage(languageValue);
   return {
     messages: [
-      { role: 'system', content: INTERVIEWER_SYSTEM_PROMPT },
+      {
+        role: 'system',
+        content: `${INTERVIEWER_SYSTEM_PROMPT}\n\n${buildResponseLanguageInstruction(language)}`,
+      },
     ],
     turnCount: 0,
     done: false,
     factsRecorded: 0,
+    language,
   };
 }
 
@@ -202,8 +211,9 @@ export async function runInterviewTurn(
   if (session.turnCount > MAX_INTERVIEW_TURNS) {
     // Safeguard: stop the loop if the agent never wrapped on its own.
     session.done = true;
-    session.farewell =
-      "We've covered a lot. Let me wrap here — I have plenty to start with. Welcome aboard.";
+    session.farewell = session.language === 'es'
+      ? 'Hemos cubierto bastante. Lo dejamos aquí; ya tengo mucho con lo que empezar. Bienvenido a bordo.'
+      : "We've covered a lot. Let me wrap here — I have plenty to start with. Welcome aboard.";
     markInterviewWrapped();
     return {
       assistantText: session.farewell,
@@ -256,7 +266,7 @@ export async function runInterviewTurn(
     if (wrappedThisTurn) {
       session.done = true;
       return {
-        assistantText: response.content || session.farewell || 'Done.',
+        assistantText: response.content || session.farewell || (session.language === 'es' ? 'Listo.' : 'Done.'),
         done: true,
         farewell: session.farewell,
         factsRecorded: session.factsRecorded,

--- a/src/daemon/ws-service.ts
+++ b/src/daemon/ws-service.ts
@@ -46,6 +46,7 @@ import { RealtimeBudgetTracker } from './realtime-budget.ts';
 import { classifyErrorString } from '../llm/provider.ts';
 import { getOrCreateConversation, addMessage } from '../vault/conversations.ts';
 import { maybeCreateUserProfileFollowupPrompt, recordUserProfileTurn } from '../user/profile-followup.ts';
+import { resolveJarvisLanguage } from '../config/language.ts';
 
 type VoiceSession = {
   requestId: string;
@@ -1440,7 +1441,9 @@ CRITICAL — when in genuine doubt between "make in a new project" vs "add to th
   ): Promise<void> {
     let session = this.interviewSessions.get(ws);
     if (!session) {
-      session = createInterviewSession();
+      session = createInterviewSession(
+        resolveJarvisLanguage(this.agentService.getConfig().user?.language),
+      );
       this.interviewSessions.set(ws, session);
     }
 

--- a/src/roles/prompt-builder.test.ts
+++ b/src/roles/prompt-builder.test.ts
@@ -33,6 +33,14 @@ describe('buildSystemPromptParts', () => {
     expect(parts.static).not.toContain('User opened the dashboard');
   });
 
+  it('pins the selected response language in the static prompt', () => {
+    const spanish = buildSystemPromptParts(role, makeContext({ responseLanguage: 'es' }));
+    expect(spanish.static).toContain('# Response Language');
+    expect(spanish.static).toContain('Use Spanish for every user-facing response.');
+    expect(spanish.static).toContain('Do not switch languages unless the user explicitly asks');
+    expect(spanish.dynamic).not.toContain('# Response Language');
+  });
+
   it('puts all volatile context in the dynamic part', () => {
     const context = makeContext();
     const parts = buildSystemPromptParts(role, context);

--- a/src/roles/prompt-builder.ts
+++ b/src/roles/prompt-builder.ts
@@ -1,5 +1,7 @@
 import type { RoleDefinition } from './types.ts';
 import { buildToolGuide } from './tool-guide.ts';
+import { buildResponseLanguageInstruction } from '../config/language.ts';
+import type { JarvisLanguage } from '../config/types.ts';
 
 export type PromptContext = {
   userName?: string;
@@ -15,6 +17,8 @@ export type PromptContext = {
   activeGoals?: string;
   hasSidecars?: boolean;
   effectiveAuthorityLevel?: number;
+  /** Language Jarvis must use for all user-facing output. */
+  responseLanguage?: JarvisLanguage;
 };
 
 /**
@@ -81,6 +85,13 @@ export function buildSystemPromptParts(role: RoleDefinition, context?: PromptCon
     sections.push(`Tone: ${role.communication_style.tone}. Verbosity: ${role.communication_style.verbosity}. Formality: ${role.communication_style.formality}.`);
     sections.push('');
   }
+
+  // Output language is a user-owned, process-stable preference. Keep it in
+  // the static/cacheable prefix and state it explicitly: without this, models
+  // tend to drift back to the English used by the rest of the system prompt.
+  sections.push(buildResponseLanguageInstruction(context?.responseLanguage));
+  sections.push('');
+
   // Task-acknowledgment rule is universal (not role-specific) - keep it.
   sections.push('**Task Acknowledgment**: When asked to perform a task that requires tool use, ALWAYS give a brief acknowledgment first (e.g., "On it.", "Let me check.", "I\'ll look into that.") before using any tools. Never silently start executing tools — the user should know you understood their request.');
   sections.push('');

--- a/ui/src/v2/language.ts
+++ b/ui/src/v2/language.ts
@@ -1,0 +1,2 @@
+/** Languages currently supported by Jarvis response and dashboard settings. */
+export type JarvisLanguage = "en" | "es";

--- a/ui/src/v2/onboarding/OnboardingWizard.tsx
+++ b/ui/src/v2/onboarding/OnboardingWizard.tsx
@@ -13,6 +13,13 @@ import "./OnboardingWizard.css";
 type StepKey =
   | "welcome" | "perms" | "brain" | "hear" | "speak" | "connect" | "interview" | "tour" | "allset";
 
+type JarvisLanguage = "en" | "es";
+
+const LANGUAGES: ReadonlyArray<{ id: JarvisLanguage; label: string }> = [
+  { id: "en", label: "English" },
+  { id: "es", label: "Español" },
+];
+
 const STEPS: ReadonlyArray<[StepKey, string]> = [
   ["welcome", "Welcome"], ["perms", "Permissions"], ["brain", "The brain"],
   ["hear", "Hearing"], ["speak", "Speaking"], ["connect", "Connect"],
@@ -63,7 +70,16 @@ const EDGE_VOICES = [
   { label: "Natasha · AU Female", id: "en-AU-NatashaNeural" },
   { label: "Jenny · US Female", id: "en-US-JennyNeural" },
   { label: "Davis · US Male", id: "en-US-DavisNeural" },
+  { label: "Elvira · España · Femenina", id: "es-ES-ElviraNeural" },
+  { label: "Álvaro · España · Masculina", id: "es-ES-AlvaroNeural" },
+  { label: "Dalia · México · Femenina", id: "es-MX-DaliaNeural" },
+  { label: "Jorge · México · Masculina", id: "es-MX-JorgeNeural" },
 ];
+
+const DEFAULT_EDGE_VOICE: Record<JarvisLanguage, string> = {
+  en: "en-US-AriaNeural",
+  es: "es-ES-ElviraNeural",
+};
 
 // ElevenLabs premade voice ids — stable, no /voices call needed (so a key
 // that can synthesize but lacks the voices_read scope still works).
@@ -130,11 +146,15 @@ export function OnboardingWizard({
   const [theme, setTheme] = useState<"light" | "dark">(
     () => (document.documentElement.getAttribute("data-theme") === "dark" ? "dark" : "light"),
   );
+  const [language, setLanguage] = useState<JarvisLanguage>(status?.language ?? "en");
   const applyTheme = (t: "light" | "dark") => {
     setTheme(t);
     document.documentElement.setAttribute("data-theme", t);
     try { localStorage.setItem("jarvis-theme", t); } catch { /* ignore */ }
   };
+  useEffect(() => {
+    document.documentElement.lang = language;
+  }, [language]);
 
   // permissions
   // brain
@@ -150,7 +170,7 @@ export function OnboardingWizard({
   const [sttEndpoint, setSttEndpoint] = useState("http://localhost:8080");
   // speaking
   const [tts, setTts] = useState<"off" | "edge" | "elevenlabs">("edge");
-  const [edgeVoice, setEdgeVoice] = useState(EDGE_VOICES[0]!.id);
+  const [edgeVoice, setEdgeVoice] = useState(DEFAULT_EDGE_VOICE[language]);
   const [elevenKey, setElevenKey] = useState("");
   const [elevenVoice, setElevenVoice] = useState(ELEVEN_PREMADE[0]!.voice_id);
   const [elevenModel, setElevenModel] = useState("eleven_flash_v2_5");
@@ -171,6 +191,10 @@ export function OnboardingWizard({
 
   // Reset the ElevenLabs test whenever the key changes or the provider flips.
   useEffect(() => { setTtsTest({ status: "idle" }); }, [elevenKey, tts]);
+
+  // Keep first-run voice output aligned with the selected response language.
+  // Users can still choose any voice manually after reaching the Speaking step.
+  useEffect(() => { setEdgeVoice(DEFAULT_EDGE_VOICE[language]); }, [language]);
 
   useEffect(() => {
     const p = PROVIDERS.find((x) => x.id === provId)!;
@@ -267,7 +291,7 @@ export function OnboardingWizard({
       if (tts === "edge") { ttsBlock.voice = edgeVoice; ttsBlock.rate = "+0%"; }
       else if (tts === "elevenlabs") ttsBlock.elevenlabs = { api_key: elevenKey, voice_id: elevenVoice, model: elevenModel };
 
-      const payload: Record<string, unknown> = { llm, tts: ttsBlock };
+      const payload: Record<string, unknown> = { user: { language }, llm, tts: ttsBlock };
       if (stt !== "skip") {
         const sttBlock: Record<string, unknown> = { provider: stt };
         if ((stt === "openai" || stt === "groq") && sttKey) sttBlock[stt] = { api_key: sttKey };
@@ -280,19 +304,23 @@ export function OnboardingWizard({
     } catch (e) {
       setError(e instanceof Error ? e.message : "Setup failed.");
     } finally { setBusy(false); }
-  }, [prov, provId, apiKey, baseUrl, model, tts, edgeVoice, elevenKey, elevenVoice, elevenModel, stt, sttKey, sttEndpoint]);
+  }, [language, prov, provId, apiKey, baseUrl, model, tts, edgeVoice, elevenKey, elevenVoice, elevenModel, stt, sttKey, sttEndpoint]);
 
   const skipAll = useCallback(async () => {
     setBusy(true);
     try {
-      const r = await fetch("/api/onboarding/skip", { method: "POST" });
+      const r = await fetch("/api/onboarding/skip", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ language }),
+      });
       if (!r.ok) throw new Error((await r.text().catch(() => "")) || `HTTP ${r.status}`);
       onComplete();
     } catch (e) {
       // Closing anyway would replay onboarding next launch — surface it instead.
       setError(e instanceof Error && e.message ? `Couldn't save the skip: ${e.message}` : "Couldn't reach the daemon — try again.");
     } finally { setBusy(false); }
-  }, [onComplete]);
+  }, [language, onComplete]);
 
   /* — speaking: ElevenLabs test via real synthesis — */
   // A synthesis call exercises the exact TTS path the app uses (and plays the
@@ -302,7 +330,7 @@ export function OnboardingWizard({
     if (!elevenKey.trim()) { setTtsTest({ status: "err", msg: "Paste your ElevenLabs key first." }); return; }
     setTtsTest({ status: "testing" });
     try {
-      const r = await fetch("/api/tts/preview", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ provider: "elevenlabs", api_key: elevenKey.trim(), voice_id: elevenVoice, model: elevenModel }) });
+      const r = await fetch("/api/tts/preview", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ provider: "elevenlabs", api_key: elevenKey.trim(), voice_id: elevenVoice, model: elevenModel, text: language === "es" ? "Hola, soy Jarvis. Así es como voy a sonar." : undefined }) });
       if (!r.ok) {
         const t = await r.json().catch(() => ({ error: "" })) as { error?: string };
         const m = (t.error || "").includes("401") ? "ElevenLabs rejected this key. Check it's valid and has text-to-speech access." : (t.error || "Test failed.").slice(0, 90);
@@ -314,7 +342,7 @@ export function OnboardingWizard({
     } catch (e) {
       setTtsTest({ status: "err", msg: e instanceof Error ? e.message : "Test failed." });
     }
-  }, [elevenKey, elevenVoice, elevenModel]);
+  }, [language, elevenKey, elevenVoice, elevenModel]);
 
   /* — connect actions — */
   // Google: real OAuth. Open the consent URL, then poll status until the
@@ -412,11 +440,12 @@ export function OnboardingWizard({
       const body: Record<string, unknown> = { provider: tts === "elevenlabs" ? "elevenlabs" : "edge" };
       if (tts === "elevenlabs") { body.api_key = elevenKey.trim(); body.voice_id = elevenVoice; body.model = elevenModel; }
       else body.voice = edgeVoice;
+      if (language === "es") body.text = "Hola, soy Jarvis. Así es como voy a sonar.";
       const r = await fetch("/api/tts/preview", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(body) });
       if (r.ok) await playPreviewAudio(r);
     } catch { /* best-effort */ }
     window.setTimeout(() => setPreviewing(false), 2000);
-  }, [previewing, tts, edgeVoice, elevenKey, elevenVoice, elevenModel]);
+  }, [language, previewing, tts, edgeVoice, elevenKey, elevenVoice, elevenModel]);
 
   const speakReady = tts !== "elevenlabs" || ttsTest.status === "ok";
 
@@ -470,6 +499,19 @@ export function OnboardingWizard({
             Let’s spend about five minutes setting it up: what it can touch, the brain and voice it runs on, and a little about you. You can skip anything and finish later.
           </div>
           <div style={{ marginTop: 22, display: "flex", flexDirection: "column", gap: 11, alignItems: "center" }}>
+            <div className="obw-themelab">Language · Idioma</div>
+            <div className="obw-themeseg" aria-label="Jarvis response language">
+              {LANGUAGES.map((option) => (
+                <button
+                  key={option.id}
+                  className={language === option.id ? "on" : ""}
+                  onClick={() => setLanguage(option.id)}
+                  aria-pressed={language === option.id}
+                >
+                  {option.label}
+                </button>
+              ))}
+            </div>
             <div className="obw-themelab">Choose your look</div>
             <div className="obw-themeseg">
               <button className={theme === "light" ? "on" : ""} onClick={() => applyTheme("light")}>Light</button>

--- a/ui/src/v2/onboarding/OnboardingWizard.tsx
+++ b/ui/src/v2/onboarding/OnboardingWizard.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useInterviewSession } from "./useInterviewSession";
 import type { OnboardingStatus } from "./useOnboardingStatus";
+import type { JarvisLanguage } from "../language";
 import "./OnboardingWizard.css";
 
 /* ═══════════════════ Onboarding · the nine-screen first-run flow ═══════════
@@ -12,8 +13,6 @@ import "./OnboardingWizard.css";
 
 type StepKey =
   | "welcome" | "perms" | "brain" | "hear" | "speak" | "connect" | "interview" | "tour" | "allset";
-
-type JarvisLanguage = "en" | "es";
 
 const LANGUAGES: ReadonlyArray<{ id: JarvisLanguage; label: string }> = [
   { id: "en", label: "English" },
@@ -152,10 +151,6 @@ export function OnboardingWizard({
     document.documentElement.setAttribute("data-theme", t);
     try { localStorage.setItem("jarvis-theme", t); } catch { /* ignore */ }
   };
-  useEffect(() => {
-    document.documentElement.lang = language;
-  }, [language]);
-
   // permissions
   // brain
   const [provId, setProvId] = useState("anthropic");

--- a/ui/src/v2/onboarding/useOnboardingStatus.ts
+++ b/ui/src/v2/onboarding/useOnboardingStatus.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import type { JarvisLanguage } from "../language";
 
 /** Phase E — same-origin BroadcastChannel name for cross-tab onboarding
  *  state sync. When one tab finishes a phase (or fires a reset), it
@@ -35,7 +36,7 @@ export interface OnboardingStatus {
   tutorial_progress_step: string | null;
   last_reset_at: number | null;
   /** User-facing response language selected during first-run setup. */
-  language?: "en" | "es";
+  language?: JarvisLanguage;
   /** Daemon process boot time (ms). Used in tandem with
    *  `post_setup_services_ready` to detect a stale daemon that needs a
    *  restart. */

--- a/ui/src/v2/onboarding/useOnboardingStatus.ts
+++ b/ui/src/v2/onboarding/useOnboardingStatus.ts
@@ -34,6 +34,8 @@ export interface OnboardingStatus {
   tutorial_dismissed: boolean;
   tutorial_progress_step: string | null;
   last_reset_at: number | null;
+  /** User-facing response language selected during first-run setup. */
+  language?: "en" | "es";
   /** Daemon process boot time (ms). Used in tandem with
    *  `post_setup_services_ready` to detect a stale daemon that needs a
    *  restart. */

--- a/ui/src/v2/rooms/settings/tabs/GeneralTab.tsx
+++ b/ui/src/v2/rooms/settings/tabs/GeneralTab.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import type { SettingsHook } from "../useSettingsData";
+import type { JarvisLanguage } from "../useSettingsData";
 import { confirmDialog } from "../../../ui/ConfirmDialog";
 import {
   resetOnboarding,
@@ -7,6 +8,10 @@ import {
 } from "../../../onboarding/resetClient";
 
 const HEARTBEAT_LEVELS = ["passive", "moderate", "aggressive"] as const;
+const RESPONSE_LANGUAGES: ReadonlyArray<{ id: JarvisLanguage; label: string }> = [
+  { id: "en", label: "English" },
+  { id: "es", label: "Español" },
+];
 
 export function GeneralTab({
   data,
@@ -28,6 +33,41 @@ export function GeneralTab({
 
   return (
     <div>
+      {/* Response language */}
+      <section className="v2-set__section">
+        <div className="v2-set__section-head">
+          <div>
+            <h3 className="v2-set__section-title">Jarvis language</h3>
+            <div className="v2-set__section-sub">
+              Pins chat, delegated work, onboarding interview, and voice replies to one language.
+            </div>
+          </div>
+          <span className="v2-set__chip">
+            {rootCfg?.user?.language === "es" ? "Español" : "English"}
+          </span>
+        </div>
+        <div style={{ display: "flex", gap: "var(--s-2)", flexWrap: "wrap" }}>
+          {RESPONSE_LANGUAGES.map((option) => (
+            <button
+              key={option.id}
+              type="button"
+              className={`v2-set__btn ${(rootCfg?.user?.language ?? "en") === option.id ? "v2-set__btn--primary" : ""}`}
+              data-active={(rootCfg?.user?.language ?? "en") === option.id}
+              aria-pressed={(rootCfg?.user?.language ?? "en") === option.id}
+              onClick={async () => {
+                const r = await data.setResponseLanguage(option.id);
+                onToast(r.message, r.ok ? "ok" : "warn");
+              }}
+            >
+              {option.label}
+            </button>
+          ))}
+        </div>
+        <p className="v2-set__hint">
+          Jarvis keeps this language unless you explicitly ask for another language in your current message.
+        </p>
+      </section>
+
       {/* Service / Restart */}
       <section className="v2-set__section">
         <div className="v2-set__section-head">

--- a/ui/src/v2/rooms/settings/useSettingsData.ts
+++ b/ui/src/v2/rooms/settings/useSettingsData.ts
@@ -1,4 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { JarvisLanguage } from "../../language";
+
+export type { JarvisLanguage } from "../../language";
 
 const POLL_INTERVAL_MS = 10000;
 
@@ -72,8 +75,6 @@ export const LLM_PROVIDER_LABELS = LLM_PROVIDER_KIND_LABELS;
 
 export type STTProvider = "openai" | "groq" | "sarvam" | "local";
 export type TTSProvider = "edge" | "elevenlabs" | "sarvam";
-export type JarvisLanguage = "en" | "es";
-
 /**
  * Per-provider summary returned by GET /api/config/llm. The credential value
  * (api_key) is never sent to the client - we only expose `has_api_key`. The

--- a/ui/src/v2/rooms/settings/useSettingsData.ts
+++ b/ui/src/v2/rooms/settings/useSettingsData.ts
@@ -72,6 +72,7 @@ export const LLM_PROVIDER_LABELS = LLM_PROVIDER_KIND_LABELS;
 
 export type STTProvider = "openai" | "groq" | "sarvam" | "local";
 export type TTSProvider = "edge" | "elevenlabs" | "sarvam";
+export type JarvisLanguage = "en" | "es";
 
 /**
  * Per-provider summary returned by GET /api/config/llm. The credential value
@@ -203,6 +204,10 @@ export interface AutostartStatus {
 }
 
 export interface RootConfig {
+  user?: {
+    name: string;
+    language: JarvisLanguage;
+  };
   heartbeat?: {
     interval_minutes: number;
     active_hours: { start: number; end: number };
@@ -780,6 +785,22 @@ export function useSettingsData() {
     [],
   );
 
+  const setResponseLanguage = useCallback(
+    async (language: JarvisLanguage): Promise<ActionResult> => {
+      try {
+        const r = await postJson<{ ok: boolean; message: string }>(
+          "/api/config/user",
+          { language },
+        );
+        await refresh();
+        return { ok: true, message: r.message || "Language preference saved." };
+      } catch (err) {
+        return { ok: false, message: err instanceof Error ? err.message : "Failed" };
+      }
+    },
+    [refresh],
+  );
+
   // ── Service control ─────────────────────────────────────────────────
   const restartDaemon = useCallback(async (): Promise<ActionResult> => {
     try {
@@ -948,6 +969,7 @@ export function useSettingsData() {
     setVoiceConfig,
     setHeartbeatInterval,
     setHeartbeatAggressiveness,
+    setResponseLanguage,
     restartDaemon,
     saveProfile,
     clearProfile,


### PR DESCRIPTION
## Summary

Adds a persisted Jarvis response-language preference, starting with English and Spanish, and exposes it during the first-run setup wizard.

This PR is intentionally limited to choosing and enforcing the language Jarvis uses when it talks to the user. It does **not** translate the dashboard UI; Spanish dashboard localization will be a separate PR so reviewers do not have to review behavior, persistence, prompt changes, and hundreds of translated strings together.

## User experience

- The Welcome screen now includes a bilingual `Language · Idioma` selector.
- Supported choices in this first increment:
  - English (`en`)
  - Español (`es`)
- The choice is saved with the rest of first-run setup.
- Clicking “I’ll do this later” also persists the selected language.
- Settings → General now exposes the same preference, so it can be changed later without replaying onboarding.
- The setting applies immediately to new model turns and new voice/interview sessions; no daemon restart is required.

## Language behavior

Every main user-facing LLM path now receives the same explicit response contract:

- use the configured language for every user-facing response;
- do not drift back to English because system instructions, tool output, source material, or history are English;
- switch only when the user explicitly requests another language in the current message;
- preserve code, identifiers, URLs, proper nouns, and verbatim quotations where appropriate.

The shared instruction is applied to:

- classic primary-agent chat;
- delegated task-tier work;
- router-first conversation-tier acknowledgments and result verbalization;
- background/proactive agent work;
- OpenAI realtime voice instructions;
- the conversational onboarding interviewer.

The router-first path reads the setting per turn, so a Settings change is not trapped in a stale conversation persona.

## Persistence and API

- Adds `user.language` as a user-owned DB-backed setting.
- Defaults old and new installs safely to `en`.
- Accepts full locale-shaped values in the shared resolver (`es-ES`, `es-MX` → `es`) while write APIs accept only currently supported product values.
- `GET /api/onboarding/status` reports the active language for wizard replay/resume.
- `GET /api/config` reports sanitized user name/language data.
- `POST /api/config/user` validates and hot-applies language changes.
- `POST /api/onboarding/setup` validates the language before any provider/config writes, avoiding partial setup on invalid input.
- `POST /api/onboarding/skip` accepts and persists the selected language.

No database migration is needed: the existing per-section JSON settings store merges older `user` rows over the new default.

## Spanish voice setup

Selecting Spanish during onboarding also defaults Edge TTS to a Spanish voice and uses a Spanish preview sentence.

Added verified voices:

- `es-ES-ElviraNeural`
- `es-ES-AlvaroNeural`
- `es-MX-DaliaNeural`
- `es-MX-JorgeNeural`

These IDs are present in Microsoft’s current [Azure Speech language and voice catalog](https://learn.microsoft.com/en-us/azure/ai-services/Speech-Service/language-support).

The user can still manually choose any available voice. Changing the response language later does not silently overwrite an already configured TTS voice.

## Safeguards and fallbacks

- Unknown/missing persisted language values fall back to English.
- The onboarding interviewer stores its resolved language in the session.
- The interview turn-limit and empty-farewell safeguards have Spanish output, so exceptional paths do not suddenly switch back to English.
- The document `lang` attribute follows the first-run selection for accessibility and the follow-up UI-localization work.

## Tests

Focused verification:

- language validation, locale normalization, and prompt generation;
- static primary/task prompt includes the Spanish contract;
- conversation-tier dynamic prompt receives the live language;
- onboarding interviewer prompt and Spanish safeguard output;
- 27 focused tests passed;
- TypeScript type-check passed;
- production UI bundle completed.

Full repository gate:

- 1,832 passed
- 22 skipped
- 0 failed
- 13,656 assertions
- template lint, migration check, EE import check, and TypeScript type-check all passed
- `git diff --check` passed

## Manual verification checklist

- Fresh setup: choose Español, finish provider/voice setup, and confirm the onboarding interview opens in Spanish.
- Ask in Spanish across several turns and confirm Jarvis does not drift to English after tool use or delegated work.
- Ask explicitly for one English response and confirm the model may switch for that request.
- Start a new turn without a language request and confirm the configured Spanish default applies again.
- Preview Edge TTS and verify the default voice and sample sentence are Spanish.
- Change Settings → General → Jarvis language and confirm the next chat response follows it without restart.
- Replay setup and confirm the saved language is preselected.
- Skip onboarding and confirm the selected language remains in Settings.

## Scope exclusions

Kept out of this PR on purpose:

- translating dashboard navigation, room content, settings labels, errors, and empty states;
- adding languages beyond English and Spanish;
- locale-aware dates/numbers;
- automatic STT language pinning;
- provider/model changes;
- unrelated mobile/theme work.

Those can land as independently reviewable follow-ups.