### PR TITLE
fix(keychain): resolve the store through JARVIS_HOME and relocate it at boot

### DIFF
--- a/src/cli/backup.test.ts
+++ b/src/cli/backup.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from 'node:os';
 import { Database } from 'bun:sqlite';
 import { cmdExport, cmdRestore, EXPORT_FORMAT, type ExportManifest } from './backup.ts';
 import { acquireLockAt } from '../daemon/pid.ts';
+import { getSecret, setSecrets } from '../vault/keychain.ts';
 
 /**
  * cmdExport/cmdRestore resolve the data dir through loadConfig(), which honors
@@ -59,6 +60,7 @@ async function tarEntries(archive: string): Promise<string[]> {
 let root: string;
 let dataDir: string;
 let prevHome: string | undefined;
+let prevSecretsDir: string | undefined;
 
 beforeEach(() => {
   root = mkdtempSync(join(tmpdir(), 'jarvis-backup-test-'));
@@ -66,11 +68,17 @@ beforeEach(() => {
   seedDataDir(dataDir);
   prevHome = process.env.JARVIS_HOME;
   process.env.JARVIS_HOME = dataDir;
+  // Pin the keychain to the throwaway dir as well: export resolves it rather
+  // than assuming data_dir, and must never reach the real ~/.jarvis store.
+  prevSecretsDir = process.env.JARVIS_SECRETS_DIR;
+  process.env.JARVIS_SECRETS_DIR = dataDir;
 });
 
 afterEach(() => {
   if (prevHome === undefined) delete process.env.JARVIS_HOME;
   else process.env.JARVIS_HOME = prevHome;
+  if (prevSecretsDir === undefined) delete process.env.JARVIS_SECRETS_DIR;
+  else process.env.JARVIS_SECRETS_DIR = prevSecretsDir;
   rmSync(root, { recursive: true, force: true });
 });
 
@@ -112,6 +120,49 @@ describe('jarvis export', () => {
     expect(entries).toContain('.secrets.enc');
     expect(entries).toContain('.secrets.key');
     expect(entries).not.toContain('config.yaml');
+  });
+
+  test('--full picks the keychain up from where it actually lives, not from data_dir', async () => {
+    // An install the daemon has not relocated yet keeps its keychain outside
+    // the data dir. Since it is the only place any API key exists, an archive
+    // without it restores to a brain with no credentials.
+    rmSync(join(dataDir, '.secrets.enc'), { force: true });
+    rmSync(join(dataDir, '.secrets.key'), { force: true });
+    const elsewhere = join(root, 'elsewhere');
+    mkdirSync(elsewhere, { recursive: true });
+    process.env.JARVIS_SECRETS_DIR = elsewhere;
+    setSecrets({ 'llm.provider.openai.api_key': 'sk-elsewhere' });
+
+    const archive = join(root, 'resolved.tar');
+    expect(await cmdExport(['--out', archive, '--full'], capture().io)).toBe(0);
+    expect(await tarEntries(archive)).toContain('.secrets.enc');
+
+    // ...and restore puts it where the daemon reads it, not merely into
+    // data_dir: a keychain restored somewhere unread is a brain with no
+    // credentials, discovered when the first LLM call fails.
+    const readAt = join(root, 'read-at');
+    mkdirSync(readAt, { recursive: true });
+    process.env.JARVIS_SECRETS_DIR = readAt;
+    expect(await cmdRestore([archive], capture().io)).toBe(0);
+    expect(getSecret('llm.provider.openai.api_key')).toBe('sk-elsewhere');
+    expect(existsSync(join(dataDir, '.secrets.enc'))).toBe(false);
+  });
+
+  test('restore leaves an existing keychain alone and says so', async () => {
+    const archive = join(root, 'full.tar');
+    expect(await cmdExport(['--out', archive, '--full'], capture().io)).toBe(0);
+
+    const readAt = join(root, 'occupied');
+    mkdirSync(readAt, { recursive: true });
+    await Bun.write(join(readAt, '.secrets.enc'), 'ALREADY-HERE\n');
+    process.env.JARVIS_SECRETS_DIR = readAt;
+
+    const { err } = capture();
+    const io = { out: () => {}, err: (l: string) => err.push(l) };
+    expect(await cmdRestore([archive], io)).toBe(0);
+
+    expect(await Bun.file(join(readAt, '.secrets.enc')).text()).toBe('ALREADY-HERE\n');
+    expect(err.join('\n')).toContain('warning: the restored keychain stayed in');
   });
 
   test('a symlinked entry is dereferenced: the archive holds real data', async () => {
@@ -402,7 +453,7 @@ describe('bin dispatch (subprocess)', () => {
   test('jarvis export --out - streams a valid tar to stdout', async () => {
     const repoRoot = join(import.meta.dir, '..', '..');
     const proc = Bun.spawn(['bun', join(repoRoot, 'bin', 'jarvis.ts'), 'export', '--out', '-', '--full'], {
-      env: { ...process.env, JARVIS_HOME: dataDir },
+      env: { ...process.env, JARVIS_HOME: dataDir, JARVIS_SECRETS_DIR: dataDir },
       stdout: 'pipe',
       stderr: 'pipe',
     });

--- a/src/cli/backup.ts
+++ b/src/cli/backup.ts
@@ -23,6 +23,13 @@
  * backups use; the default keeps the archive far less sensitive for
  * user-facing downloads (the DB it carries has no API key in it).
  *
+ * The keychain pair is staged from wherever `keychainDir()` resolves — the
+ * data dir on a JARVIS_HOME install the daemon has migrated, ~/.jarvis
+ * otherwise — because it is now the ONLY place any API key exists and an
+ * archive missing it restores to a brain with no credentials. The remaining
+ * secret entries are still ~/.jarvis-only; the legacy-root warning further
+ * down covers them.
+ *
  * Restore is stop-before-restore: it acquires the daemon's own flock (which
  * is JARVIS_HOME-aware, same resolution the daemon uses) plus the data dir's,
  * and HOLDS them until the swap is done — a running daemon makes restore
@@ -62,6 +69,7 @@ import { homedir } from 'node:os';
 import { Database } from 'bun:sqlite';
 import { loadConfig } from '../config/loader.ts';
 import { acquireLockAt, lockPathFor } from '../daemon/pid.ts';
+import { keychainDir, migrateKeychain } from '../vault/keychain.ts';
 import { getInstalledVersion } from './version.ts';
 
 interface CliIo {
@@ -197,17 +205,27 @@ export async function cmdExport(args: string[], io: CliIo = defaultIo): Promise<
       io.err(`Snapshotting database (${dbPath})...`);
       snapshotDb(dbPath, join(staging, 'jarvis.db'));
 
+      // The keychain is RESOLVED, not assumed: it sits in the data dir once
+      // the daemon has migrated it there, and in ~/.jarvis before that. Taking
+      // it from wherever it actually is keeps `--full` complete either way —
+      // and it is now the only place any API key exists.
+      const secretsDir = keychainDir();
+      const sourceDir = (entry: string): string =>
+        entry === '.secrets.enc' || entry === '.secrets.key' ? secretsDir : dataDir;
+
       const entries = [...BASE_ENTRIES, ...(full ? SECRET_ENTRIES : [])].filter((e) =>
-        existsSync(join(dataDir, e)),
+        existsSync(join(sourceDir(e), e)),
       );
 
-      // Some components write secrets to the legacy `~/.jarvis` root even when
-      // data_dir points elsewhere. Silently producing a "--full" archive that
-      // is missing them would only be discovered during a real restore — warn.
+      // The remaining secrets (google tokens, sidecar keys) are still written
+      // to the legacy `~/.jarvis` root even when data_dir points elsewhere.
+      // Silently producing a "--full" archive that is missing them would only
+      // be discovered during a real restore — warn.
       if (full) {
         const legacyRoot = join(homedir(), '.jarvis');
         if (dataDir !== legacyRoot) {
           for (const entry of SECRET_ENTRIES) {
+            if (sourceDir(entry) !== dataDir) continue; // resolved above
             if (!existsSync(join(dataDir, entry)) && existsSync(join(legacyRoot, entry))) {
               io.err(
                 `warning: '${entry}' exists at ${legacyRoot} but not in ${dataDir} — it will NOT be in this archive`,
@@ -219,7 +237,7 @@ export async function cmdExport(args: string[], io: CliIo = defaultIo): Promise<
 
       for (const entry of entries) {
         try {
-          cpSync(join(dataDir, entry), join(staging, entry), { recursive: true, dereference: true });
+          cpSync(join(sourceDir(entry), entry), join(staging, entry), { recursive: true, dereference: true });
         } catch (e) {
           throw new Error(
             `staging '${entry}' failed: ${e instanceof Error ? e.message : String(e)} (a broken symlink inside it cannot be archived)`,
@@ -475,6 +493,33 @@ export async function cmdRestore(
         }
         for (const swap of swaps) swap.commit();
         rmSync(asideDir, { recursive: true, force: true });
+
+        // The daemon resolves the keychain independently of data_dir (its own
+        // dir when JARVIS_HOME is set, ~/.jarvis otherwise), so a pair restored
+        // into data_dir can land where nothing will ever read it — a brain with
+        // no credentials, discovered only when the first LLM call fails. Put it
+        // where the daemon looks; migrateKeychain copies, verifies and only then
+        // removes, so a data dir on another filesystem is fine.
+        // Never fatal: the data is already restored and committed by now, so a
+        // keychain that cannot be moved (foreign key, unwritable target) is a
+        // warning to act on, not a reason to fail a completed restore.
+        const secretsTarget = keychainDir();
+        if (secretsTarget !== dataDir && existsSync(join(dataDir, '.secrets.enc'))) {
+          try {
+            if (migrateKeychain(dataDir, secretsTarget)) {
+              io.err(`Keychain placed at ${secretsTarget} (where the daemon reads it).`);
+            } else {
+              io.err(
+                `warning: the restored keychain stayed in ${dataDir} — ${secretsTarget} already holds one and was left untouched`,
+              );
+            }
+          } catch (e) {
+            io.err(
+              `warning: the restored keychain stayed in ${dataDir} and will not be read from there `
+              + `(moving it to ${secretsTarget} failed: ${e instanceof Error ? e.message : String(e)})`,
+            );
+          }
+        }
 
         io.out(JSON.stringify({ restored: true, brainVersion: manifest.brainVersion, files: restored }));
         io.err('Restore complete. Start the daemon with: jarvis start');

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -444,6 +444,17 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
     const { seedWebappTemplates } = await import('../vault/webapp-template-seeds.ts');
     seedWebappTemplates();
 
+    // 2a-bis. Relocate a pre-JARVIS_HOME keychain into the data dir before
+    // anything reads a credential, so hydration below sees the moved store and
+    // a data-dir backup finally includes it. No-op on a normal ~/.jarvis
+    // install, and it never removes the legacy pair unless the copy verified.
+    const { migrateKeychainToDataDir } = await import('../vault/keychain.ts');
+    try {
+      migrateKeychainToDataDir();
+    } catch (err) {
+      console.error('[Daemon] Keychain relocation failed; continuing with the existing store:', err);
+    }
+
     // 2b. Load all LLM settings (providers, credentials, single-LLM default,
     // tiers) from the DB + encrypted keychain. This is the sole source of LLM
     // config - config.yaml and env vars contribute nothing.

--- a/src/vault/keychain.test.ts
+++ b/src/vault/keychain.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Keychain location + durability.
+ *
+ * The legacy dir is `~/.jarvis` and cannot be redirected (homedir() is fixed
+ * for the process), so the location rules take their dirs as arguments and are
+ * exercised against throwaway paths. Everything that writes goes through
+ * JARVIS_SECRETS_DIR, which never touches the developer's real store.
+ */
+import { test, expect, describe, beforeEach, afterEach } from 'bun:test';
+import { mkdtempSync, rmSync, mkdirSync, existsSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  getSecret,
+  setSecret,
+  setSecrets,
+  keychainDir,
+  keychainPaths,
+  migrateKeychain,
+  resolveKeychainDir,
+} from './keychain.ts';
+
+const KEY_FILE = '.secrets.key';
+const SECRETS_FILE = '.secrets.enc';
+
+describe('keychain', () => {
+  let root: string;
+  let prevSecretsDir: string | undefined;
+  let prevHome: string | undefined;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'jarvis-keychain-'));
+    prevSecretsDir = process.env.JARVIS_SECRETS_DIR;
+    prevHome = process.env.JARVIS_HOME;
+  });
+
+  afterEach(() => {
+    if (prevSecretsDir === undefined) delete process.env.JARVIS_SECRETS_DIR;
+    else process.env.JARVIS_SECRETS_DIR = prevSecretsDir;
+    if (prevHome === undefined) delete process.env.JARVIS_HOME;
+    else process.env.JARVIS_HOME = prevHome;
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  /** Populate `dir` with a real keychain holding `entries`. */
+  function seed(dir: string, entries: Record<string, string>): void {
+    mkdirSync(dir, { recursive: true });
+    process.env.JARVIS_SECRETS_DIR = dir;
+    setSecrets(entries);
+    delete process.env.JARVIS_SECRETS_DIR;
+  }
+
+  // ── location ────────────────────────────────────────────────────────────
+
+  test('JARVIS_HOME is where a fresh install stores its keychain', () => {
+    const dataDir = join(root, 'data');
+    process.env.JARVIS_HOME = dataDir;
+
+    expect(keychainDir()).toBe(dataDir);
+    setSecret('llm.provider.openai.api_key', 'sk-1');
+    expect(existsSync(join(dataDir, SECRETS_FILE))).toBe(true);
+    expect(getSecret('llm.provider.openai.api_key')).toBe('sk-1');
+  });
+
+  test('an un-migrated install keeps using the legacy pair, both halves together', () => {
+    const legacy = join(root, 'legacy');
+    const dataDir = join(root, 'data');
+    seed(legacy, { 'a.b.api_key': 'v' });
+    mkdirSync(dataDir, { recursive: true });
+
+    // The data dir has no keychain yet: the legacy one stays authoritative,
+    // rather than the key being read from one dir and the ciphertext another.
+    expect(resolveKeychainDir(dataDir, legacy)).toBe(legacy);
+
+    // Once it has one, it wins.
+    seed(dataDir, { 'a.b.api_key': 'v2' });
+    expect(resolveKeychainDir(dataDir, legacy)).toBe(dataDir);
+  });
+
+  test('a fresh install with neither pair resolves to the configured dir', () => {
+    expect(resolveKeychainDir(join(root, 'data'), join(root, 'legacy'))).toBe(join(root, 'data'));
+  });
+
+  test('JARVIS_SECRETS_DIR overrides JARVIS_HOME and skips the fallback', () => {
+    process.env.JARVIS_HOME = join(root, 'data');
+    process.env.JARVIS_SECRETS_DIR = join(root, 'override');
+
+    expect(keychainDir()).toBe(join(root, 'override'));
+    setSecret('x', '1');
+    expect(keychainPaths().secretsPath).toBe(join(root, 'override', SECRETS_FILE));
+    expect(existsSync(join(root, 'data', SECRETS_FILE))).toBe(false);
+  });
+
+  // ── migration ───────────────────────────────────────────────────────────
+
+  test('migrate moves the pair and the secrets survive', () => {
+    const legacy = join(root, 'legacy');
+    const dataDir = join(root, 'data');
+    seed(legacy, { 'llm.provider.openai.api_key': 'sk-1', 'stt.groq.api_key': 'gk-1' });
+
+    expect(migrateKeychain(legacy, dataDir)).toBe(true);
+
+    expect(existsSync(join(legacy, SECRETS_FILE))).toBe(false);
+    expect(existsSync(join(legacy, KEY_FILE))).toBe(false);
+    process.env.JARVIS_SECRETS_DIR = dataDir;
+    expect(getSecret('llm.provider.openai.api_key')).toBe('sk-1');
+    expect(getSecret('stt.groq.api_key')).toBe('gk-1');
+  });
+
+  test('migrate is a no-op when the destination already has a keychain', () => {
+    const legacy = join(root, 'legacy');
+    const dataDir = join(root, 'data');
+    seed(legacy, { k: 'legacy-value' });
+    seed(dataDir, { k: 'data-value' });
+
+    expect(migrateKeychain(legacy, dataDir)).toBe(false);
+
+    process.env.JARVIS_SECRETS_DIR = dataDir;
+    expect(getSecret('k')).toBe('data-value');
+    expect(existsSync(join(legacy, SECRETS_FILE))).toBe(true);
+  });
+
+  test('migrate is a no-op when there is nothing to move', () => {
+    expect(migrateKeychain(join(root, 'legacy'), join(root, 'data'))).toBe(false);
+  });
+
+  test('a broken source pair aborts the move instead of destroying it', () => {
+    const legacy = join(root, 'legacy');
+    const dataDir = join(root, 'data');
+    seed(legacy, { k: 'v' });
+    // Key replaced with an unrelated one: the ciphertext no longer decrypts.
+    writeFileSync(join(legacy, KEY_FILE), 'ab'.repeat(32));
+
+    expect(() => migrateKeychain(legacy, dataDir)).toThrow();
+
+    // Nothing was removed, and no half-written copy was left behind.
+    expect(existsSync(join(legacy, SECRETS_FILE))).toBe(true);
+    expect(existsSync(join(dataDir, SECRETS_FILE))).toBe(false);
+  });
+
+  // ── durability ──────────────────────────────────────────────────────────
+
+  test('a save leaves no temp file behind', () => {
+    const dir = join(root, 'data');
+    process.env.JARVIS_SECRETS_DIR = dir;
+    setSecret('a', '1');
+    setSecrets({ b: '2', a: null });
+
+    expect(readdirSync(dir).filter((f) => f.endsWith('.tmp'))).toEqual([]);
+    expect(getSecret('b')).toBe('2');
+    expect(getSecret('a')).toBeNull();
+  });
+
+  test('an unreadable store is never overwritten: reads degrade, writes refuse', () => {
+    const dir = join(root, 'data');
+    process.env.JARVIS_SECRETS_DIR = dir;
+    setSecret('llm.provider.openai.api_key', 'sk-1');
+    const enc = join(dir, SECRETS_FILE);
+    const original = readFileSync(enc);
+
+    // A restored-from-elsewhere or half-written file: authentication fails.
+    writeFileSync(enc, original.subarray(0, 20));
+
+    // A read must not be fatal — the daemon still boots, just without keys.
+    expect(getSecret('llm.provider.openai.api_key')).toBeNull();
+
+    // A write must refuse: encrypting a fresh store over it would turn a
+    // recoverable problem (restore the matching key) into total loss.
+    expect(() => setSecret('stt.groq.api_key', 'gk-1')).toThrow(/could not be read/);
+    expect(() => setSecrets({ 'tts.elevenlabs.api_key': 'el-1' })).toThrow(/could not be read/);
+    expect(readFileSync(enc)).toEqual(original.subarray(0, 20));
+
+    // Putting the real file back makes everything work again, untouched.
+    writeFileSync(enc, original);
+    expect(getSecret('llm.provider.openai.api_key')).toBe('sk-1');
+  });
+});

