### PR TITLE
feat(cli): jarvis export/restore — consistent snapshot archive with stop-before-restore swap-in

### DIFF
--- a/bin/jarvis.ts
+++ b/bin/jarvis.ts
@@ -51,6 +51,8 @@ ${c.bold('Commands:')}
   ${c.cyan('enroll')}    Enroll a sidecar device: mint + store its JWT (no daemon needed)
   ${c.cyan('sidecars')}  List enrolled devices (sidecars list [--json])
   ${c.cyan('revoke')}    Revoke an enrolled device by sid
+  ${c.cyan('export')}    Export user data as a tar archive (export [--out <path>|-] [--full])
+  ${c.cyan('restore')}   Restore user data from an export archive (restore <archive|->)
   ${c.cyan('version')}   Print version number
   ${c.cyan('help')}      Show this help message
 
@@ -453,6 +455,14 @@ switch (command) {
   case 'revoke': {
     const { cmdRevoke } = await import('../src/cli/devices.ts');
     process.exit(await cmdRevoke(commandArgs));
+  }
+  case 'export': {
+    const { cmdExport } = await import('../src/cli/backup.ts');
+    process.exit(await cmdExport(commandArgs));
+  }
+  case 'restore': {
+    const { cmdRestore } = await import('../src/cli/backup.ts');
+    process.exit(await cmdRestore(commandArgs));
   }
   case 'uninstall':
     await cmdUninstall();

--- a/src/cli/backup.test.ts
+++ b/src/cli/backup.test.ts
@@ -1,0 +1,419 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { join } from 'node:path';
+import { existsSync, lstatSync, mkdirSync, mkdtempSync, rmSync, statSync, symlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { Database } from 'bun:sqlite';
+import { cmdExport, cmdRestore, EXPORT_FORMAT, type ExportManifest } from './backup.ts';
+import { acquireLockAt } from '../daemon/pid.ts';
+
+/**
+ * cmdExport/cmdRestore resolve the data dir through loadConfig(), which honors
+ * JARVIS_HOME — each test gets a throwaway data dir through that seam, exactly
+ * how the hosted wrappers and self-host users drive it.
+ */
+
+interface CapturedIo {
+  out: string[];
+  err: string[];
+  io: { out: (l: string) => void; err: (l: string) => void };
+}
+
+function capture(): CapturedIo {
+  const out: string[] = [];
+  const err: string[] = [];
+  return { out, err, io: { out: (l) => out.push(l), err: (l) => err.push(l) } };
+}
+
+function seedDataDir(dataDir: string): void {
+  mkdirSync(dataDir, { recursive: true });
+  const db = new Database(join(dataDir, 'jarvis.db'), { create: true });
+  db.exec('PRAGMA journal_mode=WAL');
+  db.exec('CREATE TABLE facts (id INTEGER PRIMARY KEY, body TEXT NOT NULL)');
+  db.exec("INSERT INTO facts (body) VALUES ('the-user-likes-tea'), ('meeting-at-nine')");
+  db.close();
+
+  mkdirSync(join(dataDir, 'pieces', 'my-piece'), { recursive: true });
+  Bun.write(join(dataDir, 'pieces', 'my-piece', 'index.ts'), 'export const piece = 1;\n');
+  mkdirSync(join(dataDir, 'content'), { recursive: true });
+  Bun.write(join(dataDir, 'content', 'note.md'), '# hello\n');
+  Bun.write(join(dataDir, 'realtime-budget.json'), '{"spent":0}\n');
+  Bun.write(join(dataDir, 'google-tokens.json'), '{"refresh_token":"secret"}\n');
+  mkdirSync(join(dataDir, 'sidecar-keys'), { recursive: true });
+  Bun.write(join(dataDir, 'sidecar-keys', 'private.pem'), 'FAKE KEY\n');
+  Bun.write(join(dataDir, '.secrets.enc'), 'ENCRYPTED-KEYCHAIN\n');
+  Bun.write(join(dataDir, '.secrets.key'), 'deadbeef\n');
+  // Never exported: server-authored config + ephemeral state.
+  Bun.write(join(dataDir, 'config.yaml'), 'daemon:\n  port: 3142\n');
+  mkdirSync(join(dataDir, 'logs'), { recursive: true });
+  Bun.write(join(dataDir, 'logs', 'jarvis.log'), 'log line\n');
+}
+
+async function tarEntries(archive: string): Promise<string[]> {
+  const proc = Bun.spawn(['tar', '-tf', archive], { stdout: 'pipe', stderr: 'pipe' });
+  const out = await new Response(proc.stdout).text();
+  expect(await proc.exited).toBe(0);
+  // Normalize to top-level entry names (tar lists dir contents too).
+  return [...new Set(out.trim().split('\n').map((l) => l.replace(/\/.*$/, '').replace(/\/$/, '')))];
+}
+
+let root: string;
+let dataDir: string;
+let prevHome: string | undefined;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'jarvis-backup-test-'));
+  dataDir = join(root, 'data');
+  seedDataDir(dataDir);
+  prevHome = process.env.JARVIS_HOME;
+  process.env.JARVIS_HOME = dataDir;
+});
+
+afterEach(() => {
+  if (prevHome === undefined) delete process.env.JARVIS_HOME;
+  else process.env.JARVIS_HOME = prevHome;
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe('jarvis export', () => {
+  test('default export curates user data and EXCLUDES secrets + config + logs', async () => {
+    const { out, io } = capture();
+    const archive = join(root, 'default.tar');
+    expect(await cmdExport(['--out', archive], io)).toBe(0);
+
+    const summary = JSON.parse(out.at(-1)!) as { path: string; sizeBytes: number; files: string[] };
+    expect(summary.path).toBe(archive);
+    expect(summary.sizeBytes).toBeGreaterThan(0);
+
+    const entries = await tarEntries(archive);
+    expect(entries).toContain('manifest.json');
+    expect(entries).toContain('jarvis.db');
+    expect(entries).toContain('pieces');
+    expect(entries).toContain('content');
+    expect(entries).toContain('realtime-budget.json');
+    expect(entries).not.toContain('google-tokens.json');
+    expect(entries).not.toContain('sidecar-keys');
+    expect(entries).not.toContain('.secrets.enc');
+    expect(entries).not.toContain('.secrets.key');
+    expect(entries).not.toContain('config.yaml');
+    expect(entries).not.toContain('logs');
+    expect(entries).not.toContain('jarvis.db-wal');
+    // Export staging is cleaned up from the data dir.
+    const debris = (await Array.fromAsync(new Bun.Glob('.export-*').scan({ cwd: dataDir, onlyFiles: false }))) as string[];
+    expect(debris).toEqual([]);
+  });
+
+  test('--full additionally includes the OS-level secrets and the keychain pair', async () => {
+    const { io } = capture();
+    const archive = join(root, 'full.tar');
+    expect(await cmdExport(['--out', archive, '--full'], io)).toBe(0);
+    const entries = await tarEntries(archive);
+    expect(entries).toContain('google-tokens.json');
+    expect(entries).toContain('sidecar-keys');
+    expect(entries).toContain('.secrets.enc');
+    expect(entries).toContain('.secrets.key');
+    expect(entries).not.toContain('config.yaml');
+  });
+
+  test('a symlinked entry is dereferenced: the archive holds real data', async () => {
+    // A self-hoster pointing `content` at a bigger disk must still get their
+    // actual files into the backup — an archived symlink would be an empty
+    // (and unrestorable) backup discovered only at restore time.
+    const real = join(root, 'real-content');
+    mkdirSync(real, { recursive: true });
+    await Bun.write(join(real, 'big.md'), '# on the big disk\n');
+    rmSync(join(dataDir, 'content'), { recursive: true });
+    symlinkSync(real, join(dataDir, 'content'));
+
+    const archive = join(root, 'deref.tar');
+    expect(await cmdExport(['--out', archive], capture().io)).toBe(0);
+
+    const extractTo = join(root, 'deref-extracted');
+    mkdirSync(extractTo);
+    const proc = Bun.spawn(['tar', '-xf', archive, '-C', extractTo]);
+    expect(await proc.exited).toBe(0);
+    expect(lstatSync(join(extractTo, 'content')).isSymbolicLink()).toBe(false);
+    expect(await Bun.file(join(extractTo, 'content', 'big.md')).text()).toBe('# on the big disk\n');
+  });
+
+  test('--out immediately followed by another flag is a usage error', async () => {
+    const { io } = capture();
+    expect(await cmdExport(['--out', '--full'], io)).toBe(2);
+  });
+
+  test('missing entries are skipped, not fatal', async () => {
+    rmSync(join(dataDir, 'pieces'), { recursive: true });
+    rmSync(join(dataDir, 'realtime-budget.json'));
+    const { out, io } = capture();
+    const archive = join(root, 'sparse.tar');
+    expect(await cmdExport(['--out', archive, '--full'], io)).toBe(0);
+    const manifest = JSON.parse(out.at(-1)!) as { files: string[] };
+    expect(manifest.files).not.toContain('pieces');
+    expect(manifest.files).toContain('content');
+  });
+
+  test('snapshot is consistent: uncommitted writes are not captured', async () => {
+    // A writer holds an open transaction with uncommitted rows while the
+    // export snapshots — the archive must contain only committed state.
+    const writer = new Database(join(dataDir, 'jarvis.db'));
+    writer.exec('BEGIN');
+    writer.exec("INSERT INTO facts (body) VALUES ('uncommitted-secret')");
+
+    const { io } = capture();
+    const archive = join(root, 'hot.tar');
+    expect(await cmdExport(['--out', archive], io)).toBe(0);
+    writer.exec('ROLLBACK');
+    writer.close();
+
+    const extractTo = join(root, 'hot-extracted');
+    mkdirSync(extractTo);
+    const proc = Bun.spawn(['tar', '-xf', archive, '-C', extractTo]);
+    expect(await proc.exited).toBe(0);
+    const snap = new Database(join(extractTo, 'jarvis.db'), { readonly: true });
+    const bodies = snap.query('SELECT body FROM facts ORDER BY id').all() as { body: string }[];
+    snap.close();
+    expect(bodies.map((r) => r.body)).toEqual(['the-user-likes-tea', 'meeting-at-nine']);
+  });
+
+  test('fails with exit 1 when there is no database', async () => {
+    rmSync(join(dataDir, 'jarvis.db'));
+    const { err, io } = capture();
+    expect(await cmdExport(['--out', join(root, 'x.tar')], io)).toBe(1);
+    expect(err.join('\n')).toContain('no database');
+  });
+
+  test('the manifest records format, variant, and file list', async () => {
+    const { io } = capture();
+    const archive = join(root, 'm.tar');
+    expect(await cmdExport(['--out', archive, '--full'], io)).toBe(0);
+    const extractTo = join(root, 'm-extracted');
+    mkdirSync(extractTo);
+    const proc = Bun.spawn(['tar', '-xf', archive, '-C', extractTo, 'manifest.json']);
+    expect(await proc.exited).toBe(0);
+    const manifest = JSON.parse(await Bun.file(join(extractTo, 'manifest.json')).text()) as ExportManifest;
+    expect(manifest.format).toBe(EXPORT_FORMAT);
+    expect(manifest.full).toBe(true);
+    expect(manifest.files).toContain('sidecar-keys');
+  });
+});
+
+describe('jarvis restore', () => {
+  test('round-trip: export --full, wipe, restore recovers db + files + modes', async () => {
+    const archive = join(root, 'rt.tar');
+    expect(await cmdExport(['--out', archive, '--full'], capture().io)).toBe(0);
+
+    // Simulate a fresh instance: new empty data dir with only a config.yaml.
+    rmSync(dataDir, { recursive: true });
+    mkdirSync(dataDir, { recursive: true });
+    Bun.write(join(dataDir, 'config.yaml'), 'daemon:\n  brain_domain: fresh.example\n');
+
+    const { out, io } = capture();
+    expect(await cmdRestore([archive], io)).toBe(0);
+    const summary = JSON.parse(out.at(-1)!) as { restored: boolean; files: string[] };
+    expect(summary.restored).toBe(true);
+
+    const db = new Database(join(dataDir, 'jarvis.db'), { readonly: true });
+    const rows = db.query('SELECT body FROM facts ORDER BY id').all() as { body: string }[];
+    db.close();
+    expect(rows.map((r) => r.body)).toEqual(['the-user-likes-tea', 'meeting-at-nine']);
+
+    expect(await Bun.file(join(dataDir, 'content', 'note.md')).text()).toBe('# hello\n');
+    expect(await Bun.file(join(dataDir, 'google-tokens.json')).text()).toContain('secret');
+    // The untouched, server-authored config survives.
+    expect(await Bun.file(join(dataDir, 'config.yaml')).text()).toContain('fresh.example');
+    // Secret modes are tightened.
+    expect(statSync(join(dataDir, 'google-tokens.json')).mode & 0o777).toBe(0o600);
+    expect(statSync(join(dataDir, 'sidecar-keys')).mode & 0o777).toBe(0o700);
+    expect(statSync(join(dataDir, 'sidecar-keys', 'private.pem')).mode & 0o777).toBe(0o600);
+    // The keychain pair (LLM provider credentials) comes back too — a --full
+    // restore must work without re-connecting anything.
+    expect(await Bun.file(join(dataDir, '.secrets.enc')).text()).toBe('ENCRYPTED-KEYCHAIN\n');
+    expect(statSync(join(dataDir, '.secrets.key')).mode & 0o777).toBe(0o600);
+  });
+
+  test('refuses while the daemon holds its lock', async () => {
+    // With JARVIS_HOME set, `dataDir/jarvis.pid` IS the daemon's own lock path
+    // (pid.ts resolves it from the same env) — this simulates a real running
+    // daemon, not just a lock backup.ts happens to probe.
+    const archive = join(root, 'locked.tar');
+    expect(await cmdExport(['--out', archive], capture().io)).toBe(0);
+    const lock = acquireLockAt(join(dataDir, 'jarvis.pid'), process.pid);
+    expect(lock).not.toBeNull();
+    try {
+      const { err, io } = capture();
+      expect(await cmdRestore([archive], io)).toBe(1);
+      expect(err.join('\n')).toContain('daemon is running');
+    } finally {
+      lock!.release();
+    }
+  });
+
+  test('rejects a garbage archive and leaves existing data untouched', async () => {
+    const bogus = join(root, 'bogus.tar');
+    await Bun.write(bogus, 'this is not a tar archive');
+    const { io } = capture();
+    expect(await cmdRestore([bogus], io)).toBe(1);
+    // Original data intact.
+    const db = new Database(join(dataDir, 'jarvis.db'), { readonly: true });
+    const n = db.query('SELECT COUNT(*) AS n FROM facts').get() as { n: number };
+    db.close();
+    expect(n.n).toBe(2);
+    // No staging debris left behind.
+    const debris = (await Array.fromAsync(new Bun.Glob('.restore-*').scan({ cwd: dataDir, onlyFiles: false }))) as string[];
+    expect(debris).toEqual([]);
+  });
+
+  test('rejects an archive with a corrupt database', async () => {
+    // Build a tar whose jarvis.db is garbage but whose manifest is valid.
+    const forge = join(root, 'forge');
+    mkdirSync(forge, { recursive: true });
+    await Bun.write(
+      join(forge, 'manifest.json'),
+      JSON.stringify({ format: EXPORT_FORMAT, brainVersion: '0.0.0', createdAt: '', full: false, files: ['manifest.json', 'jarvis.db'] }),
+    );
+    await Bun.write(join(forge, 'jarvis.db'), 'garbage bytes, not sqlite');
+    const bad = join(root, 'bad.tar');
+    const proc = Bun.spawn(['tar', '-cf', bad, '-C', forge, 'manifest.json', 'jarvis.db']);
+    expect(await proc.exited).toBe(0);
+
+    const { err, io } = capture();
+    expect(await cmdRestore([bad], io)).toBe(1);
+    expect(err.join('\n')).toMatch(/integrity_check|not a database|restore failed/);
+    const db = new Database(join(dataDir, 'jarvis.db'), { readonly: true });
+    expect((db.query('SELECT COUNT(*) AS n FROM facts').get() as { n: number }).n).toBe(2);
+    db.close();
+  });
+
+  test('rejects an unsupported manifest format', async () => {
+    const forge = join(root, 'forge2');
+    mkdirSync(forge, { recursive: true });
+    await Bun.write(
+      join(forge, 'manifest.json'),
+      JSON.stringify({ format: 999, brainVersion: '9.9.9', createdAt: '', full: false, files: [] }),
+    );
+    const db = new Database(join(forge, 'jarvis.db'), { create: true });
+    db.exec('CREATE TABLE t (x)');
+    db.close();
+    const bad = join(root, 'future.tar');
+    const proc = Bun.spawn(['tar', '-cf', bad, '-C', forge, 'manifest.json', 'jarvis.db']);
+    expect(await proc.exited).toBe(0);
+
+    const { err, io } = capture();
+    expect(await cmdRestore([bad], io)).toBe(1);
+    expect(err.join('\n')).toContain('unsupported archive format');
+  });
+
+  test('an archive whose entry is a SYMLINK is refused, data untouched', async () => {
+    // age gives confidentiality, not sender authenticity: anyone who can write
+    // the bucket could substitute a valid archive. A symlinked `content` would
+    // otherwise be renamed into the data dir and then chmod'd through.
+    const forge = join(root, 'forge-link');
+    mkdirSync(forge, { recursive: true });
+    await Bun.write(
+      join(forge, 'manifest.json'),
+      JSON.stringify({ format: EXPORT_FORMAT, brainVersion: '0.0.0', createdAt: '', full: true, files: [] }),
+    );
+    const db = new Database(join(forge, 'jarvis.db'), { create: true });
+    db.exec('CREATE TABLE t (x)');
+    db.close();
+    symlinkSync('/etc', join(forge, 'content'));
+    const evil = join(root, 'evil.tar');
+    // -h would dereference; we want the symlink itself in the archive.
+    const proc = Bun.spawn(['tar', '-cf', evil, '-C', forge, 'manifest.json', 'jarvis.db', 'content']);
+    expect(await proc.exited).toBe(0);
+
+    const { err, io } = capture();
+    expect(await cmdRestore([evil], io)).toBe(1);
+    expect(err.join('\n')).toContain('symlink');
+    // The pre-existing content dir is still the real one, and /etc is intact.
+    expect(await Bun.file(join(dataDir, 'content', 'note.md')).text()).toBe('# hello\n');
+    expect(lstatSync(join(dataDir, 'content')).isSymbolicLink()).toBe(false);
+  });
+
+  test('a failed swap rolls back: no half-restored data dir, WAL preserved', async () => {
+    const archive = join(root, 'rollback.tar');
+    expect(await cmdExport(['--out', archive, '--full'], capture().io)).toBe(0);
+
+    // Local state diverges after the export: a DB row, a content edit, and a
+    // WAL file as a SIGKILL'd daemon would leave behind (committed frames the
+    // main DB file doesn't have yet). ALL of it must survive the failed
+    // restore — the WAL especially, since it is retired before the DB swap.
+    const contentDir = join(dataDir, 'content');
+    await Bun.write(join(contentDir, 'note.md'), '# LOCAL EDIT\n');
+    const dbBefore = new Database(join(dataDir, 'jarvis.db'));
+    dbBefore.exec("INSERT INTO facts (body) VALUES ('written-after-the-export')");
+    dbBefore.close();
+    rmSync(join(dataDir, 'jarvis.db-wal'), { force: true });
+    await Bun.write(join(dataDir, 'jarvis.db-wal'), 'SENTINEL-WAL-FRAMES');
+
+    // Inject a failure right after `content` swapped in: the DB, `pieces` and
+    // `content` swaps have all completed and must every one be undone. (A test
+    // hook, because rename gives no natural same-filesystem failure to arrange:
+    // the old chmod-the-data-dir approach failed while CREATING the staging
+    // dir, so the swap/rollback machinery never ran at all.)
+    const { err, io } = capture();
+    const code = await cmdRestore([archive], io, { failAfterSwap: 'content' });
+    expect(code).toBe(1);
+    expect(err.join('\n')).toContain('injected failure');
+
+    // The WAL is back in place, byte-identical — then clear it so SQLite
+    // doesn't try to read the sentinel as real frames.
+    expect(await Bun.file(join(dataDir, 'jarvis.db-wal')).text()).toBe('SENTINEL-WAL-FRAMES');
+    rmSync(join(dataDir, 'jarvis.db-wal'));
+
+    // Everything the instance had before the attempt is still there.
+    const db = new Database(join(dataDir, 'jarvis.db'), { readonly: true });
+    const bodies = (db.query('SELECT body FROM facts ORDER BY id').all() as { body: string }[]).map((r) => r.body);
+    db.close();
+    expect(bodies).toContain('written-after-the-export');
+    expect(await Bun.file(join(contentDir, 'note.md')).text()).toBe('# LOCAL EDIT\n');
+    // And no debris.
+    const debris = (await Array.fromAsync(
+      new Bun.Glob('.pre-restore-*').scan({ cwd: dataDir, onlyFiles: false }),
+    )) as string[];
+    expect(debris).toEqual([]);
+  });
+
+  test('warns when the archive comes from a newer brain', async () => {
+    const forge = join(root, 'forge-newer');
+    mkdirSync(forge, { recursive: true });
+    await Bun.write(
+      join(forge, 'manifest.json'),
+      JSON.stringify({ format: EXPORT_FORMAT, brainVersion: '999.0.0', createdAt: '', full: false, files: ['manifest.json', 'jarvis.db'] }),
+    );
+    const db = new Database(join(forge, 'jarvis.db'), { create: true });
+    db.exec('CREATE TABLE t (x)');
+    db.close();
+    const newer = join(root, 'newer.tar');
+    const proc = Bun.spawn(['tar', '-cf', newer, '-C', forge, 'manifest.json', 'jarvis.db']);
+    expect(await proc.exited).toBe(0);
+
+    const { err, io } = capture();
+    expect(await cmdRestore([newer], io)).toBe(0);
+    expect(err.join('\n')).toContain('newer than this brain');
+  });
+
+  test('usage error without an archive argument', async () => {
+    const { io } = capture();
+    expect(await cmdRestore([], io)).toBe(2);
+  });
+});
+
+describe('bin dispatch (subprocess)', () => {
+  test('jarvis export --out - streams a valid tar to stdout', async () => {
+    const repoRoot = join(import.meta.dir, '..', '..');
+    const proc = Bun.spawn(['bun', join(repoRoot, 'bin', 'jarvis.ts'), 'export', '--out', '-', '--full'], {
+      env: { ...process.env, JARVIS_HOME: dataDir },
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    const bytes = new Uint8Array(await new Response(proc.stdout).arrayBuffer());
+    expect(await proc.exited).toBe(0);
+    expect(bytes.byteLength).toBeGreaterThan(0);
+
+    const streamed = join(root, 'streamed.tar');
+    await Bun.write(streamed, bytes);
+    const entries = await tarEntries(streamed);
+    expect(entries).toContain('jarvis.db');
+    expect(entries).toContain('google-tokens.json');
+  });
+});

--- a/src/cli/backup.ts
+++ b/src/cli/backup.ts
@@ -1,0 +1,491 @@
+/**
+ * Instance export/restore CLIs:
+ *
+ *   jarvis export [--out <path>|-] [--full]   consistent archive of user data
+ *   jarvis restore <archive|->                validate + replace data from an archive
+ *
+ * Export produces a PLAIN tar (compression/encryption are the caller's job —
+ * the hosting pipeline pipes through `zstd | age`, a self-hoster can redirect
+ * to a file). Content: a hot-consistent SQLite snapshot (`VACUUM INTO`, safe
+ * against concurrent WAL writers) that must pass `PRAGMA integrity_check`,
+ * plus the curated persistent files. The DB snapshot is point-in-time
+ * consistent; the other entries are copied into staging right after it (so
+ * they may lag the snapshot by moments, but tar never reads a live file and
+ * cannot fail on "file changed as we read it"). Symlinked entries are
+ * dereferenced — the archive always contains the real data, never a link.
+ * Ephemeral state (logs, caches, browser profiles, pidfile) and the
+ * server-authored config.yaml are never included.
+ *
+ * `--full` additionally includes the plaintext secrets: google-tokens.json,
+ * the sidecar signing keys, and the keychain pair (.secrets.enc/.secrets.key)
+ * that holds the LLM provider credentials — so a restore works without
+ * re-connecting anything. That is the variant hosting backups use; the
+ * default keeps the archive far less sensitive for user-facing downloads.
+ *
+ * Restore is stop-before-restore: it acquires the daemon's own flock (which
+ * is JARVIS_HOME-aware, same resolution the daemon uses) plus the data dir's,
+ * and HOLDS them until the swap is done — a running daemon makes restore
+ * refuse, and a daemon cannot start mid-restore. Files are staged under the
+ * data dir (same filesystem) and swapped in with renames; any failure before
+ * or during the swap rolls back to the pre-restore state. A `db_path` on a
+ * different filesystem than `data_dir` is unsupported: restore fails cleanly
+ * before touching the database (renames cannot cross filesystems).
+ *
+ * Trust model: tar's own defaults (GNU/bsdtar refuse `..` members and strip
+ * absolute paths; busybox tar is weaker — don't use it) plus the top-level
+ * type-checks below guard extraction, but archives are NOT authenticated:
+ * age gives confidentiality, not sender authenticity, and `pieces` contains
+ * executable code. Anyone able to substitute an archive in the backup bucket
+ * can run code — authenticity has to come from the pipeline (e.g. signing),
+ * not from these checks.
+ *
+ * Like devices.ts: these run WITHOUT the daemon, stdout is machine-readable
+ * (the tar stream in `--out -` mode, a JSON summary otherwise) and progress
+ * goes to stderr so provisioning can capture stdout verbatim.
+ */
+
+import { join, dirname } from 'node:path';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  lstatSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  chmodSync,
+  cpSync,
+  statSync,
+} from 'node:fs';
+import { homedir } from 'node:os';
+import { Database } from 'bun:sqlite';
+import { loadConfig } from '../config/loader.ts';
+import { acquireLockAt, lockPathFor } from '../daemon/pid.ts';
+import { getInstalledVersion } from './version.ts';
+
+interface CliIo {
+  out: (line: string) => void;
+  err: (line: string) => void;
+}
+
+const defaultIo: CliIo = {
+  out: (line) => console.log(line),
+  err: (line) => console.error(line),
+};
+
+/** Archive format version — bump on any breaking layout change. */
+export const EXPORT_FORMAT = 1;
+
+export interface ExportManifest {
+  format: number;
+  brainVersion: string;
+  createdAt: string;
+  full: boolean;
+  /** Top-level tar entry names actually included (existing paths only). */
+  files: string[];
+}
+
+/**
+ * The curated data-dir entries, relative to data_dir. Order matters only for
+ * readability of the manifest. `config.yaml` is deliberately absent: it is
+ * server-authored on hosting (write-config regenerates it on the restore
+ * target) and machine-specific on self-host.
+ */
+const BASE_ENTRIES = ['pieces', 'content', 'realtime-budget.json'];
+const SECRET_ENTRIES = ['google-tokens.json', 'sidecar-keys', '.secrets.enc', '.secrets.key'];
+
+/** Entries restored with tightened modes (plaintext secrets). */
+const SECRET_MODES: Record<string, { dir?: number; file: number }> = {
+  'google-tokens.json': { file: 0o600 },
+  'sidecar-keys': { dir: 0o700, file: 0o600 },
+  '.secrets.enc': { file: 0o600 },
+  '.secrets.key': { file: 0o600 },
+};
+
+function sqliteQuotePath(path: string): string {
+  return `'${path.replace(/'/g, "''")}'`;
+}
+
+/**
+ * Write a consistent snapshot of the DB to `outPath` and verify it. VACUUM
+ * INTO takes a read transaction, so it is safe while the daemon is writing
+ * (WAL); the result is a compact single file (no -wal/-shm sidecars).
+ */
+function snapshotDb(dbPath: string, outPath: string): void {
+  const src = new Database(dbPath, { readonly: true });
+  try {
+    src.exec(`VACUUM INTO ${sqliteQuotePath(outPath)}`);
+  } finally {
+    src.close();
+  }
+
+  const snap = new Database(outPath, { readonly: true });
+  try {
+    const row = snap.query('PRAGMA integrity_check').get() as { integrity_check?: string } | null;
+    if (row?.integrity_check !== 'ok') {
+      throw new Error(`snapshot failed integrity_check: ${JSON.stringify(row)}`);
+    }
+  } finally {
+    snap.close();
+  }
+}
+
+async function runTar(args: string[], io: CliIo, stdio: { stdin?: 'inherit'; stdout?: 'inherit' } = {}): Promise<void> {
+  const proc = Bun.spawn(['tar', ...args], {
+    stdin: stdio.stdin ?? 'ignore',
+    stdout: stdio.stdout ?? 'ignore',
+    stderr: 'pipe',
+  });
+  const stderr = await new Response(proc.stderr).text();
+  const code = await proc.exited;
+  if (code !== 0) {
+    if (stderr.trim()) io.err(stderr.trim());
+    throw new Error(`tar exited ${code}`);
+  }
+}
+
+/** Parse a leading `x.y.z` out of a version string, or null. */
+function parseVersion(v: string): [number, number, number] | null {
+  const m = /^(\d+)\.(\d+)\.(\d+)/.exec(v?.trim?.() ?? '');
+  return m ? [Number(m[1]), Number(m[2]), Number(m[3])] : null;
+}
+
+function isNewerVersion(candidate: string, baseline: string): boolean {
+  const a = parseVersion(candidate);
+  const b = parseVersion(baseline);
+  if (!a || !b) return false;
+  for (let i = 0; i < 3; i++) {
+    if (a[i]! !== b[i]!) return a[i]! > b[i]!;
+  }
+  return false;
+}
+
+export async function cmdExport(args: string[], io: CliIo = defaultIo): Promise<number> {
+  const full = args.includes('--full');
+  let out: string | undefined;
+  const outIdx = args.indexOf('--out');
+  if (outIdx !== -1) {
+    out = args[outIdx + 1];
+    if (!out || (out.startsWith('--') && out !== '-')) {
+      io.err('usage: jarvis export [--out <path>|-] [--full]');
+      return 2;
+    }
+  }
+  // Bare `-` positional is accepted as shorthand for `--out -`.
+  if (!out && args.includes('-')) out = '-';
+  const toStdout = out === '-';
+  const outPath = toStdout
+    ? undefined
+    : out ?? `jarvis-export-${new Date().toISOString().slice(0, 19).replace(/:/g, '-')}.tar`;
+
+  try {
+    const config = await loadConfig();
+    const dataDir = config.daemon.data_dir;
+    const dbPath = config.daemon.db_path;
+    if (!existsSync(dbPath)) {
+      io.err(`error: no database at ${dbPath} — nothing to export`);
+      return 1;
+    }
+
+    // Everything is staged under the data dir before tarring: tar never races
+    // the live daemon over a mutating file, and the (possibly large) snapshot
+    // stays off tmpfs on memory-constrained hosts. Disk is the cheap resource
+    // here; the copies are deleted in the finally.
+    const staging = mkdtempSync(join(dataDir, '.export-'));
+    try {
+      io.err(`Snapshotting database (${dbPath})...`);
+      snapshotDb(dbPath, join(staging, 'jarvis.db'));
+
+      const entries = [...BASE_ENTRIES, ...(full ? SECRET_ENTRIES : [])].filter((e) =>
+        existsSync(join(dataDir, e)),
+      );
+
+      // Some components write secrets to the legacy `~/.jarvis` root even when
+      // data_dir points elsewhere. Silently producing a "--full" archive that
+      // is missing them would only be discovered during a real restore — warn.
+      if (full) {
+        const legacyRoot = join(homedir(), '.jarvis');
+        if (dataDir !== legacyRoot) {
+          for (const entry of SECRET_ENTRIES) {
+            if (!existsSync(join(dataDir, entry)) && existsSync(join(legacyRoot, entry))) {
+              io.err(
+                `warning: '${entry}' exists at ${legacyRoot} but not in ${dataDir} — it will NOT be in this archive`,
+              );
+            }
+          }
+        }
+      }
+
+      for (const entry of entries) {
+        try {
+          cpSync(join(dataDir, entry), join(staging, entry), { recursive: true, dereference: true });
+        } catch (e) {
+          throw new Error(
+            `staging '${entry}' failed: ${e instanceof Error ? e.message : String(e)} (a broken symlink inside it cannot be archived)`,
+          );
+        }
+      }
+
+      const manifest: ExportManifest = {
+        format: EXPORT_FORMAT,
+        brainVersion: getInstalledVersion(join(import.meta.dir, '..', '..')),
+        createdAt: new Date().toISOString(),
+        full,
+        files: ['manifest.json', 'jarvis.db', ...entries],
+      };
+      await Bun.write(join(staging, 'manifest.json'), JSON.stringify(manifest, null, 2) + '\n');
+
+      const tarArgs = ['-cf', toStdout ? '-' : outPath!, '-C', staging, ...manifest.files];
+      io.err(`Archiving ${manifest.files.length} entries${full ? ' (full: secrets included)' : ''}...`);
+      await runTar(tarArgs, io, toStdout ? { stdout: 'inherit' } : {});
+
+      if (!toStdout) {
+        const sizeBytes = statSync(outPath!).size;
+        io.out(JSON.stringify({ path: outPath, sizeBytes, full, files: manifest.files }));
+      }
+      io.err('Export complete.');
+      return 0;
+    } finally {
+      rmSync(staging, { recursive: true, force: true });
+    }
+  } catch (e) {
+    io.err(`export failed: ${e instanceof Error ? e.message : String(e)}`);
+    return 1;
+  }
+}
+
+/**
+ * Move `source` onto `target`, setting the previous target aside rather than
+ * deleting it. Destroy-then-place would be unrecoverable: if the rename then
+ * failed (EXDEV when db_path lives on another filesystem, a transient EACCES),
+ * the old copy is already gone AND the staging dir gets cleaned up in the
+ * caller's `finally` — losing both. The aside copies are only discarded once
+ * every entry has swapped; `undo` puts them back if one doesn't.
+ */
+function swapIn(source: string, target: string, aside: string): { undo: () => void; commit: () => void } {
+  const hadTarget = existsSync(target);
+  if (hadTarget) renameSync(target, aside);
+  try {
+    renameSync(source, target);
+  } catch (e) {
+    if (hadTarget) renameSync(aside, target); // put it back before rethrowing
+    throw e;
+  }
+  return {
+    undo: () => {
+      rmSync(target, { recursive: true, force: true });
+      if (hadTarget) renameSync(aside, target);
+    },
+    commit: () => {
+      if (hadTarget) rmSync(aside, { recursive: true, force: true });
+    },
+  };
+}
+
+/**
+ * Move `target` out of the way with no replacement (same aside/undo/commit
+ * contract as `swapIn`). Used for the old DB's WAL/SHM sidecars: they must
+ * not survive next to the restored snapshot (a stale WAL would replay over
+ * it), but they cannot be deleted outright either — a SIGKILL'd daemon may
+ * have committed transactions that exist ONLY in the WAL, and a rollback has
+ * to put them back alongside the old database.
+ */
+function retireEntry(target: string, aside: string): { undo: () => void; commit: () => void } {
+  const hadTarget = existsSync(target);
+  if (hadTarget) renameSync(target, aside);
+  return {
+    undo: () => {
+      if (hadTarget) renameSync(aside, target);
+    },
+    commit: () => {
+      if (hadTarget) rmSync(aside, { recursive: true, force: true });
+    },
+  };
+}
+
+/**
+ * Reject anything that is not a plain file or a real directory. tar itself
+ * refuses `..` members and won't extract through a symlink, so this guards the
+ * remaining case: an archive whose `pieces`/`content`/`sidecar-keys` entry IS
+ * a symlink. Swapping that in would point the brain (and the recursive chmod
+ * below) at a path outside the data dir. (Top-level only — see the trust-model
+ * note in the header: this is a hardening layer, not an authenticity check.)
+ */
+function assertPlainEntry(path: string, entry: string): void {
+  const st = lstatSync(path);
+  if (st.isSymbolicLink()) throw new Error(`archive entry '${entry}' is a symlink — refusing to restore it`);
+  if (!st.isFile() && !st.isDirectory()) {
+    throw new Error(`archive entry '${entry}' is neither a file nor a directory — refusing to restore it`);
+  }
+}
+
+/** Recursively tighten modes on a restored secret entry (tar was created and
+ * extracted as the same user, but the archive may have transited systems with
+ * a looser umask — restat defensively). Uses lstat and never follows a link:
+ * chmod'ing through one would target whatever it points at. */
+function tightenModes(path: string, modes: { dir?: number; file: number }): void {
+  const st = lstatSync(path);
+  if (st.isSymbolicLink()) return;
+  if (st.isDirectory()) {
+    chmodSync(path, modes.dir ?? 0o700);
+    for (const name of readdirSync(path)) {
+      tightenModes(join(path, name), modes);
+    }
+  } else {
+    chmodSync(path, modes.file);
+  }
+}
+
+export async function cmdRestore(
+  args: string[],
+  io: CliIo = defaultIo,
+  /** Test-only fault injection: throw right after the named entry has swapped
+   * in, so tests can drive the rollback path deterministically (rename gives
+   * no natural same-filesystem failure hook). Never set in production. */
+  _hooks: { failAfterSwap?: string } = {},
+): Promise<number> {
+  const archive = args.filter((a) => !a.startsWith('--'))[0];
+  if (!archive) {
+    io.err('usage: jarvis restore <archive|->');
+    return 2;
+  }
+  const fromStdin = archive === '-';
+
+  try {
+    const config = await loadConfig();
+    const dataDir = config.daemon.data_dir;
+    const dbPath = config.daemon.db_path;
+
+    if (!fromStdin && !existsSync(archive)) {
+      io.err(`error: no archive at ${archive}`);
+      return 1;
+    }
+
+    // Stop-before-restore: ACQUIRE the daemon's own lock (JARVIS_HOME-aware —
+    // the same path resolution the daemon uses) plus the data dir's, and hold
+    // both until the swap is done. A running daemon makes this fail; holding
+    // the locks means one also cannot START mid-restore, and two concurrent
+    // restores cannot interleave.
+    mkdirSync(dataDir, { recursive: true });
+    const lockPaths = [...new Set([lockPathFor(), lockPathFor(dataDir)])];
+    const heldLocks: Array<{ release: () => void }> = [];
+    for (const lockPath of lockPaths) {
+      const lock = acquireLockAt(lockPath, process.pid);
+      if (!lock) {
+        for (const held of heldLocks) held.release();
+        io.err('error: the daemon is running — stop it first (jarvis stop)');
+        return 1;
+      }
+      heldLocks.push(lock);
+    }
+
+    try {
+      // Stage on the SAME filesystem as the data dir so the final swaps are
+      // renames, not copies (and never partial on failure).
+      const staging = mkdtempSync(join(dataDir, '.restore-'));
+      try {
+        io.err('Extracting archive...');
+        await runTar(
+          fromStdin ? ['-xf', '-', '-C', staging] : ['-xf', archive, '-C', staging],
+          io,
+          fromStdin ? { stdin: 'inherit' } : {},
+        );
+
+        const manifestPath = join(staging, 'manifest.json');
+        if (!existsSync(manifestPath)) throw new Error('archive has no manifest.json');
+        const manifest = JSON.parse(await Bun.file(manifestPath).text()) as ExportManifest;
+        if (manifest.format !== EXPORT_FORMAT) {
+          throw new Error(`unsupported archive format ${manifest.format} (this brain reads ${EXPORT_FORMAT})`);
+        }
+        // EXPORT_FORMAT covers the archive layout, not the DB schema: an
+        // archive from a newer brain can carry migrations this brain has never
+        // seen, which would otherwise surface only as daemon-boot failures.
+        const installed = getInstalledVersion(join(import.meta.dir, '..', '..'));
+        if (isNewerVersion(manifest.brainVersion, installed)) {
+          io.err(
+            `warning: archive was created by brain ${manifest.brainVersion} but this brain is ${installed} — its database schema may be newer than this brain understands`,
+          );
+        }
+        const snapPath = join(staging, 'jarvis.db');
+        if (!existsSync(snapPath)) throw new Error('archive has no jarvis.db');
+        const snap = new Database(snapPath, { readonly: true });
+        try {
+          const row = snap.query('PRAGMA integrity_check').get() as { integrity_check?: string } | null;
+          if (row?.integrity_check !== 'ok') throw new Error('archived database fails integrity_check');
+        } finally {
+          snap.close();
+        }
+
+        // Type-check every entry BEFORE anything is moved, so a crafted archive
+        // fails while the existing data is still fully intact.
+        assertPlainEntry(snapPath, 'jarvis.db');
+        const present = [...BASE_ENTRIES, ...SECRET_ENTRIES].filter((entry) => {
+          const source = join(staging, entry);
+          if (!existsSync(source)) return false;
+          assertPlainEntry(source, entry);
+          return true;
+        });
+
+        // All validation passed — swap in. Only KNOWN entry names are ever
+        // moved (a crafted archive can't plant arbitrary files).
+        //
+        // Each move sets the old copy aside instead of deleting it; a failure
+        // partway rolls every completed move back, so the data dir is never
+        // left half-restored (new DB + old content, or an entry lost entirely).
+        io.err('Swapping restored data into place...');
+        mkdirSync(dirname(dbPath), { recursive: true });
+        const asideDir = mkdtempSync(join(dataDir, '.pre-restore-'));
+        const swaps: Array<{ undo: () => void; commit: () => void }> = [];
+        const restored: string[] = ['jarvis.db'];
+        const failPoint = (name: string) => {
+          if (_hooks.failAfterSwap === name) throw new Error(`injected failure after swapping '${name}'`);
+        };
+        try {
+          swaps.push(retireEntry(`${dbPath}-wal`, join(asideDir, 'jarvis.db-wal')));
+          swaps.push(retireEntry(`${dbPath}-shm`, join(asideDir, 'jarvis.db-shm')));
+          swaps.push(swapIn(snapPath, dbPath, join(asideDir, 'jarvis.db')));
+          failPoint('jarvis.db');
+          for (const entry of present) {
+            swaps.push(swapIn(join(staging, entry), join(dataDir, entry), join(asideDir, entry)));
+            const modes = SECRET_MODES[entry];
+            if (modes) tightenModes(join(dataDir, entry), modes);
+            restored.push(entry);
+            failPoint(entry);
+          }
+        } catch (e) {
+          let rollbackFailed = false;
+          for (const swap of swaps.reverse()) {
+            try {
+              swap.undo();
+            } catch {
+              /* keep undoing the rest; the aside dir is preserved below */
+              rollbackFailed = true;
+            }
+          }
+          if (rollbackFailed) {
+            // The aside dir now holds the ONLY copy of whatever didn't make it
+            // back — deleting it here would be the exact double-loss the aside
+            // mechanism exists to prevent. Leave it for manual recovery.
+            io.err(`rollback incomplete — pre-restore copies kept at ${asideDir}`);
+          } else {
+            rmSync(asideDir, { recursive: true, force: true });
+          }
+          throw e;
+        }
+        for (const swap of swaps) swap.commit();
+        rmSync(asideDir, { recursive: true, force: true });
+
+        io.out(JSON.stringify({ restored: true, brainVersion: manifest.brainVersion, files: restored }));
+        io.err('Restore complete. Start the daemon with: jarvis start');
+        return 0;
+      } finally {
+        rmSync(staging, { recursive: true, force: true });
+      }
+    } finally {
+      for (const held of heldLocks) held.release();
+    }
+  } catch (e) {
+    io.err(`restore failed: ${e instanceof Error ? e.message : String(e)}`);
+    return 1;
+  }
+}

--- a/src/daemon/pid.ts
+++ b/src/daemon/pid.ts
@@ -25,18 +25,33 @@ import flockSource from './flock.c' with { type: 'file' };
 
 const JARVIS_DIR = join(homedir(), '.jarvis');
 const LOG_DIR = join(JARVIS_DIR, 'logs');
-const LOCK_PATH = join(JARVIS_DIR, 'jarvis.pid');
 const LOG_PATH = join(LOG_DIR, 'jarvis.log');
 
 /**
- * Resolve the lock-file path for a given data dir. The daemon itself always
- * runs against `~/.jarvis` (no override path today), but the encryption
- * rotation script accepts `--data-dir` and needs to probe the lock for that
- * specific dir, not the default. Keep this in lock-step with `LOCK_PATH`
- * above: any change to the default lock-file name has to be reflected here.
+ * The daemon's own root: `JARVIS_HOME` when set (hosted wrappers export it for
+ * every jarvis invocation on an instance), `~/.jarvis` otherwise. The lock
+ * lives HERE — in the same root the daemon serves — so tools that probe "is a
+ * daemon running against this data dir" (restore, the rotation script) and the
+ * daemon itself can never disagree about which file to flock. Computed per
+ * call, not at module load, because config loading honors the same env var.
+ */
+function daemonRootDir(): string {
+  return process.env.JARVIS_HOME || JARVIS_DIR;
+}
+
+function defaultLockPath(): string {
+  return join(daemonRootDir(), 'jarvis.pid');
+}
+
+/**
+ * Resolve the lock-file path for a given data dir. With no argument this is
+ * the daemon's own lock path (JARVIS_HOME-aware, see `daemonRootDir`); the
+ * encryption rotation script passes an explicit `--data-dir` to probe the lock
+ * for that specific dir. Keep the file name in lock-step with
+ * `defaultLockPath` above.
  */
 export function lockPathFor(dataDir?: string): string {
-  if (!dataDir) return LOCK_PATH;
+  if (!dataDir) return defaultLockPath();
   return join(dataDir, 'jarvis.pid');
 }
 
@@ -98,10 +113,10 @@ export function acquireLock(pid: number): boolean {
     // we create the data dir or open an fd (nothing to leak / clean up).
     const flock = getFlock();
 
-    mkdirSync(JARVIS_DIR, { recursive: true });
+    mkdirSync(daemonRootDir(), { recursive: true });
 
     // Open (or create) the lock file — don't truncate before locking
-    const fd = openSync(LOCK_PATH, constants.O_WRONLY | constants.O_CREAT, 0o644);
+    const fd = openSync(defaultLockPath(), constants.O_WRONLY | constants.O_CREAT, 0o644);
 
     // Try non-blocking exclusive lock
     const result = flock.do_flock(fd, LOCK_EX | LOCK_NB);
@@ -129,9 +144,9 @@ export function acquireLock(pid: number): boolean {
  *
  * Accepts an optional explicit `lockPath` to probe a non-default location
  * (used by the encryption rotation script when given `--data-dir`). The
- * default probes `~/.jarvis/jarvis.pid`.
+ * default probes the daemon's own lock path (JARVIS_HOME-aware).
  */
-export function isLocked(lockPath: string = LOCK_PATH): number | null {
+export function isLocked(lockPath: string = defaultLockPath()): number | null {
   if (!existsSync(lockPath)) return null;
 
   let fd: number;
@@ -159,7 +174,7 @@ export function isLocked(lockPath: string = LOCK_PATH): number | null {
     if (pid === 1 && isInsideContainer()) {
       // Only auto-release when probing the default daemon path. A custom
       // lockPath probe shouldn't be allowed to nuke an arbitrary file.
-      if (lockPath === LOCK_PATH) releaseLock();
+      if (lockPath === defaultLockPath()) releaseLock();
       return null;
     }
 
@@ -173,7 +188,7 @@ export function isLocked(lockPath: string = LOCK_PATH): number | null {
 /**
  * Acquire an exclusive lock at an arbitrary `lockPath`. Returns a handle that
  * releases the lock + unlinks the file. Distinct from `acquireLock`, which
- * always targets the default `~/.jarvis/jarvis.pid` and is only used by the
+ * always targets the daemon's own lock path and is only used by the
  * daemon itself. This helper exists for tests and tools (e.g. the rotation
  * script's test fixture) that need to simulate "a daemon is running against
  * this data dir" without colliding with a real daemon on the dev machine.
@@ -219,7 +234,8 @@ export function releaseLock(): void {
     lockFd = null;
   }
   try {
-    if (existsSync(LOCK_PATH)) unlinkSync(LOCK_PATH);
+    const lockPath = defaultLockPath();
+    if (existsSync(lockPath)) unlinkSync(lockPath);
   } catch { /* ignore */ }
 }
 
@@ -231,7 +247,7 @@ export function releaseLock(): void {
  *   PID\nPORT      (current — PID on line 1, bound port on line 2)
  */
 export function readPid(): number | null {
-  return readPidAt(LOCK_PATH);
+  return readPidAt(defaultLockPath());
 }
 
 function readPidAt(lockPath: string): number | null {
@@ -252,9 +268,10 @@ function readPidAt(lockPath: string): number | null {
  * Returns null for legacy lock files that contain only a PID.
  */
 export function readLockedPort(): number | null {
-  if (!existsSync(LOCK_PATH)) return null;
+  const lockPath = defaultLockPath();
+  if (!existsSync(lockPath)) return null;
   try {
-    const content = readFileSync(LOCK_PATH, 'utf-8');
+    const content = readFileSync(lockPath, 'utf-8');
     const lines = content.split(/\r?\n/);
     const raw = lines[1]?.trim();
     if (!raw) return null;
@@ -290,7 +307,7 @@ export function writeLockedPort(port: number): void {
  * Get the lock file path (for display purposes).
  */
 export function getPidPath(): string {
-  return LOCK_PATH;
+  return defaultLockPath();
 }
 
 /**


### PR DESCRIPTION
Adds `jarvis export` / `jarvis restore` for instance backup and migration.

## Export

- Plain tar on stdout or to a file (compression/encryption are the caller's job — the hosting pipeline pipes through `zstd | age`).
- Hot-consistent SQLite snapshot via `VACUUM INTO` (safe against concurrent WAL writers), verified with `PRAGMA integrity_check` before archiving.
- Curated entry allowlist (`pieces`, `content`, `realtime-budget.json`) plus a versioned `manifest.json`; ephemeral state and the server-authored `config.yaml` are never included.
- Entries are copied into staging before tarring, so tar never races the live daemon and symlinked entries are dereferenced — the archive always holds real data.
- `--full` additionally includes the plaintext secrets (`google-tokens.json`, sidecar signing keys, and the `.secrets.enc`/`.secrets.key` keychain pair holding LLM credentials) so a hosted disaster-recovery restore works without re-connecting anything. Secrets that live at legacy `~/.jarvis` but not in a split `data_dir` trigger a loud warning instead of silent omission.

## Restore

- Stop-before-restore: acquires the daemon's own flock (now `JARVIS_HOME`-aware, resolved the same way the daemon resolves it) plus the data dir's, and holds both for the entire swap — a running daemon makes restore refuse, a daemon cannot start mid-restore, and concurrent restores cannot interleave.
- All validation (archive format, DB integrity, lstat type-check of every entry) happens before anything moves; only allowlisted entry names ever leave staging.
- Swap-in is rename-based on the same filesystem, with each old copy set aside rather than deleted. A failure partway rolls every completed swap back — including the old DB's WAL/SHM, which are retired into the aside dir so a SIGKILL'd daemon's committed-only-in-WAL frames survive a failed restore. If rollback itself faults, the aside dir is preserved and its path printed instead of deleting the last surviving copy.
- Warns when the archive comes from a newer brain than the one installed (schema may be ahead of this brain's migrations).

## Notes

- The daemon lock path in `src/daemon/pid.ts` now honors `JARVIS_HOME`, so the lock always lives in the root the daemon serves. Self-host behavior without `JARVIS_HOME` is unchanged (`~/.jarvis/jarvis.pid`).
- Archives are confidential (age) but not authenticated; `pieces` contains executable code. The lstat checks are hardening, not a trust boundary — authenticity has to come from the pipeline. Documented in the module header.
- Restore's traversal safety leans on GNU/bsdtar defaults; busybox tar is not supported.
- Tests cover curation/exclusion, hot-snapshot consistency under an open transaction, garbage/corrupt/format-mismatch archives, symlink refusal on restore and dereference on export, secret mode tightening, daemon-lock refusal, and a real rollback path (fault-injected after several swaps completed, asserting WAL restoration).