### PR TITLE
fix(llm): honor configured fallback for tier failures

### DIFF
--- a/src/daemon/agent-service.ts
+++ b/src/daemon/agent-service.ts
@@ -10,6 +10,7 @@ import { join } from 'node:path';
 import type { Service, ServiceStatus } from './services.ts';
 import type { JarvisConfig } from '../config/types.ts';
 import type { LLMStreamEvent, LLMMessage } from '../llm/provider.ts';
+import { toLLMStreamError } from '../llm/provider.ts';
 import type { RoleDefinition } from '../roles/types.ts';
 import type { PersonalityModel } from '../personality/model.ts';
 
@@ -386,7 +387,7 @@ export class AgentService implements Service, IAgentService {
       } catch (err) {
         const errorMsg = err instanceof Error ? err.message : String(err);
         console.error('[AgentService] Conv stream error:', errorMsg);
-        yield { type: 'error', error: errorMsg };
+        yield toLLMStreamError(err);
       }
     })();
 

--- a/src/daemon/background-agent-service.ts
+++ b/src/daemon/background-agent-service.ts
@@ -141,7 +141,12 @@ export class BackgroundAgentService implements Service, IAgentService {
       this.busy = true;
       try {
         const systemPrompt = this.buildSystemPromptParts(channel);
-        return await this.orchestrator.processMessage(systemPrompt, text);
+        return await this.orchestrator.processMessage(
+          systemPrompt,
+          text,
+          'medium',
+          'background_agent',
+        );
       } catch (err) {
         console.error('[BackgroundAgent] Message error:', err);
         return `Error: ${err instanceof Error ? err.message : String(err)}`;

--- a/src/llm/config-binding.ts
+++ b/src/llm/config-binding.ts
@@ -16,7 +16,7 @@
 import type { LLMConfig, LLMProviderEntry, LLMProviderKind } from '../config/types.ts';
 import type { LLMManager } from './manager.ts';
 import type { LLMProvider } from './provider.ts';
-import { type Tier, type TierMap, parseModelRef } from './tiers.ts';
+import { type Tier, type TierAssignment, type TierMap, parseModelRef } from './tiers.ts';
 import { AnthropicProvider } from './anthropic.ts';
 import { OpenAIProvider } from './openai.ts';
 import { GroqProvider } from './groq.ts';
@@ -172,11 +172,13 @@ export function atomicReloadProviders(
  */
 export function configureLLMTiers(manager: LLMManager, llm: LLMConfig): void {
   const tierMap: TierMap = {};
+  let defaultAssignment: TierAssignment | null = null;
 
   // 1. Single-LLM mode populates task tiers from `default`.
   if (llm.default) {
     const ref = parseModelRef(llm.default);
     if (ref && manager.getProvider(ref.provider)) {
+      defaultAssignment = ref;
       tierMap.low = ref;
       tierMap.medium = ref;
       tierMap.high = ref;
@@ -202,5 +204,6 @@ export function configureLLMTiers(manager: LLMManager, llm: LLMConfig): void {
     }
   }
 
+  manager.setDefaultAssignment(defaultAssignment);
   manager.setTierMap(tierMap);
 }

--- a/src/llm/groq.ts
+++ b/src/llm/groq.ts
@@ -133,6 +133,14 @@ export function relaxOptionalFieldsToNullable(schema: unknown): unknown {
   return out;
 }
 
+/** Production chat models with independent Groq quota buckets. */
+export const GROQ_CHAT_MODEL_ROTATION = [
+  'llama-3.3-70b-versatile',
+  'llama-3.1-8b-instant',
+  'openai/gpt-oss-20b',
+  'openai/gpt-oss-120b',
+] as const;
+
 export class GroqProvider implements LLMProvider {
   name = 'groq';
   private apiKey: string;
@@ -153,58 +161,28 @@ export class GroqProvider implements LLMProvider {
   }
 
   async chat(messages: LLMMessage[], options: LLMOptions = {}): Promise<LLMResponse> {
-    let response = await this.sendRequest(
-      this.buildRequestBody(messages, options, false, GroqProvider.SAFE_PROMPT_CHAR_BUDGET)
-    );
-
-    if (!response.ok) {
-      const errorText = await response.text();
-      if (!this.shouldRetryWithTighterPrompt(response.status, errorText)) {
-        throw this.responseError(response, errorText);
-      }
-      response = await this.sendRequest(
-        this.buildRequestBody(messages, options, false, GroqProvider.RETRY_PROMPT_CHAR_BUDGET)
-      );
-      if (!response.ok) {
-        const retryError = await response.text();
-        throw this.responseError(response, retryError, 'Groq API error after compact retry');
-      }
-    }
+    const { response } = await this.sendWithModelRotation(messages, options, false);
 
     const data = await response.json() as GroqResponse;
     return this.convertResponse(data);
   }
 
   async *stream(messages: LLMMessage[], options: LLMOptions = {}): AsyncIterable<LLMStreamEvent> {
-    const body = this.buildRequestBody(
-      messages,
-      options,
-      true,
-      GroqProvider.SAFE_PROMPT_CHAR_BUDGET,
-    );
-    const responseModel = typeof body.model === 'string' ? body.model : this.defaultModel;
-
-    let response = await this.sendRequest(body);
-
-    if (!response.ok) {
-      const errorText = await response.text();
-      if (!this.shouldRetryWithTighterPrompt(response.status, errorText)) {
-        yield this.responseErrorEvent(response, errorText);
+    let response: Response;
+    let responseModel: string;
+    try {
+      ({ response, model: responseModel } = await this.sendWithModelRotation(messages, options, true));
+    } catch (err) {
+      if (err instanceof LLMProviderError) {
+        yield {
+          type: 'error',
+          error: err.message,
+          code: err.code,
+          retryAfterMs: err.retryAfterMs,
+        };
         return;
       }
-      response = await this.sendRequest(
-        this.buildRequestBody(
-          messages,
-          options,
-          true,
-          GroqProvider.RETRY_PROMPT_CHAR_BUDGET,
-        )
-      );
-      if (!response.ok) {
-        const retryError = await response.text();
-        yield this.responseErrorEvent(response, retryError, 'Groq API error after compact retry');
-        return;
-      }
+      throw err;
     }
 
     if (!response.body) {
@@ -369,6 +347,69 @@ export class GroqProvider implements LLMProvider {
       },
       body: JSON.stringify(body),
     });
+  }
+
+  private modelRotation(requestedModel: string): string[] {
+    const known = [...GROQ_CHAT_MODEL_ROTATION];
+    const index = known.indexOf(requestedModel as typeof GROQ_CHAT_MODEL_ROTATION[number]);
+    const rest = index >= 0
+      ? [...known.slice(index + 1), ...known.slice(0, index)]
+      : known;
+    return [requestedModel, ...rest.filter((model) => model !== requestedModel)];
+  }
+
+  /**
+   * Retry a token-window failure with a compact prompt, then rotate to the
+   * next chat model when that model's quota bucket is still exhausted.
+   */
+  private async sendWithModelRotation(
+    messages: LLMMessage[],
+    options: LLMOptions,
+    stream: boolean,
+  ): Promise<{ response: Response; model: string }> {
+    const requestedModel = options.model ?? this.defaultModel;
+    let lastRateLimit: { response: Response; errorText: string; model: string } | null = null;
+    const models = this.modelRotation(requestedModel);
+
+    for (let index = 0; index < models.length; index++) {
+      const model = models[index]!;
+      const modelOptions = { ...options, model };
+      let response = await this.sendRequest(
+        this.buildRequestBody(messages, modelOptions, stream, GroqProvider.SAFE_PROMPT_CHAR_BUDGET),
+      );
+      let errorText = response.ok ? '' : await response.text();
+      let compactRetried = false;
+
+      if (!response.ok && this.shouldRetryWithTighterPrompt(response.status, errorText)) {
+        compactRetried = true;
+        response = await this.sendRequest(
+          this.buildRequestBody(messages, modelOptions, stream, GroqProvider.RETRY_PROMPT_CHAR_BUDGET),
+        );
+        errorText = response.ok ? '' : await response.text();
+      }
+
+      if (response.ok) return { response, model };
+      if (response.status !== 429) {
+        throw this.responseError(
+          response,
+          errorText,
+          compactRetried ? 'Groq API error after compact retry' : 'Groq API error',
+        );
+      }
+
+      lastRateLimit = { response, errorText, model };
+      const nextModel = models[index + 1];
+      if (nextModel) {
+        console.warn(`[Groq] Model '${model}' rate-limited; rotating to '${nextModel}'.`);
+      }
+    }
+
+    const exhausted = lastRateLimit!;
+    throw this.responseError(
+      exhausted.response,
+      exhausted.errorText,
+      `Groq chat models exhausted (last model '${exhausted.model}')`,
+    );
   }
 
   private convertMessages(messages: LLMMessage[]): GroqMessage[] {
@@ -569,19 +610,6 @@ export class GroqProvider implements LLMProvider {
       code: classifyHttpStatus(response.status),
       retryAfterMs: parseRetryAfterMs(response.headers.get('retry-after'), errorText),
     });
-  }
-
-  private responseErrorEvent(
-    response: Response,
-    errorText: string,
-    prefix = 'Groq API error',
-  ): Extract<LLMStreamEvent, { type: 'error' }> {
-    return {
-      type: 'error',
-      error: `${prefix} (${response.status}): ${errorText}`,
-      code: classifyHttpStatus(response.status),
-      retryAfterMs: parseRetryAfterMs(response.headers.get('retry-after'), errorText),
-    };
   }
 
   private convertTools(tools: LLMTool[]): GroqToolDef[] {

--- a/src/llm/groq.ts
+++ b/src/llm/groq.ts
@@ -7,7 +7,7 @@ import type {
   LLMTool,
   LLMToolCall,
 } from './provider.ts';
-import { classifyHttpStatus } from './provider.ts';
+import { classifyHttpStatus, LLMProviderError, parseRetryAfterMs } from './provider.ts';
 type GroqContentPart =
   | { type: 'text'; text: string }
   | { type: 'image_url'; image_url: { url: string } };
@@ -159,15 +159,15 @@ export class GroqProvider implements LLMProvider {
 
     if (!response.ok) {
       const errorText = await response.text();
-      if (!this.isRequestTooLargeError(response.status, errorText)) {
-        throw new Error(`Groq API error (${response.status}): ${errorText}`);
+      if (!this.shouldRetryWithTighterPrompt(response.status, errorText)) {
+        throw this.responseError(response, errorText);
       }
       response = await this.sendRequest(
         this.buildRequestBody(messages, options, false, GroqProvider.RETRY_PROMPT_CHAR_BUDGET)
       );
       if (!response.ok) {
         const retryError = await response.text();
-        throw new Error(`Groq API error after retry (${response.status}): ${retryError}`);
+        throw this.responseError(response, retryError, 'Groq API error after compact retry');
       }
     }
 
@@ -188,12 +188,8 @@ export class GroqProvider implements LLMProvider {
 
     if (!response.ok) {
       const errorText = await response.text();
-      if (!this.isRequestTooLargeError(response.status, errorText)) {
-        yield {
-          type: 'error',
-          error: `Groq API error (${response.status}): ${errorText}`,
-          code: classifyHttpStatus(response.status),
-        };
+      if (!this.shouldRetryWithTighterPrompt(response.status, errorText)) {
+        yield this.responseErrorEvent(response, errorText);
         return;
       }
       response = await this.sendRequest(
@@ -206,11 +202,7 @@ export class GroqProvider implements LLMProvider {
       );
       if (!response.ok) {
         const retryError = await response.text();
-        yield {
-          type: 'error',
-          error: `Groq API error after retry (${response.status}): ${retryError}`,
-          code: classifyHttpStatus(response.status),
-        };
+        yield this.responseErrorEvent(response, retryError, 'Groq API error after compact retry');
         return;
       }
     }
@@ -556,6 +548,40 @@ export class GroqProvider implements LLMProvider {
     if (status === 413) return true;
     if (status !== 400) return false;
     return /\b(message is too large|request too large|payload too large|too many tokens|maximum context length|context window)\b/i.test(errorText);
+  }
+
+  /** A token-window 429 can often recover immediately with the compact body. */
+  private isTokenRateLimitError(status: number, errorText: string): boolean {
+    return status === 429 && /\b(?:tokens per minute|tpm)\b/i.test(errorText);
+  }
+
+  private shouldRetryWithTighterPrompt(status: number, errorText: string): boolean {
+    return this.isRequestTooLargeError(status, errorText)
+      || this.isTokenRateLimitError(status, errorText);
+  }
+
+  private responseError(
+    response: Response,
+    errorText: string,
+    prefix = 'Groq API error',
+  ): LLMProviderError {
+    return new LLMProviderError(`${prefix} (${response.status}): ${errorText}`, {
+      code: classifyHttpStatus(response.status),
+      retryAfterMs: parseRetryAfterMs(response.headers.get('retry-after'), errorText),
+    });
+  }
+
+  private responseErrorEvent(
+    response: Response,
+    errorText: string,
+    prefix = 'Groq API error',
+  ): Extract<LLMStreamEvent, { type: 'error' }> {
+    return {
+      type: 'error',
+      error: `${prefix} (${response.status}): ${errorText}`,
+      code: classifyHttpStatus(response.status),
+      retryAfterMs: parseRetryAfterMs(response.headers.get('retry-after'), errorText),
+    };
   }
 
   private convertTools(tools: LLMTool[]): GroqToolDef[] {

--- a/src/llm/manager.ts
+++ b/src/llm/manager.ts
@@ -13,6 +13,7 @@ import {
   type TierMap,
   type TierResolution,
   TIERS,
+  TIER_FALLBACK,
   resolveTier,
 } from './tiers.ts';
 import { recordUsage } from './usage.ts';
@@ -22,6 +23,8 @@ export class LLMManager {
   private primaryProvider = '';
   private fallbackChain: string[] = [];
   private tierMap: TierMap = {};
+  /** Explicit llm.default assignment; also authorizes cross-provider fallback. */
+  private defaultAssignment: TierAssignment | null = null;
   private static readonly MAX_RETRIES_PER_PROVIDER = 3;
   private static readonly REQUEST_TIMEOUT_MS = 90000; // 90 second timeout for LLM calls
   private static readonly isDebugging = process.env.JARVIS_LOG_LEVEL === 'debug' || process.env.DEBUG_LLM === 'true';
@@ -51,6 +54,15 @@ export class LLMManager {
       }
     }
     this.fallbackChain = names;
+  }
+
+  setDefaultAssignment(assignment: TierAssignment | null): void {
+    if (assignment && !this.providers.has(assignment.provider)) {
+      throw new Error(`Provider '${assignment.provider}' not registered (llm.default)`);
+    }
+    this.defaultAssignment = assignment
+      ? { provider: assignment.provider, model: assignment.model }
+      : null;
   }
 
   /**
@@ -144,6 +156,9 @@ export class LLMManager {
     this.providers = newMap;
     this.primaryProvider = newMap.has(primary) ? primary : (providers[0]?.name ?? '');
     this.fallbackChain = fallback.filter(n => newMap.has(n));
+    if (this.defaultAssignment && !newMap.has(this.defaultAssignment.provider)) {
+      this.defaultAssignment = null;
+    }
     // Prune tier assignments that reference now-removed providers
     for (const [tier, a] of Object.entries(this.tierMap) as [Tier, TierAssignment][]) {
       if (a && !newMap.has(a.provider)) delete this.tierMap[tier];
@@ -182,6 +197,29 @@ export class LLMManager {
       msg.includes('503');    // service unavailable
   }
 
+  private shouldRetryCode(code: LLMErrorCode | undefined): boolean {
+    return code === 'rate_limit' || code === 'network' || code === 'server';
+  }
+
+  /**
+   * Cross-provider fallback is allowed for provider availability failures and
+   * model-specific failures. Request/schema errors stay on the selected
+   * provider so a malformed request is never sprayed across providers.
+   */
+  private shouldFailOver(code: LLMErrorCode | undefined, message: string): boolean {
+    if (code === 'auth' || code === 'rate_limit' || code === 'network' || code === 'server') {
+      return true;
+    }
+    if (code !== 'bad_request' && code !== 'not_found') return false;
+    return /\bmodel(?:[_ -](?:decommissioned|not[_ -]found|unsupported|unavailable|retired))\b/i.test(message)
+      || /\bmodel\b.{0,160}\b(?:decommissioned|not found|does not exist|unsupported|unavailable|retired)\b/i.test(message)
+      || /\b(?:decommissioned|retired)\b.{0,160}\bmodel\b/i.test(message);
+  }
+
+  private isProviderFailure(code: LLMErrorCode | undefined): boolean {
+    return code === 'auth' || code === 'rate_limit' || code === 'network' || code === 'server';
+  }
+
   /**
    * Resolve a tier to a concrete provider + model, walking the fall-up chain
    * if the requested tier is unassigned. Throws if no tier resolves (config
@@ -205,6 +243,45 @@ export class LLMManager {
   }
 
   /**
+   * Build an ordered, explicitly-authorized fallback list. A configured
+   * provider is not enough: it must be mapped to the requested tier/fall-up
+   * path or selected as llm.default. This prevents accidental data/cost spill.
+   */
+  private tierCandidates(tier: Tier): Array<{ resolution: TierResolution; provider: LLMProvider }> {
+    const first = this.resolveTierOrThrow(tier);
+    const candidates = [first];
+    const seen = new Set([`${first.provider.name}\u0000${first.resolution.assignment.model ?? ''}`]);
+    const add = (resolution: TierResolution) => {
+      const provider = this.providers.get(resolution.assignment.provider);
+      if (!provider) return;
+      const key = `${provider.name}\u0000${resolution.assignment.model ?? ''}`;
+      if (seen.has(key)) return;
+      seen.add(key);
+      candidates.push({ resolution, provider });
+    };
+
+    // A retired saved model gets one chance to recover via that provider's
+    // current default before crossing a provider boundary.
+    add({ tier: first.resolution.tier, assignment: { provider: first.provider.name } });
+
+    for (const candidateTier of [tier, ...TIER_FALLBACK[tier]]) {
+      const assignment = this.tierMap[candidateTier];
+      if (!assignment) continue;
+      add({ tier: candidateTier, assignment });
+      add({ tier: candidateTier, assignment: { provider: assignment.provider } });
+    }
+
+    // llm.default is an explicit user-selected safety net. It is especially
+    // important for conversation, whose normal tier fall-up is intentionally
+    // empty because configuring it toggles router-first mode.
+    if (this.defaultAssignment) {
+      add({ tier, assignment: this.defaultAssignment });
+      add({ tier, assignment: { provider: this.defaultAssignment.provider } });
+    }
+    return candidates;
+  }
+
+  /**
    * Tier-aware chat. Routes to the resolved provider for the requested tier,
    * records usage labeled by subsystem.
    */
@@ -214,41 +291,50 @@ export class LLMManager {
     messages: LLMMessage[],
     options?: LLMOptions,
   ): Promise<LLMResponse> {
-    const { resolution, provider } = this.resolveTierOrThrow(tier);
-    const model = options?.model ?? resolution.assignment.model;
-    const mergedOptions: LLMOptions = { ...options, ...(model ? { model } : {}) };
+    const failures: string[] = [];
+    const exhaustedProviders = new Set<string>();
+    const candidates = this.tierCandidates(tier);
 
-    const started = Date.now();
-    try {
-      const response = await this.invokeWithRetry(provider, messages, mergedOptions);
-      recordUsage({
-        tier,
-        resolved_tier: resolution.tier,
-        subsystem,
-        provider: provider.name,
-        model: response.model || model || '',
-        input_tokens: response.usage?.input_tokens ?? 0,
-        output_tokens: response.usage?.output_tokens ?? 0,
-        cache_read_input_tokens: response.usage?.cache_read_input_tokens ?? 0,
-        cache_creation_input_tokens: response.usage?.cache_creation_input_tokens ?? 0,
-        latency_ms: Date.now() - started,
-      });
-      return response;
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      recordUsage({
-        tier,
-        resolved_tier: resolution.tier,
-        subsystem,
-        provider: provider.name,
-        model: model || '',
-        input_tokens: 0,
-        output_tokens: 0,
-        latency_ms: Date.now() - started,
-        error_code: classifyErrorString(msg),
-      });
-      throw err;
+    for (let index = 0; index < candidates.length; index++) {
+      const { resolution, provider } = candidates[index]!;
+      if (exhaustedProviders.has(provider.name)) continue;
+      const model = index === 0 ? options?.model ?? resolution.assignment.model : resolution.assignment.model;
+      const mergedOptions: LLMOptions = { ...options };
+      if (model) mergedOptions.model = model;
+      else delete mergedOptions.model;
+      const hasAlternativeProvider = candidates
+        .slice(index + 1)
+        .some((candidate) => candidate.provider.name !== provider.name
+          && !exhaustedProviders.has(candidate.provider.name));
+      const started = Date.now();
+
+      try {
+        const response = await this.invokeWithRetry(provider, messages, mergedOptions, hasAlternativeProvider);
+        recordUsage({
+          tier, resolved_tier: resolution.tier, subsystem, provider: provider.name,
+          model: response.model || model || '',
+          input_tokens: response.usage?.input_tokens ?? 0,
+          output_tokens: response.usage?.output_tokens ?? 0,
+          cache_read_input_tokens: response.usage?.cache_read_input_tokens ?? 0,
+          cache_creation_input_tokens: response.usage?.cache_creation_input_tokens ?? 0,
+          latency_ms: Date.now() - started,
+        });
+        return response;
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        const code = classifyErrorString(message);
+        failures.push(message);
+        recordUsage({
+          tier, resolved_tier: resolution.tier, subsystem, provider: provider.name,
+          model: model || '', input_tokens: 0, output_tokens: 0,
+          latency_ms: Date.now() - started, error_code: code,
+        });
+        if (!this.shouldFailOver(code, message)) throw err;
+        if (this.isProviderFailure(code)) exhaustedProviders.add(provider.name);
+      }
     }
+
+    throw new Error(failures.join('\n\n'));
   }
 
   /**
@@ -260,39 +346,68 @@ export class LLMManager {
     messages: LLMMessage[],
     options?: LLMOptions,
   ): AsyncIterable<LLMStreamEvent> {
-    const { resolution, provider } = this.resolveTierOrThrow(tier);
-    const model = options?.model ?? resolution.assignment.model;
-    const mergedOptions: LLMOptions = { ...options, ...(model ? { model } : {}) };
+    const failures: Array<Extract<LLMStreamEvent, { type: 'error' }>> = [];
+    const exhaustedProviders = new Set<string>();
+    const candidates = this.tierCandidates(tier);
 
-    const started = Date.now();
-    let finalResponse: LLMResponse | null = null;
-    let errored: string | null = null;
+    for (let index = 0; index < candidates.length; index++) {
+      const { resolution, provider } = candidates[index]!;
+      if (exhaustedProviders.has(provider.name)) continue;
+      const model = index === 0 ? options?.model ?? resolution.assignment.model : resolution.assignment.model;
+      const mergedOptions: LLMOptions = { ...options };
+      if (model) mergedOptions.model = model;
+      else delete mergedOptions.model;
+      const hasAlternativeProvider = candidates
+        .slice(index + 1)
+        .some((candidate) => candidate.provider.name !== provider.name
+          && !exhaustedProviders.has(candidate.provider.name));
+      const started = Date.now();
+      let finalResponse: LLMResponse | null = null;
+      let terminalError: Extract<LLMStreamEvent, { type: 'error' }> | null = null;
+      let emittedContent = false;
 
-    try {
-      for await (const event of this.streamWithRetry(provider, messages, mergedOptions)) {
+      for await (const event of this.streamWithRetry(provider, messages, mergedOptions, hasAlternativeProvider)) {
         if (event.type === 'done') finalResponse = event.response;
-        if (event.type === 'error') errored = event.error;
+        if (event.type === 'text' || event.type === 'tool_call') emittedContent = true;
+        if (event.type === 'error') {
+          terminalError = event;
+          continue;
+        }
         yield event;
       }
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      errored = msg;
-      throw err;
-    } finally {
+
       recordUsage({
-        tier,
-        resolved_tier: resolution.tier,
-        subsystem,
-        provider: provider.name,
+        tier, resolved_tier: resolution.tier, subsystem, provider: provider.name,
         model: finalResponse?.model || model || '',
         input_tokens: finalResponse?.usage?.input_tokens ?? 0,
         output_tokens: finalResponse?.usage?.output_tokens ?? 0,
         cache_read_input_tokens: finalResponse?.usage?.cache_read_input_tokens ?? 0,
         cache_creation_input_tokens: finalResponse?.usage?.cache_creation_input_tokens ?? 0,
         latency_ms: Date.now() - started,
-        error_code: errored ? classifyErrorString(errored) : undefined,
+        error_code: terminalError?.code
+          ?? (terminalError ? classifyErrorString(terminalError.error) : undefined),
       });
+
+      if (!terminalError) return;
+      if (emittedContent) {
+        yield terminalError;
+        return;
+      }
+      const code = terminalError.code ?? classifyErrorString(terminalError.error);
+      if (!this.shouldFailOver(code, terminalError.error)) {
+        yield terminalError;
+        return;
+      }
+      if (this.isProviderFailure(code)) exhaustedProviders.add(provider.name);
+      failures.push(terminalError);
     }
+
+    const error = failures.map((failure) => failure.error).join('\n\n');
+    yield {
+      type: 'error',
+      error,
+      code: failures.at(-1)?.code ?? classifyErrorString(error),
+    };
   }
 
   /**
@@ -304,6 +419,7 @@ export class LLMManager {
     provider: LLMProvider,
     messages: LLMMessage[],
     options?: LLMOptions,
+    failFastForAlternative = false,
   ): Promise<LLMResponse> {
     const errors: string[] = [];
     for (let attempt = 1; attempt <= LLMManager.MAX_RETRIES_PER_PROVIDER; attempt++) {
@@ -320,6 +436,7 @@ export class LLMManager {
         console.error(
           `[LLM] Provider ${provider.name} failed (attempt ${attempt}/${LLMManager.MAX_RETRIES_PER_PROVIDER})${!shouldRetry ? ' [no retry]' : ''}: ${errorMsg}`
         );
+        if (failFastForAlternative && this.shouldFailOver(classifyErrorString(errorMsg), errorMsg)) break;
         if (!shouldRetry) break;
       }
     }
@@ -330,11 +447,13 @@ export class LLMManager {
     provider: LLMProvider,
     messages: LLMMessage[],
     options?: LLMOptions,
+    failFastForAlternative = false,
   ): AsyncIterable<LLMStreamEvent> {
     const errors: string[] = [];
     let lastErrorCode: LLMErrorCode | undefined;
     for (let attempt = 1; attempt <= LLMManager.MAX_RETRIES_PER_PROVIDER; attempt++) {
       let emittedContent = false;
+      let retryableEvent = true;
       try {
         let hasError = false;
         for await (const event of provider.stream(messages, options)) {
@@ -342,6 +461,7 @@ export class LLMManager {
             hasError = true;
             errors.push(`attempt ${attempt}: ${event.error}`);
             lastErrorCode = event.code ?? classifyErrorString(event.error);
+            retryableEvent = this.shouldRetryCode(lastErrorCode);
             console.error(
               `[LLM] Provider ${provider.name} stream error (attempt ${attempt}/${LLMManager.MAX_RETRIES_PER_PROVIDER}): ${event.error}`
             );
@@ -361,6 +481,7 @@ export class LLMManager {
           yield event;
         }
         if (!hasError) return;
+        if (!retryableEvent || failFastForAlternative) break;
       } catch (err) {
         const errorMsg = err instanceof Error ? err.message : String(err);
         errors.push(`attempt ${attempt}: ${errorMsg}`);
@@ -377,6 +498,7 @@ export class LLMManager {
           };
           return;
         }
+        if (failFastForAlternative && this.shouldFailOver(lastErrorCode, errorMsg)) break;
         if (!shouldRetry) break;
       }
     }

--- a/src/llm/manager.ts
+++ b/src/llm/manager.ts
@@ -6,7 +6,7 @@ import type {
   LLMStreamEvent,
   LLMErrorCode,
 } from './provider.ts';
-import { classifyErrorString } from './provider.ts';
+import { classifyErrorString, LLMProviderError, parseRetryAfterMs } from './provider.ts';
 import {
   type Tier,
   type TierAssignment,
@@ -26,6 +26,7 @@ export class LLMManager {
   /** Explicit llm.default assignment; also authorizes cross-provider fallback. */
   private defaultAssignment: TierAssignment | null = null;
   private static readonly MAX_RETRIES_PER_PROVIDER = 3;
+  private static readonly MAX_RETRY_SLEEP_MS = 60_000;
   private static readonly REQUEST_TIMEOUT_MS = 90000; // 90 second timeout for LLM calls
   private static readonly isDebugging = process.env.JARVIS_LOG_LEVEL === 'debug' || process.env.DEBUG_LLM === 'true';
 
@@ -144,6 +145,41 @@ export class LLMManager {
     return `Provider '${providerName}' failed after ${n} ${word}:\n${errors.map((error) => `  ${error}`).join('\n')}`;
   }
 
+  private errorCode(error: unknown): LLMErrorCode {
+    const structured = error && typeof error === 'object'
+      ? (error as { code?: LLMErrorCode }).code
+      : undefined;
+    if (structured) return structured;
+    return classifyErrorString(error instanceof Error ? error.message : String(error));
+  }
+
+  private retryAfterMs(error: unknown): number | undefined {
+    const structured = error && typeof error === 'object'
+      ? (error as { retryAfterMs?: unknown }).retryAfterMs
+      : undefined;
+    if (typeof structured === 'number' && Number.isFinite(structured) && structured >= 0) {
+      return structured;
+    }
+    return parseRetryAfterMs(undefined, error instanceof Error ? error.message : String(error));
+  }
+
+  /**
+   * Wait only when this provider is the last authorized candidate. Long waits
+   * are surfaced to the caller instead of freezing an interactive request.
+   */
+  private async waitForRetry(provider: string, retryAfterMs: number | undefined): Promise<boolean> {
+    if (retryAfterMs === undefined) return true;
+    if (retryAfterMs > LLMManager.MAX_RETRY_SLEEP_MS) return false;
+    if (retryAfterMs > 0) {
+      const delay = retryAfterMs >= 1000
+        ? `${Math.ceil(retryAfterMs / 1000)}s`
+        : `${Math.ceil(retryAfterMs)}ms`;
+      console.log(`[LLM] ${provider} rate-limited — retrying in ${delay}`);
+      await Bun.sleep(retryAfterMs);
+    }
+    return true;
+  }
+
   /**
    * Atomically replace all providers. Safe for in-flight requests because
    * JS is single-threaded and the map assignment is atomic.
@@ -185,6 +221,8 @@ export class LLMManager {
    */
   private shouldRetry(error: unknown): boolean {
     if (!(error instanceof Error)) return false;
+
+    if (this.shouldRetryCode(this.errorCode(error))) return true;
 
     const msg = error.message.toLowerCase();
     // Retry on network/timeout errors, not on auth/validation errors
@@ -291,7 +329,7 @@ export class LLMManager {
     messages: LLMMessage[],
     options?: LLMOptions,
   ): Promise<LLMResponse> {
-    const failures: string[] = [];
+    const failures: Array<{ message: string; code: LLMErrorCode; retryAfterMs?: number }> = [];
     const exhaustedProviders = new Set<string>();
     const candidates = this.tierCandidates(tier);
 
@@ -322,8 +360,9 @@ export class LLMManager {
         return response;
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
-        const code = classifyErrorString(message);
-        failures.push(message);
+        const code = this.errorCode(err);
+        const retryAfterMs = this.retryAfterMs(err);
+        failures.push({ message, code, retryAfterMs });
         recordUsage({
           tier, resolved_tier: resolution.tier, subsystem, provider: provider.name,
           model: model || '', input_tokens: 0, output_tokens: 0,
@@ -334,7 +373,11 @@ export class LLMManager {
       }
     }
 
-    throw new Error(failures.join('\n\n'));
+    const last = failures.at(-1);
+    throw new LLMProviderError(failures.map((failure) => failure.message).join('\n\n'), {
+      code: last?.code,
+      retryAfterMs: last?.retryAfterMs,
+    });
   }
 
   /**
@@ -403,10 +446,12 @@ export class LLMManager {
     }
 
     const error = failures.map((failure) => failure.error).join('\n\n');
+    const lastFailure = failures.at(-1);
     yield {
       type: 'error',
       error,
-      code: failures.at(-1)?.code ?? classifyErrorString(error),
+      code: lastFailure?.code ?? classifyErrorString(error),
+      retryAfterMs: lastFailure?.retryAfterMs,
     };
   }
 
@@ -422,6 +467,8 @@ export class LLMManager {
     failFastForAlternative = false,
   ): Promise<LLMResponse> {
     const errors: string[] = [];
+    let lastErrorCode: LLMErrorCode | undefined;
+    let lastRetryAfterMs: number | undefined;
     for (let attempt = 1; attempt <= LLMManager.MAX_RETRIES_PER_PROVIDER; attempt++) {
       try {
         const result = await this.withTimeout(provider.chat(messages, options), provider.name);
@@ -432,15 +479,24 @@ export class LLMManager {
       } catch (err) {
         const errorMsg = err instanceof Error ? err.message : String(err);
         errors.push(`attempt ${attempt}: ${errorMsg}`);
+        lastErrorCode = this.errorCode(err);
+        lastRetryAfterMs = this.retryAfterMs(err);
         const shouldRetry = this.shouldRetry(err);
         console.error(
           `[LLM] Provider ${provider.name} failed (attempt ${attempt}/${LLMManager.MAX_RETRIES_PER_PROVIDER})${!shouldRetry ? ' [no retry]' : ''}: ${errorMsg}`
         );
-        if (failFastForAlternative && this.shouldFailOver(classifyErrorString(errorMsg), errorMsg)) break;
+        if (failFastForAlternative && this.shouldFailOver(lastErrorCode, errorMsg)) break;
         if (!shouldRetry) break;
+        if (
+          attempt < LLMManager.MAX_RETRIES_PER_PROVIDER
+          && !(await this.waitForRetry(provider.name, lastRetryAfterMs))
+        ) break;
       }
     }
-    throw new Error(this.formatFailure(provider.name, errors));
+    throw new LLMProviderError(this.formatFailure(provider.name, errors), {
+      code: lastErrorCode,
+      retryAfterMs: lastRetryAfterMs,
+    });
   }
 
   private async *streamWithRetry(
@@ -451,6 +507,7 @@ export class LLMManager {
   ): AsyncIterable<LLMStreamEvent> {
     const errors: string[] = [];
     let lastErrorCode: LLMErrorCode | undefined;
+    let lastRetryAfterMs: number | undefined;
     for (let attempt = 1; attempt <= LLMManager.MAX_RETRIES_PER_PROVIDER; attempt++) {
       let emittedContent = false;
       let retryableEvent = true;
@@ -461,6 +518,8 @@ export class LLMManager {
             hasError = true;
             errors.push(`attempt ${attempt}: ${event.error}`);
             lastErrorCode = event.code ?? classifyErrorString(event.error);
+            lastRetryAfterMs = event.retryAfterMs
+              ?? parseRetryAfterMs(undefined, event.error);
             retryableEvent = this.shouldRetryCode(lastErrorCode);
             console.error(
               `[LLM] Provider ${provider.name} stream error (attempt ${attempt}/${LLMManager.MAX_RETRIES_PER_PROVIDER}): ${event.error}`
@@ -482,10 +541,15 @@ export class LLMManager {
         }
         if (!hasError) return;
         if (!retryableEvent || failFastForAlternative) break;
+        if (
+          attempt < LLMManager.MAX_RETRIES_PER_PROVIDER
+          && !(await this.waitForRetry(provider.name, lastRetryAfterMs))
+        ) break;
       } catch (err) {
         const errorMsg = err instanceof Error ? err.message : String(err);
         errors.push(`attempt ${attempt}: ${errorMsg}`);
-        lastErrorCode = classifyErrorString(errorMsg);
+        lastErrorCode = this.errorCode(err);
+        lastRetryAfterMs = this.retryAfterMs(err);
         const shouldRetry = this.shouldRetry(err);
         console.error(
           `[LLM] Provider ${provider.name} stream failed (attempt ${attempt}/${LLMManager.MAX_RETRIES_PER_PROVIDER})${!shouldRetry ? ' [no retry]' : ''}: ${errorMsg}`
@@ -500,12 +564,17 @@ export class LLMManager {
         }
         if (failFastForAlternative && this.shouldFailOver(lastErrorCode, errorMsg)) break;
         if (!shouldRetry) break;
+        if (
+          attempt < LLMManager.MAX_RETRIES_PER_PROVIDER
+          && !(await this.waitForRetry(provider.name, lastRetryAfterMs))
+        ) break;
       }
     }
     yield {
       type: 'error',
       error: this.formatFailure(provider.name, errors),
       code: lastErrorCode ?? classifyErrorString(errors.join('\n')),
+      retryAfterMs: lastRetryAfterMs,
     };
   }
 

--- a/src/llm/manager.ts
+++ b/src/llm/manager.ts
@@ -18,6 +18,30 @@ import {
 } from './tiers.ts';
 import { recordUsage } from './usage.ts';
 
+/**
+ * Subsystems that are allowed to send user content across provider boundaries
+ * when their assigned provider fails. Keep this list explicit: background and
+ * newly-added subsystems must not inherit cross-provider routing by accident.
+ */
+const CROSS_PROVIDER_FALLBACK_SUBSYSTEMS = new Set([
+  'chat_orchestrator',
+  'chat_orchestrator_stream',
+  'chat_orchestrator_subagent',
+  'conv_orchestrator',
+  'sub_agent',
+  'task_code',
+  'task_general',
+  'task_plan',
+  'task_research',
+  'task_write',
+  'onboarding_interviewer',
+  'nl_goal_builder',
+  'nl_goal_chat',
+  'manual_test',
+  'manual_test_stream',
+  'manual_cache_test',
+]);
+
 export class LLMManager {
   private providers: Map<string, LLMProvider> = new Map();
   private primaryProvider = '';
@@ -285,7 +309,10 @@ export class LLMManager {
    * provider is not enough: it must be mapped to the requested tier/fall-up
    * path or selected as llm.default. This prevents accidental data/cost spill.
    */
-  private tierCandidates(tier: Tier): Array<{ resolution: TierResolution; provider: LLMProvider }> {
+  private tierCandidates(
+    tier: Tier,
+    allowCrossProvider: boolean,
+  ): Array<{ resolution: TierResolution; provider: LLMProvider }> {
     const first = this.resolveTierOrThrow(tier);
     const candidates = [first];
     const seen = new Set([`${first.provider.name}\u0000${first.resolution.assignment.model ?? ''}`]);
@@ -305,6 +332,7 @@ export class LLMManager {
     for (const candidateTier of [tier, ...TIER_FALLBACK[tier]]) {
       const assignment = this.tierMap[candidateTier];
       if (!assignment) continue;
+      if (!allowCrossProvider && assignment.provider !== first.provider.name) continue;
       add({ tier: candidateTier, assignment });
       add({ tier: candidateTier, assignment: { provider: assignment.provider } });
     }
@@ -312,7 +340,7 @@ export class LLMManager {
     // llm.default is an explicit user-selected safety net. It is especially
     // important for conversation, whose normal tier fall-up is intentionally
     // empty because configuring it toggles router-first mode.
-    if (this.defaultAssignment) {
+    if (allowCrossProvider && this.defaultAssignment) {
       add({ tier, assignment: this.defaultAssignment });
       add({ tier, assignment: { provider: this.defaultAssignment.provider } });
     }
@@ -331,7 +359,10 @@ export class LLMManager {
   ): Promise<LLMResponse> {
     const failures: Array<{ message: string; code: LLMErrorCode; retryAfterMs?: number }> = [];
     const exhaustedProviders = new Set<string>();
-    const candidates = this.tierCandidates(tier);
+    const candidates = this.tierCandidates(
+      tier,
+      CROSS_PROVIDER_FALLBACK_SUBSYSTEMS.has(subsystem),
+    );
 
     for (let index = 0; index < candidates.length; index++) {
       const { resolution, provider } = candidates[index]!;
@@ -391,7 +422,10 @@ export class LLMManager {
   ): AsyncIterable<LLMStreamEvent> {
     const failures: Array<Extract<LLMStreamEvent, { type: 'error' }>> = [];
     const exhaustedProviders = new Set<string>();
-    const candidates = this.tierCandidates(tier);
+    const candidates = this.tierCandidates(
+      tier,
+      CROSS_PROVIDER_FALLBACK_SUBSYSTEMS.has(subsystem),
+    );
 
     for (let index = 0; index < candidates.length; index++) {
       const { resolution, provider } = candidates[index]!;

--- a/src/llm/provider.test.ts
+++ b/src/llm/provider.test.ts
@@ -251,7 +251,7 @@ describe('LLMManager', () => {
       tiers: { conversation: 'anthropic:claude', medium: 'anthropic:claude' },
     });
 
-    const response = await manager.chatTier('conversation', 'test', sampleMessages);
+    const response = await manager.chatTier('conversation', 'conv_orchestrator', sampleMessages);
     expect(response.content).toBe('groq recovered');
     expect(anthropicCalls).toBe(1);
     expect(groqCalls).toBe(1);
@@ -285,7 +285,7 @@ describe('LLMManager', () => {
     });
 
     const events = [];
-    for await (const event of manager.streamTier('conversation', 'test', sampleMessages)) events.push(event);
+    for await (const event of manager.streamTier('conversation', 'conv_orchestrator', sampleMessages)) events.push(event);
     expect(events.some((event) => event.type === 'text' && event.text === 'fallback stream')).toBe(true);
     expect(events.some((event) => event.type === 'error')).toBe(false);
   });
@@ -313,7 +313,7 @@ describe('LLMManager', () => {
       tiers: { medium: 'primary:model-a' },
     });
 
-    await expect(manager.chatTier('medium', 'test', sampleMessages)).rejects.toThrow('invalid tool schema');
+    await expect(manager.chatTier('medium', 'chat_orchestrator', sampleMessages)).rejects.toThrow('invalid tool schema');
     expect(fallbackCalls).toBe(0);
   });
 
@@ -365,10 +365,38 @@ describe('LLMManager', () => {
     });
 
     const events = [];
-    for await (const event of manager.streamTier('medium', 'test', sampleMessages)) events.push(event);
+    for await (const event of manager.streamTier('medium', 'chat_orchestrator_stream', sampleMessages)) events.push(event);
     expect(events.some((event) => event.type === 'text' && event.text === 'partial')).toBe(true);
     expect(events.some((event) => event.type === 'error')).toBe(true);
     expect(fallbackCalls).toBe(0);
+  });
+
+  test('background tier failures never cross provider boundaries', async () => {
+    const manager = new LLMManager();
+    let groqCalls = 0;
+    const anthropic = {
+      name: 'anthropic', listModels: async () => ['claude'],
+      async chat() { throw new Error('Anthropic API error (401): invalid x-api-key'); },
+      async *stream() { /* not used */ },
+    };
+    const groq = {
+      name: 'groq', listModels: async () => ['llama'],
+      async chat() {
+        groqCalls++;
+        throw new Error('must not run');
+      },
+      async *stream() { /* not used */ },
+    };
+    manager.registerProvider(anthropic);
+    manager.registerProvider(groq);
+    configureLLMTiers(manager, {
+      default: 'groq:llama',
+      tiers: { medium: 'anthropic:claude' },
+    });
+
+    await expect(manager.chatTier('medium', 'background_agent', sampleMessages))
+      .rejects.toThrow('invalid x-api-key');
+    expect(groqCalls).toBe(0);
   });
 
   test('last tier candidate honors retryAfterMs before retrying chat', async () => {

--- a/src/llm/provider.test.ts
+++ b/src/llm/provider.test.ts
@@ -7,6 +7,7 @@ import { OpenRouterProvider } from './openrouter.ts';
 import { NVIDIAProvider } from './nvidia.ts';
 import { LiteLLMProvider } from './litellm.ts';
 import { LLMManager } from './manager.ts';
+import { configureLLMTiers } from './config-binding.ts';
 import { guardImageSize, classifyHttpStatus, classifyErrorString, type LLMMessage, type ContentBlock } from './provider.ts';
 import { isToolResult, type ToolResult } from '../actions/tools/registry.ts';
 
@@ -210,6 +211,157 @@ describe('LLMManager', () => {
     expect(events.some((event) => event.type === 'text' && event.text === 'fallback stream ok')).toBe(true);
     expect(events.some((event) => event.type === 'done')).toBe(true);
     expect(events.some((event) => event.type === 'error')).toBe(false);
+  });
+
+  test('tier chat falls back from a broken conversation provider to llm.default', async () => {
+    const manager = new LLMManager();
+    let anthropicCalls = 0;
+    let groqCalls = 0;
+    const anthropic = {
+      name: 'anthropic', listModels: async () => ['claude'],
+      async chat() {
+        anthropicCalls++;
+        throw new Error('Anthropic API error (401): invalid x-api-key');
+      },
+      async *stream() { /* not used */ },
+    };
+    const groq = {
+      name: 'groq', listModels: async () => ['llama'],
+      async chat(_messages: LLMMessage[], options?: { model?: string }) {
+        groqCalls++;
+        expect(options?.model).toBe('llama');
+        return {
+          content: 'groq recovered', tool_calls: [], usage: { input_tokens: 1, output_tokens: 1 },
+          model: 'llama', finish_reason: 'stop' as const,
+        };
+      },
+      async *stream() { /* not used */ },
+    };
+    manager.registerProvider(anthropic);
+    manager.registerProvider(groq);
+    configureLLMTiers(manager, {
+      default: 'groq:llama',
+      tiers: { conversation: 'anthropic:claude', medium: 'anthropic:claude' },
+    });
+
+    const response = await manager.chatTier('conversation', 'test', sampleMessages);
+    expect(response.content).toBe('groq recovered');
+    expect(anthropicCalls).toBe(1);
+    expect(groqCalls).toBe(1);
+  });
+
+  test('tier stream falls back before output and never exposes the primary error', async () => {
+    const manager = new LLMManager();
+    const anthropic = {
+      name: 'anthropic', listModels: async () => ['claude'],
+      async chat() { throw new Error('not used'); },
+      async *stream() {
+        yield { type: 'error' as const, error: 'invalid x-api-key', code: 'auth' as const };
+      },
+    };
+    const groq = {
+      name: 'groq', listModels: async () => ['llama'],
+      async chat() { throw new Error('not used'); },
+      async *stream() {
+        yield { type: 'text' as const, text: 'fallback stream' };
+        yield { type: 'done' as const, response: {
+          content: 'fallback stream', tool_calls: [], usage: { input_tokens: 1, output_tokens: 1 },
+          model: 'llama', finish_reason: 'stop' as const,
+        } };
+      },
+    };
+    manager.registerProvider(anthropic);
+    manager.registerProvider(groq);
+    configureLLMTiers(manager, {
+      default: 'groq:llama',
+      tiers: { conversation: 'anthropic:claude' },
+    });
+
+    const events = [];
+    for await (const event of manager.streamTier('conversation', 'test', sampleMessages)) events.push(event);
+    expect(events.some((event) => event.type === 'text' && event.text === 'fallback stream')).toBe(true);
+    expect(events.some((event) => event.type === 'error')).toBe(false);
+  });
+
+  test('tier fallback does not resend malformed requests', async () => {
+    const manager = new LLMManager();
+    let fallbackCalls = 0;
+    const primary = {
+      name: 'primary', listModels: async () => ['model-a'],
+      async chat() { throw new Error('400 invalid_request: invalid tool schema'); },
+      async *stream() { /* not used */ },
+    };
+    const fallback = {
+      name: 'fallback', listModels: async () => ['model-b'],
+      async chat() {
+        fallbackCalls++;
+        throw new Error('must not run');
+      },
+      async *stream() { /* not used */ },
+    };
+    manager.registerProvider(primary);
+    manager.registerProvider(fallback);
+    configureLLMTiers(manager, {
+      default: 'fallback:model-b',
+      tiers: { medium: 'primary:model-a' },
+    });
+
+    await expect(manager.chatTier('medium', 'test', sampleMessages)).rejects.toThrow('invalid tool schema');
+    expect(fallbackCalls).toBe(0);
+  });
+
+  test('tier fallback never sends content to a merely registered provider', async () => {
+    const manager = new LLMManager();
+    let unmappedCalls = 0;
+    const primary = {
+      name: 'primary', listModels: async () => ['model-a'],
+      async chat() { throw new Error('401 invalid x-api-key'); },
+      async *stream() { /* not used */ },
+    };
+    const unmapped = {
+      name: 'unmapped', listModels: async () => ['model-b'],
+      async chat() {
+        unmappedCalls++;
+        throw new Error('must not run');
+      },
+      async *stream() { /* not used */ },
+    };
+    manager.registerProvider(primary);
+    manager.registerProvider(unmapped);
+    manager.setTierMap({ medium: { provider: 'primary', model: 'model-a' } });
+
+    await expect(manager.chatTier('medium', 'test', sampleMessages)).rejects.toThrow('invalid x-api-key');
+    expect(unmappedCalls).toBe(0);
+  });
+
+  test('tier stream never crosses providers after output has started', async () => {
+    const manager = new LLMManager();
+    let fallbackCalls = 0;
+    const primary = {
+      name: 'primary', listModels: async () => ['model-a'],
+      async chat() { throw new Error('not used'); },
+      async *stream() {
+        yield { type: 'text' as const, text: 'partial' };
+        yield { type: 'error' as const, error: '429 quota exhausted', code: 'rate_limit' as const };
+      },
+    };
+    const fallback = {
+      name: 'fallback', listModels: async () => ['model-b'],
+      async chat() { throw new Error('not used'); },
+      async *stream() { fallbackCalls++; },
+    };
+    manager.registerProvider(primary);
+    manager.registerProvider(fallback);
+    configureLLMTiers(manager, {
+      default: 'fallback:model-b',
+      tiers: { medium: 'primary:model-a' },
+    });
+
+    const events = [];
+    for await (const event of manager.streamTier('medium', 'test', sampleMessages)) events.push(event);
+    expect(events.some((event) => event.type === 'text' && event.text === 'partial')).toBe(true);
+    expect(events.some((event) => event.type === 'error')).toBe(true);
+    expect(fallbackCalls).toBe(0);
   });
 });
 

--- a/src/llm/provider.test.ts
+++ b/src/llm/provider.test.ts
@@ -980,6 +980,31 @@ describe('Groq request shaping', () => {
     expect(JSON.stringify(secondBody).length).toBeLessThan(JSON.stringify(firstBody).length);
   });
 
+  test('GroqProvider rotates chat to the next model when daily model quota is exhausted', async () => {
+    globalThis.fetch = mock(async (_url: string, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body));
+      if (body.model === 'llama-3.3-70b-versatile') {
+        return new Response(JSON.stringify({
+          error: { message: 'Tokens per day (TPD): Limit 100000, Used 98608, Requested 3019.' },
+        }), { status: 429, headers: { 'Retry-After': '1200' } });
+      }
+      return new Response(JSON.stringify({
+        id: 'cmpl_rotated', object: 'chat.completion', created: Date.now(), model: body.model,
+        choices: [{ index: 0, message: { role: 'assistant', content: 'rotated ok' }, finish_reason: 'stop' }],
+        usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+    }) as unknown as typeof fetch;
+
+    const provider = new GroqProvider('test-key');
+    const response = await provider.chat([{ role: 'user', content: 'hello' }]);
+    const fetchMock = globalThis.fetch as unknown as ReturnType<typeof mock>;
+    const models = fetchMock.mock.calls.map((call) => JSON.parse(String(call[1]?.body)).model);
+
+    expect(response.content).toBe('rotated ok');
+    expect(response.model).toBe('llama-3.1-8b-instant');
+    expect(models).toEqual(['llama-3.3-70b-versatile', 'llama-3.1-8b-instant']);
+  });
+
   test('GroqProvider compaction never orphans a tool message from its assistant tool_call', async () => {
     let captured: any = null;
     globalThis.fetch = mock(async (_url: string, init?: RequestInit) => {
@@ -1077,6 +1102,42 @@ describe('Groq request shaping', () => {
     expect(events.join('')).toBe('retry-stream ok');
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(JSON.stringify(secondBody).length).toBeLessThan(JSON.stringify(firstBody).length);
+  });
+
+  test('GroqProvider rotates streaming to the next model on a model rate limit', async () => {
+    const enc = new TextEncoder();
+    globalThis.fetch = mock(async (_url: string, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body));
+      if (body.model === 'llama-3.3-70b-versatile') {
+        return new Response(JSON.stringify({ error: { message: 'TPD quota exhausted' } }), {
+          status: 429,
+          headers: { 'Retry-After': '1200' },
+        });
+      }
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(enc.encode(`data: ${JSON.stringify({
+            id: 'rotated', object: 'chat.completion.chunk', created: 0, model: body.model,
+            choices: [{ index: 0, delta: { content: 'stream rotated ok' }, finish_reason: null }],
+          })}\n\n`));
+          controller.enqueue(enc.encode('data: [DONE]\n\n'));
+          controller.close();
+        },
+      });
+      return new Response(stream, { status: 200, headers: { 'Content-Type': 'text/event-stream' } });
+    }) as unknown as typeof fetch;
+
+    const provider = new GroqProvider('test-key');
+    const events = [];
+    for await (const event of provider.stream([{ role: 'user', content: 'hello' }])) events.push(event);
+    const fetchMock = globalThis.fetch as unknown as ReturnType<typeof mock>;
+    const models = fetchMock.mock.calls.map((call) => JSON.parse(String(call[1]?.body)).model);
+    const done = events.find((event) => event.type === 'done');
+
+    expect(models).toEqual(['llama-3.3-70b-versatile', 'llama-3.1-8b-instant']);
+    expect(events.some((event) => event.type === 'text' && event.text === 'stream rotated ok')).toBe(true);
+    expect(done?.type === 'done' ? done.response.model : null).toBe('llama-3.1-8b-instant');
+    expect(events.some((event) => event.type === 'error')).toBe(false);
   });
 });
 

--- a/src/llm/provider.test.ts
+++ b/src/llm/provider.test.ts
@@ -12,7 +12,9 @@ import {
   guardImageSize,
   classifyHttpStatus,
   classifyErrorString,
+  LLMProviderError,
   parseRetryAfterMs,
+  toLLMStreamError,
   type LLMMessage,
   type ContentBlock,
 } from './provider.ts';
@@ -1241,5 +1243,21 @@ describe('parseRetryAfterMs', () => {
 
   test('returns undefined when the provider gives no retry timing', () => {
     expect(parseRetryAfterMs(undefined, 'rate limited')).toBeUndefined();
+  });
+});
+
+describe('toLLMStreamError', () => {
+  test('preserves the final provider code and retry timing over earlier error text', () => {
+    const error = new LLMProviderError(
+      'Anthropic API error (401): invalid x-api-key\n\nGroq API error (429): rate limited',
+      { code: 'rate_limit', retryAfterMs: 90_000 },
+    );
+
+    expect(toLLMStreamError(error)).toEqual({
+      type: 'error',
+      error: error.message,
+      code: 'rate_limit',
+      retryAfterMs: 90_000,
+    });
   });
 });

--- a/src/llm/provider.test.ts
+++ b/src/llm/provider.test.ts
@@ -12,7 +12,6 @@ import {
   guardImageSize,
   classifyHttpStatus,
   classifyErrorString,
-  LLMProviderError,
   parseRetryAfterMs,
   toLLMStreamError,
   type LLMMessage,
@@ -1248,10 +1247,9 @@ describe('parseRetryAfterMs', () => {
 
 describe('toLLMStreamError', () => {
   test('preserves the final provider code and retry timing over earlier error text', () => {
-    const error = new LLMProviderError(
+    const error = Object.assign(new Error(
       'Anthropic API error (401): invalid x-api-key\n\nGroq API error (429): rate limited',
-      { code: 'rate_limit', retryAfterMs: 90_000 },
-    );
+    ), { code: 'rate_limit' as const, retryAfterMs: 90_000 });
 
     expect(toLLMStreamError(error)).toEqual({
       type: 'error',

--- a/src/llm/provider.test.ts
+++ b/src/llm/provider.test.ts
@@ -8,7 +8,14 @@ import { NVIDIAProvider } from './nvidia.ts';
 import { LiteLLMProvider } from './litellm.ts';
 import { LLMManager } from './manager.ts';
 import { configureLLMTiers } from './config-binding.ts';
-import { guardImageSize, classifyHttpStatus, classifyErrorString, type LLMMessage, type ContentBlock } from './provider.ts';
+import {
+  guardImageSize,
+  classifyHttpStatus,
+  classifyErrorString,
+  parseRetryAfterMs,
+  type LLMMessage,
+  type ContentBlock,
+} from './provider.ts';
 import { isToolResult, type ToolResult } from '../actions/tools/registry.ts';
 
 describe('LLM Provider Types', () => {
@@ -362,6 +369,68 @@ describe('LLMManager', () => {
     expect(events.some((event) => event.type === 'text' && event.text === 'partial')).toBe(true);
     expect(events.some((event) => event.type === 'error')).toBe(true);
     expect(fallbackCalls).toBe(0);
+  });
+
+  test('last tier candidate honors retryAfterMs before retrying chat', async () => {
+    const manager = new LLMManager();
+    let calls = 0;
+    const provider = {
+      name: 'groq', listModels: async () => ['llama'],
+      async chat() {
+        calls++;
+        if (calls === 1) {
+          throw Object.assign(new Error('Groq API error (429): rate limited'), {
+            code: 'rate_limit' as const,
+            retryAfterMs: 1,
+          });
+        }
+        return {
+          content: 'recovered', tool_calls: [], usage: { input_tokens: 1, output_tokens: 1 },
+          model: 'llama', finish_reason: 'stop' as const,
+        };
+      },
+      async *stream() { /* not used */ },
+    };
+    manager.registerProvider(provider);
+    manager.setTierMap({ medium: { provider: 'groq', model: 'llama' } });
+
+    const response = await manager.chatTier('medium', 'test', sampleMessages);
+    expect(response.content).toBe('recovered');
+    expect(calls).toBe(2);
+  });
+
+  test('last tier candidate honors stream retryAfterMs instead of retrying immediately', async () => {
+    const manager = new LLMManager();
+    let calls = 0;
+    const provider = {
+      name: 'groq', listModels: async () => ['llama'],
+      async chat() { throw new Error('not used'); },
+      async *stream() {
+        calls++;
+        if (calls === 1) {
+          yield {
+            type: 'error' as const,
+            error: 'Groq API error (429): rate limited',
+            code: 'rate_limit' as const,
+            retryAfterMs: 1,
+          };
+          return;
+        }
+        yield { type: 'text' as const, text: 'recovered stream' };
+        yield { type: 'done' as const, response: {
+          content: 'recovered stream', tool_calls: [], usage: { input_tokens: 1, output_tokens: 1 },
+          model: 'llama', finish_reason: 'stop' as const,
+        } };
+      },
+    };
+    manager.registerProvider(provider);
+    manager.setTierMap({ medium: { provider: 'groq', model: 'llama' } });
+
+    const events = [];
+    for await (const event of manager.streamTier('medium', 'test', sampleMessages)) events.push(event);
+    expect(events.some((event) => event.type === 'text' && event.text === 'recovered stream')).toBe(true);
+    expect(events.some((event) => event.type === 'error')).toBe(false);
+    expect(calls).toBe(2);
   });
 });
 
@@ -848,6 +917,40 @@ describe('Groq request shaping', () => {
     expect(JSON.stringify(secondBody).length).toBeLessThan(JSON.stringify(firstBody).length);
   });
 
+  test('GroqProvider retries TPM quota failures once with a tighter payload', async () => {
+    globalThis.fetch = mock(async (_url: string, init?: RequestInit) => {
+      const callCount = (globalThis.fetch as unknown as ReturnType<typeof mock>).mock.calls.length;
+      if (callCount === 1) {
+        return new Response(JSON.stringify({
+          error: {
+            message: 'Rate limit reached on tokens per minute (TPM). Used 9524, Requested 9754. Please try again in 36.39s.',
+          },
+        }), { status: 429, headers: { 'Retry-After': '37' } });
+      }
+      return new Response(JSON.stringify({
+        id: 'cmpl_quota_retry', object: 'chat.completion', created: Date.now(), model: 'llama-test',
+        choices: [{ index: 0, message: { role: 'assistant', content: 'compact quota retry ok' }, finish_reason: 'stop' }],
+        usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+    }) as unknown as typeof fetch;
+
+    const provider = new GroqProvider('test-key');
+    const messages: LLMMessage[] = [
+      { role: 'system', content: 'S'.repeat(14_000) },
+      { role: 'user', content: 'U'.repeat(10_000) },
+      { role: 'assistant', content: 'A'.repeat(10_000) },
+      { role: 'user', content: 'Can you still answer?' },
+    ];
+
+    const response = await provider.chat(messages);
+    const fetchMock = globalThis.fetch as unknown as ReturnType<typeof mock>;
+    const firstBody = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body));
+    const secondBody = JSON.parse(String(fetchMock.mock.calls[1]?.[1]?.body));
+    expect(response.content).toBe('compact quota retry ok');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(JSON.stringify(secondBody).length).toBeLessThan(JSON.stringify(firstBody).length);
+  });
+
   test('GroqProvider compaction never orphans a tool message from its assistant tool_call', async () => {
     let captured: any = null;
     globalThis.fetch = mock(async (_url: string, init?: RequestInit) => {
@@ -1099,5 +1202,16 @@ describe('classifyErrorString', () => {
     expect(classifyErrorString('something unexpected happened')).toBe('unknown');
     expect(classifyErrorString(undefined)).toBe('unknown');
     expect(classifyErrorString('')).toBe('unknown');
+  });
+});
+
+describe('parseRetryAfterMs', () => {
+  test('parses standard seconds and Groq decimal-second quota messages', () => {
+    expect(parseRetryAfterMs('37')).toBe(37_000);
+    expect(parseRetryAfterMs(undefined, 'Please try again in 36.39s.')).toBe(36_390);
+  });
+
+  test('returns undefined when the provider gives no retry timing', () => {
+    expect(parseRetryAfterMs(undefined, 'rate limited')).toBeUndefined();
   });
 });

--- a/src/llm/provider.ts
+++ b/src/llm/provider.ts
@@ -55,7 +55,40 @@ export type LLMStreamEvent =
   | { type: 'text'; text: string }
   | { type: 'tool_call'; tool_call: LLMToolCall }
   | { type: 'done'; response: LLMResponse }
-  | { type: 'error'; error: string; code?: LLMErrorCode };
+  | { type: 'error'; error: string; code?: LLMErrorCode; retryAfterMs?: number };
+
+/** Provider failure metadata that must survive manager aggregation/retry. */
+export class LLMProviderError extends Error {
+  code?: LLMErrorCode;
+  retryAfterMs?: number;
+
+  constructor(message: string, opts?: { code?: LLMErrorCode; retryAfterMs?: number }) {
+    super(message);
+    this.name = 'LLMProviderError';
+    this.code = opts?.code;
+    this.retryAfterMs = opts?.retryAfterMs;
+  }
+}
+
+/**
+ * Parse standard Retry-After values and the decimal-second wording used in
+ * Groq quota bodies. The result is rounded up so we never retry just before
+ * the provider window actually opens.
+ */
+export function parseRetryAfterMs(header: string | null | undefined, body = ''): number | undefined {
+  const raw = header?.trim();
+  if (raw) {
+    const seconds = Number(raw);
+    if (Number.isFinite(seconds) && seconds >= 0) return Math.ceil(seconds * 1000);
+    const dateMs = Date.parse(raw);
+    if (Number.isFinite(dateMs)) return Math.max(dateMs - Date.now(), 0);
+  }
+
+  const match = /(?:please\s+)?try again in\s+([\d.]+)\s*(?:s|sec|secs|second|seconds)\b/i.exec(body);
+  if (!match) return undefined;
+  const seconds = Number(match[1]);
+  return Number.isFinite(seconds) && seconds >= 0 ? Math.ceil(seconds * 1000) : undefined;
+}
 
 /**
  * Map an HTTP status code returned by a provider to a canonical error code.

--- a/src/llm/provider.ts
+++ b/src/llm/provider.ts
@@ -73,13 +73,16 @@ export class LLMProviderError extends Error {
 /** Preserve provider metadata when a non-streaming tier call is exposed as a stream. */
 export function toLLMStreamError(error: unknown): Extract<LLMStreamEvent, { type: 'error' }> {
   const message = error instanceof Error ? error.message : String(error);
+  const structured = error && typeof error === 'object'
+    ? error as { code?: LLMErrorCode; retryAfterMs?: unknown }
+    : undefined;
   return {
     type: 'error',
     error: message,
-    code: error instanceof LLMProviderError && error.code
-      ? error.code
-      : classifyErrorString(message),
-    retryAfterMs: error instanceof LLMProviderError ? error.retryAfterMs : undefined,
+    code: structured?.code ?? classifyErrorString(message),
+    retryAfterMs: typeof structured?.retryAfterMs === 'number'
+      ? structured.retryAfterMs
+      : undefined,
   };
 }
 

--- a/src/llm/provider.ts
+++ b/src/llm/provider.ts
@@ -70,6 +70,19 @@ export class LLMProviderError extends Error {
   }
 }
 
+/** Preserve provider metadata when a non-streaming tier call is exposed as a stream. */
+export function toLLMStreamError(error: unknown): Extract<LLMStreamEvent, { type: 'error' }> {
+  const message = error instanceof Error ? error.message : String(error);
+  return {
+    type: 'error',
+    error: message,
+    code: error instanceof LLMProviderError && error.code
+      ? error.code
+      : classifyErrorString(message),
+    retryAfterMs: error instanceof LLMProviderError ? error.retryAfterMs : undefined,
+  };
+}
+
 /**
  * Parse standard Retry-After values and the decimal-second wording used in
  * Groq quota bodies. The result is rounded up so we never retry just before


### PR DESCRIPTION
## Summary

- make the explicitly configured llm.default provider the safe final fallback for tier requests
- restrict candidates to tier-routed providers plus that explicit default, never every registered provider
- fail over only for provider/model/quota/auth/outage-shaped failures and do not resend malformed requests
- avoid crossing providers after streamed output has already started
- retry Groq TPM failures once with a compact payload instead of resending the same oversized request
- preserve Retry-After metadata and wait up to 60 seconds only when no healthy fallback remains
- preserve the final providers typed error code across aggregated failures

## Verification

- bun test: 1,903 passed, 37 skipped, 0 failed
- bun run tsc --noEmit
- focused Groq compaction, Retry-After, streaming retry, and tier fallback regressions
- git diff --check