### PR TITLE
fix(daemon): stop deleting a live daemon's lockfile, and resolve logs through JARVIS_HOME

### DIFF
--- a/bin/jarvis.ts
+++ b/bin/jarvis.ts
@@ -19,7 +19,7 @@
 import { join } from 'node:path';
 import { existsSync, openSync } from 'node:fs';
 import { spawn } from 'node:child_process';
-import { acquireLock, releaseLock, isLocked, getLogPath } from '../src/daemon/pid.ts';
+import { acquireLock, releaseLock, isLocked, getLogPath, isProcessAlive, waitForProcessExit } from '../src/daemon/pid.ts';
 import { c } from '../src/cli/helpers.ts';
 import { ensurePortReleased, getConfiguredPort, resolveStopPort } from '../src/cli/lifecycle.ts';
 import { getInstalledVersion } from '../src/cli/version.ts';
@@ -259,13 +259,27 @@ async function cmdStop(args: string[] = [], opts: { verb?: string } = {}): Promi
     let ticks = 0;
     while (Date.now() < deadline) {
       await new Promise(resolve => setTimeout(resolve, 500));
-      try { process.kill(pid, 0); } catch { alive = false; break; }
+      if (!isProcessAlive(pid)) { alive = false; break; }
       if (++ticks === 6) console.log(c.dim('  Draining in-flight work...'));
     }
 
     if (alive) {
       console.log(c.dim('  Drain deadline exceeded, sending SIGKILL...'));
       try { process.kill(pid, 'SIGKILL'); } catch { /* already gone */ }
+      // SIGKILL returns before the kernel finishes the teardown.
+      await waitForProcessExit(pid, 2000);
+    }
+
+    // releaseLock() unlinks the lockfile whether or not we hold it, so it must
+    // only run once the daemon is confirmed gone. Clearing a LIVE daemon's lock
+    // lets the next `jarvis start` take a fresh inode and run a second daemon
+    // against the same data dir. The usual reason to land here is EPERM — a
+    // daemon owned by another user, which isProcessAlive correctly reports as
+    // alive.
+    if (isProcessAlive(pid)) {
+      console.error(c.red(`✗ Could not stop JARVIS daemon (PID ${pid}) — it is still running.`));
+      console.error(c.dim('  Its lockfile was left in place. Stop it as its owner, or with root.'));
+      process.exit(1);
     }
 
     if (port === null) {
@@ -288,6 +302,13 @@ async function cmdStop(args: string[] = [], opts: { verb?: string } = {}): Promi
     console.log(c.green(`✓ JARVIS daemon stopped.${details}`));
   } catch (err) {
     console.error(c.red(`Failed to stop process ${pid}: ${err}`));
+    // Same rule as the success path: clear the lock only for a daemon that is
+    // genuinely gone (SIGTERM raising ESRCH — a stale lockfile), never for one
+    // we simply failed to signal.
+    if (isProcessAlive(pid)) {
+      console.error(c.dim('  Daemon is still running; its lockfile was left in place.'));
+      process.exit(1);
+    }
     releaseLock();
   }
 }

--- a/bin/jarvis.ts
+++ b/bin/jarvis.ts
@@ -270,15 +270,26 @@ async function cmdStop(args: string[] = [], opts: { verb?: string } = {}): Promi
       await waitForProcessExit(pid, 2000);
     }
 
