### PR TITLE
fix(llm): clear tiers for removed providers

### DIFF
--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -330,6 +330,14 @@ export type LLMConfig = {
   providers?: Record<string, LLMProviderEntry>;
 
   /**
+   * Provider selected as the real runtime primary. Unlike `default`, this
+   * does not require a model id: gateways such as OmniRoute can apply their
+   * own default/auto routing. An explicit `default` model is used only when
+   * it belongs to this provider.
+   */
+  default_provider?: string;
+
+  /**
    * Single-LLM mode model reference. When set and `tiers` is absent, all
    * task tiers (low/medium/high) resolve to this model and the classic
    * orchestrator runs. Ignored when `tiers` is configured.

--- a/src/daemon/llm-settings.test.ts
+++ b/src/daemon/llm-settings.test.ts
@@ -56,6 +56,32 @@ describe('LLM default provider settings', () => {
     expect(() => saveLLMSettings(config, { default_provider: 'missing' }))
       .toThrow("Default provider 'missing' is not configured");
   });
+
+  it('does not derive a provider from a model ref with an empty model id', () => {
+    const config = configWithProviders();
+    config.llm.default = 'test-anthropic:';
+
+    expect(getLLMSettings(config).default_provider).toBeNull();
+  });
+
+  it('clears every model assignment owned by a deleted provider', () => {
+    const config = configWithProviders();
+    config.llm.default_provider = 'test-anthropic';
+    config.llm.default = 'test-anthropic:claude-sonnet';
+    config.llm.tiers = {
+      conversation: 'test-anthropic:claude-haiku',
+      high: 'test-omniroute:auto',
+      medium: 'test-anthropic:claude-sonnet',
+    };
+
+    saveLLMSettings(config, { providers: { 'test-anthropic': null } });
+
+    expect(config.llm.default_provider).toBeUndefined();
+    expect(config.llm.default).toBeUndefined();
+    expect(config.llm.tiers).toEqual({ high: 'test-omniroute:auto' });
+    expect(getSetting('llm.tiers.conversation')).toBe('');
+    expect(getSetting('llm.tiers.medium')).toBe('');
+  });
 });
 
 describe('LLM settings model migrations', () => {

--- a/src/daemon/llm-settings.test.ts
+++ b/src/daemon/llm-settings.test.ts
@@ -1,14 +1,68 @@
-import { afterEach, describe, expect, it } from 'bun:test';
-import { initDatabase, closeDb } from '../vault/schema.ts';
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { DEFAULT_CONFIG, type JarvisConfig } from '../config/types.ts';
+import { closeDb, initDatabase } from '../vault/schema.ts';
 import { getSetting, setSetting } from '../vault/settings.ts';
-import { DEFAULT_CONFIG } from '../config/types.ts';
-import { mergeLLMSettingsIntoConfig } from './llm-settings.ts';
+import { getLLMSettings, mergeLLMSettingsIntoConfig, saveLLMSettings } from './llm-settings.ts';
 
-afterEach(() => closeDb());
+function configWithProviders(): JarvisConfig {
+  const config = structuredClone(DEFAULT_CONFIG);
+  config.llm.providers = {
+    'test-anthropic': { kind: 'anthropic' },
+    'test-omniroute': { kind: 'omniroute', base_url: 'http://router.test/v1' },
+  };
+  config.llm.tiers = {};
+  return config;
+}
+
+describe('LLM default provider settings', () => {
+  beforeEach(() => initDatabase(':memory:', { quiet: true }));
+  afterEach(() => closeDb());
+
+  it('persists and reloads the provider separately from its model', () => {
+    const config = configWithProviders();
+    saveLLMSettings(config, { default_provider: 'test-omniroute' });
+
+    expect(config.llm.default_provider).toBe('test-omniroute');
+    expect(config.llm.default).toBeUndefined();
+    expect(getSetting('llm.default_provider')).toBe('test-omniroute');
+    expect(getLLMSettings(config).default_provider).toBe('test-omniroute');
+
+    const reloaded = structuredClone(DEFAULT_CONFIG);
+    mergeLLMSettingsIntoConfig(reloaded);
+    expect(reloaded.llm.default_provider).toBe('test-omniroute');
+  });
+
+  it('clears a stale model override when switching providers', () => {
+    const config = configWithProviders();
+    config.llm.default = 'test-anthropic:claude-sonnet';
+
+    saveLLMSettings(config, { default_provider: 'test-omniroute' });
+
+    expect(config.llm.default_provider).toBe('test-omniroute');
+    expect(config.llm.default).toBeUndefined();
+    expect(getSetting('llm.default')).toBe('');
+  });
+
+  it('keeps model selection and provider selection synchronized', () => {
+    const config = configWithProviders();
+    saveLLMSettings(config, { default: 'test-anthropic:claude-sonnet' });
+
+    expect(config.llm.default_provider).toBe('test-anthropic');
+    expect(config.llm.default).toBe('test-anthropic:claude-sonnet');
+  });
+
+  it('rejects a provider that is not configured', () => {
+    const config = configWithProviders();
+    expect(() => saveLLMSettings(config, { default_provider: 'missing' }))
+      .toThrow("Default provider 'missing' is not configured");
+  });
+});
 
 describe('LLM settings model migrations', () => {
+  beforeEach(() => initDatabase(':memory:', { quiet: true }));
+  afterEach(() => closeDb());
+
   it('replaces saved decommissioned Groq IDs and persists the repair', () => {
-    initDatabase(':memory:');
     setSetting('llm.providers', JSON.stringify({ groq: { kind: 'groq' } }));
     setSetting('llm.default', 'groq:deepseek-r1-distill-llama-70b');
     setSetting('llm.tiers.medium', 'groq:llama-3.1-8b-instant');
@@ -23,7 +77,6 @@ describe('LLM settings model migrations', () => {
   });
 
   it('can hydrate repaired references without mutating settings', () => {
-    initDatabase(':memory:');
     setSetting('llm.providers', JSON.stringify({ groq: { kind: 'groq' } }));
     setSetting('llm.default', 'groq:deepseek-r1-distill-llama-70b');
     const config = structuredClone(DEFAULT_CONFIG);

--- a/src/daemon/llm-settings.ts
+++ b/src/daemon/llm-settings.ts
@@ -3,6 +3,7 @@
  *
  * Canonical config shape (after the provider/model split):
  *   llm.providers           Record<name, { kind?, api_key?, base_url? }>
+ *   llm.default_provider    "name" (real runtime primary; model optional)
  *   llm.default             "name:model" (single-LLM mode)
  *   llm.tiers.{conversation,high,medium,low}  "name:model" (router-first)
  *
@@ -30,6 +31,7 @@ import { GROQ_DEPRECATED_MODEL_REPLACEMENTS } from '../llm/groq-models.ts';
 
 // ── DB keys ──────────────────────────────────────────────────────────────
 const SETTING_PROVIDERS = 'llm.providers';
+const SETTING_DEFAULT_PROVIDER = 'llm.default_provider';
 const SETTING_DEFAULT = 'llm.default';
 const SETTING_MODE = 'llm.mode';
 const SETTING_TIER_CONVERSATION = 'llm.tiers.conversation';
@@ -58,6 +60,7 @@ export type LLMMode = 'single' | 'multi-tier';
 
 export type LLMSettingsResponse = {
   providers: Record<string, LLMSettingsProviderView>;
+  default_provider: string | null;
   default: string | null;
   /**
    * The user's persisted architecture choice. Stored explicitly rather than
@@ -86,6 +89,7 @@ export type LLMSettingsRequest = {
     api_key?: string;
     base_url?: string;
   } | null>;            // null deletes the provider
+  default_provider?: string | null; // null clears
   default?: string | null;     // null clears
   mode?: LLMMode;              // persisted architecture choice
   tiers?: {
@@ -145,6 +149,9 @@ export function getLLMSettings(config: JarvisConfig): LLMSettingsResponse {
 
   return {
     providers,
+    default_provider: config.llm.default_provider
+      ?? providerFromModelRef(config.llm.default)
+      ?? null,
     default: config.llm.default ?? null,
     mode,
     tiers,
@@ -206,6 +213,8 @@ export function saveLLMSettings(
     for (const [name, update] of updates) {
       if (update === null) {
         delete config.llm.providers[name];
+        if (config.llm.default_provider === name) config.llm.default_provider = undefined;
+        if (providerFromModelRef(config.llm.default) === name) config.llm.default = undefined;
         try { deleteSecret(keychainKey(name)); } catch { /* ignore */ }
         continue;
       }
