### PR TITLE
fix(build): typecheck bin/ and scripts/, and repair the crash in jarvis setup

### DIFF
--- a/bin/jarvis.ts
+++ b/bin/jarvis.ts
@@ -394,7 +394,7 @@ function cmdLogs(args: string[]): void {
   let lines = 50;
   const nIdx = args.indexOf('-n') !== -1 ? args.indexOf('-n') : args.indexOf('--lines');
   if (nIdx !== -1 && args[nIdx + 1]) {
-    const n = parseInt(args[nIdx + 1], 10);
+    const n = parseInt(args[nIdx + 1]!, 10);
     if (!isNaN(n) && n > 0) lines = n;
   }
 

--- a/scripts/setup-config.ts
+++ b/scripts/setup-config.ts
@@ -64,8 +64,13 @@ async function validateConfig(): Promise<any> {
     console.log(`  Daemon port: ${config.daemon.port}`);
     console.log(`  Data directory: ${config.daemon.data_dir}`);
     console.log(`  Database: ${config.daemon.db_path}`);
-    console.log(`  Primary LLM: ${config.llm.primary}`);
-    console.log(`  Fallback chain: ${config.llm.fallback.join(' → ')}`);
+    // `llm.primary` / `llm.fallback` are a schema that no longer exists — the
+    // fallback line threw on `undefined.join` every time this ran. The current
+    // shape is a single `default` model plus an optional per-tier map.
+    console.log(`  Default LLM: ${config.llm.default ?? '(not set)'}`);
+    const tiers = Object.entries(config.llm.tiers ?? {}).filter(([, v]) => v);
+    console.log(`  Tiers: ${tiers.length > 0 ? tiers.map(([k, v]) => `${k}=${v}`).join(', ') : '(none)'}`);
+    console.log(`  Providers: ${Object.keys(config.llm.providers ?? {}).join(', ') || '(none)'}`);
     console.log(`  Active role: ${config.active_role}`);
     console.log('');
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,6 @@
     "noUnusedParameters": false,
     "noPropertyAccessFromIndexSignature": false
   },
-  "include": ["src/**/*.ts", "ui/**/*.ts", "ui/**/*.tsx"],
+  "include": ["src/**/*.ts", "ui/**/*.ts", "ui/**/*.tsx", "bin/**/*.ts", "scripts/**/*.ts"],
   "exclude": ["src/workflows/activepieces/**"]
 }


### PR DESCRIPTION
Closes the second gap noted in #334:

> **`tsconfig.json` includes only `src/` and `ui/`**, so `bunx tsc --noEmit` never typechecks `bin/` or `scripts/` — the CLI entry point is unguarded in CI.

`bin/jarvis.ts` is the CLI entry point — every `jarvis` command runs through it — and `scripts/` holds the maintenance commands wired into `package.json`. Neither has ever been typechecked. This is not theoretical: while working on #334 I used an unimported symbol in `bin/jarvis.ts` and `bunx tsc --noEmit` passed clean.

## The bug this surfaced

Turning typechecking on immediately exposed a **runtime crash** in `bun run setup`:

```
llm.fallback is: undefined
OLD LINE THROWS: TypeError - undefined is not an object (evaluating 'config.llm.fallback.join')
```

`scripts/setup-config.ts` printed its config summary from `config.llm.primary` and `config.llm.fallback` — a schema that no longer exists. The current `LLMConfig` is `default` + `tiers` + `providers` (`src/config/types.ts:324`). So the summary threw on every run, at the last step of the setup command. The summary now reports the real shape:

```
  Default LLM: (not set)
  Tiers: (none)
  Providers: (none)
```

## Changes

- `tsconfig.json` — add `bin/**/*.ts` and `scripts/**/*.ts` to `include`.
- `scripts/setup-config.ts` — print the current LLM schema instead of the removed one.
- `bin/jarvis.ts:397` — `parseInt(args[nIdx + 1]!, 10)`; the truthiness guard on the line above already proves it is defined, and `!` is the pattern used by the other flag parsers in the file.

Those three were the complete set of errors — nothing else in `bin/` or `scripts/` needed touching.

## Verification

`bunx tsc --noEmit` clean with the wider include; full suite **2090 pass, 18 skip, 0 fail** across 172 files. Since the same `tsc --noEmit` step already runs in CI and in the pre-commit hook, both now cover the CLI entry point with no workflow change.
