### PR TITLE
Installer: report a pre-bundle sidecar package clearly instead of blaming the signature

### DIFF
--- a/sidecar/installer/autostart_policy_test.go
+++ b/sidecar/installer/autostart_policy_test.go
@@ -27,3 +27,22 @@ func TestShouldApplyAutostart(t *testing.T) {
 		}
 	}
 }
+
+// The darwin npm package only started shipping Jarvis.app at
+// minBundledSidecarVersion; earlier ones carry a bare binary that cannot
+// notify or hold TCC grants. The installer must refuse those — and must say so
+// in terms of the PACKAGE rather than blaming the signature. The first real
+// macOS test run reported "code-signature verification failed" for exactly
+// this case, which sends the reader after a signing bug that does not exist.
+func TestBundledSidecarVersionFloor(t *testing.T) {
+	for _, v := range []string{"0.8.0", "0.9.0"} {
+		if !versionLess(v, minBundledSidecarVersion) {
+			t.Errorf("%s predates the Jarvis.app bundle and must be refused", v)
+		}
+	}
+	for _, v := range []string{minBundledSidecarVersion, "0.9.2", "1.0.0"} {
+		if versionLess(v, minBundledSidecarVersion) {
+			t.Errorf("%s ships the bundle and must be accepted", v)
+		}
+	}
+}

--- a/sidecar/installer/flow.go
+++ b/sidecar/installer/flow.go
@@ -12,6 +12,13 @@ import (
 	"strings"
 )
 
+// minBundledSidecarVersion is the first sidecar release whose darwin npm
+// package ships the Jarvis.app bundle rather than a bare binary. Earlier
+// packages cannot be installed: macOS notifications are unavailable to a bare
+// binary, and TCC grants bind to a bundle identity, so installing one would
+// produce a sidecar that silently cannot notify or hold permissions.
+const minBundledSidecarVersion = "0.9.1"
+
 // minSetupSidecarVersion is the first sidecar release whose flag.Parse knows
 // --setup. Older sidecars hard-exit on unknown flags with a dead stderr under
 // -H windowsgui, so the handoff is version-gated.
@@ -99,6 +106,12 @@ func performInstall(registryURL string, silent bool, progress progressFn) instal
 		return fail(exitFilesystem, fmt.Errorf("could not unpack the payload: %w", err))
 	}
 	stagedBin := filepath.Join(staged, "bin")
+	// Layout before signature: a package that predates the current layout would
+	// otherwise surface as "code-signature verification failed", sending the
+	// reader after a signing problem that does not exist.
+	if err := checkPayloadLayout(stagedBin, rel.Version); err != nil {
+		return fail(exitVerification, err)
+	}
 	if err := verifyPayloadSignature(stagedBin); err != nil {
 		return fail(exitVerification, fmt.Errorf("code-signature verification failed (refusing to install an unverified sidecar): %w", err))
 	}

--- a/sidecar/installer/platform_darwin.go
+++ b/sidecar/installer/platform_darwin.go
@@ -143,11 +143,24 @@ func pidsForExecutable(binPath string) ([]int, error) {
 // verifyPayloadSignature runs Gatekeeper's own checks on the staged bundle.
 // With expectedTeamID set (release builds) the codesign requirement pins the
 // Developer ID team, so a valid-but-foreign signature is refused.
+// checkPayloadLayout rejects a package that predates the Jarvis.app bundle.
+func checkPayloadLayout(stagedBin, version string) error {
+	if _, err := os.Stat(filepath.Join(stagedBin, appBundleName)); err == nil {
+		return nil
+	}
+	if versionLess(version, minBundledSidecarVersion) {
+		return fmt.Errorf(
+			"sidecar %s ships a bare binary, not the %s bundle this installer requires "+
+				"(macOS notifications and permission grants both need the bundle). "+
+				"The npm 'latest' tag has to reach %s or newer before this installer can be used",
+			version, appBundleName, minBundledSidecarVersion)
+	}
+	return fmt.Errorf("sidecar %s should contain %s but does not — the published package looks malformed",
+		version, appBundleName)
+}
+
 func verifyPayloadSignature(stagedBin string) error {
 	app := filepath.Join(stagedBin, appBundleName)
-	if _, err := os.Stat(app); err != nil {
-		return fmt.Errorf("payload lacks %s: %w", appBundleName, err)
-	}
 	args := []string{"--verify", "--deep", "--strict", app}
 	if expectedTeamID != "" {
 		req := fmt.Sprintf(`anchor apple generic and certificate leaf[subject.OU] = "%s"`, expectedTeamID)

--- a/sidecar/installer/platform_other.go
+++ b/sidecar/installer/platform_other.go
@@ -27,6 +27,8 @@ func installedBinaryVersion(string) (string, error) {
 
 func stopRunningSidecar(installedSidecar, bool) error { return nil }
 
+func checkPayloadLayout(string, string) error { return nil }
+
 func verifyPayloadSignature(string) error {
 	return fmt.Errorf("code-signature verification is not available on this platform")
 }

--- a/sidecar/installer/platform_windows.go
+++ b/sidecar/installer/platform_windows.go
@@ -165,6 +165,16 @@ func findTrayWindow() uintptr {
 	return hwnd
 }
 
+// checkPayloadLayout rejects a package missing the executable we install, so
+// a malformed publish does not surface as a signature failure.
+func checkPayloadLayout(stagedBin, version string) error {
+	if _, err := os.Stat(filepath.Join(stagedBin, sidecarExeName)); err != nil {
+		return fmt.Errorf("sidecar %s should contain %s but does not — the published package looks malformed",
+			version, sidecarExeName)
+	}
+	return nil
+}
+
 // swapInstall replaces jarvis.exe in installDir (the only file the win32
 // package ships) with a rename-based rollback: the running instance was
 // already stopped, so the file lock is released.


### PR DESCRIPTION
Found by running the installer on a real macOS machine against the current npm `latest`.

## What happened

```
code-signature verification failed (refusing to install an unverified sidecar):
payload lacks Jarvis.app: stat .../staged/bin/Jarvis.app: no such file or directory
```

The refusal was correct — but the diagnosis was not. Nothing is wrong with any signature. `@usejarvis/sidecar-darwin-*` at 0.9.0 ships a bare `bin/jarvis`; the `Jarvis.app` bundle only starts shipping with the first release built by the new pipeline. The message sends the reader after a signing bug that does not exist.

## Change

Payload *layout* is now checked before signature verification, as its own step, and says what is actually wrong:

> sidecar 0.9.0 ships a bare binary, not the Jarvis.app bundle this installer requires (macOS notifications and permission grants both need the bundle). The npm 'latest' tag has to reach 0.9.1 or newer before this installer can be used

A missing executable in the Windows package is reported the same way ("the published package looks malformed") rather than as a signature failure.

The version floor is a named constant with a comment explaining *why* the bundle is mandatory — notifications are unavailable to a bare binary and TCC grants bind to a bundle identity, so installing the old layout would produce a sidecar that silently cannot notify or hold permissions. Covered by a test, mutation-checked.

## Not fixed here

The installer still cannot install anything on macOS until a sidecar release ships the bundle. That is intended: it now explains itself instead of failing cryptically.

Windows behaved correctly in the same test — it reached signature verification and refused an unsigned payload, which is the designed behaviour until the certificate is issued.