@@ -229,6 +238,23 @@ export function saveLLMSettings(
     }
   }
 
+  // A provider default is independent of a model id. Gateways can therefore
+  // apply their own default/auto route without inheriting an invalid model id
+  // from whichever provider used to be selected.
+  if (body.default_provider !== undefined) {
+    if (body.default_provider === null || body.default_provider === '') {
+      config.llm.default_provider = undefined;
+    } else if (typeof body.default_provider === 'string') {
+      if (!config.llm.providers[body.default_provider]) {
+        throw new Error(`Default provider '${body.default_provider}' is not configured`);
+      }
+      config.llm.default_provider = body.default_provider;
+      if (providerFromModelRef(config.llm.default) !== body.default_provider) {
+        config.llm.default = undefined;
+      }
+    }
+  }
+
   // Persist the architecture choice. Kept in its own setting (not derived) so
   // the selection survives reloads and the user can flip either direction even
   // before any tier model is picked. Does NOT drive runtime routing - that
@@ -239,7 +265,15 @@ export function saveLLMSettings(
 
   // Apply default + tier model refs.
   if (body.default !== undefined) {
-    config.llm.default = body.default ?? undefined;
+    const nextDefault = body.default ?? undefined;
+    const modelProvider = providerFromModelRef(nextDefault);
+    if (modelProvider) {
+      if (!config.llm.providers[modelProvider]) {
+        throw new Error(`Default model references unconfigured provider '${modelProvider}'`);
+      }
+      config.llm.default_provider = modelProvider;
+    }
+    config.llm.default = nextDefault;
   }
   if (body.tiers) {
     for (const tier of ['conversation', 'high', 'medium', 'low'] as const) {
@@ -263,6 +297,7 @@ export function saveLLMSettings(
   // injected from the keychain (see mergeLLMSettingsIntoConfig), and the
   // settings table is plaintext.
   setSetting(SETTING_PROVIDERS, JSON.stringify(stripSecretsFromProviders(config.llm.providers)));
+  setSetting(SETTING_DEFAULT_PROVIDER, config.llm.default_provider ?? '');
   setSetting(SETTING_DEFAULT, config.llm.default ?? '');
   setSetting(SETTING_TIER_CONVERSATION, config.llm.tiers.conversation ?? '');
   setSetting(SETTING_TIER_HIGH, config.llm.tiers.high ?? '');
@@ -316,6 +351,7 @@ export function mergeLLMSettingsIntoConfig(
   // Replace, don't merge: the DB is authoritative for every LLM setting.
   config.llm.providers = {};
   config.llm.tiers = {};
+  config.llm.default_provider = undefined;
   config.llm.default = undefined;
 
   // 1. New shape: load providers JSON + default + tier strings.
@@ -330,6 +366,9 @@ export function mergeLLMSettingsIntoConfig(
       console.warn('[LLM] Failed to parse stored providers JSON:', err);
     }
   }
+
+  const dbDefaultProvider = getSetting(SETTING_DEFAULT_PROVIDER);
+  if (dbDefaultProvider) config.llm.default_provider = dbDefaultProvider;
 
   const dbDefault = getSetting(SETTING_DEFAULT);
   if (dbDefault) config.llm.default = dbDefault;
@@ -474,9 +513,18 @@ function migrateLegacyDBSettings(config: JarvisConfig): void {
     const legacyPrimary = getSetting('llm.primary');
     if (legacyPrimary) {
       const model = legacyModels[legacyPrimary as LLMProviderKind];
-      if (model) config.llm.default = `${legacyPrimary}:${model}`;
+      if (model) {
+        config.llm.default = `${legacyPrimary}:${model}`;
+        config.llm.default_provider = legacyPrimary;
+      }
     }
   }
+}
+
+function providerFromModelRef(ref: string | null | undefined): string | null {
+  if (!ref) return null;
+  const separator = ref.indexOf(':');
+  return separator > 0 ? ref.slice(0, separator) : null;
 }
 
 // ── hotReloadLLMProviders ────────────────────────────────────────────────

--- a/src/daemon/llm-settings.ts
+++ b/src/daemon/llm-settings.ts
@@ -215,6 +215,11 @@ export function saveLLMSettings(
         delete config.llm.providers[name];
         if (config.llm.default_provider === name) config.llm.default_provider = undefined;
         if (providerFromModelRef(config.llm.default) === name) config.llm.default = undefined;
+        for (const tier of ['conversation', 'high', 'medium', 'low'] as const) {
+          if (providerFromModelRef(config.llm.tiers[tier]) === name) {
+            delete config.llm.tiers[tier];
+          }
+        }
         try { deleteSecret(keychainKey(name)); } catch { /* ignore */ }
         continue;
       }
@@ -524,7 +529,7 @@ function migrateLegacyDBSettings(config: JarvisConfig): void {
 function providerFromModelRef(ref: string | null | undefined): string | null {
   if (!ref) return null;
   const separator = ref.indexOf(':');
-  return separator > 0 ? ref.slice(0, separator) : null;
+  return separator > 0 && separator < ref.length - 1 ? ref.slice(0, separator) : null;
 }
 
 // ── hotReloadLLMProviders ────────────────────────────────────────────────

--- a/src/llm/config-binding.test.ts
+++ b/src/llm/config-binding.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'bun:test';
+import type { LLMConfig } from '../config/types.ts';
+import { configureLLMTiers } from './config-binding.ts';
+import { LLMManager } from './manager.ts';
+import type { LLMProvider } from './provider.ts';
+
+function fakeProvider(name: string): LLMProvider {
+  return {
+    name,
+    async chat() {
+      return {
+        content: name,
+        tool_calls: [],
+        usage: { input_tokens: 0, output_tokens: 0 },
+        model: 'provider-default',
+        finish_reason: 'stop',
+      };
+    },
+    async *stream() {},
+    async listModels() { return []; },
+  };
+}
+
+describe('configureLLMTiers default provider', () => {
+  it('sets the actual manager primary and routes single-mode calls through it', async () => {
+    const manager = new LLMManager();
+    manager.registerProvider(fakeProvider('anthropic'));
+    manager.registerProvider(fakeProvider('omniroute'));
+
+    configureLLMTiers(manager, {
+      default_provider: 'omniroute',
+      tiers: {},
+    } satisfies LLMConfig);
+
+    expect(manager.getPrimary()).toBe('omniroute');
+    expect(manager.getTierMap()).toEqual({
+      low: { provider: 'omniroute' },
+      medium: { provider: 'omniroute' },
+      high: { provider: 'omniroute' },
+    });
+    const response = await manager.chat([{ role: 'user', content: 'hello' }]);
+    expect(response.content).toBe('omniroute');
+  });
+
+  it('does not carry another provider model across a provider switch', () => {
+    const manager = new LLMManager();
+    manager.registerProvider(fakeProvider('anthropic'));
+    manager.registerProvider(fakeProvider('omniroute'));
+
+    configureLLMTiers(manager, {
+      default_provider: 'omniroute',
+      default: 'anthropic:claude-sonnet',
+      tiers: {},
+    } satisfies LLMConfig);
+
+    expect(manager.getTierMap().medium).toEqual({ provider: 'omniroute' });
+  });
+
+  it('keeps old model-only configs backward compatible', () => {
+    const manager = new LLMManager();
+    manager.registerProvider(fakeProvider('omniroute'));
+    manager.registerProvider(fakeProvider('anthropic'));
+
+    configureLLMTiers(manager, {
+      default: 'anthropic:claude-sonnet',
+      tiers: {},
+    } satisfies LLMConfig);
+
+    expect(manager.getPrimary()).toBe('anthropic');
+    expect(manager.getTierMap().medium).toEqual({
+      provider: 'anthropic',
+      model: 'claude-sonnet',
+    });
+  });
+
+  it('still lets explicit tier routes override the provider default', () => {
+    const manager = new LLMManager();
+    manager.registerProvider(fakeProvider('omniroute'));
+    manager.registerProvider(fakeProvider('groq'));
+
+    configureLLMTiers(manager, {
+      default_provider: 'omniroute',
+      tiers: { conversation: 'groq:llama', medium: 'groq:llama' },
+    } satisfies LLMConfig);
+
+    expect(manager.getPrimary()).toBe('omniroute');
+    expect(manager.getTierMap().conversation).toEqual({ provider: 'groq', model: 'llama' });
+    expect(manager.getTierMap().medium).toEqual({ provider: 'groq', model: 'llama' });
+    expect(manager.getTierMap().low).toEqual({ provider: 'omniroute' });
+  });
+});

--- a/src/llm/config-binding.ts
+++ b/src/llm/config-binding.ts
@@ -6,8 +6,8 @@
  * Two responsibilities:
  *  1. Instantiate provider classes from a `LLMProviderEntry` map and register
  *     them with the manager.
- *  2. Resolve `llm.default` + `llm.tiers` model-ref strings into a TierMap
- *     and apply it to the manager.
+ *  2. Resolve `llm.default_provider`, the optional default model, and tier
+ *     model refs into the manager's real primary + TierMap.
  *
  * Used by both the cold-start path (AgentService.start) and the hot-reload
  * path (llm-settings.hotReloadLLMProviders) so they stay in sync.
@@ -16,7 +16,7 @@
 import type { LLMConfig, LLMProviderEntry, LLMProviderKind } from '../config/types.ts';
 import type { LLMManager } from './manager.ts';
 import type { LLMProvider } from './provider.ts';
-import { type Tier, type TierMap, parseModelRef } from './tiers.ts';
+import { type Tier, type TierAssignment, type TierMap, parseModelRef } from './tiers.ts';
 import { AnthropicProvider } from './anthropic.ts';
 import { OpenAIProvider } from './openai.ts';
 import { GroqProvider } from './groq.ts';
@@ -159,11 +159,15 @@ export function atomicReloadProviders(
 }
 
 /**
- * Build a TierMap from llm.default + llm.tiers and apply it to the manager.
+ * Build a TierMap from llm.default_provider + llm.default + llm.tiers and
+ * apply it to the manager.
  *
  * Semantics:
- *   - `llm.default` (single-LLM mode) populates low/medium/high to the same
- *     model. The conversation tier is left unset (router-first stays off).
+ *   - `llm.default_provider` is the real runtime primary and can omit a model
+ *     so a gateway applies its own default/auto route.
+ *   - `llm.default` optionally supplies that provider's model override.
+ *   - The effective default populates low/medium/high. The conversation tier
+ *     is left unset (router-first stays off).
  *   - `llm.tiers` overrides individual slots. When `tiers.conversation` is
  *     set, the router-first mode activates.
  *   - When both are set, tier values win over the default for that tier.
@@ -174,16 +178,25 @@ export function atomicReloadProviders(
 export function configureLLMTiers(manager: LLMManager, llm: LLMConfig): void {
   const tierMap: TierMap = {};
 
-  // 1. Single-LLM mode populates task tiers from `default`.
-  if (llm.default) {
-    const ref = parseModelRef(llm.default);
-    if (ref && manager.getProvider(ref.provider)) {
-      tierMap.low = ref;
-      tierMap.medium = ref;
-      tierMap.high = ref;
-    } else if (ref) {
+  // 1. Resolve provider independently from the optional model. Old installs
+  // with only llm.default derive their provider from that model ref.
+  const modelDefault = parseModelRef(llm.default);
+  const defaultProvider = llm.default_provider ?? modelDefault?.provider;
+  if (defaultProvider) {
+    if (manager.getProvider(defaultProvider)) {
+      const assignment: TierAssignment = {
+        provider: defaultProvider,
+        ...(modelDefault?.provider === defaultProvider && modelDefault.model
+          ? { model: modelDefault.model }
+          : {}),
+      };
+      manager.setPrimary(defaultProvider);
+      tierMap.low = assignment;
+      tierMap.medium = assignment;
+      tierMap.high = assignment;
+    } else {
       console.warn(
-        `[LLM] llm.default ('${llm.default}') references unregistered provider '${ref.provider}' - skipping.`,
+        `[LLM] Default provider '${defaultProvider}' is not registered - skipping.`,
       );
     }
   }

--- a/ui/src/v2/rooms/settings/tabs/LLMTab.tsx
+++ b/ui/src/v2/rooms/settings/tabs/LLMTab.tsx
@@ -322,6 +322,7 @@ function ProviderRow({
   const usesKey = KEY_BASED_KINDS.has(entry.kind);
   const needsKey = usesKey && !OPTIONAL_KEY_KINDS.has(entry.kind);
   const configured = (!usesUrl || !!entry.base_url?.trim()) && (!needsKey || entry.has_api_key);
+  const isDefault = data.llm?.default_provider === name;
 
   const [apiKey, setApiKey] = useState("");
   const [baseUrl, setBaseUrl] = useState(entry.base_url ?? "");
@@ -338,6 +339,7 @@ function ProviderRow({
   const endpointChanged = (usesUrl || optionalUrl)
     && entry.has_api_key
     && effectiveBaseUrl !== normalizeBaseUrl(entry.base_url ?? "");
+  const [settingDefault, setSettingDefault] = useState(false);
 
   useEffect(() => {
     setBaseUrl(entry.base_url ?? "");
@@ -360,6 +362,11 @@ function ProviderRow({
           <span className="v2-set__chip" style={{ marginLeft: 6 }}>
             kind: {LLM_PROVIDER_KIND_LABELS[entry.kind]}
           </span>
+          {isDefault && (
+            <span className="v2-set__chip v2-set__chip--ok" style={{ marginLeft: 6 }}>
+              default
+            </span>
+          )}
         </span>
         <span className="v2-set__row-state">
           {configured ? (
@@ -373,6 +380,34 @@ function ProviderRow({
 
       {expanded && (
         <div className="v2-set__row-body">
+          <div className="v2-set__field">
+            <label className="v2-set__toggle-row">
+              <button
+                type="button"
+                className="v2-set__toggle"
+                data-checked={isDefault}
+                aria-checked={isDefault}
+                role="switch"
+                disabled={isDefault || settingDefault || !configured}
+                onClick={async () => {
+                  if (isDefault || settingDefault) return;
+                  setSettingDefault(true);
+                  const r = await data.setDefaultProvider(name);
+                  onToast(r.message, r.ok ? "ok" : "warn");
+                  setSettingDefault(false);
+                }}
+              />
+              <span>
+                <strong>Default provider</strong>
+                <span className="v2-set__hint" style={{ display: "block", marginTop: 2 }}>
+                  {isDefault
+                    ? "Jarvis uses this as its runtime primary and fallback provider."
+                    : "Make this Jarvis’s runtime primary. Tier-specific routes still take priority."}
+                </span>
+              </span>
+            </label>
+          </div>
+
           {usesKey && (
             <div className="v2-set__field">
               <label className="v2-set__field-label">

--- a/ui/src/v2/rooms/settings/useSettingsData.ts
+++ b/ui/src/v2/rooms/settings/useSettingsData.ts
@@ -117,6 +117,7 @@ export interface LLMConfigProviderView {
  */
 export interface LLMConfig {
   providers: Record<string, LLMConfigProviderView>;
+  default_provider: string | null;
   default: string | null;
   mode: "single" | "multi-tier";
   tiers: {
@@ -531,6 +532,26 @@ export function useSettingsData() {
         return {
           ok: true,
           message: r.message || (ref ? `Default model set to ${ref}.` : "Default model cleared."),
+        };
+      } catch (err) {
+        return { ok: false, message: err instanceof Error ? err.message : "Failed" };
+      }
+    },
+    [refresh],
+  );
+
+  /** Select the provider used as the real runtime primary. */
+  const setDefaultProvider = useCallback(
+    async (name: string): Promise<ActionResult> => {
+      try {
+        const r = await postJson<{ ok: boolean; message: string }>(
+          "/api/config/llm",
+          { default_provider: name },
+        );
+        await refresh();
+        return {
+          ok: true,
+          message: r.message || `Default provider set to ${name}.`,
         };
       } catch (err) {
         return { ok: false, message: err instanceof Error ? err.message : "Failed" };
@@ -960,6 +981,7 @@ export function useSettingsData() {
     // New-shape LLM actions
     upsertProvider,
     removeProvider,
+    setDefaultProvider,
     setDefaultModel,
     setTierModel,
     clearAllTiers,


### PR DESCRIPTION
## Summary

- clear saved tier assignments when their provider is removed
- preserve tiers that belong to other configured providers
- use the existing parseModelRef helper instead of introducing parallel provider parsing or settings
- prevent stale conversation routes from returning after a daemon restart

## Verification

- `bun test src/daemon/llm-settings.test.ts`
- `bun x tsc --noEmit`
- `git diff --check`