### PR TITLE
fix(auth): resolve the public origin from config and secure Google OAuth with state and PKCE

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -5,11 +5,13 @@ daemon:
   port: 3142
   data_dir: "~/.jarvis"
   db_path: "~/.jarvis/jarvis.db"
-  # Public origin written into sidecar enrollment JWTs (`brain` + `jwks`).
-  # For remote sidecars, set this to the externally reachable URL/host they
-  # can actually reach, not localhost or a private/container-only hostname.
-  # Env override: JARVIS_BRAIN_DOMAIN="https://brain.example.com"
-  # brain_domain: "https://brain.example.com"
+  # Canonical public origin: OAuth callbacks, generated links, and the sidecar
+  # enrollment JWTs (`brain` + `jwks`). Behind a reverse proxy or for remote
+  # sidecars, set this to the externally reachable HTTPS origin — never
+  # localhost or a private/container-only hostname. No path, query, or
+  # credentials. Env override: JARVIS_PUBLIC_URL="https://jarvis.example.com"
+  # (legacy alias: brain_domain / JARVIS_BRAIN_DOMAIN)
+  # public_url: "https://jarvis.example.com"
   # Bind a unix domain socket INSTEAD of a TCP port (for a reverse proxy on
   # the same host). When set, nothing listens on TCP. See docs/SELF_HOSTING.md.
   # listen: "unix:/run/jarvis/jarvis.sock"

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -58,10 +58,11 @@ connections and token mints.
 ### The URL baked into enrollment tokens
 
 `jarvis enroll` embeds the brain's address into the token - that is where the
-sidecar will connect. It comes from `daemon.brain_domain` in `config.yaml`
-(env override: `JARVIS_BRAIN_DOMAIN`). If unset, tokens point at
-`localhost:<port>` and only work for sidecars on the same machine; the CLI
-warns when this happens.
+sidecar will connect. It comes from `daemon.public_url` in `config.yaml`
+(environment override: `JARVIS_PUBLIC_URL`). The older `daemon.brain_domain`
+and `JARVIS_BRAIN_DOMAIN` names remain supported as aliases. If unset, tokens
+point at `localhost:<port>` and only work for sidecars on the same machine;
+the CLI warns when this happens.
 
 The scheme rules are secure by default:
 
@@ -116,7 +117,7 @@ Set the brain address so tokens point somewhere reachable, with an explicit
 
 ```yaml
 daemon:
-  brain_domain: "http://192.168.1.10:3142"
+  public_url: "http://192.168.1.10:3142"
 ```
 
 Then enroll each device and paste the token into its sidecar. Remember:
@@ -153,14 +154,17 @@ default to `wss`):
 ## 3. VPS with a domain
 
 The production shape: a reverse proxy owns ports 80/443 and TLS, the daemon
