### PR TITLE
fix(settings): keep controls within compact windows

### DIFF
--- a/ui/src/components/settings/SidecarConfigEditor.tsx
+++ b/ui/src/components/settings/SidecarConfigEditor.tsx
@@ -114,6 +114,9 @@ export function SidecarConfigEditor({ sidecarId, sidecarName, unavailableCapabil
     if (config) setConfig(updater(config));
   };
 
+  // NOTE: overlayStyle is `position: fixed`, so this must not be mounted
+  // inside an element that establishes a containing block for fixed
+  // descendants (a transform, or `container-type` — see SidecarTab).
   return (
     <div style={overlayStyle} onClick={onClose}>
       <div style={modalStyle} onClick={(e) => e.stopPropagation()}>
@@ -440,6 +443,7 @@ const modalStyle: React.CSSProperties = {
   border: "1px solid var(--rule)",
   borderRadius: "10px",
   width: "560px",
+  maxWidth: "calc(100vw - 32px)",
   maxHeight: "80vh",
   display: "flex",
   flexDirection: "column",
@@ -526,6 +530,7 @@ const fieldRowStyle: React.CSSProperties = {
   display: "flex",
   alignItems: "center",
   gap: "8px",
+  flexWrap: "wrap",
 };
 
 const fieldLabelStyle: React.CSSProperties = {
@@ -543,6 +548,7 @@ const fieldInputStyle: React.CSSProperties = {
   fontSize: "12px",
   outline: "none",
   width: "160px",
+  maxWidth: "100%",
 };
 
 const checkboxLabelStyle: React.CSSProperties = {

--- a/ui/src/v2/rooms/settings/SettingsRoom.css
+++ b/ui/src/v2/rooms/settings/SettingsRoom.css
@@ -80,11 +80,13 @@
   color: var(--ink);
   font-family: var(--font-sans);
   font-size: var(--text-sm);
+  flex-wrap: wrap;
 }
 
 .v2-set__banner > svg { color: var(--warn); flex-shrink: 0; }
 
 .v2-set__banner > span { flex: 1; }
+.v2-set__banner > span { min-width: min(240px, 100%); }
 
 .v2-set__banner-btn {
   padding: 4px 12px;
@@ -161,6 +163,7 @@
   min-height: 0;
   overflow-y: auto;
   padding: var(--s-5) var(--s-6) var(--s-8);
+  overflow-x: hidden;
 }
 
 /* ── Section card (used by every tab) ── */
@@ -174,6 +177,7 @@
   display: flex;
   flex-direction: column;
   gap: var(--s-3);
+  min-width: 0;
 }
 
 .v2-set__section-head {
@@ -205,6 +209,7 @@
   display: flex;
   flex-direction: column;
   gap: var(--s-2);
+  min-width: 0;
 }
 
 .v2-set__field-label {
@@ -222,6 +227,7 @@
   gap: var(--s-3);
   font-family: var(--font-sans);
   font-size: var(--text-sm);
+  flex-wrap: wrap;
 }
 
 .v2-set__row-label { color: var(--ink-2); }
@@ -250,12 +256,19 @@
   font: inherit;
   text-align: left;
   cursor: pointer;
+  min-width: 0;
+}
+
+.v2-set__row-name {
+  min-width: 0;
+  overflow-wrap: anywhere;
 }
 
 .v2-set__row-state {
   display: inline-flex;
   align-items: center;
   gap: var(--s-2);
+  flex: 0 0 auto;
 }
 
 .v2-set__provider-row--open .v2-set__row-state svg {
@@ -264,6 +277,7 @@
 
 .v2-set__row-body {
   padding: 0 0 var(--s-4);
+  min-width: 0;
 }
 
 .v2-set__provider-grid {
@@ -318,6 +332,7 @@
   color: var(--ink);
   outline: 0;
   box-sizing: border-box;
+  min-width: 0;
 }
 
 .v2-set__textarea {
@@ -436,6 +451,10 @@
   transition: background var(--dur-fast) var(--ease-out),
               color var(--dur-fast) var(--ease-out),
               border-color var(--dur-fast) var(--ease-out);
+  min-height: 32px;
+  max-width: 100%;
+  white-space: normal;
+  text-align: center;
 }
 
 .v2-set__btn:hover { background: var(--paper-3); color: var(--ink); }
@@ -535,6 +554,9 @@
   color: var(--ink-2);
   font-family: var(--font-mono);
   font-size: var(--text-xs);
+  max-width: 100%;
+  overflow-wrap: anywhere;
+  white-space: normal;
 }
 
 .v2-set__chip--ok { background: color-mix(in srgb, var(--ok) 14%, transparent); color: var(--ok); }
@@ -644,6 +666,7 @@
   display: flex;
   align-items: center;
   gap: var(--s-2);
+  flex-wrap: wrap;
 }
 
 .v2-set__token-box {
@@ -821,6 +844,7 @@
   padding: var(--s-3) var(--s-5);
   border-top: var(--hair-soft);
   background: var(--paper-2);
+  flex-wrap: wrap;
 }
 
 /* ── Embedded legacy SidecarConfigEditor — retheme cascade ── */
@@ -870,6 +894,7 @@
   display: flex;
   flex-direction: column;
   gap: var(--s-1);
+  min-width: 0;
 }
 
 .v2-set__mode-card:hover:not(:disabled) {
@@ -899,6 +924,33 @@
   font-size: var(--text-xs);
   color: var(--ink-3);
   line-height: 1.4;
+  overflow-wrap: anywhere;
+}
+
+.v2-set__row-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--s-2);
+  margin-top: var(--s-3);
+  flex-wrap: wrap;
+}
+
+.v2-set__row-actions .v2-set__btn--danger {
+  margin-left: auto;
+}
+
+@media (max-width: 560px) {
+  .v2-set__stats,
+  .v2-set--inline .v2-set__stats { grid-template-columns: 1fr; }
+  .v2-set__body,
+  .v2-set--inline .v2-set__body { padding: var(--s-3); }
+  .v2-set__tabs,
+  .v2-set--inline .v2-set__tabs { padding: 0 var(--s-2); }
+  .v2-set__section { padding: var(--s-3); }
+  .v2-set__mode { grid-template-columns: 1fr; }
+  .v2-set__row-actions > .v2-set__btn,
+  .v2-set__row-actions .v2-set__btn--danger { flex: 1 1 140px; margin-left: 0 !important; }
+  .v2-set__dialog-foot > .v2-set__btn { flex: 1 1 120px; }
 }
 
 /* ════════════ Brand Book III / Monochrome Lab ════════════
@@ -909,4 +961,3 @@
 .v2-set__tab[data-active="true"] { border-radius: 7px 2px 7px 7px; }
 .v2-set__stat-value, .v2-set__section-title { font-family: var(--sans); font-weight: 700; letter-spacing: -0.015em; }
 .v2-set :focus-visible { outline-color: var(--speak); }
-

--- a/ui/src/v2/rooms/settings/SettingsRoom.css
+++ b/ui/src/v2/rooms/settings/SettingsRoom.css
@@ -8,6 +8,12 @@
   height: 100%;
   min-height: 0;
   position: relative;
+  /* Size against this element's own width, not the viewport: Settings is
+     rendered inside a resizable RoomWindow (320px min) as well as
+     full-screen, so a viewport media query can't tell "cramped window"
+     from "wide page". Same pattern as .wf-room. */
+  container-type: inline-size;
+  container-name: setroom;
 }
 
 /* ── Stats ── */
