### PR TITLE
fix(sidecar): make enrollment usable across machines

### DIFF
--- a/sidecar/client.go
+++ b/sidecar/client.go
@@ -211,10 +211,16 @@ func (c *SidecarClient) Start(ctx context.Context) {
 			// (connError was set in connectAndServe) until the user quits or
 			// restarts after fixing the config.
 			log.Printf("[sidecar] Token rejected by the brain (HTTP %d). Not reconnecting until reconfigured.", tokErr.status)
+			hint := "Re-enroll it by running 'jarvis enroll \"<device-name>\"' on the brain machine, update the token in the config, then restart."
+			if isLoopbackBrainURL(c.claims.Brain) {
+				// The address in use names localhost: on any machine but the
+				// brain itself that reaches a different daemon (or nothing),
+				// which reads as a rejected token. Point at the override first.
+				hint = "The connection is using a localhost address. If your brain runs on another machine, set 'brain:' in ~/.jarvis/sidecar.yaml to that machine's address and restart. Otherwise re-enroll: run 'jarvis enroll \"<device-name>\"' on the brain machine, update the token, then restart."
+			}
 			c.alertOnce.Do(func() {
 				platformShowAlert("JARVIS Sidecar",
-					"This machine's enrollment token is not valid — the brain rejected it.\n\n"+
-						"Re-enroll it by running 'jarvis enroll \"<device-name>\"' on the brain machine, update the token in the config, then restart.")
+					"This machine's enrollment token is not valid — the brain rejected it.\n\n"+hint)
 			})
 			<-ctx.Done()
 			return

--- a/sidecar/hosted.go
+++ b/sidecar/hosted.go
@@ -57,10 +57,11 @@ func resolveHostedBaseURLWith(overrideAllowed bool, cfgValue, envValue string) s
 // the gate, any page in the Clerk/Stripe redirect chain could silently
 // enroll this sidecar to an attacker-controlled brain (enrollment JWTs are
 // self-describing via their brain/jwks claims). accept receives a