--- a/src/vault/keychain.ts
+++ b/src/vault/keychain.ts
@@ -1,44 +1,88 @@
 /**
  * Encrypted secrets store for JARVIS.
  *
- * Stores secrets in an AES-256-GCM encrypted file (~/.jarvis/.secrets.enc)
- * with a random key stored in ~/.jarvis/.secrets.key (chmod 600).
+ * Stores secrets in an AES-256-GCM encrypted file (.secrets.enc) with a random
+ * key alongside it (.secrets.key, chmod 600), in the daemon's data dir:
+ * `JARVIS_HOME` when set, else ~/.jarvis — the same resolution pid.ts and the
+ * config loader use. Installs that predate that awareness keep reading their
+ * ~/.jarvis pair until migrateKeychainToDataDir() relocates it.
  *
  * This avoids depending on OS keychain daemons (which are unreliable on WSL2).
  */
 
 import { randomBytes, createCipheriv, createDecipheriv } from 'node:crypto';
-import { constants as fsConstants, existsSync, readFileSync, mkdirSync, chmodSync, openSync, writeSync, closeSync } from 'node:fs';
-import { join } from 'node:path';
+import { constants as fsConstants, existsSync, readFileSync, mkdirSync, chmodSync, openSync, writeSync, closeSync, fsyncSync, renameSync, rmSync, unlinkSync } from 'node:fs';
+import { join, resolve } from 'node:path';
 import { homedir } from 'node:os';
 
 const ALGORITHM = 'aes-256-gcm';
 const IV_LENGTH = 12;
 const TAG_LENGTH = 16;
 