@@ -19,7 +25,7 @@
   padding: var(--s-4) var(--s-6) var(--s-3);
 }
 
-@media (max-width: 720px) {
+@container setroom (max-width: 720px) {
   .v2-set__stats { grid-template-columns: repeat(2, minmax(0, 1fr)); }
 }
 
@@ -85,8 +91,7 @@
 
 .v2-set__banner > svg { color: var(--warn); flex-shrink: 0; }
 
-.v2-set__banner > span { flex: 1; }
-.v2-set__banner > span { min-width: min(240px, 100%); }
+.v2-set__banner > span { flex: 1; min-width: min(240px, 100%); }
 
 .v2-set__banner-btn {
   padding: 4px 12px;
@@ -163,7 +168,6 @@
   min-height: 0;
   overflow-y: auto;
   padding: var(--s-5) var(--s-6) var(--s-8);
-  overflow-x: hidden;
 }
 
 /* ── Section card (used by every tab) ── */
@@ -177,7 +181,6 @@
   display: flex;
   flex-direction: column;
   gap: var(--s-3);
-  min-width: 0;
 }
 
 .v2-set__section-head {
@@ -256,7 +259,6 @@
   font: inherit;
   text-align: left;
   cursor: pointer;
-  min-width: 0;
 }
 
 .v2-set__row-name {
@@ -277,7 +279,6 @@
 
 .v2-set__row-body {
   padding: 0 0 var(--s-4);
-  min-width: 0;
 }
 
 .v2-set__provider-grid {
@@ -313,7 +314,7 @@
   overflow: auto;
 }
 
-@media (max-width: 680px) {
+@container setroom (max-width: 680px) {
   .v2-set__provider-grid { grid-template-columns: 1fr; }
   .v2-set__provider-grid-wide { grid-column: auto; }
 }
@@ -451,9 +452,7 @@
   transition: background var(--dur-fast) var(--ease-out),
               color var(--dur-fast) var(--ease-out),
               border-color var(--dur-fast) var(--ease-out);
-  min-height: 32px;
   max-width: 100%;
-  white-space: normal;
   text-align: center;
 }
 
@@ -556,7 +555,6 @@
   font-size: var(--text-xs);
   max-width: 100%;
   overflow-wrap: anywhere;
-  white-space: normal;
 }
 
 .v2-set__chip--ok { background: color-mix(in srgb, var(--ok) 14%, transparent); color: var(--ok); }
