### PR TITLE
fix(workflows): bound the engine RPC by the flow's timeout budget instead of a flat 60s ack deadline

### DIFF
--- a/src/workflows/runner/engine-runtime/engine-handle-lifecycle.test.ts
+++ b/src/workflows/runner/engine-runtime/engine-handle-lifecycle.test.ts
@@ -1,0 +1,261 @@
+/**
+ * `EngineHandle` operation lifecycle, exercised against a fake EngineContract
+ * so it runs without the engine bundle on disk.
+ *
+ * Covers the three things that turned one slow flow into "every run fails":
+ *   1. the RPC ack deadline is derived from the budget we hand the engine,
+ *      not from the client-wide default;
+ *   2. a non-OK engine reply is surfaced instead of swallowed (swallowing it
+ *      left the caller polling a run row the engine would never settle);
+ *   3. an engine with an abandoned / in-flight operation is destroyed on
+ *      release instead of being parked in the warm pool.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import { closeWorkflowDb, initWorkflowDb } from "../../db";
+import { createFlow } from "../../db/repos/flow";
+import { createDraftVersion, lockVersion } from "../../db/repos/flow-version";
+import { createFlowRun } from "../../db/repos/flow-run";
+import { DEFAULT_IDS } from "../../db/schema";
+import { SandboxRegistry } from "../../sandbox-api/sandbox-registry";
+import type { EngineContract, EngineResponse } from "../../sandbox-api/contracts";
+import type { SpawnedEngine } from "./spawn";
+import { EngineHandle } from "./engine-runtime";
+import { CONTROL_OPERATION_TIMEOUT_S, ENGINE_ACK_MARGIN_MS } from "./operation-builder";
+import type { UpstreamFlowVersion } from "./flow-version-adapter";
+
+interface FakeEngine extends EngineContract {
+  calls: Array<{ operationType: string; timeoutMs: number | undefined }>;
+}
+
+/** An engine whose reply is driven by the supplied responder. */
+function fakeEngine(
+  responder: (operationType: string) => Promise<EngineResponse<unknown>>,
+): FakeEngine {
+  const calls: FakeEngine["calls"] = [];
+  return {
+    calls,
+    async executeOperation(input, opts) {
+      calls.push({ operationType: input.operationType, timeoutMs: opts?.timeoutMs });
+      return responder(input.operationType);
+    },
+  };
+}
+
+function fakeProc(): SpawnedEngine & { killed: NodeJS.Signals[] } {
+  const killed: NodeJS.Signals[] = [];
+  let alive = true;
+  let resolveExit: (v: { code: number | null; signal: NodeJS.Signals | null }) => void;
+  const exited = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((r) => {
+    resolveExit = r;
+  });
+  return {
+    killed,
+    pid: 4242,
+    stdout: null,
+    stderr: null,
+    child: {} as SpawnedEngine["child"],
+    exited,
+    alive: () => alive,
+    kill(signal = "SIGTERM") {
+      killed.push(signal);
+      alive = false;
+      resolveExit({ code: null, signal });
+    },
+  };
+}
+
+describe("EngineHandle operation lifecycle", () => {
+  let registry: SandboxRegistry;
+  let baseCodeDir: string;
+  let runId: string;
+  const sandboxId = "sandbox-under-test";
+
+  const flowVersion = (id: string): UpstreamFlowVersion => ({
+    id,
+    created: new Date(0).toISOString(),
+    updated: new Date(0).toISOString(),
+    flowId: "flow-1",
+    displayName: "briefing",
+    trigger: {
+      name: "trigger",
+      valid: true,
+      displayName: "Manual",
+      lastUpdatedDate: new Date(0).toISOString(),
+      type: "EMPTY",
+      settings: {},
+    },
+    updatedBy: null,
+    valid: true,
+    schemaVersion: null,
+    agentIds: [],
+    state: "LOCKED",
+    connectionIds: [],
+    backupFiles: null,
+    notes: [],
+  });
+
+  function makeHandle(
+    engine: EngineContract,
+    proc: SpawnedEngine,
+    releaseImpl?: () => Promise<void>,
+  ): EngineHandle {
+    return new EngineHandle(
+      sandboxId,
+      runId,
+      DEFAULT_IDS.project,
+      engine,
+      "engine-token",
+      proc,
+      registry,
+      5,
+      { baseUrl: "http://127.0.0.1:1234" } as never,
+      baseCodeDir,
+      releaseImpl,
+    );
+  }
+
+  beforeEach(() => {
+    initWorkflowDb(":memory:");
+    registry = new SandboxRegistry();
+    baseCodeDir = mkdtempSync(resolve(tmpdir(), "engine-handle-"));
+    const flow = createFlow({ projectId: DEFAULT_IDS.project });
+    const v = createDraftVersion({ flowId: flow.id, displayName: "v1" });
+    lockVersion(v.id);
+    runId = createFlowRun({ flowId: flow.id, flowVersionId: v.id }).id;
+    registry.register({
+      sandboxId,
+      runId,
+      projectId: DEFAULT_IDS.project,
+      engineToken: "engine-token",
+      expiresAt: Date.now() + 60_000,
+      terminatedAt: null,
+    });
+  });
+
+  afterEach(() => {
+    rmSync(baseCodeDir, { recursive: true, force: true });
+    closeWorkflowDb();
+  });
+
+  test("executeFlow's ack deadline follows the budget handed to the engine", async () => {
+    const engine = fakeEngine(async () => ({ status: "OK", response: undefined }));
+    const handle = makeHandle(engine, fakeProc());
+
+    await handle.executeFlow({
+      flowVersion: flowVersion("v-budget"),
+      timeoutInSeconds: 900,
+    });
+
+    expect(engine.calls[0]?.operationType).toBe("EXECUTE_FLOW");
+    expect(engine.calls[0]?.timeoutMs).toBe(900_000 + ENGINE_ACK_MARGIN_MS);
+  });
+
+  // The regression itself: the flow budget defaults to 600s, so the ack
+  // deadline must be far above the 60s the RPC client defaults to. A flow
+  // that legitimately runs for minutes (an LLM step, say) used to die at 60s
+  // while the engine kept executing it.
+  test("the default ack deadline is well past the RPC client's 60s default", async () => {
+    const engine = fakeEngine(async () => ({ status: "OK", response: undefined }));
+    const handle = makeHandle(engine, fakeProc());
+
+    await handle.executeFlow({ flowVersion: flowVersion("v-default") });
+
+    expect(engine.calls[0]?.timeoutMs).toBeGreaterThan(60_000);
+  });
+
+  // Control-plane operations keep a tight deadline: they sit on the trigger
+  // manager's polling path, where a hung hook must not stall a flow's polling
+  // for a flow-sized budget.
+  test("trigger hooks and metadata extraction keep a short deadline", async () => {
+    const engine = fakeEngine(async () => ({ status: "OK", response: {} }));
+    const handle = makeHandle(engine, fakeProc());
+    const expected = CONTROL_OPERATION_TIMEOUT_S * 1000 + ENGINE_ACK_MARGIN_MS;
+
+    await handle.executeTriggerHook("RUN", { flowVersion: flowVersion("v-hook") });
+    await handle.extractPieceMetadata({ pieceName: "p", pieceVersion: "1.0.0" });
+
+    expect(engine.calls.map((c) => c.timeoutMs)).toEqual([expected, expected]);
+    expect(expected).toBeLessThan(600_000);
+  });
+
+  test("a non-OK engine reply throws, carrying the engine's error detail", async () => {
+    const engine = fakeEngine(async () => ({
+      status: "INTERNAL_ERROR",
+      response: undefined,
+      error: "EngineGenericError: PieceNotFoundError",
+    }));
+    const handle = makeHandle(engine, fakeProc());
+
+    await expect(
+      handle.executeFlow({ flowVersion: flowVersion("v-reject") }),
+    ).rejects.toThrow(/INTERNAL_ERROR.*PieceNotFoundError/);
+  });
+
+  test("a rejected engine reply does not mark the engine reusable-hostile twice over", async () => {
+    // A non-OK *status* means the engine answered and is healthy: it may go
+    // back to the pool. Only transport failures poison the process.
+    const engine = fakeEngine(async () => ({ status: "INTERNAL_ERROR", response: undefined }));
+    const proc = fakeProc();
+    let pooled = false;
+    const handle = makeHandle(engine, proc, async () => {
+      pooled = true;
+    });
+
+    await expect(handle.executeFlow({ flowVersion: flowVersion("v-ok-engine") })).rejects.toThrow();
+    expect(handle.isAbandoned).toBe(false);
+
+    await handle.release();
+    expect(pooled).toBe(true);
+    expect(proc.killed).toEqual([]);
+  });
+
+  test("an abandoned operation destroys the engine instead of pooling it", async () => {
+    const engine = fakeEngine(async () => {
+      throw new Error("RPC [executeOperation] failed (timeout: 630000ms): operation has timed out");
+    });
+    const proc = fakeProc();
+    let pooled = false;
+    const handle = makeHandle(engine, proc, async () => {
+      pooled = true;
+    });
+
+    await expect(handle.executeFlow({ flowVersion: flowVersion("v-timeout") })).rejects.toThrow(
+      /timed out/,
+    );
+    expect(handle.isAbandoned).toBe(true);
+
+    await handle.release();
+    expect(pooled).toBe(false);
+    expect(proc.killed[0]).toBe("SIGTERM");
+    expect(registry.get(sandboxId)).toBeNull();
+  });
+
+  test("releasing while an operation is still in flight destroys the engine", async () => {
+    let finishOperation: (() => void) | null = null;
+    const engine = fakeEngine(
+      () =>
+        new Promise<EngineResponse<unknown>>((res) => {
+          finishOperation = () => res({ status: "OK", response: undefined });
+        }),
+    );
+    const proc = fakeProc();
+    let pooled = false;
+    const handle = makeHandle(engine, proc, async () => {
+      pooled = true;
+    });
+
+    const pending = handle.executeFlow({ flowVersion: flowVersion("v-inflight") });
+    await Promise.resolve();
+
+    await handle.release();
+    expect(pooled).toBe(false);
+    expect(proc.killed[0]).toBe("SIGTERM");
+
+    finishOperation!();
+    await pending.catch(() => {});
+  });
+});

