### PR TITLE
feat(chat): add response interruption controls

### DIFF
--- a/src/comms/streaming.test.ts
+++ b/src/comms/streaming.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from 'bun:test';
+import type { LLMStreamEvent } from '../llm/provider.ts';
+import type { WebSocketServer, WSMessage } from './websocket.ts';
+import { StreamRelay } from './streaming.ts';
+
+function doneEvent(content: string): LLMStreamEvent {
+  return {
+    type: 'done',
+    response: {
+      content,
+      tool_calls: [],
+      usage: { input_tokens: 1, output_tokens: 1 },
+      model: 'test',
+      finish_reason: 'stop',
+    },
+  };
+}
+
+describe('StreamRelay cancellation', () => {
+  test('stops relaying late chunks and does not emit done after abort', async () => {
+    const messages: WSMessage[] = [];
+    const controller = new AbortController();
+    const server = {
+      broadcast(message: WSMessage) {
+        messages.push(message);
+        if (
+          message.type === 'stream'
+          && typeof (message.payload as { text?: unknown } | undefined)?.text === 'string'
+        ) {
+          controller.abort('test');
+        }
+      },
+    } as unknown as WebSocketServer;
+    const relay = new StreamRelay(server);
+
+    async function* stream(): AsyncGenerator<LLMStreamEvent> {
+      yield { type: 'text', text: 'first' };
+      yield { type: 'text', text: ' late' };
+      yield doneEvent('first late');
+    }
+
+    const text = await relay.relayStream(stream(), 'req-1', { signal: controller.signal });
+    expect(text).toBe('first');
+    expect(messages.map((message) => message.type)).toEqual(['stream']);
+  });
+
+  test('keeps the normal done lifecycle when not cancelled', async () => {
+    const messages: WSMessage[] = [];
+    const server = {
+      broadcast(message: WSMessage) { messages.push(message); },
+    } as unknown as WebSocketServer;
+    const relay = new StreamRelay(server);
+
+    async function* stream(): AsyncGenerator<LLMStreamEvent> {
+      yield { type: 'text', text: 'hello' };
+      yield doneEvent('hello');
+    }
+
+    expect(await relay.relayStream(stream(), 'req-2')).toBe('hello');
+    expect(messages.map((message) => message.type)).toEqual(['stream', 'status']);
+  });
+});

--- a/src/comms/streaming.ts
+++ b/src/comms/streaming.ts
@@ -7,6 +7,8 @@ export type RelayOptions = {
   onSentence?: (sentence: string) => void;
   /** Called when all text is done streaming. */
   onTextDone?: () => void;
+  /** Stops relaying immediately when the owning client cancels/supersedes the turn. */
+  signal?: AbortSignal;
 };
 
 // Sentence boundary: period, exclamation, question mark, colon followed by whitespace or end