@@ -939,7 +937,11 @@
   margin-left: auto;
 }
 
-@media (max-width: 560px) {
+/* Cramped window: single-column everything and let the action buttons
+   share the row width instead of overflowing it. The .v2-set--inline
+   variants are repeated because the inline-mode rules further up are more
+   specific and would otherwise win. */
+@container setroom (max-width: 560px) {
   .v2-set__stats,
   .v2-set--inline .v2-set__stats { grid-template-columns: 1fr; }
   .v2-set__body,
@@ -948,8 +950,8 @@
   .v2-set--inline .v2-set__tabs { padding: 0 var(--s-2); }
   .v2-set__section { padding: var(--s-3); }
   .v2-set__mode { grid-template-columns: 1fr; }
-  .v2-set__row-actions > .v2-set__btn,
-  .v2-set__row-actions .v2-set__btn--danger { flex: 1 1 140px; margin-left: 0 !important; }
+  .v2-set__row-actions > .v2-set__btn { flex: 1 1 140px; }
+  .v2-set__row-actions .v2-set__btn--danger { margin-left: 0; }
   .v2-set__dialog-foot > .v2-set__btn { flex: 1 1 120px; }
 }
 

--- a/ui/src/v2/rooms/settings/tabs/LLMTab.tsx
+++ b/ui/src/v2/rooms/settings/tabs/LLMTab.tsx
@@ -424,7 +424,7 @@ function ProviderRow({
             </div>
           )}
 
-          <div className="v2-set__row-actions" style={{ display: "flex", gap: "var(--s-2)", marginTop: "var(--s-3)" }}>
+          <div className="v2-set__row-actions">
             <button
               type="button"
               className="v2-set__btn"
@@ -470,7 +470,6 @@ function ProviderRow({
             <button
               type="button"
               className="v2-set__btn v2-set__btn--danger"
-              style={{ marginLeft: "auto" }}
               onClick={async () => {
                 if (!await confirmDialog(`Remove provider '${name}'? This deletes the stored API key.`)) return;
                 const r = await data.removeProvider(name);
@@ -617,7 +616,7 @@ function NewProviderRow({
         )}
         </div>
 
-        <div className="v2-set__row-actions" style={{ display: "flex", gap: "var(--s-2)", marginTop: "var(--s-3)" }}>
+        <div className="v2-set__row-actions">
           <button type="button" className="v2-set__btn" onClick={onDone}>
             Cancel
           </button>

--- a/ui/src/v2/rooms/settings/tabs/SidecarTab.tsx
+++ b/ui/src/v2/rooms/settings/tabs/SidecarTab.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { createPortal } from "react-dom";
 import type { SettingsHook } from "../useSettingsData";
 import { confirmDialog } from "../../../ui/ConfirmDialog";
 // Embed the legacy config editor — it's a 200+ LOC YAML+form editor with
@@ -197,8 +198,13 @@ export function SidecarTab({
         )}
       </section>
 
-      {/* Legacy config editor modal — rethemed via cascade */}
-      {configTarget && (
+      {/* Legacy config editor modal — rethemed via cascade. Portaled to
+          <body> because .v2-set is a container-query container, which makes
+          it the containing block + stacking context for the editor's
+          `position: fixed` overlay; mounted in place, the overlay would
+          cover only the Settings room. The wrapper travels with it so the
+          --j-* cascade still applies. */}
+      {configTarget && createPortal(
         <div className="v2-set__legacy-embed">
           <SidecarConfigEditor
             sidecarId={configTarget.id}
@@ -208,7 +214,8 @@ export function SidecarTab({
             }
             onClose={() => setConfigTarget(null)}
           />
-        </div>
+        </div>,
+        document.body,
       )}
     </div>
   );


### PR DESCRIPTION
## Summary

- make settings sections, provider editors, and model controls shrink without overflowing their window
- wrap action groups, banners, sidecar actions, and dialog footers before they collide
- collapse mode cards and stats cleanly in narrow native windows
- contain long provider names, model IDs, chips, and field content
- standardize compact button sizing and remove conflicting inline LLM action layout
- preserve the existing Jarvis typography, asymmetric corners, colors, and focus treatment

## Verification

- `bun x tsc --noEmit`
- `bun run build:ui`
- `git diff --check`