-// structurally valid JWT; the caller then verifies it against its brain
-// (verify_token.go) and closes the window only on success.
-func submitTokenHandler(isActive func() bool, accept func(token string)) func(string) error {
-	return func(raw string) error {
+// structurally valid JWT plus the optional (already normalized) brain-address
+// override typed alongside it; the caller then verifies the token against its
+// brain (verify_token.go) and closes the window only on success.
+func submitTokenHandler(isActive func() bool, accept func(token, brain string)) func(string, string) error {
+	return func(raw, brain string) error {
 		if !isActive() {
 			log.Printf("[hosted] submitToken called while the token form is not active - ignored")
 			return fmt.Errorf("Token entry is not active.")
@@ -72,7 +73,13 @@ func submitTokenHandler(isActive func() bool, accept func(token string)) func(st
 		if _, err := DecodeJWTPayload(raw); err != nil {
 			return fmt.Errorf("That doesn't look like a valid token. Copy the full token printed by 'jarvis enroll'.")
 		}
-		accept(raw)
+		// The brain address is an OPTIONAL override for the URL baked into the
+		// token's brain claim — the escape hatch for tokens that name an address
+		// this machine can't use (the classic case: brain_domain was unset at
+		// enroll time, so the claim says localhost). Normalized here exactly as
+		// the config override is, so what gets verified is what gets saved.
+		brain = normalizeBrainOverride(brain)
+		accept(raw, brain)
 		return nil
 	}
 }

--- a/sidecar/hosted_test.go
+++ b/sidecar/hosted_test.go
@@ -197,13 +197,16 @@ func TestHandshakeCancelledByContext(t *testing.T) {
 func TestSubmitTokenHandlerGate(t *testing.T) {
 	jwt := testJWT(t)
 	active := false
-	var accepted string
-	handler := submitTokenHandler(func() bool { return active }, func(tok string) { accepted = tok })
+	var accepted, acceptedBrain string
+	handler := submitTokenHandler(func() bool { return active }, func(tok, brain string) {
+		accepted = tok
+		acceptedBrain = brain
+	})
 
 	// Regression (review major 1): with the hosted flow showing remote
 	// content (Clerk/Stripe redirects), any page can call the binding. While
 	// the local form is NOT active it must refuse even a valid JWT.
-	if err := handler(jwt); err == nil {
+	if err := handler(jwt, ""); err == nil {
 		t.Fatal("submitToken must be refused while the token form is inactive")
 	}
 	if accepted != "" {
@@ -212,14 +215,27 @@ func TestSubmitTokenHandlerGate(t *testing.T) {
 
 	// Active form: garbage rejected, valid JWT accepted.
 	active = true
-	if err := handler("not-a-jwt"); err == nil {
+	if err := handler("not-a-jwt", ""); err == nil {
 		t.Fatal("garbage token must be rejected")
 	}
-	if err := handler("  " + jwt + "  "); err != nil {
+	if err := handler("  "+jwt+"  ", ""); err != nil {
 		t.Fatalf("valid token rejected: %v", err)
 	}
 	if accepted != jwt {
 		t.Fatalf("accepted token mismatch: %q", accepted)
+	}
+	if acceptedBrain != "" {
+		t.Fatalf("brain override must be empty when not supplied, got %q", acceptedBrain)
+	}
+
+	// A supplied brain address is normalized exactly like the config override
+	// (bare host:port -> ws(s)://host:port/sidecar/connect) before the caller
+	// sees it, so verification and persistence agree.
+	if err := handler(jwt, " 192.168.1.20:3142 "); err != nil {
+		t.Fatalf("valid token with brain override rejected: %v", err)
+	}
+	if acceptedBrain != "ws://192.168.1.20:3142/sidecar/connect" {
+		t.Fatalf("brain override not normalized: %q", acceptedBrain)
 	}
 }
 

--- a/sidecar/hosted_window.go
+++ b/sidecar/hosted_window.go
@@ -151,15 +151,17 @@ func hostedShellWithSelfHostHint() string {
 }
 
 // runFirstRunWindow drives the no-token first run: hosted connect by default,
-// self-host token form one click away. Returns the enrollment JWT ("" if the
-// user closed the window). Blocks; must run on the main OS thread.
-func runFirstRunWindow(cfg *SidecarConfig) (string, error) {
+// self-host token form one click away. Returns the enrollment JWT plus an
+// optional brain-address override the user typed into the self-host form
+// (both "" if the user closed the window). Blocks; must run on the main OS
+// thread.
+func runFirstRunWindow(cfg *SidecarConfig) (string, string, error) {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
 	w := webview.New(false)
 	if w == nil {
-		return "", fmt.Errorf("could not open the setup window (no display, or the system webview runtime is missing)")
+		return "", "", fmt.Errorf("could not open the setup window (no display, or the system webview runtime is missing)")
 	}
 	defer w.Destroy()
 
@@ -191,6 +193,11 @@ func runFirstRunWindow(cfg *SidecarConfig) (string, error) {
 	// site in startHandshake.
 	var tokenMu sync.Mutex
 	var token string
+	// Optional brain-address override typed into the self-host form alongside
+	// the token ("" = use whatever the token names / the config already has).
+	// Guarded by tokenMu exactly like token: written by the submitToken
+	// goroutine, read after Run() returns.
+	var brainOverride string
 
 	// The user explicitly clicked "paste your own token". Distinct from ctx,
 	// which the deferred teardown ALSO cancels — so `ctx.Err() != nil` cannot
@@ -254,23 +261,32 @@ func runFirstRunWindow(cfg *SidecarConfig) (string, error) {
 			w.SetHtml(setupWindowHTML)
 		})
 	}); err != nil {
-		return "", fmt.Errorf("bind chooseSelfHost: %w", err)
+		return "", "", fmt.Errorf("bind chooseSelfHost: %w", err)
 	}
 
 	if err := w.Bind("submitToken", submitTokenHandler(
 		func() bool { return selfHostFormActive && !verifyInFlight },
-		func(tok string) {
+		func(tok, brain string) {
 			// Structurally valid — now prove it works against the brain it
 			// names before it is persisted. A wrong-URL token used to be saved
 			// blind: the window closed and the only trace of the failure was
 			// the reconnect loop in the log. The form shows "checking" while
 			// this runs; the verdict lands via window.__tokenVerdict, and
 			// success closes the window as before.
+			//
+			// A brain address typed into the form outranks the saved config
+			// override for this check, and (on success) replaces it: that is
+			// the whole point of the field — correcting a token that names an
+			// address this machine can't reach.
+			override := cfg.Brain
+			if brain != "" {
+				override = brain
+			}
 			verifyInFlight = true
 			handshakeWG.Add(1)
 			go func() {
 				defer handshakeWG.Done()
-				verr := verifyBrainToken(verifyCtx, tok, cfg.Brain)
+				verr := verifyBrainToken(verifyCtx, tok, override)
 				w.Dispatch(func() {
 					if torndown.Load() || verifyCtx.Err() != nil {
 						return
@@ -282,13 +298,14 @@ func runFirstRunWindow(cfg *SidecarConfig) (string, error) {
 					}
 					tokenMu.Lock()
 					token = tok
+					brainOverride = brain
 					tokenMu.Unlock()
 					w.Terminate()
 				})
 			}()
 		},
 	)); err != nil {
-		return "", fmt.Errorf("bind setup handler: %w", err)
+		return "", "", fmt.Errorf("bind setup handler: %w", err)
 	}
 
 	// Fallback for the shell's "open the sign-in page again" link: the
@@ -323,7 +340,7 @@ func runFirstRunWindow(cfg *SidecarConfig) (string, error) {
 			}
 		}()
 	}); err != nil {
-		return "", fmt.Errorf("bind openConnectPage: %w", err)
+		return "", "", fmt.Errorf("bind openConnectPage: %w", err)
 	}
 
 	startHandshake := func() {
@@ -481,7 +498,7 @@ func runFirstRunWindow(cfg *SidecarConfig) (string, error) {
 		})
 		startHandshake()
 	}); err != nil {
-		return "", fmt.Errorf("bind retryHosted: %w", err)
+		return "", "", fmt.Errorf("bind retryHosted: %w", err)
 	}
 
 	// Enrollment deep links (jarvis://enroll — the connect page's free door):
@@ -562,7 +579,7 @@ func runFirstRunWindow(cfg *SidecarConfig) (string, error) {
 	handshakeWG.Wait()
 	tokenMu.Lock()
 	defer tokenMu.Unlock()
-	return token, nil
+	return token, brainOverride, nil
 }
 
 // jsEscape makes a Go string safe inside a single-quoted JS string literal.

--- a/sidecar/main.go
+++ b/sidecar/main.go
@@ -154,7 +154,7 @@ Usage:
 		// Unconfigured: pop up the first-run window asking for the enrollment
 		// token instead of erroring out. (--token still works headlessly.)
 		log.Println("[sidecar] No token configured - opening connect window...")
-		tok, err := runFirstRunWindow(cfg)
+		tok, brain, err := runFirstRunWindow(cfg)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\nAlternatively, run: jarvis-sidecar --token <jwt>\n", err)
 			os.Exit(1)
@@ -164,6 +164,12 @@ Usage:
 			os.Exit(1)
 		}
 		cfg.Token = tok
+		if brain != "" {
+			// The user corrected the token's baked-in brain address in the
+			// setup form (typically a localhost-pointing token used from
+			// another machine); persist it so reconnects use it too.
+			cfg.Brain = brain
+		}
 		if err := SaveConfig(cfg); err != nil {
 			log.Fatalf("[sidecar] Failed to save config: %v", err)
 		}

--- a/sidecar/settings_window.go
+++ b/sidecar/settings_window.go
@@ -28,7 +28,11 @@ func (c *SidecarClient) OpenSettings() {
 // binding (webview_go marshals it to JSON for the JS side).
 type settingsState struct {
 	Status string `json:"status"` // "connected" | "connecting" | "error"
-	Prefs  struct {
+	// Manual brain-address override from sidecar.yaml ("" = the token's own
+	// brain claim). Shown in the enrollment panel so it can be corrected
+	// without hand-editing the config file.
+	Brain string `json:"brain"`
+	Prefs struct {
 		StartAtStartup      bool `json:"start_at_startup"`
 		EtherealPebble      bool `json:"ethereal_pebble"`
 		EtherealIdleSeconds int  `json:"ethereal_idle_seconds"`
@@ -65,6 +69,7 @@ func (c *SidecarClient) runSettingsWindow() {
 			prefs := c.Preferences()
 			var st settingsState
 			st.Status = connStateString(c.ConnState())
+			st.Brain = c.BrainOverride()
 			st.Prefs.StartAtStartup = prefs.StartAtStartup
 			st.Prefs.EtherealPebble = prefs.EtherealPebble
 			st.Prefs.EtherealIdleSeconds = prefs.EtherealIdleSeconds
@@ -81,13 +86,21 @@ func (c *SidecarClient) runSettingsWindow() {
 		// saved, or why not — lands async via window.__tokenVerdict. Only a
 		// token the brain accepted is written to the config; it applies on the
 		// next reconnect attempt, and a restart guarantees a clean reconnect.
-		_ = w.Bind("saveToken", func(raw string) error {
+		_ = w.Bind("saveToken", func(raw, brain string) error {
 			raw = trimToken(raw)
 			if raw == "" {
 				return fmt.Errorf("Paste a token to save.")
 			}
 			if _, err := DecodeJWTPayload(raw); err != nil {
 				return fmt.Errorf("That doesn't look like a valid token. Copy the full token printed by 'jarvis enroll'.")
+			}
+			// Optional brain-address override (normalized like the config
+			// field); outranks the stored override for this check and, on
+			// success, replaces it.
+			brain = normalizeBrainOverride(brain)
+			override := c.BrainOverride()
+			if brain != "" {
+				override = brain
 			}
 			if !checkInFlight.CompareAndSwap(false, true) {
 				return fmt.Errorf("A token check is already running.")
@@ -96,9 +109,14 @@ func (c *SidecarClient) runSettingsWindow() {
 			go func() {
 				defer verifyWG.Done()
 				defer checkInFlight.Store(false)
-				verr := verifyBrainToken(verifyCtx, raw, c.BrainOverride())
+				verr := verifyBrainToken(verifyCtx, raw, override)
 				if verr == nil {
-					if err := c.editConfig(func(cfg *SidecarConfig) { cfg.Token = raw }); err != nil {
+					if err := c.editConfig(func(cfg *SidecarConfig) {
+						cfg.Token = raw
+						if brain != "" {
+							cfg.Brain = brain
+						}
+					}); err != nil {
 						verr = fmt.Errorf("Could not save the token: %v", err)
 					} else {
 						log.Printf("[settings] enrollment token verified with the brain and updated")
@@ -234,9 +252,14 @@ const settingsWindowHTML = `<!doctype html>
   .sw input:checked + .track::after { transform: translateX(16px); }
   /* token field */
   .field { font-size: 11px; font-weight: 600; color: var(--ink2); display: block; margin-bottom: 7px; }
+  .field .opt { color: var(--faint); font-weight: 500; }
   textarea { width: 100%; height: 80px; resize: none; padding: 10px 12px; font-family: var(--mono); font-size: 11.5px; line-height: 1.5; border: 1px solid var(--rule); border-radius: var(--corner-sm); background: var(--panel2); color: var(--ink); outline: none; transition: border-color .12s, box-shadow .12s, background .12s; }
   textarea::placeholder { color: var(--faint); }
   textarea:focus { border-color: var(--speak); background: var(--raise); box-shadow: 0 0 0 3px rgba(45,120,255,.14); }
+  input.txt { width: 100%; height: 36px; padding: 0 12px; font-family: var(--mono); font-size: 11.5px; border: 1px solid var(--rule); border-radius: var(--corner-sm); background: var(--panel2); color: var(--ink); outline: none; transition: border-color .12s, box-shadow .12s, background .12s; box-sizing: border-box; }
+  input.txt::placeholder { color: var(--faint); }
+  input.txt:focus { border-color: var(--speak); background: var(--raise); box-shadow: 0 0 0 3px rgba(45,120,255,.14); }
+  .subhint { font-size: 11px; color: var(--faint); margin: 7px 0 0; line-height: 1.5; }
   .row { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin-top: 11px; }
   .msg { font-size: 11.5px; min-height: 16px; flex: 1; color: var(--ink3); }
   .msg.ok { color: var(--ok-tx); }
@@ -271,6 +294,10 @@ const settingsWindowHTML = `<!doctype html>
   <div class="panel pad">
     <label class="field" for="tok">Paste a new token to re-point this machine</label>
     <textarea id="tok" placeholder="eyJhbGciOiJFUzI1NiIs…" spellcheck="false"></textarea>
+    <label class="field" for="brain" style="margin-top:11px">Brain address <span class="opt">(optional)</span></label>
+    <input id="brain" class="txt" type="text" placeholder="e.g. 192.168.1.20:3142 or https://brain.example.com" spellcheck="false">
+    <p class="subhint">Only set this if the brain runs somewhere the token can't reach — for example when the token
+      points at localhost but your brain is on another machine. Leave it blank to keep the current address.</p>
     <div class="row">
       <span id="tokMsg" class="msg"></span>
       <button id="saveTok" class="sbtn pri" onclick="doSaveToken()">Save token</button>
@@ -340,6 +367,9 @@ const settingsWindowHTML = `<!doctype html>
   async function init() {
     var st = await window.getState();
     paintStatus(st.status);
+    if (st.brain) {
+      document.getElementById('brain').value = st.brain;
+    }
     document.getElementById('start_at_startup').checked = !!st.prefs.start_at_startup;
     document.getElementById('ethereal_pebble').checked = !!st.prefs.ethereal_pebble;
     document.getElementById('ethereal_idle_seconds').value = st.prefs.ethereal_idle_seconds || 5;
@@ -347,6 +377,7 @@ const settingsWindowHTML = `<!doctype html>
     updateIdleRow();
     // Typing a new token after a save reverts the button from Restart to Save.
     document.getElementById('tok').addEventListener('input', resetTokenButton);
+    document.getElementById('brain').addEventListener('input', resetTokenButton);
     setInterval(pollStatus, 2000);
   }
 
@@ -355,6 +386,7 @@ const settingsWindowHTML = `<!doctype html>
   // and remembers what was submitted so the verdict never wipes newer input.
   var tokenChecking = false;
   var submittedTok = '';
+  var submittedBrain = '';
 
   function resetTokenButton() {
     if (tokenChecking) return;
@@ -390,12 +422,14 @@ const settingsWindowHTML = `<!doctype html>
     var btn = document.getElementById('saveTok');
     var msg = document.getElementById('tokMsg');
     var tok = document.getElementById('tok');
+    var brain = document.getElementById('brain');
     msg.className = 'msg'; msg.textContent = '';
     btn.disabled = true;
     tokenChecking = true;
     submittedTok = tok.value;
+    submittedBrain = brain.value;
     try {
-      await window.saveToken(tok.value);
+      await window.saveToken(tok.value, brain.value);
       msg.textContent = 'Checking the token with your brain…';
     } catch (e) {
       tokenChecking = false;
@@ -409,6 +443,7 @@ const settingsWindowHTML = `<!doctype html>
     var btn = document.getElementById('saveTok');
     var msg = document.getElementById('tokMsg');
     var tok = document.getElementById('tok');
+    var brain = document.getElementById('brain');
     tokenChecking = false;
     btn.disabled = false;
     if (errMsg) {
@@ -421,6 +456,7 @@ const settingsWindowHTML = `<!doctype html>
     // Only clear what was actually saved — never a newer token typed while
     // the check was running.
     if (tok.value === submittedTok) tok.value = '';
+    if (brain.value === submittedBrain) brain.value = '';
     // Morph Save -> Restart for a one-click apply.
     btn.textContent = 'Restart Jarvis';
     btn.onclick = doRestart;

--- a/sidecar/setup_window.go
+++ b/sidecar/setup_window.go
@@ -18,10 +18,12 @@ package main
 
 // setupWindowHTML is the self-host first-run form, Monochrome Lab
 // (brand_css.go): a centered raised card with the signature corner.
-// `window.submitToken(value)` is the Go binding installed below; it rejects with
-// a message when the token is empty/malformed so the form can show it inline,
-// and resolves when the brain check has STARTED (not passed) — the async
-// verdict lands in window.__tokenVerdict with an empty message on success.
+// `window.submitToken(token, brain)` is the Go binding installed below; the
+// second argument is an optional brain-address override for tokens whose baked-in
+// URL this machine can't use. It rejects with a message when the token is
+// empty/malformed so the form can show it inline, and resolves when the brain
+// check has STARTED (not passed) — the async verdict lands in
+// window.__tokenVerdict with an empty message on success.
 const setupWindowHTML = `<!doctype html>
 <html>
 <head>
@@ -53,7 +55,17 @@ const setupWindowHTML = `<!doctype html>
   }
   textarea::placeholder { color: var(--faint); }
   textarea:focus { border-color: var(--speak); background: var(--raise); box-shadow: 0 0 0 3px rgba(45,120,255,.14); }
+  input[type=text] {
+    width: 100%; height: 38px; padding: 0 12px;
+    font-family: var(--mono); font-size: 11.5px;
+    border: 1px solid var(--rule); border-radius: var(--corner-sm);
+    background: var(--panel2); color: var(--ink); outline: none;
+    transition: border-color .12s, box-shadow .12s, background .12s;
+  }
+  input[type=text]::placeholder { color: var(--faint); }
+  input[type=text]:focus { border-color: var(--speak); background: var(--raise); box-shadow: 0 0 0 3px rgba(45,120,255,.14); }
   .hint { font-size: 11px; color: var(--faint); margin: 8px 0 0; line-height: 1.5; }
+  .hint b { color: var(--ink3); font-weight: 600; }
   .row { display: flex; align-items: center; justify-content: space-between; margin-top: 16px; gap: 12px; }
   #err { color: var(--listen-tx); font-size: 12px; line-height: 1.5; min-height: 16px; flex: 1; text-align: left; }
   #err.checking { color: var(--ink3); }
@@ -80,7 +92,12 @@ const setupWindowHTML = `<!doctype html>
         authenticates it.</p>
       <label for="tok">Enrollment token</label>
       <textarea id="tok" placeholder="eyJhbGciOiJFUzI1NiIs..." spellcheck="false" autofocus></textarea>
-      <p class="hint">The token is stored locally at ~/.jarvis/sidecar.yaml. Press Cmd/Ctrl+Enter to connect.</p>
+      <p class="hint" id="brainHint"></p>
+      <label for="brain" style="margin-top:14px">Brain address <span style="color:var(--faint);font-weight:500">(optional)</span></label>
+      <input id="brain" type="text" placeholder="e.g. 192.168.1.20:3142 or https://brain.example.com" spellcheck="false">
+      <p class="hint">Only set this if the brain runs somewhere this token can't reach — for example
+        when the token points at <b>localhost</b> but your brain is on another machine.
+        The token is stored locally at ~/.jarvis/sidecar.yaml. Press Cmd/Ctrl+Enter to connect.</p>
       <div class="row">
         <span id="err"></span>
         <button id="go" onclick="submit()">Connect</button>
@@ -89,15 +106,42 @@ const setupWindowHTML = `<!doctype html>
   </div>
 <script>
   var tok = document.getElementById('tok');
+  var brain = document.getElementById('brain');
+  var brainHint = document.getElementById('brainHint');
   var err = document.getElementById('err');
   var btn = document.getElementById('go');
+
+  // Best-effort decode of the token's brain claim so the user can SEE the
+  // address they are about to connect to before submitting. When it names a
+  // loopback host we call that out, because a token minted without
+  // daemon.brain_domain points at localhost and only works on the brain
+  // machine itself — the Brain address field exists to correct exactly that.
+  function tokenBrain() {
+    try {
+      var parts = tok.value.trim().split('.');
+      if (parts.length !== 3) return '';
+      var b64 = parts[1].replace(/-/g, '+').replace(/_/g, '/');
+      while (b64.length % 4) b64 += '=';
+      var claims = JSON.parse(decodeURIComponent(escape(atob(b64))));
+      return typeof claims.brain === 'string' ? claims.brain : '';
+    } catch (e) { return ''; }
+  }
+  function refreshBrainHint() {
+    var b = tokenBrain();
+    if (!b) { brainHint.innerHTML = ''; return; }
+    var loopback = /\/\/(localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\])(:|\/|$)/i.test(b);
+    brainHint.innerHTML = loopback
+      ? 'This token points at <b>' + b + '</b> — that only works on the brain machine itself. If this is a different machine, enter the brain\'s address below.'
+      : 'This token points at <b>' + b + '</b>.';
+  }
+
   async function submit() {
     if (btn.disabled) return; // Cmd/Ctrl+Enter during an in-flight check
     err.className = '';
     err.textContent = '';
     btn.disabled = true;
     try {
-      await window.submitToken(tok.value);
+      await window.submitToken(tok.value, brain.value);
       // Structurally valid: Go is now checking it against the brain. The
       // verdict arrives via __tokenVerdict below; success closes the window.
       err.className = 'checking';
@@ -116,6 +160,10 @@ const setupWindowHTML = `<!doctype html>
     tok.focus();
   };
   tok.addEventListener('keydown', function (e) {
+    if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') { e.preventDefault(); submit(); }
+  });
+  tok.addEventListener('input', refreshBrainHint);
+  brain.addEventListener('keydown', function (e) {
     if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') { e.preventDefault(); submit(); }
   });
   tok.focus();

--- a/sidecar/verify_token.go
+++ b/sidecar/verify_token.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -57,6 +58,17 @@ func verifyBrainToken(ctx context.Context, raw, brainOverride string) error {
 	}
 	mintURL := deriveMintURL(brainURL)
 	host := hostForDisplay(mintURL)
+	// A token minted without daemon.brain_domain names localhost, which only
+	// works on the brain machine itself. When the probe then fails from THIS
+	// machine, the fix is usually a brain-address override, not a new token —
+	// say so instead of sending the user re-enrolling. Keyed on the token's
+	// own claim, and only while no override is in play: once the user has
+	// supplied one they already know the mechanism, and the probed address is
+	// theirs to own.
+	loopbackHint := ""
+	if isLoopbackBrainURL(claims.Brain) && normalizeBrainOverride(brainOverride) == "" {
+		loopbackHint = " The token points at localhost — if your brain runs on another machine, enter that machine's address in the Brain address field (or set 'brain:' in ~/.jarvis/sidecar.yaml) and try again."
+	}
 
 	ctx, cancel := context.WithTimeout(ctx, verifyBrainTimeout)
 	defer cancel()
@@ -71,7 +83,7 @@ func verifyBrainToken(ctx context.Context, raw, brainOverride string) error {
 			return context.Canceled
 		}
 		log.Printf("[verify] brain probe %s failed: %v", mintURL, err)
-		return fmt.Errorf("Could not reach the brain at %s. Check that it is running and reachable from this machine, then try again.", host)
+		return fmt.Errorf("Could not reach the brain at %s. Check that it is running and reachable from this machine, then try again.%s", host, loopbackHint)
 	}
 	defer resp.Body.Close()
 
@@ -79,7 +91,7 @@ func verifyBrainToken(ctx context.Context, raw, brainOverride string) error {
 	case resp.StatusCode == http.StatusOK:
 		// Fall through to the body check below.
 	case resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden:
-		return fmt.Errorf("The brain at %s rejected this token — it may be revoked or belong to a different brain. Run 'jarvis enroll \"<device-name>\"' again and paste the fresh token.", host)
+		return fmt.Errorf("The brain at %s rejected this token — it may be revoked or belong to a different brain. Run 'jarvis enroll \"<device-name>\"' again and paste the fresh token.%s", host, loopbackHint)
 	case resp.StatusCode >= 500:
 		// A brain (or its proxy) that is up but erroring is not a wrong URL —
 		// don't steer the user into re-checking their token or address.
@@ -112,4 +124,23 @@ func hostForDisplay(rawURL string) string {
 		return u.Host
 	}
 	return rawURL
+}
+
+// isLoopbackBrainURL reports whether a brain connect URL points at a loopback
+// address (localhost, 127.0.0.1, ::1). Such URLs only work on the brain
+// machine itself; a sidecar anywhere else needs an address override, which is
+// exactly what the failure messages steer the user toward.
+func isLoopbackBrainURL(rawURL string) bool {
+	u, err := url.Parse(rawURL)
+	if err != nil || u.Host == "" {
+		return false
+	}
+	host := u.Hostname()
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return ip.IsLoopback()
+	}
+	return false
 }

--- a/sidecar/verify_token_test.go
+++ b/sidecar/verify_token_test.go
@@ -147,3 +147,77 @@ func TestVerifyBrainTokenCancelled(t *testing.T) {
 		t.Fatalf("a cancelled check must surface context.Canceled, got %v", err)
 	}
 }
+
+func TestIsLoopbackBrainURL(t *testing.T) {
+	cases := []struct {
+		url  string
+		want bool
+	}{
+		{"ws://localhost:3142/sidecar/connect", true},
+		{"ws://127.0.0.1:3142/sidecar/connect", true},
+		{"ws://[::1]:3142/sidecar/connect", true},
+		{"wss://brain.example.com/sidecar/connect", false},
+		{"ws://192.168.1.20:3142/sidecar/connect", false}, // LAN, not loopback
+		{"", false},
+		{"not a url", false},
+	}
+	for _, c := range cases {
+		if got := isLoopbackBrainURL(c.url); got != c.want {
+			t.Errorf("isLoopbackBrainURL(%q) = %v, want %v", c.url, got, c.want)
+		}
+	}
+}
+
+// A token minted without daemon.brain_domain names localhost (on Linux test
+// boxes, the httptest servers used as fake brains are loopback too, exactly
+// like a real localhost-pointing token probed in place). When that probe
+// fails, the message must steer the user toward the brain-address override
+// instead of a pointless re-enroll — but only while no override is in play.
+func TestVerifyBrainTokenLoopbackHint(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	t.Cleanup(srv.Close)
+
+	// Loopback token, no override: rejection carries the override hint.
+	err := verifyBrainToken(context.Background(), enrollJWT(t, wsURLFor(srv)), "")
+	if err == nil || !strings.Contains(err.Error(), "rejected this token") {
+		t.Fatalf("401 must read as a rejection, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "localhost") || !strings.Contains(err.Error(), "Brain address") {
+		t.Fatalf("loopback token failure must explain the override, got: %v", err)
+	}
+
+	// Non-loopback token (probed via override): no hint — the address is
+	// already a real one.
+	err = verifyBrainToken(context.Background(), enrollJWT(t, "wss://brain.example.com/sidecar/connect"), srv.URL)
+	if err == nil || !strings.Contains(err.Error(), "rejected this token") {
+		t.Fatalf("401 must read as a rejection, got %v", err)
+	}
+	if strings.Contains(err.Error(), "Brain address") {
+		t.Fatalf("non-loopback failure must not push the override hint, got: %v", err)
+	}
+
+	// Loopback token WITH an override: the user already corrected the
+	// address; repeating the hint would just blame the token again.
+	err = verifyBrainToken(context.Background(), enrollJWT(t, "ws://localhost:3142/sidecar/connect"), srv.URL)
+	if err == nil || !strings.Contains(err.Error(), "rejected this token") {
+		t.Fatalf("401 must read as a rejection, got %v", err)
+	}
+	if strings.Contains(err.Error(), "Brain address") {
+		t.Fatalf("override-supplied failure must not push the override hint, got: %v", err)
+	}
+
+	// Unreachable loopback brain (nothing listens): same hint on the
+	// "Could not reach" path.
+	dead := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	deadURL := wsURLFor(dead)
+	dead.Close()
+	err = verifyBrainToken(context.Background(), enrollJWT(t, deadURL), "")
+	if err == nil || !strings.Contains(err.Error(), "Could not reach the brain") {
+		t.Fatalf("dead endpoint must read as unreachable, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "Brain address") {
+		t.Fatalf("unreachable loopback brain must explain the override, got: %v", err)
+	}
+}

--- a/src/cli/devices.ts
+++ b/src/cli/devices.ts
@@ -17,9 +17,10 @@
 
 import { loadConfig } from '../config/loader.ts';
 import { initDatabase, getDb } from '../vault/schema.ts';
-import { enrollDevice } from '../sidecar/enrollment.ts';
+import { buildEnrollmentUrls, enrollDevice, isLocalhostBrainUrl } from '../sidecar/enrollment.ts';
 import type { SidecarRecord } from '../sidecar/types.ts';
 import { resolveExternalOrigin } from '../util/external-origin.ts';
+import { networkInterfaces } from 'node:os';
 
 interface CliIo {
   out: (line: string) => void;
@@ -38,12 +39,34 @@ async function openVault(io: CliIo): Promise<{ dataDir: string; brainUrl: string
   for (const warning of resolved.warnings) io.err(`warning: ${warning}`);
   const brainUrl = resolved.httpOrigin;
   if (resolved.source === 'fallback' && resolved.warnings.length === 0) {
+    const lan = firstLanAddress();
     io.err(
       'warning: daemon.public_url is not set; tokens will point at ' +
-        `localhost:${config.daemon.port} and only work for sidecars on this machine.`,
+        `localhost:${config.daemon.port} and only work for sidecars on this machine.` +
+        (lan
+          ? ` For other devices, set it to e.g. http://${lan}:${config.daemon.port} and enroll again.`
+          : ' For other devices, set it to this machine\'s reachable address and enroll again.'),
     );
   }
   return { dataDir: config.daemon.data_dir, brainUrl };
+}
+
+/**
+ * First non-internal IPv4 address of this machine — used only to suggest a
+ * public_url that sidecars on the same network can actually reach. Returns ''
+ * when there is none (offline / loopback-only hosts).
+ */
+function firstLanAddress(): string {
+  try {
+    for (const ifaces of Object.values(networkInterfaces())) {
+      for (const info of ifaces ?? []) {
+        if (info.family === 'IPv4' && !info.internal) return info.address;
+      }
+    }
+  } catch {
+    // Suggestion only — never fail enrollment over it.
+  }
+  return '';
 }
 
 export async function cmdEnroll(args: string[], io: CliIo = defaultIo): Promise<number> {
@@ -58,6 +81,7 @@ export async function cmdEnroll(args: string[], io: CliIo = defaultIo): Promise<
   try {
     const { dataDir, brainUrl } = await openVault(io);
     const result = await enrollDevice(dataDir, brainUrl, name, { onExisting: 'upsert', rotate });
+    const { brainWs } = buildEnrollmentUrls(brainUrl);
     if (json) {
       io.out(
         JSON.stringify({
@@ -65,6 +89,7 @@ export async function cmdEnroll(args: string[], io: CliIo = defaultIo): Promise<
           sid: result.sidecar.id,
           name: result.sidecar.name,
           created: result.created,
+          brain: brainWs,
         }),
       );
     } else {
@@ -73,6 +98,17 @@ export async function cmdEnroll(args: string[], io: CliIo = defaultIo): Promise<
           ? `enrolled "${result.sidecar.name}" (${result.sidecar.id})`
           : `re-minted token for existing device "${result.sidecar.name}" (${result.sidecar.id}); previous tokens REMAIN VALID (use --rotate to invalidate them)`,
       );
+      // The brain URL is baked into the token at mint time; print it so a
+      // cross-machine setup fails here (loudly, at enroll) instead of later
+      // as a mysterious rejected-token error on the other device.
+      io.err(`token points at ${brainWs}`);
+      if (isLocalhostBrainUrl(brainWs)) {
+        io.err(
+          'note: that is a loopback address, so this token only works on this machine. ' +
+            'On another device you can still fix it by entering the brain address in the setup window ' +
+            "(or setting 'brain:' in ~/.jarvis/sidecar.yaml).",
+        );
+      }
       io.out(result.token);
     }
     return 0;

--- a/src/sidecar/manager.test.ts
+++ b/src/sidecar/manager.test.ts
@@ -3,7 +3,7 @@ import { statSync } from 'node:fs';
 import { chmod, mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { decodeJwt } from 'jose';
+import { decodeJwt, SignJWT } from 'jose';
 import { buildEnrollmentUrls, isLocalhostBrainUrl, SidecarManager } from './manager.ts';
 import { initDatabase, closeDb } from '../vault/schema.ts';
 import { computeAnonId } from '../telemetry/anon-id.ts';
@@ -213,6 +213,43 @@ describe('SidecarManager access tokens', () => {
       const manager = new SidecarManager(dataDir);
       await manager.start();
       expect(await manager.issueAccessToken('does-not-exist')).toBeNull();
+      await manager.stop();
+    } finally {
+      closeDb();
+      await rm(dataDir, { recursive: true, force: true });
+    }
+  });
+
+  test('tolerates modest clock skew on access-token expiry', async () => {
+    // Brain and sidecar are usually different machines; consumer clocks drift
+    // (or jump after sleep/NTP). A freshly minted token read against a slightly
+    // ahead clock used to fail as expired -> a mysterious 401 on the data
+    // plane even though enrollment was fine. Within the tolerance window the
+    // token must still verify; well past it, it must not.
+    const dataDir = await mkdtemp(join(tmpdir(), 'jarvis-sidecar-manager-'));
+    initDatabase(':memory:');
+    try {
+      const manager = new SidecarManager(dataDir);
+      await manager.start();
+      manager.setBrainUrl('https://brain.example.com');
+      const { sidecar } = await manager.enrollSidecar('clock-skew-test');
+      const privateKey = (manager as unknown as { privateKey: CryptoKey }).privateKey;
+
+      const now = Math.floor(Date.now() / 1000);
+      const signWith = (exp: number) =>
+        new SignJWT({ sid: sidecar.id })
+          .setProtectedHeader({ alg: 'ES256' })
+          .setSubject(`sidecar:${sidecar.id}`)
+          .setAudience('brain-api')
+          .setIssuedAt(now)
+          .setExpirationTime(exp)
+          .sign(privateKey);
+
+      // Expired 30s ago: inside the tolerance, still accepted.
+      expect(await manager.verifyAccessToken(await signWith(now - 30))).toEqual({ sid: sidecar.id });
+      // Expired 2 minutes ago: beyond the tolerance, rejected.
+      expect(await manager.verifyAccessToken(await signWith(now - 120))).toBeNull();
+
       await manager.stop();
     } finally {
       closeDb();

--- a/src/sidecar/manager.ts
+++ b/src/sidecar/manager.ts
@@ -47,6 +47,15 @@ const PUBLIC_KEY_FILE = 'public.pem';
 const ACCESS_TOKEN_AUDIENCE = 'brain-api';
 const ACCESS_TOKEN_TTL_SECONDS = 600; // 10 minutes
 
+// Clock tolerance for JWT time checks. The brain and a sidecar are often
+// different machines, and consumer clocks routinely drift by tens of seconds
+// (or jump after sleep/NTP sync). With zero tolerance, a slightly-ahead clock
+// makes freshly minted access tokens read as not-yet-valid (and a behind
+// clock expires them early), surfacing as a confusing 401 on the data plane
+// even though the enrollment token is fine. 60s absorbs ordinary drift while
+// staying far below the access-token TTL.
+const CLOCK_TOLERANCE_SECONDS = 60;
+
 /**
  * Accept only strings shaped like IANA zone names ("Area/City", up to three
  * segments, "UTC"), max 64 chars. Mirrors the Go sidecar's ianaNameRe.
@@ -487,6 +496,7 @@ export class SidecarManager implements Service {
     try {
       const { payload } = await jwtVerify(token, this.publicKey, {
         algorithms: [ALG],
+        clockTolerance: CLOCK_TOLERANCE_SECONDS,
       });
 
       const claims = payload as unknown as SidecarTokenClaims;
@@ -544,6 +554,7 @@ export class SidecarManager implements Service {
       const { payload } = await jwtVerify(token, this.publicKey, {
         algorithms: [ALG],
         audience: ACCESS_TOKEN_AUDIENCE,
+        clockTolerance: CLOCK_TOLERANCE_SECONDS,
       });
       const sid = typeof payload.sid === 'string' ? payload.sid : '';
       if (!sid) return null;


### PR DESCRIPTION
## Summary

Fixes the rejected-token errors people hit when enrolling a sidecar from a machine other than the brain (#83). The root problem: when `daemon.public_url`/`brain_domain` isn't set, `jarvis enroll` mints a token whose brain URL is `localhost` — fine on the brain machine, but on any other device the connect attempt fails, and it surfaces as a 401/403 that reads like a bad enrollment key.

## What changed

**Sidecar (Go)**
- Setup window and settings window token forms now have an optional **Brain address** field. It's saved as the sidecar's `brain:` override, so a localhost-pointing token can be corrected right in the UI instead of hand-editing `~/.jarvis/sidecar.yaml`.
- The setup form decodes the pasted token and shows the address it names, flagging loopback targets before you hit Connect.
- `verifyBrainToken` failure messages now detect loopback tokens and explain the override instead of only suggesting a re-enroll; the reconnect alert does the same.
- Added tests for the loopback detection and the new hint behavior.

**Brain (TS)**
- `jarvis enroll` prints the URL the token points at, suggests a LAN address when it resolves to loopback, and includes the brain URL in `--json` output.
- Sidecar JWT verification now accepts up to 60s of clock skew. Brain and sidecar are usually different machines, and drifted clocks were making freshly minted access tokens read as not-yet-valid/expired — another source of mystery 401s on the data plane.

## Scope

Only the enrollment/connect path. No changes to the data-plane auth model (access tokens still short-lived, enrollment JWT still rejected there), hosted handshake, or pebble behavior.