-    // releaseLock() unlinks the lockfile whether or not we hold it, so it must
-    // only run once the daemon is confirmed gone. Clearing a LIVE daemon's lock
-    // lets the next `jarvis start` take a fresh inode and run a second daemon
-    // against the same data dir. The usual reason to land here is EPERM — a
-    // daemon owned by another user, which isProcessAlive correctly reports as
-    // alive.
-    if (isProcessAlive(pid)) {
-      console.error(c.red(`✗ Could not stop JARVIS daemon (PID ${pid}) — it is still running.`));
-      console.error(c.dim('  Its lockfile was left in place. Stop it as its owner, or with root.'));
+    // releaseLock() unlinks the lockfile whether or not we hold it, so it may
+    // only run when nothing holds the flock. Probing the LOCK (rather than the
+    // pid we signalled) covers all three ways a daemon can still be there: it
+    // ignored/refused our signals (EPERM), or a service manager relaunched it
+    // under a new pid (launchd KeepAlive, systemd Restart). Unlinking in either
+    // case would let the next `jarvis start` take a fresh inode and run a
+    // second daemon against the same data dir.
+    const holder = isLocked();
+    if (holder !== null) {
+      const relaunched = holder !== pid;
+      console.error(c.red(
+        relaunched
+          ? `✗ JARVIS daemon (PID ${pid}) stopped, but a new one (PID ${holder}) is already running.`
+          : `✗ Could not stop JARVIS daemon (PID ${pid}) — it is still running.`,
+      ));
+      console.error(c.dim(
+        relaunched
+          ? '  A service manager restarted it. Disable autostart first: jarvis autostart disable'
+          : '  Its lockfile was left in place. Stop it as its owner, or with root.',
+      ));
       process.exit(1);
     }
 
@@ -302,11 +313,10 @@ async function cmdStop(args: string[] = [], opts: { verb?: string } = {}): Promi
     console.log(c.green(`✓ JARVIS daemon stopped.${details}`));
   } catch (err) {
     console.error(c.red(`Failed to stop process ${pid}: ${err}`));
-    // Same rule as the success path: clear the lock only for a daemon that is
-    // genuinely gone (SIGTERM raising ESRCH — a stale lockfile), never for one
-    // we simply failed to signal.
-    if (isProcessAlive(pid)) {
-      console.error(c.dim('  Daemon is still running; its lockfile was left in place.'));
+    // Same rule as the success path: clear the lock only when nothing holds it
+    // (SIGTERM raising ESRCH — a stale lockfile), never while a daemon is live.
+    if (isLocked() !== null) {
+      console.error(c.dim('  A daemon still holds the lock; its lockfile was left in place.'));
       process.exit(1);
     }
     releaseLock();

--- a/bin/jarvis.ts
+++ b/bin/jarvis.ts
@@ -19,7 +19,7 @@
 import { join } from 'node:path';
 import { existsSync, openSync } from 'node:fs';
 import { spawn } from 'node:child_process';
-import { acquireLock, releaseLock, isLocked, getLogPath, isProcessAlive, waitForProcessExit } from '../src/daemon/pid.ts';
+import { acquireLock, releaseLock, releaseLockIfUnheld, isLocked, getLogPath, isProcessAlive, waitForProcessExit } from '../src/daemon/pid.ts';
 import { c } from '../src/cli/helpers.ts';
 import { ensurePortReleased, getConfiguredPort, resolveStopPort } from '../src/cli/lifecycle.ts';
 import { getInstalledVersion } from '../src/cli/version.ts';
@@ -201,7 +201,10 @@ async function cmdStart(args: string[]): Promise<void> {
   }
 }
 
-async function cmdStop(args: string[] = [], opts: { verb?: string } = {}): Promise<void> {
+// Returns true when the daemon is stopped and its lock cleared; false when a
+// daemon still holds the lock (unsignalable, or relaunched by a supervisor).
+// Callers decide whether that is fatal — `jarvis restart` must not exit here.
+async function cmdStop(args: string[] = [], opts: { verb?: string } = {}): Promise<boolean> {
   const verb = opts.verb ?? 'Stopping';
   const pid = isLocked();
 
@@ -230,7 +233,7 @@ async function cmdStop(args: string[] = [], opts: { verb?: string } = {}): Promi
   if (!pid) {
     if (port === null) {
       console.log(c.yellow('JARVIS is not running.'));
-      return;
+      return true;
     }
     const cleanup = await ensurePortReleased(port);
     if (cleanup.terminated.length > 0 || cleanup.forced.length > 0) {
@@ -241,7 +244,7 @@ async function cmdStop(args: string[] = [], opts: { verb?: string } = {}): Promi
     } else {
       console.log(c.yellow('JARVIS is not running.'));
     }
-    return;
+    return true;
   }
 
   console.log(c.cyan(`${verb} JARVIS daemon (PID ${pid})...`));
@@ -277,9 +280,13 @@ async function cmdStop(args: string[] = [], opts: { verb?: string } = {}): Promi
     // under a new pid (launchd KeepAlive, systemd Restart). Unlinking in either
     // case would let the next `jarvis start` take a fresh inode and run a
     // second daemon against the same data dir.
-    const holder = isLocked();
-    if (holder !== null) {
-      const relaunched = holder !== pid;
+    // releaseLockIfUnheld() unlinks ONLY when nothing holds the flock, and does
+    // it while holding the lock itself — so a supervisor-spawned replacement
+    // (launchd KeepAlive, systemd Restart) can neither be mistaken for a dead
+    // daemon nor slip in between the check and the unlink.
+    if (!releaseLockIfUnheld()) {
+      const holder = isLocked();
+      const relaunched = holder !== null && holder !== pid;
       console.error(c.red(
         relaunched
           ? `✗ JARVIS daemon (PID ${pid}) stopped, but a new one (PID ${holder}) is already running.`
@@ -287,22 +294,20 @@ async function cmdStop(args: string[] = [], opts: { verb?: string } = {}): Promi
       ));
       console.error(c.dim(
         relaunched
-          ? '  A service manager restarted it. Disable autostart first: jarvis autostart disable'
+          ? '  A service manager restarted it. Remove autostart first: jarvis uninstall (or disable the service).'
           : '  Its lockfile was left in place. Stop it as its owner, or with root.',
       ));
-      process.exit(1);
+      return false;
     }
 
     if (port === null) {
-      releaseLock();
       console.log(c.green('✓ JARVIS daemon stopped.'));
-      return;
+      return true;
     }
     const cleanup = await ensurePortReleased(port);
-    releaseLock();
     if (!cleanup.released) {
       console.error(c.red(`✗ JARVIS stopped but port ${port} is still occupied.`));
-      process.exit(1);
+      return false;
     }
 
     const details = cleanup.forced.length > 0
@@ -311,15 +316,16 @@ async function cmdStop(args: string[] = [], opts: { verb?: string } = {}): Promi
         ? ` Cleaned up lingering listener(s) on port ${port}: ${cleanup.terminated.join(', ')}.`
         : '';
     console.log(c.green(`✓ JARVIS daemon stopped.${details}`));
+    return true;
   } catch (err) {
     console.error(c.red(`Failed to stop process ${pid}: ${err}`));
     // Same rule as the success path: clear the lock only when nothing holds it
     // (SIGTERM raising ESRCH — a stale lockfile), never while a daemon is live.
-    if (isLocked() !== null) {
+    if (!releaseLockIfUnheld()) {
       console.error(c.dim('  A daemon still holds the lock; its lockfile was left in place.'));
-      process.exit(1);
+      return false;
     }
-    releaseLock();
+    return true;
   }
 }
 
@@ -356,7 +362,18 @@ async function cmdUninstall(): Promise<void> {
 async function cmdRestart(args: string[]): Promise<void> {
   const pid = isLocked();
   if (pid) {
-    await cmdStop();
+    if (!await cmdStop()) {
+      // Under launchd KeepAlive / systemd Restart the daemon comes straight
+      // back under a new pid. That IS the restart the user asked for — report
+      // it rather than exiting, and never fall through to cmdStart, which would
+      // only fail acquireLock() against the live replacement.
+      const holder = isLocked();
+      if (holder !== null && holder !== pid) {
+        console.log(c.green(`✓ JARVIS restarted by its service manager (PID ${holder}).`));
+        return;
+      }
+      process.exit(1);
+    }
   }
 
   console.log('');
@@ -445,11 +462,11 @@ switch (command) {
     await cmdStart(commandArgs);
     break;
   case 'stop':
-    await cmdStop(commandArgs);
+    if (!await cmdStop(commandArgs)) process.exit(1);
     break;
   case 'drain':
     // Same signal as stop (SIGTERM -> bounded graceful drain); clearer label.
-    await cmdStop(commandArgs, { verb: 'Draining' });
+    if (!await cmdStop(commandArgs, { verb: 'Draining' })) process.exit(1);
     break;
   case 'restart':
     await cmdRestart(commandArgs);

--- a/src/actions/browser/browser-primitives.test.ts
+++ b/src/actions/browser/browser-primitives.test.ts
@@ -155,9 +155,13 @@ describe.skipIf(!chromiumExe)('browser primitives (integration)', () => {
   // #editor, and the no-body test below navigates away entirely. That made the
   // suite order-dependent: a test's assertions silently depended on which
   // sibling had run before it, and any incomplete restore leaked forward.
+  // 60s, matching the worst case of the call itself: navigate()'s 30s
+  // Page.loadEventFired wait + up to 3s settle + the 15s readiness poll. A
+  // 30s budget would time the HOOK out on exactly the loaded runner this is
+  // meant to harden against — trading one flake for another.
   beforeEach(async () => {
     await loadTestPage();
-  }, 30_000);
+  }, 60_000);
 
   async function events(): Promise<string[]> {
     return await browser.evaluate('window.__events') as string[];

--- a/src/actions/browser/browser-primitives.test.ts
+++ b/src/actions/browser/browser-primitives.test.ts
@@ -6,7 +6,7 @@
  * to it instead of launching a headed window via WSLg). Skipped entirely when
  * no Chromium executable is available.
  */
-import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { describe, test, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
 import { existsSync, mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -97,7 +97,7 @@ describe.skipIf(!chromiumExe)('browser primitives (integration)', () => {
     if (!up) throw new Error(`Chromium CDP did not come up on port ${TEST_PORT}`);
 
     browser = new BrowserController(TEST_PORT);
-    await browser.navigate(`data:text/html,${encodeURIComponent(TEST_PAGE)}`);
+    await loadTestPage();
     // 90s, not 60s: the poll alone may run ~46s and navigate() carries an
     // internal 30s load wait — the hook must exceed their sum.
   }, 90_000);
@@ -107,6 +107,57 @@ describe.skipIf(!chromiumExe)('browser primitives (integration)', () => {
     proc?.kill();
     if (profileDir) rmSync(profileDir, { recursive: true, force: true });
   });
+
+  /**
+   * Navigate to a pristine TEST_PAGE and block until the DOM the tests assert
+   * on actually exists.
+   *
+   * navigate() resolves on Page.loadEventFired plus a FIXED 800ms settle, and
+   * when the load wait times out it only warns and continues — so on a loaded
+   * runner it can hand back a page whose script hasn't run. That produced the
+   * two failure shapes seen in CI: `document.getElementById("field")` being
+   * null (TypeError reading 'value'), and window.__events coming back empty
+   * because the listeners weren't attached yet. Polling for the real
+   * postcondition removes the dependence on that fixed sleep.
+   */
+  async function loadTestPage(): Promise<void> {
+    await browser.navigate(`data:text/html,${encodeURIComponent(TEST_PAGE)}`);
+
+    const deadline = Date.now() + 15_000;
+    let last = 'never evaluated';
+    while (Date.now() < deadline) {
+      try {
+        const ready = await browser.evaluate(`(() => {
+          const el = document.getElementById('field');
+          const ed = document.getElementById('editor');
+          const btn = document.getElementById('clickme');
+          if (!el || !ed || !btn) return 'dom-missing';
+          if (!Array.isArray(window.__events)) return 'script-not-run';
+          if (window.frames.length < 2) return 'iframes-missing';
+          // The iframes are written synchronously, but their documents settle a
+          // tick later — the snapshot walker needs both to be traversable.
+          if (!window.frames[0].document.querySelector('button')) return 'frame0-empty';
+          if (!window.frames[1].document.querySelector('[contenteditable]')) return 'frame1-empty';
+          return 'ready';
+        })()`) as string;
+        if (ready === 'ready') return;
+        last = ready;
+      } catch (err) {
+        last = `evaluate threw: ${err}`;
+      }
+      await Bun.sleep(100);
+    }
+    throw new Error(`TEST_PAGE never became ready (last state: ${last})`);
+  }
+
+  // Every test starts from a pristine page. These tests share one browser and
+  // one document, and several of them MUTATE it — typing into #field and
+  // #editor, and the no-body test below navigates away entirely. That made the
+  // suite order-dependent: a test's assertions silently depended on which
+  // sibling had run before it, and any incomplete restore leaked forward.
+  beforeEach(async () => {
+    await loadTestPage();
+  }, 30_000);
 
   async function events(): Promise<string[]> {
     return await browser.evaluate('window.__events') as string[];
@@ -144,7 +195,9 @@ describe.skipIf(!chromiumExe)('browser primitives (integration)', () => {
     const snap = await browser.snapshot();
     expect(snap.text).toBe('');
     expect(Array.isArray(snap.elements)).toBe(true);
-    await browser.navigate(`data:text/html,${encodeURIComponent(TEST_PAGE)}`);
+    // No manual restore: beforeEach re-loads TEST_PAGE and waits for it to be
+    // ready. The old restore here was fire-and-forget — if it hadn't settled,
+    // the NEXT test ran against this body-less page.
   }, 20_000);
 
   test('pressKey sends plain and modified keys to the page', async () => {

--- a/src/actions/browser/session.ts
+++ b/src/actions/browser/session.ts
@@ -302,16 +302,15 @@ export class BrowserController {
       }
       failures = 0;
 
-      // A stable element count is the settle signal; readyState decides how
-      // much corroboration it needs. 'complete' is conclusive, so return at
-      // once. Otherwise — an SPA, or a page whose load event already timed out,
-      // which may sit at 'loading'/'interactive' forever — accept a stable DOM
-      // once minSettleMs has passed. Without that floor those pages never
-      // satisfy the 'complete' conjunct and burn the whole maxMs budget, making
-      // navigation SLOWER than the flat 800ms sleep this replaced.
-      const state = sample.split(':')[0];
+      // A stable element count is the settle signal, floored at minSettleMs for
+      // EVERY page — `readyState === 'complete'` is not a licence to return
+      // early. Plenty of pages build their DOM from a load handler or a short
+      // setTimeout, which run AFTER 'complete'; returning at ~300ms would
+      // snapshot them empty, a regression against the flat 800ms sleep this
+      // replaced. The floor keeps the old guarantee; the stability check is
+      // what lets a slow page take longer, up to maxMs.
       const stable = count === lastCount;
-      if (stable && (state === 'complete' || Date.now() - start >= minSettleMs)) return;
+      if (stable && Date.now() - start >= minSettleMs) return;
       lastCount = count;
     }
   }

--- a/src/actions/browser/session.ts
+++ b/src/actions/browser/session.ts
@@ -259,18 +259,26 @@ export class BrowserController {
    *
    * Polls readyState plus the element count and returns as soon as two
    * consecutive samples agree, so the common case is FASTER than the old sleep
-   * while a slow page gets up to `maxMs`. Never throws: a page we can't
-   * evaluate in (cross-origin redirect, crashed tab) just ends the wait and
-   * lets the caller's snapshot report whatever is there.
+   * while a slow page gets up to `maxMs`.
+   *
+   * A failed sample is RETRIED rather than treated as terminal. Chrome rejects
+   * Runtime.evaluate with "Cannot find context with specified id" while the
+   * execution context is being swapped — i.e. exactly during the navigation we
+   * are waiting on. Bailing on the first such error would end the wait after a
+   * single tick and hand back a page whose scripts have not run, which is worse
+   * than the flat sleep this replaced. Only a sustained run of failures (a
+   * crashed tab, a closed target) ends the wait early.
    */
   private async waitForSettled(maxMs = 3000, intervalMs = 150): Promise<void> {
     const deadline = Date.now() + maxMs;
+    const maxConsecutiveFailures = 5;
     let lastCount = -1;
+    let failures = 0;
 
     while (Date.now() < deadline) {
       await Bun.sleep(intervalMs);
 
-      let sample: string;
+      let sample: string | null = null;
       try {
         const result = await this.cdp.send('Runtime.evaluate', {
           expression: `(() => {
@@ -279,17 +287,21 @@ export class BrowserController {
           })()`,
           returnByValue: true,
         });
-        if (result.exceptionDetails) return;
-        sample = String(result.result?.value ?? '');
+        if (!result.exceptionDetails && result.result?.value !== undefined) {
+          sample = String(result.result.value);
+        }
       } catch {
-        // CDP call failed — nothing useful left to wait for.
-        return;
+        // Transient during a context swap — fall through to the retry counter.
       }
 
-      const [state, rawCount] = sample.split(':');
-      const count = Number.parseInt(rawCount ?? '', 10);
-      if (Number.isNaN(count)) return;
+      const count = sample === null ? Number.NaN : Number.parseInt(sample.split(':')[1] ?? '', 10);
+      if (sample === null || Number.isNaN(count)) {
+        if (++failures >= maxConsecutiveFailures) return;
+        continue;
+      }
+      failures = 0;
 
+      const state = sample.split(':')[0];
       if (state === 'complete' && count === lastCount) return;
       lastCount = count;
     }

--- a/src/actions/browser/session.ts
+++ b/src/actions/browser/session.ts
@@ -243,10 +243,56 @@ export class BrowserController {
       console.warn(`[BrowserController] Page load timeout for ${url}, continuing anyway`);
     }
 
-    // Wait for JS to settle
-    await Bun.sleep(800);
+    await this.waitForSettled();
 
     return this.snapshot();
+  }
+
+  /**
+   * Wait for the document to stop changing, bounded.
+   *
+   * This replaces a flat `Bun.sleep(800)`. That sleep was wrong in both
+   * directions: on a static page it burned 800ms doing nothing, and on a loaded
+   * machine — or when the load-event wait above timed out and we continued
+   * anyway — 800ms wasn't enough, so callers got a snapshot of a page whose
+   * scripts hadn't run yet (missing elements, unattached listeners).
+   *
+   * Polls readyState plus the element count and returns as soon as two
+   * consecutive samples agree, so the common case is FASTER than the old sleep
+   * while a slow page gets up to `maxMs`. Never throws: a page we can't
+   * evaluate in (cross-origin redirect, crashed tab) just ends the wait and
+   * lets the caller's snapshot report whatever is there.
+   */
+  private async waitForSettled(maxMs = 3000, intervalMs = 150): Promise<void> {
+    const deadline = Date.now() + maxMs;
+    let lastCount = -1;
+
+    while (Date.now() < deadline) {
+      await Bun.sleep(intervalMs);
+
+      let sample: string;
+      try {
+        const result = await this.cdp.send('Runtime.evaluate', {
+          expression: `(() => {
+            try { return document.readyState + ':' + document.getElementsByTagName('*').length; }
+            catch { return 'error:-1'; }
+          })()`,
+          returnByValue: true,
+        });
+        if (result.exceptionDetails) return;
+        sample = String(result.result?.value ?? '');
+      } catch {
+        // CDP call failed — nothing useful left to wait for.
+        return;
+      }
+
+      const [state, rawCount] = sample.split(':');
+      const count = Number.parseInt(rawCount ?? '', 10);
+      if (Number.isNaN(count)) return;
+
+      if (state === 'complete' && count === lastCount) return;
+      lastCount = count;
+    }
   }
 
   /**

--- a/src/actions/browser/session.ts
+++ b/src/actions/browser/session.ts
@@ -269,8 +269,9 @@ export class BrowserController {
    * than the flat sleep this replaced. Only a sustained run of failures (a
    * crashed tab, a closed target) ends the wait early.
    */
-  private async waitForSettled(maxMs = 3000, intervalMs = 150): Promise<void> {
-    const deadline = Date.now() + maxMs;
+  private async waitForSettled(maxMs = 3000, intervalMs = 150, minSettleMs = 800): Promise<void> {
+    const start = Date.now();
+    const deadline = start + maxMs;
     const maxConsecutiveFailures = 5;
     let lastCount = -1;
     let failures = 0;
@@ -301,8 +302,16 @@ export class BrowserController {
       }
       failures = 0;
 
+      // A stable element count is the settle signal; readyState decides how
+      // much corroboration it needs. 'complete' is conclusive, so return at
+      // once. Otherwise — an SPA, or a page whose load event already timed out,
+      // which may sit at 'loading'/'interactive' forever — accept a stable DOM
+      // once minSettleMs has passed. Without that floor those pages never
+      // satisfy the 'complete' conjunct and burn the whole maxMs budget, making
+      // navigation SLOWER than the flat 800ms sleep this replaced.
       const state = sample.split(':')[0];
-      if (state === 'complete' && count === lastCount) return;
+      const stable = count === lastCount;
+      if (stable && (state === 'complete' || Date.now() - start >= minSettleMs)) return;
       lastCount = count;
     }
   }

--- a/src/cli/autostart.test.ts
+++ b/src/cli/autostart.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, test } from 'bun:test';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { mkdtempSync, writeFileSync } from 'node:fs';
 import {
   canUseSystemdUserService,
   generateLaunchdPlist,
@@ -261,5 +264,34 @@ describe('service definitions propagate JARVIS_HOME', () => {
     const plist = withJarvisHome('/srv/a&b/<c>', generateLaunchdPlist);
     expect(plist).toContain('<string>/srv/a&amp;b/&lt;c&gt;</string>');
     expect(plist).not.toContain('/srv/a&b/<c>');
+  });
+
+  // ── The generated files must be valid to the tools that consume them ──
+  //
+  // "contains the right substring" is not enough: systemd and launchctl reject
+  // malformed input, and a rejected service definition means autostart quietly
+  // does nothing.
+
+  const SYSTEMD_ANALYZE = Bun.which('systemd-analyze');
+  test.skipIf(!SYSTEMD_ANALYZE)('systemd-analyze accepts the generated unit', () => {
+    const unit = withJarvisHome('/srv/my data/100%', generateSystemdUnit);
+    const path = join(mkdtempSync(join(tmpdir(), 'jarvis-unit-')), 'jarvis-verify.service');
+    writeFileSync(path, unit, 'utf-8');
+    const r = Bun.spawnSync([SYSTEMD_ANALYZE!, 'verify', path], { stdout: 'pipe', stderr: 'pipe' });
+    const out = `${r.stdout.toString()}${r.stderr.toString()}`.trim();
+    expect({ code: r.exitCode, out }).toEqual({ code: 0, out: '' });
+  });
+
+  // plutil is macOS-only; xmllint covers well-formedness everywhere else.
+  const PLIST_LINT = Bun.which('plutil') ?? Bun.which('xmllint');
+  test.skipIf(!PLIST_LINT)('the generated plist parses with a hostile data root', () => {
+    const plist = withJarvisHome('/srv/a&b/<c>/"d"', generateLaunchdPlist);
+    const path = join(mkdtempSync(join(tmpdir(), 'jarvis-plist-')), 'jarvis.plist');
+    writeFileSync(path, plist, 'utf-8');
+    const cmd = PLIST_LINT!.endsWith('plutil')
+      ? [PLIST_LINT!, '-lint', path]
+      : [PLIST_LINT!, '--noout', path];
+    const r = Bun.spawnSync(cmd, { stdout: 'pipe', stderr: 'pipe' });
+    expect({ code: r.exitCode, err: r.stderr.toString().trim() }).toEqual({ code: 0, err: '' });
   });
 });

--- a/src/cli/autostart.test.ts
+++ b/src/cli/autostart.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from 'bun:test';
 import {
   canUseSystemdUserService,
+  generateLaunchdPlist,
+  generateSystemdUnit,
   decodeLaunchctlOutput,
   isLaunchdAlreadyLoaded,
   probeSystemdUserService,
@@ -198,5 +200,50 @@ describe('decodeLaunchctlOutput', () => {
 
   test('returns empty string for undefined', () => {
     expect(decodeLaunchctlOutput(undefined)).toBe('');
+  });
+});
+
+// ── Service definitions carry the data root ──────────────────────────
+//
+// The daemon resolves its lock AND its logs through JARVIS_HOME. A service
+// definition that doesn't export the var launches a daemon under ~/.jarvis
+// while every CLI tool in the same shell looks under $JARVIS_HOME.
+describe('service definitions propagate JARVIS_HOME', () => {
+  function withJarvisHome<T>(value: string | undefined, fn: () => T): T {
+    const prev = process.env.JARVIS_HOME;
+    if (value === undefined) delete process.env.JARVIS_HOME;
+    else process.env.JARVIS_HOME = value;
+    try { return fn(); } finally {
+      if (prev === undefined) delete process.env.JARVIS_HOME;
+      else process.env.JARVIS_HOME = prev;
+    }
+  }
+
+  test('systemd unit omits JARVIS_HOME when unset', () => {
+    const unit = withJarvisHome(undefined, generateSystemdUnit);
+    expect(unit).not.toContain('JARVIS_HOME');
+    expect(unit).toContain('[Install]');
+    expect(unit).toContain('Environment=HOME=');
+  });
+
+  test('systemd unit exports JARVIS_HOME when set', () => {
+    const unit = withJarvisHome('/srv/tenant7', generateSystemdUnit);
+    expect(unit).toContain('Environment=JARVIS_HOME=/srv/tenant7');
+    // The section header must not get swallowed by the injected line.
+    expect(unit).toContain('[Install]');
+    expect(unit).toContain('WantedBy=default.target');
+  });
+
+  test('launchd plist logs under JARVIS_HOME and exports it', () => {
+    const plist = withJarvisHome('/srv/tenant7', generateLaunchdPlist);
+    expect(plist).toContain('<string>/srv/tenant7/logs/jarvis.log</string>');
+    expect(plist).toContain('<key>JARVIS_HOME</key>');
+    expect(plist).toContain('<string>/srv/tenant7</string>');
+  });
+
+  test('launchd plist falls back to ~/.jarvis/logs with no JARVIS_HOME', () => {
+    const plist = withJarvisHome(undefined, generateLaunchdPlist);
+    expect(plist).toContain('/.jarvis/logs/jarvis.log');
+    expect(plist).not.toContain('JARVIS_HOME');
   });
 });

--- a/src/cli/autostart.test.ts
+++ b/src/cli/autostart.test.ts
@@ -228,7 +228,7 @@ describe('service definitions propagate JARVIS_HOME', () => {
 
   test('systemd unit exports JARVIS_HOME when set', () => {
     const unit = withJarvisHome('/srv/tenant7', generateSystemdUnit);
-    expect(unit).toContain('Environment=JARVIS_HOME=/srv/tenant7');
+    expect(unit).toContain('Environment="JARVIS_HOME=/srv/tenant7"');
     // The section header must not get swallowed by the injected line.
     expect(unit).toContain('[Install]');
     expect(unit).toContain('WantedBy=default.target');
@@ -245,5 +245,21 @@ describe('service definitions propagate JARVIS_HOME', () => {
     const plist = withJarvisHome(undefined, generateLaunchdPlist);
     expect(plist).toContain('/.jarvis/logs/jarvis.log');
     expect(plist).not.toContain('JARVIS_HOME');
+  });
+
+  // systemd splits an unquoted Environment= on whitespace and reads % as a
+  // specifier introducer. Either would truncate the path and put the daemon on
+  // a different root than the CLI — the split this line exists to close.
+  test('systemd quotes a data root containing spaces and escapes %', () => {
+    const unit = withJarvisHome('/srv/my data/100%', generateSystemdUnit);
+    expect(unit).toContain('Environment="JARVIS_HOME=/srv/my data/100%%"');
+  });
+
+  // An unescaped & or < yields a plist launchctl refuses to load, so autostart
+  // silently does nothing.
+  test('launchd plist XML-escapes the data root', () => {
+    const plist = withJarvisHome('/srv/a&b/<c>', generateLaunchdPlist);
+    expect(plist).toContain('<string>/srv/a&amp;b/&lt;c&gt;</string>');
+    expect(plist).not.toContain('/srv/a&b/<c>');
   });
 });

--- a/src/cli/autostart.ts
+++ b/src/cli/autostart.ts
@@ -123,25 +123,39 @@ ExecStart=${bunPath} ${jarvisPath} start --foreground
 Restart=on-failure
 RestartSec=5
 Environment=HOME=${homedir()}
-${jarvisHomeEnvLine('Environment=JARVIS_HOME=')}
+${systemdJarvisHomeLine()}
 [Install]
 WantedBy=default.target
 `;
 }
 
 /**
- * Propagate JARVIS_HOME into the service definition when the installing shell
- * has one set.
+ * Propagate JARVIS_HOME into the systemd unit when the installing shell has one
+ * set.
  *
  * Without this the service runs against ~/.jarvis while the CLI that installed
  * it (and `jarvis logs`, and the restart in `jarvis update`) resolves
  * $JARVIS_HOME — so the daemon locks and logs under one root while every tool
  * looks under another. Emits nothing when the var is unset, which keeps the
  * default single-root install byte-identical.
+ *
+ * The assignment is quoted and `%` doubled: systemd splits an unquoted
+ * `Environment=` on whitespace and reads `%` as a specifier introducer, so a
+ * data root containing either would be silently truncated or mangled — landing
+ * the daemon on a different root than the CLI, the exact split this prevents.
  */
-function jarvisHomeEnvLine(prefix: string): string {
+function systemdJarvisHomeLine(): string {
   const home = process.env.JARVIS_HOME;
-  return home ? `${prefix}${home}\n` : '';
+  if (!home) return '';
+  return `Environment="JARVIS_HOME=${home.replace(/%/g, '%%')}"\n`;
+}
+
+/** Escape a value for interpolation into plist text content. */
+function xmlEscape(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
 }
 
 async function installSystemd(): Promise<boolean> {
@@ -250,8 +264,8 @@ export function generateLaunchdPlist(): string {
   <string>ai.jarvis.daemon</string>
   <key>ProgramArguments</key>
   <array>
-    <string>${bunPath}</string>
-    <string>${jarvisPath}</string>
+    <string>${xmlEscape(bunPath)}</string>
+    <string>${xmlEscape(jarvisPath)}</string>
     <string>start</string>
     <string>--foreground</string>
   </array>
@@ -260,15 +274,15 @@ export function generateLaunchdPlist(): string {
   <key>KeepAlive</key>
   <true/>
   <key>StandardOutPath</key>
-  <string>${logDir}/jarvis.log</string>
+  <string>${xmlEscape(logDir)}/jarvis.log</string>
   <key>StandardErrorPath</key>
-  <string>${logDir}/jarvis-error.log</string>
+  <string>${xmlEscape(logDir)}/jarvis-error.log</string>
   <key>EnvironmentVariables</key>
   <dict>
     <key>HOME</key>
-    <string>${homedir()}</string>
-${process.env.JARVIS_HOME ? `    <key>JARVIS_HOME</key>\n    <string>${process.env.JARVIS_HOME}</string>\n` : ''}    <key>PATH</key>
-    <string>/usr/local/bin:/usr/bin:/bin:${join(homedir(), '.bun', 'bin')}</string>
+    <string>${xmlEscape(homedir())}</string>
+${process.env.JARVIS_HOME ? `    <key>JARVIS_HOME</key>\n    <string>${xmlEscape(process.env.JARVIS_HOME)}</string>\n` : ''}    <key>PATH</key>
+    <string>/usr/local/bin:/usr/bin:/bin:${xmlEscape(join(homedir(), '.bun', 'bin'))}</string>
   </dict>
 </dict>
 </plist>

--- a/src/cli/autostart.ts
+++ b/src/cli/autostart.ts
@@ -139,15 +139,21 @@ WantedBy=default.target
  * looks under another. Emits nothing when the var is unset, which keeps the
  * default single-root install byte-identical.
  *
- * The assignment is quoted and `%` doubled: systemd splits an unquoted
- * `Environment=` on whitespace and reads `%` as a specifier introducer, so a
- * data root containing either would be silently truncated or mangled — landing
- * the daemon on a different root than the CLI, the exact split this prevents.
+ * The assignment is quoted and escaped: systemd splits an unquoted
+ * `Environment=` on whitespace, reads `%` as a specifier introducer, and treats
+ * `\` and `"` as escape/terminator INSIDE the quotes. Any of them in the data
+ * root would truncate or mangle the value — landing the daemon on a different
+ * root than the CLI, the exact split this prevents. Backslash first, so the
+ * escapes added afterwards aren't doubled.
  */
 function systemdJarvisHomeLine(): string {
   const home = process.env.JARVIS_HOME;
   if (!home) return '';
-  return `Environment="JARVIS_HOME=${home.replace(/%/g, '%%')}"\n`;
+  const escaped = home
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/%/g, '%%');
+  return `Environment="JARVIS_HOME=${escaped}"\n`;
 }
 
 /** Escape a value for interpolation into plist text content. */

--- a/src/cli/autostart.ts
+++ b/src/cli/autostart.ts
@@ -11,6 +11,7 @@ import { homedir } from 'node:os';
 import { spawn } from 'node:child_process';
 import { existsSync, mkdirSync, writeFileSync, unlinkSync } from 'node:fs';
 import { c, printOk, printErr, printWarn } from './helpers.ts';
+import { getLogDir } from '../daemon/pid.ts';
 
 function canSpawnBinary(binary: string): boolean {
   try {
@@ -108,7 +109,7 @@ export function canUseSystemdUserService(spawnSync: SpawnSyncFn = defaultSpawnSy
 const SYSTEMD_DIR = join(homedir(), '.config', 'systemd', 'user');
 const SYSTEMD_SERVICE = join(SYSTEMD_DIR, 'jarvis.service');
 
-function generateSystemdUnit(): string {
+export function generateSystemdUnit(): string {
   const bunPath = getBunPath();
   const jarvisPath = getJarvisPath();
 
@@ -122,10 +123,25 @@ ExecStart=${bunPath} ${jarvisPath} start --foreground
 Restart=on-failure
 RestartSec=5
 Environment=HOME=${homedir()}
-
+${jarvisHomeEnvLine('Environment=JARVIS_HOME=')}
 [Install]
 WantedBy=default.target
 `;
+}
+
+/**
+ * Propagate JARVIS_HOME into the service definition when the installing shell
+ * has one set.
+ *
+ * Without this the service runs against ~/.jarvis while the CLI that installed
+ * it (and `jarvis logs`, and the restart in `jarvis update`) resolves
+ * $JARVIS_HOME — so the daemon locks and logs under one root while every tool
+ * looks under another. Emits nothing when the var is unset, which keeps the
+ * default single-root install byte-identical.
+ */
+function jarvisHomeEnvLine(prefix: string): string {
+  const home = process.env.JARVIS_HOME;
+  return home ? `${prefix}${home}\n` : '';
 }
 
 async function installSystemd(): Promise<boolean> {
@@ -218,10 +234,13 @@ function isSystemdInstalled(): boolean {
 const LAUNCHD_DIR = join(homedir(), 'Library', 'LaunchAgents');
 const LAUNCHD_PLIST = join(LAUNCHD_DIR, 'ai.jarvis.daemon.plist');
 
-function generateLaunchdPlist(): string {
+export function generateLaunchdPlist(): string {
   const bunPath = getBunPath();
   const jarvisPath = getJarvisPath();
-  const logDir = join(homedir(), '.jarvis', 'logs');
+  // getLogDir() so the plist's StandardOutPath matches where the daemon itself
+  // resolves its log file (both honor JARVIS_HOME) — and the plist exports the
+  // var below, so the launched daemon agrees with this path.
+  const logDir = getLogDir();
 
   return `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -248,7 +267,7 @@ function generateLaunchdPlist(): string {
   <dict>
     <key>HOME</key>
     <string>${homedir()}</string>
-    <key>PATH</key>
+${process.env.JARVIS_HOME ? `    <key>JARVIS_HOME</key>\n    <string>${process.env.JARVIS_HOME}</string>\n` : ''}    <key>PATH</key>
     <string>/usr/local/bin:/usr/bin:/bin:${join(homedir(), '.bun', 'bin')}</string>
   </dict>
 </dict>
@@ -263,7 +282,7 @@ async function installLaunchd(): Promise<boolean> {
     }
 
     // Ensure log directory exists
-    const logDir = join(homedir(), '.jarvis', 'logs');
+    const logDir = getLogDir();
     if (!existsSync(logDir)) {
       mkdirSync(logDir, { recursive: true });
     }

--- a/src/cli/daemon-control.systemd.test.ts
+++ b/src/cli/daemon-control.systemd.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Integration tests against a REAL systemd user manager.
+ *
+ * The rest of the suite simulates a supervisor with a process that spins on
+ * acquireLock. That models the shape but proves nothing about systemd itself —
+ * and the two worst regressions in this area were found in exactly the
+ * launchd/systemd paths. These tests use a genuine `Restart=always` unit:
+ *
+ *  1. the lockfile survives a stop when systemd relaunches the daemon;
+ *  2. the escaped `Environment=` line we generate round-trips through systemd's
+ *     own parser back to the exact path.
+ *
+ * Skipped wherever `systemctl --user` is unusable (containers, most CI
+ * runners, macOS), so this is a local/dev-machine gate rather than a CI one.
+ * Units are linked under a unique per-run name and unlinked afterwards; they
+ * never touch the real `jarvis.service`.
+ */
+import { test, expect, describe, beforeAll, afterAll } from 'bun:test';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { existsSync, mkdtempSync, rmSync, readFileSync, writeFileSync } from 'node:fs';
+import { stopDaemonGracefully } from './daemon-control.ts';
+import { generateSystemdUnit } from './autostart.ts';
+import { isLocked } from '../daemon/pid.ts';
+
+const PID_MODULE = join(import.meta.dir, '..', 'daemon', 'pid.ts');
+const UNIT_PREFIX = `jarvis-itest-${process.pid}`;
+const USER_UNIT_DIR = join(process.env.HOME ?? '', '.config', 'systemd', 'user');
+
+function sh(cmd: string[]): { code: number; out: string } {
+  const r = Bun.spawnSync(cmd, { stdout: 'pipe', stderr: 'pipe' });
+  return { code: r.exitCode ?? -1, out: `${r.stdout.toString()}${r.stderr.toString()}`.trim() };
+}
+
+function systemdUsable(): boolean {
+  if (process.platform !== 'linux') return false;
+  if (!Bun.which('systemctl')) return false;
+  // `is-system-running` exits non-zero when degraded but still manageable, so
+  // fall back to a command that only works with a reachable user manager.
+  return sh(['systemctl', '--user', 'is-system-running']).code === 0
+    || sh(['systemctl', '--user', 'show-environment']).code === 0;
+}
+
+const ENABLED = systemdUsable();
+
+let DATA_DIR: string;
+let prevJarvisHome: string | undefined;
+const linkedUnits: string[] = [];
+
+/** Link + start a unit built from `body`; returns its unit name. */
+function startUnit(name: string, body: string): void {
+  const unitPath = join(DATA_DIR, `${name}.service`);
+  writeFileSync(unitPath, body, 'utf-8');
+
+  const link = sh(['systemctl', '--user', 'link', unitPath]);
+  if (link.code !== 0) throw new Error(`systemctl link failed: ${link.out}`);
+  linkedUnits.push(name);
+
+  const start = sh(['systemctl', '--user', 'start', `${name}.service`]);
+  if (start.code !== 0) throw new Error(`systemctl start failed: ${start.out}`);
+}
+
+function stopAndUnlink(name: string): void {
+  sh(['systemctl', '--user', 'stop', `${name}.service`]);
+  sh(['systemctl', '--user', 'disable', `${name}.service`]);
+  try { rmSync(join(USER_UNIT_DIR, `${name}.service`), { force: true }); } catch { /* ignore */ }
+}
+
+describe.skipIf(!ENABLED)('daemon stop under a real systemd supervisor', () => {
+  beforeAll(() => {
+    prevJarvisHome = process.env.JARVIS_HOME;
+    DATA_DIR = mkdtempSync(join(tmpdir(), 'jarvis-systemd-test-'));
+    process.env.JARVIS_HOME = DATA_DIR;
+  });
+
+  afterAll(() => {
+    for (const name of linkedUnits) stopAndUnlink(name);
+    if (linkedUnits.length > 0) sh(['systemctl', '--user', 'daemon-reload']);
+    if (prevJarvisHome === undefined) delete process.env.JARVIS_HOME;
+    else process.env.JARVIS_HOME = prevJarvisHome;
+    try { rmSync(DATA_DIR, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  test('systemd relaunch keeps its lockfile through a stop', async () => {
+    const holder = join(DATA_DIR, 'holder.ts');
+    writeFileSync(holder, `
+import { acquireLock } from ${JSON.stringify(PID_MODULE)};
+while (!acquireLock(process.pid)) await Bun.sleep(20);
+await Bun.sleep(600000);
+`, 'utf-8');
+
+    const name = `${UNIT_PREFIX}-relaunch`;
+    startUnit(name, `[Unit]
+Description=jarvis lock relaunch probe
+[Service]
+Type=simple
+ExecStart=${Bun.which('bun')} ${holder}
+Restart=always
+RestartSec=0
+Environment="JARVIS_HOME=${DATA_DIR}"
+`);
+
+    // Wait for the supervised process to take the lock.
+    const deadline = Date.now() + 30_000;
+    let originalPid: number | null = null;
+    while (Date.now() < deadline && originalPid === null) {
+      originalPid = isLocked();
+      if (originalPid === null) await Bun.sleep(100);
+    }
+    expect(originalPid).not.toBeNull();
+
+    // 2s poll: a measured systemd relaunch takes ~90ms, so the replacement is
+    // reliably holding the lock by the time the stop makes its decision.
+    const result = await stopDaemonGracefully({ timeoutMs: 8000, pollIntervalMs: 2000 });
+
+    const newPid = isLocked();
+    expect(newPid).not.toBeNull();          // systemd brought it back
+    expect(newPid).not.toBe(originalPid);   // under a different pid
+    expect(result.stopped).toBe(false);     // so we did NOT stop the daemon
+    expect(existsSync(join(DATA_DIR, 'jarvis.pid'))).toBe(true); // and left its lock alone
+  }, 60_000);
+
+  test('the generated Environment= line round-trips through systemd', () => {
+    // A path with every character that systemd treats specially inside a
+    // quoted value: whitespace, %, backslash, and a double quote.
+    const hostile = `${DATA_DIR}/we ird/100%/back\\slash/qu"ote`;
+    const prev = process.env.JARVIS_HOME;
+    process.env.JARVIS_HOME = hostile;
+    let envLine: string;
+    try {
+      envLine = generateSystemdUnit()
+        .split('\n')
+        .find((l) => l.startsWith('Environment="JARVIS_HOME='))!;
+    } finally {
+      process.env.JARVIS_HOME = prev;
+    }
+    expect(envLine).toBeDefined();
+
+    const outFile = join(DATA_DIR, 'roundtrip.txt');
+    const dump = join(DATA_DIR, 'dump-env.ts');
+    writeFileSync(dump,
+      `import { writeFileSync } from 'node:fs';\n`
+      + `writeFileSync(${JSON.stringify(outFile)}, process.env.JARVIS_HOME ?? '<unset>');\n`,
+      'utf-8');
+
+    const name = `${UNIT_PREFIX}-env`;
+    startUnit(name, `[Unit]
+Description=jarvis env round-trip probe
+[Service]
+Type=oneshot
+ExecStart=${Bun.which('bun')} ${dump}
+${envLine}
+`);
+
+    const deadline = Date.now() + 20_000;
+    while (Date.now() < deadline && !existsSync(outFile)) {
+      Bun.spawnSync(['sleep', '0.05']); // sync wait: this test is not async
+    }
+    expect(existsSync(outFile)).toBe(true);
+    // systemd's parser must hand the daemon back the ORIGINAL path — if the
+    // escaping is wrong the value arrives truncated at the first space, or the
+    // unit fails to load at all.
+    expect(readFileSync(outFile, 'utf-8')).toBe(hostile);
+  }, 60_000);
+});

--- a/src/cli/daemon-control.test.ts
+++ b/src/cli/daemon-control.test.ts
@@ -28,21 +28,39 @@ const realKill = process.kill.bind(process);
  * KeepAlive=true, systemd Restart=). Returns immediately — it cannot acquire
  * anything until the current holder exits.
  */
-function spawnSupervisedReplacement(): { proc: ReturnType<typeof Bun.spawn>; ready: string } {
-  const readySignal = join(DATA_DIR, `replacement-ready-${Math.floor(performance.now() * 1000)}`);
-  const script = join(DATA_DIR, 'replacement.ts');
-  Bun.write(script, `
+async function spawnSupervisedReplacement(): Promise<ReturnType<typeof Bun.spawn>> {
+  const stamp = Math.floor(performance.now() * 1000);
+  const spinningSignal = join(DATA_DIR, `replacement-spinning-${stamp}`);
+  const script = join(DATA_DIR, `replacement-${stamp}.ts`);
+
+  // The first acquireLock attempt is expected to FAIL (the original still holds
+  // the lock) — its purpose is to pay the one-time TinyCC compile of flock.c
+  // before we signal "spinning", so the replacement can win the lock inside a
+  // single poll interval rather than racing a cold start against it.
+  await Bun.write(script, `
 import { acquireLock } from ${JSON.stringify(PID_MODULE)};
 import { writeFileSync } from 'node:fs';
-while (!acquireLock(process.pid)) await Bun.sleep(25);
-writeFileSync(${JSON.stringify(readySignal)}, String(process.pid));
+let got = acquireLock(process.pid);
+writeFileSync(${JSON.stringify(spinningSignal)}, '1');
+while (!got) { await Bun.sleep(25); got = acquireLock(process.pid); }
 await Bun.sleep(60000);
 `);
+
   const proc = Bun.spawn(['bun', script], {
     stdio: ['ignore', 'ignore', 'ignore'],
     env: { ...process.env, JARVIS_HOME: DATA_DIR },
   });
-  return { proc, ready: readySignal };
+
+  // Block until it is actually spinning; otherwise the test races a cold `bun`
+  // start and intermittently sees the lock go free.
+  const deadline = Date.now() + 20_000;
+  while (Date.now() < deadline) {
+    if (existsSync(spinningSignal)) return proc;
+    await Bun.sleep(25);
+  }
+  proc.kill();
+  await proc.exited;
+  throw new Error('replacement never started spinning');
 }
 
 /** Spawn a child holding the real flock, and wait until it confirms. */
@@ -173,11 +191,13 @@ describe('stopDaemonGracefully', () => {
     const originalPid = isLocked();
     expect(originalPid).not.toBeNull();
 
-    // Starts spinning now; it can only win the lock once `original` is killed.
-    const replacement = spawnSupervisedReplacement();
+    // Already spinning (and past its cold start) before the stop begins; it can
+    // only win the lock once `original` is killed.
+    const replacement = await spawnSupervisedReplacement();
 
-    // 500ms poll: `original` dies on SIGTERM, and the replacement claims the
-    // lock during the interval before stopDaemonGracefully looks again.
+    // 500ms poll: `original` dies on SIGTERM, and the replacement — already
+    // warm, retrying every 25ms — claims the lock well within the interval
+    // before stopDaemonGracefully looks again.
     const result = await stopDaemonGracefully({ timeoutMs: 5000, pollIntervalMs: 500 });
     await original.exited;
 
@@ -187,7 +207,7 @@ describe('stopDaemonGracefully', () => {
     expect(result.stopped).toBe(false);   // a daemon IS running against this dir
     expect(existsSync(LOCK_PATH)).toBe(true);
 
-    replacement.proc.kill(9);
-    await replacement.proc.exited;
-  }, 30_000);
+    replacement.kill(9);
+    await replacement.exited;
+  }, 45_000);
 });

--- a/src/cli/daemon-control.test.ts
+++ b/src/cli/daemon-control.test.ts
@@ -22,6 +22,29 @@ let prevJarvisHome: string | undefined;
 
 const realKill = process.kill.bind(process);
 
+/**
+ * Spawn a child that spins until it can take the lock, the way a service
+ * manager relaunches the daemon the moment the old one dies (launchd
+ * KeepAlive=true, systemd Restart=). Returns immediately — it cannot acquire
+ * anything until the current holder exits.
+ */
+function spawnSupervisedReplacement(): { proc: ReturnType<typeof Bun.spawn>; ready: string } {
+  const readySignal = join(DATA_DIR, `replacement-ready-${Math.floor(performance.now() * 1000)}`);
+  const script = join(DATA_DIR, 'replacement.ts');
+  Bun.write(script, `
+import { acquireLock } from ${JSON.stringify(PID_MODULE)};
+import { writeFileSync } from 'node:fs';
+while (!acquireLock(process.pid)) await Bun.sleep(25);
+writeFileSync(${JSON.stringify(readySignal)}, String(process.pid));
+await Bun.sleep(60000);
+`);
+  const proc = Bun.spawn(['bun', script], {
+    stdio: ['ignore', 'ignore', 'ignore'],
+    env: { ...process.env, JARVIS_HOME: DATA_DIR },
+  });
+  return { proc, ready: readySignal };
+}
+
 /** Spawn a child holding the real flock, and wait until it confirms. */
 async function spawnHolder(opts: { ignoreSigterm?: boolean } = {}): Promise<ReturnType<typeof Bun.spawn>> {
   const readySignal = join(DATA_DIR, `ready-${Math.floor(performance.now() * 1000)}`);
@@ -139,5 +162,32 @@ describe('stopDaemonGracefully', () => {
 
     holder.kill(9);
     await holder.exited;
+  }, 30_000);
+
+  // The relaunch case: checking "is the pid we signalled gone" is not enough,
+  // because a service manager brings the daemon straight back under a NEW pid.
+  // The old pid is then dead, and a pid-based guard would unlink the lockfile
+  // the live replacement is holding.
+  test('leaves the lockfile intact when a supervisor relaunches the daemon', async () => {
+    const original = await spawnHolder();
+    const originalPid = isLocked();
+    expect(originalPid).not.toBeNull();
+
+    // Starts spinning now; it can only win the lock once `original` is killed.
+    const replacement = spawnSupervisedReplacement();
+
+    // 500ms poll: `original` dies on SIGTERM, and the replacement claims the
+    // lock during the interval before stopDaemonGracefully looks again.
+    const result = await stopDaemonGracefully({ timeoutMs: 5000, pollIntervalMs: 500 });
+    await original.exited;
+
+    const newPid = isLocked();
+    expect(newPid).not.toBeNull();
+    expect(newPid).not.toBe(originalPid); // a different process holds it now
+    expect(result.stopped).toBe(false);   // a daemon IS running against this dir
+    expect(existsSync(LOCK_PATH)).toBe(true);
+
+    replacement.proc.kill(9);
+    await replacement.proc.exited;
   }, 30_000);
 });

--- a/src/cli/daemon-control.test.ts
+++ b/src/cli/daemon-control.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Tests for the shared daemon-stop helper.
+ *
+ * The invariant under test: the lockfile is cleared ONLY when the holder is
+ * confirmed gone. releaseLock() unlinks the path unconditionally, so a stop
+ * that fails to kill the daemon must leave the lock alone — otherwise
+ * isLocked() reports nothing and a second daemon starts against the same data
+ * dir while the first is still writing to it.
+ */
+import { test, expect, describe, beforeAll, afterAll, beforeEach, afterEach } from 'bun:test';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { existsSync, mkdtempSync, rmSync, readFileSync, unlinkSync } from 'node:fs';
+import { stopDaemonGracefully } from './daemon-control.ts';
+import { isLocked, releaseLock } from '../daemon/pid.ts';
+
+const PID_MODULE = join(import.meta.dir, '..', 'daemon', 'pid.ts');
+
+let DATA_DIR: string;
+let LOCK_PATH: string;
+let prevJarvisHome: string | undefined;
+
+const realKill = process.kill.bind(process);
+
+/** Spawn a child holding the real flock, and wait until it confirms. */
+async function spawnHolder(opts: { ignoreSigterm?: boolean } = {}): Promise<ReturnType<typeof Bun.spawn>> {
+  const readySignal = join(DATA_DIR, `ready-${Math.floor(performance.now() * 1000)}`);
+  const script = join(DATA_DIR, 'holder.ts');
+  await Bun.write(script, `
+import { acquireLock } from ${JSON.stringify(PID_MODULE)};
+import { writeFileSync } from 'node:fs';
+${opts.ignoreSigterm ? "process.on('SIGTERM', () => {});" : ''}
+const ok = acquireLock(process.pid);
+writeFileSync(${JSON.stringify(readySignal)}, ok ? String(process.pid) : 'FAIL');
+await Bun.sleep(60000);
+`);
+
+  const proc = Bun.spawn(['bun', script], {
+    stdio: ['ignore', 'ignore', 'pipe'],
+    env: { ...process.env, JARVIS_HOME: DATA_DIR },
+  });
+
+  const deadline = Date.now() + 15_000;
+  while (Date.now() < deadline) {
+    await Bun.sleep(50);
+    if (!existsSync(readySignal)) continue;
+    const content = readFileSync(readySignal, 'utf-8').trim();
+    try { unlinkSync(readySignal); } catch { /* ignore */ }
+    if (content === 'FAIL') {
+      proc.kill();
+      await proc.exited;
+      throw new Error('holder could not acquire the lock');
+    }
+    return proc;
+  }
+  proc.kill();
+  await proc.exited;
+  throw new Error('timed out waiting for the holder to acquire the lock');
+}
+
+describe('stopDaemonGracefully', () => {
+  beforeAll(() => {
+    prevJarvisHome = process.env.JARVIS_HOME;
+    DATA_DIR = mkdtempSync(join(tmpdir(), 'jarvis-daemon-control-test-'));
+    process.env.JARVIS_HOME = DATA_DIR;
+    LOCK_PATH = join(DATA_DIR, 'jarvis.pid');
+  });
+
+  afterAll(() => {
+    releaseLock();
+    if (prevJarvisHome === undefined) delete process.env.JARVIS_HOME;
+    else process.env.JARVIS_HOME = prevJarvisHome;
+    try { rmSync(DATA_DIR, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  beforeEach(() => releaseLock());
+  afterEach(() => {
+    process.kill = realKill;
+    releaseLock();
+  });
+
+  test('reports no daemon when nothing holds the lock', async () => {
+    const result = await stopDaemonGracefully();
+    expect(result).toEqual({ wasRunning: false, pid: null, graceful: true, stopped: true });
+  });
+
+  test('stops a live daemon and clears the lockfile', async () => {
+    const holder = await spawnHolder();
+    expect(isLocked()).not.toBeNull();
+
+    const result = await stopDaemonGracefully({ timeoutMs: 5000, pollIntervalMs: 100 });
+    await holder.exited;
+
+    expect(result.wasRunning).toBe(true);
+    expect(result.stopped).toBe(true);
+    expect(existsSync(LOCK_PATH)).toBe(false);
+  }, 30_000);
+
+  test('escalates to SIGKILL when the daemon ignores SIGTERM', async () => {
+    const holder = await spawnHolder({ ignoreSigterm: true });
+
+    const result = await stopDaemonGracefully({ timeoutMs: 1500, pollIntervalMs: 100 });
+    await holder.exited;
+
+    expect(result.wasRunning).toBe(true);
+    expect(result.graceful).toBe(false); // SIGTERM did not do it
+    expect(result.stopped).toBe(true);   // SIGKILL did
+    expect(existsSync(LOCK_PATH)).toBe(false);
+  }, 30_000);
+
+  // The regression this whole change exists for.
+  test('leaves the lockfile intact when the daemon cannot be signalled (EPERM)', async () => {
+    const holder = await spawnHolder();
+    const heldPid = isLocked();
+    expect(heldPid).not.toBeNull();
+
+    // Simulate a daemon owned by another user: every signal — including the
+    // liveness probe — raises EPERM. That is the case where the process is
+    // very much alive but not ours to kill.
+    process.kill = ((pid: number, signal?: string | number) => {
+      if (pid === heldPid) {
+        const err = new Error('kill EPERM') as NodeJS.ErrnoException;
+        err.code = 'EPERM';
+        throw err;
+      }
+      return realKill(pid, signal as never);
+    }) as typeof process.kill;
+
+    const result = await stopDaemonGracefully({ timeoutMs: 600, pollIntervalMs: 100 });
+    process.kill = realKill;
+
+    expect(result.wasRunning).toBe(true);
+    expect(result.stopped).toBe(false);
+    // The live holder's lock must survive — this is what used to be deleted.
+    expect(existsSync(LOCK_PATH)).toBe(true);
+    expect(isLocked()).toBe(heldPid);
+
+    holder.kill(9);
+    await holder.exited;
+  }, 30_000);
+});

--- a/src/cli/daemon-control.test.ts
+++ b/src/cli/daemon-control.test.ts
@@ -131,6 +131,8 @@ describe('stopDaemonGracefully', () => {
 
     expect(result.wasRunning).toBe(true);
     expect(result.stopped).toBe(false);
+    // A daemon that never exited did not exit "gracefully".
+    expect(result.graceful).toBe(false);
     // The live holder's lock must survive — this is what used to be deleted.
     expect(existsSync(LOCK_PATH)).toBe(true);
     expect(isLocked()).toBe(heldPid);

--- a/src/cli/daemon-control.ts
+++ b/src/cli/daemon-control.ts
@@ -4,7 +4,7 @@
  * and both need to release the lockfile afterward.
  */
 
-import { isLocked, releaseLock } from '../daemon/pid.ts';
+import { isLocked, releaseLock, isProcessAlive, waitForProcessExit } from '../daemon/pid.ts';
 
 export interface StopOptions {
   /** How long to wait for graceful exit before SIGKILL. Default 5s. */
@@ -31,27 +31,6 @@ export interface StopResult {
    * false here as "stopped".
    */
   stopped: boolean;
-}
-
-function isAlive(pid: number): boolean {
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch (err) {
-    // EPERM means the process EXISTS but isn't ours to signal (a daemon running
-    // as another user). Only ESRCH means "no such process". Treating EPERM as
-    // dead is what would let the caller clear a live daemon's lockfile.
-    return (err as NodeJS.ErrnoException)?.code === 'EPERM';
-  }
-}
-
-/** Poll until `pid` is gone, or the budget runs out. */
-async function waitForExit(pid: number, timeoutMs: number, pollIntervalMs = 50): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    if (!isAlive(pid)) return;
-    await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
-  }
 }
 
 /**
@@ -81,7 +60,7 @@ export async function stopDaemonGracefully(options: StopOptions = {}): Promise<S
     let alive = true;
     for (let i = 0; i < attempts; i += 1) {
       await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
-      if (!isAlive(pid)) {
+      if (!isProcessAlive(pid)) {
         alive = false;
         break;
       }
@@ -100,7 +79,7 @@ export async function stopDaemonGracefully(options: StopOptions = {}): Promise<S
       // Without this wait the liveness check below loses that race, reports
       // the daemon as alive, and leaves a stale lockfile blocking the next
       // start — the exact case the unconditional release used to cover.
-      await waitForExit(pid, 2000);
+      await waitForProcessExit(pid, 2000);
     }
   } catch {
     // SIGTERM failed. Usually the process was already dead (ESRCH), but it can
@@ -114,8 +93,12 @@ export async function stopDaemonGracefully(options: StopOptions = {}): Promise<S
   // and a second daemon can start against the same data dir. The stale-lock
   // case this double-tap exists for is unaffected: a dead holder still gets its
   // lockfile cleared.
-  const stopped = !isAlive(pid);
+  const stopped = !isProcessAlive(pid);
   if (stopped) releaseLock();
 
-  return { wasRunning: true, pid, graceful, stopped };
+  // A daemon that outlived both signals did not exit gracefully — it did not
+  // exit at all. Without this, an EPERM stop short-circuits to the catch above
+  // with `graceful` still at its initial true, reporting a clean shutdown that
+  // never happened.
+  return { wasRunning: true, pid, graceful: graceful && stopped, stopped };
 }

--- a/src/cli/daemon-control.ts
+++ b/src/cli/daemon-control.ts
@@ -4,7 +4,7 @@
  * and both need to release the lockfile afterward.
  */
 
-import { isLocked, releaseLock, isProcessAlive, waitForProcessExit } from '../daemon/pid.ts';
+import { isLocked, releaseLockIfUnheld, isProcessAlive, waitForProcessExit } from '../daemon/pid.ts';
 
 export interface StopOptions {
   /** How long to wait for graceful exit before SIGKILL. Default 5s. */
@@ -88,17 +88,12 @@ export async function stopDaemonGracefully(options: StopOptions = {}): Promise<S
     // another user). The liveness check below tells the two apart.
   }
 
-  // Ask the LOCK, not the pid we signalled. releaseLock() unlinks the path
-  // unconditionally, so it may only run when nothing holds the flock.
-  //
-  // Checking `!isProcessAlive(pid)` is not enough: autostart installs a launchd
-  // plist with KeepAlive=true (and a systemd unit with Restart=), so killing
-  // the daemon gets it relaunched under a NEW pid. The old pid is then gone,
-  // and we would unlink the lockfile the live replacement is holding — the
-  // double-daemon hazard this guard exists to prevent. Probing the lock covers
-  // that, the EPERM case, and the stale-lockfile case in one check.
-  const stopped = isLocked() === null;
-  if (stopped) releaseLock();
+  // Ask the LOCK, not the pid we signalled — and let the release itself make
+  // that decision atomically. `isLocked() === null` was still wrong twice over:
+  // it reports "free" for a lock whose pid is momentarily unreadable, and it
+  // leaves a window between the check and the unlink for a supervisor-spawned
+  // replacement to acquire. See releaseLockIfUnheld.
+  const stopped = releaseLockIfUnheld();
 
   // A daemon that outlived both signals did not exit gracefully — it did not
   // exit at all. Without this, an EPERM stop short-circuits to the catch above

--- a/src/cli/daemon-control.ts
+++ b/src/cli/daemon-control.ts
@@ -24,27 +24,47 @@ export interface StopResult {
   pid: number | null;
   /** True if the daemon exited via SIGTERM; false if we had to SIGKILL. */
   graceful: boolean;
+  /**
+   * True when the daemon is confirmed gone (or there was none). False means it
+   * survived both signals — e.g. `kill` raised EPERM because the daemon belongs
+   * to another user. Callers that go on to modify the data dir must not treat a
+   * false here as "stopped".
+   */
+  stopped: boolean;
 }
 
 function isAlive(pid: number): boolean {
   try {
     process.kill(pid, 0);
     return true;
-  } catch {
-    return false;
+  } catch (err) {
+    // EPERM means the process EXISTS but isn't ours to signal (a daemon running
+    // as another user). Only ESRCH means "no such process". Treating EPERM as
+    // dead is what would let the caller clear a live daemon's lockfile.
+    return (err as NodeJS.ErrnoException)?.code === 'EPERM';
+  }
+}
+
+/** Poll until `pid` is gone, or the budget runs out. */
+async function waitForExit(pid: number, timeoutMs: number, pollIntervalMs = 50): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!isAlive(pid)) return;
+    await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
   }
 }
 
 /**
  * Stop the running daemon, if any. Sends SIGTERM, polls for exit, escalates
- * to SIGKILL on timeout. Releases the lockfile on return regardless of path
- * (the daemon normally releases it on SIGTERM, but we double-tap in case of
- * a crashed daemon that never cleared its lock).
+ * to SIGKILL on timeout. Clears the lockfile once the holder is confirmed gone
+ * — including for a crashed daemon that never cleared its own lock — but
+ * leaves it in place if the daemon survived, since releaseLock() would
+ * otherwise unlink a live holder's lock. See `StopResult.stopped`.
  */
 export async function stopDaemonGracefully(options: StopOptions = {}): Promise<StopResult> {
   const pid = isLocked();
   if (!pid) {
-    return { wasRunning: false, pid: null, graceful: true };
+    return { wasRunning: false, pid: null, graceful: true, stopped: true };
   }
 
   const timeoutMs = options.timeoutMs ?? 5000;
@@ -75,12 +95,27 @@ export async function stopDaemonGracefully(options: StopOptions = {}): Promise<S
       } catch {
         // Already gone between our last check and the kill attempt.
       }
+      // SIGKILL returns before the kernel has finished tearing the process
+      // down, and a killed-but-unreaped zombie still answers kill(pid, 0).
+      // Without this wait the liveness check below loses that race, reports
+      // the daemon as alive, and leaves a stale lockfile blocking the next
+      // start — the exact case the unconditional release used to cover.
+      await waitForExit(pid, 2000);
     }
   } catch {
-    // SIGTERM failed — process was likely already dead. Fall through to
-    // releaseLock() so a stale lockfile doesn't block the next start.
+    // SIGTERM failed. Usually the process was already dead (ESRCH), but it can
+    // also mean we're not allowed to signal it (EPERM — a daemon owned by
+    // another user). The liveness check below tells the two apart.
   }
 
-  releaseLock();
-  return { wasRunning: true, pid, graceful };
+  // Only clear the lockfile once the holder is confirmed gone. releaseLock()
+  // unlinks the path unconditionally, so calling it while the daemon is still
+  // alive deletes a LIVE holder's lock — after which isLocked() reports nothing
+  // and a second daemon can start against the same data dir. The stale-lock
+  // case this double-tap exists for is unaffected: a dead holder still gets its
+  // lockfile cleared.
+  const stopped = !isAlive(pid);
+  if (stopped) releaseLock();
+
+  return { wasRunning: true, pid, graceful, stopped };
 }

--- a/src/cli/daemon-control.ts
+++ b/src/cli/daemon-control.ts
@@ -25,10 +25,11 @@ export interface StopResult {
   /** True if the daemon exited via SIGTERM; false if we had to SIGKILL. */
   graceful: boolean;
   /**
-   * True when the daemon is confirmed gone (or there was none). False means it
-   * survived both signals — e.g. `kill` raised EPERM because the daemon belongs
-   * to another user. Callers that go on to modify the data dir must not treat a
-   * false here as "stopped".
+   * True when NO daemon holds the lock any more. False means one still does —
+   * either the daemon survived both signals (`kill` raised EPERM because it
+   * belongs to another user) or a service manager already relaunched it under a
+   * new pid. Callers that go on to modify the data dir must not treat a false
+   * here as "stopped".
    */
   stopped: boolean;
 }
@@ -87,13 +88,16 @@ export async function stopDaemonGracefully(options: StopOptions = {}): Promise<S
     // another user). The liveness check below tells the two apart.
   }
 
-  // Only clear the lockfile once the holder is confirmed gone. releaseLock()
-  // unlinks the path unconditionally, so calling it while the daemon is still
-  // alive deletes a LIVE holder's lock — after which isLocked() reports nothing
-  // and a second daemon can start against the same data dir. The stale-lock
-  // case this double-tap exists for is unaffected: a dead holder still gets its
-  // lockfile cleared.
-  const stopped = !isProcessAlive(pid);
+  // Ask the LOCK, not the pid we signalled. releaseLock() unlinks the path
+  // unconditionally, so it may only run when nothing holds the flock.
+  //
+  // Checking `!isProcessAlive(pid)` is not enough: autostart installs a launchd
+  // plist with KeepAlive=true (and a systemd unit with Restart=), so killing
+  // the daemon gets it relaunched under a NEW pid. The old pid is then gone,
+  // and we would unlink the lockfile the live replacement is holding — the
+  // double-daemon hazard this guard exists to prevent. Probing the lock covers
+  // that, the EPERM case, and the stale-lockfile case in one check.
+  const stopped = isLocked() === null;
   if (stopped) releaseLock();
 
   // A daemon that outlived both signals did not exit gracefully — it did not

--- a/src/cli/lifecycle.ts
+++ b/src/cli/lifecycle.ts
@@ -90,12 +90,18 @@ export async function ensurePortReleased(
 
     try {
       process.kill(pid, 'SIGTERM');
-      if (await waitForExit(pid, 2000)) {
-        terminated.push(pid);
-        continue;
-      }
-    } catch {
-      // Fall through to final verification and force-kill path.
+    } catch (err) {
+      // EPERM: someone else's listener on our port — we can neither signal it
+      // nor wait it out, so skip instead of burning the 2s + 1s waits below.
+      // (The old local isPidAlive reported EPERM as dead and skipped at the top
+      // of the loop; now that it reports alive, the skip has to be explicit.)
+      if ((err as NodeJS.ErrnoException)?.code === 'EPERM') continue;
+      // ESRCH and friends: fall through — the wait below returns at once.
+    }
+
+    if (await waitForExit(pid, 2000)) {
+      terminated.push(pid);
+      continue;
     }
 
     if (!isPidAlive(pid)) {

--- a/src/cli/lifecycle.ts
+++ b/src/cli/lifecycle.ts
@@ -3,7 +3,7 @@ import { homedir } from 'node:os';
 import os from 'node:os';
 import { join } from 'node:path';
 import YAML from 'yaml';
-import { readLockedPort } from '../daemon/pid.ts';
+import { readLockedPort, isProcessAlive } from '../daemon/pid.ts';
 
 export const DEFAULT_DAEMON_PORT = 3142;
 
@@ -17,14 +17,11 @@ function parsePidList(output: string, currentPid: number): number[] {
   )];
 }
 
-function isPidAlive(pid: number): boolean {
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch {
-    return false;
-  }
-}
+// Re-exported under the local name this module already uses. The EPERM-vs-ESRCH
+// distinction lives in one place now (pid.ts) — this file used to have its own
+// copy that reported another user's listener as dead, so ensurePortReleased
+// skipped it silently.
+const isPidAlive = isProcessAlive;
 
 async function waitForExit(pid: number, timeoutMs: number): Promise<boolean> {
   const deadline = Date.now() + timeoutMs;

--- a/src/cli/uninstall.ts
+++ b/src/cli/uninstall.ts
@@ -225,15 +225,19 @@ try {
 
 // ── Side-effect cleanup (synchronous, parent process) ───────────────
 
-async function runSideEffectCleanup(plan: CleanupPlan): Promise<void> {
+async function runSideEffectCleanup(plan: CleanupPlan): Promise<boolean> {
   const stop = await stopDaemonGracefully({
     onStart: (pid) => console.log(c.dim(`Stopping daemon (PID ${pid})...`)),
     onForce: (pid) => console.log(c.dim(`Force-killing daemon (PID ${pid})...`)),
   });
-  // Deleting the data dir out from under a daemon we failed to kill corrupts
-  // whatever it writes next — warn instead of pretending it stopped.
+  // A daemon we failed to kill is still writing jarvis.db, the keychain, and
+  // workflow state. removablePaths includes the data dir, so continuing would
+  // rm -rf it underneath a live writer. Bail — the caller aborts the uninstall.
   if (!stop.stopped) {
-    console.log(c.yellow(`Warning: daemon (PID ${stop.pid}) could not be stopped — remove it manually before reinstalling.`));
+    console.log(c.red(`\n✗ Daemon (PID ${stop.pid}) could not be stopped.`));
+    console.log(c.dim('  Uninstall aborted: removing the data dir while it is running would corrupt it.'));
+    console.log(c.dim('  Stop it as its owner (or with root), then re-run `jarvis uninstall`.'));
+    return false;
   }
 
   if (plan.autostartInstalled) {
@@ -248,6 +252,8 @@ async function runSideEffectCleanup(plan: CleanupPlan): Promise<void> {
       console.log(c.dim(`    You may need to remove it manually.`));
     }
   }
+
+  return true;
 }
 
 // ── Package removal (detached process) ──────────────────────────────
@@ -337,7 +343,13 @@ export async function runUninstallWizard(packageRoot = PACKAGE_ROOT): Promise<vo
 
   closeRL();
 
-  await runSideEffectCleanup(plan);
+  // A false here means the daemon survived the stop. Nothing further may run:
+  // both the dev/unknown path and schedulePackageRemoval below delete the data
+  // dir that daemon is still writing to.
+  if (!await runSideEffectCleanup(plan)) {
+    process.exitCode = 1;
+    return;
+  }
 
   if (plan.method === 'dev' || plan.method === 'unknown') {
     console.log(c.green('\n✓ Side-effect cleanup complete.'));

--- a/src/cli/uninstall.ts
+++ b/src/cli/uninstall.ts
@@ -24,6 +24,7 @@ import { homedir, tmpdir } from 'node:os';
 import { join, resolve, sep } from 'node:path';
 import { closeRL, ask, askYesNo, c } from './helpers.ts';
 import { stopDaemonGracefully } from './daemon-control.ts';
+import { isLocked } from '../daemon/pid.ts';
 import { getAutostartName, isAutostartInstalled, uninstallAutostart } from './autostart.ts';
 import {
   detectInstallMethod,
@@ -226,20 +227,11 @@ try {
 // ── Side-effect cleanup (synchronous, parent process) ───────────────
 
 async function runSideEffectCleanup(plan: CleanupPlan): Promise<boolean> {
-  const stop = await stopDaemonGracefully({
-    onStart: (pid) => console.log(c.dim(`Stopping daemon (PID ${pid})...`)),
-    onForce: (pid) => console.log(c.dim(`Force-killing daemon (PID ${pid})...`)),
-  });
-  // A daemon we failed to kill is still writing jarvis.db, the keychain, and
-  // workflow state. removablePaths includes the data dir, so continuing would
-  // rm -rf it underneath a live writer. Bail — the caller aborts the uninstall.
-  if (!stop.stopped) {
-    console.log(c.red(`\n✗ Daemon (PID ${stop.pid}) could not be stopped.`));
-    console.log(c.dim('  Uninstall aborted: removing the data dir while it is running would corrupt it.'));
-    console.log(c.dim('  Stop it as its owner (or with root), then re-run `jarvis uninstall`.'));
-    return false;
-  }
-
+  // Autostart FIRST, then the daemon. The launchd plist is installed with
+  // KeepAlive=true (and the systemd unit with Restart=), so stopping the daemon
+  // while the service is still registered just gets it relaunched under a new
+  // pid — the stop then reports `stopped: false`, we abort, and the unload that
+  // would have broken the cycle never runs. Every retry loops the same way.
   if (plan.autostartInstalled) {
     console.log(c.dim(`Removing ${getAutostartName()}...`));
     try {
@@ -251,6 +243,21 @@ async function runSideEffectCleanup(plan: CleanupPlan): Promise<boolean> {
       console.log(c.yellow(`  ! Autostart removal failed: ${String(err).slice(0, 120)}`));
       console.log(c.dim(`    You may need to remove it manually.`));
     }
+  }
+
+  const stop = await stopDaemonGracefully({
+    onStart: (pid) => console.log(c.dim(`Stopping daemon (PID ${pid})...`)),
+    onForce: (pid) => console.log(c.dim(`Force-killing daemon (PID ${pid})...`)),
+  });
+  // A daemon we failed to kill is still writing jarvis.db, the keychain, and
+  // workflow state. removablePaths includes the data dir, so continuing would
+  // rm -rf it underneath a live writer. Bail — the caller aborts the uninstall.
+  if (!stop.stopped) {
+    const holder = isLocked();
+    console.log(c.red(`\n✗ Daemon (PID ${holder ?? stop.pid}) could not be stopped.`));
+    console.log(c.dim('  Uninstall aborted: removing the data dir while it is running would corrupt it.'));
+    console.log(c.dim('  Stop it as its owner (or with root), then re-run `jarvis uninstall`.'));
+    return false;
   }
 
   return true;

--- a/src/cli/uninstall.ts
+++ b/src/cli/uninstall.ts
@@ -226,10 +226,15 @@ try {
 // ── Side-effect cleanup (synchronous, parent process) ───────────────
 
 async function runSideEffectCleanup(plan: CleanupPlan): Promise<void> {
-  await stopDaemonGracefully({
+  const stop = await stopDaemonGracefully({
     onStart: (pid) => console.log(c.dim(`Stopping daemon (PID ${pid})...`)),
     onForce: (pid) => console.log(c.dim(`Force-killing daemon (PID ${pid})...`)),
   });
+  // Deleting the data dir out from under a daemon we failed to kill corrupts
+  // whatever it writes next — warn instead of pretending it stopped.
+  if (!stop.stopped) {
+    console.log(c.yellow(`Warning: daemon (PID ${stop.pid}) could not be stopped — remove it manually before reinstalling.`));
+  }
 
   if (plan.autostartInstalled) {
     console.log(c.dim(`Removing ${getAutostartName()}...`));

--- a/src/cli/update.test.ts
+++ b/src/cli/update.test.ts
@@ -264,7 +264,7 @@ describe('runUpdate — script install', () => {
       checkRunning: () => 12345, // pretend daemon is running
       stopDaemon: async () => {
         stopCalls += 1;
-        return { wasRunning: true, pid: 12345, graceful: true };
+        return { wasRunning: true, pid: 12345, graceful: true, stopped: true };
       },
       restartDaemon: false,
     });

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -312,13 +312,15 @@ export async function runUpdate(deps: UpdateDeps): Promise<UpdateResult> {
   const checkRunning = deps.checkRunning ?? isLocked;
   const stopDaemon = deps.stopDaemon ?? (() => stopDaemonGracefully());
   const runningPid = checkRunning();
+  // `stopped: false` means the process survived both signals (e.g. it belongs
+  // to another user). Tracked out here because the restart at the end must not
+  // fire against a daemon that is still holding the lock.
+  let daemonStopped = true;
   if (runningPid) {
     console.log(c.dim(`  Stopping daemon (PID ${runningPid}) before update...`));
     const stop = await stopDaemon();
-    // `stopped: false` means the process survived both signals (e.g. it belongs
-    // to another user). Updating underneath a live daemon is what we were
-    // trying to avoid, so say so rather than continuing silently.
     if (stop && stop.stopped === false) {
+      daemonStopped = false;
       console.log(c.yellow(`  Warning: daemon (PID ${stop.pid}) is still running — update may not take effect until it restarts.`));
     }
   }
@@ -340,8 +342,16 @@ export async function runUpdate(deps: UpdateDeps): Promise<UpdateResult> {
   }
 
   if (runningPid && result.outcome !== 'failed' && restart) {
-    console.log(c.dim('\nRestarting daemon...'));
-    restartDaemonDetached(deps.packageRoot);
+    if (daemonStopped) {
+      console.log(c.dim('\nRestarting daemon...'));
+      restartDaemonDetached(deps.packageRoot);
+    } else {
+      // The old daemon still holds the lock, so a spawned replacement would
+      // fail acquireLock() and die into the log while the user reads
+      // "Restarting daemon..." followed by "✓ Updated".
+      console.log(c.yellow('\nSkipping restart — the previous daemon is still running.'));
+      console.log(c.dim(`  Stop PID ${runningPid} and run \`jarvis start\` to pick up the update.`));
+    }
   }
 
   return result;

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -321,7 +321,10 @@ export async function runUpdate(deps: UpdateDeps): Promise<UpdateResult> {
     const stop = await stopDaemon();
     if (stop && stop.stopped === false) {
       daemonStopped = false;
-      console.log(c.yellow(`  Warning: daemon (PID ${stop.pid}) is still running — update may not take effect until it restarts.`));
+      // isLocked(), not stop.pid: under a supervisor the pid we signalled IS
+      // gone and a NEW daemon holds the lock — naming the dead one misleads.
+      const holder = isLocked() ?? stop.pid;
+      console.log(c.yellow(`  Warning: daemon (PID ${holder}) is still running — update may not take effect until it restarts.`));
     }
   }
 
@@ -349,8 +352,9 @@ export async function runUpdate(deps: UpdateDeps): Promise<UpdateResult> {
       // The old daemon still holds the lock, so a spawned replacement would
       // fail acquireLock() and die into the log while the user reads
       // "Restarting daemon..." followed by "✓ Updated".
-      console.log(c.yellow('\nSkipping restart — the previous daemon is still running.'));
-      console.log(c.dim(`  Stop PID ${runningPid} and run \`jarvis start\` to pick up the update.`));
+      const holder = isLocked() ?? runningPid;
+      console.log(c.yellow('\nSkipping restart — a daemon is still running.'));
+      console.log(c.dim(`  Stop PID ${holder} and run \`jarvis start\` to pick up the update.`));
     }
   }
 

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -314,7 +314,13 @@ export async function runUpdate(deps: UpdateDeps): Promise<UpdateResult> {
   const runningPid = checkRunning();
   if (runningPid) {
     console.log(c.dim(`  Stopping daemon (PID ${runningPid}) before update...`));
-    await stopDaemon();
+    const stop = await stopDaemon();
+    // `stopped: false` means the process survived both signals (e.g. it belongs
+    // to another user). Updating underneath a live daemon is what we were
+    // trying to avoid, so say so rather than continuing silently.
+    if (stop && stop.stopped === false) {
+      console.log(c.yellow(`  Warning: daemon (PID ${stop.pid}) is still running — update may not take effect until it restarts.`));
+    }
   }
 
   let result: UpdateResult;

--- a/src/daemon/pid.test.ts
+++ b/src/daemon/pid.test.ts
@@ -1,7 +1,7 @@
-import { test, expect, describe, beforeEach, afterEach } from 'bun:test';
+import { test, expect, describe, beforeAll, afterAll, beforeEach, afterEach } from 'bun:test';
 import { join } from 'node:path';
 import { homedir, tmpdir } from 'node:os';
-import { existsSync, readFileSync, writeFileSync, unlinkSync, mkdirSync, rmSync } from 'node:fs';
+import { existsSync, readFileSync, writeFileSync, unlinkSync, mkdirSync, mkdtempSync, rmSync } from 'node:fs';
 import {
   acquireLock,
   isLocked,
@@ -14,8 +14,23 @@ import {
   getLogDir,
 } from './pid.ts';
 
-const JARVIS_DIR = join(homedir(), '.jarvis');
-const LOCK_PATH = join(JARVIS_DIR, 'jarvis.pid');
+// The lock lives at `JARVIS_HOME`/jarvis.pid, resolved per call (see
+// pid.ts:daemonRootDir). These tests used to flock the developer's REAL
+// ~/.jarvis/jarvis.pid, which made them fail whenever anything else held that
+// lock — a jarvis daemon running on the dev machine, or a child process leaked
+// by an earlier test file that hadn't been reaped yet. Under full-suite load
+// that showed up as "Child process failed to acquire lock". Point JARVIS_HOME
+// at a throwaway dir instead, the same seam backup.test.ts uses, so this file
+// owns its lock and can't collide with anything.
+let DATA_DIR: string;
+let LOCK_PATH: string;
+let prevJarvisHome: string | undefined;
+
+// Logs are the exception: getLogPath/getLogDir read a module-level constant
+// built from homedir() at import time, so they are NOT JARVIS_HOME-aware and
+// still resolve under the real home. Asserted against this on purpose.
+const REAL_JARVIS_DIR = join(homedir(), '.jarvis');
+
 const PID_MODULE = join(import.meta.dir, 'pid.ts');
 const READY_SIGNAL = join(tmpdir(), 'jarvis-test-lock-ready');
 const HOLDER_SCRIPT = join(tmpdir(), 'jarvis-test-lock-holder.ts');
@@ -29,6 +44,10 @@ function cleanup(): void {
 /**
  * Spawn a child process that acquires the flock and holds it until killed.
  * Returns once the child has confirmed it holds the lock.
+ *
+ * The child gets this file's isolated JARVIS_HOME explicitly, so it flocks the
+ * same throwaway path the parent asserts on rather than inheriting whatever the
+ * ambient environment points at.
  */
 async function spawnLockHolder(): Promise<{ proc: ReturnType<typeof Bun.spawn>; pid: number }> {
   try { unlinkSync(READY_SIGNAL); } catch {}
@@ -41,28 +60,62 @@ writeFileSync(${JSON.stringify(READY_SIGNAL)}, ok ? String(process.pid) : 'FAIL'
 await Bun.sleep(60000);
 `);
 
+  // stderr is piped, not ignored: when the child can't take the lock its reason
+  // (pid.ts logs one) is the only thing that explains the failure, and a bare
+  // "failed to acquire lock" on a CI runner is undebuggable.
   const proc = Bun.spawn(['bun', HOLDER_SCRIPT], {
-    stdio: ['ignore', 'ignore', 'ignore'],
+    stdio: ['ignore', 'ignore', 'pipe'],
+    env: { ...process.env, JARVIS_HOME: DATA_DIR },
   });
 
-  for (let i = 0; i < 50; i++) {
-    await Bun.sleep(100);
-    if (existsSync(READY_SIGNAL)) {
-      const content = readFileSync(READY_SIGNAL, 'utf-8').trim();
-      if (content === 'FAIL') {
-        proc.kill();
-        await proc.exited;
-        throw new Error('Child process failed to acquire lock');
-      }
-      return { proc, pid: parseInt(content, 10) };
+  const childStderr = async (): Promise<string> => {
+    try { return (await new Response(proc.stderr as ReadableStream).text()).trim(); }
+    catch { return '<no stderr>'; }
+  };
+
+  // 15s, not 5s: the child pays for a cold `bun` start AND the one-time TinyCC
+  // compile of flock.c (pid.ts:getFlock). On a loaded 2-core runner that can
+  // take several seconds on its own, and a timeout here read as a real bug.
+  const deadline = Date.now() + 15_000;
+  while (Date.now() < deadline) {
+    await Bun.sleep(50);
+    if (!existsSync(READY_SIGNAL)) continue;
+
+    const content = readFileSync(READY_SIGNAL, 'utf-8').trim();
+    if (content === 'FAIL') {
+      const err = await childStderr();
+      proc.kill();
+      await proc.exited;
+      throw new Error(
+        `Child process failed to acquire lock at ${LOCK_PATH}` +
+        `\n  holder stderr: ${err || '<empty>'}` +
+        `\n  lock currently held by pid: ${isLocked() ?? 'nobody'}`,
+      );
     }
+    return { proc, pid: parseInt(content, 10) };
   }
+
+  const err = await childStderr();
   proc.kill();
   await proc.exited;
-  throw new Error('Timed out waiting for child to acquire lock');
+  throw new Error(`Timed out waiting for child to acquire lock\n  holder stderr: ${err || '<empty>'}`);
 }
 
 describe('Process Lock Manager', () => {
+  beforeAll(() => {
+    prevJarvisHome = process.env.JARVIS_HOME;
+    DATA_DIR = mkdtempSync(join(tmpdir(), 'jarvis-pid-test-'));
+    process.env.JARVIS_HOME = DATA_DIR;
+    LOCK_PATH = join(DATA_DIR, 'jarvis.pid');
+  });
+
+  afterAll(() => {
+    cleanup();
+    if (prevJarvisHome === undefined) delete process.env.JARVIS_HOME;
+    else process.env.JARVIS_HOME = prevJarvisHome;
+    try { rmSync(DATA_DIR, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
   beforeEach(() => cleanup());
   afterEach(() => cleanup());
 
@@ -100,7 +153,7 @@ describe('Process Lock Manager', () => {
     });
 
     test('returns null for stale file (file exists, no lock held)', () => {
-      mkdirSync(JARVIS_DIR, { recursive: true });
+      mkdirSync(DATA_DIR, { recursive: true });
       writeFileSync(LOCK_PATH, '99999');
       // No flock held — probe should succeed → not locked
       expect(isLocked()).toBeNull();
@@ -156,37 +209,37 @@ describe('Process Lock Manager', () => {
     });
 
     test('returns PID from file', () => {
-      mkdirSync(JARVIS_DIR, { recursive: true });
+      mkdirSync(DATA_DIR, { recursive: true });
       writeFileSync(LOCK_PATH, '12345');
       expect(readPid()).toBe(12345);
     });
 
     test('trims whitespace', () => {
-      mkdirSync(JARVIS_DIR, { recursive: true });
+      mkdirSync(DATA_DIR, { recursive: true });
       writeFileSync(LOCK_PATH, '  42\n');
       expect(readPid()).toBe(42);
     });
 
     test('returns null for non-numeric content', () => {
-      mkdirSync(JARVIS_DIR, { recursive: true });
+      mkdirSync(DATA_DIR, { recursive: true });
       writeFileSync(LOCK_PATH, 'not-a-pid');
       expect(readPid()).toBeNull();
     });
 
     test('returns null for empty file', () => {
-      mkdirSync(JARVIS_DIR, { recursive: true });
+      mkdirSync(DATA_DIR, { recursive: true });
       writeFileSync(LOCK_PATH, '');
       expect(readPid()).toBeNull();
     });
 
     test('returns null for zero', () => {
-      mkdirSync(JARVIS_DIR, { recursive: true });
+      mkdirSync(DATA_DIR, { recursive: true });
       writeFileSync(LOCK_PATH, '0');
       expect(readPid()).toBeNull();
     });
 
     test('returns null for negative PID', () => {
-      mkdirSync(JARVIS_DIR, { recursive: true });
+      mkdirSync(DATA_DIR, { recursive: true });
       writeFileSync(LOCK_PATH, '-1');
       expect(readPid()).toBeNull();
     });
@@ -200,31 +253,31 @@ describe('Process Lock Manager', () => {
     });
 
     test('returns null for legacy PID-only lock file', () => {
-      mkdirSync(JARVIS_DIR, { recursive: true });
+      mkdirSync(DATA_DIR, { recursive: true });
       writeFileSync(LOCK_PATH, '12345');
       expect(readLockedPort()).toBeNull();
     });
 
     test('returns the port from a two-line lock file', () => {
-      mkdirSync(JARVIS_DIR, { recursive: true });
+      mkdirSync(DATA_DIR, { recursive: true });
       writeFileSync(LOCK_PATH, '12345\n9000\n');
       expect(readLockedPort()).toBe(9000);
     });
 
     test('returns null for out-of-range port', () => {
-      mkdirSync(JARVIS_DIR, { recursive: true });
+      mkdirSync(DATA_DIR, { recursive: true });
       writeFileSync(LOCK_PATH, '12345\n99999\n');
       expect(readLockedPort()).toBeNull();
     });
 
     test('returns null for non-numeric port line', () => {
-      mkdirSync(JARVIS_DIR, { recursive: true });
+      mkdirSync(DATA_DIR, { recursive: true });
       writeFileSync(LOCK_PATH, '12345\nabc\n');
       expect(readLockedPort()).toBeNull();
     });
 
     test('readPid still works for two-line format', () => {
-      mkdirSync(JARVIS_DIR, { recursive: true });
+      mkdirSync(DATA_DIR, { recursive: true });
       writeFileSync(LOCK_PATH, '12345\n9000\n');
       expect(readPid()).toBe(12345);
     });
@@ -266,18 +319,29 @@ describe('Process Lock Manager', () => {
   // ── path getters ─────────────────────────────────────────────────
 
   describe('path getters', () => {
-    test('getPidPath returns ~/.jarvis/jarvis.pid', () => {
-      expect(getPidPath()).toBe(join(homedir(), '.jarvis', 'jarvis.pid'));
+    test('getPidPath tracks JARVIS_HOME', () => {
+      expect(getPidPath()).toBe(join(DATA_DIR, 'jarvis.pid'));
+    });
+
+    test('getPidPath falls back to ~/.jarvis/jarvis.pid with no JARVIS_HOME', () => {
+      // The path is resolved per call, so unsetting the var mid-test is enough
+      // to exercise the default branch that the isolated DATA_DIR otherwise hides.
+      delete process.env.JARVIS_HOME;
+      try {
+        expect(getPidPath()).toBe(join(homedir(), '.jarvis', 'jarvis.pid'));
+      } finally {
+        process.env.JARVIS_HOME = DATA_DIR;
+      }
     });
 
     test('getLogPath returns path and creates logs dir', () => {
       const logPath = getLogPath();
-      expect(logPath).toBe(join(JARVIS_DIR, 'logs', 'jarvis.log'));
-      expect(existsSync(join(JARVIS_DIR, 'logs'))).toBe(true);
+      expect(logPath).toBe(join(REAL_JARVIS_DIR, 'logs', 'jarvis.log'));
+      expect(existsSync(join(REAL_JARVIS_DIR, 'logs'))).toBe(true);
     });
 
     test('getLogDir returns logs directory', () => {
-      expect(getLogDir()).toBe(join(JARVIS_DIR, 'logs'));
+      expect(getLogDir()).toBe(join(REAL_JARVIS_DIR, 'logs'));
     });
   });
 

--- a/src/daemon/pid.test.ts
+++ b/src/daemon/pid.test.ts
@@ -26,11 +26,6 @@ let DATA_DIR: string;
 let LOCK_PATH: string;
 let prevJarvisHome: string | undefined;
 
-// Logs are the exception: getLogPath/getLogDir read a module-level constant
-// built from homedir() at import time, so they are NOT JARVIS_HOME-aware and
-// still resolve under the real home. Asserted against this on purpose.
-const REAL_JARVIS_DIR = join(homedir(), '.jarvis');
-
 const PID_MODULE = join(import.meta.dir, 'pid.ts');
 const READY_SIGNAL = join(tmpdir(), 'jarvis-test-lock-ready');
 const HOLDER_SCRIPT = join(tmpdir(), 'jarvis-test-lock-holder.ts');
@@ -336,12 +331,29 @@ describe('Process Lock Manager', () => {
 
     test('getLogPath returns path and creates logs dir', () => {
       const logPath = getLogPath();
-      expect(logPath).toBe(join(REAL_JARVIS_DIR, 'logs', 'jarvis.log'));
-      expect(existsSync(join(REAL_JARVIS_DIR, 'logs'))).toBe(true);
+      expect(logPath).toBe(join(DATA_DIR, 'logs', 'jarvis.log'));
+      expect(existsSync(join(DATA_DIR, 'logs'))).toBe(true);
     });
 
     test('getLogDir returns logs directory', () => {
-      expect(getLogDir()).toBe(join(REAL_JARVIS_DIR, 'logs'));
+      expect(getLogDir()).toBe(join(DATA_DIR, 'logs'));
+    });
+
+    test('logs and lock resolve under the SAME root', () => {
+      // The bug this guards: logs were built from homedir() at import time
+      // while the lock honored JARVIS_HOME, so the daemon locked one root and
+      // logged to another.
+      expect(getLogDir().startsWith(DATA_DIR)).toBe(true);
+      expect(getPidPath().startsWith(DATA_DIR)).toBe(true);
+    });
+
+    test('getLogDir falls back to ~/.jarvis/logs with no JARVIS_HOME', () => {
+      delete process.env.JARVIS_HOME;
+      try {
+        expect(getLogDir()).toBe(join(homedir(), '.jarvis', 'logs'));
+      } finally {
+        process.env.JARVIS_HOME = DATA_DIR;
+      }
     });
   });
 

--- a/src/daemon/pid.test.ts
+++ b/src/daemon/pid.test.ts
@@ -63,7 +63,13 @@ await Bun.sleep(60000);
     env: { ...process.env, JARVIS_HOME: DATA_DIR },
   });
 
-  const childStderr = async (): Promise<string> => {
+  // MUST be called only after the child has exited: reading the pipe drains it
+  // to EOF, and EOF arrives when the process ends. The holder sleeps 60s, so
+  // reading it while alive blocks for the full minute and turns a fast
+  // lock-acquisition failure into a silent test timeout.
+  const killThenStderr = async (): Promise<string> => {
+    proc.kill();
+    await proc.exited;
     try { return (await new Response(proc.stderr as ReadableStream).text()).trim(); }
     catch { return '<no stderr>'; }
   };
@@ -78,9 +84,7 @@ await Bun.sleep(60000);
 
     const content = readFileSync(READY_SIGNAL, 'utf-8').trim();
     if (content === 'FAIL') {
-      const err = await childStderr();
-      proc.kill();
-      await proc.exited;
+      const err = await killThenStderr();
       throw new Error(
         `Child process failed to acquire lock at ${LOCK_PATH}` +
         `\n  holder stderr: ${err || '<empty>'}` +
@@ -90,9 +94,7 @@ await Bun.sleep(60000);
     return { proc, pid: parseInt(content, 10) };
   }
 
-  const err = await childStderr();
-  proc.kill();
-  await proc.exited;
+  const err = await killThenStderr();
   throw new Error(`Timed out waiting for child to acquire lock\n  holder stderr: ${err || '<empty>'}`);
 }
 

--- a/src/daemon/pid.test.ts
+++ b/src/daemon/pid.test.ts
@@ -1,7 +1,7 @@
 import { test, expect, describe, beforeAll, afterAll, beforeEach, afterEach } from 'bun:test';
 import { join } from 'node:path';
 import { homedir, tmpdir } from 'node:os';
-import { existsSync, readFileSync, writeFileSync, unlinkSync, mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { existsSync, readFileSync, writeFileSync, unlinkSync, mkdirSync, mkdtempSync, rmSync, truncateSync, chmodSync } from 'node:fs';
 import {
   acquireLock,
   isLocked,
@@ -12,6 +12,7 @@ import {
   getPidPath,
   getLogPath,
   getLogDir,
+  releaseLockIfUnheld,
 } from './pid.ts';
 
 // The lock lives at `JARVIS_HOME`/jarvis.pid, resolved per call (see
@@ -357,6 +358,56 @@ describe('Process Lock Manager', () => {
         process.env.JARVIS_HOME = DATA_DIR;
       }
     });
+  });
+
+  // ── releaseLockIfUnheld ──────────────────────────────────────────
+  //
+  // The guard behind `jarvis stop` / `update` / `uninstall`. It must never
+  // unlink a lockfile some process still holds — doing so lets a second daemon
+  // start against the same data dir.
+
+  describe('releaseLockIfUnheld', () => {
+    test('clears a stale lockfile that nobody holds', () => {
+      mkdirSync(DATA_DIR, { recursive: true });
+      writeFileSync(LOCK_PATH, '99999');
+      expect(releaseLockIfUnheld()).toBe(true);
+      expect(existsSync(LOCK_PATH)).toBe(false);
+    });
+
+    test('refuses a held lock whose pid is unreadable', async () => {
+      const { proc } = await spawnLockHolder();
+      try {
+        // acquireLock truncates before writing the pid, so a held lock is
+        // briefly empty. Reproduce that window exactly.
+        truncateSync(LOCK_PATH, 0);
+
+        // isLocked() cannot tell this from "free" — it reads the pid and gets
+        // nothing. This is precisely why the guard must not be built on it.
+        expect(isLocked()).toBeNull();
+
+        expect(releaseLockIfUnheld()).toBe(false);
+        expect(existsSync(LOCK_PATH)).toBe(true);
+      } finally {
+        proc.kill();
+        await proc.exited;
+      }
+    }, 20_000);
+
+    // Root bypasses permission bits, so the unreadable case can't be staged.
+    test.skipIf(typeof process.getuid === 'function' && process.getuid() === 0)(
+      'refuses a lockfile it cannot even open',
+      async () => {
+        const { proc } = await spawnLockHolder();
+        try {
+          chmodSync(LOCK_PATH, 0o000);
+          expect(releaseLockIfUnheld()).toBe(false);
+          expect(existsSync(LOCK_PATH)).toBe(true);
+        } finally {
+          try { chmodSync(LOCK_PATH, 0o644); } catch { /* ignore */ }
+          proc.kill();
+          await proc.exited;
+        }
+      }, 20_000);
   });
 
   // ── cross-process locking ────────────────────────────────────────

--- a/src/daemon/pid.ts
+++ b/src/daemon/pid.ts
@@ -329,6 +329,47 @@ export function getLogDir(): string {
   return join(daemonRootDir(), 'logs');
 }
 
+/**
+ * Is `pid` still running?
+ *
+ * EPERM means the process EXISTS but isn't ours to signal (a daemon running as
+ * another user) — that is ALIVE. Only ESRCH means "no such process". Getting
+ * this backwards is dangerous: callers use it to decide whether it's safe to
+ * clear the lockfile, and reporting a live daemon as dead lets a second one
+ * start against the same data dir.
+ *
+ * Lives here, next to the lock, because every caller that asks "is the daemon
+ * alive" is really asking "is it safe to touch its lock" — and three separate
+ * copies of this check had already drifted apart.
+ */
+export function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return (err as NodeJS.ErrnoException)?.code === 'EPERM';
+  }
+}
+
+/**
+ * Poll until `pid` is gone, or the budget runs out. Returns true if it exited.
+ *
+ * Needed after SIGKILL: the signal returns before the kernel finishes tearing
+ * the process down, and a killed-but-unreaped zombie still answers kill(pid, 0).
+ */
+export async function waitForProcessExit(
+  pid: number,
+  timeoutMs: number,
+  pollIntervalMs = 50,
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!isProcessAlive(pid)) return true;
+    await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+  }
+  return !isProcessAlive(pid);
+}
+
 // ── Helpers ──────────────────────────────────────────────────────────
 
 function isInsideContainer(): boolean {

--- a/src/daemon/pid.ts
+++ b/src/daemon/pid.ts
@@ -24,8 +24,6 @@ import { cc } from 'bun:ffi';
 import flockSource from './flock.c' with { type: 'file' };
 
 const JARVIS_DIR = join(homedir(), '.jarvis');
-const LOG_DIR = join(JARVIS_DIR, 'logs');
-const LOG_PATH = join(LOG_DIR, 'jarvis.log');
 
 /**
  * The daemon's own root: `JARVIS_HOME` when set (hosted wrappers export it for
@@ -312,17 +310,23 @@ export function getPidPath(): string {
 
 /**
  * Get the log file path. Creates the log directory if needed.
+ *
+ * JARVIS_HOME-aware, like the lock path above. These used to be module-level
+ * constants built from homedir() at import time, so on an instance that sets
+ * JARVIS_HOME the daemon locked one root and logged to a different one —
+ * `jarvis logs` then tailed a file the daemon wasn't writing.
  */
 export function getLogPath(): string {
-  mkdirSync(LOG_DIR, { recursive: true });
-  return LOG_PATH;
+  const dir = getLogDir();
+  mkdirSync(dir, { recursive: true });
+  return join(dir, 'jarvis.log');
 }
 
 /**
- * Get the log directory path.
+ * Get the log directory path. Resolved per call — see `daemonRootDir`.
  */
 export function getLogDir(): string {
-  return LOG_DIR;
+  return join(daemonRootDir(), 'logs');
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────

--- a/src/daemon/pid.ts
+++ b/src/daemon/pid.ts
@@ -238,6 +238,59 @@ export function releaseLock(): void {
 }
 
 /**
+ * Remove the lockfile ONLY if no process currently holds the flock.
+ * Returns true when the lock is free afterwards (cleared, or never there).
+ *
+ * Callers that stop the daemon need "is it safe to unlink this file", and
+ * neither `isProcessAlive` nor `isLocked` answers that correctly:
+ *
+ *  - a pid check misses a supervisor relaunch (launchd KeepAlive, systemd
+ *    Restart) that put a NEW process behind the same lock;
+ *  - `isLocked` returns null for "held but the pid is unreadable" — the lock
+ *    file is empty for an instant during acquireLock's truncate→write, and
+ *    unreadable entirely if it belongs to another user — which would read as
+ *    "free" and unlink a live holder's lock.
+ *
+ * This asks the only authoritative question (can I take the flock?) and does
+ * the unlink WHILE HOLDING it, so no acquirer can slip into the gap between
+ * the check and the removal.
+ */
+export function releaseLockIfUnheld(): boolean {
+  // We hold it ourselves — the normal release path already handles that.
+  if (lockFd !== null) {
+    releaseLock();
+    return true;
+  }
+
+  const lockPath = defaultLockPath();
+  if (!existsSync(lockPath)) return true;
+
+  let fd: number;
+  try {
+    fd = openSync(lockPath, constants.O_RDONLY);
+  } catch {
+    // Can't even open it (e.g. EACCES on another user's file) — treat as held,
+    // never as free.
+    return false;
+  }
+
+  try {
+    const flock = getFlock();
+    if (flock.do_flock(fd, LOCK_EX | LOCK_NB) !== 0) {
+      closeSync(fd);
+      return false; // someone holds it
+    }
+    try { unlinkSync(lockPath); } catch { /* already gone */ }
+    flock.do_flock(fd, LOCK_UN);
+    closeSync(fd);
+    return true;
+  } catch {
+    try { closeSync(fd); } catch { /* already closed */ }
+    return false;
+  }
+}
+
+/**
  * Read the PID from the lock file. Returns null if no file or invalid content.
  *
  * Lock file format (either form is accepted):


### PR DESCRIPTION
Follow-up to #332. That PR fixed the install-time flake; running its verification surfaced two flaky test files, and fixing those exposed a real lockfile bug behind them.

## The bug

`releaseLock()` unlinks the lockfile whether or not the caller holds it. `jarvis stop`, `update`, and `uninstall` all called it unconditionally after signalling the daemon — so a daemon that survived the signals had its **live** lockfile deleted. Demonstrated directly:

```
before tests: lock file exists? YES
after  tests: lock file exists? NO
holder still alive? YES
```

After that, `isLocked()` reports nothing and the next `jarvis start` opens a fresh inode, `flock`s it successfully, and runs a **second daemon against the same data dir** — both writing `jarvis.db`, the keychain, and workflow state.

Three separate copies of the "is it alive" check had drifted, and all three treated `EPERM` as dead. `EPERM` means the process *exists* but isn't ours to signal — reporting it dead is what made the deletion reachable.

## The fix

`pid.ts` gains one authoritative primitive, `releaseLockIfUnheld()`: it asks the only question that matters — can I take the flock? — and unlinks **while holding it**, so no acquirer can slip between the check and the removal. Weaker guards were tried and discarded during review:

- `!isProcessAlive(pid)` misses a supervisor relaunch: the launchd plist sets `KeepAlive` `true` and the systemd unit sets `Restart=`, so killing the daemon brings it back under a *new* pid. The old pid is gone, and a pid-based guard unlinks the live replacement's lock.
- `isLocked() === null` reports "free" when the pid is momentarily unreadable — `acquireLock` truncates before writing — and leaves a check-to-unlink gap.

`isProcessAlive`/`waitForProcessExit` now live in `pid.ts` as the single definition, used by `daemon-control.ts`, `lifecycle.ts`, and `bin/jarvis.ts`. `waitForProcessExit` matters on its own: `SIGKILL` returns before the kernel finishes teardown, and a killed-but-unreaped zombie still answers `kill(pid, 0)`.

`StopResult` gains `stopped`, and callers act on it: `uninstall` **aborts** instead of `rm -rf`ing the data dir under a live writer, and `update` skips the restart that would otherwise fail `acquireLock()` and die into the log while printing "✓ Updated".

Autostart removal now runs **before** the daemon stop. The other order deadlocks on macOS: `KeepAlive` relaunches the daemon, the guard sees it and aborts, and the `launchctl unload` that breaks the cycle never runs.

## Also fixed

- **Logs ignored `JARVIS_HOME`.** `getLogPath`/`getLogDir` were import-time constants built from `homedir()` while the lock honored the env var, so an instance with it set locked one root and logged to another. Both are per-call now, and the service definitions export the variable so a launchd/systemd daemon agrees with the CLI. Service values are escaped: systemd splits unquoted `Environment=` on whitespace and reads `%` as a specifier; the plist needs XML escaping or `launchctl load` rejects it.
- **`navigate()`'s flat `Bun.sleep(800)`** is now a bounded poll on `readyState` + element count, floored at the old 800ms so pages that build DOM in a load handler aren't snapshotted empty, and extending to 3s for pages still mutating.
- **Two flaky test files.** `pid.test.ts` ran against the developer's real `~/.jarvis` (and deleted a running daemon's lockfile); it now uses a throwaway `JARVIS_HOME`. `browser-primitives.test.ts` shared one mutable page across tests, so assertions silently depended on execution order; each test now starts from a pristine page and every previously order-dependent test passes standalone.

## Tests

`daemon-control.ts` had no tests at all. Now 5, including the two that caught bugs in the fix itself — `SIGKILL` escalation (the zombie race) and the `EPERM` case — plus a supervisor-relaunch regression test.

`releaseLockIfUnheld` is tested against the two states that defeated the earlier guards: a lock held with an **empty** file (reproducing `acquireLock`'s truncate→write window, where `isLocked()` returns `null` while the flock is genuinely held) and one that cannot be opened at all.

**Against real systemd** (`daemon-control.systemd.test.ts`, skipped where `systemctl --user` is unusable, so it gates locally rather than in CI): a genuine `Restart=always` unit is installed under a unique name, and the stop path must leave its lockfile alone when systemd relaunches the daemon — measured relaunch latency is ~90ms. A second test round-trips the generated `Environment=` line through systemd's own parser with a path containing a space, `%`, a backslash, and a double quote, asserting the daemon receives the original string.

Service definitions are validated by the tools that actually consume them: `systemd-analyze verify` for the unit, `plutil -lint`/`xmllint` for the plist with a hostile data root.

Every one of these was checked by counterfactual — reverted to the buggy version, confirmed failing, restored. The relaunch test fails with `Received: null` under a pid-based guard (the lockfile unlinked out from under the live replacement); the plist test fails with XML parse errors without escaping.

Full suite: **2090 pass, 18 skip, 0 fail** across 172 files; `tsc --noEmit` clean.

## Worth knowing before merge

- **launchd is still unverified.** systemd now has real integration coverage, but the macOS side is asserted only at the file level (`plutil`/`xmllint` on the generated plist). `KeepAlive` relaunch behaviour under a live `launchctl` is untested, and the ordering bug fixed here — stopping the daemon before unloading the agent — was a macOS-only deadlock. Worth a manual check on a real macOS autostart install.
- **`tsconfig.json` includes only `src/` and `ui/`**, so `bunx tsc --noEmit` never typechecks `bin/` or `scripts/` — the CLI entry point is unguarded in CI. Checking them explicitly shows 3 pre-existing errors (`bin/jarvis.ts:397`, `scripts/setup-config.ts:67-68`). Left alone here; worth its own PR.
- **The check-to-unlink race is closed by construction, not by a test.** `releaseLockIfUnheld` unlinks while holding the flock, so the window cannot be observed from outside; hitting it deliberately would need fault injection.
- **Migration:** on an instance that already sets `JARVIS_HOME`, logs move from `~/.jarvis/logs` to `$JARVIS_HOME/logs`. New logs land in the new place; the old file stays put.
