### PR TITLE
fix(ui): surface provider HTTP failures

### DIFF
--- a/ui/src/hooks/useWebSocket.test.ts
+++ b/ui/src/hooks/useWebSocket.test.ts
@@ -29,7 +29,13 @@ describe("extractNestedMessage", () => {
 describe("formatProviderErrorMessage — buckets", () => {
   test("auth: 401 status code", () => {
     const r = formatProviderErrorMessage("OpenAI API error (401): invalid_api_key");
-    expect(r.summary).toContain("API key");
+    expect(r.summary).toContain("401 Unauthorized");
+  });
+
+  test("auth: distinguishes 403 permission failures from invalid credentials", () => {
+    const r = formatProviderErrorMessage("OpenAI API error (403): model access denied", "auth");
+    expect(r.summary).toContain("403 Forbidden");
+    expect(r.summary).toContain("denied access");
   });
 
   test("auth: invalid x-api-key", () => {
@@ -50,7 +56,7 @@ describe("formatProviderErrorMessage — buckets", () => {
 
   test("network: 503", () => {
     const r = formatProviderErrorMessage("Service temporarily unavailable (503)");
-    expect(r.summary).toContain("connection");
+    expect(r.summary).toContain("503 Provider Error");
     expect(r.summary).not.toContain("rate-limit");
   });
 
@@ -117,12 +123,12 @@ describe("formatProviderErrorMessage — structured code branching (Phase B)", (
 
   test("server has its own copy", () => {
     const r = formatProviderErrorMessage("500 internal server error", "server");
-    expect(r.summary).toContain("server error");
+    expect(r.summary).toContain("500 Provider Error");
   });
 
   test("unknown code falls back to keyword heuristic", () => {
     const r = formatProviderErrorMessage("OpenAI API error (401): invalid_api_key", "unknown");
-    expect(r.summary).toContain("API key");
+    expect(r.summary).toContain("401 Unauthorized");
   });
 
   test("code present but no raw still returns a summary", () => {
@@ -145,6 +151,6 @@ describe("formatProviderErrorMessage — status-code brittleness fix", () => {
 
   test("DOES match '\\b401\\b' when it is a real status code", () => {
     const r = formatProviderErrorMessage("HTTP 401 Unauthorized");
-    expect(r.summary).toContain("Check your API key and model settings");
+    expect(r.summary).toContain("401 Unauthorized");
   });
 });

--- a/ui/src/hooks/useWebSocket.ts
+++ b/ui/src/hooks/useWebSocket.ts
@@ -291,6 +291,29 @@ function summaryForCode(code: ProviderErrorCode | undefined): string | null {
   }
 }
 
+function summaryForHttpStatus(raw: string): string | null {
+  if (/\b401\b/.test(raw)) {
+    return "401 Unauthorized — the AI provider rejected the API key or authentication header.";
+  }
+  if (/\b403\b/.test(raw)) {
+    return "403 Forbidden — the AI provider accepted the credentials but denied access to this model or endpoint.";
+  }
+  if (/\b400\b|\b422\b/.test(raw)) {
+    return "400 Bad Request — the AI provider rejected the request payload or model parameters.";
+  }
+  if (/\b404\b/.test(raw)) {
+    return "404 Not Found — the configured model or provider endpoint does not exist.";
+  }
+  if (/\b429\b/.test(raw)) {
+    return "429 Too Many Requests — the AI provider is rate-limiting this request.";
+  }
+  if (/\b50[0-9]\b/.test(raw)) {
+    const status = raw.match(/\b50[0-9]\b/)?.[0] ?? "5xx";
+    return `${status} Provider Error — the AI provider or gateway failed while handling the request.`;
+  }
+  return null;
+}
+
 export function formatProviderErrorMessage(
   raw: string | undefined,
   code?: ProviderErrorCode,
@@ -314,6 +337,12 @@ export function formatProviderErrorMessage(
       }
     }
   }
+
+  // Preserve an upstream HTTP status when the provider included one. The
+  // structured auth bucket intentionally combines 401 and 403, but those
+  // require different corrective actions for the user.
+  const statusSummary = summaryForHttpStatus(original);
+  if (statusSummary) return { summary: statusSummary, detail: normalized };
 
   // Prefer the server-supplied structured code when available — the emission
   // site knows the HTTP status and error type, and doesn't need us to guess


### PR DESCRIPTION
## Summary

- show the upstream HTTP status directly in chat error messages when available
- distinguish invalid credentials (401) from valid credentials without model or endpoint permission (403)
- give specific guidance for 400/422, 404, 429, and 5xx provider failures
- preserve the complete upstream response in the expandable detail and browser error log
- keep structured error-code fallback behavior for transports without an HTTP status

## Verification

- `bun test ui/src/hooks/useWebSocket.test.ts` (27 passed)
- `bun x tsc --noEmit`
- `git diff --check`