@@ -35,6 +37,7 @@ export class StreamRelay {
 
     try {
       for await (const event of stream) {
+        if (options?.signal?.aborted) break;
         if (event.type === 'text') {
           fullText += event.text;
 
@@ -105,7 +108,7 @@ export class StreamRelay {
             options.onSentence(sentenceBuffer.trim());
             sentenceBuffer = '';
           }
-          options?.onTextDone?.();
+          if (!options?.signal?.aborted) options?.onTextDone?.();
 
           console.log('[StreamRelay] Stream complete for request:', requestId);
 
@@ -121,7 +124,7 @@ export class StreamRelay {
             timestamp: Date.now(),
           };
 
-          this.wsServer.broadcast(doneMessage);
+          if (!options?.signal?.aborted) this.wsServer.broadcast(doneMessage);
         }
       }
 

--- a/src/comms/websocket.test.ts
+++ b/src/comms/websocket.test.ts
@@ -1,4 +1,7 @@
 import { test, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
 import { WebSocketServer, type WSMessage } from './websocket.ts';
 
 let server: WebSocketServer;
@@ -68,6 +71,23 @@ test('WebSocketServer - root endpoint returns 404 without static dir', async () 
   expect(response.status).toBe(404);
 
   server.stop();
+});
+
+test('WebSocketServer - dashboard HTML is never cached by a reverse proxy', async () => {
+  const staticDir = mkdtempSync(path.join(tmpdir(), 'jarvis-static-'));
+  try {
+    await Bun.write(path.join(staticDir, 'index.html'), '<!doctype html><title>Jarvis</title>');
+    server.setStaticDir(staticDir);
+    server.start();
+
+    const response = await fetch('http://localhost:3143/');
+    expect(response.status).toBe(200);
+    expect(response.headers.get('cache-control')).toBe('no-store');
+    expect(response.headers.get('content-type')).toContain('text/html');
+  } finally {
+    server.stop();
+    rmSync(staticDir, { recursive: true, force: true });
+  }
 });
 
 test('WebSocketServer - WebSocket connection', async () => {

--- a/src/comms/websocket.test.ts
+++ b/src/comms/websocket.test.ts
@@ -75,17 +75,22 @@ test('WebSocketServer - root endpoint returns 404 without static dir', async () 
 
 test('WebSocketServer - dashboard HTML is never cached by a reverse proxy', async () => {
   const staticDir = mkdtempSync(path.join(tmpdir(), 'jarvis-static-'));
+  // Own port: earlier tests leave a pooled keep-alive connection to 3143
+  // whose (stopped, draining) server instance would answer this fetch with
+  // its own routing — a 404, since it had no staticDir.
+  const htmlServer = new WebSocketServer(3144);
+  htmlServer.setInsecureOpenAccess(true);
   try {
     await Bun.write(path.join(staticDir, 'index.html'), '<!doctype html><title>Jarvis</title>');
-    server.setStaticDir(staticDir);
-    server.start();
+    htmlServer.setStaticDir(staticDir);
+    htmlServer.start();
 
-    const response = await fetch('http://localhost:3143/');
+    const response = await fetch('http://localhost:3144/');
     expect(response.status).toBe(200);
     expect(response.headers.get('cache-control')).toBe('no-store');
     expect(response.headers.get('content-type')).toContain('text/html');
   } finally {
-    server.stop();
+    htmlServer.stop();
     rmSync(staticDir, { recursive: true, force: true });
   }
 });

--- a/src/comms/websocket.ts
+++ b/src/comms/websocket.ts
@@ -6,7 +6,7 @@ import type { SidecarManager } from '../sidecar/manager.ts';
 
 /** Constant-time string comparison to prevent timing attacks */
 export type WSMessage = {
-  type: 'chat' | 'command' | 'status' | 'stream' | 'error' | 'notification'
+  type: 'chat' | 'cancel' | 'command' | 'status' | 'stream' | 'error' | 'notification'
       | 'tts_start' | 'tts_text' | 'tts_end' | 'voice_start' | 'voice_end' | 'voice_text'
       | 'interview_start' | 'interview_user_message' | 'interview_assistant' | 'interview_done' | 'interview_error'
       | 'thinking_start' | 'thinking_end'

--- a/src/comms/websocket.ts
+++ b/src/comms/websocket.ts
@@ -472,9 +472,20 @@ export class WebSocketServer {
 
           const file = Bun.file(filePath);
           if (await file.exists()) {
-            if (!self.insecureOpenAccess && filePath.endsWith('.html')) {
-              const html = await file.text();
-              return new Response(injectTokenStrip(html), { headers: { 'Content-Type': 'text/html' } });
+            if (filePath.endsWith('.html')) {
+              // The HTML points at content-hashed JS/CSS bundles. Never let a
+              // browser or reverse proxy retain an old shell after an update,
+              // otherwise newly deployed controls (such as Stop) remain
+              // invisible even though the new bundle exists on the server.
+              const headers = {
+                'Content-Type': 'text/html',
+                'Cache-Control': 'no-store',
+              };
+              if (!self.insecureOpenAccess) {
+                const html = await file.text();
+                return new Response(injectTokenStrip(html), { headers });
+              }
+              return new Response(file, { headers });
             }
             return new Response(file);
           }

--- a/src/daemon/realtime-voice.ts
+++ b/src/daemon/realtime-voice.ts
@@ -103,6 +103,11 @@ export class RealtimeVoiceSession {
     return this.session.connect();
   }
 
+  /** Stop the current spoken response without closing the conversation. */
+  interrupt(): void {
+    if (!this.closed) this.session.interrupt();
+  }
+
   close(): void {
     this.closed = true;
     this.session.close();

--- a/src/daemon/ws-service-cleanup.test.ts
+++ b/src/daemon/ws-service-cleanup.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 import {
   cleanupPerSocketMaps,
+  isVoiceStopCommand,
   sweepExpiredVoiceConfirmations,
 } from './ws-service.ts';
 
@@ -8,6 +9,16 @@ import {
 // objects as fake sockets so identity equality (===) matches what the
 // real ServerWebSocket comparison does in cleanupPerSocketMaps.
 const makeFakeSocket = (label: string) => Object.freeze({ __socket: label });
+
+describe('isVoiceStopCommand', () => {
+  test('accepts stop-only voice controls without matching ordinary requests', () => {
+    expect(isVoiceStopCommand('Jarvis stop')).toBe(true);
+    expect(isVoiceStopCommand('HEY JARVIS, BE QUIET!')).toBe(true);
+    expect(isVoiceStopCommand('stop')).toBe(true);
+    expect(isVoiceStopCommand('Jarvis stop the timer')).toBe(false);
+    expect(isVoiceStopCommand('Can you stop talking eventually?')).toBe(false);
+  });
+});
 
 describe('cleanupPerSocketMaps', () => {
   test('removes the disconnecting socket from voiceSessions and interviewSessions, and sweeps pendingVoiceConfirmations entries that reference it', () => {

--- a/src/daemon/ws-service.ts
+++ b/src/daemon/ws-service.ts
@@ -135,6 +135,24 @@ export function sweepExpiredVoiceConfirmations<W>(
   return expired;
 }
 
+/** Voice-only hard interrupt; never forward these phrases to the LLM. */
+export function isVoiceStopCommand(transcript: string): boolean {
+  const normalized = transcript
+    .toLowerCase()
+    .replace(/[.,!?;:]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  return new Set([
+    'stop',
+    'jarvis stop',
+    'hey jarvis stop',
+    'jarvis be quiet',
+    'hey jarvis be quiet',
+    'jarvis quiet',
+    'hey jarvis quiet',
+  ]).has(normalized);
+}
+
 export class WebSocketService implements Service {
   name = 'websocket';
   private _status: ServiceStatus = 'stopped';
@@ -149,6 +167,11 @@ export class WebSocketService implements Service {
   private ttsProvider: TTSProvider | null = null;
   private sttProvider: STTProvider | null = null;
   private voiceSessions = new Map<ServerWebSocket<unknown>, VoiceSession>();
+  /** One foreground chat turn per dashboard socket. A new turn supersedes it. */
+  private activeChats = new Map<
+    ServerWebSocket<unknown>,
+    { requestId: string; controller: AbortController }
+  >();
   private pendingVoiceConfirmations = new Map<string, PendingVoiceConfirmation>();
   /**
    * Premium realtime voice (gpt-realtime-2) sessions, keyed by socket. Present
@@ -321,6 +344,7 @@ export class WebSocketService implements Service {
           console.log('[WSService] Client connected');
         },
         onDisconnect: (ws) => {
+          this.cancelActiveChat(ws, 'disconnect', false);
           // Tear down any realtime voice session (closes the OpenAI WS + timer).
           this.closeRealtimeVoice(ws);
           // Clean up every per-socket map so a long-running daemon doesn't
@@ -768,10 +792,55 @@ export class WebSocketService implements Service {
   /**
    * Route incoming WebSocket messages to the appropriate handler.
    */
+  private cancelActiveChat(
+    ws: ServerWebSocket<unknown>,
+    reason: 'user' | 'superseded' | 'voice' | 'disconnect',
+    notify = true,
+    expectedRequestId?: string,
+  ): boolean {
+    const active = this.activeChats.get(ws);
+    if (!active) return false;
+    if (expectedRequestId && active.requestId !== expectedRequestId) return false;
+    this.activeChats.delete(ws);
+    active.controller.abort(reason);
+    if (notify) {
+      this.wsServer.sendToClient(ws, {
+        type: 'status',
+        payload: { status: 'cancelled', requestId: active.requestId, reason },
+        id: active.requestId,
+        timestamp: Date.now(),
+      });
+      // Flush both the browser audio queue and its speaking/thinking state now;
+      // the provider stream may need another network chunk before its iterator
+      // observes the AbortSignal.
+      this.wsServer.sendToClient(ws, {
+        type: 'tts_end',
+        payload: { requestId: active.requestId, cancelled: true },
+        id: active.requestId,
+        timestamp: Date.now(),
+      });
+      this.wsServer.sendToClient(ws, {
+        type: 'thinking_end',
+        payload: { requestId: active.requestId, cancelled: true },
+        id: active.requestId,
+        timestamp: Date.now(),
+      });
+    }
+    return true;
+  }
+
   private async routeMessage(msg: WSMessage, ws: ServerWebSocket<unknown>): Promise<WSMessage | void> {
     switch (msg.type) {
       case 'chat':
         return this.handleChat(msg, ws);
+
+      case 'cancel': {
+        const requestId = (msg.payload as { requestId?: string } | undefined)?.requestId;
+        this.cancelActiveChat(ws, 'user', true, requestId);
+        this.realtimeSessions.get(ws)?.session.interrupt();
+        this.voiceSessions.delete(ws);
+        return undefined;
+      }
 
       case 'command':
         return this.handleCommand(msg);
@@ -893,6 +962,11 @@ export class WebSocketService implements Service {
 
     const channel = payload.channel ?? 'websocket';
     const requestId = msg.id ?? crypto.randomUUID();
+
+    // A dashboard socket owns at most one foreground turn. This is the
+    // server-side half of typed barge-in: cancel old generation/TTS before
+    // classifying or starting the replacement message.
+    if (ws) this.cancelActiveChat(ws, 'superseded');
 
     // Text-driven Room navigation + room actions. Run the same intent
     // classifier the voice path uses on the typed text. If it parses
@@ -1017,6 +1091,12 @@ CRITICAL — when in genuine doubt between "make in a new project" vs "add to th
       }
     }
 
+    const activeChat = ws
+      ? { requestId, controller: new AbortController() }
+      : null;
+    if (ws && activeChat) this.activeChats.set(ws, activeChat);
+    let retainActiveForTTS = false;
+
     // Persist user message
     try {
       const conversation = getOrCreateConversation(channel);
@@ -1042,6 +1122,10 @@ CRITICAL — when in genuine doubt between "make in a new project" vs "add to th
       let ttsChunkCount = 0;
 
       const speakNextSentence = async () => {
+        if (activeChat?.controller.signal.aborted) {
+          ttsSentenceQueue = [];
+          return;
+        }
         if (ttsSpeaking || !ttsActive || !ws) return;
         const sentence = ttsSentenceQueue.shift();
         if (!sentence) {
@@ -1055,6 +1139,10 @@ CRITICAL — when in genuine doubt between "make in a new project" vs "add to th
               timestamp: Date.now(),
             });
             ttsStartSent = false; // prevent duplicate tts_end
+            retainActiveForTTS = false;
+            if (activeChat && this.activeChats.get(ws) === activeChat) {
+              this.activeChats.delete(ws);
+            }
           }
           return;
         }
@@ -1092,6 +1180,7 @@ CRITICAL — when in genuine doubt between "make in a new project" vs "add to th
         try {
           if (this.ttsProvider) {
             for await (const chunk of this.ttsProvider.synthesizeStream(sentence)) {
+              if (activeChat?.controller.signal.aborted) break;
               ttsChunkCount++;
               this.wsServer.sendBinary(ws, chunk);
             }
@@ -1107,12 +1196,32 @@ CRITICAL — when in genuine doubt between "make in a new project" vs "add to th
       // onSentence fires for each complete sentence during streaming.
       // NOTE: onTextDone fires per LLM turn (tool loop), NOT once at the end.
       // We ignore onTextDone and use the relayStream return to mark stream completion.
-      const fullText = await this.streamRelay.relayStream(stream, requestId, ttsActive ? {
-        onSentence: (sentence) => {
-          ttsSentenceQueue.push(sentence);
-          speakNextSentence();
-        },
-      } : undefined);
+      const fullText = await this.streamRelay.relayStream(stream, requestId, {
+        signal: activeChat?.controller.signal,
+        ...(ttsActive ? {
+          onSentence: (sentence: string) => {
+            if (activeChat?.controller.signal.aborted) return;
+            ttsSentenceQueue.push(sentence);
+            speakNextSentence();
+          },
+        } : {}),
+      });
+
+      if (activeChat?.controller.signal.aborted) {
+        ttsSentenceQueue = [];
+        setDefaultCwd(null);
+        if (taskCommitment) {
+          try {
+            const updated = updateCommitmentStatus(taskCommitment.id, 'failed', 'Stopped by user');
+            if (updated) this.broadcastTaskUpdate(updated, 'updated');
+          } catch (err) {
+            console.error('[WSService] Failed to cancel task:', err);
+          } finally {
+            this.activeTaskId = null;
+          }
+        }
+        return undefined;
+      }
 
       // Stream is now fully done (all tool loop turns complete)
       ttsStreamFullyDone = true;
@@ -1128,6 +1237,7 @@ CRITICAL — when in genuine doubt between "make in a new project" vs "add to th
           ttsStartSent = false;
         }
         // Otherwise speakNextSentence will send tts_end when queue drains
+        retainActiveForTTS = ttsSpeaking || ttsSentenceQueue.length > 0 || ttsStartSent;
       }
 
       // Persist assistant response
@@ -1217,6 +1327,10 @@ CRITICAL — when in genuine doubt between "make in a new project" vs "add to th
         id: requestId,
         timestamp: Date.now(),
       };
+    } finally {
+      if (ws && activeChat && !retainActiveForTTS && this.activeChats.get(ws) === activeChat) {
+        this.activeChats.delete(ws);
+      }
     }
   }
 
@@ -1643,6 +1757,21 @@ CRITICAL — when in genuine doubt between "make in a new project" vs "add to th
     if (!trimmed) return;
 
     console.log('[WSService] Voice transcript:', trimmed);
+
+    // Hard interrupt is transport control, not a conversational turn. Do it
+    // before transcript echo/classification so "Jarvis stop" never produces a
+    // user bubble, an LLM answer, or another overlapping TTS stream.
+    if (isVoiceStopCommand(trimmed)) {
+      this.cancelActiveChat(ws, 'voice');
+      this.realtimeSessions.get(ws)?.session.interrupt();
+      this.wsServer.sendToClient(ws, {
+        type: 'tts_end',
+        payload: { requestId, cancelled: true },
+        id: requestId,
+        timestamp: Date.now(),
+      });
+      return;
+    }
 
     // Echo transcript back so the UI shows it as a user message immediately,
     // regardless of which routing path the classifier picks.

--- a/src/daemon/ws-service.ts
+++ b/src/daemon/ws-service.ts
@@ -27,7 +27,7 @@ import { getUserProfile } from '../vault/user-profile.ts';
 import { formatUserProfileForPrompt } from '../user/profile.ts';
 import { routeByConfidence, intentToRoomKey, intentIsBackToThread, type Intent, type RoomKey } from '../voice/intent.ts';
 import { matchWindowControl, type WindowControl } from '../voice/window-control.ts';
-import { containsWakePhrase } from '../voice/wake-phrase.ts';
+import { containsStopPhrase, containsWakePhrase } from '../voice/wake-phrase.ts';
 import {
   createInterviewSession,
   runInterviewTurn,
@@ -135,22 +135,30 @@ export function sweepExpiredVoiceConfirmations<W>(
   return expired;
 }
 
-/** Voice-only hard interrupt; never forward these phrases to the LLM. */
+/**
+ * Voice-only hard interrupt; never forward these phrases to the LLM.
+ * Twin of `isSpeechStopCommand` in ui/src/hooks/useVoice.ts (browser-STT
+ * path) — keep the phrase lists in sync when editing either one. The bare
+ * "stop" is server-only: daemon STT runs per recorded utterance, so it can't
+ * collide with TTS echo the way the browser's always-on recognizer can.
+ */
+const VOICE_STOP_PHRASES = new Set([
+  'stop',
+  'jarvis stop',
+  'hey jarvis stop',
+  'jarvis be quiet',
+  'hey jarvis be quiet',
+  'jarvis quiet',
+  'hey jarvis quiet',
+]);
+
 export function isVoiceStopCommand(transcript: string): boolean {
   const normalized = transcript
     .toLowerCase()
     .replace(/[.,!?;:]+/g, ' ')
     .replace(/\s+/g, ' ')
     .trim();
-  return new Set([
-    'stop',
-    'jarvis stop',
-    'hey jarvis stop',
-    'jarvis be quiet',
-    'hey jarvis be quiet',
-    'jarvis quiet',
-    'hey jarvis quiet',
-  ]).has(normalized);
+  return VOICE_STOP_PHRASES.has(normalized);
 }
 
 export class WebSocketService implements Service {
@@ -804,22 +812,27 @@ export class WebSocketService implements Service {
     this.activeChats.delete(ws);
     active.controller.abort(reason);
     if (notify) {
-      this.wsServer.sendToClient(ws, {
+      // Stream chunks are broadcast to every dashboard, and the aborted relay
+      // never emits its `status: done` — so the terminal `cancelled` status
+      // (and the thinking_end that mirrors the broadcast thinking_start) must
+      // broadcast too, or mirroring clients keep a spinner forever.
+      this.wsServer.broadcast({
         type: 'status',
         payload: { status: 'cancelled', requestId: active.requestId, reason },
         id: active.requestId,
         timestamp: Date.now(),
       });
-      // Flush both the browser audio queue and its speaking/thinking state now;
-      // the provider stream may need another network chunk before its iterator
-      // observes the AbortSignal.
+      // Flush the browser audio queue and its speaking state now; the provider
+      // stream may need another network chunk before its iterator observes the
+      // AbortSignal. TTS audio is per-socket (sendBinary), so this one stays
+      // addressed to the owning client.
       this.wsServer.sendToClient(ws, {
         type: 'tts_end',
         payload: { requestId: active.requestId, cancelled: true },
         id: active.requestId,
         timestamp: Date.now(),
       });
-      this.wsServer.sendToClient(ws, {
+      this.wsServer.broadcast({
         type: 'thinking_end',
         payload: { requestId: active.requestId, cancelled: true },
         id: active.requestId,
@@ -835,10 +848,12 @@ export class WebSocketService implements Service {
         return this.handleChat(msg, ws);
 
       case 'cancel': {
+        // Cancel stops the *response* (generation + TTS). It deliberately
+        // leaves any in-flight voiceSessions recording alone — that buffer is
+        // user input, and voice_end will process it normally.
         const requestId = (msg.payload as { requestId?: string } | undefined)?.requestId;
         this.cancelActiveChat(ws, 'user', true, requestId);
         this.realtimeSessions.get(ws)?.session.interrupt();
-        this.voiceSessions.delete(ws);
         return undefined;
       }
 
@@ -1152,13 +1167,17 @@ CRITICAL — when in genuine doubt between "make in a new project" vs "add to th
         // recognizer for the duration of the audio (otherwise TTS
         // playback echoes through the mic and self-triggers).
         const sentenceHasWake = containsWakePhrase(sentence);
+        // A spoken stop phrase ("say 'Jarvis, stop'…") would echo through the
+        // mic and hit the UI's stop-phrase bypass, cancelling the very reply
+        // that's explaining it. Flag it so the UI suppresses stop matches too.
+        const sentenceHasStop = containsStopPhrase(sentence);
 
         // Send tts_start exactly once before the first audio chunk
         if (!ttsStartSent) {
           ttsStartSent = true;
           this.wsServer.sendToClient(ws, {
             type: 'tts_start',
-            payload: { requestId, containsWake: sentenceHasWake },
+            payload: { requestId, containsWake: sentenceHasWake, containsStop: sentenceHasStop },
             id: requestId,
             timestamp: Date.now(),
           });
@@ -1169,7 +1188,7 @@ CRITICAL — when in genuine doubt between "make in a new project" vs "add to th
           // still be in the speaker buffer.)
           this.wsServer.sendToClient(ws, {
             type: 'tts_text',
-            payload: { requestId, containsWake: true },
+            payload: { requestId, containsWake: true, containsStop: sentenceHasStop },
             id: requestId,
             timestamp: Date.now(),
           });

--- a/src/voice/wake-phrase.test.ts
+++ b/src/voice/wake-phrase.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { containsWakePhrase } from './wake-phrase.ts';
+import { containsStopPhrase, containsWakePhrase } from './wake-phrase.ts';
 
 describe('containsWakePhrase', () => {
   test('matches the bare wake phrase', () => {
@@ -47,5 +47,21 @@ describe('containsWakePhrase', () => {
 
   test('matches multiple occurrences (still returns true; not a count)', () => {
     expect(containsWakePhrase('Jarvis told Jarvis about Jarvis')).toBe(true);
+  });
+});
+
+describe('containsStopPhrase', () => {
+  test('matches spoken stop phrases with TTS punctuation', () => {
+    expect(containsStopPhrase("Say 'Jarvis, stop' to interrupt me.")).toBe(true);
+    expect(containsStopPhrase('Jarvis stop')).toBe(true);
+    expect(containsStopPhrase('You can say "Jarvis... be quiet" anytime.')).toBe(true);
+    expect(containsStopPhrase('jarvis quiet')).toBe(true);
+  });
+
+  test('does not match ordinary mentions of Jarvis or stop', () => {
+    expect(containsStopPhrase('Jarvis stopped the timer for you')).toBe(false);
+    expect(containsStopPhrase('Ask Jarvis about the bus stop')).toBe(false);
+    expect(containsStopPhrase('Please stop by tomorrow')).toBe(false);
+    expect(containsStopPhrase('')).toBe(false);
   });
 });

--- a/src/voice/wake-phrase.ts
+++ b/src/voice/wake-phrase.ts
@@ -15,3 +15,19 @@ export function containsWakePhrase(text: string): boolean {
   if (!text) return false;
   return /\bjarvis\b/i.test(text);
 }
+
+/**
+ * True when outgoing TTS text contains a spoken stop command ("Jarvis
+ * stop" / "Jarvis (be) quiet"). Stop phrases deliberately bypass the
+ * containsWake echo suppression on the UI side so the user can interrupt
+ * a reply that says "Jarvis" — but if the reply itself *speaks* a stop
+ * phrase (e.g. explaining "say 'Jarvis, stop' to interrupt me"), that
+ * bypass would let the echo cancel the playback. This flag closes that
+ * hole: the UI re-enables suppression for stop phrases while flagged
+ * audio is playing. Tolerates punctuation between the words, which is
+ * how TTS text usually renders them ("Jarvis, stop").
+ */
+export function containsStopPhrase(text: string): boolean {
+  if (!text) return false;
+  return /\bjarvis\b\W+(?:stop|(?:be\s+)?quiet)\b/i.test(text);
+}

--- a/ui/src/hooks/useVoice.test.ts
+++ b/ui/src/hooks/useVoice.test.ts
@@ -7,7 +7,21 @@ import {
   selectActiveWakeEngine,
   isWithinSpeakingTailCooldown,
   planContainsWakeFlip,
+  isSpeechStopCommand,
 } from "./useVoice.ts";
+
+describe("isSpeechStopCommand", () => {
+  test("recognizes direct stop/quiet commands", () => {
+    expect(isSpeechStopCommand("Jarvis stop")).toBe(true);
+    expect(isSpeechStopCommand("Hey Jarvis, stop!")).toBe(true);
+    expect(isSpeechStopCommand("Jarvis be quiet")).toBe(true);
+  });
+
+  test("does not turn ordinary wake phrases into stop-only commands", () => {
+    expect(isSpeechStopCommand("Jarvis")).toBe(false);
+    expect(isSpeechStopCommand("Jarvis what time is it")).toBe(false);
+  });
+});
 
 describe("matchesSpeechWakePhrase (strict; used during TTS playback)", () => {
   test("accepts direct wake phrases", () => {

--- a/ui/src/hooks/useVoice.ts
+++ b/ui/src/hooks/useVoice.ts
@@ -63,7 +63,14 @@ export function matchesSpeechWakePrefix(transcript: string): boolean {
   return getWakePrefix(normalized) != null;
 }
 
-/** A wake phrase that means stop only; do not open a new recording turn. */
+/**
+ * A wake phrase that means stop only; do not open a new recording turn.
+ * Twin of `isVoiceStopCommand` in src/daemon/ws-service.ts (daemon-STT
+ * path) — keep the phrase lists in sync when editing either one. Unlike
+ * the daemon list, bare "stop" is excluded here: this recognizer runs
+ * continuously, so a lone "stop" is too easy to false-trigger via echo
+ * or ambient speech.
+ */
 export function isSpeechStopCommand(transcript: string): boolean {
   const normalized = normalizeTranscript(transcript);
   return normalized === "jarvis stop"
@@ -252,10 +259,11 @@ export type UseVoiceReturn = {
   activeWakeEngine: ActiveWakeEngine;
   // Called by useWebSocket for TTS events
   handleTTSBinary: (data: ArrayBuffer) => void;
-  handleTTSStart: (requestId: string, containsWake?: boolean) => void;
-  /** Mid-turn flip: a later sentence in the same TTS turn contains "Jarvis". */
-  handleTTSContainsWake: () => void;
-  handleTTSEnd: () => void;
+  handleTTSStart: (requestId: string, containsWake?: boolean, containsStop?: boolean) => void;
+  /** Mid-turn flip: a later sentence in the same TTS turn contains "Jarvis"
+   *  (and, when `containsStop`, a spoken stop phrase). */
+  handleTTSContainsWake: (containsStop?: boolean) => void;
+  handleTTSEnd: (requestId?: string, bargeIn?: boolean) => void;
   handleError: (message?: string) => void;
   /** Realtime session closed server-side — stop the mic, return to idle. */
   handleRealtimeClosed: () => void;
@@ -330,6 +338,12 @@ export function useVoice({ wsRef, wakeWordEnabled = true, wakeEngine = "openwake
   // for the duration of the speaking state. When false, the recognizer
   // stays running so a real human "Jarvis" can interrupt the reply.
   const ttsContainsWakeRef = useRef(false);
+  // Same lifecycle as ttsContainsWakeRef, but for spoken *stop phrases*
+  // ("Jarvis, stop"). Stop phrases normally bypass the containsWake echo
+  // suppression so a human can always interrupt; when the TTS audio itself
+  // says a stop phrase, that bypass must be disabled or the echo cancels
+  // the playback mid-sentence.
+  const ttsContainsStopRef = useRef(false);
   const startRecordingRef = useRef<(autoStop?: boolean) => void>(() => {});
   const autoStopRef = useRef(false);
   const cancelTTSRef = useRef<() => void>(() => {});
@@ -653,9 +667,12 @@ export function useVoice({ wsRef, wakeWordEnabled = true, wakeEngine = "openwake
         for (let i = event.resultIndex; i < event.results.length; i++) {
           const transcript = String(event.results[i]?.[0]?.transcript ?? "").toLowerCase().trim();
           if (!transcript) continue;
-          const stopOnly = isSpeechStopCommand(transcript);
+          // Stop phrases bypass echo suppression so a human can always
+          // interrupt — except while the TTS audio itself speaks a stop
+          // phrase, when the "match" is almost certainly our own echo.
+          const stopOnly = isSpeechStopCommand(transcript) && !ttsContainsStopRef.current;
           // Suppress normal wake matches when the speaker itself said
-          // "Jarvis", but always let the explicit stop phrase through.
+          // "Jarvis", but let the explicit stop phrase through.
           if (sNow === "speaking" && ttsContainsWakeRef.current && !stopOnly) continue;
           if (
             isWithinSpeakingTailCooldown(
@@ -927,7 +944,7 @@ export function useVoice({ wsRef, wakeWordEnabled = true, wakeEngine = "openwake
     }
   }, [playNextTTSChunk, getRealtimeController]);
 
-  const handleTTSStart = useCallback((requestId: string, containsWake = false) => {
+  const handleTTSStart = useCallback((requestId: string, containsWake = false, containsStop = false) => {
     console.log("[Voice] TTS start:", requestId, containsWake ? "(contains wake)" : "");
     // Stop any lingering playback from a previous TTS session
     if (ttsPlayingRef.current || ttsQueueRef.current.length > 0) {
@@ -936,6 +953,7 @@ export function useVoice({ wsRef, wakeWordEnabled = true, wakeEngine = "openwake
     }
     ttsRequestIdRef.current = requestId;
     ttsContainsWakeRef.current = containsWake;
+    ttsContainsStopRef.current = containsStop;
     ttsQueueRef.current = [];
     ttsPlayingRef.current = false;
     setVoiceState("speaking");
@@ -944,7 +962,10 @@ export function useVoice({ wsRef, wakeWordEnabled = true, wakeEngine = "openwake
     getAudioContext();
   }, [getAudioContext]);
 
-  const handleTTSContainsWake = useCallback(() => {
+  const handleTTSContainsWake = useCallback((containsStop = false) => {
+    // Like containsWake, the stop flip is one-way within a turn: earlier
+    // flagged audio may still be in the speaker buffer.
+    if (containsStop) ttsContainsStopRef.current = true;
     // The plan is computed by a pure helper so the regression boundary
     // (cooldown stamp on first flip) is unit-testable without React.
     const plan = planContainsWakeFlip(ttsContainsWakeRef.current);
@@ -980,6 +1001,7 @@ export function useVoice({ wsRef, wakeWordEnabled = true, wakeEngine = "openwake
     }
     ttsRequestIdRef.current = null;
     ttsContainsWakeRef.current = false;
+    ttsContainsStopRef.current = false;
     // If nothing is playing and queue is empty, transition now
     if (!ttsPlayingRef.current && ttsQueueRef.current.length === 0) {
       setVoiceState("idle");
@@ -1010,6 +1032,7 @@ export function useVoice({ wsRef, wakeWordEnabled = true, wakeEngine = "openwake
     ttsPlayingRef.current = false;
     ttsRequestIdRef.current = null;
     ttsContainsWakeRef.current = false;
+    ttsContainsStopRef.current = false;
     // Close and recreate AudioContext to stop current playback
     audioContextRef.current?.close();
     audioContextRef.current = null;

--- a/ui/src/hooks/useVoice.ts
+++ b/ui/src/hooks/useVoice.ts
@@ -8,6 +8,7 @@ const SPEECH_WAKE_INTERRUPT_COMMANDS = new Set([
   "pause",
   "listen",
   "quiet",
+  "be quiet",
   "sorry",
   "question",
   "hold on",
@@ -60,6 +61,17 @@ export function matchesSpeechWakePrefix(transcript: string): boolean {
   if (!normalized) return false;
   if (normalized === "jarvis" || normalized === "hey jarvis") return true;
   return getWakePrefix(normalized) != null;
+}
+
+/** A wake phrase that means stop only; do not open a new recording turn. */
+export function isSpeechStopCommand(transcript: string): boolean {
+  const normalized = normalizeTranscript(transcript);
+  return normalized === "jarvis stop"
+    || normalized === "hey jarvis stop"
+    || normalized === "jarvis quiet"
+    || normalized === "hey jarvis quiet"
+    || normalized === "jarvis be quiet"
+    || normalized === "hey jarvis be quiet";
 }
 
 export type VoiceState =
@@ -632,14 +644,6 @@ export function useVoice({ wsRef, wakeWordEnabled = true, wakeEngine = "openwake
         // session, forcing a re-wake mid-conversation. Ignore browser-SR matches
         // during any active realtime turn. (Idle wake still works to start one.)
         if (realtimeActiveRef.current && sNow !== "idle") return;
-        // During speaking with "Jarvis" in the TTS text: ignore wake
-        // matches; the recognizer is hearing its own voice through the
-        // speakers. The daemon flips this flag; UI honors it.
-        if (sNow === "speaking" && ttsContainsWakeRef.current) return;
-        // Trailing-tail guard: a short window after exiting a containsWake
-        // speaking turn so trailing TTS audio can't false-trigger.
-        if (isWithinSpeakingTailCooldown(Date.now(), speakingExitedAtRef.current, speakingTailCooldownMsRef.current)) return;
-
         // Strict matcher during speaking to keep TTS echo from self-triggering;
         // loose prefix matcher when idle so "hey jarvis <command>" wakes in one breath.
         const matcher = voiceStateRef.current === "speaking"
@@ -649,6 +653,18 @@ export function useVoice({ wsRef, wakeWordEnabled = true, wakeEngine = "openwake
         for (let i = event.resultIndex; i < event.results.length; i++) {
           const transcript = String(event.results[i]?.[0]?.transcript ?? "").toLowerCase().trim();
           if (!transcript) continue;
+          const stopOnly = isSpeechStopCommand(transcript);
+          // Suppress normal wake matches when the speaker itself said
+          // "Jarvis", but always let the explicit stop phrase through.
+          if (sNow === "speaking" && ttsContainsWakeRef.current && !stopOnly) continue;
+          if (
+            isWithinSpeakingTailCooldown(
+              Date.now(),
+              speakingExitedAtRef.current,
+              speakingTailCooldownMsRef.current,
+            )
+            && !stopOnly
+          ) continue;
           if (!matcher(transcript)) continue;
 
           const now = Date.now();
@@ -657,6 +673,11 @@ export function useVoice({ wsRef, wakeWordEnabled = true, wakeEngine = "openwake
 
           console.log(`[Voice] Speech wake phrase detected: "${transcript}"`);
           const s = voiceStateRef.current;
+          if (stopOnly && s !== "idle") {
+            cancelTTSRef.current();
+            forceIdleRef.current();
+            return;
+          }
           if (s === "speaking") {
             cancelTTSRef.current();
           } else if (s === "processing" || s === "wake_detected") {
@@ -896,6 +917,10 @@ export function useVoice({ wsRef, wakeWordEnabled = true, wakeEngine = "openwake
       getRealtimeController()?.enqueuePlayback(data);
       return;
     }
+    // Cancellation clears the request id immediately. The server/provider may
+    // still have one buffered frame in flight; discard it instead of letting
+    // speech restart after the user pressed Stop.
+    if (!ttsRequestIdRef.current) return;
     ttsQueueRef.current.push(data);
     if (!ttsPlayingRef.current) {
       playNextTTSChunk();
@@ -943,11 +968,14 @@ export function useVoice({ wsRef, wakeWordEnabled = true, wakeEngine = "openwake
     }
   }, [stopSpeechWakeIfNeeded]);
 
-  const handleTTSEnd = useCallback((bargeIn = false) => {
+  const handleTTSEnd = useCallback((requestId?: string, bargeIn = false) => {
     // Realtime: tts_end is used by the server only as a barge-in signal
     // (user started speaking) — flush queued output so we stop talking over them.
     if (realtimeActiveRef.current) {
       if (bargeIn) realtimeCtrlRef.current?.flushPlayback();
+      return;
+    }
+    if (requestId && ttsRequestIdRef.current && requestId !== ttsRequestIdRef.current) {
       return;
     }
     ttsRequestIdRef.current = null;
@@ -961,6 +989,16 @@ export function useVoice({ wsRef, wakeWordEnabled = true, wakeEngine = "openwake
   }, []);
 
   const cancelTTS = useCallback(() => {
+    const requestId = ttsRequestIdRef.current;
+    const ws = wsRef.current;
+    if (ws && ws.readyState === WebSocket.OPEN) {
+      ws.send(JSON.stringify({
+        type: "cancel",
+        payload: requestId ? { requestId } : {},
+        id: requestId ?? undefined,
+        timestamp: Date.now(),
+      }));
+    }
     if (realtimeActiveRef.current) {
       // Realtime: "stop talking" is a local flush (barge-in), NOT a session
       // teardown. Keep the mic streaming so the conversation continues — calling
@@ -977,7 +1015,7 @@ export function useVoice({ wsRef, wakeWordEnabled = true, wakeEngine = "openwake
     audioContextRef.current = null;
     setVoiceState("idle");
     setTtsAudioPlaying(false);
-  }, []);
+  }, [wsRef]);
 
   useEffect(() => {
     cancelTTSRef.current = cancelTTS;

--- a/ui/src/hooks/useWebSocket.ts
+++ b/ui/src/hooks/useWebSocket.ts
@@ -106,7 +106,7 @@ export type VoiceCallbacks = {
   onTTSContainsWake?: () => void;
   /** `bargeIn` — realtime voice sends tts_end{bargeIn:true} when the user
    *  starts speaking, so the player can flush queued output immediately. */
-  onTTSEnd: (bargeIn?: boolean) => void;
+  onTTSEnd: (requestId?: string, bargeIn?: boolean) => void;
   onError: (message?: string) => void;
   /** Realtime session ended server-side (max_session_minutes timeout or
    *  server close). The client must stop the mic — it's otherwise streaming
@@ -381,6 +381,7 @@ export function useWebSocket() {
   const [clarifiers, setClarifiers] = useState<PendingClarifier[]>([]);
   const [repeatBacks, setRepeatBacks] = useState<PendingRepeatBack[]>([]);
   const [thinking, setThinking] = useState(false);
+  const [isResponding, setIsResponding] = useState(false);
   const [roomNavRequest, setRoomNavRequest] = useState<{ key: string; ts: number } | null>(null);
   const [windowControlRequest, setWindowControlRequest] = useState<{
     action: "close" | "minimize" | "expand" | "restore" | "reorder";
@@ -401,6 +402,8 @@ export function useWebSocket() {
   const subAgentEventsRef = useRef<SubAgentEvent[]>([]);
   const voiceCallbacksRef = useRef<VoiceCallbacks | null>(null);
   const pendingChatIdsRef = useRef<Set<string>>(new Set());
+  /** Request whose chunks currently own the single foreground composer turn. */
+  const currentChatRequestIdRef = useRef<string | null>(null);
 
   const connect = useCallback(() => {
     // A manual "Retry now" or the scheduled backoff can fire while a socket is
@@ -474,6 +477,8 @@ export function useWebSocket() {
 
     ws.onclose = () => {
       setIsConnected(false);
+      setIsResponding(false);
+      currentChatRequestIdRef.current = null;
       console.log("[WS] Disconnected, reconnecting in 2s...");
       reconnectTimerRef.current = setTimeout(connect, 2000);
     };
@@ -511,7 +516,10 @@ export function useWebSocket() {
           return;
         }
         if (msg.type === "tts_end") {
-          voiceCallbacksRef.current?.onTTSEnd(Boolean(msg.payload?.bargeIn));
+          voiceCallbacksRef.current?.onTTSEnd(
+            msg.payload?.requestId,
+            Boolean(msg.payload?.bargeIn),
+          );
           return;
         }
         // Premium realtime voice (gpt-realtime-2) status + live captions.
@@ -553,9 +561,17 @@ export function useWebSocket() {
         }
         if (msg.type === "thinking_start") {
           setThinking(true);
+          setIsResponding(true);
+          if (msg.id) currentChatRequestIdRef.current = msg.id;
           return;
         }
         if (msg.type === "thinking_end") {
+          const requestId = String(msg.payload?.requestId ?? msg.id ?? "");
+          if (
+            currentChatRequestIdRef.current
+            && requestId
+            && requestId !== currentChatRequestIdRef.current
+          ) return;
           setThinking(false);
           return;
         }
@@ -599,6 +615,14 @@ export function useWebSocket() {
         },
       ]);
     } else if (msg.type === "stream") {
+      const requestId = String(msg.payload?.requestId ?? msg.id ?? "");
+      const currentRequestId = currentChatRequestIdRef.current;
+      // A cancelled/superseded provider can deliver one final network chunk
+      // while its async iterator unwinds. Never append it to the replacement
+      // response (the old single-buffer behavior caused overlapping answers).
+      if (currentRequestId && requestId && requestId !== currentRequestId) return;
+      if (!currentRequestId && requestId) currentChatRequestIdRef.current = requestId;
+      setIsResponding(true);
       if (msg.payload?.source === "sub-agent") {
         // Sub-agent progress event
         const event: SubAgentEvent = {
@@ -677,8 +701,18 @@ export function useWebSocket() {
           );
         }
       }
-    } else if (msg.type === "status" && msg.payload?.status === "done") {
-      // Stream complete
+    } else if (
+      msg.type === "status"
+      && (msg.payload?.status === "done" || msg.payload?.status === "cancelled")
+    ) {
+      const requestId = String(msg.payload?.requestId ?? msg.id ?? "");
+      if (
+        currentChatRequestIdRef.current
+        && requestId
+        && requestId !== currentChatRequestIdRef.current
+      ) return;
+      // Stream complete or explicitly stopped. Keep partial text visible but
+      // remove its speaking/streaming state immediately.
       if (streamIdRef.current) {
         const finalId = streamIdRef.current;
         const finalToolCalls = toolCallsRef.current;
@@ -707,6 +741,9 @@ export function useWebSocket() {
       subAgentEventsRef.current = [];
       // A successful completion ends any in-flight chat request correlation.
       pendingChatIdsRef.current.clear();
+      currentChatRequestIdRef.current = null;
+      setIsResponding(false);
+      setThinking(false);
     } else if (msg.type === "goal_event") {
       const goalEvent = msg.payload as GoalEvent;
       setGoalEvents((prev) => [...prev.slice(-100), goalEvent]);
@@ -957,6 +994,9 @@ export function useWebSocket() {
       streamIdRef.current = null;
       toolCallsRef.current = [];
       subAgentEventsRef.current = [];
+      currentChatRequestIdRef.current = null;
+      setIsResponding(false);
+      setThinking(false);
     }
   }, []);
 
@@ -973,11 +1013,46 @@ export function useWebSocket() {
     };
   }, [connect]);
 
+  const cancelResponse = useCallback(() => {
+    const requestId = currentChatRequestIdRef.current;
+    const ws = wsRef.current;
+    if (ws && ws.readyState === WebSocket.OPEN) {
+      ws.send(JSON.stringify({
+        type: "cancel",
+        payload: requestId ? { requestId } : {},
+        id: requestId ?? undefined,
+        timestamp: Date.now(),
+      }));
+    }
+
+    if (streamIdRef.current) {
+      const finalId = streamIdRef.current;
+      setMessages((prev) => prev.map((message) =>
+        message.id === finalId ? { ...message, isStreaming: false } : message
+      ));
+    }
+    streamBufferRef.current = "";
+    streamIdRef.current = null;
+    toolCallsRef.current = [];
+    subAgentEventsRef.current = [];
+    pendingChatIdsRef.current.clear();
+    currentChatRequestIdRef.current = null;
+    setThinking(false);
+    setIsResponding(false);
+  }, []);
+
   const sendMessage = useCallback(
     (text: string, options?: { projectId?: string; currentRoom?: string }) => {
       if (!wsRef.current || wsRef.current.readyState !== WebSocket.OPEN) return;
 
+      // Typed barge-in: the replacement turn owns the composer immediately.
+      // The daemon also enforces this, but doing it here prevents even a single
+      // late chunk from the old request flashing into the new response.
+      if (currentChatRequestIdRef.current || isResponding) cancelResponse();
+
       const id = uuid();
+      currentChatRequestIdRef.current = id;
+      setIsResponding(true);
 
       // Add user message to local state
       setMessages((prev) => [
@@ -1024,7 +1099,7 @@ export function useWebSocket() {
         setNotices((prev) => [notice, ...prev.filter((item) => item.text !== notice.text)].slice(0, 3));
       }
     },
-    []
+    [cancelResponse, isResponding]
   );
 
   const dismissNotice = useCallback((noticeId: string) => {
@@ -1032,7 +1107,7 @@ export function useWebSocket() {
   }, []);
 
   return {
-    messages, isConnected, sendMessage, taskEvents, contentEvents, agentActivity, workflowEvents, goalEvents, siteEvents, settingsEvents, notices, dismissNotice,
+    messages, isConnected, sendMessage, cancelResponse, isResponding, taskEvents, contentEvents, agentActivity, workflowEvents, goalEvents, siteEvents, settingsEvents, notices, dismissNotice,
     approvals,
     clarifiers,
     repeatBacks,

--- a/ui/src/hooks/useWebSocket.ts
+++ b/ui/src/hooks/useWebSocket.ts
@@ -100,10 +100,14 @@ export type VoiceCallbacks = {
   onTTSBinary: (data: ArrayBuffer) => void;
   /** `containsWake` — true if the TTS sentence about to play contains
    *  "Jarvis". UI uses it to suppress the wake-word recognizer for the
-   *  duration of the playback so TTS doesn't self-trigger via mic echo. */
-  onTTSStart: (requestId: string, containsWake: boolean) => void;
-  /** Mid-turn flip: a later sentence in the same turn contains "Jarvis". */
-  onTTSContainsWake?: () => void;
+   *  duration of the playback so TTS doesn't self-trigger via mic echo.
+   *  `containsStop` — the sentence contains a spoken stop phrase
+   *  ("Jarvis, stop"), so the UI must also suppress its stop-phrase
+   *  bypass or the echo cancels the playback. */
+  onTTSStart: (requestId: string, containsWake: boolean, containsStop?: boolean) => void;
+  /** Mid-turn flip: a later sentence in the same turn contains "Jarvis"
+   *  (and possibly a stop phrase). */
+  onTTSContainsWake?: (containsStop?: boolean) => void;
   /** `bargeIn` — realtime voice sends tts_end{bargeIn:true} when the user
    *  starts speaking, so the player can flush queued output immediately. */
   onTTSEnd: (requestId?: string, bargeIn?: boolean) => void;
@@ -502,6 +506,7 @@ export function useWebSocket() {
           voiceCallbacksRef.current?.onTTSStart(
             msg.payload?.requestId,
             Boolean(msg.payload?.containsWake),
+            Boolean(msg.payload?.containsStop),
           );
           setThinking(false); // speaking supersedes thinking
           return;
@@ -511,7 +516,9 @@ export function useWebSocket() {
           // UI must suppress the wake recognizer so TTS playback doesn't
           // self-trigger.
           if (msg.payload?.containsWake) {
-            voiceCallbacksRef.current?.onTTSContainsWake?.();
+            voiceCallbacksRef.current?.onTTSContainsWake?.(
+              Boolean(msg.payload?.containsStop),
+            );
           }
           return;
         }
@@ -560,9 +567,21 @@ export function useWebSocket() {
           return;
         }
         if (msg.type === "thinking_start") {
+          // thinking_start is a broadcast (voice pipeline), so it can arrive
+          // for a turn other than the one this client owns. Never overwrite
+          // an active turn's id — a stale broadcast would make the gate drop
+          // the active response's stream chunks and strand the composer in
+          // its Stop state.
+          if (
+            currentChatRequestIdRef.current
+            && msg.id
+            && msg.id !== currentChatRequestIdRef.current
+          ) return;
           setThinking(true);
           setIsResponding(true);
-          if (msg.id) currentChatRequestIdRef.current = msg.id;
+          if (msg.id && !currentChatRequestIdRef.current) {
+            currentChatRequestIdRef.current = msg.id;
+          }
           return;
         }
         if (msg.type === "thinking_end") {
@@ -1047,8 +1066,10 @@ export function useWebSocket() {
 
       // Typed barge-in: the replacement turn owns the composer immediately.
       // The daemon also enforces this, but doing it here prevents even a single
-      // late chunk from the old request flashing into the new response.
-      if (currentChatRequestIdRef.current || isResponding) cancelResponse();
+      // late chunk from the old request flashing into the new response. The ref
+      // is set before isResponding in every path, so it alone is a sufficient
+      // (and render-stable) guard.
+      if (currentChatRequestIdRef.current) cancelResponse();
 
       const id = uuid();
       currentChatRequestIdRef.current = id;
@@ -1099,7 +1120,7 @@ export function useWebSocket() {
         setNotices((prev) => [notice, ...prev.filter((item) => item.text !== notice.text)].slice(0, 3));
       }
     },
-    [cancelResponse, isResponding]
+    [cancelResponse]
   );
 
   const dismissNotice = useCallback((noticeId: string) => {

--- a/ui/src/v2/shell/AppShell.tsx
+++ b/ui/src/v2/shell/AppShell.tsx
@@ -362,10 +362,22 @@ function AppShellLive() {
     (text: string) => {
       // Per the design rule: voice and text share one pipeline.
       // A suggestion click sends the same payload as typing it.
+      if (voice.voiceState === "speaking") voice.cancelTTS();
       live.send(text);
     },
-    [live],
+    [live, voice],
   );
+
+  const stopCurrentResponse = useCallback(() => {
+    live.stopResponse();
+    voice.cancelTTS();
+    voice.forceIdle();
+  }, [live, voice]);
+
+  const handleChatSubmit = useCallback((text: string) => {
+    if (voice.voiceState === "speaking") voice.cancelTTS();
+    live.send(text, { currentRoom: getCurrentRoom() });
+  }, [getCurrentRoom, live, voice]);
 
   // ── Palette wiring (Phase 5A) ──
   const [paletteOpen, setPaletteOpen] = useState(false);
@@ -514,9 +526,9 @@ function AppShellLive() {
             ? "Ask Jarvis, or press / to summon a tool…"
             : "Waiting for daemon…"
         }
-        onSubmit={(text) =>
-          live.send(text, { currentRoom: getCurrentRoom() })
-        }
+        composerResponding={live.isResponding || live.thinking || voice.voiceState === "speaking"}
+        onStopResponse={stopCurrentResponse}
+        onSubmit={handleChatSubmit}
         onApprove={handleApprove}
         onCancel={handleCancel}
         onFocusCard={(id) => {
@@ -765,6 +777,8 @@ interface ShellLayoutProps {
   threadRef?: React.MutableRefObject<ThreadHandle | null>;
   composerDisabled?: boolean;
   composerPlaceholder?: string;
+  composerResponding?: boolean;
+  onStopResponse?: () => void;
   onSubmit: (text: string) => void;
   onApprove: (id: string) => void;
   onCancel: (id: string) => void;
@@ -817,6 +831,8 @@ function ShellLayout({
   threadRef,
   composerDisabled,
   composerPlaceholder,
+  composerResponding,
+  onStopResponse,
   onSubmit,
   onApprove,
   onCancel,
@@ -1011,6 +1027,8 @@ function ShellLayout({
                 onSubmit={onSubmit}
                 onSlash={onOpenPalette}
                 disabled={composerDisabled}
+                responding={composerResponding}
+                onStop={onStopResponse}
                 placeholder={composerPlaceholder}
               />
             </div>

--- a/ui/src/v2/shell/Composer.css
+++ b/ui/src/v2/shell/Composer.css
@@ -97,6 +97,15 @@
   background: #A62F22;
 }
 
+.v2-composer__send--stop {
+  background: var(--ink);
+  color: var(--paper);
+}
+
+.v2-composer__send--stop:hover:not(:disabled) {
+  background: var(--ink-2);
+}
+
 .v2-composer__send:active:not(:disabled) {
   transform: scale(0.92);
 }

--- a/ui/src/v2/shell/Composer.tsx
+++ b/ui/src/v2/shell/Composer.tsx
@@ -1,5 +1,5 @@
 import React, { useRef, useState } from "react";
-import { ArrowRight } from "lucide-react";
+import { ArrowRight, Square } from "lucide-react";
 import { Icon } from "../ui";
 import "./Composer.css";
 
@@ -8,6 +8,8 @@ export interface ComposerProps {
   onSlash?: () => void;
   placeholder?: string;
   disabled?: boolean;
+  responding?: boolean;
+  onStop?: () => void;
 }
 
 export function Composer({
@@ -15,6 +17,8 @@ export function Composer({
   onSlash,
   placeholder = "Ask Jarvis, or press / to summon a tool…",
   disabled,
+  responding = false,
+  onStop,
 }: ComposerProps) {
   const [value, setValue] = useState("");
   const inputRef = useRef<HTMLTextAreaElement>(null);
@@ -110,12 +114,14 @@ export function Composer({
           /
         </button>
         <button
-          type="submit"
-          className="v2-composer__send"
-          disabled={disabled || value.trim().length === 0}
-          aria-label="Send"
+          type={responding ? "button" : "submit"}
+          className={`v2-composer__send${responding ? " v2-composer__send--stop" : ""}`}
+          disabled={disabled || (!responding && value.trim().length === 0)}
+          aria-label={responding ? "Stop response" : "Send"}
+          title={responding ? "Stop response" : "Send"}
+          onClick={responding ? onStop : undefined}
         >
-          <Icon icon={ArrowRight} size={12} strokeWidth={2} />
+          <Icon icon={responding ? Square : ArrowRight} size={12} strokeWidth={2.5} />
         </button>
       </div>
     </form>

--- a/ui/src/v2/thread/useLiveThread.ts
+++ b/ui/src/v2/thread/useLiveThread.ts
@@ -278,6 +278,8 @@ export function useLiveThread() {
     items,
     isConnected: ws.isConnected,
     send: ws.sendMessage,
+    stopResponse: ws.cancelResponse,
+    isResponding: ws.isResponding,
     notices: ws.notices,
     dismissNotice: ws.dismissNotice,
     approve,


### PR DESCRIPTION
## Summary

- turn the composer send button into a Stop control while a response is active
- cancel provider streaming and queued TTS on the server, and discard late chunks
- let a new typed message supersede the active turn instead of producing overlapping answers
- recognize direct spoken stop commands such as Jarvis stop during playback
- keep wake recognition available for mid-response interruption while retaining echo protection

## Verification

- bun test: 1,898 passed, 37 skipped, 0 failed
- bun run tsc --noEmit
- git diff --check