### PR TITLE
Rewrite the sidecar README around subsystems

### DIFF
--- a/sidecar/README.md
+++ b/sidecar/README.md
@@ -1,100 +1,162 @@
 # Sidecar
 
-A Go client that connects to the JARVIS brain over WebSocket and exposes local machine capabilities (terminal, filesystem, clipboard, screenshots, etc.) as RPC handlers.
+A Go program that runs on the user's machine, connects to the JARVIS brain over
+WebSocket, and exposes local capabilities (terminal, filesystem, clipboard,
+screenshots, browser control, OCR, …) as RPC handlers.
+
+It is also a **desktop application**, which is the part that surprises people
+reading the handler code: a menu-bar/tray item, a floating "pebble" overlay with
+wake-word audio, frameless always-on-top panels, global hotkeys and native
+notifications. That is why it is cgo-heavy and why the build has real platform
+prerequisites.
 
 ## Building
 
 ```bash
-go build -o jarvis-sidecar .
+make build          # -> ./jarvis   (injects the version from VERSION)
+make test           # vet + unit tests + cross-compiled tester binaries
+make dist           # all five target platforms into dist/
 ```
 
-Cross-compile for other platforms:
+Prefer `make` over a bare `go build`: the Makefile injects `-X
+main.sidecarVersion` from [`VERSION`](VERSION), and on macOS sets the 11.0
+deployment target that keeps APIs newer SDKs mark obsoleted compilable.
+
+### Cross-compilation
+
+**Plain `GOOS=… go build` does not work.** The sidecar needs cgo (webview_go,
+GTK/Cocoa overlays, malgo audio), so every target needs its own toolchain and
+headers. Two paths actually work:
 
 ```bash
-GOOS=darwin  go build -o jarvis-sidecar-macos .
-GOOS=windows go build -o jarvis-sidecar.exe .
+# Windows, from Linux — mingw-w64 plus the bundled EventToken.h shim.
+# This is what CI does; no Windows machine required.
+CC=x86_64-w64-mingw32-gcc CXX=x86_64-w64-mingw32-g++ \
+  GOOS=windows GOARCH=amd64 CGO_ENABLED=1 \
+  CGO_CFLAGS="-I$(pwd)/include" CGO_CXXFLAGS="-I$(pwd)/include" \
+  go build -ldflags "-H windowsgui" -o jarvis.exe .
+
+# macOS — must be built on a Mac; both arches via clang -target.
+CC="clang -target arm64-apple-macos11" GOOS=darwin GOARCH=arm64 go build -o jarvis .
 ```
 
