### PR TITLE
fix(voice): store STT and TTS API keys in the encrypted keychain

### DIFF
--- a/src/cli/backup.ts
+++ b/src/cli/backup.ts
@@ -23,12 +23,6 @@
  * backups use; the default keeps the archive far less sensitive for
  * user-facing downloads (the DB it carries has no API key in it).
  *
- * CAVEAT, and the reason for the legacy-root warning further down: the
- * keychain always lives in ~/.jarvis, so on an install whose data_dir points
- * elsewhere (JARVIS_HOME) it is NOT under the staged tree and even `--full`
- * comes back without any API key. Every credential now rides in that pair —
- * nothing key-shaped is left in the DB to soften the landing.
- *
  * Restore is stop-before-restore: it acquires the daemon's own flock (which
  * is JARVIS_HOME-aware, same resolution the daemon uses) plus the data dir's,
  * and HOLDS them until the swap is done — a running daemon makes restore

--- a/src/cli/backup.ts
+++ b/src/cli/backup.ts
@@ -18,9 +18,16 @@
  *
  * `--full` additionally includes the plaintext secrets: google-tokens.json,
  * the sidecar signing keys, and the keychain pair (.secrets.enc/.secrets.key)
- * that holds the LLM provider credentials — so a restore works without
- * re-connecting anything. That is the variant hosting backups use; the
- * default keeps the archive far less sensitive for user-facing downloads.
+ * that holds the LLM provider credentials and the STT/TTS API keys — so a
+ * restore works without re-connecting anything. That is the variant hosting
+ * backups use; the default keeps the archive far less sensitive for
+ * user-facing downloads (the DB it carries has no API key in it).
+ *
+ * CAVEAT, and the reason for the legacy-root warning further down: the
+ * keychain always lives in ~/.jarvis, so on an install whose data_dir points
+ * elsewhere (JARVIS_HOME) it is NOT under the staged tree and even `--full`
+ * comes back without any API key. Every credential now rides in that pair —
+ * nothing key-shaped is left in the DB to soften the landing.
  *
  * Restore is stop-before-restore: it acquires the daemon's own flock (which
  * is JARVIS_HOME-aware, same resolution the daemon uses) plus the data dir's,

--- a/src/daemon/settings-reload.test.ts
+++ b/src/daemon/settings-reload.test.ts
@@ -1,4 +1,7 @@
 import { test, expect, describe, beforeEach, afterEach } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { initDatabase, closeDb } from '../vault/schema.ts';
 import { setSetting } from '../vault/settings.ts';
 import { DEFAULT_CONFIG, type JarvisConfig } from '../config/types.ts';
