### PR TITLE
fix(build): drop the dead javascriptcoregtk .pc symlinks and document the webkit2gtk-4.1 shim per distro

### DIFF
--- a/sidecar/README.md
+++ b/sidecar/README.md
@@ -42,16 +42,49 @@ CC="clang -target arm64-apple-macos11" GOOS=darwin GOARCH=arm64 go build -o jarv
 
 ### Linux prerequisites
 
+`third_party/webview_go/webview.go` hardcodes the pkg-config name
+`webkit2gtk-4.0`, which recent distros no longer ship — Arch removed it
+outright, Debian 13 and Ubuntu 24.04 dropped it, and only older releases
+(Ubuntu 22.04, Debian 12) still carry `libwebkit2gtk-4.0-dev`. Install **4.1**
+and add a `.pc` name shim rather than chasing a 4.0 package. The two differ
+only where libsoup types surface in the API (4.1 is libsoup3, 4.0 libsoup2) —
+webview_go touches none of them, so the shim is a pure rename. On Arch in
+particular, do **not** install a 4.0 package: it resolves to an AUR source
+build that compiles WebKit from scratch and typically fails.
+
+**Debian / Ubuntu**
+
 ```bash
 sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev build-essential pkg-config
 
-# webview_go's cgo line hardcodes the pkg-config name webkit2gtk-4.0, but
-# current distros only ship 4.1. Symlink the .pc files so build-time
-# pkg-config resolves (the runtime loader already prefers 4.1).
 sudo ln -sf /usr/lib/x86_64-linux-gnu/pkgconfig/webkit2gtk-4.1.pc \
             /usr/lib/x86_64-linux-gnu/pkgconfig/webkit2gtk-4.0.pc
 sudo ln -sf /usr/lib/x86_64-linux-gnu/pkgconfig/javascriptcoregtk-4.1.pc \
             /usr/lib/x86_64-linux-gnu/pkgconfig/javascriptcoregtk-4.0.pc
+```
+
+**Arch**
+
+Arch's pkgconfig dir is `/usr/lib/pkgconfig` (no multiarch triplet), so the
+Debian paths above do not apply. Keep the shims out of the pacman-managed tree
+by putting them in `~/.local` — Arch's default search path is only
+`/usr/lib/pkgconfig:/usr/share/pkgconfig`, so `PKG_CONFIG_PATH` must name it:
+
+```bash
+sudo pacman -S --needed webkit2gtk-4.1 gtk3 base-devel pkgconf
+
+mkdir -p ~/.local/lib/pkgconfig
+ln -sf /usr/lib/pkgconfig/webkit2gtk-4.1.pc        ~/.local/lib/pkgconfig/webkit2gtk-4.0.pc
+ln -sf /usr/lib/pkgconfig/javascriptcoregtk-4.1.pc ~/.local/lib/pkgconfig/javascriptcoregtk-4.0.pc
+
+# add to ~/.bashrc or ~/.zshrc so `make build` works without a prefix
+export PKG_CONFIG_PATH="$HOME/.local/lib/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
+```
+
+Verify the shim before building — this should print `-lwebkit2gtk-4.1`:
+
+```bash
+pkg-config --libs gtk+-3.0 webkit2gtk-4.0
 ```
 
 Windows needs the **WebView2 runtime** (pre-installed on Win11; the sidecar

--- a/sidecar/javascriptcoregtk-4.0.pc
+++ b/sidecar/javascriptcoregtk-4.0.pc
@@ -1,1 +1,0 @@
-/usr/lib/x86_64-linux-gnu/pkgconfig/javascriptcoregtk-4.1.pc/usr/lib/x86_64-linux-gnu/pkgconfig/javascriptcoregtk-4.0.pc

--- a/sidecar/javascriptcoregtk-4.1.pc
+++ b/sidecar/javascriptcoregtk-4.1.pc
@@ -1,1 +1,0 @@
-/usr/lib/x86_64-linux-gnu/pkgconfig/javascriptcoregtk-4.1.pc


### PR DESCRIPTION
## Problem

Two `.pc` symlinks were committed to `sidecar/`, both broken:

```
javascriptcoregtk-4.1.pc -> /usr/lib/x86_64-linux-gnu/pkgconfig/javascriptcoregtk-4.1.pc
javascriptcoregtk-4.0.pc -> /usr/lib/x86_64-linux-gnu/pkgconfig/javascriptcoregtk-4.1.pc/usr/lib/x86_64-linux-gnu/pkgconfig/javascriptcoregtk-4.0.pc
```

The 4.0 one is malformed — two absolute paths concatenated into a single target, so it can never resolve on any machine. Both hardcode Debian multiarch paths, leaving them dead on any non-Debian layout regardless. And nothing ever consumed them: the repo root is not on `PKG_CONFIG_PATH`, and CI builds its own aliases at setup time (`test.yml`, `sidecar-release.yml`, `update-webview.yml` each symlink `webkit2gtk-4.1.pc` → `webkit2gtk-4.0.pc` across `/usr/lib/*/pkgconfig`). They were checked-in noise that reads like real build configuration.

The README's Linux section had a related gap. `third_party/webview_go/webview.go` pins the pkg-config name `webkit2gtk-4.0`, and the documented workaround was Debian-only — `/usr/lib/x86_64-linux-gnu/pkgconfig`, a path that does not exist outside Debian multiarch. On Arch, where pkgconfig lives in `/usr/lib/pkgconfig` and 4.0 was removed from the repos entirely, following the README leads to a package that only exists as an AUR source build of WebKit.

## Fix

- Delete both symlinks. No consumer, no CI dependency; verified by a repo-wide grep that only the three workflows and the README mention these names.
- Restructure the Linux prerequisites into **Debian / Ubuntu** and **Arch** blocks. The Debian commands are unchanged.
- The Arch block uses `/usr/lib/pkgconfig`, keeps the shims in `~/.local/lib/pkgconfig` so nothing lands in the pacman-managed tree, and sets `PKG_CONFIG_PATH` — required, since Arch's default search path is only `/usr/lib/pkgconfig:/usr/share/pkgconfig`.
- Explain up front why the shim exists and which releases still ship 4.0 (Ubuntu 22.04, Debian 12) versus which dropped it (Arch, Debian 13, Ubuntu 24.04), so the alias reads as deliberate rather than superstition.
- Note that 4.0 and 4.1 diverge only where libsoup types surface in the API, which webview_go never touches — that is what makes the rename safe here, rather than a blanket claim that the two are interchangeable.
- Add a verification command so the shim can be confirmed before a build rather than during one.

## Verification

Built on Arch (`webkit2gtk-4.1 2.52.5-2`, no 4.0 present) following the new instructions:

```
go build -tags jarvisdebug -o ./jarvis .    # exit 0
ldd jarvis | grep -E 'webkit|javascriptcore|soup'
    libwebkit2gtk-4.1.so.0
    libjavascriptcoregtk-4.1.so.0
    libsoup-3.0.so.0
```

Links 4.1 cleanly with no libsoup2 alongside libsoup3. Docs and dead files only — no Go source, build config, or CI changes, so existing Debian and CI paths are untouched.