-### Panel service prerequisites (Phase 2 ambient UX)
-
-The sidecar can spawn native panel windows (frameless, always-on-top, transparent, click-through) via `github.com/webview/webview_go`. This requires a system webview runtime per platform:
-
-| Platform | Runtime | Install |
-|---|---|---|
-| Windows 11 | WebView2 (Edge Chromium) | Pre-installed on Win11; on Win10 see [WebView2 runtime](https://developer.microsoft.com/microsoft-edge/webview2/) |
-| macOS | WKWebView | Pre-installed (system) |
-| Linux | WebKitGTK 4.1 | see "Linux setup" below |
-
-#### Linux setup (Ubuntu 22.04/24.04 + WSL)
+### Linux prerequisites
 
 ```bash
 sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev build-essential pkg-config
 
-# webview_go's cgo line hardcodes pkg-config name webkit2gtk-4.0, but Noble
-# only ships 4.1. Symlink the .pc files so build-time pkg-config resolves
-# (the webview.h runtime loader already prefers libwebkit2gtk-4.1.so).
+# webview_go's cgo line hardcodes the pkg-config name webkit2gtk-4.0, but
+# current distros only ship 4.1. Symlink the .pc files so build-time
+# pkg-config resolves (the runtime loader already prefers 4.1).
 sudo ln -sf /usr/lib/x86_64-linux-gnu/pkgconfig/webkit2gtk-4.1.pc \
             /usr/lib/x86_64-linux-gnu/pkgconfig/webkit2gtk-4.0.pc
 sudo ln -sf /usr/lib/x86_64-linux-gnu/pkgconfig/javascriptcoregtk-4.1.pc \
             /usr/lib/x86_64-linux-gnu/pkgconfig/javascriptcoregtk-4.0.pc
 ```
 
-WSL note: WebKitGTK runs but the panel window appears on the WSL X server, not Windows directly. For real-world dev/test, build for Windows and run natively on Win11.
+Windows needs the **WebView2 runtime** (pre-installed on Win11; the sidecar
+offers to install it on Win10). macOS uses the system WKWebView.
 
-Cross-compilation with cgo: the panel service uses cgo, so cross-compiling needs the target's webview headers available. For Windows builds from Linux, the simplest path is to build natively on Windows; for macOS, build on a Mac.
+WSL note: WebKitGTK runs, but panels appear on the WSL X server rather than the
+Windows desktop. For realistic testing, cross-build for Windows and run natively.
 
-## Usage
+## Running
 
 ```bash
-# First run — enroll with a token from the brain
-./jarvis-sidecar --token <jwt>
-
-# Subsequent runs — uses saved token
-./jarvis-sidecar
+./jarvis                  # start using the saved token
+./jarvis --token <jwt>    # enroll: verified against the brain, then saved
+./jarvis --setup          # first-launch onboarding (permissions, autostart)
+./jarvis --version
+./jarvis --help
+./jarvis --test <cmd>     # built-in platform tests; needs -tags sidecartest
 ```
 
-## File Structure
+Config lives at `~/.jarvis/sidecar.yaml` (shared with the brain — the sidecar
+owns only its own keys). A token can also arrive from the dashboard as a
+`jarvis://` deep link, and unconfigured launches open a connect window.
 
-### Core
+`--token` is verified against the brain it names *before* being saved; a
+wrong-URL token used to be persisted blind and then fail invisibly in the
+reconnect loop.
 
-| File | Purpose |
+## Layout
+
+The package is flat Go at the top level — ~150 files in `package main` — so
+this is a map of **subsystems by filename prefix**, not a file list.
+
+| Prefix / file | Subsystem |
 |---|---|
-| `main.go` | Entry point, flag parsing, signal handling |
-| `config.go` | YAML config loading/saving (`~/.jarvis/sidecar.yaml`) |
-| `types.go` | Shared types: capabilities, RPC messages, config structs |
-| `client.go` | WebSocket client, reconnect loop, preflight integration |
-| `handlers.go` | RPC handler registry (terminal, filesystem, clipboard, screenshot, config, system info) |
-| `observers.go` | Background observers (clipboard polling, screen capture, window tracking) |
+| `main.go`, `client.go`, `handlers.go` | entry point, WebSocket client + reconnect, RPC handler registry |
+| `config.go`, `types.go` | `~/.jarvis/sidecar.yaml`, shared message/config types |
+| `observers.go` | background clipboard / screen / window observers |
+| `tray_*` | menu-bar / system-tray item and its menu |
+| `pebble_*` | floating overlay, audio capture, wake word |
+| `panels_*` | frameless always-on-top webview panels |
+| `hotkeys_*` | global hotkeys |
+| `notify_*` | native notifications and their click-through actions |
+| `region_select_*` | interactive screen-region picker |
+| `browser_*` | Chrome control over CDP |
+| `ocr_*` | text extraction (macOS delegates to `helpers/ocr-helper.swift`) |
+| `setup_*` | `--setup` onboarding and its permission checks |
 
-### Platform-specific (build tags)
+| Directory | Contents |
+|---|---|
+| `internal/` | packages shared with the installer: `brand` (CSS), `webviewui` (window host), `autostart` (login items), `webview2` (runtime bootstrap) |
+| `installer/` | the standalone desktop installer — see its own package docs |
+| `npm/` | per-platform npm packages plus the `@usejarvis/sidecar` wrapper |
+| `packaging/` | macOS `.app` bundle assets; Windows manifest/icon resources |
+| `helpers/` | `ocr-helper.swift`, built as a universal binary on macOS |
+| `scripts/` | release-time shell tooling and its tests |
+| `tester/` | standalone binaries for manual platform validation |
+| `include/` | `EventToken.h` — the one WebView2 SDK header mingw lacks |
+| `third_party/` | vendored `webview_go` fork (patched to create windows hidden) |
 
-Go build constraints (`//go:build linux`, etc.) ensure only the correct OS file is compiled. All three files export the same function signatures:
+### Platform-specific files (build tags)
+
+Build constraints (`//go:build linux`, etc.) ensure only the correct OS file
+compiles. Each set exports identical signatures, so callers are OS-agnostic:
 
 | Function | Linux | macOS | Windows |
 |---|---|---|---|
-| `platformClipboardRead()` | xclip | pbpaste | powershell Get-Clipboard |
-| `platformClipboardWrite()` | xclip | pbcopy | powershell Set-Clipboard |
-| `platformCaptureScreen()` | scrot / import / gnome-screenshot | screencapture | powershell System.Windows.Forms |
+| `platformClipboardRead()` | xclip | pbpaste | PowerShell Get-Clipboard |
+| `platformClipboardWrite()` | xclip | pbcopy | PowerShell Set-Clipboard |
+| `platformCaptureScreen()` | scrot / import / gnome-screenshot | screencapture | PowerShell System.Windows.Forms |
 | `platformDefaultShell()` | `"sh"` | `"sh"` | `"cmd.exe"` |
-| `platformGetActiveWindow()` | xdotool + ps | osascript (System Events) | powershell Get-Process |
+| `platformGetActiveWindow()` | xdotool + ps | osascript (System Events) | PowerShell Get-Process |
 
-Files: `platform_linux.go`, `platform_darwin.go`, `platform_windows.go`
+Anything compiled only for one OS is invisible to the others' builds — which is
+why CI compiles all three targets rather than trusting a Linux build.
 
-### Preflight checks (build tags)
+### Preflight checks
 
-Before registering handlers, the client validates that required system tools are present. Each capability maps to a check function that returns `""` (available) or a reason string (unavailable).
+Before registering handlers, the client checks which capabilities the machine
+can actually serve. Each check returns `""` (available) or a reason string.
+`preflight.go` orchestrates; `preflight_{linux,darwin,windows}.go` implement
+terminal, clipboard, screenshot, awareness, processes, notifications, browser
+and desktop checks per platform.
 
-| File | Checks |
-|---|---|
-| `preflight.go` | `CheckCapabilities()` orchestrator (platform-independent) |
-| `preflight_linux.go` | xclip/xsel, scrot/import/gnome-screenshot, xdotool, Chrome, DISPLAY/WAYLAND_DISPLAY |
-| `preflight_darwin.go` | pbpaste, screencapture, osascript, Chrome |
-| `preflight_windows.go` | powershell, cmd.exe, Chrome |
+Unavailable capabilities are reported to the brain in the `register` and
+`capabilities_update` messages, so the dashboard can warn and the routing layer
+can return a clear error instead of timing out.
 
-Unavailable capabilities are reported to the brain in the `register` and `capabilities_update` messages so the dashboard can show warnings and the routing layer can return clear errors.
+## Distribution
+
+Published as platform npm packages (`@usejarvis/sidecar-*`) behind the
+`@usejarvis/sidecar` wrapper, and installed for non-developers by the desktop
+installer in `installer/`.
+
+On macOS the sidecar ships as **`Jarvis.app`**, not a bare binary:
+`UNUserNotificationCenter` is unavailable outside a bundle, and TCC grants
+(microphone, screen recording, accessibility) bind to a bundle identifier — so
+a loose binary cannot notify and loses its permissions.
 
 ## Tests
 
 ```bash
-go test ./...
+go test ./...                    # unit tests (also run in CI on Linux)
+make test                        # the above, plus cross-built tester binaries
+scripts/sign-windows.test.sh     # release tooling, no credentials needed
 ```
+
+UI and platform behaviour that cannot run headless is covered by the `tester/`
+binaries and by `--test` on a `-tags sidecartest` build.


### PR DESCRIPTION
Triggered by #303, which flagged that `sidecar/README.md` had fallen out of date. We're taking a different approach here, so this supersedes it and #303 is closed.

Scope note: this covers **`sidecar/README.md` only**. #303 also touched the root `README.md`; if that needs refreshing it should be its own change.

## Why it needed rewriting

The file described a 147-file program as if it were six files, and its opening commands no longer worked:

- `go build -o jarvis-sidecar .` — the binary is `jarvis`, and the npm launcher, installer and `Info.plist` all expect that name.
- `GOOS=darwin go build` / `GOOS=windows go build` — plain cross-compilation fails outright; the sidecar is cgo-heavy. (The old file admitted this 30 lines later, after you'd already run the broken command.)
- The Makefile was invisible, so `-ldflags` version injection and the macOS deployment target were easy to miss.
- `preflight_darwin.go`'s check list was wrong — four listed, eight actual.
- `--setup`, `--version`, `--test` and `--help` were undocumented.

Whole subsystems went unmentioned: tray, panels, the pebble overlay and wake word, hotkeys, notifications, region select, browser control, OCR, plus `installer/`, `internal/`, `scripts/` and `packaging/`. Nothing told a reader the sidecar has a UI at all.

## What this does

**Drops the per-file table.** That was the part guaranteed to rot. Replaced by subsystems keyed on **filename prefix** (`tray_*`, `pebble_*`, `panels_*`, …) plus a directory table, so adding a file no longer invalidates the doc.

**Fixes the build section.** Leads with `make build`, states plainly that plain cross-compilation does not work, then gives the two recipes that do — mingw for Windows-from-Linux (what CI uses) and `clang -target` on a Mac. The WebKitGTK `.pc` symlink hack is kept: still needed, still non-obvious.

**Adds what was undiscoverable** — that this is a desktop application, and how it is distributed (npm packages for developers, the installer for everyone else, and why macOS ships `Jarvis.app` rather than a bare binary: notifications and TCC grants both require it).

This stays a **developer** document. Build knowledge is expanded rather than removed, and distribution is described as context, not as install instructions.

## Verification

Every file, directory and filename prefix it names was checked to exist; all three `make` targets exist; the documented mingw cross-compile was run and produced a PE32+ binary; `make build` was run and produced `./jarvis` reporting `0.9.1`. The macOS `clang -target` line is copied verbatim from the release workflow (no Mac available to run it here).

100 → 162 lines, with far less that can go stale.