+const KEY_FILE = '.secrets.key';
+const SECRETS_FILE = '.secrets.enc';
+
+/** Where the keychain lived before JARVIS_HOME was honored. */
+function legacyDir(): string {
+  return join(homedir(), '.jarvis');
+}
+
+/** True when a dir holds either half of a keychain pair. */
+function hasKeychain(dir: string): boolean {
+  return existsSync(join(dir, KEY_FILE)) || existsSync(join(dir, SECRETS_FILE));
+}
+
 /**
- * Directory holding the keychain pair. Resolved per call, not at module load,
- * so `JARVIS_SECRETS_DIR` can redirect it — a seam for tests, which must never
- * write into the developer's real store.
+ * The data dir this install is configured for, ignoring what is on disk.
  *
- * Deliberately NOT JARVIS_HOME-aware: hosted deployments set that variable and
- * their existing secrets live in ~/.jarvis, so honoring it here would move the
- * keychain out from under them on upgrade.
+ * `JARVIS_SECRETS_DIR` is an explicit override that wins over everything and
+ * disables the legacy fallback below: tests point it at a throwaway dir so
+ * they can never touch the real store, and an operator can point it at a
+ * mounted secrets volume. Everything that needs to know where the keychain is
+ * (e.g. `jarvis export`) must resolve it through here rather than assume a
+ * path, or the two drift apart.
  */