@@ -12,12 +15,23 @@ function freshConfig(): JarvisConfig {
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
 describe('settings-reload', () => {
+  // reloadAll hydrates stt/tts, which moves any api_key in those rows into the
+  // keychain — redirect it to a throwaway dir, never the real secrets store.
+  let secretsDir: string;
+  let prevSecretsDir: string | undefined;
+
   beforeEach(() => {
+    prevSecretsDir = process.env.JARVIS_SECRETS_DIR;
+    secretsDir = mkdtempSync(join(tmpdir(), 'jarvis-settings-reload-'));
+    process.env.JARVIS_SECRETS_DIR = secretsDir;
     initDatabase(':memory:');
   });
 
   afterEach(() => {
     closeDb();
+    if (prevSecretsDir === undefined) delete process.env.JARVIS_SECRETS_DIR;
+    else process.env.JARVIS_SECRETS_DIR = prevSecretsDir;
+    rmSync(secretsDir, { recursive: true, force: true });
   });
 
   test('sectionChanged runs the applier with the live config', async () => {

--- a/src/daemon/user-settings.test.ts
+++ b/src/daemon/user-settings.test.ts
@@ -1,4 +1,7 @@
 import { test, expect, describe, beforeEach, afterEach } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { initDatabase, closeDb } from '../vault/schema.ts';
 import { getSetting, setSetting } from '../vault/settings.ts';
 import { loadConfig } from '../config/loader.ts';
@@ -17,13 +20,24 @@ function freshConfig(): JarvisConfig {
 }
 
 describe('user-settings', () => {
+  // stt/tts saves reach the keychain (see voice-secrets.ts) — redirect it to a
+  // throwaway dir so tests never touch the developer's real secrets store.
+  let secretsDir: string;
+  let prevSecretsDir: string | undefined;
+
   beforeEach(() => {
+    prevSecretsDir = process.env.JARVIS_SECRETS_DIR;
+    secretsDir = mkdtempSync(join(tmpdir(), 'jarvis-user-settings-'));
+    process.env.JARVIS_SECRETS_DIR = secretsDir;
     initDatabase(':memory:');
   });
 
   afterEach(() => {
     setSectionSavedListener(null);
     closeDb();
+    if (prevSecretsDir === undefined) delete process.env.JARVIS_SECRETS_DIR;
+    else process.env.JARVIS_SECRETS_DIR = prevSecretsDir;
+    rmSync(secretsDir, { recursive: true, force: true });
   });
 
   test('workflows: file-provided SYSTEM path keys win over a saved user section', () => {

--- a/src/daemon/user-settings.ts
+++ b/src/daemon/user-settings.ts
@@ -15,11 +15,25 @@
  *
  * Layout: one settings row per section, key `cfg.<section>`, value JSON.
  *
+ * Secrets are the one exception to "the row holds the section": the settings
+ * table is plaintext, so the `stt`/`tts` API keys are split out to the
+ * encrypted keychain on the way in and injected back on the way out (see
+ * voice-secrets.ts) — the same treatment llm-settings.ts gives provider keys.
+ *
  * Requires the vault DB (initDatabase) to be open, same as llm-settings.
  */
 
+import { createHash } from 'node:crypto';
 import { getSetting, setSetting } from '../vault/settings.ts';
 import { deepMerge } from '../config/loader.ts';
+import {
+  VOICE_SECRET_SECTIONS,
+  hasInlineVoiceSecret,
+  injectVoiceSecrets,
+  isVoiceSecretSection,
+  persistVoiceSecrets,
+  stripVoiceSecrets,
+} from './voice-secrets.ts';
 import {
   DEFAULT_CONFIG,
   USER_OWNED_SECTIONS,
@@ -63,12 +77,29 @@ function notifySectionSaved(section: UserOwnedSection | 'google'): void {
  * then persist that section — the write is per-section, so there is no
  * load-modify-save race across unrelated sections (which is what the old
  * `loadConfig -> mutate -> saveConfig` dance existed to avoid).
+ *
+ * The `stt`/`tts` sections carry API keys. The settings table is plaintext,
+ * so those keys go to the encrypted keychain and the row is written stripped —
+ * same split llm-settings.ts uses for provider credentials. Callers always
+ * pass the live in-memory section (which mergeUserSettingsIntoConfig hydrated
+ * with the stored keys), so nothing is lost by the round-trip.
+ *
+ * THROWS when the keychain write fails. Writing the stripped row anyway would
+ * destroy the key — absent from the keychain, erased from the row — and report
+ * success while doing it. Failing leaves both stores exactly as they were.
  */
 export function saveUserSection<K extends UserOwnedSection>(
   section: K,
   value: JarvisConfig[K],
 ): void {
-  setSetting(settingKey(section), JSON.stringify(value ?? null));
+  let stored: unknown = value;
+  if (isVoiceSecretSection(section)) {
+    if (!persistVoiceSecrets(section, value)) {
+      throw new Error(`Could not store the ${section} API key(s) in the encrypted keychain; ${section} settings were NOT saved`);
+    }
+    stored = stripVoiceSecrets(section, value);
+  }
+  setSetting(settingKey(section), JSON.stringify(stored ?? null));
   notifySectionSaved(section);
 }
 
@@ -87,6 +118,22 @@ export function loadUserSection(section: UserOwnedSection): unknown {
 
 /** Meta row remembering the file value each section was last imported from. */
 const IMPORT_STATE_KEY = 'cfg.__import_state';
+
+const DIGEST_PREFIX = 'sha256:';
+
+/**
+ * Change-tracking marker for a section's file value. For the API-key-bearing
+ * sections it is a digest rather than the JSON itself: the import-state row
+ * lives in the same plaintext settings table, and mirroring a config.yaml
+ * credential there would undo the keychain split. Rows written before this
+ * hold the raw JSON; importLegacyUserSettings upgrades them in place, which
+ * keeps change detection intact (same input, same digest). A stored JSON value
+ * always starts with `{`, so it can never collide with the digest prefix.
+ */
+function importMarker(section: UserOwnedSection, fileJson: string): string {
+  if (!isVoiceSecretSection(section)) return fileJson;
+  return `${DIGEST_PREFIX}${createHash('sha256').update(fileJson).digest('hex')}`;
+}
 
 function loadImportState(): Record<string, string> {
   const raw = getSetting(IMPORT_STATE_KEY);
@@ -120,22 +167,49 @@ export function importLegacyUserSettings(rawYaml: Record<string, unknown> | null
   const state = loadImportState();
   let stateChanged = false;
 
+  // Normalize pre-digest baselines for the key-bearing sections BEFORE the
+  // loop: their raw JSON may itself be a config.yaml credential, and a section
+  // the user has since deleted from the file is never reached below — the
+  // plaintext would sit in this row forever.
+  for (const section of VOICE_SECRET_SECTIONS) {
+    const raw = state[section];
+    if (raw === undefined || raw.startsWith(DIGEST_PREFIX)) continue;
+    state[section] = importMarker(section, raw);
+    stateChanged = true;
+  }
+
   for (const section of USER_OWNED_SECTIONS) {
     const fileValue = rawYaml[section];
     if (fileValue === undefined || fileValue === null) continue;
     const fileJson = JSON.stringify(fileValue);
+    const marker = importMarker(section, fileJson);
     const hasDbValue = getSetting(settingKey(section)) !== null;
     const lastImported = state[section];
 
     if (hasDbValue && lastImported === undefined) {
-      state[section] = fileJson; // baseline only
+      state[section] = marker; // baseline only
       stateChanged = true;
       continue;
     }
-    if (hasDbValue && fileJson === lastImported) continue;
+    if (hasDbValue && lastImported === marker) continue;
 
-    setSetting(settingKey(section), fileJson);
-    state[section] = fileJson;
+    if (isVoiceSecretSection(section)) {
+      // The file value is authoritative for the whole section, exactly as the
+      // raw setSetting below: keys move to the keychain, the row is stripped.
+      // A failed keychain write skips the section entirely (no marker either),
+      // so the next boot retries instead of importing a key-less section.
+      if (!persistVoiceSecrets(section, fileValue)) {
+        console.error(`[UserSettings] Keychain write failed — skipping the ${section} import from config.yaml (will retry on the next boot)`);
+        continue;
+      }
+      setSetting(settingKey(section), JSON.stringify(stripVoiceSecrets(section, fileValue)));
+      if (hasInlineVoiceSecret(section, fileValue)) {
+        console.log(`[UserSettings] Imported ${section} API key(s) from config.yaml into the encrypted keychain — the plaintext key can be removed from the file`);
+      }
+    } else {
+      setSetting(settingKey(section), fileJson);
+    }
+    state[section] = marker;
     stateChanged = true;
     imported.push(section);
   }
@@ -151,11 +225,18 @@ export function importLegacyUserSettings(rawYaml: Record<string, unknown> | null
  *
  * Call AFTER loadConfig (which discarded any file-provided user sections)
  * and re-apply env overrides afterwards if env must win (the daemon does).
+ *
+ * STT/TTS API keys are pulled from the encrypted keychain and injected back
+ * into their sub-blocks, so consumers keep reading `config.stt.openai.api_key`
+ * without knowing where it is stored.
  */
 export function mergeUserSettingsIntoConfig(config: JarvisConfig): void {
+  migratePlaintextVoiceSecrets();
+  const hasStoredRow = new Set<string>();
   for (const section of USER_OWNED_SECTIONS) {
     const stored = loadUserSection(section);
     if (stored === undefined) continue;
+    hasStoredRow.add(section);
     const def = (DEFAULT_CONFIG as Record<string, unknown>)[section];
     const target = config as Record<string, unknown>;
     // `workflows` system path keys are FILE-owned (loadConfig preserved them
@@ -181,7 +262,43 @@ export function mergeUserSettingsIntoConfig(config: JarvisConfig): void {
       target[section] = { ...(target[section] as object), ...filePaths };
     }
   }
+  // Inject stored keys only into sections that actually have a settings row.
+  // Every path that stores a key writes one (save, import, migration), so a
+  // secret without a row is an orphan - e.g. a default backup (DB only, no
+  // keychain) restored onto a machine whose keychain holds another install's
+  // keys. Grafting those onto the restored config would silently hand the
+  // user a credential their settings never referenced.
+  const target = config as Record<string, unknown>;
+  for (const section of VOICE_SECRET_SECTIONS) {
+    if (!hasStoredRow.has(section)) continue;
+    target[section] = injectVoiceSecrets(section, target[section]);
+  }
   mergeGoogleSettingsIntoConfig(config);
+}
+
+/**
+ * Upgrade path for installs written before the keychain split: move any
+ * api_key still sitting in a plaintext `cfg.stt` / `cfg.tts` row into the
+ * keychain and rewrite the row stripped. Idempotent and cheap (two rows), so
+ * it runs on every hydration — including SettingsReloadCoordinator.reloadAll,
+ * which is what a restore-from-backup of an older DB goes through.
+ */
+function migratePlaintextVoiceSecrets(): void {
+  for (const section of VOICE_SECRET_SECTIONS) {
+    const stored = loadUserSection(section);
+    if (!hasInlineVoiceSecret(section, stored)) continue;
+    // The row predates the split, so it is the authority for the whole
+    // section: persist every key it carries, drop stale ones.
+    if (!persistVoiceSecrets(section, stored)) {
+      // Keep the plaintext row rather than strip a key the keychain never
+      // took: a working (if unencrypted) credential beats a destroyed one.
+      // The next hydration retries.
+      console.error(`[UserSettings] Keychain write failed — leaving the plaintext ${section} API key(s) in the settings table for now`);
+      continue;
+    }
+    setSetting(settingKey(section), JSON.stringify(stripVoiceSecrets(section, stored)));
+    console.log(`[UserSettings] Moved plaintext ${section} API key(s) from the settings table into the encrypted keychain`);
+  }
 }
 
 // ── google: system-owned when the FILE provides it ─────────────────────────

--- a/src/daemon/voice-secrets.test.ts
+++ b/src/daemon/voice-secrets.test.ts
@@ -1,0 +1,265 @@
+/**
+ * STT/TTS API keys must live in the encrypted keychain, never in the plaintext
+ * `settings` table — the same split llm-settings.ts applies to provider keys.
+ *
+ * The keychain writes to `~/.jarvis`, so every test redirects it to a
+ * throwaway dir via JARVIS_SECRETS_DIR — never the developer's real store.
+ */
+import { test, expect, describe, beforeEach, afterEach } from 'bun:test';
+import { mkdtempSync, rmSync, readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { initDatabase, closeDb } from '../vault/schema.ts';
+import { getSetting, setSetting } from '../vault/settings.ts';
+import { DEFAULT_CONFIG, type JarvisConfig } from '../config/types.ts';
+import { getSecret, setSecret } from '../vault/keychain.ts';
+import {
+  saveUserSection,
+  loadUserSection,
+  importLegacyUserSettings,
+  mergeUserSettingsIntoConfig,
+} from './user-settings.ts';
+import { createApiRoutes, type ApiContext } from './api-routes.ts';
+
+function freshConfig(): JarvisConfig {
+  return structuredClone(DEFAULT_CONFIG);
+}
+
+/** Raw bytes of the row as stored — the assertion that matters for leaks. */
+function rawRow(section: 'stt' | 'tts'): string {
+  return getSetting(`cfg.${section}`) ?? '';
+}
+
+describe('voice secrets (stt/tts api keys)', () => {
+  let secretsDir: string;
+  let prevSecretsDir: string | undefined;
+
+  beforeEach(() => {
+    prevSecretsDir = process.env.JARVIS_SECRETS_DIR;
+    secretsDir = mkdtempSync(join(tmpdir(), 'jarvis-voice-secrets-'));
+    process.env.JARVIS_SECRETS_DIR = secretsDir;
+    initDatabase(':memory:');
+  });
+
+  afterEach(() => {
+    closeDb();
+    if (prevSecretsDir === undefined) delete process.env.JARVIS_SECRETS_DIR;
+    else process.env.JARVIS_SECRETS_DIR = prevSecretsDir;
+    rmSync(secretsDir, { recursive: true, force: true });
+  });
+
+  test('save keeps the key out of the settings row and in the keychain', () => {
+    saveUserSection('stt', { provider: 'groq', groq: { api_key: 'gk-secret', model: 'whisper' } });
+
+    expect(rawRow('stt')).not.toContain('gk-secret');
+    expect(loadUserSection('stt')).toEqual({ provider: 'groq', groq: { model: 'whisper' } });
+    expect(getSecret('stt.groq.api_key')).toBe('gk-secret');
+
+    // ...and the secrets file on disk is ciphertext, not the key in the clear.
+    const enc = join(secretsDir, '.secrets.enc');
+    expect(existsSync(enc)).toBe(true);
+    expect(readFileSync(enc).toString('latin1')).not.toContain('gk-secret');
+  });
+
+  test('merge injects the stored key back into the in-memory config', () => {
+    saveUserSection('stt', { provider: 'openai', openai: { api_key: 'sk-1' } });
+    saveUserSection('tts', {
+      enabled: true,
+      provider: 'elevenlabs',
+      elevenlabs: { api_key: 'el-1', voice_id: 'v1' },
+    });
+
+    const config = freshConfig();
+    mergeUserSettingsIntoConfig(config);
+
+    expect(config.stt?.openai?.api_key).toBe('sk-1');
+    expect(config.tts?.elevenlabs?.api_key).toBe('el-1');
+    expect(config.tts?.elevenlabs?.voice_id).toBe('v1');
+  });
+
+  test('a secret with no settings row is NOT injected (orphan from another install)', () => {
+    // e.g. a default (DB-only) backup restored onto a machine whose keychain
+    // still holds the previous install's keys.
+    setSecret('tts.sarvam.api_key', 'orphan');
+
+    const config = freshConfig(); // DEFAULT_CONFIG always defines tts
+    mergeUserSettingsIntoConfig(config);
+
+    expect(config.tts?.sarvam).toBeUndefined();
+  });
+
+  test('an empty key deletes the secret instead of leaving it behind', () => {
+    saveUserSection('tts', { enabled: true, provider: 'elevenlabs', elevenlabs: { api_key: 'el-1' } });
+    expect(getSecret('tts.elevenlabs.api_key')).toBe('el-1');
+
+    // NB: the HTTP routes cannot produce this — mergeCloudSubBlock falls back
+    // to the stored key when the patch sends '' (the GET redacts keys, so
+    // every UI round-trip would otherwise wipe them). This covers direct
+    // callers and keeps a cleared key from lingering in the keychain.
+    saveUserSection('tts', { enabled: true, provider: 'edge', elevenlabs: { api_key: '' } });
+    expect(getSecret('tts.elevenlabs.api_key')).toBeNull();
+
+    const config = freshConfig();
+    mergeUserSettingsIntoConfig(config);
+    expect(config.tts?.elevenlabs?.api_key).toBeUndefined();
+  });
+
+  test('dropping a sub-block deletes its secret (no stale credential)', () => {
+    saveUserSection('stt', { provider: 'groq', groq: { api_key: 'gk-1' } });
+    saveUserSection('stt', { provider: 'local', local: { endpoint: 'http://127.0.0.1:8080' } });
+
+    expect(getSecret('stt.groq.api_key')).toBeNull();
+  });
+
+  test('one provider key is untouched by a save that only changes another', () => {
+    saveUserSection('stt', {
+      provider: 'openai',
+      openai: { api_key: 'sk-1' },
+      sarvam: { api_key: 'sv-1' },
+    });
+
+    const config = freshConfig();
+    mergeUserSettingsIntoConfig(config);
+    config.stt!.provider = 'sarvam';
+    saveUserSection('stt', config.stt);
+
+    expect(getSecret('stt.openai.api_key')).toBe('sk-1');
+    expect(getSecret('stt.sarvam.api_key')).toBe('sv-1');
+  });
+
+  test('migration: a plaintext row from an older build moves to the keychain', () => {
+    // Exactly what the pre-split build wrote.
+    setSetting('cfg.stt', JSON.stringify({ provider: 'openai', openai: { api_key: 'legacy-sk', model: 'whisper-1' } }));
+    setSetting('cfg.tts', JSON.stringify({ enabled: true, provider: 'sarvam', sarvam: { api_key: 'legacy-sv' } }));
+
+    const config = freshConfig();
+    mergeUserSettingsIntoConfig(config);
+
+    // Config still works...
+    expect(config.stt?.openai?.api_key).toBe('legacy-sk');
+    expect(config.tts?.sarvam?.api_key).toBe('legacy-sv');
+    // ...and the plaintext copies are gone from the DB.
+    expect(rawRow('stt')).not.toContain('legacy-sk');
+    expect(rawRow('tts')).not.toContain('legacy-sv');
+    expect(getSecret('stt.openai.api_key')).toBe('legacy-sk');
+    expect(getSecret('tts.sarvam.api_key')).toBe('legacy-sv');
+    // Non-secret fields survive the rewrite.
+    expect(config.stt?.openai?.model).toBe('whisper-1');
+    expect(config.tts?.provider).toBe('sarvam');
+
+    // Idempotent: a second hydration changes nothing.
+    const row = rawRow('stt');
+    const again = freshConfig();
+    mergeUserSettingsIntoConfig(again);
+    expect(rawRow('stt')).toBe(row);
+    expect(again.stt?.openai?.api_key).toBe('legacy-sk');
+  });
+
+  test('import: a config.yaml key lands in the keychain, not in any DB row', () => {
+    const yaml = { stt: { provider: 'groq', groq: { api_key: 'file-gk' } } };
+    expect(importLegacyUserSettings(yaml)).toEqual(['stt']);
+
+    expect(rawRow('stt')).not.toContain('file-gk');
+    expect(getSetting('cfg.__import_state')).not.toContain('file-gk');
+    expect(getSecret('stt.groq.api_key')).toBe('file-gk');
+
+    const config = freshConfig();
+    mergeUserSettingsIntoConfig(config);
+    expect(config.stt?.groq?.api_key).toBe('file-gk');
+
+    // Unchanged file on the next boot: no re-import, dashboard edits survive.
+    expect(importLegacyUserSettings(yaml)).toEqual([]);
+  });
+
+  test('import: an EDITED file key still re-imports (digest tracks the change)', () => {
+    importLegacyUserSettings({ stt: { provider: 'groq', groq: { api_key: 'file-gk' } } });
+    const imported = importLegacyUserSettings({ stt: { provider: 'groq', groq: { api_key: 'file-gk-2' } } });
+
+    expect(imported).toEqual(['stt']);
+    expect(getSecret('stt.groq.api_key')).toBe('file-gk-2');
+  });
+
+  test('the real route path keeps the key out of the row and still reports it set', async () => {
+    const config = freshConfig();
+    const ctx = {
+      daemonStartedAt: Date.now(),
+      healthMonitor: {},
+      config,
+    } as unknown as ApiContext;
+    const routes = createApiRoutes(ctx);
+    const route = routes['/api/config/tts'] as {
+      GET: () => Response;
+      POST: (req: Request) => Promise<Response>;
+    };
+
+    const saved = await route.POST(new Request('http://x/api/config/tts', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ enabled: true, provider: 'elevenlabs', elevenlabs: { api_key: 'el-http' } }),
+    }));
+    expect(await saved.json()).toMatchObject({ ok: true });
+
+    expect(rawRow('tts')).not.toContain('el-http');
+    expect(getSecret('tts.elevenlabs.api_key')).toBe('el-http');
+    // The dashboard's "key is set" indicator reads the live config.
+    expect(await route.GET().json()).toMatchObject({ elevenlabs: { has_api_key: true } });
+
+    // And a restart (fresh hydration) gets the key back.
+    const rebooted = freshConfig();
+    mergeUserSettingsIntoConfig(rebooted);
+    expect(rebooted.tts?.elevenlabs?.api_key).toBe('el-http');
+  });
+
+  test('a failed keychain write never destroys the key', () => {
+    // Point the keychain at a path that cannot become a directory.
+    const blocked = join(secretsDir, 'blocked');
+    writeFileSync(blocked, 'not a dir');
+    process.env.JARVIS_SECRETS_DIR = blocked;
+
+    // Migration keeps the plaintext row rather than stripping a key the
+    // keychain never accepted — the credential still works, and the next
+    // hydration retries the move.
+    const legacyRow = JSON.stringify({ provider: 'openai', openai: { api_key: 'legacy-sk' } });
+    setSetting('cfg.stt', legacyRow);
+    const config = freshConfig();
+    mergeUserSettingsIntoConfig(config);
+    expect(rawRow('stt')).toBe(legacyRow);
+    expect(config.stt?.openai?.api_key).toBe('legacy-sk');
+
+    // A save fails loudly instead of reporting success and writing a row with
+    // the key stripped out of both stores.
+    expect(() => saveUserSection('tts', {
+      enabled: true,
+      provider: 'elevenlabs',
+      elevenlabs: { api_key: 'el-1' },
+    })).toThrow(/keychain/i);
+    expect(rawRow('tts')).toBe('');
+  });
+
+  test('import: a plaintext key in the import-state row is scrubbed even after the file drops the section', () => {
+    setSetting('cfg.__import_state', JSON.stringify({
+      stt: JSON.stringify({ provider: 'groq', groq: { api_key: 'file-gk' } }),
+    }));
+
+    // The config.yaml no longer carries an `stt` block at all, so the import
+    // loop never visits that section.
+    expect(importLegacyUserSettings({ personality: { assistant_name: 'Edith' } })).toEqual(['personality']);
+    expect(getSetting('cfg.__import_state')).not.toContain('file-gk');
+  });
+
+  test('import: a pre-digest baseline row is upgraded without re-importing', () => {
+    // An instance that baselined under the old behavior: the import-state row
+    // holds the raw file JSON, api_key included.
+    const yaml = { stt: { provider: 'groq', groq: { api_key: 'file-gk' } } };
+    setSetting('cfg.stt', JSON.stringify({ provider: 'openai' }));
+    setSetting('cfg.__import_state', JSON.stringify({ stt: JSON.stringify(yaml.stt) }));
+
+    expect(importLegacyUserSettings(yaml)).toEqual([]);
+    expect(getSetting('cfg.__import_state')).not.toContain('file-gk');
+
+    // The dashboard value is still the one that wins.
+    const config = freshConfig();
+    mergeUserSettingsIntoConfig(config);
+    expect(config.stt?.provider).toBe('openai');
+  });
+});

--- a/src/daemon/voice-secrets.ts
+++ b/src/daemon/voice-secrets.ts
@@ -1,0 +1,129 @@
+/**
+ * Keychain-backed API keys for the `stt` and `tts` config sections.
+ *
+ * Same contract llm-settings.ts established for LLM provider credentials: the
+ * vault `settings` table is PLAINTEXT, so an api_key must never be serialized
+ * into the `cfg.stt` / `cfg.tts` rows. The keys live in the encrypted keychain
+ * (~/.jarvis/.secrets.enc, AES-256-GCM) under `stt.<block>.api_key` /
+ * `tts.<block>.api_key`, and are injected back into the in-memory config at
+ * hydration time so every consumer (createSTTProvider, createTTSProvider,
+ * /api/tts/voices, the GET redaction checks…) keeps reading
+ * `config.stt.openai.api_key` exactly as before.
+ *
+ * user-settings.ts is the sole caller: routing strip/persist/inject through
+ * saveUserSection + mergeUserSettingsIntoConfig + importLegacyUserSettings
+ * means every writer (config routes, onboarding, voice intents) is covered
+ * without touching each call site.
+ */
+
+import { getSecret, setSecrets } from '../vault/keychain.ts';
+
+/** Sub-blocks of each section that carry an `api_key`. */
+const VOICE_SECRET_BLOCKS = {
+  stt: ['openai', 'groq', 'sarvam'],
+  tts: ['elevenlabs', 'sarvam'],
+} as const;
+
+export const VOICE_SECRET_SECTIONS = Object.keys(VOICE_SECRET_BLOCKS) as VoiceSecretSection[];
+
+export type VoiceSecretSection = keyof typeof VOICE_SECRET_BLOCKS;
+
+type AnyRec = Record<string, unknown>;
+
+export function isVoiceSecretSection(section: string): section is VoiceSecretSection {
+  return section in VOICE_SECRET_BLOCKS;
+}
+
+/** Keychain key for one section/sub-block pair, e.g. `tts.elevenlabs.api_key`. */
+function keychainKey(section: VoiceSecretSection, block: string): string {
+  return `${section}.${block}.api_key`;
+}
+
+function asRecord(value: unknown): AnyRec | null {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as AnyRec : null;
+}
+
+/** The api_key of one sub-block, or undefined when absent/blank/not a string. */
+function readKey(sectionValue: AnyRec | null, block: string): string | undefined {
+  const sub = asRecord(sectionValue?.[block]);
+  const key = sub?.['api_key'];
+  return typeof key === 'string' && key !== '' ? key : undefined;
+}
+
+/** True when the value still carries an inline api_key (pre-keychain row). */
+export function hasInlineVoiceSecret(section: VoiceSecretSection, value: unknown): boolean {
+  const rec = asRecord(value);
+  if (!rec) return false;
+  return VOICE_SECRET_BLOCKS[section].some((block) => readKey(rec, block) !== undefined);
+}
+
+/**
+ * Copy of the section value with every api_key removed - what gets persisted
+ * to the settings table. Empty sub-blocks are KEPT (`{}` instead of dropped)
+ * so a block that held nothing but a key still signals "configured", and
+ * injectVoiceSecrets can fill it back in.
+ */
+export function stripVoiceSecrets<T>(section: VoiceSecretSection, value: T): T {
+  const rec = asRecord(value);
+  if (!rec) return value;
+  const out: AnyRec = { ...rec };
+  for (const block of VOICE_SECRET_BLOCKS[section]) {
+    const sub = asRecord(out[block]);
+    if (!sub) continue;
+    const { api_key: _omit, ...rest } = sub;
+    void _omit;
+    out[block] = rest;
+  }
+  return out as T;
+}
+
+/**
+ * Write the section's api_keys to the keychain. The caller always passes the
+ * WHOLE section (saveUserSection semantics), so the value is authoritative:
+ * a sub-block that is gone - or whose key was cleared to '' - has its stored
+ * secret deleted rather than left behind as a stale credential.
+ *
+ * Returns false when the keychain could not be written (unwritable home dir,
+ * full disk…). Callers MUST NOT persist the stripped section in that case:
+ * the key would be gone from the settings row AND absent from the keychain,
+ * i.e. destroyed. Errors are reported, not thrown, so the caller decides.
+ */
+export function persistVoiceSecrets(section: VoiceSecretSection, value: unknown): boolean {
+  const rec = asRecord(value);
+  const entries: Record<string, string | null> = {};
+  for (const block of VOICE_SECRET_BLOCKS[section]) {
+    entries[keychainKey(section, block)] = readKey(rec, block) ?? null;
+  }
+  try {
+    setSecrets(entries);
+    return true;
+  } catch (err) {
+    console.error(`[VoiceSecrets] Failed to persist ${section} API key(s) to the keychain:`, err);
+    return false;
+  }
+}
+
+/**
+ * Merge the stored secrets back into a hydrated section value. Returns the
+ * same reference when there is nothing to inject. The caller decides WHICH
+ * sections to hydrate (mergeUserSettingsIntoConfig gates on the section having
+ * a settings row) - the object check here is only a shape guard, since
+ * DEFAULT_CONFIG always defines `stt`/`tts`.
+ */
+export function injectVoiceSecrets<T>(section: VoiceSecretSection, value: T): T {
+  const rec = asRecord(value);
+  if (!rec) return value;
+  let out: AnyRec | null = null;
+  for (const block of VOICE_SECRET_BLOCKS[section]) {
+    let key: string | null = null;
+    try {
+      key = getSecret(keychainKey(section, block));
+    } catch (err) {
+      console.warn(`[VoiceSecrets] Failed to read ${keychainKey(section, block)}:`, err);
+    }
+    if (!key) continue;
+    out ??= { ...rec };
+    out[block] = { ...asRecord(out[block]), api_key: key };
+  }
+  return (out ?? rec) as T;
+}

--- a/src/vault/keychain.ts
+++ b/src/vault/keychain.ts
@@ -12,18 +12,37 @@ import { constants as fsConstants, existsSync, readFileSync, mkdirSync, chmodSyn
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 
-const JARVIS_DIR = join(homedir(), '.jarvis');
-const KEY_PATH = join(JARVIS_DIR, '.secrets.key');
-const SECRETS_PATH = join(JARVIS_DIR, '.secrets.enc');
 const ALGORITHM = 'aes-256-gcm';
 const IV_LENGTH = 12;
 const TAG_LENGTH = 16;
 
+/**
+ * Directory holding the keychain pair. Resolved per call, not at module load,
+ * so `JARVIS_SECRETS_DIR` can redirect it — a seam for tests, which must never
+ * write into the developer's real store.
+ *
+ * Deliberately NOT JARVIS_HOME-aware: hosted deployments set that variable and
+ * their existing secrets live in ~/.jarvis, so honoring it here would move the
+ * keychain out from under them on upgrade.
+ */
+function jarvisDir(): string {
+  return process.env.JARVIS_SECRETS_DIR || join(homedir(), '.jarvis');
+}
+
+function keyPath(): string {
+  return join(jarvisDir(), '.secrets.key');
+}
+
+function secretsPath(): string {
+  return join(jarvisDir(), '.secrets.enc');
+}
+
 function ensureDir(): void {
-  mkdirSync(JARVIS_DIR, { recursive: true, mode: 0o700 });
-  try { chmodSync(JARVIS_DIR, 0o700); } catch (err) {
+  const dir = jarvisDir();
+  mkdirSync(dir, { recursive: true, mode: 0o700 });
+  try { chmodSync(dir, 0o700); } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    console.warn(`[Keychain] Failed to chmod ${JARVIS_DIR} to 700: ${message}`);
+    console.warn(`[Keychain] Failed to chmod ${dir} to 700: ${message}`);
   }
 }
 
@@ -47,12 +66,13 @@ function writeSecretFileSync(path: string, data: string | Buffer, mode: number):
 
 function getOrCreateKey(): Buffer {
   ensureDir();
-  if (existsSync(KEY_PATH)) {
-    const hex = readFileSync(KEY_PATH, 'utf-8').trim();
+  const path = keyPath();
+  if (existsSync(path)) {
+    const hex = readFileSync(path, 'utf-8').trim();
     return Buffer.from(hex, 'hex');
   }
   const key = randomBytes(32);
-  writeSecretFileSync(KEY_PATH, key.toString('hex'), 0o600);
+  writeSecretFileSync(path, key.toString('hex'), 0o600);
   return key;
 }
 
@@ -74,10 +94,10 @@ function decrypt(key: Buffer, data: Buffer): string {
 }
 
 function loadSecrets(): Record<string, string> {
-  if (!existsSync(SECRETS_PATH)) return {};
+  if (!existsSync(secretsPath())) return {};
   try {
     const key = getOrCreateKey();
-    const raw = readFileSync(SECRETS_PATH);
+    const raw = readFileSync(secretsPath());
     const json = decrypt(key, raw);
     return JSON.parse(json);
   } catch (err) {
@@ -91,7 +111,7 @@ function saveSecrets(secrets: Record<string, string>): void {
   const key = getOrCreateKey();
   const json = JSON.stringify(secrets);
   const encrypted = encrypt(key, json);
-  writeSecretFileSync(SECRETS_PATH, encrypted, 0o600);
+  writeSecretFileSync(secretsPath(), encrypted, 0o600);
 }
 
 export function getSecret(name: string): string | null {
@@ -103,6 +123,30 @@ export function setSecret(name: string, value: string): void {
   const secrets = loadSecrets();
   secrets[name] = value;
   saveSecrets(secrets);
+}
+
+/**
+ * Apply several writes in ONE decrypt/encrypt pass; `null` deletes the entry.
+ * Callers that persist a group of related credentials (e.g. every API key of a
+ * config section) should prefer this over N setSecret calls: each of those
+ * rewrites the whole file, and a crash midway would leave the group half
+ * applied. No-ops when every entry already has the requested value.
+ */
+export function setSecrets(entries: Record<string, string | null>): void {
+  const secrets = loadSecrets();
+  let changed = false;
+  for (const [name, value] of Object.entries(entries)) {
+    if (value === null) {
+      if (name in secrets) {
+        delete secrets[name];
+        changed = true;
+      }
+    } else if (secrets[name] !== value) {
+      secrets[name] = value;
+      changed = true;
+    }
+  }
+  if (changed) saveSecrets(secrets);
 }
 
 export function deleteSecret(name: string): void {


### PR DESCRIPTION
STT/TTS API keys (`stt.{openai,groq,sarvam}`, `tts.{elevenlabs,sarvam}`) were persisted as plaintext JSON in the `settings` table, unlike LLM provider keys which go to the encrypted keychain. This applies the same split.

- `voice-secrets.ts`: strip keys on the way into the DB, persist them to `~/.jarvis/.secrets.enc`, inject them back on hydration — so consumers keep reading `config.stt.openai.api_key` unchanged.
- Wired through `saveUserSection` / `mergeUserSettingsIntoConfig` / `importLegacyUserSettings`, so every writer (config routes, onboarding, voice intents) is covered.
- Existing installs migrate on the next hydration; a key still in `config.yaml` is imported into the keychain instead of a row.
- The `cfg.__import_state` row stored the raw file JSON, i.e. a second plaintext copy — it now keeps a digest for those sections.
- A failed keychain write never strips the row: the save throws and the migration leaves the plaintext in place to retry, rather than erasing a key from both stores.
- `keychain.ts` resolves its paths per call (`JARVIS_SECRETS_DIR` seam) so tests stop writing into the developer's real secrets store; `setSecrets()` applies a section's keys in one pass.