--- a/src/workflows/runner/engine-runtime/engine-runtime.ts
+++ b/src/workflows/runner/engine-runtime/engine-runtime.ts
@@ -22,7 +22,7 @@
 
 import { existsSync, mkdirSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { resolve } from "node:path";
-import type { EngineContract } from "../../sandbox-api/contracts";
+import type { EngineContract, EngineResponse } from "../../sandbox-api/contracts";
 import type { SandboxApi } from "../../sandbox-api/server";
 import { SandboxRegistry } from "../../sandbox-api/sandbox-registry";
 import { workflowLogsBase } from "../../sandbox-api/config";
@@ -30,9 +30,11 @@ import { spawnEngine, type SpawnedEngine, type SpawnEngineOptions } from "./spaw
 import { ENGINE_BUILD_PATHS } from "./build";
 import { materializeCodeActions } from "./code-materialize";
 import {
+  ackTimeoutMsForOperation,
   buildExecuteFlowOperation,
   buildExecuteTriggerHookOperation,
   buildExtractPieceMetadataOperation,
+  type EngineOperationEnvelope,
   type ExecuteFlowOptions,
   type ExecuteTriggerHookOptions,
   type TriggerHookType,
@@ -140,6 +142,22 @@ export class EngineHandle {
    */
   private readonly releaseImpl: () => Promise<void>;
 
+  /**
+   * Number of `executeOperation` calls currently awaiting an engine reply.
+   * A handle with work in flight must never be parked in the warm pool --
+   * the next acquire would rebind the sandbox to a different run while the
+   * engine is still executing the previous one.
+   */
+  private inFlight = 0;
+  /**
+   * Set when an `executeOperation` call fails at the transport level (ack
+   * timeout, socket error). At that point the engine's state is unknown:
+   * there is no cancel message in EngineContract, so it is most likely
+   * still executing the abandoned operation. Such an engine is destroyed on
+   * release rather than reused.
+   */
+  private abandoned = false;
+
   constructor(
     public readonly sandboxId: string,
     public readonly runId: string,
@@ -167,6 +185,40 @@ export class EngineHandle {
 
   get stderr(): NodeJS.ReadableStream | null {
     return this.proc.stderr;
+  }
+
+  /**
+   * True once an operation on this handle failed at the transport level.
+   * Exposed for tests and for callers that want to log why an engine was
+   * destroyed instead of pooled.
+   */
+  get isAbandoned(): boolean {
+    return this.abandoned;
+  }
+
+  /**
+   * Send one operation to the engine, bounding the wait by the budget we
+   * told the engine to honour rather than by the RPC client's default.
+   *
+   * The engine does not enforce `timeoutInSeconds` itself (upstream relies
+   * on its worker killing the sandbox), so this deadline is the only thing
+   * bounding a hung piece -- which is exactly why exceeding it marks the
+   * engine abandoned and gets it destroyed on release.
+   */
+  private async send(operation: EngineOperationEnvelope): Promise<EngineResponse<unknown>> {
+    this.inFlight++;
+    try {
+      return await this.engineClient.executeOperation(operation, {
+        timeoutMs: ackTimeoutMsForOperation(operation),
+      });
+    } catch (e) {
+      // Transport-level failure: we stopped waiting, the engine did not stop
+      // working. Never reuse this process.
+      this.abandoned = true;
+      throw e;
+    } finally {
+      this.inFlight--;
+    }
   }
 
   /**
@@ -217,7 +269,16 @@ export class EngineHandle {
     if (opts.executionState !== undefined) baseExecuteFlowOptions.executionState = opts.executionState;
 
     const operation = buildExecuteFlowOperation(baseExecuteFlowOptions);
-    await this.engineClient.executeOperation(operation);
+    const reply = await this.send(operation);
+    // A non-OK status means the engine bailed out of the operation itself --
+    // it threw before (or instead of) recording the failure on the run. It
+    // never uploads a terminal run log in that case, so swallowing this
+    // status leaves the caller polling a row that will never settle. Upstream
+    // attaches the inspected error; surface it verbatim.
+    if (reply.status !== "OK") {
+      const detail = typeof reply.error === "string" && reply.error.length > 0 ? `: ${reply.error}` : "";
+      throw new Error(`executeFlow(run ${this.runId}) -> ${reply.status}${detail}`);
+    }
 
     const run = getFlowRun(this.runId);
     if (!run) throw new Error(`flow_run ${this.runId} disappeared after executeFlow`);
@@ -275,9 +336,10 @@ export class EngineHandle {
     if (opts.timeoutInSeconds !== undefined) merged.timeoutInSeconds = opts.timeoutInSeconds;
 
     const op = buildExecuteTriggerHookOperation(merged);
-    const reply = await this.engineClient.executeOperation(op);
+    const reply = await this.send(op);
     if (reply.status !== "OK") {
-      throw new Error(`executeTriggerHook(${hookType}) -> ${reply.status}`);
+      const detail = typeof reply.error === "string" && reply.error.length > 0 ? `: ${reply.error}` : "";
+      throw new Error(`executeTriggerHook(${hookType}) -> ${reply.status}${detail}`);
     }
     return reply.response;
   }
@@ -313,10 +375,11 @@ export class EngineHandle {
       baseOpts.timeoutInSeconds = opts.timeoutInSeconds;
     }
     const op = buildExtractPieceMetadataOperation(baseOpts);
-    const reply = await this.engineClient.executeOperation(op);
+    const reply = await this.send(op);
     if (reply.status !== "OK") {
+      const detail = typeof reply.error === "string" && reply.error.length > 0 ? `: ${reply.error}` : "";
       throw new Error(
-        `extractPieceMetadata(${opts.pieceName}@${opts.pieceVersion}) -> ${reply.status}`,
+        `extractPieceMetadata(${opts.pieceName}@${opts.pieceVersion}) -> ${reply.status}${detail}`,
       );
     }
     return reply.response as import("../../runtime/piece-catalog").RawPieceMetadata;
@@ -327,8 +390,19 @@ export class EngineHandle {
    * sandbox in the registry so subsequent calls from a zombie engine are
    * rejected. When the runtime is pooled, the runtime supplies a different
    * strategy that returns the engine to the idle slot.
+   *
+   * The pooled strategy is bypassed when this handle abandoned an operation
+   * or still has one in flight. Parking such an engine is what turns one
+   * slow flow into a cascade: the next acquire rebinds the sandbox to a new
+   * run, so the still-running operation's `uploadRunLog` is dropped by the
+   * runId guard (its run hangs in RUNNING forever) and a retry re-issues the
+   * same flow into a process already executing it -- duplicating whatever
+   * side effects the flow performs.
    */
   async release(): Promise<void> {
+    if (this.abandoned || this.inFlight > 0) {
+      return this.killAndTerminate();
+    }
     return this.releaseImpl();
   }
 

--- a/src/workflows/runner/engine-runtime/operation-builder.ts
+++ b/src/workflows/runner/engine-runtime/operation-builder.ts
@@ -71,7 +71,61 @@ export interface ExecuteFlowOptions {
   executionState?: { steps: Record<string, unknown>; tags?: string[] };
 }
 
-const DEFAULT_TIMEOUT_S = 600;
+/**
+ * Per-operation budget handed to the engine. The engine itself does NOT
+ * enforce this (upstream relies on its worker killing the sandbox); it is
+ * the daemon that must hold the deadline. `EngineHandle` derives the RPC ack
+ * timeout from whatever value ends up on the operation, so this constant is
+ * the single knob that bounds how long a flow may run.
+ *
+ * Override via `JARVIS_WORKFLOW_FLOW_TIMEOUT_SECONDS` for deployments that
+ * want to fail long flows sooner (or allow longer ones).
+ */
+export const DEFAULT_TIMEOUT_S = parsePositiveIntEnv(
+  process.env["JARVIS_WORKFLOW_FLOW_TIMEOUT_SECONDS"],
+  600,
+);
+
+function parsePositiveIntEnv(raw: string | undefined, fallback: number): number {
+  if (!raw) return fallback;
+  const n = parseInt(raw, 10);
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+
+/**
+ * Slack added on top of an operation's `timeoutInSeconds` when deriving the
+ * RPC ack deadline. The engine needs a little room past the flow's own budget
+ * to serialize the final execution state, PUT the zstd log backup, and send
+ * the terminal `uploadRunLog` before it replies to EXECUTE_FLOW. Waiting
+ * exactly `timeoutInSeconds` would race that tail and abandon runs that were
+ * about to report success.
+ */
+export const ENGINE_ACK_MARGIN_MS = 30_000;
+
+/**
+ * Budget for the control-plane operations -- trigger hooks and piece-metadata
+ * extraction. These are short by nature (register a webhook, poll a trigger,
+ * import a piece module), and they sit on latency-sensitive paths: a stuck
+ * poll blocks that flow's polling for the whole budget, and extraction is
+ * already bounded daemon-side at 10s per piece by `buildPieceCatalog`.
+ *
+ * Kept separate from the flow budget on purpose. Flows legitimately run for
+ * minutes; hooks that take minutes are hung, and waiting out a flow-sized
+ * deadline for them would trade one stall for another.
+ */
+export const CONTROL_OPERATION_TIMEOUT_S = 60;
+
+/**
+ * The ack deadline for an operation envelope: the budget we told the engine,
+ * plus the flush margin. Falls back to the default budget when an operation
+ * carries no explicit `timeoutInSeconds` (never the case for the builders
+ * here, but callers may hand-roll envelopes).
+ */
+export function ackTimeoutMsForOperation(envelope: EngineOperationEnvelope): number {
+  const raw = envelope.operation["timeoutInSeconds"];
+  const seconds = typeof raw === "number" && Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_TIMEOUT_S;
+  return seconds * 1000 + ENGINE_ACK_MARGIN_MS;
+}
 
 export function buildExecuteFlowOperation(opts: ExecuteFlowOptions): EngineOperationEnvelope {
   const executionType = opts.executionType ?? "BEGIN";
@@ -141,7 +195,7 @@ export function buildExtractPieceMetadataOperation(
       engineToken: opts.engineToken,
       internalApiUrl: ensureTrailingSlash(opts.internalApiUrl),
       publicApiUrl: ensureApiSuffix(opts.publicApiUrl ?? opts.internalApiUrl),
-      timeoutInSeconds: opts.timeoutInSeconds ?? DEFAULT_TIMEOUT_S,
+      timeoutInSeconds: opts.timeoutInSeconds ?? CONTROL_OPERATION_TIMEOUT_S,
     },
   };
 }
@@ -191,7 +245,7 @@ export function buildExecuteTriggerHookOperation(
     engineToken: opts.engineToken,
     internalApiUrl: ensureTrailingSlash(opts.internalApiUrl),
     publicApiUrl: ensureApiSuffix(opts.publicApiUrl ?? opts.internalApiUrl),
-    timeoutInSeconds: opts.timeoutInSeconds ?? DEFAULT_TIMEOUT_S,
+    timeoutInSeconds: opts.timeoutInSeconds ?? CONTROL_OPERATION_TIMEOUT_S,
     webhookUrl: opts.webhookUrl ?? "",
   };
   if (opts.triggerPayload !== undefined) op.triggerPayload = opts.triggerPayload;

--- a/src/workflows/runner/handler.test.ts
+++ b/src/workflows/runner/handler.test.ts
@@ -154,7 +154,11 @@ describe("RUN_FLOW handler with custom executor", () => {
     await worker.drain();
     const after = getFlowRun(runId);
     expect(after?.status).toBe("FAILED");
-    expect(after?.failedStep).toEqual({ name: "step2", displayName: "Send Email" });
+    expect(after?.failedStep).toEqual({
+      name: "step2",
+      displayName: "Send Email",
+      errorMessage: "step2 blew up",
+    });
     expect(after?.steps).toEqual({ step1: { output: "ok" }, step2: { error: "blew up" } });
     expect(after?.stepsCount).toBe(2);
   });
@@ -182,6 +186,8 @@ describe("RUN_FLOW handler with custom executor", () => {
     const after = getFlowRun(run.id);
     expect(after?.status).toBe("FAILED");
     expect(after?.failedStep?.name).toBe("<engine>");
+    // The reason must survive onto the run row, not just the daemon log.
+    expect(after?.failedStep?.errorMessage).toBe("network blip");
   });
 
   test("clears failed_step from a prior attempt before retry", async () => {

--- a/src/workflows/runner/handler.ts
+++ b/src/workflows/runner/handler.ts
@@ -209,18 +209,23 @@ export function createRunFlowHandler(opts: CreateRunFlowHandlerOptions): JobHand
       }
     } catch (e) {
       const ts = now();
+      // Persist the reason, not just the step. Both branches used to record a
+      // bare `{name, displayName}`, so an operator looking at a failed run saw
+      // "engine" and nothing else -- the actual message (RPC timeout, engine
+      // rejection, ...) lived only in the daemon log.
+      const errorMessage = e instanceof Error ? e.message : String(e);
       if (e instanceof FlowExecutionError) {
         updateRun(runId, {
           status: "FAILED",
           steps: e.steps,
           stepsCount: Object.keys(e.steps).length,
-          failedStep: e.failedStep,
+          failedStep: { ...e.failedStep, errorMessage },
           finishTime: ts,
         });
       } else {
         updateRun(runId, {
           status: "FAILED",
-          failedStep: { name: "<engine>", displayName: "engine" },
+          failedStep: { name: "<engine>", displayName: "engine", errorMessage },
           finishTime: ts,
         });
       }

--- a/src/workflows/sandbox-api/contracts.ts
+++ b/src/workflows/sandbox-api/contracts.ts
@@ -123,11 +123,35 @@ export type EngineOperationType =
 export interface EngineResponse<T> {
   status: "OK" | "USER_FAILURE" | "INTERNAL_ERROR" | "TIMEOUT" | "MEMORY_ISSUE" | "LOG_SIZE_EXCEEDED";
   response: T;
+  /**
+   * Inspected error string the engine attaches when an operation throws
+   * before it could record the failure on the run itself (see upstream
+   * `engine/src/lib/operations/index.ts`). Populated alongside a non-OK
+   * status; callers should surface it verbatim -- it is often the only
+   * description of why a flow never started.
+   */
+  error?: string;
+}
+
+/**
+ * Per-call knobs for a daemon -> engine call. `timeoutMs` overrides the RPC
+ * client's default ack timeout for this one operation; the engine sees no
+ * difference (it is a client-side deadline only).
+ *
+ * Needed because a single ack timeout cannot fit every operation: metadata
+ * extraction is a sub-second call, while EXECUTE_FLOW may legitimately run
+ * for the flow's whole `timeoutInSeconds` budget.
+ */
+export interface EngineCallOptions {
+  timeoutMs?: number;
 }
 
 export interface EngineContract {
-  executeOperation(input: {
-    operationType: EngineOperationType;
-    operation: Record<string, unknown>;
-  }): Promise<EngineResponse<unknown>>;
+  executeOperation(
+    input: {
+      operationType: EngineOperationType;
+      operation: Record<string, unknown>;
+    },
+    opts?: EngineCallOptions,
+  ): Promise<EngineResponse<unknown>>;
 }

--- a/src/workflows/sandbox-api/rpc.test.ts
+++ b/src/workflows/sandbox-api/rpc.test.ts
@@ -1,0 +1,70 @@
+/**
+ * RPC client/server helpers. The per-call ack timeout is the interesting
+ * part: a single client-wide default cannot bound both a sub-second metadata
+ * extraction and a ten-minute flow, and using the default for EXECUTE_FLOW
+ * is what made every long flow fail at exactly 60s.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { createRpcClient } from "./rpc";
+
+interface Contract {
+  doThing(input: unknown, opts?: { timeoutMs?: number }): Promise<unknown>;
+}
+
+/** Records the timeout each call asks for; always acks successfully. */
+function stubSocket(): {
+  socket: Parameters<typeof createRpcClient>[0];
+  timeouts: number[];
+} {
+  const timeouts: number[] = [];
+  const socket = {
+    emit: () => undefined,
+    on: () => undefined,
+    timeout(ms: number) {
+      timeouts.push(ms);
+      return { emitWithAck: async () => "ok" };
+    },
+  };
+  return { socket: socket as Parameters<typeof createRpcClient>[0], timeouts };
+}
+
+describe("createRpcClient per-call timeout", () => {
+  test("uses the client default when no override is given", async () => {
+    const { socket, timeouts } = stubSocket();
+    const client = createRpcClient<Contract>(socket, 60_000);
+    await client.doThing({});
+    expect(timeouts).toEqual([60_000]);
+  });
+
+  test("an override replaces the default for that call only", async () => {
+    const { socket, timeouts } = stubSocket();
+    const client = createRpcClient<Contract>(socket, 60_000);
+    await client.doThing({}, { timeoutMs: 630_000 });
+    await client.doThing({});
+    expect(timeouts).toEqual([630_000, 60_000]);
+  });
+
+  test("a non-positive override falls back to the default", async () => {
+    const { socket, timeouts } = stubSocket();
+    const client = createRpcClient<Contract>(socket, 60_000);
+    await client.doThing({}, { timeoutMs: 0 });
+    expect(timeouts).toEqual([60_000]);
+  });
+
+  test("the timeout error names the deadline that was actually applied", async () => {
+    const socket = {
+      emit: () => undefined,
+      on: () => undefined,
+      timeout: () => ({
+        emitWithAck: async () => {
+          throw new Error("operation has timed out");
+        },
+      }),
+    } as unknown as Parameters<typeof createRpcClient>[0];
+    const client = createRpcClient<Contract>(socket, 60_000);
+    await expect(client.doThing({}, { timeoutMs: 630_000 })).rejects.toThrow(
+      /timeout: 630000ms/,
+    );
+  });
+});

--- a/src/workflows/sandbox-api/rpc.ts
+++ b/src/workflows/sandbox-api/rpc.ts
@@ -58,14 +58,34 @@ const NON_RPC_KEYS: ReadonlySet<string | symbol> = new Set<string | symbol>([
   Symbol.asyncIterator,
 ]);
 
+/**
+ * Per-call overrides. The ack timeout is the only thing a caller can vary --
+ * the wire envelope (`{method, payload}`) is unchanged, so this stays
+ * compatible with the engine's own `createRpcServer`.
+ *
+ * Callers pass this when the default client timeout is the wrong bound for
+ * one particular operation: EXECUTE_FLOW, for instance, must be allowed to
+ * take as long as the flow's own `timeoutInSeconds` budget rather than the
+ * client-wide default (see `EngineHandle.executeFlow`).
+ */
+export interface RpcCallOptions {
+  timeoutMs?: number;
+}
+
 export function createRpcClient<T extends Contract>(socket: RpcSocket, timeoutMs: number): T {
   return new Proxy({} as T, {
     get(_target, method) {
       if (NON_RPC_KEYS.has(method)) return undefined;
       const name = typeof method === "symbol" ? method.description ?? "" : method;
-      return async (payload: unknown) => {
+      return async (payload: unknown, callOpts?: RpcCallOptions) => {
+        const effectiveTimeoutMs =
+          callOpts?.timeoutMs !== undefined && callOpts.timeoutMs > 0
+            ? callOpts.timeoutMs
+            : timeoutMs;
         try {
-          const result = await socket.timeout(timeoutMs).emitWithAck(RPC_EVENT, { method: name, payload });
+          const result = await socket
+            .timeout(effectiveTimeoutMs)
+            .emitWithAck(RPC_EVENT, { method: name, payload });
           if (isRpcErrorEnvelope(result)) {
             throw new Error(`RPC [${name}] handler threw: ${result.__rpcError}`);
           }
@@ -73,7 +93,7 @@ export function createRpcClient<T extends Contract>(socket: RpcSocket, timeoutMs
         } catch (error) {
           if (error instanceof Error && error.message.startsWith("RPC [")) throw error;
           const message = error instanceof Error ? error.message : String(error);
-          throw new Error(`RPC [${name}] failed (timeout: ${timeoutMs}ms): ${message}`);
+          throw new Error(`RPC [${name}] failed (timeout: ${effectiveTimeoutMs}ms): ${message}`);
         }
       };
     },

--- a/src/workflows/sandbox-api/worker-handlers.ts
+++ b/src/workflows/sandbox-api/worker-handlers.ts
@@ -19,9 +19,35 @@ import type {
   UpdateStepProgressRequest,
   UploadRunLogsRequest,
 } from "./contracts";
-import { getFlowRun, updateRun } from "../db/repos/flow-run";
+import { getFlowRun, updateRun, type FlowRunStatus } from "../db/repos/flow-run";
 
 const PER_RUN_LOG_BUFFER_MAX = 200;
+
+/**
+ * Statuses a run never leaves on its own. Once the row reads one of these,
+ * the attempt that produced it is over and late engine chatter must not
+ * drag it back to RUNNING.
+ *
+ * The engine's 15-second backup loop keeps sending `uploadRunLog` with
+ * `status: RUNNING` for as long as its process is alive. If the daemon has
+ * already given up on that operation and marked the run FAILED, an
+ * unguarded write flips the row back to RUNNING -- permanently, since
+ * nothing else will ever touch it again. That is the "zombie stuck in
+ * RUNNING" failure mode.
+ *
+ * PAUSED is deliberately NOT here: a paused run is resumed under the same
+ * runId, and its resume attempt legitimately reports RUNNING again.
+ */
+const TERMINAL_RUN_STATUSES: ReadonlySet<FlowRunStatus> = new Set<FlowRunStatus>([
+  "SUCCEEDED",
+  "FAILED",
+  "INTERNAL_ERROR",
+  "TIMEOUT",
+  "QUOTA_EXCEEDED",
+  "STOPPED",
+  "MEMORY_LIMIT_EXCEEDED",
+  "SCHEDULE_FAILURE",
+]);
 
 export interface WorkerHandlersOptions {
   registry: SandboxRegistry;
@@ -68,9 +94,36 @@ export class DefaultWorkerHandlers
     return record?.runId ?? null;
   }
 
+  /**
+   * True when this engine message would drag an already-settled run BACK to
+   * a non-terminal state -- the zombie case. A missing row also counts:
+   * there is nothing to update, and re-creating one from an engine message
+   * is not something these handlers do.
+   *
+   * Deliberately narrow. A settled run still accepts a terminal message,
+   * because that is the normal end of a run: the engine reports the final
+   * verdict via `updateRunProgress` first and only then sends the
+   * `uploadRunLog` carrying `failedStep` / `stepsCount` / `finishTime`.
+   * Rejecting the whole message once the row reads FAILED would throw that
+   * detail away and leave the run history showing a failure with no step
+   * and no reason.
+   */
+  private isStaleWrite(runId: string, incoming: FlowRunStatus): boolean {
+    if (TERMINAL_RUN_STATUSES.has(incoming)) return false;
+    try {
+      const row = getFlowRun(runId);
+      if (!row) return true;
+      return TERMINAL_RUN_STATUSES.has(row.status);
+    } catch {
+      return true;
+    }
+  }
+
   async updateRunProgress(sandboxId: string, input: UpdateRunProgressRequest): Promise<void> {
     if (!this.requireRunId(sandboxId)) return;
     this.lastProgress.set(sandboxId, input);
+    // Late progress from an engine whose run the daemon already settled.
+    if (this.isStaleWrite(input.flowRun.id, input.flowRun.status)) return;
     // Persist in-flight status. In TESTING mode the engine also streams per-
     // step output via `input.step` -- accumulate it onto the run's `steps`
     // record so callers reading `flow_run.steps[stepName].output` see the
@@ -102,9 +155,17 @@ export class DefaultWorkerHandlers
     const runId = this.requireRunId(sandboxId);
     if (!runId) return;
     if (input.runId !== runId) return; // mismatch: engine talking about a different run
+    if (this.isStaleWrite(input.runId, input.status)) return; // don't resurrect a settled run
 
     const patch: Parameters<typeof updateRun>[1] = { status: input.status };
-    if (input.failedStep) patch.failedStep = input.failedStep;
+    if (input.failedStep) {
+      // The engine's wire shape carries the detail as `message`; the run row
+      // reads it back as `errorMessage` (see FailedStep in repos/flow-run).
+      // Without this mapping the detail is written under a key nothing reads
+      // and the run history shows a bare step name with no reason.
+      const { name, displayName, message } = input.failedStep;
+      patch.failedStep = message ? { name, displayName, errorMessage: message } : { name, displayName };
+    }
     if (input.stepsCount !== undefined) patch.stepsCount = input.stepsCount;
     if (input.finishTime) patch.finishTime = Date.parse(input.finishTime);
     if (input.startTime) patch.startTime = Date.parse(input.startTime);

--- a/src/workflows/sandbox-api/worker-rpc.test.ts
+++ b/src/workflows/sandbox-api/worker-rpc.test.ts
@@ -13,7 +13,7 @@ import { io as socketIoClient } from "socket.io-client";
 import { closeWorkflowDb, initWorkflowDb } from "../db";
 import { createFlow } from "../db/repos/flow";
 import { createDraftVersion, lockVersion } from "../db/repos/flow-version";
-import { createFlowRun, getFlowRun } from "../db/repos/flow-run";
+import { createFlowRun, getFlowRun, updateRun } from "../db/repos/flow-run";
 import { DEFAULT_IDS } from "../db/schema";
 import { CredentialResolver } from "../credentials/adapter";
 import { EngineTokenSigner } from "./engine-token";
@@ -181,6 +181,120 @@ describe("WorkerRpcServer (B4: socket.io engine <-> daemon)", () => {
       const updated = getFlowRun(sb.runId);
       // Original status preserved (initial state is QUEUED from createFlowRun)
       expect(updated?.status).not.toBe("FAILED");
+    } finally {
+      sb.client.close();
+    }
+  });
+
+  test("uploadRunLog maps the engine's failedStep.message onto errorMessage", async () => {
+    const sb = await makeSandbox();
+    try {
+      await sb.workerClient.uploadRunLog({
+        runId: sb.runId,
+        projectId: sb.projectId,
+        status: "FAILED",
+        failedStep: { name: "step2", displayName: "Send Email", message: "boom" },
+      });
+      const updated = getFlowRun(sb.runId);
+      expect(updated?.failedStep).toEqual({
+        name: "step2",
+        displayName: "Send Email",
+        errorMessage: "boom",
+      });
+    } finally {
+      sb.client.close();
+    }
+  });
+
+  // Regression: an engine the daemon has already given up on keeps its 15s
+  // backup loop running and re-reports RUNNING. Letting that land flips a
+  // settled run back to RUNNING forever -- the "zombie run" symptom.
+  test("uploadRunLog does not resurrect a run that already settled", async () => {
+    const sb = await makeSandbox();
+    try {
+      updateRun(sb.runId, { status: "FAILED", finishTime: 999 });
+      await sb.workerClient.uploadRunLog({
+        runId: sb.runId,
+        projectId: sb.projectId,
+        status: "RUNNING",
+      });
+      expect(getFlowRun(sb.runId)?.status).toBe("FAILED");
+    } finally {
+      sb.client.close();
+    }
+  });
+
+  test("updateRunProgress does not resurrect a run that already settled", async () => {
+    const sb = await makeSandbox();
+    try {
+      updateRun(sb.runId, { status: "FAILED", finishTime: 999 });
+      await sb.workerClient.updateRunProgress({
+        flowRun: {
+          id: sb.runId,
+          status: "RUNNING",
+          flowId: sb.flowId,
+          flowVersionId: sb.flowVersionId,
+          projectId: sb.projectId,
+        },
+        step: { name: "late", path: [], output: { late: true } },
+      });
+      const after = getFlowRun(sb.runId);
+      expect(after?.status).toBe("FAILED");
+      expect(after?.steps ?? {}).not.toHaveProperty("late");
+    } finally {
+      sb.client.close();
+    }
+  });
+
+  // The normal end of a failing run: the engine reports the terminal verdict
+  // via updateRunProgress and only then sends the uploadRunLog carrying
+  // failedStep / stepsCount / finishTime. A guard that rejected everything
+  // once the row reads FAILED would drop exactly the detail the run history
+  // needs.
+  test("a settled run still accepts the engine's terminal uploadRunLog", async () => {
+    const sb = await makeSandbox();
+    try {
+      await sb.workerClient.updateRunProgress({
+        flowRun: {
+          id: sb.runId,
+          status: "FAILED",
+          flowId: sb.flowId,
+          flowVersionId: sb.flowVersionId,
+          projectId: sb.projectId,
+        },
+      });
+      expect(getFlowRun(sb.runId)?.status).toBe("FAILED");
+
+      await sb.workerClient.uploadRunLog({
+        runId: sb.runId,
+        projectId: sb.projectId,
+        status: "FAILED",
+        failedStep: { name: "step2", displayName: "Send Email", message: "boom" },
+        stepsCount: 2,
+        finishTime: new Date(456_000).toISOString(),
+      });
+      const after = getFlowRun(sb.runId);
+      expect(after?.failedStep?.name).toBe("step2");
+      expect(after?.failedStep?.errorMessage).toBe("boom");
+      expect(after?.stepsCount).toBe(2);
+      expect(after?.finishTime).toBe(456_000);
+    } finally {
+      sb.client.close();
+    }
+  });
+
+  // PAUSED is not terminal: a resumed run reports RUNNING again under the
+  // same runId, and that must still be recorded.
+  test("a PAUSED run still accepts progress from its resume attempt", async () => {
+    const sb = await makeSandbox();
+    try {
+      updateRun(sb.runId, { status: "PAUSED" });
+      await sb.workerClient.uploadRunLog({
+        runId: sb.runId,
+        projectId: sb.projectId,
+        status: "RUNNING",
+      });
+      expect(getFlowRun(sb.runId)?.status).toBe("RUNNING");
     } finally {
       sb.client.close();
     }


### PR DESCRIPTION
## Summary

Investigating a bug report against 0.9.0 ("Cybersecurity Daily Briefing — engine-level execution failure"): every run of every workflow fails after ~60s with `failedStep: engine` and 0 steps executed, one run stuck permanently in RUNNING, and the flow flagged `valid: false`.

The report attributes this to an Activepieces engine bug. It isn't one, and the flow is not being rejected. **The daemon abandons `EXECUTE_FLOW` after 60 seconds while the engine is still executing it.**

The daemon→engine RPC client is built with a flat 60s ack timeout (`worker-rpc.ts`, `engineRpcTimeoutMs ?? 60_000`, never overridden), but the operation it sends grants the engine 600 seconds (`operation-builder.ts`, `DEFAULT_TIMEOUT_S = 600`). The transport gives up at one minute on a flow budgeted for ten. Nothing cancels the engine — there is no cancel message in `EngineContract` — so it keeps running the flow after the daemon has written the run off.

The reported flow's second step delegates to a sub-agent, which runs a full tool-using LLM loop synchronously inside that RPC (`routes/jarvis-agent.ts`). It exceeds 60s essentially every time. Hence "every run fails".

## How each reported symptom follows

- **`failedStep: engine`** — the rejected RPC surfaces as a plain `Error`, so `createRunFlowHandler` takes its generic branch and stamps `{ name: "<engine>", displayName: "engine" }`. No message was persisted, which is why the report has no detail beyond "engine".
- **"0 steps executed"** — that branch never writes `steps`, so the run shows zero regardless of how far the engine actually got. Steps 1 and 2 very likely did run. "The engine rejects the flow before step 1" is an artifact of this reporting gap, not an observation.
- **"~60 seconds (185s in some runs)"** — RUN_FLOW jobs default to `maxAttempts: 3` with a 1s base and ×4 exponential backoff, and the run row preserves `start_time` across attempts. Three attempts: `60 + 1 + 60 + 4 + 60 = 185s` exactly. The 60s is one attempt; the 185s is the whole run.
- **"1 stuck in RUNNING (zombie)"** — two compounding defects. On timeout, `EngineFlowExecutor`'s `finally { await handle.release() }` parked the still-busy engine in the warm pool (`returnToPoolOrKill` only checked `proc.alive()`). Meanwhile the abandoned engine's 15-second backup loop kept calling `uploadRunLog` with `status: RUNNING`, which `worker-handlers.ts` wrote blindly — a late RUNNING overwrote the FAILED the daemon had already recorded, pinning the row in RUNNING forever.
- **Undetected, worse:** retry attempt 2 acquired that same parked engine and re-sent `EXECUTE_FLOW` for a flow already executing inside it. The reported flow's third step publishes to a content pipeline, so this is a path to duplicate publishes, not just failures.

**`valid: false` is a red herring.** It is a local SQLite column defaulting to `0`; the only writer is the PATCH route, and neither the composer nor publish ever sets it true, so every flow reads `valid: false`. The adapter forwards it to the engine and the engine never reads it (`flow.operation.ts`, `engine-constants.ts`). Zero effect on execution.

## Verification

Probed the mechanism against the real `WorkerRpcServer` and a real socket.io client (short timeout for speed; production value is the 60s default):

```
executeOperation REJECTED after 1505 ms: RPC [executeOperation] failed (timeout: 1500ms): operation has timed out
engine finished at that moment? false
engine kept executing after daemon gave up? true
```

## Changes

**1. Ack deadline derived from the flow budget** — `rpc.ts`, `contracts.ts`, `operation-builder.ts`, `engine-runtime.ts`
`createRpcClient` accepts a per-call ack timeout; `EngineHandle` derives it from the budget it hands the engine (`timeoutInSeconds × 1000` + a 30s flush margin, so the engine can serialize its final state and send the terminal `uploadRunLog` before replying). Overridable via `JARVIS_WORKFLOW_FLOW_TIMEOUT_SECONDS`. The wire envelope is unchanged — this is a client-side deadline only.

Trigger hooks and piece-metadata extraction deliberately keep a short 60s budget (`CONTROL_OPERATION_TIMEOUT_S`). They sit on latency-sensitive paths — a hung poll blocks that flow's polling for the whole budget, since `pollingInFlight` prevents re-entry — and extraction is already bounded daemon-side at 10s per piece. Only flows get the longer deadline.

**2. Abandoned engines are destroyed, not pooled** — `engine-runtime.ts`
`EngineHandle` tracks in-flight operations and a transport-failure flag; `release()` bypasses the pool strategy and kills when either is set. The engine does not enforce `timeoutInSeconds` itself (upstream relies on its worker killing the sandbox), so this deadline is the only bound on a hung piece — which is exactly why exceeding it must destroy the process rather than recycle it.

**3. Engine rejections surface instead of being swallowed** — `engine-runtime.ts`, `contracts.ts`
`executeFlow` ignored `reply.status`, unlike `executeTriggerHook`. Any engine-side throw becomes `{status: INTERNAL_ERROR, error: inspect(err)}` (`operations/index.ts`) and never produces a terminal run log, so swallowing it left the caller polling a row that would never settle — resurfacing 60s later as a contentless `waitForTerminalStatus` timeout. Now checked, with the engine's `error` string included.

**4. Settled runs cannot be resurrected** — `worker-handlers.ts`
Late non-terminal writes onto a terminal run are dropped. Deliberately narrow: a settled run still accepts a terminal message, because that is the normal end of a run — the engine reports the final verdict via `updateRunProgress` first and only then sends the `uploadRunLog` carrying `failedStep`/`stepsCount`/`finishTime`. PAUSED is not treated as terminal, since a resumed run legitimately reports RUNNING again under the same runId.

Also maps the engine's `failedStep.message` onto the row's `errorMessage`. Upstream's wire shape is `{name, displayName, message}` while `repos/flow-run` reads `errorMessage`, so the engine's own failure detail was being written under a key nothing reads.

**5. Failure reasons persist on the run** — `handler.ts`
Both catch branches now record `errorMessage`, so a failed run says why rather than just `engine`.

## Testing

`bun test`: 2014 pass, 18 skip, 0 fail. `tsc --noEmit` clean.

New coverage:
- `engine-handle-lifecycle.test.ts` — fakes `EngineContract`, so it runs without the engine bundle on disk: derived deadline, the short control-plane deadline, non-OK replies surfacing, abandoned/in-flight engines being destroyed rather than pooled.
- `rpc.test.ts` — per-call timeout override, fallback, and the deadline named in the timeout error.
- `worker-rpc.test.ts` — the zombie guard on both handlers, PAUSED still accepting progress, terminal `uploadRunLog` still landing on a settled run, and the `message` → `errorMessage` mapping.

The engine-bundle end-to-end suites remain gated behind `JARVIS_TEST_ENGINE_BUILD=1` and were skipped locally.

## Notes for review

- **A hung flow now fails slower.** Each attempt holds a worker slot ~630s instead of 60s, ×3 retries. That is the cost of honoring the declared 600s budget. For a cautious first deploy, set `JARVIS_WORKFLOW_FLOW_TIMEOUT_SECONDS=180` and raise it once a run completes cleanly.
- **Retries of non-idempotent flows.** Now that flows can run to completion, a failure at minute 10 is retried twice against a flow that may have already published. Pre-existing, but previously masked by everything dying at 60s. Worth considering `maxAttempts: 1` for RUN_FLOW.
- **Piece-catalog pre-warm.** An extraction exceeding its 10s daemon-side bound now kills the engine at release rather than parking it warm, losing the "pre-warm for free" effect in that one case. Intentional — that engine is stuck on a piece import.
- **Not addressed here** (separate, latent): `flow-version-adapter.ts` hardcodes `pieceVersion: "0.0.0"` and discards the stored value (harmless today, since the loader trims the version before resolving), and `valid` is never set true by any writer.

## Confirming against the reporter's instance

The original logs are still outstanding. The daemon log line `job <id> (RUN_FLOW) failed:` distinguishes the two 60s paths: `RPC [executeOperation] failed (timeout: 60000ms)` is the transport ceiling this PR fixes; `did not reach terminal status within 60000ms` is the swallowed-rejection path that change 3 fixes. Both are addressed, so the logs confirm the diagnosis rather than change the fix — and after this PR the next failure carries an actual message instead of a bare `engine`.