-listens privately behind it.
+listens privately behind it. Set `daemon.public_url` (or the
+`JARVIS_PUBLIC_URL` environment variable) to the public HTTPS origin and
+restart Jarvis — network configuration is deliberately config-file/env only,
+never editable from the dashboard.
 
 `~/.jarvis/config.yaml` on the VPS:
 
 ```yaml
 daemon:
   port: 3142                                    # bound behind the proxy
-  brain_domain: "https://jarvis.example.com"    # what goes into device tokens
+  public_url: "https://jarvis.example.com"      # OAuth, webhooks, device tokens
 ```
 
 Caddy makes the proxy a two-liner (automatic Let's Encrypt certificates,
@@ -192,6 +196,26 @@ server {
 }
 ```
 
+Jarvis uses `public_url` as the authoritative external origin for OAuth
+callbacks, sidecar enrollment, CORS, and generated public links. It is never
+inferred from request headers: if it is unset, Jarvis assumes
+`localhost:<port>` and warns when requests appear to come through a proxy.
+
+For Google OAuth, register this exact Authorized redirect URI in Google Cloud:
+
+```text
+https://jarvis.example.com/api/auth/google/callback
+```
+
+Settings → Integrations displays the resolved value reported by the daemon, so
+you do not need to translate a localhost example manually.
+
+> **Upgrading with `brain_domain` set?** The dashboard Google flow used to
+> always call back to `http://localhost:3142/...`; it now calls back to your
+> configured origin. Register the new redirect URI shown in Settings →
+> Integrations in Google Cloud, and make sure that origin routes to the
+> daemon, or re-connecting Google will fail.
+
 Make sure port 3142 is not directly reachable from the internet (bind
 firewall rules accordingly, or use the unix socket below and skip TCP
 entirely). If you expose it raw, the failure mode is at least the safe one:
@@ -205,7 +229,7 @@ Then, over SSH on the VPS:
 jarvis enroll "my-laptop"
 ```
 
-Because `brain_domain` is an `https://` URL, the token carries
+Because `public_url` is an `https://` URL, the token carries
 `wss://jarvis.example.com/sidecar/connect`. Paste it into the sidecar on
 your laptop and everything - dashboard included - flows through TLS. The
 dashboard is a secure context, so voice and all other features work.
@@ -255,7 +279,7 @@ timezone: "Europe/Rome"
 | | Single machine | LAN via IP | VPS + domain |
 |---|---|---|---|
 | TLS needed | no | no (with tradeoffs) | yes, via reverse proxy |
-| `brain_domain` | not needed | `http://<ip>:3142` (explicit scheme) | `https://your.domain` |
+| `public_url` | not needed | `http://<ip>:3142` (explicit scheme) | `https://your.domain` |
 | Voice / mic in dashboard | yes | no (secure-context gated) | yes |
 | Tokens on the wire | loopback only | cleartext on your LAN | encrypted |
 | Sidecar URL in tokens | `ws://localhost:3142` | `ws://<ip>:3142` | `wss://your.domain` |

--- a/docs/sidecar/SIDECAR_AUTHENTICATION.md
+++ b/docs/sidecar/SIDECAR_AUTHENTICATION.md
@@ -11,11 +11,13 @@ Each enrollment token contains two operator-controlled URLs:
 - `brain` → the WebSocket endpoint the sidecar dials (`wss://.../sidecar/connect` or `ws://.../sidecar/connect`)
 - `jwks` → the HTTP(S) endpoint the sidecar uses to fetch the signing key (`https://.../api/sidecars/.well-known/jwks.json`)
 
-In the current daemon, those claims are chosen from a single configured brain origin with this precedence:
+In the current daemon, those claims are chosen from a single configured public origin with this precedence:
 
-1. `JARVIS_BRAIN_DOMAIN`
-2. `daemon.brain_domain`
-3. `localhost:<daemon.port>` fallback
+1. `JARVIS_PUBLIC_URL`
+2. `daemon.public_url`
+3. `JARVIS_BRAIN_DOMAIN` (legacy alias)
+4. `daemon.brain_domain` (legacy alias)
+5. `localhost:<daemon.port>` fallback
 
 At startup, the daemon applies the env override in `src/config/loader.ts`, then passes the effective value into `SidecarManager` in `src/daemon/index.ts`. `src/sidecar/manager.ts` derives both JWT claims from that one origin:
 
@@ -25,7 +27,8 @@ At startup, the daemon applies the env override in `src/config/loader.ts`, then 
 
 ### What to Set for Remote Sidecars
 
-For sidecars running on another machine, set `JARVIS_BRAIN_DOMAIN` or `daemon.brain_domain` to the public origin that machine can actually reach.
+For sidecars running on another machine, set `JARVIS_PUBLIC_URL` or
+`daemon.public_url` to the public origin that machine can actually reach.
 
 Good examples:
 
@@ -224,7 +227,7 @@ Symptoms:
 
 Fix:
 
-1. Set `JARVIS_BRAIN_DOMAIN` or `daemon.brain_domain` to the correct public origin
+1. Set `JARVIS_PUBLIC_URL` or `daemon.public_url` to the correct public origin
 2. Restart/reload Jarvis so the daemon uses the new value
 3. Re-enroll the sidecar so a fresh token is minted with corrected claims
 
@@ -260,7 +263,9 @@ Fix:
 
 ### YAML and environment disagree
 
-`JARVIS_BRAIN_DOMAIN` overrides `daemon.brain_domain`. If the token does not match the YAML value you expected, check the daemon process environment first.
+`JARVIS_PUBLIC_URL` overrides `daemon.public_url`, which overrides the legacy
+brain-domain settings. If the token does not match the YAML value you expected,
+check the daemon process environment first.
 
 ## Security Considerations
 

--- a/src/cli/deps.ts
+++ b/src/cli/deps.ts
@@ -13,6 +13,8 @@ import { homedir } from 'node:os';
 import { spawnSync } from 'bun';
 import { c, printOk, printWarn, printErr, printInfo, askYesNo, ask, askSecret, startSpinner, detectPlatform } from './helpers.ts';
 import { LINUX_BROWSER_PATHS, MACOS_BROWSER_PATHS, type BrowserExecutable } from '../actions/browser/chrome-launcher.ts';
+import { externalUrl, resolveExternalOrigin } from '../util/external-origin.ts';
+import { GoogleOAuthFlowStore } from '../integrations/google-oauth-flow.ts';
 
 export type DepKind = 'core' | 'browser' | 'linux' | 'google';
 
@@ -370,6 +372,9 @@ export async function installCoreTools(missing: string[]): Promise<boolean> {
  * Run inline Google OAuth setup flow.
  */
 export async function setupGoogleOAuth(config: any): Promise<boolean> {
+  const externalOrigin = resolveExternalOrigin(config);
+  for (const warning of externalOrigin.warnings) printWarn(warning);
+  const redirectUri = externalUrl(externalOrigin, '/api/auth/google/callback');
   let clientId = config.google?.client_id ?? '';
   let clientSecret = config.google?.client_secret ?? '';
 
@@ -377,7 +382,7 @@ export async function setupGoogleOAuth(config: any): Promise<boolean> {
     printInfo('Google OAuth requires OAuth2 credentials from Google Cloud Console.');
     printInfo('1. Go to https://console.cloud.google.com/apis/credentials');
     printInfo('2. Create an OAuth2 client ID (Web application)');
-    printInfo('3. Add redirect URI: http://localhost:3142/api/auth/google/callback');
+    printInfo(`3. Add redirect URI: ${redirectUri}`);
     console.log('');
 
     clientId = await ask('Google OAuth Client ID (or press Enter to skip)');
@@ -392,7 +397,7 @@ export async function setupGoogleOAuth(config: any): Promise<boolean> {
 
   // Import GoogleAuth and start inline flow
   const { GoogleAuth } = await import('../integrations/google-auth.ts');
-  const auth = new GoogleAuth(clientId, clientSecret);
+  const auth = new GoogleAuth(clientId, clientSecret, { redirectUri });
 
   if (auth.isAuthenticated()) {
     printOk('Already authenticated with Google!');
@@ -404,7 +409,12 @@ export async function setupGoogleOAuth(config: any): Promise<boolean> {
     'https://www.googleapis.com/auth/calendar.readonly',
   ];
 
-  const authUrl = auth.getAuthUrl(SCOPES);
+  const oauthFlows = new GoogleOAuthFlowStore();
+  const startedFlow = oauthFlows.start(redirectUri);
+  const authUrl = auth.getAuthUrl(SCOPES, {
+    state: startedFlow.state,
+    codeChallenge: startedFlow.codeChallenge,
+  });
 
   console.log('');
   printInfo('Opening browser for Google authorization...');
@@ -426,19 +436,20 @@ export async function setupGoogleOAuth(config: any): Promise<boolean> {
   }
 
   // Start temporary callback server for OAuth redirect
-  printInfo('Waiting for authorization callback on port 3142...');
+  printInfo(`Waiting for authorization callback at ${redirectUri}...`);
 
   return new Promise<boolean>((resolve) => {
     let server: ReturnType<typeof Bun.serve>;
     try {
       server = Bun.serve({
-        port: 3142,
+        port: config.daemon.port,
         async fetch(req) {
           const url = new URL(req.url);
 
           if (url.pathname === '/api/auth/google/callback') {
             const code = url.searchParams.get('code');
             const error = url.searchParams.get('error');
+            const state = url.searchParams.get('state');
 
             if (error) {
               clearTimeout(timeout);
@@ -454,8 +465,13 @@ export async function setupGoogleOAuth(config: any): Promise<boolean> {
               return new Response('Missing code', { status: 400 });
             }
 
+            const pendingFlow = state ? oauthFlows.consume(state) : null;
+            if (!pendingFlow) {
+              return new Response('Invalid or expired OAuth state', { status: 400 });
+            }
+
             try {
-              await auth.exchangeCode(code);
+              await auth.exchangeCode(code, { codeVerifier: pendingFlow.codeVerifier });
               clearTimeout(timeout);
               printOk('Google OAuth configured! Tokens saved.');
               setTimeout(() => { server.stop(); resolve(true); }, 300);
@@ -478,8 +494,9 @@ export async function setupGoogleOAuth(config: any): Promise<boolean> {
         },
       });
     } catch (err) {
-      printErr(`Could not start OAuth callback server on port 3142 (port in use?)`);
-      printInfo('Stop the JARVIS daemon first, or run later with: bun run setup:google');
+      printErr(`Could not start OAuth callback server on port ${config.daemon.port} (port in use?)`);
+      printInfo('The JARVIS daemon is probably running — connect Google from the dashboard (Settings → Integrations),');
+      printInfo('or stop the daemon and run: bun run setup:google');
       resolve(false);
       return;
     }

--- a/src/cli/devices.ts
+++ b/src/cli/devices.ts
@@ -19,6 +19,7 @@ import { loadConfig } from '../config/loader.ts';
 import { initDatabase, getDb } from '../vault/schema.ts';
 import { enrollDevice } from '../sidecar/enrollment.ts';
 import type { SidecarRecord } from '../sidecar/types.ts';
+import { resolveExternalOrigin } from '../util/external-origin.ts';
 
 interface CliIo {
   out: (line: string) => void;
@@ -33,10 +34,12 @@ const defaultIo: CliIo = {
 async function openVault(io: CliIo): Promise<{ dataDir: string; brainUrl: string }> {
   const config = await loadConfig();
   initDatabase(config.daemon.db_path, { quiet: true });
-  const brainUrl = config.daemon.brain_domain ?? `localhost:${config.daemon.port}`;
-  if (!config.daemon.brain_domain) {
+  const resolved = resolveExternalOrigin(config);
+  for (const warning of resolved.warnings) io.err(`warning: ${warning}`);
+  const brainUrl = resolved.httpOrigin;
+  if (resolved.source === 'fallback' && resolved.warnings.length === 0) {
     io.err(
-      'warning: daemon.brain_domain is not set; tokens will point at ' +
+      'warning: daemon.public_url is not set; tokens will point at ' +
         `localhost:${config.daemon.port} and only work for sidecars on this machine.`,
     );
   }

--- a/src/comms/websocket.ts
+++ b/src/comms/websocket.ts
@@ -166,6 +166,10 @@ export class WebSocketServer {
     this.insecureOpenAccess = enabled;
   }
 
+  setCorsOrigin(origin: string): void {
+    this.corsOrigin = origin.replace(/\/+$/, '');
+  }
+
   setHandler(handler: WSClientHandler): void {
     this.handler = handler;
   }

--- a/src/config/README.md
+++ b/src/config/README.md
@@ -77,6 +77,7 @@ daemon: {
   port: number;          // WebSocket server port (default: 7777)
   data_dir: string;      // Data directory path (default: ~/.jarvis)
   db_path: string;       // SQLite database path (default: ~/.jarvis/jarvis.db)
+  public_url?: string;   // Public HTTPS origin behind a reverse proxy
 }
 ```
 
@@ -161,6 +162,7 @@ daemon:
   port: 7777
   data_dir: "~/.jarvis"
   db_path: "~/.jarvis/jarvis.db"
+  # public_url: "https://jarvis.example.com"
 
 llm:
   primary: "anthropic"

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -119,6 +119,7 @@ authority:
 daemon:
   port: 9090
   brain_domain: "u1.vps1.usejarvis.host"
+  public_url: "https://jarvis.example.com"
 auth:
   insecure_open_access: true
 google:
@@ -128,6 +129,7 @@ google:
     await Bun.write(TEST_CONFIG_PATH, systemYaml);
     const loaded = await loadConfig(TEST_CONFIG_PATH);
     expect(loaded.daemon.brain_domain).toBe('u1.vps1.usejarvis.host');
+    expect(loaded.daemon.public_url).toBe('https://jarvis.example.com');
     expect(loaded.auth?.insecure_open_access).toBe(true);
     // google is system-owned when the file provides it (hosted: the shared
     // company OAuth client). The DB fallback only applies when absent here.

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -73,6 +73,10 @@ export function applyEnvOverrides(config: JarvisConfig): void {
     config.daemon.brain_domain = env.JARVIS_BRAIN_DOMAIN;
   }
 
+  if (env.JARVIS_PUBLIC_URL) {
+    config.daemon.public_url = env.JARVIS_PUBLIC_URL;
+  }
+
   if (env.JARVIS_WAKE_ENGINE) {
     const engine = env.JARVIS_WAKE_ENGINE;
     if (engine === 'openwakeword' || engine === 'webspeech' || engine === 'auto') {

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -385,7 +385,8 @@ export type JarvisConfig = {
      * (`brain.example.com`, `10.0.0.5:3142`). Bare local hosts default to
      * ws/http; everything else defaults to wss/https.
      *
-     * Precedence: `JARVIS_BRAIN_DOMAIN` env var > this field > internal
+     * Legacy alias for `public_url`. Precedence is `JARVIS_PUBLIC_URL` /
+     * `public_url`, then `JARVIS_BRAIN_DOMAIN` / this field, then the internal
      * `localhost:<port>` fallback (with a startup warning).
      *
      * Sidecars must be able to reach both derived endpoints from the
@@ -393,6 +394,13 @@ export type JarvisConfig = {
      * the token is re-issued with a reachable origin.
      */
     brain_domain?: string;
+    /**
+     * Canonical public HTTP(S) origin for OAuth callbacks, webhooks, dashboard
+     * links, and sidecar enrollment. Prefer this clearer name for new
+     * deployments; `brain_domain` remains a backwards-compatible alias.
+     * Must be an origin with no path, query, fragment, or credentials.
+     */
+    public_url?: string;
     /**
      * Graceful-drain deadline (ms). On SIGTERM the daemon quiesces (stops
      * accepting new work) and waits up to this long for in-flight agent turns

--- a/src/daemon/api-google-oauth.test.ts
+++ b/src/daemon/api-google-oauth.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import { createHash } from 'node:crypto';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { createApiRoutes, type ApiContext } from './api-routes.ts';
+import type { JarvisConfig } from '../config/types.ts';
+
+type Handler = (req: Request) => Response | Promise<Response>;
+
+function makeRoutes(publicUrl: string | null = 'https://jarvis.example.com') {
+  const config = {
+    daemon: {
+      port: 3142,
+      data_dir: '/tmp/jarvis',
+      db_path: '/tmp/jarvis/jarvis.db',
+      ...(publicUrl ? { public_url: publicUrl } : {}),
+    },
+    google: { client_id: 'client-id', client_secret: 'client-secret' },
+  } as JarvisConfig;
+  return createApiRoutes({
+    daemonStartedAt: Date.now(),
+    healthMonitor: {} as ApiContext['healthMonitor'],
+    config,
+  } as ApiContext) as Record<string, { GET?: Handler; POST?: Handler }>;
+}
+
+describe('Google OAuth API external origin', () => {
+  it('returns an authorization URL bound to the configured public callback', async () => {
+    const routes = makeRoutes();
+    const response = await routes['/api/auth/google/init']!.POST!(new Request(
+      'http://localhost:3142/api/auth/google/init',
+      { method: 'POST' },
+    ));
+    const body = await response.json() as { auth_url: string; redirect_uri: string };
+    const authUrl = new URL(body.auth_url);
+
+    expect(body.redirect_uri).toBe('https://jarvis.example.com/api/auth/google/callback');
+    expect(authUrl.searchParams.get('redirect_uri')).toBe(body.redirect_uri);
+    expect(authUrl.searchParams.get('state')?.length).toBeGreaterThan(30);
+    expect(authUrl.searchParams.get('code_challenge')?.length).toBeGreaterThan(30);
+    expect(authUrl.searchParams.get('code_challenge_method')).toBe('S256');
+  });
+
+  it('publishes the resolved callback through deployment diagnostics', async () => {
+    const routes = makeRoutes('https://jarvis.example.com/');
+    const response = await routes['/api/system/external-origin']!.GET!(new Request(
+      'http://localhost:3142/api/system/external-origin',
+    ));
+    expect(await response.json()).toMatchObject({
+      public_origin: 'https://jarvis.example.com',
+      websocket_origin: 'wss://jarvis.example.com',
+      source: 'public_url',
+      google_callback: 'https://jarvis.example.com/api/auth/google/callback',
+    });
+  });
+
+  it('never derives the callback from request headers when no public URL is configured', async () => {
+    const routes = makeRoutes(null);
+    const response = await routes['/api/auth/google/init']!.POST!(new Request(
+      'http://jarvis.example.com/api/auth/google/init',
+      { method: 'POST', headers: { Origin: 'https://attacker.example.com' } },
+    ));
+    const body = await response.json() as { redirect_uri: string };
+    expect(body.redirect_uri).toBe('http://localhost:3142/api/auth/google/callback');
+  });
+
+  it('rejects callbacks without a valid one-time state', async () => {
+    const routes = makeRoutes();
+    const response = await routes['/api/auth/google/callback']!.GET!(new Request(
+      'https://jarvis.example.com/api/auth/google/callback?code=attacker-code',
+    ));
+    expect(response.status).toBe(400);
+    expect(response.headers.get('Content-Type')).toBe('text/html');
+    expect(await response.text()).toContain('missing its OAuth state');
+  });
+
+  it('rejects callbacks whose state is unknown or already used', async () => {
+    const routes = makeRoutes();
+    const response = await routes['/api/auth/google/callback']!.GET!(new Request(
+      'https://jarvis.example.com/api/auth/google/callback?code=attacker-code&state=forged-state',
+    ));
+    expect(response.status).toBe(400);
+    expect(await response.text()).toContain('already used or has expired');
+  });
+
+  describe('callback happy path', () => {
+    const realFetch = globalThis.fetch;
+    const realHome = process.env.HOME;
+
+    afterEach(() => {
+      globalThis.fetch = realFetch;
+      if (realHome !== undefined) process.env.HOME = realHome;
+    });
+
+    it('exchanges the code with the state-bound verifier and redirect URI', async () => {
+      process.env.HOME = mkdtempSync(path.join(tmpdir(), 'jarvis-oauth-test-'));
+      const exchangeRequests: URLSearchParams[] = [];
+      globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+        exchangeRequests.push(new URLSearchParams(String(init?.body)));
+        return new Response(JSON.stringify({
+          access_token: 'access',
+          refresh_token: 'refresh',
+          expires_in: 3600,
+          token_type: 'Bearer',
+        }), { headers: { 'Content-Type': 'application/json' } });
+      }) as typeof fetch;
+
+      const routes = makeRoutes();
+      const initResponse = await routes['/api/auth/google/init']!.POST!(new Request(
+        'http://localhost:3142/api/auth/google/init', { method: 'POST' },
+      ));
+      const { auth_url, redirect_uri } = await initResponse.json() as { auth_url: string; redirect_uri: string };
+      const authUrl = new URL(auth_url);
+      const state = authUrl.searchParams.get('state')!;
+      const codeChallenge = authUrl.searchParams.get('code_challenge')!;
+
+      const callbackResponse = await routes['/api/auth/google/callback']!.GET!(new Request(
+        `https://jarvis.example.com/api/auth/google/callback?code=auth-code&state=${state}`,
+      ));
+      expect(callbackResponse.status).toBe(200);
+      expect(await callbackResponse.text()).toContain('Authorization Complete');
+
+      expect(exchangeRequests).toHaveLength(1);
+      const body = exchangeRequests[0]!;
+      expect(body.get('code')).toBe('auth-code');
+      expect(body.get('redirect_uri')).toBe(redirect_uri);
+      const verifier = body.get('code_verifier')!;
+      expect(createHash('sha256').update(verifier).digest('base64url')).toBe(codeChallenge);
+
+      // The state is one-time: replaying the same callback must fail.
+      const replay = await routes['/api/auth/google/callback']!.GET!(new Request(
+        `https://jarvis.example.com/api/auth/google/callback?code=auth-code&state=${state}`,
+      ));
+      expect(replay.status).toBe(400);
+    });
+  });
+});

--- a/src/daemon/api-routes.ts
+++ b/src/daemon/api-routes.ts
@@ -62,6 +62,8 @@ import { mkdirSync, existsSync } from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 import { isWithin } from '../util/path.ts';
+import { externalUrl, resolveExternalOrigin } from '../util/external-origin.ts';
+import { GoogleOAuthFlowStore } from '../integrations/google-oauth-flow.ts';
 
 // --- Security helpers ---
 
@@ -175,9 +177,9 @@ let CORS: Record<string, string> = {
 };
 
 /** Call once during init to set the correct CORS origin from config */
-export function setCorsOrigin(port: number, host = 'localhost') {
+export function setCorsOrigin(origin: string) {
   CORS = {
-    'Access-Control-Allow-Origin': `http://${host}:${port}`,
+    'Access-Control-Allow-Origin': origin.replace(/\/+$/, ''),
     'Access-Control-Allow-Methods': 'GET, POST, PATCH, DELETE, OPTIONS',
     'Access-Control-Allow-Headers': 'Content-Type',
   };
@@ -286,10 +288,25 @@ function buildAgentSnapshots(ctx: ApiContext) {
  * Create all API route handlers.
  */
 export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
+  const googleOAuthFlows = new GoogleOAuthFlowStore();
   return {
     // --- Health ---
     '/api/health': {
       GET: () => json(ctx.healthMonitor.getHealth()),
+    },
+
+    '/api/system/external-origin': {
+      GET: (req: Request) => {
+        const resolved = resolveExternalOrigin(ctx.config, req);
+        return json({
+          public_origin: resolved.httpOrigin,
+          websocket_origin: resolved.wsOrigin,
+          source: resolved.source,
+          proxy_detected: resolved.proxyDetected,
+          google_callback: externalUrl(resolved, '/api/auth/google/callback'),
+          warnings: resolved.warnings,
+        });
+      },
     },
 
     // --- Vault: Entities ---
@@ -1940,7 +1957,10 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
         const params = getSearchParams(req);
         const code = params.get('code');
         const authError = params.get('error');
+        const state = params.get('state');
 
+        // A denial has nothing to protect and nothing to exchange — render it
+        // before touching (and burning) the one-time state.
         if (authError) {
           return new Response(
             `<html><body><h1>Authorization Denied</h1><p>${escapeHtml(authError)}</p><p>You can close this tab.</p></body></html>`,
@@ -1952,6 +1972,18 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
           return error('Missing authorization code', 400);
         }
 
+        // Top-level browser navigation: state failures get an HTML page, not JSON.
+        const pendingFlow = state ? googleOAuthFlows.consume(state) : null;
+        if (!pendingFlow) {
+          const reason = state
+            ? 'This authorization link was already used or has expired.'
+            : 'This authorization link is missing its OAuth state.';
+          return new Response(
+            `<html><body><h1>Authorization Failed</h1><p>${reason}</p><p>Start Google authorization again from the Jarvis dashboard.</p></body></html>`,
+            { headers: { ...CORS, 'Content-Type': 'text/html' }, status: 400 }
+          );
+        }
+
         // Try to exchange the code using GoogleAuth from context
         const googleConfig = ctx.config.google;
         if (!googleConfig?.client_id || !googleConfig?.client_secret) {
@@ -1961,8 +1993,10 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
         try {
           // Lazy import to avoid circular deps
           const { GoogleAuth } = await import('../integrations/google-auth.ts');
-          const auth = new GoogleAuth(googleConfig.client_id, googleConfig.client_secret);
-          await auth.exchangeCode(code);
+          const auth = new GoogleAuth(googleConfig.client_id, googleConfig.client_secret, {
+            redirectUri: pendingFlow.redirectUri,
+          });
+          await auth.exchangeCode(code, { codeVerifier: pendingFlow.codeVerifier });
 
           // The exchange above used a throwaway GoogleAuth that saved the
           // tokens to disk; nudge the hot-reload applier so the daemon's
@@ -2054,13 +2088,19 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
 
         try {
           const { GoogleAuth } = await import('../integrations/google-auth.ts');
-          const auth = new GoogleAuth(googleConfig.client_id, googleConfig.client_secret);
+          const externalOrigin = resolveExternalOrigin(ctx.config);
+          const redirectUri = externalUrl(externalOrigin, '/api/auth/google/callback');
+          const flow = googleOAuthFlows.start(redirectUri);
+          const auth = new GoogleAuth(googleConfig.client_id, googleConfig.client_secret, { redirectUri });
           const scopes = [
             'https://www.googleapis.com/auth/gmail.readonly',
             'https://www.googleapis.com/auth/calendar.readonly',
           ];
-          const authUrl = auth.getAuthUrl(scopes);
-          return json({ auth_url: authUrl });
+          const authUrl = auth.getAuthUrl(scopes, {
+            state: flow.state,
+            codeChallenge: flow.codeChallenge,
+          });
+          return json({ auth_url: authUrl, redirect_uri: redirectUri });
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);
           return error(`Failed to generate auth URL: ${msg}`, 500);

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -47,6 +47,7 @@ import { DeferredExecutor } from "../authority/deferred-executor.ts";
 import { applyApprovalDecision } from "./approval-decision.ts";
 import { sendDesktopNotification } from "../comms/desktop-notify.ts";
 import { SidecarManager, buildEnrollmentUrls } from "../sidecar/manager.ts";
+import { resolveExternalOrigin } from "../util/external-origin.ts";
 import { ensureWorkflowSchema } from "../workflows/db/index.ts";
 import { Worker as WorkflowWorker } from "../workflows/queue/worker.ts";
 import { recoverOrphanedJobs } from "../workflows/db/repos/job-queue.ts";
@@ -580,16 +581,18 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
 
     // 6c. Create sidecar manager
     const sidecarManager = new SidecarManager(jarvisConfig.daemon.data_dir.replace('~', os.homedir()));
-    // Brain URL precedence: env > config.yaml > default fallback. The loader
-    // already collapses env into config.daemon.brain_domain, so we re-check
-    // the env var here only to attribute the source in the startup log —
-    // the operator needs to see which knob is active when debugging.
-    const brainSource: 'env' | 'config' | 'default' = process.env.JARVIS_BRAIN_DOMAIN
-      ? 'env'
-      : jarvisConfig.daemon.brain_domain
-        ? 'config'
+    // Public-origin precedence: env > public_url > legacy brain_domain >
+    // local fallback. Re-check env only to attribute the startup log source.
+    const externalOrigin = resolveExternalOrigin(jarvisConfig);
+    for (const warning of externalOrigin.warnings) {
+      console.warn(`[ExternalOrigin] ${warning}`);
+    }
+    const brainSource: 'env' | 'config' | 'public_url' | 'default' = externalOrigin.source === 'public_url'
+      ? (process.env.JARVIS_PUBLIC_URL ? 'env' : 'public_url')
+      : externalOrigin.source === 'brain_domain'
+        ? (process.env.JARVIS_BRAIN_DOMAIN ? 'env' : 'config')
         : 'default';
-    const brainDomain = jarvisConfig.daemon.brain_domain ?? `localhost:${config.port}`;
+    const brainDomain = externalOrigin.httpOrigin;
     sidecarManager.setBrainUrl(brainDomain, brainSource);
 
     // Panel webviews must render the same brain origin the JWT pins: the sidecar
@@ -3976,7 +3979,8 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
       sidecarManager,
       settingsReload,
     };
-    setCorsOrigin(jarvisConfig.daemon.port);
+    setCorsOrigin(externalOrigin.httpOrigin);
+    wsService.getServer().setCorsOrigin(externalOrigin.httpOrigin);
 
     // Construct the workflow runtime's shared collaborators early so the
     // route table can carry a TriggerManager reference (used for cron /

--- a/src/integrations/google-auth.test.ts
+++ b/src/integrations/google-auth.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'bun:test';
+import { afterEach, describe, expect, test } from 'bun:test';
 import { existsSync, statSync } from 'node:fs';
 import { chmod, mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
@@ -6,6 +6,12 @@ import { join } from 'node:path';
 import { GoogleAuth } from './google-auth.ts';
 
 describe('GoogleAuth token storage', () => {
+  const realFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
   test('saves OAuth tokens with owner-only permissions', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'jarvis-google-auth-'));
     const tokensPath = join(dir, 'google-tokens.json');
@@ -45,6 +51,40 @@ describe('GoogleAuth token storage', () => {
       expect(statSync(join(dir, 'google-tokens.json')).mode & 0o777).toBe(0o600);
     } finally {
       process.chdir(originalCwd);
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('uses the same custom redirect URI and PKCE verifier during exchange', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'jarvis-google-auth-exchange-'));
+    const tokensPath = join(dir, 'google-tokens.json');
+    let exchangeBody = new URLSearchParams();
+    globalThis.fetch = (async (_input: string | URL | Request, init?: RequestInit) => {
+      exchangeBody = new URLSearchParams(String(init?.body));
+      return new Response(JSON.stringify({
+        access_token: 'access',
+        refresh_token: 'refresh',
+        expires_in: 3600,
+        token_type: 'Bearer',
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+    }) as unknown as typeof fetch;
+
+    try {
+      const redirectUri = 'https://jarvis.example.com/api/auth/google/callback';
+      const auth = new GoogleAuth('client-id', 'client-secret', { tokensPath, redirectUri });
+      const authUrl = new URL(auth.getAuthUrl(['scope-a'], {
+        state: 'state-token',
+        codeChallenge: 'challenge-token',
+      }));
+      expect(authUrl.searchParams.get('redirect_uri')).toBe(redirectUri);
+      expect(authUrl.searchParams.get('state')).toBe('state-token');
+      expect(authUrl.searchParams.get('code_challenge')).toBe('challenge-token');
+      expect(authUrl.searchParams.get('code_challenge_method')).toBe('S256');
+
+      await auth.exchangeCode('authorization-code', { codeVerifier: 'verifier-token' });
+      expect(exchangeBody.get('redirect_uri')).toBe(redirectUri);
+      expect(exchangeBody.get('code_verifier')).toBe('verifier-token');
+    } finally {
       await rm(dir, { recursive: true, force: true });
     }
   });

--- a/src/integrations/google-auth.ts
+++ b/src/integrations/google-auth.ts
@@ -115,7 +115,10 @@ export class GoogleAuth {
   /**
    * Generate OAuth2 consent URL.
    */
-  getAuthUrl(scopes: string[]): string {
+  getAuthUrl(
+    scopes: string[],
+    opts: { state?: string; codeChallenge?: string } = {},
+  ): string {
     const params = new URLSearchParams({
       client_id: this.clientId,
       redirect_uri: this.redirectUri,
@@ -124,23 +127,30 @@ export class GoogleAuth {
       access_type: 'offline',
       prompt: 'consent',
     });
+    if (opts.state) params.set('state', opts.state);
+    if (opts.codeChallenge) {
+      params.set('code_challenge', opts.codeChallenge);
+      params.set('code_challenge_method', 'S256');
+    }
     return `${AUTH_ENDPOINT}?${params.toString()}`;
   }
 
   /**
    * Exchange authorization code for tokens.
    */
-  async exchangeCode(code: string): Promise<GoogleTokens> {
+  async exchangeCode(code: string, opts: { codeVerifier?: string } = {}): Promise<GoogleTokens> {
+    const body = new URLSearchParams({
+      code,
+      client_id: this.clientId,
+      client_secret: this.clientSecret,
+      redirect_uri: this.redirectUri,
+      grant_type: 'authorization_code',
+    });
+    if (opts.codeVerifier) body.set('code_verifier', opts.codeVerifier);
     const resp = await fetch(TOKEN_ENDPOINT, {
       method: 'POST',
       headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-      body: new URLSearchParams({
-        code,
-        client_id: this.clientId,
-        client_secret: this.clientSecret,
-        redirect_uri: this.redirectUri,
-        grant_type: 'authorization_code',
-      }),
+      body,
     });
 
     if (!resp.ok) {

--- a/src/integrations/google-oauth-flow.test.ts
+++ b/src/integrations/google-oauth-flow.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'bun:test';
+import { GoogleOAuthFlowStore } from './google-oauth-flow.ts';
+
+describe('GoogleOAuthFlowStore', () => {
+  it('binds a one-time state to the exact callback and PKCE verifier', () => {
+    const store = new GoogleOAuthFlowStore(60_000);
+    const started = store.start('https://jarvis.example.com/api/auth/google/callback', 1_000);
+    expect(started.state.length).toBeGreaterThan(30);
+    expect(started.codeChallenge.length).toBeGreaterThan(30);
+
+    expect(store.consume(started.state, 2_000)).toEqual({
+      redirectUri: 'https://jarvis.example.com/api/auth/google/callback',
+      codeVerifier: started.codeVerifier,
+      expiresAt: 61_000,
+    });
+    expect(store.consume(started.state, 2_000)).toBeNull();
+  });
+
+  it('rejects expired attempts', () => {
+    const store = new GoogleOAuthFlowStore(1_000);
+    const started = store.start('https://jarvis.example.com/callback', 1_000);
+    expect(store.consume(started.state, 2_001)).toBeNull();
+  });
+});

--- a/src/integrations/google-oauth-flow.ts
+++ b/src/integrations/google-oauth-flow.ts
@@ -1,0 +1,51 @@
+import { createHash, randomBytes } from 'node:crypto';
+
+export type PendingGoogleOAuthFlow = {
+  redirectUri: string;
+  codeVerifier: string;
+  expiresAt: number;
+};
+
+export type StartedGoogleOAuthFlow = PendingGoogleOAuthFlow & {
+  state: string;
+  codeChallenge: string;
+};
+
+/** One-time, in-memory OAuth attempts. A daemon restart simply requires retrying connect. */
+export class GoogleOAuthFlowStore {
+  private readonly pending = new Map<string, PendingGoogleOAuthFlow>();
+
+  constructor(
+    private readonly ttlMs = 10 * 60_000,
+    private readonly maxPending = 100,
+  ) {}
+
+  start(redirectUri: string, now = Date.now()): StartedGoogleOAuthFlow {
+    this.prune(now);
+    while (this.pending.size >= this.maxPending) {
+      const oldest = this.pending.keys().next().value as string | undefined;
+      if (!oldest) break;
+      this.pending.delete(oldest);
+    }
+
+    const state = randomBytes(32).toString('base64url');
+    const codeVerifier = randomBytes(48).toString('base64url');
+    const codeChallenge = createHash('sha256').update(codeVerifier).digest('base64url');
+    const flow = { redirectUri, codeVerifier, expiresAt: now + this.ttlMs };
+    this.pending.set(state, flow);
+    return { state, codeChallenge, ...flow };
+  }
+
+  consume(state: string, now = Date.now()): PendingGoogleOAuthFlow | null {
+    const flow = this.pending.get(state);
+    this.pending.delete(state);
+    if (!flow || flow.expiresAt <= now) return null;
+    return flow;
+  }
+
+  private prune(now: number): void {
+    for (const [state, flow] of this.pending) {
+      if (flow.expiresAt <= now) this.pending.delete(state);
+    }
+  }
+}

--- a/src/scripts/google-setup.ts
+++ b/src/scripts/google-setup.ts
@@ -10,6 +10,8 @@
 
 import { GoogleAuth } from '../integrations/google-auth.ts';
 import { loadConfig } from '../config/loader.ts';
+import { externalUrl, resolveExternalOrigin } from '../util/external-origin.ts';
+import { GoogleOAuthFlowStore } from '../integrations/google-oauth-flow.ts';
 
 const SCOPES = [
   'https://www.googleapis.com/auth/gmail.readonly',
@@ -36,6 +38,9 @@ async function main() {
 
   let clientId = config.google?.client_id ?? '';
   let clientSecret = config.google?.client_secret ?? '';
+  const externalOrigin = resolveExternalOrigin(config);
+  for (const warning of externalOrigin.warnings) console.warn(`Warning: ${warning}`);
+  const redirectUri = externalUrl(externalOrigin, '/api/auth/google/callback');
 
   if (!clientId || !clientSecret) {
     console.log('No Google OAuth credentials found in config.yaml.');
@@ -49,7 +54,7 @@ async function main() {
     console.log('To get credentials:');
     console.log('  1. Go to https://console.cloud.google.com/apis/credentials');
     console.log('  2. Create an OAuth2 client ID (Web application)');
-    console.log('  3. Add http://localhost:3142/api/auth/google/callback as a redirect URI');
+    console.log(`  3. Add ${redirectUri} as a redirect URI`);
     console.log('  4. Copy client_id and client_secret into config.yaml');
     console.log('');
 
@@ -79,7 +84,7 @@ async function main() {
     rl.close();
   }
 
-  const auth = new GoogleAuth(clientId, clientSecret);
+  const auth = new GoogleAuth(clientId, clientSecret, { redirectUri });
 
   // Check if already authenticated
   if (auth.isAuthenticated()) {
@@ -88,7 +93,12 @@ async function main() {
     process.exit(0);
   }
 
-  const authUrl = auth.getAuthUrl(SCOPES);
+  const oauthFlows = new GoogleOAuthFlowStore();
+  const startedFlow = oauthFlows.start(redirectUri);
+  const authUrl = auth.getAuthUrl(SCOPES, {
+    state: startedFlow.state,
+    codeChallenge: startedFlow.codeChallenge,
+  });
 
   console.log('');
   console.log('Opening browser for Google authorization...');
@@ -110,66 +120,80 @@ async function main() {
   }
 
   // Start temporary HTTP server to receive the callback
-  console.log('Waiting for authorization callback on port 3142...');
+  console.log(`Waiting for authorization callback at ${redirectUri}...`);
   console.log('');
 
-  const server = Bun.serve({
-    port: 3142,
-    async fetch(req) {
-      const url = new URL(req.url);
+  let server: ReturnType<typeof Bun.serve>;
+  try {
+    server = Bun.serve({
+      port: config.daemon.port,
+      async fetch(req) {
+        const url = new URL(req.url);
 
-      if (url.pathname === '/api/auth/google/callback') {
-        const code = url.searchParams.get('code');
-        const error = url.searchParams.get('error');
+        if (url.pathname === '/api/auth/google/callback') {
+          const code = url.searchParams.get('code');
+          const error = url.searchParams.get('error');
+          const state = url.searchParams.get('state');
 
-        if (error) {
-          console.error('Authorization denied:', error);
-          setTimeout(() => {
-            server.stop();
-            process.exit(1);
-          }, 500);
-          return new Response(
-            '<html><body><h1>Authorization Denied</h1><p>You can close this tab.</p></body></html>',
-            { headers: { 'Content-Type': 'text/html' } }
-          );
+          if (error) {
+            console.error('Authorization denied:', error);
+            setTimeout(() => {
+              server.stop();
+              process.exit(1);
+            }, 500);
+            return new Response(
+              '<html><body><h1>Authorization Denied</h1><p>You can close this tab.</p></body></html>',
+              { headers: { 'Content-Type': 'text/html' } }
+            );
+          }
+
+          if (!code) {
+            return new Response('Missing code', { status: 400 });
+          }
+
+          const pendingFlow = state ? oauthFlows.consume(state) : null;
+          if (!pendingFlow) {
+            return new Response('Invalid or expired OAuth state', { status: 400 });
+          }
+
+          try {
+            const tokens = await auth.exchangeCode(code, { codeVerifier: pendingFlow.codeVerifier });
+            console.log('Authorization successful!');
+            console.log(`Access token: ${tokens.access_token.slice(0, 20)}...`);
+            console.log(`Refresh token: ${tokens.refresh_token.slice(0, 20)}...`);
+            console.log(`Tokens saved to ~/.jarvis/google-tokens.json`);
+
+            setTimeout(() => {
+              server.stop();
+              process.exit(0);
+            }, 500);
+
+            return new Response(
+              '<html><body><h1>JARVIS Google Authorization Complete!</h1><p>Tokens saved. You can close this tab.</p></body></html>',
+              { headers: { 'Content-Type': 'text/html' } }
+            );
+          } catch (err) {
+            console.error('Token exchange failed:', err);
+            setTimeout(() => {
+              server.stop();
+              process.exit(1);
+            }, 500);
+            return new Response(
+              `<html><body><h1>Token Exchange Failed</h1><pre>${err}</pre></body></html>`,
+              { headers: { 'Content-Type': 'text/html' }, status: 500 }
+            );
+          }
         }
 
-        if (!code) {
-          return new Response('Missing code', { status: 400 });
-        }
-
-        try {
-          const tokens = await auth.exchangeCode(code);
-          console.log('Authorization successful!');
-          console.log(`Access token: ${tokens.access_token.slice(0, 20)}...`);
-          console.log(`Refresh token: ${tokens.refresh_token.slice(0, 20)}...`);
-          console.log(`Tokens saved to ~/.jarvis/google-tokens.json`);
-
-          setTimeout(() => {
-            server.stop();
-            process.exit(0);
-          }, 500);
-
-          return new Response(
-            '<html><body><h1>JARVIS Google Authorization Complete!</h1><p>Tokens saved. You can close this tab.</p></body></html>',
-            { headers: { 'Content-Type': 'text/html' } }
-          );
-        } catch (err) {
-          console.error('Token exchange failed:', err);
-          setTimeout(() => {
-            server.stop();
-            process.exit(1);
-          }, 500);
-          return new Response(
-            `<html><body><h1>Token Exchange Failed</h1><pre>${err}</pre></body></html>`,
-            { headers: { 'Content-Type': 'text/html' }, status: 500 }
-          );
-        }
-      }
-
-      return new Response('Not found', { status: 404 });
-    },
-  });
+        return new Response('Not found', { status: 404 });
+      },
+    });
+  } catch (err) {
+    console.error(`Could not listen on port ${config.daemon.port}: ${err instanceof Error ? err.message : err}`);
+    console.error('The Jarvis daemon is probably running and already owns that port.');
+    console.error('Connect Google from the dashboard instead: Settings → Integrations.');
+    process.exit(1);
+  }
 }
 
 main().catch((err) => {

--- a/src/sidecar/enrollment.test.ts
+++ b/src/sidecar/enrollment.test.ts
@@ -102,7 +102,7 @@ describe('standalone enrollment', () => {
 
   test('missing brain URL is a hard error, not a localhost token', async () => {
     await expect(enrollDevice(dataDir, '', 'desktop-NA23', { onExisting: 'upsert' })).rejects.toThrow(
-      /brain_domain/i,
+      /public_url/i,
     );
   });
 });

--- a/src/sidecar/enrollment.ts
+++ b/src/sidecar/enrollment.ts
@@ -187,7 +187,7 @@ export async function enrollDevice(
   options: EnrollOptions,
 ): Promise<EnrollResult> {
   if (!brainUrl) {
-    throw new Error('Brain URL not configured - set daemon.brain_domain (or JARVIS_BRAIN_DOMAIN)');
+    throw new Error('Brain URL not configured - set daemon.public_url (or JARVIS_PUBLIC_URL)');
   }
   const trimmed = validateSidecarName(name);
   const keys = options.keys ?? (await loadOrGenerateSidecarKeys(dataDir));

--- a/src/sidecar/manager.ts
+++ b/src/sidecar/manager.ts
@@ -133,17 +133,18 @@ export class SidecarManager implements Service {
    * glance which knob is active when something looks wrong (env var vs
    * config.yaml vs default-fallback). Pass undefined for silent setters.
    */
-  setBrainUrl(url: string, source?: 'env' | 'config' | 'default'): void {
+  setBrainUrl(url: string, source?: 'env' | 'config' | 'public_url' | 'default'): void {
     this.brainUrl = url;
     if (source) {
       const { brainWs } = buildEnrollmentUrls(url);
-      const sourceLabel = source === 'env' ? 'JARVIS_BRAIN_DOMAIN env var'
+      const sourceLabel = source === 'env' ? 'JARVIS_PUBLIC_URL / JARVIS_BRAIN_DOMAIN env var'
+        : source === 'public_url' ? 'daemon.public_url / JARVIS_PUBLIC_URL'
         : source === 'config' ? 'config.yaml daemon.brain_domain'
-        : `default fallback — set daemon.brain_domain in config.yaml or JARVIS_BRAIN_DOMAIN env to override`;
+        : `default fallback — set daemon.public_url in config.yaml or JARVIS_PUBLIC_URL env to override`;
       console.log(`[SidecarManager] Brain URL: ${brainWs} (source: ${sourceLabel})`);
       if (isLocalhostBrainUrl(url)) {
         console.warn(
-          `[SidecarManager] Brain URL points at a local host. Sidecars on other machines will NOT be able to reach this URL — only enroll local sidecars, or set daemon.brain_domain to a routable hostname before enrolling remote sidecars.`,
+          `[SidecarManager] Brain URL points at a local host. Sidecars on other machines will NOT be able to reach this URL — only enroll local sidecars, or set daemon.public_url to a routable HTTPS origin before enrolling remote sidecars.`,
         );
       }
     }

--- a/src/util/external-origin.test.ts
+++ b/src/util/external-origin.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'bun:test';
+import type { JarvisConfig } from '../config/types.ts';
+import {
+  externalUrl,
+  normalizePublicOrigin,
+  resolveExternalOrigin,
+} from './external-origin.ts';
+
+function config(daemon: Partial<JarvisConfig['daemon']> = {}): JarvisConfig {
+  return {
+    daemon: {
+      port: 3142,
+      data_dir: '/tmp/jarvis',
+      db_path: '/tmp/jarvis/jarvis.db',
+      ...daemon,
+    },
+  } as JarvisConfig;
+}
+
+describe('resolveExternalOrigin', () => {
+  it('uses public_url as the authoritative origin', () => {
+    const result = resolveExternalOrigin(config({
+      public_url: 'https://jarvis.example.com/',
+      brain_domain: 'https://old.example.com',
+    }));
+    expect(result).toMatchObject({
+      httpOrigin: 'https://jarvis.example.com',
+      wsOrigin: 'wss://jarvis.example.com',
+      source: 'public_url',
+      warnings: [],
+    });
+  });
+
+  it('keeps brain_domain as a backwards-compatible public origin', () => {
+    const result = resolveExternalOrigin(config({ brain_domain: 'wss://brain.example.com:8443' }));
+    expect(result.httpOrigin).toBe('https://brain.example.com:8443');
+    expect(result.wsOrigin).toBe('wss://brain.example.com:8443');
+    expect(result.source).toBe('brain_domain');
+  });
+
+  it('falls back to localhost when nothing is configured', () => {
+    const result = resolveExternalOrigin(config());
+    expect(result.httpOrigin).toBe('http://localhost:3142');
+    expect(result.source).toBe('fallback');
+  });
+
+  it('ignores forwarded headers when choosing the origin', () => {
+    const req = new Request('http://localhost:3142/api/system/external-origin', {
+      headers: {
+        'x-forwarded-proto': 'https',
+        'x-forwarded-host': 'attacker.example',
+      },
+    });
+    const result = resolveExternalOrigin(config({ public_url: 'https://jarvis.example.com' }), req);
+    expect(result.httpOrigin).toBe('https://jarvis.example.com');
+    expect(result.source).toBe('public_url');
+  });
+
+  it('warns when the proxy-reported origin differs from the configured one', () => {
+    const req = new Request('http://localhost:3142/api/system/external-origin', {
+      headers: {
+        'x-forwarded-proto': 'https',
+        'x-forwarded-host': 'other.example.com',
+      },
+    });
+    const result = resolveExternalOrigin(config({ public_url: 'https://jarvis.example.com' }), req);
+    expect(result.proxyDetected).toBe(true);
+    expect(result.warnings[0]).toContain('differs');
+  });
+
+  it('warns when a proxy is detected but no public URL is configured', () => {
+    const req = new Request('http://localhost:3142/api/system/external-origin', {
+      headers: {
+        'x-forwarded-proto': 'https',
+        'x-forwarded-host': 'jarvis.example.com',
+      },
+    });
+    const result = resolveExternalOrigin(config(), req);
+    expect(result.httpOrigin).toBe('http://localhost:3142');
+    expect(result.source).toBe('fallback');
+    expect(result.warnings[0]).toContain('daemon.public_url is not set');
+  });
+
+  it('salvages the origin of a legacy value with a path instead of failing', () => {
+    const result = resolveExternalOrigin(config({ brain_domain: 'brain.example.com/jarvis' }));
+    expect(result.httpOrigin).toBe('https://brain.example.com');
+    expect(result.source).toBe('brain_domain');
+    expect(result.warnings[0]).toContain('not a plain origin');
+  });
+
+  it('falls back to localhost with a warning on an unusable configured value', () => {
+    for (const value of ['ftp://weird.example.com', 'https:/example.com', 'my host.com']) {
+      const result = resolveExternalOrigin(config({ public_url: value }));
+      expect(result.httpOrigin).toBe('http://localhost:3142');
+      expect(result.source).toBe('fallback');
+      expect(result.warnings[0]).toContain('unusable');
+    }
+  });
+
+  it('builds external callback paths without changing the origin', () => {
+    const origin = resolveExternalOrigin(config({ public_url: 'https://jarvis.example.com' }));
+    expect(externalUrl(origin, '/api/auth/google/callback'))
+      .toBe('https://jarvis.example.com/api/auth/google/callback');
+  });
+});
+
+describe('normalizePublicOrigin', () => {
+  it('rejects URLs with a path', () => {
+    expect(() => normalizePublicOrigin('https://example.com/jarvis')).toThrow('without a path');
+  });
+
+  it('rejects credentials, query, and fragments', () => {
+    expect(() => normalizePublicOrigin('https://user:pw@example.com')).toThrow();
+    expect(() => normalizePublicOrigin('https://example.com?x=1')).toThrow();
+  });
+
+  it('defaults bare public hosts to https and loopback hosts to http', () => {
+    expect(normalizePublicOrigin('jarvis.example.com')).toBe('https://jarvis.example.com');
+    expect(normalizePublicOrigin('localhost:3142')).toBe('http://localhost:3142');
+  });
+});

--- a/src/util/external-origin.ts
+++ b/src/util/external-origin.ts
@@ -1,0 +1,186 @@
+import type { JarvisConfig } from '../config/types.ts';
+
+export type ExternalOriginSource = 'public_url' | 'brain_domain' | 'fallback';
+
+export type ExternalOriginResolution = {
+  httpOrigin: string;
+  wsOrigin: string;
+  source: ExternalOriginSource;
+  proxyDetected: boolean;
+  warnings: string[];
+};
+
+const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '0.0.0.0', '::1']);
+
+function isLoopbackHostname(hostname: string): boolean {
+  return LOOPBACK_HOSTS.has(hostname.replace(/^\[|\]$/g, '').toLowerCase());
+}
+
+/** Validate and canonicalize a user/config supplied public origin. */
+export function normalizePublicOrigin(raw: string): string {
+  const value = raw.trim();
+  if (!value) throw new Error('Public Jarvis URL cannot be empty');
+
+  let withScheme = value;
+  if (!/^(https?|wss?):\/\//i.test(value)) {
+    const host = value.replace(/\/+$/, '');
+    const hostname = host.startsWith('[')
+      ? host.slice(1, host.indexOf(']'))
+      : host.split(':')[0];
+    withScheme = `${LOOPBACK_HOSTS.has(hostname?.toLowerCase() ?? '') ? 'http' : 'https'}://${host}`;
+  }
+
+  const parsed = new URL(withScheme);
+  if (!['http:', 'https:', 'ws:', 'wss:'].includes(parsed.protocol)) {
+    throw new Error(`Unsupported public Jarvis URL scheme: ${parsed.protocol}`);
+  }
+  if (parsed.username || parsed.password || parsed.search || parsed.hash) {
+    throw new Error('Public Jarvis URL must not contain credentials, a query, or a fragment');
+  }
+  if (parsed.pathname !== '/' && parsed.pathname !== '') {
+    throw new Error('Public Jarvis URL must be an origin without a path');
+  }
+
+  const secure = parsed.protocol === 'https:' || parsed.protocol === 'wss:';
+  return `${secure ? 'https' : 'http'}://${parsed.host}`;
+}
+
+/**
+ * Legacy `brain_domain` values were never validated, so a config that booted
+ * fine before this validation existed must keep booting. Keep the host and
+ * drop whatever made the value invalid; return null only when unparseable.
+ */
+function salvageLegacyPublicOrigin(raw: string): string | null {
+  const value = raw.trim();
+  if (!value) return null;
+  // A scheme-looking prefix that is not a supported scheme (ftp://) or is
+  // malformed (https:/one-slash) would parse into a nonsense host; give up.
+  if (/^[a-z][a-z0-9+.-]*:\//i.test(value) && !/^(https?|wss?):\/\//i.test(value)) return null;
+  const hadScheme = /^(https?|wss?):\/\//i.test(value);
+  try {
+    const parsed = new URL(hadScheme ? value : `https://${value}`);
+    if (!['http:', 'https:', 'ws:', 'wss:'].includes(parsed.protocol) || !parsed.host) {
+      return null;
+    }
+    const hostname = parsed.hostname.replace(/^\[|\]$/g, '');
+    if (!hostname.includes('.') && !hostname.includes(':') && !isLoopbackHostname(hostname)) {
+      return null;
+    }
+    const secure = hadScheme
+      ? parsed.protocol === 'https:' || parsed.protocol === 'wss:'
+      : !isLoopbackHostname(parsed.hostname);
+    return `${secure ? 'https' : 'http'}://${parsed.host}`;
+  } catch {
+    return null;
+  }
+}
+
+function wsOrigin(httpOrigin: string): string {
+  const parsed = new URL(httpOrigin);
+  return `${parsed.protocol === 'https:' ? 'wss' : 'ws'}://${parsed.host}`;
+}
+
+function firstHeaderValue(value: string | null): string | undefined {
+  return value?.split(',')[0]?.trim() || undefined;
+}
+
+/**
+ * Origin the reverse proxy reports via Forwarded / X-Forwarded-* headers.
+ * Diagnostics only: it feeds warnings shown to the operator and never decides
+ * the resolved origin, so no proxy trust model is needed.
+ */
+function observedProxyOrigin(req: Request): { origin: string | null; detected: boolean } {
+  const standard = firstHeaderValue(req.headers.get('forwarded'));
+  let proto: string | undefined;
+  let host: string | undefined;
+  if (standard) {
+    for (const part of standard.split(';')) {
+      const [rawKey, ...rawValue] = part.split('=');
+      const key = rawKey?.trim().toLowerCase();
+      const value = rawValue.join('=').trim().replace(/^"|"$/g, '');
+      if (key === 'proto') proto = value;
+      if (key === 'host') host = value;
+    }
+  }
+  proto ??= firstHeaderValue(req.headers.get('x-forwarded-proto'));
+  host ??= firstHeaderValue(req.headers.get('x-forwarded-host'));
+  const detected = Boolean(standard || req.headers.has('x-forwarded-proto') || req.headers.has('x-forwarded-host'));
+
+  if (!proto || !/^https?$/i.test(proto)) return { origin: null, detected };
+  const effectiveHost = host ?? req.headers.get('host') ?? undefined;
+  if (!effectiveHost) return { origin: null, detected };
+  try {
+    return { origin: normalizePublicOrigin(`${proto.toLowerCase()}://${effectiveHost}`), detected };
+  } catch {
+    return { origin: null, detected };
+  }
+}
+
+/**
+ * Resolve the canonical externally reachable Jarvis origin.
+ *
+ * Purely a function of configuration: `daemon.public_url` (or the legacy
+ * `daemon.brain_domain` alias), falling back to `localhost:<port>`. The
+ * optional request only contributes diagnostics (proxy detection, mismatch
+ * warnings) — it never changes the resolved origin.
+ */
+export function resolveExternalOrigin(config: JarvisConfig, req?: Request): ExternalOriginResolution {
+  const publicUrl = config.daemon.public_url?.trim();
+  const brainDomain = config.daemon.brain_domain?.trim();
+  const configured = publicUrl || brainDomain;
+  const configuredSource: ExternalOriginSource = publicUrl
+    ? 'public_url'
+    : brainDomain
+      ? 'brain_domain'
+      : 'fallback';
+  const warnings: string[] = [];
+
+  let httpOrigin: string | null = null;
+  if (configured) {
+    try {
+      httpOrigin = normalizePublicOrigin(configured);
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      const salvaged = salvageLegacyPublicOrigin(configured);
+      if (salvaged) {
+        warnings.push(
+          `Configured public URL "${configured}" is not a plain origin (${detail}); using ${salvaged}`,
+        );
+        httpOrigin = salvaged;
+      } else {
+        warnings.push(
+          `Configured public URL "${configured}" is unusable (${detail}); falling back to localhost:${config.daemon.port}`,
+        );
+      }
+    }
+  }
+  const source = httpOrigin ? configuredSource : 'fallback';
+  httpOrigin ??= `http://localhost:${config.daemon.port}`;
+
+  const observed = req ? observedProxyOrigin(req) : { origin: null, detected: false };
+  if (source === 'fallback' && observed.detected) {
+    warnings.push(
+      'This request came through a reverse proxy but daemon.public_url is not set — '
+      + 'OAuth callbacks and enrollment tokens will point at localhost. '
+      + 'Set daemon.public_url (or JARVIS_PUBLIC_URL) to the public origin.',
+    );
+  } else if (observed.origin && observed.origin !== httpOrigin) {
+    warnings.push(
+      `Configured public origin ${httpOrigin} differs from the origin reported by the proxy (${observed.origin}). `
+      + 'Check daemon.public_url if external links are wrong.',
+    );
+  }
+
+  return {
+    httpOrigin,
+    wsOrigin: wsOrigin(httpOrigin),
+    source,
+    proxyDetected: observed.detected,
+    warnings,
+  };
+}
+
+export function externalUrl(origin: ExternalOriginResolution, pathname: string): string {
+  const path = pathname.startsWith('/') ? pathname : `/${pathname}`;
+  return `${origin.httpOrigin}${path}`;
+}

--- a/ui/src/v2/rooms/settings/tabs/IntegrationsTab.tsx
+++ b/ui/src/v2/rooms/settings/tabs/IntegrationsTab.tsx
@@ -14,11 +14,28 @@ export function IntegrationsTab({
   const [clientSecret, setClientSecret] = useState("");
   const [phase, setPhase] = useState<"idle" | "saving" | "authenticating">("idle");
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const [googleRedirectUri, setGoogleRedirectUri] = useState(
+    () => `${window.location.origin}/api/auth/google/callback`,
+  );
+  const [originWarnings, setOriginWarnings] = useState<string[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    void fetch("/api/system/external-origin")
+      .then((response) => response.json())
+      .then((result: { google_callback?: string; warnings?: string[] }) => {
+        if (cancelled) return;
+        if (result.google_callback) setGoogleRedirectUri(result.google_callback);
+        setOriginWarnings(result.warnings ?? []);
+      })
+      .catch(() => { /* keep the browser-origin guess; may differ from the daemon's resolved origin */ });
+    return () => { cancelled = true; };
+  }, []);
 
   // Listen for the OAuth popup completion event
   const handleMessage = useCallback(
     (event: MessageEvent) => {
-      if (event.data === "google-auth-complete") {
+      if (event.origin === window.location.origin && event.data === "google-auth-complete") {
         if (pollRef.current) {
           clearInterval(pollRef.current);
           pollRef.current = null;
@@ -150,12 +167,15 @@ export function IntegrationsTab({
                 <li>
                   Add this Authorized redirect URI:
                   <code className="v2-set__code v2-set__code--block">
-                    http://localhost:3142/api/auth/google/callback
+                    {googleRedirectUri}
                   </code>
                 </li>
                 <li>Paste the Client ID and Client Secret below</li>
               </ol>
             </div>
+            {originWarnings.map((warning) => (
+              <p className="v2-set__hint v2-set__hint--warn" key={warning}>{warning}</p>
+            ))}
             <div className="v2-set__field">
               <label className="v2-set__field-label">Client ID</label>
               <input
@@ -188,6 +208,13 @@ export function IntegrationsTab({
         ) : g.status === "credentials_saved" && phase === "idle" ? (
           <>
             <p className="v2-set__hint">Credentials saved. Connect a Google account to authorize.</p>
+            <div className="v2-set__field">
+              <div className="v2-set__field-label">Authorized redirect URI</div>
+              <code className="v2-set__code v2-set__code--block">{googleRedirectUri}</code>
+            </div>
+            {originWarnings.map((warning) => (
+              <p className="v2-set__hint v2-set__hint--warn" key={warning}>{warning}</p>
+            ))}
             <div style={{ display: "flex", gap: "var(--s-2)", flexWrap: "wrap" }}>
               <button
                 type="button"


### PR DESCRIPTION
## What

Fixes Google OAuth and the external origin for reverse-proxied / remote deployments, purely from configuration.

- **`daemon.public_url`** (env: `JARVIS_PUBLIC_URL`) is the new canonical public origin for OAuth callbacks, sidecar enrollment, CORS/WS origin, and generated links. `brain_domain` / `JARVIS_BRAIN_DOMAIN` remain as deprecated aliases.
- **`resolveExternalOrigin()`** is a pure function of config: `public_url` → `brain_domain` → `localhost:<port>`. Request headers **never** decide the origin — they only feed diagnostics warnings (`/api/system/external-origin`, startup log, CLI).
- **Google OAuth security fix**: all three flows (dashboard, `jarvis deps`, `google-setup`) now use a one-time `state` + PKCE (S256), with `redirect_uri` and verifier bound server-side. Previously the callback had no `state` at all (login-CSRF) and the redirect URI was hardcoded to `http://localhost:3142`, ignoring even a custom port.
- **Boot safety**: legacy `brain_domain` values that predate validation (paths, queries, odd schemes) can no longer crash startup — the origin is salvaged (or falls back to localhost) with a loud warning.
- CLI OAuth flows now bind the daemon's configured port, print resolver warnings, and give a clear "daemon is running — use the dashboard" message on port collision.
- Settings → Integrations shows the daemon-resolved redirect URI instead of a hardcoded localhost example, and the OAuth popup `postMessage` handler now checks `event.origin`.

## What this deliberately does NOT do

Network configuration stays config-file/env only. There is no DB-stored hosting setting, no editable dashboard control, no `trust_proxy` option, and no header-derived origin. Jarvis behaves identically regardless of who wrote the config — a plain localhost user gets byte-identical behavior to `main`.

## Migration note

If you had `brain_domain` set, the dashboard Google flow now calls back to that origin instead of `http://localhost:3142/...` — register the redirect URI shown in Settings → Integrations in Google Cloud.