-function jarvisDir(): string {
-  return process.env.JARVIS_SECRETS_DIR || join(homedir(), '.jarvis');
+function configuredDir(): string {
+  const override = process.env.JARVIS_SECRETS_DIR || process.env.JARVIS_HOME;
+  return override ? resolve(override) : legacyDir();
+}
+
+/**
+ * Which of the two candidate dirs holds the live keychain. An install whose
+ * data dir has no keychain yet, but whose ~/.jarvis does, keeps using the
+ * legacy pair for BOTH reads and writes — splitting .secrets.key from
+ * .secrets.enc across two directories would leave the ciphertext
+ * undecryptable. migrateKeychain() ends that state deliberately.
+ *
+ * Takes its dirs as arguments so the rule is testable without a real home dir.
+ */
+export function resolveKeychainDir(configured: string, legacy: string): string {
+  if (configured === legacy || hasKeychain(configured)) return configured;
+  return hasKeychain(legacy) ? legacy : configured;
+}
+
+/** Directory actually in use. Resolved per call, never cached. */
+export function keychainDir(): string {
+  const configured = configuredDir();
+  if (process.env.JARVIS_SECRETS_DIR) return configured;
+  return resolveKeychainDir(configured, legacyDir());
+}
+
+/** Absolute paths of the keychain pair currently in use. */
+export function keychainPaths(): { keyPath: string; secretsPath: string } {
+  const dir = keychainDir();
+  return { keyPath: join(dir, KEY_FILE), secretsPath: join(dir, SECRETS_FILE) };
 }
 
 function keyPath(): string {
-  return join(jarvisDir(), '.secrets.key');
+  return keychainPaths().keyPath;
 }
 
 function secretsPath(): string {
-  return join(jarvisDir(), '.secrets.enc');
+  return keychainPaths().secretsPath;
 }
 
-function ensureDir(): void {
-  const dir = jarvisDir();
+function ensureDir(dir = keychainDir()): void {
   mkdirSync(dir, { recursive: true, mode: 0o700 });
   try { chmodSync(dir, 0o700); } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
@@ -49,14 +93,30 @@ function ensureDir(): void {
 /**
  * Write a secret file with O_NOFOLLOW so the call fails (ELOOP) if the path
  * is a symlink, preventing redirection to an attacker-controlled target.
+ *
+ * The write goes to a temp file that is fsynced and then renamed over the
+ * target, so a crash or a short write can never leave a truncated
+ * .secrets.enc behind — which loadSecrets would read as "no secrets" and the
+ * next save would then make permanent.
  */
 function writeSecretFileSync(path: string, data: string | Buffer, mode: number): void {
+  const tmp = `${path}.tmp`;
   const flags = fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_TRUNC | fsConstants.O_NOFOLLOW;
-  const fd = openSync(path, flags, mode);
+  const fd = openSync(tmp, flags, mode);
   try {
     writeSync(fd, data as never);
-  } finally {
+    fsyncSync(fd);
+  } catch (err) {
     closeSync(fd);
+    try { unlinkSync(tmp); } catch { /* best effort */ }
+    throw err;
+  }
+  closeSync(fd);
+  try {
+    renameSync(tmp, path);
+  } catch (err) {
+    try { unlinkSync(tmp); } catch { /* best effort */ }
+    throw err;
   }
   try { chmodSync(path, mode); } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
@@ -93,15 +153,41 @@ function decrypt(key: Buffer, data: Buffer): string {
   return Buffer.concat([decipher.update(encrypted), decipher.final()]).toString('utf-8');
 }
 
-function loadSecrets(): Record<string, string> {
-  if (!existsSync(secretsPath())) return {};
+/** Decrypt the pair in `dir`, throwing on any failure. {} when nothing stored. */
+function readSecretsAt(dir: string): Record<string, string> {
+  const secrets = join(dir, SECRETS_FILE);
+  if (!existsSync(secrets)) return {};
+  const hex = readFileSync(join(dir, KEY_FILE), 'utf-8').trim();
+  return JSON.parse(decrypt(Buffer.from(hex, 'hex'), readFileSync(secrets)));
+}
+
+/**
+ * The active store, throwing when it exists but cannot be read — a missing key
+ * file, a wrong key, a truncated file. Writers use this so a store we could
+ * not read is never encrypted over: that would turn a recoverable problem
+ * (restore the matching .secrets.key) into the permanent loss of every
+ * credential. Readers use loadSecrets() below, which degrades to "no secrets".
+ */
+function readSecrets(): Record<string, string> {
+  const dir = keychainDir();
   try {
-    const key = getOrCreateKey();
-    const raw = readFileSync(secretsPath());
-    const json = decrypt(key, raw);
-    return JSON.parse(json);
+    return readSecretsAt(dir);
   } catch (err) {
-    console.warn('[Keychain] Failed to decrypt secrets file, starting fresh:', err);
+    const reason = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `Keychain at ${join(dir, SECRETS_FILE)} could not be read (${reason}). `
+      + `Restore the matching ${KEY_FILE}, or move both files aside to start a new store.`,
+      { cause: err },
+    );
+  }
+}
+
+/** Read-side view: an unreadable store behaves as empty, loudly, never fatally. */
+function loadSecrets(): Record<string, string> {
+  try {
+    return readSecrets();
+  } catch (err) {
+    console.error(`[Keychain] ${err instanceof Error ? err.message : String(err)}`);
     return {};
   }
 }
@@ -114,13 +200,60 @@ function saveSecrets(secrets: Record<string, string>): void {
   writeSecretFileSync(secretsPath(), encrypted, 0o600);
 }
 
+/**
+ * Move a keychain pair from `from` to `to`: copy, verify the copy decrypts to
+ * the same secrets, and only then remove the originals. A failed verification
+ * leaves the source untouched and authoritative, so the worst case is "not
+ * migrated yet", never "lost". Returns true when the pair moved.
+ *
+ * No-op when the destination already holds a keychain or the source has none.
+ */
+export function migrateKeychain(from: string, to: string): boolean {
+  if (from === to || hasKeychain(to) || !hasKeychain(from)) return false;
+
+  const expected = readSecretsAt(from); // throws only if the source pair is broken
+  ensureDir(to);
+  // Any failure past this point must leave the destination EMPTY: one stray
+  // file there makes hasKeychain(to) true forever, and resolveKeychainDir
+  // would stop falling back to the intact pair still sitting in `from`.
+  try {
+    for (const name of [KEY_FILE, SECRETS_FILE]) {
+      const src = join(from, name);
+      if (existsSync(src)) writeSecretFileSync(join(to, name), readFileSync(src), 0o600);
+    }
+    if (JSON.stringify(readSecretsAt(to)) !== JSON.stringify(expected)) {
+      throw new Error('the copy does not match the source');
+    }
+  } catch (err) {
+    for (const name of [KEY_FILE, SECRETS_FILE]) rmSync(join(to, name), { force: true });
+    console.error(`[Keychain] Copy to ${to} failed (${err instanceof Error ? err.message : String(err)}); keeping the keychain in ${from}`);
+    return false;
+  }
+
+  for (const name of [KEY_FILE, SECRETS_FILE]) rmSync(join(from, name), { force: true });
+  console.log(`[Keychain] Moved the keychain from ${from} to ${to}; backups of the data dir now include it`);
+  return true;
+}
+
+/**
+ * Relocate a pre-JARVIS_HOME keychain into the configured data dir.
+ *
+ * Called once at daemon boot. Deliberately NOT triggered by path resolution:
+ * a CLI, a test, or any process that merely reads a secret must never move the
+ * store out from under the machine it is running on.
+ */
+export function migrateKeychainToDataDir(): void {
+  if (process.env.JARVIS_SECRETS_DIR) return; // explicit override: leave it alone
+  migrateKeychain(legacyDir(), configuredDir());
+}
+
 export function getSecret(name: string): string | null {
   const secrets = loadSecrets();
   return secrets[name] ?? null;
 }
 
 export function setSecret(name: string, value: string): void {
-  const secrets = loadSecrets();
+  const secrets = readSecrets();
   secrets[name] = value;
   saveSecrets(secrets);
 }
@@ -132,12 +265,11 @@ export function setSecret(name: string, value: string): void {
  * rewrites the whole file. No-ops when every entry already has the requested
  * value.
  *
- * One file write, not an atomic one: saveSecrets truncates in place, so a
- * crash mid-write still loses the file (and loadSecrets then starts empty).
- * Grouping shrinks that window; it does not close it.
+ * Throws when the existing store cannot be read, rather than replacing it with
+ * one holding only these entries.
  */
 export function setSecrets(entries: Record<string, string | null>): void {
-  const secrets = loadSecrets();
+  const secrets = readSecrets();
   let changed = false;
   for (const [name, value] of Object.entries(entries)) {
     if (value === null) {
@@ -154,7 +286,7 @@ export function setSecrets(entries: Record<string, string | null>): void {
 }
 
 export function deleteSecret(name: string): void {
-  const secrets = loadSecrets();
+  const secrets = readSecrets();
   delete secrets[name];
   saveSecrets(secrets);
 }


### PR DESCRIPTION
Stacked on #327 (which is stacked on #326) — review those first.

The keychain was hardcoded to `~/.jarvis` while everything else (pid file, data dir, db) honors `JARVIS_HOME`, so on an install configured for another data dir the secrets store sat outside it — invisible to `jarvis export --full`, which stages from `data_dir`.

- `keychainDir()` resolves `JARVIS_HOME` (else `~/.jarvis`), and is exported so callers stop assuming a path.
- Existing installs are not stranded: while the data dir has no keychain, the legacy pair stays authoritative for reads *and* writes — splitting `.secrets.key` from `.secrets.enc` across dirs would make the ciphertext undecryptable. `migrateKeychainToDataDir()` ends that state at daemon boot: copy, verify the copy decrypts to the same secrets, and only then remove the originals. It is explicit, never a side effect of path resolution, so no CLI or test can move the store.
- `jarvis export --full` stages the pair from `keychainDir()`, and restore places it where the daemon reads it instead of blindly into `data_dir` (which can differ when `daemon.data_dir` is set in config.yaml). Neither is fatal on failure — a completed restore warns rather than aborts.
- Writes are atomic (temp file + fsync + rename), so a crash can no longer truncate `.secrets.enc`.
- Writers refuse to overwrite a store they could not read, instead of silently replacing it with a fresh one holding only the entries being saved — that path could drop every LLM credential on a single settings save.