### PR TITLE
Stop channel presets from overwriting learned personality preferences

### DIFF
--- a/src/personality/adapter.ts
+++ b/src/personality/adapter.ts
@@ -1,4 +1,4 @@
-import type { PersonalityModel } from './model.ts';
+import type { LearnedPreferenceKey, PersonalityModel } from './model.ts';
 
 /**
  * Channel-specific personality defaults
@@ -61,11 +61,23 @@ const CHANNEL_DEFAULTS: Record<string, Partial<PersonalityModel>> = {
 };
 
 /**
+ * What mergePersonality actually accepts. Partial<PersonalityModel> is shallow,
+ * so it would type a half-filled learned_preferences as a complete one.
+ */
+type PersonalityOverride = Omit<
+  Partial<PersonalityModel>,
+  'learned_preferences' | 'relationship'
+> & {
+  learned_preferences?: Partial<PersonalityModel['learned_preferences']>;
+  relationship?: Partial<PersonalityModel['relationship']>;
+};
+
+/**
  * Deep merge helper for personality overrides
  */
 function mergePersonality(
   base: PersonalityModel,
-  override: Partial<PersonalityModel>
+  override: PersonalityOverride
 ): PersonalityModel {
   return {
     ...base,
@@ -86,18 +98,48 @@ function mergePersonality(
 }
 
 /**
+ * Drop the preferences the learner has explicitly moved from a channel preset.
+ *
+ * A preset is a floor, not a ceiling: it fills in preferences the user has
+ * never expressed an opinion about, and stays out of the way of the ones they
+ * have. Without this filter the preset overwrites every learned value, because
+ * learned_preferences is always fully populated.
+ */
+function presetForUnlearnedKeys(
+  preset: Partial<PersonalityModel>,
+  learnedKeys: LearnedPreferenceKey[] | undefined
+): PersonalityOverride {
+  const presetPreferences = preset.learned_preferences;
+  if (!presetPreferences || !learnedKeys?.length) return preset;
+
+  const remaining: Partial<PersonalityModel['learned_preferences']> = {};
+  for (const [key, value] of Object.entries(presetPreferences)) {
+    if (learnedKeys.includes(key as LearnedPreferenceKey)) continue;
+    (remaining as Record<string, unknown>)[key] = value;
+  }
+
+  return { ...preset, learned_preferences: remaining };
+}
+
+/**
  * Get personality adapted for a specific channel
  */
 export function getChannelPersonality(personality: PersonalityModel, channel: string): PersonalityModel {
-  // First, apply channel-specific overrides from stored personality
+  // First, apply channel-specific overrides from stored personality. These are
+  // set deliberately for one channel, so they outrank both the learner and the
+  // preset.
   let adapted = personality;
   if (personality.channel_overrides[channel]) {
     adapted = mergePersonality(personality, personality.channel_overrides[channel]);
   }
 
-  // Then, apply default channel adaptations if no stored override exists
+  // Then, apply default channel adaptations if no stored override exists -
+  // but only for preferences the learner has not already moved.
   if (!personality.channel_overrides[channel] && CHANNEL_DEFAULTS[channel]) {
-    adapted = mergePersonality(adapted, CHANNEL_DEFAULTS[channel]);
+    adapted = mergePersonality(
+      adapted,
+      presetForUnlearnedKeys(CHANNEL_DEFAULTS[channel], personality.learned_keys)
+    );
   }
 
   return adapted;

--- a/src/personality/index.ts
+++ b/src/personality/index.ts
@@ -1,5 +1,5 @@
 // Re-export all personality engine modules
-export type { PersonalityModel } from './model.ts';
+export type { LearnedPreferenceKey, LearnedPreferences, PersonalityModel } from './model.ts';
 export {
   loadPersonality,
   savePersonality,

--- a/src/personality/learner.ts
+++ b/src/personality/learner.ts
@@ -1,4 +1,4 @@
-import type { PersonalityModel } from './model.ts';
+import type { LearnedPreferenceKey, PersonalityModel } from './model.ts';
 
 export type InteractionSignal = {
   type: 'user_feedback' | 'message_style' | 'explicit_preference';
@@ -145,8 +145,16 @@ export function extractSignals(userMessage: string, assistantResponse: string): 
  */
 export function applySignals(personality: PersonalityModel, signals: InteractionSignal[]): PersonalityModel {
   const updated = { ...personality };
+  // Built as a copy, so recording a learned key never mutates the caller's
+  // array. Channel presets defer to every key that lands in here.
+  const learnedKeys = new Set<LearnedPreferenceKey>(personality.learned_keys ?? []);
 
   for (const signal of signals) {
+    // Only preferences the user actually asked for outrank a channel preset.
+    // `message_style` is passive mimicry - we copy the user's emoji habit, but
+    // a formal channel is still entitled to suppress it.
+    const isExplicit = signal.type !== 'message_style';
+
     const { preference, direction, value } = signal.data as {
       preference?: string;
       direction?: number;
@@ -165,11 +173,13 @@ export function applySignals(personality: PersonalityModel, signals: Interaction
       const adjustment = direction ?? 0;
       const newValue = clamp(currentValue + adjustment, 0, 10);
       (updated.learned_preferences as any)[preference] = newValue;
+      if (isExplicit) learnedKeys.add(preference);
     }
 
     // Handle boolean preferences
     if (preference === 'emoji_usage' && typeof value === 'boolean') {
       updated.learned_preferences.emoji_usage = value;
+      if (isExplicit) learnedKeys.add('emoji_usage');
     }
 
     // Handle enum preferences
@@ -182,9 +192,12 @@ export function applySignals(personality: PersonalityModel, signals: Interaction
       ];
       if (validFormats.includes(value as any)) {
         updated.learned_preferences.preferred_format = value as any;
+        if (isExplicit) learnedKeys.add('preferred_format');
       }
     }
   }
+
+  updated.learned_keys = [...learnedKeys];
 
   return updated;
 }

--- a/src/personality/model.ts
+++ b/src/personality/model.ts
@@ -1,14 +1,25 @@
 import { getDb } from '../vault/schema.ts';
 
+export type LearnedPreferences = {
+  verbosity: number;        // 0-10
+  formality: number;        // 0-10
+  humor_level: number;      // 0-10
+  emoji_usage: boolean;
+  preferred_format: 'lists' | 'prose' | 'tables' | 'adaptive';
+};
+
+export type LearnedPreferenceKey = keyof LearnedPreferences;
+
 export type PersonalityModel = {
   core_traits: string[];
-  learned_preferences: {
-    verbosity: number;        // 0-10
-    formality: number;        // 0-10
-    humor_level: number;      // 0-10
-    emoji_usage: boolean;
-    preferred_format: 'lists' | 'prose' | 'tables' | 'adaptive';
-  };
+  learned_preferences: LearnedPreferences;
+  /**
+   * Preferences the learner has explicitly moved. Every field of
+   * learned_preferences always holds a value, so this is the only way to tell
+   * a learned preference from an untouched default - which is what lets a
+   * learned value outrank a channel preset in getChannelPersonality().
+   */
+  learned_keys: LearnedPreferenceKey[];
   relationship: {
     first_interaction: number;
     message_count: number;
@@ -27,6 +38,7 @@ const DEFAULT_PERSONALITY: PersonalityModel = {
     emoji_usage: false,
     preferred_format: 'adaptive',
   },
+  learned_keys: [],
   relationship: {
     first_interaction: Date.now(),
     message_count: 0,
@@ -35,6 +47,41 @@ const DEFAULT_PERSONALITY: PersonalityModel = {
   },
   channel_overrides: {},
 };
+
+/**
+ * Preferences a user can move by asking. emoji_usage is deliberately absent:
+ * it is only ever set by passive mimicry, never by an explicit request, so it
+ * stays under the channel presets' control. Keep in sync with applySignals().
+ */
+const EXPLICITLY_LEARNABLE_KEYS: LearnedPreferenceKey[] = [
+  'verbosity',
+  'formality',
+  'humor_level',
+  'preferred_format',
+];
+
+/**
+ * Reconstruct learned_keys for personalities stored before the field existed.
+ *
+ * The learner is the only writer of learned_preferences, so any preference
+ * that deviates from the shipped default was necessarily learned. Without
+ * this, every pre-existing user's learned state would stay masked by the
+ * channel presets even after the precedence fix.
+ *
+ * The converse is only approximate: a user who moved a preference and then
+ * moved it back reads as untouched. That self-corrects the next time the
+ * learner records a signal, which is every interaction.
+ */
+function backfillLearnedKeys(model: PersonalityModel): PersonalityModel {
+  if (Array.isArray(model.learned_keys)) return model;
+
+  const prefs = model.learned_preferences ?? DEFAULT_PERSONALITY.learned_preferences;
+  model.learned_keys = EXPLICITLY_LEARNABLE_KEYS.filter(
+    (key) => prefs[key] !== DEFAULT_PERSONALITY.learned_preferences[key]
+  );
+
+  return model;
+}
 
 type DeepPartial<T> = {
   [P in keyof T]?: T[P] extends object ? DeepPartial<T[P]> : T[P]
@@ -60,7 +107,7 @@ export function loadPersonality(): PersonalityModel {
   }
 
   try {
-    return JSON.parse(row.data) as PersonalityModel;
+    return backfillLearnedKeys(JSON.parse(row.data) as PersonalityModel);
   } catch (error) {
     console.error('Failed to parse personality data:', error);
     return structuredClone(DEFAULT_PERSONALITY);

--- a/src/personality/personality.test.ts
+++ b/src/personality/personality.test.ts
@@ -37,6 +37,23 @@ describe('Personality Engine', () => {
       expect(personality.relationship.message_count).toBe(0);
     });
 
+    test('backfills learned_keys for personalities stored before the field existed', () => {
+      const legacy = getPersonality();
+      legacy.learned_preferences.verbosity = 2;   // deviates: was learned
+      legacy.learned_preferences.emoji_usage = true;
+      delete (legacy as Partial<PersonalityModel>).learned_keys;
+      savePersonality(legacy as PersonalityModel);
+
+      const loaded = getPersonality();
+
+      expect(loaded.learned_keys).toEqual(['verbosity']);
+      // Untouched preferences stay unlearned, so presets still shape them.
+      expect(loaded.learned_keys).not.toContain('formality');
+      // emoji_usage is never explicitly learned, so presets keep governing it.
+      expect(loaded.learned_keys).not.toContain('emoji_usage');
+      expect(getChannelPersonality(loaded, 'websocket').learned_preferences.verbosity).toBe(2);
+    });
+
     test('default personality is not shared across calls', () => {
       const first = getPersonality();
       first.relationship.message_count = 99;
@@ -187,6 +204,86 @@ describe('Personality Engine', () => {
       expect(adapted.learned_preferences.formality).toBe(0);
     });
 
+    test('learned preferences survive the channel preset', () => {
+      // The regression: the preset used to be merged over the learned values,
+      // so "keep it brief" never reached the prompt on any real channel.
+      let personality = getPersonality();
+      personality = applySignals(personality, extractSignals('keep it brief', 'Response'));
+
+      const learnedVerbosity = personality.learned_preferences.verbosity;
+      expect(learnedVerbosity).toBe(4);
+
+      // websocket is the app itself, and its preset is identical to the
+      // shipped defaults - so the bug reset learned values to factory values.
+      const adapted = getChannelPersonality(personality, 'websocket');
+      expect(adapted.learned_preferences.verbosity).toBe(learnedVerbosity);
+    });
+
+    test('channel preset still applies to preferences the user never moved', () => {
+      let personality = getPersonality();
+      personality = applySignals(personality, extractSignals('keep it brief', 'Response'));
+
+      const adapted = getChannelPersonality(personality, 'email');
+
+      // Learned: wins over the preset's verbosity of 7.
+      expect(adapted.learned_preferences.verbosity).toBe(4);
+      // Untouched: the email preset still shapes these.
+      expect(adapted.learned_preferences.formality).toBe(8);
+      expect(adapted.learned_preferences.humor_level).toBe(2);
+      expect(adapted.learned_preferences.preferred_format).toBe('prose');
+    });
+
+    test('an explicit format request survives the preset', () => {
+      let personality = getPersonality();
+      personality = applySignals(personality, extractSignals('answer in prose please', 'Response'));
+
+      // The email preset would also set prose, so use a channel that disagrees.
+      const adapted = getChannelPersonality(personality, 'whatsapp');
+      expect(adapted.learned_preferences.preferred_format).toBe('prose');
+      // Never expressed an opinion on emoji, so WhatsApp's preset stands.
+      expect(adapted.learned_preferences.emoji_usage).toBe(true);
+    });
+
+    test('passively copied emoji habit does not outrank a formal preset', () => {
+      let personality = getPersonality();
+      personality = applySignals(personality, extractSignals('sounds good 🎉', 'Response'));
+
+      // The habit is copied...
+      expect(personality.learned_preferences.emoji_usage).toBe(true);
+      // ...but it was never asked for, so it is not a learned preference.
+      expect(personality.learned_keys).not.toContain('emoji_usage');
+      // Email stays emoji-free.
+      expect(getChannelPersonality(personality, 'email').learned_preferences.emoji_usage).toBe(false);
+      // And a channel that likes emoji still gets them.
+      expect(getChannelPersonality(personality, 'whatsapp').learned_preferences.emoji_usage).toBe(true);
+    });
+
+    test('stored channel overrides outrank learned preferences', () => {
+      let personality = getPersonality();
+      personality = applySignals(personality, extractSignals('keep it brief', 'Response'));
+      personality.channel_overrides.email = {
+        learned_preferences: {
+          verbosity: 9,
+          formality: 9,
+          humor_level: 0,
+          emoji_usage: false,
+          preferred_format: 'prose',
+        },
+      };
+
+      const adapted = getChannelPersonality(personality, 'email');
+      expect(adapted.learned_preferences.verbosity).toBe(9);
+    });
+
+    test('learned preferences reach the generated prompt', () => {
+      let personality = getPersonality();
+      personality = applySignals(personality, extractSignals('too long, be concise', 'Response'));
+
+      const prompt = personalityToPrompt(getChannelPersonality(personality, 'websocket'));
+
+      expect(prompt).toContain('verbosity (4/10)');
+    });
+
     test('should generate personality prompt', () => {
       const personality = getPersonality();
       personality.relationship.message_count = 25;
@@ -227,6 +324,8 @@ describe('Personality Engine', () => {
       const loaded = getPersonality();
       // Verbosity should have decreased from initial value
       expect(loaded.learned_preferences.verbosity).toBeLessThan(initialVerbosity);
+      // And it must round-trip as learned, or the presets would mask it again
+      expect(loaded.learned_keys).toContain('verbosity');
       // Message count should have increased by 3
       expect(loaded.relationship.message_count).toBeGreaterThanOrEqual(3);
     });


### PR DESCRIPTION
## The problem

Learned personality preferences were saved to the database and then discarded before they reached the system prompt.

Every system prompt runs through `getChannelPersonality()` (`src/daemon/agent-service.ts:818`). When a channel has no explicit `channel_overrides` entry, that function merged `CHANNEL_DEFAULTS[channel]` over the stored personality — and `mergePersonality()` spreads the override last, so the preset won:

```ts
learned_preferences: {
  ...base.learned_preferences,      // what the learner saved
  ...override.learned_preferences,  // the preset, wins
}
```

`CHANNEL_DEFAULTS` covers `websocket`, `terminal`, `email`, `whatsapp`, `telegram` and `discord`, so this applied on every real channel. The only escape was an explicit stored `channel_overrides` entry, and nothing outside the tests ever writes one.

The user-visible effect: someone asks to keep it brief, the learner moves `verbosity` and persists it, and nothing they ever see changes. On `websocket` and `terminal` the presets are byte-identical to the shipped defaults, so learned values were reset to exactly the factory numbers. The Settings screen renders the raw stored preferences rather than the channel-adapted ones, so it showed the learning working while the prompt kept receiving the default.

`relationship` was unaffected — `CHANNEL_DEFAULTS` has no entry for it, so `trust_level` and `message_count` always reached the prompt intact.

## The fix

A channel preset should be a floor, not a ceiling: it fills in preferences the user has never expressed an opinion about and stays out of the way of the ones they have.

Simply reversing the merge order does not achieve that. `learned_preferences` is a fully populated required object — every field always holds a value, learned or not — so merging the stored personality over the preset would overwrite all five preset fields and disable channel adaptation entirely for every user.

Telling a learned preference apart from an untouched default requires recording the difference:

- **`model.ts`** — adds `learned_keys` to `PersonalityModel`, tracking which preferences the learner has explicitly moved. The personality is stored as a JSON blob in a single column, so this needs no schema migration. `loadPersonality()` backfills the field for rows written before it existed by diffing against the shipped defaults; the learner is the only writer of `learned_preferences`, so any deviation was necessarily learned. Without the backfill, existing users' learned state would stay masked.
- **`learner.ts`** — `applySignals()` records each preference it moves.
- **`adapter.ts`** — `getChannelPersonality()` applies the channel preset only to keys absent from `learned_keys`. Explicit `channel_overrides` continue to outrank both.

### Explicit requests vs. copied habits

Only preferences the user actually asked for outrank a preset. `emoji_usage` is deliberately excluded: it is set by passive mimicry — the learner flips it on whenever the user types an emoji — and nothing ever sets it back. Treating it as learned would mean one emoji anywhere permanently defeats emoji suppression in email. Signals of type `message_style` therefore still update the preference but do not claim it, leaving formal channels free to override. The backfill applies the same rule so it cannot produce a key that new writes never would.

### Incidental

`mergePersonality()` took a `Partial<PersonalityModel>`, which is shallow and so types a half-filled `learned_preferences` as a complete one. Replaced with a `PersonalityOverride` type describing what the function actually accepts, which removes a cast asserting a partial object was complete.

## Tests

Seven tests covering a path nothing previously exercised — the existing integration test asserted a learned value round-trips through the database and stopped one call short of the prompt:

- a learned value survives `getChannelPersonality()` and reaches the generated prompt
- an untouched preference still picks up its channel preset, guarding against a fix that disables channel adaptation
- a passively copied emoji habit does not outrank a formal preset, but still applies where the preset agrees
- explicit `channel_overrides` still outrank learned values
- `learned_keys` backfills for legacy rows and round-trips through save/load

Reverting only the `adapter.ts` change fails five of them. Full suite: 1933 tests, 0 failures.
