### PR TITLE
test: stop the usage-migration and keychain tests failing on environment rather than code

### DIFF
--- a/src/llm/usage.test.ts
+++ b/src/llm/usage.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it, beforeEach } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { initDatabase, closeDb } from '../vault/schema.ts';
 import {
   setUsageDatabase,
@@ -154,7 +157,11 @@ describe('queryUsage', () => {
 describe('llm_usage cache column migration', () => {
   it('ALTER path adds cache columns to a legacy-shaped table and inserts succeed', async () => {
     const { Database } = await import('bun:sqlite');
-    const path = `${process.env.TMPDIR ?? '/tmp'}/jarvis-usage-migration-${Date.now()}.db`;
+    // mkdtemp, not a Date.now() filename: two runs in the same millisecond
+    // would collide, and a crash left the stray .db behind. The whole dir goes
+    // in the finally below.
+    const dir = mkdtempSync(join(tmpdir(), 'jarvis-usage-migration-'));
+    const path = join(dir, 'usage.db');
 
     // Simulate a DB created before prompt caching landed: legacy llm_usage
     // without the cache columns.
@@ -207,9 +214,15 @@ describe('llm_usage cache column migration', () => {
     } finally {
       closeDb();
       setUsageDatabase(() => null);
-      await import('node:fs/promises').then((fs) => fs.rm(path, { force: true }));
+      rmSync(dir, { recursive: true, force: true });
     }
-  });
+    // 30s, explicit. This test runs ~50ms locally (loaded or not) but timed out
+    // at bun's default 5s on a CI runner: unlike its siblings it opens a REAL
+    // on-disk SQLite database and runs the full schema migration through it, so
+    // it is at the mercy of the runner's disk rather than its CPU. The budget is
+    // for a stalled fsync, not for slow logic — if this ever approaches 30s,
+    // something is genuinely wrong rather than merely slow.
+  }, 30_000);
 });
 
 describe('recordUsage resilience', () => {

--- a/src/vault/keychain.test.ts
+++ b/src/vault/keychain.test.ts
@@ -8,7 +8,7 @@
  */
 import { test, expect, describe, beforeEach, afterEach } from 'bun:test';
 import { mkdtempSync, rmSync, mkdirSync, existsSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { tmpdir, homedir } from 'node:os';
 import { join } from 'node:path';
 import {
   getSecret,
@@ -52,14 +52,40 @@ describe('keychain', () => {
 
   // ── location ────────────────────────────────────────────────────────────
 
-  test('JARVIS_HOME is where a fresh install stores its keychain', () => {
+  // keychainDir() consults the REAL ~/.jarvis as the legacy dir — homedir() is
+  // fixed for the process, per the note at the top of this file. On a machine
+  // with an actual install, the documented relocate-at-boot rule CORRECTLY
+  // prefers that existing pair, so an unguarded `keychainDir() === dataDir`
+  // assertion fails for every developer who runs Jarvis and passes only on a
+  // clean runner. Split in two: the location rule is skipped where a real
+  // keychain exists, and the write path is pinned so it always runs.
+  const realLegacyHasKeychain =
+    existsSync(join(homedir(), '.jarvis', KEY_FILE)) ||
+    existsSync(join(homedir(), '.jarvis', SECRETS_FILE));
+
+  test.skipIf(realLegacyHasKeychain)(
+    'JARVIS_HOME is where a fresh install stores its keychain',
+    () => {
+      const dataDir = join(root, 'data');
+      process.env.JARVIS_HOME = dataDir;
+      expect(keychainDir()).toBe(dataDir);
+    },
+  );
+
+  test('a fresh install writes and reads its keychain under the configured dir', () => {
     const dataDir = join(root, 'data');
     process.env.JARVIS_HOME = dataDir;
-
-    expect(keychainDir()).toBe(dataDir);
-    setSecret('llm.provider.openai.api_key', 'sk-1');
-    expect(existsSync(join(dataDir, SECRETS_FILE))).toBe(true);
-    expect(getSecret('llm.provider.openai.api_key')).toBe('sk-1');
+    // JARVIS_SECRETS_DIR pins the location, so this exercises the read/write
+    // round-trip without depending on the legacy fallback — and, as the header
+    // says, never touches the developer's real store.
+    process.env.JARVIS_SECRETS_DIR = dataDir;
+    try {
+      setSecret('llm.provider.openai.api_key', 'sk-1');
+      expect(existsSync(join(dataDir, SECRETS_FILE))).toBe(true);
+      expect(getSecret('llm.provider.openai.api_key')).toBe('sk-1');
+    } finally {
+      delete process.env.JARVIS_SECRETS_DIR;
+    }
   });
 
   test('an un-migrated install keeps using the legacy pair, both halves together', () => {


### PR DESCRIPTION
Two tests that fail on their environment rather than on the code. Neither is a product bug; both cost real debugging time.

## 1. `llm_usage cache column migration` — timed out on CI

This failed the `Tests` run on main for #334's merge commit:

```
(fail) llm_usage cache column migration > ALTER path adds cache columns … [5047.20ms]
```

5047ms against bun's default 5000ms per-test timeout — a timeout, not an assertion. It measures **~50ms locally**, unchanged under 12-way CPU load, so this is not a slow-CPU problem: unlike its siblings it opens a **real on-disk SQLite database** and runs the full schema migration through it, leaving it at the mercy of the runner's disk. Given an explicit 30s budget, sized for a stalled fsync rather than slow logic.

While confirming it, the temp-file handling turned out to be leaking:

```
158 × jarvis-usage-migration-*.db-wal
158 × jarvis-usage-migration-*.db-shm
246M  total
```

Cleanup was `fs.rm(path)` on the `.db` alone, which never removes SQLite's `-wal`/`-shm` sidecars — 246MB accumulated in `/tmp` on one machine since Aug 10. The DB now lives in an `mkdtemp` directory removed wholesale, which also drops the `Date.now()` filename (two runs in the same millisecond would have collided). Verified: repeated runs now leave **zero** files behind.

## 2. `keychain > JARVIS_HOME is where a fresh install stores its keychain` — fails for anyone with Jarvis installed

```
Expected: "/tmp/jarvis-keychain-XpEhH1/data"
Received: "/home/kuroi/.jarvis"
```

`keychainDir()` consults the real `~/.jarvis` as the legacy dir, and `resolveKeychainDir` prefers an existing legacy pair when the configured dir has none. That is the documented relocate-at-boot rule working **correctly** — the test simply never isolated itself from it, so it fails on every developer machine with a real install and passes only on a clean runner. It also contradicts the note at the top of its own file:

> The legacy dir is `~/.jarvis` and cannot be redirected … so the location rules take their dirs as arguments and are exercised against throwaway paths.

Split in two rather than weakened:

- the **location** assertion keeps using `keychainDir()` end-to-end, skipped only where a real keychain pair exists;
- the **write path** is pinned with `JARVIS_SECRETS_DIR`, so the read/write round-trip always runs and never touches the developer's real store.

Coverage on CI is unchanged. Verified with a clean `HOME`: **11 pass, 0 skip, 0 fail** — the location test runs and passes exactly as it will on a runner. On a machine with an install it now skips instead of failing.

## Verification

Full suite **2090 pass, 22 skip, 0 fail** across 173 files; `tsc --noEmit` clean.
