### PR TITLE
feat(chat): narrate progress during tool work

### DIFF
--- a/src/agents/conv/conv-orchestrator.test.ts
+++ b/src/agents/conv/conv-orchestrator.test.ts
@@ -151,6 +151,27 @@ describe('ConvOrchestrator', () => {
     expect(result.tasksRun).toHaveLength(1);
   });
 
+  it('hides and executes a parenthesized delegate call', async () => {
+    const provider = new MockProvider([
+      textResponse('(delegate {"intent":"Check the last email in my inbox","template":"research","tier":"medium"}) Let me check your inbox now.'),
+      textResponse('Your latest email is from Alice.'),
+      textResponse('Your latest email is from Alice.'),
+    ]);
+    const llm = makeManager(provider);
+    const runner = async ({ tier, subsystem, originalMessage }: { tier: 'low' | 'medium' | 'high'; subsystem: string; template: string; intent: string; originalMessage: string; signal: AbortSignal; history?: unknown[] }) => {
+      const r = await llm.chatTier(tier, subsystem, [{ role: 'user', content: originalMessage }]);
+      return { kind: 'completed' as const, text: r.content, conversation: [] };
+    };
+    const dispatcher = new TaskDispatcher(llm, registry, runner as never);
+    const conv = new ConvOrchestrator(llm, registry, dispatcher, 'TestBot persona.');
+
+    const result = await conv.processTurn('Check my last email', {});
+    expect(result.text).toBe('Let me check your inbox now.\nYour latest email is from Alice.');
+    expect(result.text).not.toContain('(delegate');
+    expect(result.text).not.toContain('"template"');
+    expect(result.tasksRun).toHaveLength(1);
+  });
+
   it('surfaces a fallback acknowledgment before a silent delegated task starts', async () => {
     const provider = new MockProvider([
       toolCallResponse('delegate', {

--- a/src/agents/conv/conv-orchestrator.test.ts
+++ b/src/agents/conv/conv-orchestrator.test.ts
@@ -10,6 +10,9 @@ import { ConvOrchestrator } from './conv-orchestrator.ts';
  * the conv tier emitting delegate tool calls and the task tier returning
  * text results.
  */
+/** Deliberately small and not aligned to any token boundary. */
+const CHUNK_SIZE = 4;
+
 class MockProvider implements LLMProvider {
   name = 'mock';
   private queue: LLMResponse[] = [];
@@ -29,9 +32,16 @@ class MockProvider implements LLMProvider {
     }
     return next;
   }
+  /**
+   * Emits content in small pieces the way a real provider does. Streaming a
+   * whole response as one text event would hide anything that depends on where
+   * chunk boundaries fall — which is exactly where serialized tool calls leak.
+   */
   async *stream(messages: LLMMessage[], opts?: LLMOptions): AsyncIterable<LLMStreamEvent> {
     const response = await this.chat(messages, opts);
-    if (response.content) yield { type: 'text', text: response.content };
+    for (let index = 0; index < response.content.length; index += CHUNK_SIZE) {
+      yield { type: 'text', text: response.content.slice(index, index + CHUNK_SIZE) };
+    }
     for (const toolCall of response.tool_calls) {
       yield { type: 'tool_call', tool_call: toolCall };
     }
@@ -50,10 +60,10 @@ function textResponse(content: string): LLMResponse {
   };
 }
 
-function toolCallResponse(name: string, args: Record<string, unknown>): LLMResponse {
+function toolCallResponse(name: string, args: Record<string, unknown>, content = ''): LLMResponse {
   const call: LLMToolCall = { id: `call_${Math.random()}`, name, arguments: args };
   return {
-    content: '',
+    content,
     tool_calls: [call],
     usage: { input_tokens: 10, output_tokens: 5 },
     model: 'mock',
@@ -170,6 +180,79 @@ describe('ConvOrchestrator', () => {
     expect(result.text).not.toContain('(delegate');
     expect(result.text).not.toContain('"template"');
     expect(result.tasksRun).toHaveLength(1);
+  });
+
+  it('hides a serialized delegate call the model prints after its prose', async () => {
+    // The prompt asks the model to acknowledge first, so the leaked call
+    // usually arrives *after* prose — the position a prefix-only guard misses.
+    const provider = new MockProvider([
+      textResponse('Sure, let me look into that. /delegate{"tier":"medium","template":"research","intent":"Check the inbox"}'),
+      textResponse('Your latest email is from Alice.'),
+      textResponse('Your latest email is from Alice.'),
+    ]);
+    const llm = makeManager(provider);
+    const runner = async ({ tier, subsystem, originalMessage }: { tier: 'low' | 'medium' | 'high'; subsystem: string; originalMessage: string }) => {
+      const r = await llm.chatTier(tier, subsystem, [{ role: 'user', content: originalMessage }]);
+      return { kind: 'completed' as const, text: r.content, conversation: [] };
+    };
+    const dispatcher = new TaskDispatcher(llm, registry, runner as never);
+    const conv = new ConvOrchestrator(llm, registry, dispatcher, 'TestBot persona.');
+
+    const spoken: string[] = [];
+    for await (const event of conv.streamTurn('Check my email', {})) {
+      if (event.type === 'text') spoken.push(event.text);
+    }
+    const streamed = spoken.join('');
+    expect(streamed).not.toContain('/delegate');
+    expect(streamed).not.toContain('"template"');
+    expect(streamed).not.toContain('{');
+    expect(streamed).toBe('Sure, let me look into that. Your latest email is from Alice.');
+  });
+
+  it('marks the acknowledgment segment complete before delegating', async () => {
+    const provider = new MockProvider([
+      textResponse('Let me check that. /delegate{"tier":"medium","template":"research","intent":"x"}'),
+      textResponse('All done.'),
+      textResponse('All done.'),
+    ]);
+    const llm = makeManager(provider);
+    let dispatched = false;
+    const runner = async () => {
+      dispatched = true;
+      return { kind: 'completed' as const, text: 'All done.', conversation: [] };
+    };
+    const dispatcher = new TaskDispatcher(llm, registry, runner as never);
+    const conv = new ConvOrchestrator(llm, registry, dispatcher, 'TestBot persona.');
+
+    let sawSegmentEnd = false;
+    for await (const event of conv.streamTurn('Check it', {})) {
+      if (event.type === 'text' && event.segmentEnd) {
+        // The signal has to arrive while the task tier is still idle, or TTS
+        // gains nothing over waiting for the answer.
+        expect(dispatched).toBe(false);
+        sawSegmentEnd = true;
+      }
+    }
+    expect(sawSegmentEnd).toBe(true);
+  });
+
+  it('separates the routing-failure message from the preceding acknowledgment', async () => {
+    // Every turn delegates and never settles, so the loop runs to its cap.
+    const responses = Array.from({ length: 40 }, (_, index) => toolCallResponse(
+      'delegate',
+      { tier: 'medium', template: 'research', intent: `step ${index}` },
+      'Working on it.',
+    ));
+    const provider = new MockProvider(responses);
+    const llm = makeManager(provider);
+    const runner = async () => ({ kind: 'completed' as const, text: 'partial', conversation: [] });
+    const dispatcher = new TaskDispatcher(llm, registry, runner as never);
+    const conv = new ConvOrchestrator(llm, registry, dispatcher, 'TestBot persona.');
+
+    const result = await conv.processTurn('go', {});
+    expect(result.text).toContain('I got stuck routing your request.');
+    expect(result.text).not.toContain('it.I got stuck');
+    expect(result.text.endsWith('\nI got stuck routing your request. Could you rephrase or try again?')).toBe(true);
   });
 
   it('surfaces a fallback acknowledgment before a silent delegated task starts', async () => {

--- a/src/agents/conv/conv-orchestrator.test.ts
+++ b/src/agents/conv/conv-orchestrator.test.ts
@@ -29,9 +29,13 @@ class MockProvider implements LLMProvider {
     }
     return next;
   }
-  // eslint-disable-next-line require-yield
-  async *stream(): AsyncIterable<LLMStreamEvent> {
-    throw new Error('stream not used in these tests');
+  async *stream(messages: LLMMessage[], opts?: LLMOptions): AsyncIterable<LLMStreamEvent> {
+    const response = await this.chat(messages, opts);
+    if (response.content) yield { type: 'text', text: response.content };
+    for (const toolCall of response.tool_calls) {
+      yield { type: 'tool_call', tool_call: toolCall };
+    }
+    yield { type: 'done', response };
   }
   async listModels(): Promise<string[]> { return ['mock']; }
 }
@@ -115,12 +119,41 @@ describe('ConvOrchestrator', () => {
     const conv = new ConvOrchestrator(llm, registry, dispatcher, 'TestBot persona.');
 
     const result = await conv.processTurn('What is the capital of Italy?', {});
-    expect(result.text).toBe('Rome is the capital of Italy.');
+    expect(result.text).toBe(
+      'I’m looking into that now and I’ll report back.\nRome is the capital of Italy.',
+    );
     expect(result.tasksRun).toHaveLength(1);
 
     // The task should be completed in the registry
     const taskId = result.tasksRun[0]!;
     expect(registry.get(taskId)?.status).toBe('completed');
+  });
+
+  it('surfaces a fallback acknowledgment before a silent delegated task starts', async () => {
+    const provider = new MockProvider([
+      toolCallResponse('delegate', {
+        tier: 'medium',
+        template: 'code',
+        intent: 'Inspect the failing route',
+      }),
+    ]);
+    const llm = makeManager(provider);
+    let runnerStarted = false;
+    const runner = async () => {
+      runnerStarted = true;
+      return { kind: 'completed' as const, text: 'done', conversation: [] };
+    };
+    const dispatcher = new TaskDispatcher(llm, registry, runner as never);
+    const conv = new ConvOrchestrator(llm, registry, dispatcher, 'TestBot persona.');
+
+    const stream = conv.streamTurn('Fix the route', {});
+    const first = await stream.next();
+    expect(first.value).toMatchObject({
+      type: 'text',
+      text: 'I’m checking the relevant code now.',
+    });
+    expect(runnerStarted).toBe(false);
+    await stream.return(undefined);
   });
 
   it('handles check_task on an unknown task gracefully', async () => {

--- a/src/agents/conv/conv-orchestrator.test.ts
+++ b/src/agents/conv/conv-orchestrator.test.ts
@@ -129,6 +129,28 @@ describe('ConvOrchestrator', () => {
     expect(registry.get(taskId)?.status).toBe('completed');
   });
 
+  it('hides and executes a delegate call serialized as fallback text', async () => {
+    const provider = new MockProvider([
+      textResponse('FALLBACK_OK/delegate{"intent":"Provide friendly greeting.","template":"general","tier":"medium"} I’ll handle that.'),
+      textResponse('Hi again!'),
+      textResponse('Hi again, how is your day going?'),
+    ]);
+    const llm = makeManager(provider);
+    const runner = async ({ tier, subsystem, originalMessage }: { tier: 'low' | 'medium' | 'high'; subsystem: string; template: string; intent: string; originalMessage: string; signal: AbortSignal; history?: unknown[] }) => {
+      const r = await llm.chatTier(tier, subsystem, [{ role: 'user', content: originalMessage }]);
+      return { kind: 'completed' as const, text: r.content, conversation: [] };
+    };
+    const dispatcher = new TaskDispatcher(llm, registry, runner as never);
+    const conv = new ConvOrchestrator(llm, registry, dispatcher, 'TestBot persona.');
+
+    const result = await conv.processTurn('Hello', {});
+    expect(result.text).toBe('I’ll handle that.\nHi again, how is your day going?');
+    expect(result.text).not.toContain('FALLBACK_OK');
+    expect(result.text).not.toContain('/delegate');
+    expect(result.text).not.toContain('"template"');
+    expect(result.tasksRun).toHaveLength(1);
+  });
+
   it('surfaces a fallback acknowledgment before a silent delegated task starts', async () => {
     const provider = new MockProvider([
       toolCallResponse('delegate', {

--- a/src/agents/conv/conv-orchestrator.ts
+++ b/src/agents/conv/conv-orchestrator.ts
@@ -21,6 +21,7 @@
 
 import type { LLMManager } from '../../llm/manager.ts';
 import type { LLMMessage, LLMToolCall } from '../../llm/provider.ts';
+import { progressAcknowledgement } from '../progress.ts';
 import { CONV_TOOLS, CONV_TOOL_NAMES } from './conv-tools.ts';
 import { TaskDispatcher } from './task-dispatcher.ts';
 import { TaskRegistry } from './task-registry.ts';
@@ -62,7 +63,7 @@ export type ConvProcessResult = {
  * user immediately, instead of waiting for the slow task tier to finish.
  */
 export type ConvStreamEvent =
-  | { type: 'text'; text: string }
+  | { type: 'text'; text: string; newSegment?: boolean }
   | { type: 'task'; event: ConvTaskEvent }
   | { type: 'done'; tasksRun: string[] };
 
@@ -90,7 +91,8 @@ export class ConvOrchestrator {
     const tasksRun: string[] = [];
     for await (const event of this.streamTurn(userMessage, context)) {
       if (event.type === 'text') {
-        fullText += (fullText && !fullText.endsWith('\n') ? '\n' : '') + event.text;
+        const separator = event.newSegment && fullText && !fullText.endsWith('\n') ? '\n' : '';
+        fullText += separator + event.text;
       } else if (event.type === 'task') {
         onTaskEvent?.(event.event);
       } else if (event.type === 'done') {
@@ -132,30 +134,73 @@ export class ConvOrchestrator {
     ];
 
     const tasksRun: string[] = [];
+    let hasVisibleText = false;
+    let acknowledgedWork = false;
     // Remember the user's verbatim message so we can attach it to every
     // delegate request - the task tier sees what the user actually said,
     // not the conv LLM's paraphrase.
     this.currentUserMessage = userMessage;
 
     for (let iteration = 0; iteration < MAX_CONV_ITERATIONS; iteration++) {
-      const response = await this.llm.chatTier('conversation', 'conv_orchestrator', messages, {
+      let responseText = '';
+      const responseToolCalls: LLMToolCall[] = [];
+      let response: import('../../llm/provider.ts').LLMResponse | null = null;
+      let firstTextChunk = true;
+
+      // Stream the conversation layer itself instead of waiting for a full
+      // chat response. Natural acknowledgments now reach the user as soon as
+      // the model writes them, before a delegated task begins.
+      for await (const event of this.llm.streamTier('conversation', 'conv_orchestrator', messages, {
         tools: CONV_TOOLS,
         tool_choice: 'auto',
-      });
+      })) {
+        if (event.type === 'text') {
+          responseText += event.text;
+          yield {
+            type: 'text',
+            text: event.text,
+            newSegment: firstTextChunk && hasVisibleText,
+          };
+          firstTextChunk = false;
+          hasVisibleText = true;
+        } else if (event.type === 'tool_call') {
+          responseToolCalls.push(event.tool_call);
+        } else if (event.type === 'done') {
+          response = event.response;
+        } else if (event.type === 'error') {
+          throw new Error(event.error);
+        }
+      }
+
+      response ??= {
+        content: responseText,
+        tool_calls: responseToolCalls,
+        usage: { input_tokens: 0, output_tokens: 0 },
+        model: 'unknown',
+        finish_reason: responseToolCalls.length > 0 ? 'tool_use' : 'stop',
+      };
+      response = {
+        ...response,
+        content: responseText || response.content || '',
+        tool_calls: responseToolCalls.length > 0 ? responseToolCalls : response.tool_calls,
+      };
 
       // Conv LLM emitted text only (no tool calls) -> final user-facing reply.
       if (!response.tool_calls || response.tool_calls.length === 0) {
-        if (response.content) yield { type: 'text', text: response.content };
         yield { type: 'done', tasksRun };
         return;
       }
 
-      // Conv LLM emitted tool calls. If it also wrote any prose (the
-      // acknowledgment - "I'm looking into that"), surface it NOW so the
-      // user gets immediate feedback before the slow task tier starts.
-      if (response.content && response.content.trim().length > 0) {
-        yield { type: 'text', text: response.content };
+      // Some tool-calling models return null content even when explicitly
+      // prompted to acknowledge the user. Supply one concise activity update
+      // so the delegated task never creates minutes of silent "thinking".
+      if (!response.content.trim() && !acknowledgedWork) {
+        const acknowledgment = progressAcknowledgement(response.tool_calls);
+        response.content = acknowledgment;
+        yield { type: 'text', text: acknowledgment, newSegment: hasVisibleText };
+        hasVisibleText = true;
       }
+      if (response.content.trim()) acknowledgedWork = true;
 
       messages.push({
         role: 'assistant',

--- a/src/agents/conv/conv-orchestrator.ts
+++ b/src/agents/conv/conv-orchestrator.ts
@@ -20,10 +20,10 @@
  */
 
 import type { LLMManager } from '../../llm/manager.ts';
-import type { LLMMessage, LLMToolCall } from '../../llm/provider.ts';
+import type { LLMMessage, LLMResponse, LLMToolCall } from '../../llm/provider.ts';
 import { progressAcknowledgement } from '../progress.ts';
 import { CONV_TOOLS, CONV_TOOL_NAMES } from './conv-tools.ts';
-import { couldStartWithSerializedConvTool, recoverSerializedConvTools } from './conv-tool-recovery.ts';
+import { recoverSerializedConvTools, visibleStreamText } from './conv-tool-recovery.ts';
 import { TaskDispatcher } from './task-dispatcher.ts';
 import { TaskRegistry } from './task-registry.ts';
 import type { TaskRecord, TaskRequest, TaskResultEnvelope } from './task-envelope.ts';
@@ -64,7 +64,7 @@ export type ConvProcessResult = {
  * user immediately, instead of waiting for the slow task tier to finish.
  */
 export type ConvStreamEvent =
-  | { type: 'text'; text: string; newSegment?: boolean }
+  | { type: 'text'; text: string; newSegment?: boolean; segmentEnd?: boolean }
   | { type: 'task'; event: ConvTaskEvent }
   | { type: 'done'; tasksRun: string[] };
 
@@ -92,6 +92,8 @@ export class ConvOrchestrator {
     const tasksRun: string[] = [];
     for await (const event of this.streamTurn(userMessage, context)) {
       if (event.type === 'text') {
+        // Skip segmentEnd-only events: they carry a TTS signal, not content.
+        if (!event.text) continue;
         const separator = event.newSegment && fullText && !fullText.endsWith('\n') ? '\n' : '';
         fullText += separator + event.text;
       } else if (event.type === 'task') {
@@ -145,9 +147,12 @@ export class ConvOrchestrator {
     for (let iteration = 0; iteration < MAX_CONV_ITERATIONS; iteration++) {
       let responseText = '';
       const responseToolCalls: LLMToolCall[] = [];
-      let response: import('../../llm/provider.ts').LLMResponse | null = null;
+      let response: LLMResponse | null = null;
       let firstTextChunk = true;
-      let deferPotentialToolText = true;
+      // Visible text already yielded for this iteration, after serialized-tool
+      // removal. Successive strips of a growing buffer only ever extend this,
+      // so the delta is what's new.
+      let emittedVisible = '';
 
       // Stream the conversation layer itself instead of waiting for a full
       // chat response. Natural acknowledgments now reach the user as soon as
@@ -158,17 +163,17 @@ export class ConvOrchestrator {
       })) {
         if (event.type === 'text') {
           responseText += event.text;
-          // Do not expose a text-serialized tool call to either the chat UI
-          // or TTS. Ordinary prose still streams as soon as the prefix can no
-          // longer be mistaken for an internal conversation tool.
-          if (deferPotentialToolText && couldStartWithSerializedConvTool(responseText)) {
-            continue;
-          }
-          const visibleChunk = deferPotentialToolText ? responseText : event.text;
-          deferPotentialToolText = false;
+          // Never expose a text-serialized tool call to the chat UI or TTS.
+          // Only the tail that could still become one is withheld — anywhere in
+          // the response, not just at the start — so ordinary prose keeps
+          // streaming at token latency.
+          const visible = visibleStreamText(responseText);
+          if (visible.length <= emittedVisible.length) continue;
+          const delta = visible.slice(emittedVisible.length);
+          emittedVisible = visible;
           yield {
             type: 'text',
-            text: visibleChunk,
+            text: delta,
             newSegment: firstTextChunk && hasVisibleText,
           };
           firstTextChunk = false;
@@ -201,14 +206,21 @@ export class ConvOrchestrator {
       );
       response = { ...response, content: recovered.text, tool_calls: recovered.toolCalls };
 
-      // A possible serialized-tool prefix was buffered for safety. Emit only
-      // the recovered human-facing portion once parsing is complete.
-      if (deferPotentialToolText && response.content) {
+      // Flush anything the hold-back buffer was still holding when the stream
+      // ended — e.g. a trailing "/deleg" that never became a call, or content
+      // a provider only reports on its `done` event.
+      //
+      // `emittedVisible` is always a prefix of the recovered content (stripping
+      // a growing buffer only ever extends the visible text — see the
+      // monotonicity test in conv-tool-recovery.test.ts), so the tail is the
+      // part the user hasn't seen.
+      if (response.content.length > emittedVisible.length) {
         yield {
           type: 'text',
-          text: response.content,
+          text: response.content.slice(emittedVisible.length),
           newSegment: firstTextChunk && hasVisibleText,
         };
+        emittedVisible = response.content;
         firstTextChunk = false;
         hasVisibleText = true;
       }
@@ -225,8 +237,13 @@ export class ConvOrchestrator {
       if (!response.content.trim() && !acknowledgedWork) {
         const acknowledgment = progressAcknowledgement(response.tool_calls);
         response.content = acknowledgment;
-        yield { type: 'text', text: acknowledgment, newSegment: hasVisibleText };
+        yield { type: 'text', text: acknowledgment, newSegment: hasVisibleText, segmentEnd: true };
         hasVisibleText = true;
+      } else if (response.content.trim()) {
+        // The model wrote its own acknowledgment. Tell downstream TTS that it
+        // is complete so the sentence is spoken before the delegated task runs
+        // instead of waiting for the task's answer to arrive.
+        yield { type: 'text', text: '', segmentEnd: true };
       }
       if (response.content.trim()) acknowledgedWork = true;
 
@@ -265,6 +282,10 @@ export class ConvOrchestrator {
     yield {
       type: 'text',
       text: 'I got stuck routing your request. Could you rephrase or try again?',
+      // Separators are opt-in now, so this must be marked or it runs straight
+      // into whatever acknowledgment the loop already emitted.
+      newSegment: true,
+      segmentEnd: true,
     };
     yield { type: 'done', tasksRun };
   }

--- a/src/agents/conv/conv-orchestrator.ts
+++ b/src/agents/conv/conv-orchestrator.ts
@@ -168,7 +168,7 @@ export class ConvOrchestrator {
         } else if (event.type === 'done') {
           response = event.response;
         } else if (event.type === 'error') {
-          throw new Error(event.error);
+          throw Object.assign(new Error(event.error), { code: event.code });
         }
       }
 

--- a/src/agents/conv/conv-orchestrator.ts
+++ b/src/agents/conv/conv-orchestrator.ts
@@ -23,6 +23,7 @@ import type { LLMManager } from '../../llm/manager.ts';
 import type { LLMMessage, LLMToolCall } from '../../llm/provider.ts';
 import { progressAcknowledgement } from '../progress.ts';
 import { CONV_TOOLS, CONV_TOOL_NAMES } from './conv-tools.ts';
+import { couldStartWithSerializedConvTool, recoverSerializedConvTools } from './conv-tool-recovery.ts';
 import { TaskDispatcher } from './task-dispatcher.ts';
 import { TaskRegistry } from './task-registry.ts';
 import type { TaskRecord, TaskRequest, TaskResultEnvelope } from './task-envelope.ts';
@@ -146,6 +147,7 @@ export class ConvOrchestrator {
       const responseToolCalls: LLMToolCall[] = [];
       let response: import('../../llm/provider.ts').LLMResponse | null = null;
       let firstTextChunk = true;
+      let deferPotentialToolText = true;
 
       // Stream the conversation layer itself instead of waiting for a full
       // chat response. Natural acknowledgments now reach the user as soon as
@@ -156,9 +158,17 @@ export class ConvOrchestrator {
       })) {
         if (event.type === 'text') {
           responseText += event.text;
+          // Do not expose a text-serialized tool call to either the chat UI
+          // or TTS. Ordinary prose still streams as soon as the prefix can no
+          // longer be mistaken for an internal conversation tool.
+          if (deferPotentialToolText && couldStartWithSerializedConvTool(responseText)) {
+            continue;
+          }
+          const visibleChunk = deferPotentialToolText ? responseText : event.text;
+          deferPotentialToolText = false;
           yield {
             type: 'text',
-            text: event.text,
+            text: visibleChunk,
             newSegment: firstTextChunk && hasVisibleText,
           };
           firstTextChunk = false;
@@ -184,6 +194,24 @@ export class ConvOrchestrator {
         content: responseText || response.content || '',
         tool_calls: responseToolCalls.length > 0 ? responseToolCalls : response.tool_calls,
       };
+      const recovered = recoverSerializedConvTools(
+        response.content,
+        response.tool_calls ?? [],
+        `recovered_conv_${iteration}`,
+      );
+      response = { ...response, content: recovered.text, tool_calls: recovered.toolCalls };
+
+      // A possible serialized-tool prefix was buffered for safety. Emit only
+      // the recovered human-facing portion once parsing is complete.
+      if (deferPotentialToolText && response.content) {
+        yield {
+          type: 'text',
+          text: response.content,
+          newSegment: firstTextChunk && hasVisibleText,
+        };
+        firstTextChunk = false;
+        hasVisibleText = true;
+      }
 
       // Conv LLM emitted text only (no tool calls) -> final user-facing reply.
       if (!response.tool_calls || response.tool_calls.length === 0) {

--- a/src/agents/conv/conv-tool-recovery.test.ts
+++ b/src/agents/conv/conv-tool-recovery.test.ts
@@ -1,13 +1,62 @@
 import { describe, expect, it } from 'bun:test';
-import { couldStartWithSerializedConvTool, recoverSerializedConvTools } from './conv-tool-recovery.ts';
+import {
+  pendingSerializedToolSuffix,
+  recoverSerializedConvTools,
+  visibleStreamText as visibleWhileStreaming,
+} from './conv-tool-recovery.ts';
 
 describe('conversation text tool recovery', () => {
-  it('buffers partial internal prefixes without delaying ordinary prose', () => {
-    expect(couldStartWithSerializedConvTool('F')).toBe(true);
-    expect(couldStartWithSerializedConvTool('FALLBACK_OK/dele')).toBe(true);
-    expect(couldStartWithSerializedConvTool('/delegate')).toBe(true);
-    expect(couldStartWithSerializedConvTool('(dele')).toBe(true);
-    expect(couldStartWithSerializedConvTool('Hi again')).toBe(false);
+  it('withholds partial internal prefixes without delaying ordinary prose', () => {
+    expect(pendingSerializedToolSuffix('F')).toBe(1);
+    // Only `/dele` is ambiguous — the complete marker before it is stripped
+    // outright, so it never needs withholding.
+    expect(pendingSerializedToolSuffix('FALLBACK_OK/dele')).toBe(5);
+    expect(visibleWhileStreaming('FALLBACK_OK/dele')).toBe('');
+    expect(pendingSerializedToolSuffix('/delegate')).toBe(9);
+    expect(pendingSerializedToolSuffix('(dele')).toBe(5);
+    expect(pendingSerializedToolSuffix('Hi again')).toBe(0);
+    // Prose that merely starts like a marker must not be held once it can no
+    // longer become one.
+    expect(pendingSerializedToolSuffix('Fantastic news')).toBe(0);
+    expect(pendingSerializedToolSuffix('/delegated the work')).toBe(0);
+  });
+
+  it('withholds a serialized call that begins mid-response', () => {
+    const text = 'Sure, let me look into that. /delegate{"tier":"medium"';
+    expect(pendingSerializedToolSuffix(text)).toBe(text.length - 'Sure, let me look into that. '.length);
+    expect(visibleWhileStreaming(text)).toBe('Sure, let me look into that. ');
+  });
+
+  it('withholds an unresolved call that precedes a resolved one', () => {
+    // The inner `/check_task` sits inside the outer call's unfinished JSON.
+    const text = '/delegate{"intent":"run /check_task{\\"a\\":1} later"';
+    expect(pendingSerializedToolSuffix(text)).toBe(text.length);
+    expect(visibleWhileStreaming(text)).toBe('');
+  });
+
+  it('withholds the paren form until its closing parenthesis arrives', () => {
+    const text = 'On it. (delegate {"tier":"medium","template":"code","intent":"x"}';
+    expect(pendingSerializedToolSuffix(text)).toBe(text.length - 'On it. '.length);
+    expect(visibleWhileStreaming(`${text})`)).toBe('On it. ');
+  });
+
+  it('recovers a leaked delegate call and keeps only visible prose', () => {
+    const recovered = recoverSerializedConvTools(
+      'FALLBACK_OK/delegate{"intent":"Provide friendly greeting.","template":"general","tier":"medium"} Hi again, how is your day going?',
+      [],
+      'test',
+    );
+
+    expect(recovered.text).toBe('Hi again, how is your day going?');
+    expect(recovered.toolCalls).toEqual([{
+      id: 'test_0',
+      name: 'delegate',
+      arguments: {
+        intent: 'Provide friendly greeting.',
+        template: 'general',
+        tier: 'medium',
+      },
+    }]);
   });
 
   it('recovers the parenthesized tool syntax without exposing it to TTS', () => {
@@ -29,23 +78,25 @@ describe('conversation text tool recovery', () => {
     }]);
   });
 
-  it('recovers a leaked delegate call and keeps only visible prose', () => {
+  it('closes the seam when a call is removed from the middle of prose', () => {
     const recovered = recoverSerializedConvTools(
-      'FALLBACK_OK/delegate{"intent":"Provide friendly greeting.","template":"general","tier":"medium"} Hi again, how is your day going?',
+      'Checking now. /delegate{"tier":"medium","template":"code","intent":"x"} Back shortly.',
       [],
       'test',
     );
+    expect(recovered.text).toBe('Checking now. Back shortly.');
+    expect(recovered.toolCalls).toHaveLength(1);
+  });
 
-    expect(recovered.text).toBe('Hi again, how is your day going?');
-    expect(recovered.toolCalls).toEqual([{
-      id: 'test_0',
-      name: 'delegate',
-      arguments: {
-        intent: 'Provide friendly greeting.',
-        template: 'general',
-        tier: 'medium',
-      },
-    }]);
+  it('does not re-emit JSON from a marker nested inside a recovered call', () => {
+    const recovered = recoverSerializedConvTools(
+      '/delegate{"tier":"medium","template":"code","intent":"run /check_task{\\"task_id\\":\\"t1\\"} first"} On it.',
+      [],
+      'test',
+    );
+    expect(recovered.text).toBe('On it.');
+    expect(recovered.toolCalls).toHaveLength(1);
+    expect(recovered.toolCalls[0]?.name).toBe('delegate');
   });
 
   it('does not duplicate a structured call also printed in text', () => {
@@ -72,5 +123,24 @@ describe('conversation text tool recovery', () => {
     );
     expect(recovered.text).toBe('Working on it.');
     expect(recovered.toolCalls[0]?.arguments.intent).toBe('Explain {this} and "that"');
+  });
+
+  it('leaves an unparseable call visible rather than swallowing the turn', () => {
+    const recovered = recoverSerializedConvTools('/delegate{not json} Hi.', [], 'test');
+    expect(recovered.text).toBe('/delegate{not json} Hi.');
+    expect(recovered.toolCalls).toEqual([]);
+  });
+
+  it('streams a growing buffer monotonically', () => {
+    // Whatever order the chunks arrive in, the visible text only ever extends —
+    // otherwise a streaming caller would have to un-say something.
+    const full = 'Sure. /delegate{"tier":"medium","template":"code","intent":"x"} Done.';
+    let previous = '';
+    for (let length = 1; length <= full.length; length++) {
+      const visible = visibleWhileStreaming(full.slice(0, length));
+      expect(visible.startsWith(previous)).toBe(true);
+      previous = visible;
+    }
+    expect(previous).toBe('Sure. Done.');
   });
 });

--- a/src/agents/conv/conv-tool-recovery.test.ts
+++ b/src/agents/conv/conv-tool-recovery.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'bun:test';
+import { couldStartWithSerializedConvTool, recoverSerializedConvTools } from './conv-tool-recovery.ts';
+
+describe('conversation text tool recovery', () => {
+  it('buffers partial internal prefixes without delaying ordinary prose', () => {
+    expect(couldStartWithSerializedConvTool('F')).toBe(true);
+    expect(couldStartWithSerializedConvTool('FALLBACK_OK/dele')).toBe(true);
+    expect(couldStartWithSerializedConvTool('/delegate')).toBe(true);
+    expect(couldStartWithSerializedConvTool('Hi again')).toBe(false);
+  });
+
+  it('recovers a leaked delegate call and keeps only visible prose', () => {
+    const recovered = recoverSerializedConvTools(
+      'FALLBACK_OK/delegate{"intent":"Provide friendly greeting.","template":"general","tier":"medium"} Hi again, how is your day going?',
+      [],
+      'test',
+    );
+
+    expect(recovered.text).toBe('Hi again, how is your day going?');
+    expect(recovered.toolCalls).toEqual([{
+      id: 'test_0',
+      name: 'delegate',
+      arguments: {
+        intent: 'Provide friendly greeting.',
+        template: 'general',
+        tier: 'medium',
+      },
+    }]);
+  });
+
+  it('does not duplicate a structured call also printed in text', () => {
+    const existing = {
+      id: 'structured',
+      name: 'check_task',
+      arguments: { task_id: 'task-1' },
+    };
+    const recovered = recoverSerializedConvTools(
+      '/check_task{"task_id":"task-1"}',
+      [existing],
+      'test',
+    );
+
+    expect(recovered.text).toBe('');
+    expect(recovered.toolCalls).toEqual([existing]);
+  });
+
+  it('handles braces and escaped quotes inside JSON strings', () => {
+    const recovered = recoverSerializedConvTools(
+      '/delegate{"tier":"medium","template":"general","intent":"Explain {this} and \\"that\\""} Working on it.',
+      [],
+      'test',
+    );
+    expect(recovered.text).toBe('Working on it.');
+    expect(recovered.toolCalls[0]?.arguments.intent).toBe('Explain {this} and "that"');
+  });
+});

--- a/src/agents/conv/conv-tool-recovery.test.ts
+++ b/src/agents/conv/conv-tool-recovery.test.ts
@@ -6,7 +6,27 @@ describe('conversation text tool recovery', () => {
     expect(couldStartWithSerializedConvTool('F')).toBe(true);
     expect(couldStartWithSerializedConvTool('FALLBACK_OK/dele')).toBe(true);
     expect(couldStartWithSerializedConvTool('/delegate')).toBe(true);
+    expect(couldStartWithSerializedConvTool('(dele')).toBe(true);
     expect(couldStartWithSerializedConvTool('Hi again')).toBe(false);
+  });
+
+  it('recovers the parenthesized tool syntax without exposing it to TTS', () => {
+    const recovered = recoverSerializedConvTools(
+      '(delegate {"intent":"Check the last email in my inbox","template":"research","tier":"medium"}) Let me check your inbox now.',
+      [],
+      'test',
+    );
+
+    expect(recovered.text).toBe('Let me check your inbox now.');
+    expect(recovered.toolCalls).toEqual([{
+      id: 'test_0',
+      name: 'delegate',
+      arguments: {
+        intent: 'Check the last email in my inbox',
+        template: 'research',
+        tier: 'medium',
+      },
+    }]);
   });
 
   it('recovers a leaked delegate call and keeps only visible prose', () => {

--- a/src/agents/conv/conv-tool-recovery.ts
+++ b/src/agents/conv/conv-tool-recovery.ts
@@ -1,0 +1,108 @@
+import type { LLMToolCall } from '../../llm/provider.ts';
+import { CONV_TOOL_NAMES } from './conv-tools.ts';
+
+const SERIALIZED_TOOL_NAMES = new Set<string>(Object.values(CONV_TOOL_NAMES));
+const SERIALIZED_TOOL_PREFIXES = [...SERIALIZED_TOOL_NAMES].map((name) => `/${name}`);
+const FALLBACK_MARKER = 'FALLBACK_OK';
+
+/**
+ * Some OpenAI-compatible models occasionally print a tool call as ordinary
+ * text instead of returning it in the structured tool_calls field. Hold that
+ * response back from the UI/TTS while its prefix is still ambiguous.
+ */
+export function couldStartWithSerializedConvTool(text: string): boolean {
+  const candidate = text.trimStart();
+  if (!candidate) return true;
+
+  const upper = candidate.toUpperCase();
+  if (FALLBACK_MARKER.startsWith(upper) || upper.startsWith(FALLBACK_MARKER)) {
+    return true;
+  }
+
+  if (!candidate.startsWith('/')) return false;
+  const lower = candidate.toLowerCase();
+  return SERIALIZED_TOOL_PREFIXES.some((prefix) => (
+    prefix.startsWith(lower) || lower.startsWith(prefix)
+  ));
+}
+
+function jsonObjectEnd(text: string, start: number): number | null {
+  if (text[start] !== '{') return null;
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+
+  for (let index = start; index < text.length; index++) {
+    const char = text[index]!;
+    if (inString) {
+      if (escaped) escaped = false;
+      else if (char === '\\') escaped = true;
+      else if (char === '"') inString = false;
+      continue;
+    }
+    if (char === '"') inString = true;
+    else if (char === '{') depth++;
+    else if (char === '}' && --depth === 0) return index + 1;
+  }
+  return null;
+}
+
+function callSignature(call: Pick<LLMToolCall, 'name' | 'arguments'>): string {
+  return `${call.name}:${JSON.stringify(call.arguments)}`;
+}
+
+/**
+ * Convert valid text-serialized conversation tools into the same structured
+ * calls the orchestrator already validates and dispatches. Internal protocol
+ * markers and JSON are removed from the user-facing text before it can be
+ * rendered or spoken.
+ */
+export function recoverSerializedConvTools(
+  text: string,
+  existingCalls: LLMToolCall[],
+  idPrefix: string,
+): { text: string; toolCalls: LLMToolCall[] } {
+  const withoutMarker = text.replace(/\bFALLBACK_OK\b\s*/gi, '');
+  const recovered: LLMToolCall[] = [];
+  const existingSignatures = new Set(existingCalls.map(callSignature));
+  const pattern = /\/(delegate|check_task|cancel_task|resume_task)\s*(?=\{)/gi;
+  let visible = '';
+  let cursor = 0;
+
+  for (const match of withoutMarker.matchAll(pattern)) {
+    const matchIndex = match.index;
+    const jsonStart = matchIndex + match[0].length;
+    const jsonEnd = jsonObjectEnd(withoutMarker, jsonStart);
+    if (jsonEnd === null) continue;
+
+    let args: unknown;
+    try {
+      args = JSON.parse(withoutMarker.slice(jsonStart, jsonEnd));
+    } catch {
+      continue;
+    }
+    if (!args || typeof args !== 'object' || Array.isArray(args)) continue;
+
+    const name = match[1]!.toLowerCase();
+    if (!SERIALIZED_TOOL_NAMES.has(name)) continue;
+    visible += withoutMarker.slice(cursor, matchIndex);
+    cursor = jsonEnd;
+
+    const call: LLMToolCall = {
+      id: `${idPrefix}_${recovered.length}`,
+      name,
+      arguments: args as Record<string, unknown>,
+    };
+    const signature = callSignature(call);
+    if (!existingSignatures.has(signature)) {
+      recovered.push(call);
+      existingSignatures.add(signature);
+    }
+  }
+
+  visible += withoutMarker.slice(cursor);
+  return {
+    text: visible.trim(),
+    toolCalls: [...existingCalls, ...recovered],
+  };
+}

--- a/src/agents/conv/conv-tool-recovery.ts
+++ b/src/agents/conv/conv-tool-recovery.ts
@@ -3,6 +3,7 @@ import { CONV_TOOL_NAMES } from './conv-tools.ts';
 
 const SERIALIZED_TOOL_NAMES = new Set<string>(Object.values(CONV_TOOL_NAMES));
 const SERIALIZED_TOOL_PREFIXES = [...SERIALIZED_TOOL_NAMES].map((name) => `/${name}`);
+const PAREN_TOOL_PREFIXES = [...SERIALIZED_TOOL_NAMES].map((name) => `(${name}`);
 const FALLBACK_MARKER = 'FALLBACK_OK';
 
 /**
@@ -19,9 +20,10 @@ export function couldStartWithSerializedConvTool(text: string): boolean {
     return true;
   }
 
-  if (!candidate.startsWith('/')) return false;
+  if (!candidate.startsWith('/') && !candidate.startsWith('(')) return false;
   const lower = candidate.toLowerCase();
-  return SERIALIZED_TOOL_PREFIXES.some((prefix) => (
+  const prefixes = candidate.startsWith('(') ? PAREN_TOOL_PREFIXES : SERIALIZED_TOOL_PREFIXES;
+  return prefixes.some((prefix) => (
     prefix.startsWith(lower) || lower.startsWith(prefix)
   ));
 }
@@ -65,7 +67,7 @@ export function recoverSerializedConvTools(
   const withoutMarker = text.replace(/\bFALLBACK_OK\b\s*/gi, '');
   const recovered: LLMToolCall[] = [];
   const existingSignatures = new Set(existingCalls.map(callSignature));
-  const pattern = /\/(delegate|check_task|cancel_task|resume_task)\s*(?=\{)/gi;
+  const pattern = /([/(])(delegate|check_task|cancel_task|resume_task)\s*(?=\{)/gi;
   let visible = '';
   let cursor = 0;
 
@@ -83,10 +85,16 @@ export function recoverSerializedConvTools(
     }
     if (!args || typeof args !== 'object' || Array.isArray(args)) continue;
 
-    const name = match[1]!.toLowerCase();
+    const name = match[2]!.toLowerCase();
     if (!SERIALIZED_TOOL_NAMES.has(name)) continue;
     visible += withoutMarker.slice(cursor, matchIndex);
     cursor = jsonEnd;
+    // Groq may print `(delegate {...})` rather than `/delegate{...}`.
+    // Consume the protocol's closing parenthesis along with the call.
+    if (match[1] === '(') {
+      while (/\s/.test(withoutMarker[cursor] ?? '')) cursor++;
+      if (withoutMarker[cursor] === ')') cursor++;
+    }
 
     const call: LLMToolCall = {
       id: `${idPrefix}_${recovered.length}`,

--- a/src/agents/conv/conv-tool-recovery.ts
+++ b/src/agents/conv/conv-tool-recovery.ts
@@ -2,31 +2,28 @@ import type { LLMToolCall } from '../../llm/provider.ts';
 import { CONV_TOOL_NAMES } from './conv-tools.ts';
 
 const SERIALIZED_TOOL_NAMES = new Set<string>(Object.values(CONV_TOOL_NAMES));
-const SERIALIZED_TOOL_PREFIXES = [...SERIALIZED_TOOL_NAMES].map((name) => `/${name}`);
-const PAREN_TOOL_PREFIXES = [...SERIALIZED_TOOL_NAMES].map((name) => `(${name}`);
+/** Both syntaxes we've seen models print: `/delegate{...}` and `(delegate {...})`. */
+const CALL_OPENERS = ['/', '('] as const;
+const CALL_PREFIXES = CALL_OPENERS.flatMap(
+  (opener) => [...SERIALIZED_TOOL_NAMES].map((name) => `${opener}${name}`),
+);
 const FALLBACK_MARKER = 'FALLBACK_OK';
+/** Longest ambiguous tail we ever need to hold back. */
+const MAX_PREFIX_LEN = Math.max(FALLBACK_MARKER.length, ...CALL_PREFIXES.map((p) => p.length));
 
-/**
- * Some OpenAI-compatible models occasionally print a tool call as ordinary
- * text instead of returning it in the structured tool_calls field. Hold that
- * response back from the UI/TTS while its prefix is still ambiguous.
- */
-export function couldStartWithSerializedConvTool(text: string): boolean {
-  const candidate = text.trimStart();
-  if (!candidate) return true;
-
-  const upper = candidate.toUpperCase();
-  if (FALLBACK_MARKER.startsWith(upper) || upper.startsWith(FALLBACK_MARKER)) {
-    return true;
-  }
-
-  if (!candidate.startsWith('/') && !candidate.startsWith('(')) return false;
-  const lower = candidate.toLowerCase();
-  const prefixes = candidate.startsWith('(') ? PAREN_TOOL_PREFIXES : SERIALIZED_TOOL_PREFIXES;
-  return prefixes.some((prefix) => (
-    prefix.startsWith(lower) || lower.startsWith(prefix)
-  ));
+function escapeForRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
+
+// Derived from CONV_TOOL_NAMES rather than hardcoded, so adding a conv tool
+// can't leave the recovery scanner silently blind to it (which would leak the
+// serialized call to the chat UI and TTS instead of executing it).
+const TOOL_NAME_ALTERNATION = [...SERIALIZED_TOOL_NAMES].map(escapeForRegex).join('|');
+const CALL_PATTERN = new RegExp(`([/(])(${TOOL_NAME_ALTERNATION})\\s*(?=\\{)`, 'gi');
+/** Same as CALL_PATTERN but without the `{` lookahead — used while streaming,
+ *  where the JSON may not have arrived yet. */
+const PARTIAL_CALL_PATTERN = new RegExp(`([/(])(${TOOL_NAME_ALTERNATION})`, 'gi');
+const FALLBACK_PATTERN = new RegExp(`\\b${escapeForRegex(FALLBACK_MARKER)}\\b\\s*`, 'gi');
 
 function jsonObjectEnd(text: string, start: number): number | null {
   if (text[start] !== '{') return null;
@@ -49,30 +46,106 @@ function jsonObjectEnd(text: string, start: number): number | null {
   return null;
 }
 
+/**
+ * True when `tail` could still grow into an internal marker, so it is not yet
+ * safe to show or speak. Covers complete markers too: `FALLBACK_OK` may still
+ * become `FALLBACK_OKAY` (which the word-boundary strip would leave alone).
+ */
+function isMarkerPrefix(tail: string): boolean {
+  if (FALLBACK_MARKER.startsWith(tail.toUpperCase())) return true;
+  const lower = tail.toLowerCase();
+  return CALL_PREFIXES.some((prefix) => prefix.startsWith(lower));
+}
+
+/**
+ * True when `rest` (everything after a complete `/name` or `(name`) has not yet
+ * settled into either a parseable call or ordinary prose.
+ */
+function isUnresolvedCallTail(opener: string, rest: string): boolean {
+  const jsonStart = rest.length - rest.trimStart().length;
+  // Nothing but whitespace so far — the `{` may still be coming.
+  if (jsonStart === rest.length) return true;
+  // Anything other than `{` means this was prose all along (e.g. "/delegated").
+  if (rest[jsonStart] !== '{') return false;
+  const end = jsonObjectEnd(rest, jsonStart);
+  if (end === null) return true; // JSON arguments still streaming
+  if (opener !== '(') return false;
+  // Paren syntax: the closing `)` is part of the call and may still arrive.
+  return rest.slice(end).trim().length === 0;
+}
+
+/**
+ * Number of trailing characters of `text` that must be withheld from the chat
+ * UI and TTS because they may still turn out to be part of a serialized tool
+ * call. Returns 0 when all of `text` is safe to emit.
+ *
+ * Callers stream `text.slice(0, text.length - pending)` through
+ * `stripSerializedConvTools` and emit only the delta they haven't shown yet.
+ * Checking every position (rather than only the start of the response) is what
+ * keeps a call the model prints *after* its acknowledgment from leaking.
+ */
+export function pendingSerializedToolSuffix(text: string): number {
+  let pending = 0;
+
+  // A complete `/name` / `(name` whose call hasn't finished arriving. Scan all
+  // occurrences: an unresolved marker can sit before a resolved one that the
+  // pattern also matched inside the unfinished JSON.
+  for (const match of text.matchAll(PARTIAL_CALL_PATTERN)) {
+    const rest = text.slice(match.index + match[0].length);
+    if (isUnresolvedCallTail(match[1]!, rest)) {
+      pending = Math.max(pending, text.length - match.index);
+    }
+  }
+  if (pending > 0) return pending;
+
+  // A partial marker at the very end, e.g. "…now. /deleg" or "FALLB".
+  const windowStart = Math.max(0, text.length - MAX_PREFIX_LEN);
+  for (let index = windowStart; index < text.length; index++) {
+    if (isMarkerPrefix(text.slice(index))) return text.length - index;
+  }
+  return 0;
+}
+
+/**
+ * The visible text a streaming caller may show or speak given everything
+ * received so far. Withholds any tail that could still become a serialized tool
+ * call and removes the ones that already resolved.
+ *
+ * The result only ever extends as `text` grows, so callers keep what they last
+ * emitted and yield the delta.
+ */
+export function visibleStreamText(text: string): string {
+  const safe = text.slice(0, text.length - pendingSerializedToolSuffix(text));
+  // trimStart is monotone once any non-whitespace has arrived, so applying it on
+  // every pass never shifts a delta the caller already emitted.
+  return stripSerializedConvTools(safe, [], 'stream').text.trimStart();
+}
+
 function callSignature(call: Pick<LLMToolCall, 'name' | 'arguments'>): string {
   return `${call.name}:${JSON.stringify(call.arguments)}`;
 }
 
 /**
- * Convert valid text-serialized conversation tools into the same structured
- * calls the orchestrator already validates and dispatches. Internal protocol
- * markers and JSON are removed from the user-facing text before it can be
- * rendered or spoken.
+ * Core of the recovery: turn valid text-serialized conversation tools into the
+ * same structured calls the orchestrator already validates and dispatches, and
+ * remove the internal protocol markers and JSON from the user-facing text.
+ * Whitespace is not trimmed, so callers can diff successive results while
+ * streaming.
  */
-export function recoverSerializedConvTools(
+export function stripSerializedConvTools(
   text: string,
   existingCalls: LLMToolCall[],
   idPrefix: string,
 ): { text: string; toolCalls: LLMToolCall[] } {
-  const withoutMarker = text.replace(/\bFALLBACK_OK\b\s*/gi, '');
+  const withoutMarker = text.replace(FALLBACK_PATTERN, '');
   const recovered: LLMToolCall[] = [];
   const existingSignatures = new Set(existingCalls.map(callSignature));
-  const pattern = /([/(])(delegate|check_task|cancel_task|resume_task)\s*(?=\{)/gi;
   let visible = '';
   let cursor = 0;
 
-  for (const match of withoutMarker.matchAll(pattern)) {
+  for (const match of withoutMarker.matchAll(CALL_PATTERN)) {
     const matchIndex = match.index;
+    if (matchIndex < cursor) continue; // inside a call we already consumed
     const jsonStart = matchIndex + match[0].length;
     const jsonEnd = jsonObjectEnd(withoutMarker, jsonStart);
     if (jsonEnd === null) continue;
@@ -95,6 +168,11 @@ export function recoverSerializedConvTools(
       while (/\s/.test(withoutMarker[cursor] ?? '')) cursor++;
       if (withoutMarker[cursor] === ')') cursor++;
     }
+    // Close the seam the removal left behind so surrounding prose doesn't gain
+    // a leading or doubled space (which would also shift streaming deltas).
+    if (!visible || /\s$/.test(visible)) {
+      while (/\s/.test(withoutMarker[cursor] ?? '')) cursor++;
+    }
 
     const call: LLMToolCall = {
       id: `${idPrefix}_${recovered.length}`,
@@ -109,8 +187,18 @@ export function recoverSerializedConvTools(
   }
 
   visible += withoutMarker.slice(cursor);
-  return {
-    text: visible.trim(),
-    toolCalls: [...existingCalls, ...recovered],
-  };
+  return { text: visible, toolCalls: [...existingCalls, ...recovered] };
+}
+
+/**
+ * `stripSerializedConvTools` with the user-facing text trimmed — use this for
+ * the finished response content.
+ */
+export function recoverSerializedConvTools(
+  text: string,
+  existingCalls: LLMToolCall[],
+  idPrefix: string,
+): { text: string; toolCalls: LLMToolCall[] } {
+  const stripped = stripSerializedConvTools(text, existingCalls, idPrefix);
+  return { ...stripped, text: stripped.text.trim() };
 }

--- a/src/agents/orchestrator-progress.test.ts
+++ b/src/agents/orchestrator-progress.test.ts
@@ -1,0 +1,154 @@
+import { test, expect, describe, beforeEach, afterEach } from 'bun:test';
+import { AgentOrchestrator } from './orchestrator.ts';
+import { LLMManager } from '../llm/manager.ts';
+import { ToolRegistry, type ToolDefinition } from '../actions/tools/registry.ts';
+import { initDatabase, closeDb } from '../vault/schema.ts';
+import type { RoleDefinition } from '../roles/types.ts';
+import type {
+  LLMProvider, LLMMessage, LLMOptions, LLMResponse, LLMStreamEvent, LLMToolCall,
+} from '../llm/provider.ts';
+
+const ROLE = {
+  id: 'personal-assistant',
+  name: 'PA',
+  authority_level: 5,
+  tools: [],
+  sub_roles: [],
+} as unknown as RoleDefinition;
+
+/** Records the assistant messages the orchestrator feeds back to the model. */
+let seenAssistantContent: string[] = [];
+
+class ScriptedProvider implements LLMProvider {
+  name = 'scripted';
+  private queue: LLMResponse[];
+  constructor(responses: LLMResponse[]) { this.queue = [...responses]; }
+  async chat(): Promise<LLMResponse> {
+    return this.queue.shift() ?? {
+      content: 'fallback',
+      tool_calls: [],
+      usage: { input_tokens: 0, output_tokens: 0 },
+      model: 'scripted',
+      finish_reason: 'stop',
+    };
+  }
+  async *stream(messages: LLMMessage[], _opts?: LLMOptions): AsyncIterable<LLMStreamEvent> {
+    for (const message of messages) {
+      if (message.role === 'assistant') seenAssistantContent.push(String(message.content ?? ''));
+    }
+    const response = await this.chat();
+    if (response.content) yield { type: 'text', text: response.content };
+    for (const call of response.tool_calls) yield { type: 'tool_call', tool_call: call };
+    yield { type: 'done', response };
+  }
+  async listModels(): Promise<string[]> { return ['scripted']; }
+}
+
+function silentToolCall(name: string, args: Record<string, unknown>): LLMResponse {
+  const call: LLMToolCall = { id: `call_${name}`, name, arguments: args };
+  return {
+    content: '', // the failure mode: tools called with no prose at all
+    tool_calls: [call],
+    usage: { input_tokens: 0, output_tokens: 0 },
+    model: 'scripted',
+    finish_reason: 'tool_use',
+  };
+}
+
+function textResponse(content: string): LLMResponse {
+  return {
+    content,
+    tool_calls: [],
+    usage: { input_tokens: 0, output_tokens: 0 },
+    model: 'scripted',
+    finish_reason: 'stop',
+  };
+}
+
+function makeOrchestrator(provider: LLMProvider): AgentOrchestrator {
+  const registry = new ToolRegistry();
+  const readFile: ToolDefinition = {
+    name: 'read_file',
+    description: 'Read a file',
+    category: 'file-ops',
+    parameters: { path: { type: 'string', description: 'path', required: true } },
+    execute: async (p) => `contents of ${p.path}`,
+  };
+  registry.register(readFile);
+
+  const manager = new LLMManager();
+  manager.registerProvider(provider);
+  manager.setTierMap({ medium: { provider: provider.name } });
+
+  const orch = new AgentOrchestrator();
+  orch.setToolRegistry(registry);
+  orch.setLLMManager(manager);
+  orch.createPrimary(ROLE);
+  return orch;
+}
+
+describe('AgentOrchestrator.streamMessage progress narration', () => {
+  beforeEach(() => { initDatabase(':memory:'); seenAssistantContent = []; });
+  afterEach(() => { closeDb(); });
+
+  test('narrates a silent tool call and keeps it clear of the answer', async () => {
+    const orch = makeOrchestrator(new ScriptedProvider([
+      silentToolCall('read_file', { path: '/tmp/example' }),
+      textResponse('The file lists three entries.'),
+    ]));
+
+    const chunks: LLMStreamEvent[] = [];
+    let final = '';
+    for await (const event of orch.streamMessage('system', 'what is in the file?')) {
+      chunks.push(event);
+      if (event.type === 'done') final = event.response.content;
+    }
+
+    const narration = chunks.find(
+      (c): c is Extract<LLMStreamEvent, { type: 'text' }> =>
+        c.type === 'text' && c.text.includes('I’m checking'),
+    );
+    expect(narration).toBeDefined();
+    // Marked complete so TTS speaks it while the tool is still running.
+    expect(narration?.segmentEnd).toBe(true);
+
+    // The answer must not run into the narration.
+    expect(final).not.toContain('now.The file');
+    expect(final).toBe('I’m checking the relevant details now.\n\nThe file lists three entries.');
+  });
+
+  test('does not attribute the narration back to the model', async () => {
+    const orch = makeOrchestrator(new ScriptedProvider([
+      silentToolCall('read_file', { path: '/tmp/example' }),
+      textResponse('Done.'),
+    ]));
+
+    for await (const _event of orch.streamMessage('system', 'read it')) { /* drain */ }
+
+    // The second LLM call must not see fabricated assistant prose — the model
+    // never wrote it, and echoing it back makes the next turn reason from
+    // words it didn't produce.
+    expect(seenAssistantContent).not.toContain('I’m checking the relevant details now.');
+    for (const content of seenAssistantContent) {
+      expect(content).not.toContain('I’m checking');
+    }
+  });
+
+  test('stays quiet when the model writes its own prose alongside tool calls', async () => {
+    const chatty: LLMResponse = {
+      content: 'Let me open that file.',
+      tool_calls: [{ id: 'c1', name: 'read_file', arguments: { path: '/tmp/example' } }],
+      usage: { input_tokens: 0, output_tokens: 0 },
+      model: 'scripted',
+      finish_reason: 'tool_use',
+    };
+    const orch = makeOrchestrator(new ScriptedProvider([chatty, textResponse('All set.')]));
+
+    let final = '';
+    for await (const event of orch.streamMessage('system', 'read it')) {
+      if (event.type === 'done') final = event.response.content;
+    }
+    expect(final).not.toContain('I’m checking');
+    expect(final).toBe('Let me open that file.All set.');
+  });
+});

--- a/src/agents/orchestrator.ts
+++ b/src/agents/orchestrator.ts
@@ -628,8 +628,15 @@ export class AgentOrchestrator {
 
       // Tool calls present — execute them
       if (!accumulatedText.trim() && !acknowledgedWork) {
-        accumulatedText = progressAcknowledgement(toolCalls);
-        yield { type: 'text', text: accumulatedText };
+        // Display-only activity narration for a model that called tools
+        // silently. It trails a blank line so the answer that follows doesn't
+        // run into it, and it stays out of `messages` — the model never said
+        // this, and attributing it back to the model would make the next turn
+        // reason from words it didn't write.
+        const narration = progressAcknowledgement(toolCalls) + '\n\n';
+        acknowledgedWork = true;
+        yield { type: 'text', text: narration, segmentEnd: true };
+        finalText += narration;
       }
       if (accumulatedText.trim()) acknowledgedWork = true;
       finalText += accumulatedText;

--- a/src/agents/orchestrator.ts
+++ b/src/agents/orchestrator.ts
@@ -15,6 +15,7 @@ import type { AuditTrail } from '../authority/audit.ts';
 import type { DeferredExecutor } from '../authority/deferred-executor.ts';
 import type { EmergencyController } from '../authority/emergency.ts';
 import { getActionForTool } from '../authority/tool-action-map.ts';
+import { progressAcknowledgement } from './progress.ts';
 
 /**
  * Convert a system prompt (legacy string or static/dynamic parts) into the
@@ -559,6 +560,7 @@ export class AgentOrchestrator {
     const totalUsage = { input_tokens: 0, output_tokens: 0 };
     let finalText = '';
     let responseModel = 'unknown';
+    let acknowledgedWork = false;
 
     // Tool execution loop
     for (let iteration = 0; iteration < MAX_TOOL_ITERATIONS; iteration++) {
@@ -625,6 +627,11 @@ export class AgentOrchestrator {
       }
 
       // Tool calls present — execute them
+      if (!accumulatedText.trim() && !acknowledgedWork) {
+        accumulatedText = progressAcknowledgement(toolCalls);
+        yield { type: 'text', text: accumulatedText };
+      }
+      if (accumulatedText.trim()) acknowledgedWork = true;
       finalText += accumulatedText;
 
       // Add assistant message with tool calls to local messages

--- a/src/agents/progress.test.ts
+++ b/src/agents/progress.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from 'bun:test';
+import { progressAcknowledgement } from './progress.ts';
+
+describe('progressAcknowledgement', () => {
+  test('describes delegated work without exposing reasoning', () => {
+    expect(progressAcknowledgement([{
+      id: '1',
+      name: 'delegate',
+      arguments: { template: 'research', intent: 'compare providers' },
+    }])).toBe('I’m looking into that now and I’ll report back.');
+    expect(progressAcknowledgement([{
+      id: '2',
+      name: 'delegate',
+      arguments: { template: 'code', intent: 'fix the route' },
+    }])).toBe('I’m checking the relevant code now.');
+  });
+
+  test('uses concise activity labels for direct tools', () => {
+    expect(progressAcknowledgement([{
+      id: '1', name: 'read_file', arguments: { path: '/tmp/example' },
+    }])).toBe('I’m checking the relevant details now.');
+    expect(progressAcknowledgement([{
+      id: '2', name: 'write_file', arguments: { path: '/tmp/example' },
+    }])).toBe('I’m working through that now.');
+  });
+});

--- a/src/agents/progress.ts
+++ b/src/agents/progress.ts
@@ -1,0 +1,31 @@
+import type { LLMToolCall } from '../llm/provider.ts';
+
+/**
+ * Human-facing acknowledgment used only when a model silently emits tools.
+ * This is activity narration, not hidden reasoning: it says what Jarvis is
+ * doing without exposing chain-of-thought or inventing intermediate results.
+ */
+export function progressAcknowledgement(toolCalls: LLMToolCall[]): string {
+  const first = toolCalls[0];
+  if (!first) return 'I’m working on that now.';
+
+  if (first.name === 'delegate') {
+    const template = String(first.arguments.template ?? '').toLowerCase();
+    if (template === 'research') return 'I’m looking into that now and I’ll report back.';
+    if (template === 'code') return 'I’m checking the relevant code now.';
+    if (template === 'plan') return 'I’m working through the plan now.';
+    if (template === 'write') return 'I’m drafting that now.';
+    return 'I’m working on that now.';
+  }
+
+  if (first.name === 'check_task') return 'I’m checking on that task now.';
+  if (first.name === 'resume_task') return 'I’m picking that task back up now.';
+
+  if (/^(read|list|get|find|search|inspect|browser_|web_)/i.test(first.name)) {
+    return 'I’m checking the relevant details now.';
+  }
+  if (/^(write|create|update|edit|delete|run|execute|send|desktop_)/i.test(first.name)) {
+    return 'I’m working through that now.';
+  }
+  return 'I’m working on that now.';
+}

--- a/src/comms/streaming.test.ts
+++ b/src/comms/streaming.test.ts
@@ -60,3 +60,31 @@ describe('StreamRelay cancellation', () => {
     expect(messages.map((message) => message.type)).toEqual(['stream', 'status']);
   });
 });
+
+describe('StreamRelay progress narration', () => {
+  test('starts UI/TTS immediately for a complete acknowledgment sentence', async () => {
+    const messages: WSMessage[] = [];
+    const sentences: string[] = [];
+    let starts = 0;
+    const server = {
+      broadcast(message: WSMessage) { messages.push(message); },
+    } as unknown as WebSocketServer;
+    const relay = new StreamRelay(server);
+
+    async function* stream(): AsyncGenerator<LLMStreamEvent> {
+      yield { type: 'text', text: 'I’m checking that now.' };
+      // A slow tool would run here. The sentence callback must already have
+      // fired instead of waiting for a later chunk or the done event.
+      expect(starts).toBe(1);
+      expect(sentences).toEqual(['I’m checking that now.']);
+      yield doneEvent('I’m checking that now.');
+    }
+
+    await relay.relayStream(stream(), 'req-progress', {
+      onTextStart: () => { starts++; },
+      onSentence: (sentence) => sentences.push(sentence),
+    });
+    expect(starts).toBe(1);
+    expect(sentences).toEqual(['I’m checking that now.']);
+  });
+});

--- a/src/comms/streaming.test.ts
+++ b/src/comms/streaming.test.ts
@@ -61,18 +61,38 @@ describe('StreamRelay cancellation', () => {
   });
 });
 
+function makeRelay() {
+  const broadcasts: WSMessage[] = [];
+  const server = {
+    broadcast(message: WSMessage) { broadcasts.push(message); },
+  } as unknown as WebSocketServer;
+  return { relay: new StreamRelay(server), broadcasts };
+}
+
+/** Relay `chunks` as text events and collect the sentences handed to TTS. */
+async function speak(chunks: LLMStreamEvent[]): Promise<string[]> {
+  const { relay } = makeRelay();
+  const sentences: string[] = [];
+  async function* stream(): AsyncGenerator<LLMStreamEvent> {
+    for (const chunk of chunks) yield chunk;
+    yield doneEvent('');
+  }
+  await relay.relayStream(stream(), 'req', { onSentence: (s) => sentences.push(s) });
+  return sentences;
+}
+
+function text(...parts: string[]): LLMStreamEvent[] {
+  return parts.map((part) => ({ type: 'text', text: part }) as LLMStreamEvent);
+}
+
 describe('StreamRelay progress narration', () => {
-  test('starts UI/TTS immediately for a complete acknowledgment sentence', async () => {
-    const messages: WSMessage[] = [];
+  test('starts UI/TTS immediately for a segment the producer marked complete', async () => {
+    const { relay } = makeRelay();
     const sentences: string[] = [];
     let starts = 0;
-    const server = {
-      broadcast(message: WSMessage) { messages.push(message); },
-    } as unknown as WebSocketServer;
-    const relay = new StreamRelay(server);
 
     async function* stream(): AsyncGenerator<LLMStreamEvent> {
-      yield { type: 'text', text: 'I’m checking that now.' };
+      yield { type: 'text', text: 'I’m checking that now.', segmentEnd: true };
       // A slow tool would run here. The sentence callback must already have
       // fired instead of waiting for a later chunk or the done event.
       expect(starts).toBe(1);
@@ -86,5 +106,94 @@ describe('StreamRelay progress narration', () => {
     });
     expect(starts).toBe(1);
     expect(sentences).toEqual(['I’m checking that now.']);
+  });
+
+  test('flushes a segment the model streamed in pieces', async () => {
+    const { relay } = makeRelay();
+    const sentences: string[] = [];
+
+    async function* stream(): AsyncGenerator<LLMStreamEvent> {
+      yield { type: 'text', text: 'Let me' };
+      yield { type: 'text', text: ' check that' };
+      yield { type: 'text', text: ' for you.' };
+      expect(sentences).toEqual([]);
+      // segmentEnd-only event: signal without content.
+      yield { type: 'text', text: '', segmentEnd: true };
+      expect(sentences).toEqual(['Let me check that for you.']);
+      yield doneEvent('Let me check that for you.');
+    }
+
+    const full = await relay.relayStream(stream(), 'req', {
+      onSentence: (sentence) => sentences.push(sentence),
+    });
+    expect(sentences).toEqual(['Let me check that for you.']);
+    // The empty signal event must not add anything to the response text.
+    expect(full).toBe('Let me check that for you.');
+  });
+
+  test('an empty text event is not broadcast to clients', async () => {
+    const { relay, broadcasts } = makeRelay();
+    async function* stream(): AsyncGenerator<LLMStreamEvent> {
+      yield { type: 'text', text: 'Hi.' };
+      yield { type: 'text', text: '', segmentEnd: true };
+      yield doneEvent('Hi.');
+    }
+    await relay.relayStream(stream(), 'req');
+    const streamChunks = broadcasts.filter((m) => m.type === 'stream');
+    expect(streamChunks).toHaveLength(1);
+    expect((streamChunks[0]?.payload as { text?: string })?.text).toBe('Hi.');
+  });
+
+  test('onTextStart does not fire for a signal-only event', async () => {
+    const { relay } = makeRelay();
+    let starts = 0;
+    async function* stream(): AsyncGenerator<LLMStreamEvent> {
+      yield { type: 'text', text: '', segmentEnd: true };
+      expect(starts).toBe(0);
+      yield { type: 'text', text: 'Now there is text.' };
+      yield doneEvent('Now there is text.');
+    }
+    await relay.relayStream(stream(), 'req', { onTextStart: () => { starts++; } });
+    expect(starts).toBe(1);
+  });
+});
+
+describe('StreamRelay sentence boundaries', () => {
+  test('splits on a terminator followed by whitespace', async () => {
+    expect(await speak(text('One sentence. ', 'And another. '))).toEqual([
+      'One sentence.',
+      'And another.',
+    ]);
+  });
+
+  // A chunk boundary is not a sentence boundary: the buffer holds a partial
+  // token stream, so a trailing "." may still be mid-word.
+  test('does not split a decimal spanning chunks', async () => {
+    expect(await speak(text('Version 1', '.', '5 is out now. '))).toEqual([
+      'Version 1.5 is out now.',
+    ]);
+  });
+
+  test('does not split a filename spanning chunks', async () => {
+    expect(await speak(text('Check src/agents/progress', '.', 'ts for details. '))).toEqual([
+      'Check src/agents/progress.ts for details.',
+    ]);
+  });
+
+  test('does not split a price spanning chunks', async () => {
+    expect(await speak(text('That costs $4', '.', '99 total. '))).toEqual([
+      'That costs $4.99 total.',
+    ]);
+  });
+
+  test('flushes the trailing sentence on done', async () => {
+    const { relay } = makeRelay();
+    const sentences: string[] = [];
+    async function* stream(): AsyncGenerator<LLMStreamEvent> {
+      yield { type: 'text', text: 'No trailing space.' };
+      yield doneEvent('No trailing space.');
+    }
+    await relay.relayStream(stream(), 'req', { onSentence: (s) => sentences.push(s) });
+    expect(sentences).toEqual(['No trailing space.']);
   });
 });

--- a/src/comms/streaming.ts
+++ b/src/comms/streaming.ts
@@ -13,10 +13,15 @@ export type RelayOptions = {
   onTextStart?: () => void;
 };
 
-// A completed sentence can end at a chunk boundary. Colons still require
-// following whitespace so a token chunk such as "Here are:" is not spoken
-// prematurely while the model is still producing the list.
-const SENTENCE_END_RE = /[.!?](?:\s|$)|:\s/;
+// Sentence boundary: period, exclamation, question mark, colon followed by
+// whitespace or end.
+//
+// The terminator must be followed by whitespace, NOT by end-of-buffer: this
+// buffer holds a partial token stream, so "end of what has arrived" is not end
+// of sentence. Treating it as one splits "Version 1.5" into "Version 1." /
+// "5" whenever a chunk happens to end on the period. A producer that knows its
+// text is complete says so with `segmentEnd` instead.
+const SENTENCE_END_RE = /[.!?:]\s/;
 
 export class StreamRelay {
   private wsServer: WebSocketServer;
@@ -44,11 +49,13 @@ export class StreamRelay {
       for await (const event of stream) {
         if (options?.signal?.aborted) break;
         if (event.type === 'text') {
-          if (!textStarted) {
-            textStarted = true;
-            options?.onTextStart?.();
+          if (event.text) {
+            if (!textStarted) {
+              textStarted = true;
+              options?.onTextStart?.();
+            }
+            fullText += event.text;
           }
-          fullText += event.text;
 
           // Sentence-level TTS callback
           if (options?.onSentence) {
@@ -63,7 +70,18 @@ export class StreamRelay {
               }
               sentenceBuffer = sentenceBuffer.slice(end);
             }
+            // The producer says this text is a finished unit (an acknowledgment
+            // ahead of slow tool work), so speak it now rather than waiting for
+            // the next segment or the end of the stream.
+            if (event.segmentEnd && sentenceBuffer.trim()) {
+              options.onSentence(sentenceBuffer.trim());
+              sentenceBuffer = '';
+            }
           }
+
+          // An empty text event carries only the segmentEnd signal — there is
+          // nothing for clients to render.
+          if (!event.text) continue;
 
           // Broadcast chunk to all connected clients
           const message: WSMessage = {

--- a/src/comms/streaming.ts
+++ b/src/comms/streaming.ts
@@ -9,10 +9,14 @@ export type RelayOptions = {
   onTextDone?: () => void;
   /** Stops relaying immediately when the owning client cancels/supersedes the turn. */
   signal?: AbortSignal;
+  /** Called once, immediately before the first visible text chunk is relayed. */
+  onTextStart?: () => void;
 };
 
-// Sentence boundary: period, exclamation, question mark, colon followed by whitespace or end
-const SENTENCE_END_RE = /[.!?:]\s/;
+// A completed sentence can end at a chunk boundary. Colons still require
+// following whitespace so a token chunk such as "Here are:" is not spoken
+// prematurely while the model is still producing the list.
+const SENTENCE_END_RE = /[.!?](?:\s|$)|:\s/;
 
 export class StreamRelay {
   private wsServer: WebSocketServer;
@@ -34,11 +38,16 @@ export class StreamRelay {
     let fullText = '';
     let sentenceBuffer = '';
     let streamError: string | null = null;
+    let textStarted = false;
 
     try {
       for await (const event of stream) {
         if (options?.signal?.aborted) break;
         if (event.type === 'text') {
+          if (!textStarted) {
+            textStarted = true;
+            options?.onTextStart?.();
+          }
           fullText += event.text;
 
           // Sentence-level TTS callback

--- a/src/daemon/agent-service.ts
+++ b/src/daemon/agent-service.ts
@@ -9,7 +9,7 @@
 import { join } from 'node:path';
 import type { Service, ServiceStatus } from './services.ts';
 import type { JarvisConfig } from '../config/types.ts';
-import type { LLMStreamEvent, LLMMessage } from '../llm/provider.ts';
+import type { LLMStreamEvent, LLMMessage, LLMErrorCode } from '../llm/provider.ts';
 import type { RoleDefinition } from '../roles/types.ts';
 import type { PersonalityModel } from '../personality/model.ts';
 
@@ -386,8 +386,11 @@ export class AgentService implements Service, IAgentService {
         };
       } catch (err) {
         const errorMsg = err instanceof Error ? err.message : String(err);
+        const code = err && typeof err === 'object'
+          ? (err as { code?: LLMErrorCode }).code
+          : undefined;
         console.error('[AgentService] Conv stream error:', errorMsg);
-        yield { type: 'error', error: errorMsg };
+        yield { type: 'error', error: errorMsg, code };
       }
     })();
 

--- a/src/daemon/agent-service.ts
+++ b/src/daemon/agent-service.ts
@@ -366,7 +366,8 @@ export class AgentService implements Service, IAgentService {
           if (event.type === 'text') {
             // Insert a separator so the acknowledgment text doesn't blur into
             // the later verbalization on the client side.
-            const chunk = (fullText && !fullText.endsWith('\n') ? '\n\n' : '') + event.text;
+            const separator = event.newSegment && fullText && !fullText.endsWith('\n') ? '\n\n' : '';
+            const chunk = separator + event.text;
             fullText += chunk;
             yield { type: 'text', text: chunk };
           }

--- a/src/daemon/agent-service.ts
+++ b/src/daemon/agent-service.ts
@@ -369,7 +369,9 @@ export class AgentService implements Service, IAgentService {
             const separator = event.newSegment && fullText && !fullText.endsWith('\n') ? '\n\n' : '';
             const chunk = separator + event.text;
             fullText += chunk;
-            yield { type: 'text', text: chunk };
+            // A segmentEnd-only event has no text; forward the signal so TTS
+            // can speak the finished acknowledgment without waiting.
+            yield { type: 'text', text: chunk, segmentEnd: event.segmentEnd };
           }
           // 'done' is implicit - the generator ends.
         }

--- a/src/daemon/ws-service.ts
+++ b/src/daemon/ws-service.ts
@@ -1217,6 +1217,10 @@ CRITICAL — when in genuine doubt between "make in a new project" vs "add to th
       // We ignore onTextDone and use the relayStream return to mark stream completion.
       const fullText = await this.streamRelay.relayStream(stream, requestId, {
         signal: activeChat?.controller.signal,
+        // Voice enters "thinking" after STT-final. Flip it off as soon as
+        // acknowledgment/final prose becomes visible instead of leaving the
+        // orb stuck there until the whole tool loop completes.
+        onTextStart: () => this.broadcastThinkingEnd(requestId),
         ...(ttsActive ? {
           onSentence: (sentence: string) => {
             if (activeChat?.controller.signal.aborted) return;

--- a/src/llm/provider.ts
+++ b/src/llm/provider.ts
@@ -52,7 +52,15 @@ export type LLMErrorCode =
   | 'unknown';
 
 export type LLMStreamEvent =
-  | { type: 'text'; text: string }
+  /**
+   * `segmentEnd` marks the text as a finished, speakable unit — set by
+   * orchestrators when an acknowledgment is complete and slow tool work is
+   * about to start. Consumers use it to flush a pending TTS sentence instead
+   * of inferring completion from punctuation in a partial token buffer.
+   * Providers never set it; the text may be empty when the signal is all the
+   * producer has to say.
+   */
+  | { type: 'text'; text: string; segmentEnd?: boolean }
   | { type: 'tool_call'; tool_call: LLMToolCall }
   | { type: 'done'; response: LLMResponse }
   | { type: 'error'; error: string; code?: LLMErrorCode };


### PR DESCRIPTION
## Summary

- stream conversation-layer acknowledgments instead of buffering them until tool work finishes
- synthesize one concise contextual acknowledgment when a model emits a silent tool call
- begin TTS as soon as a complete acknowledgment sentence reaches a chunk boundary
- end the voice thinking state on the first visible text
- keep activity narration high-level without exposing hidden chain-of-thought

## Scope

This PR is independent of the response interruption controls and LLM fallback PRs.

## Verification

- bun test: 1,897 passed, 37 skipped, 0 failed
- bun run tsc --noEmit
- live VPS smoke: first acknowledgment and TTS start at about 0.82s; first audio at about 1.69s
- git diff --check