### PR TITLE
fix(llm): clear a deleted provider's model refs from the settings table

### DIFF
--- a/src/daemon/llm-settings.test.ts
+++ b/src/daemon/llm-settings.test.ts
@@ -1,10 +1,54 @@
 import { afterEach, describe, expect, it } from 'bun:test';
 import { initDatabase, closeDb } from '../vault/schema.ts';
 import { getSetting, setSetting } from '../vault/settings.ts';
-import { DEFAULT_CONFIG } from '../config/types.ts';
-import { mergeLLMSettingsIntoConfig } from './llm-settings.ts';
+import { DEFAULT_CONFIG, type JarvisConfig } from '../config/types.ts';
+import { mergeLLMSettingsIntoConfig, saveLLMSettings } from './llm-settings.ts';
 
 afterEach(() => closeDb());
+
+describe('LLM provider deletion', () => {
+  it('clears every model ref the deleted provider owned', () => {
+    initDatabase(':memory:');
+    const config: JarvisConfig = structuredClone(DEFAULT_CONFIG);
+    config.llm.providers = {
+      'test-anthropic': { kind: 'anthropic' },
+      'test-omniroute': { kind: 'omniroute', base_url: 'http://router.test/v1' },
+    };
+    config.llm.default = 'test-anthropic:claude-sonnet';
+    config.llm.tiers = {
+      conversation: 'test-anthropic:claude-haiku',
+      high: 'test-omniroute:auto',
+      medium: 'test-anthropic:claude-sonnet',
+    };
+
+    saveLLMSettings(config, { providers: { 'test-anthropic': null } });
+
+    expect(config.llm.default).toBeUndefined();
+    expect(config.llm.tiers).toEqual({ high: 'test-omniroute:auto' });
+    // The settings table is the authority on cold start - the dead refs must
+    // be gone from there too, not just from the in-memory config.
+    expect(getSetting('llm.default')).toBe('');
+    expect(getSetting('llm.tiers.conversation')).toBe('');
+    expect(getSetting('llm.tiers.medium')).toBe('');
+    expect(getSetting('llm.tiers.high')).toBe('test-omniroute:auto');
+  });
+
+  it('leaves refs owned by other providers untouched', () => {
+    initDatabase(':memory:');
+    const config: JarvisConfig = structuredClone(DEFAULT_CONFIG);
+    config.llm.providers = {
+      'test-anthropic': { kind: 'anthropic' },
+      'test-groq': { kind: 'groq' },
+    };
+    config.llm.default = 'test-groq:openai/gpt-oss-120b';
+    config.llm.tiers = { medium: 'test-groq:openai/gpt-oss-20b' };
+
+    saveLLMSettings(config, { providers: { 'test-anthropic': null } });
+
+    expect(config.llm.default).toBe('test-groq:openai/gpt-oss-120b');
+    expect(config.llm.tiers).toEqual({ medium: 'test-groq:openai/gpt-oss-20b' });
+  });
+});
 
 describe('LLM settings model migrations', () => {
   it('replaces saved decommissioned Groq IDs and persists the repair', () => {

--- a/src/daemon/llm-settings.test.ts
+++ b/src/daemon/llm-settings.test.ts
@@ -48,6 +48,85 @@ describe('LLM provider deletion', () => {
     expect(config.llm.default).toBe('test-groq:openai/gpt-oss-120b');
     expect(config.llm.tiers).toEqual({ medium: 'test-groq:openai/gpt-oss-20b' });
   });
+
+  it('does not resurrect the deleted routes on the next cold start', () => {
+    initDatabase(':memory:');
+    const config: JarvisConfig = structuredClone(DEFAULT_CONFIG);
+    config.llm.providers = {
+      'test-anthropic': { kind: 'anthropic' },
+      'test-groq': { kind: 'groq' },
+    };
+    config.llm.tiers = {
+      conversation: 'test-anthropic:claude-haiku',
+      medium: 'test-groq:openai/gpt-oss-20b',
+    };
+
+    saveLLMSettings(config, { providers: { 'test-anthropic': null } });
+
+    const restarted = structuredClone(DEFAULT_CONFIG);
+    mergeLLMSettingsIntoConfig(restarted);
+
+    expect(restarted.llm.tiers).toEqual({ medium: 'test-groq:openai/gpt-oss-20b' });
+  });
+});
+
+describe('LLM orphaned model refs', () => {
+  it('repairs an install dirtied before deletion cleaned up after itself', () => {
+    initDatabase(':memory:');
+    setSetting('llm.providers', JSON.stringify({ 'test-groq': { kind: 'groq' } }));
+    setSetting('llm.default', 'test-anthropic:claude-sonnet');
+    setSetting('llm.tiers.conversation', 'test-anthropic:claude-haiku');
+    setSetting('llm.tiers.medium', 'test-groq:openai/gpt-oss-20b');
+    const config = structuredClone(DEFAULT_CONFIG);
+
+    mergeLLMSettingsIntoConfig(config);
+
+    expect(config.llm.default).toBeUndefined();
+    expect(config.llm.tiers).toEqual({ medium: 'test-groq:openai/gpt-oss-20b' });
+    expect(getSetting('llm.default')).toBe('');
+    expect(getSetting('llm.tiers.conversation')).toBe('');
+    expect(getSetting('llm.tiers.medium')).toBe('test-groq:openai/gpt-oss-20b');
+  });
+
+  it('can repair in memory without persisting', () => {
+    initDatabase(':memory:');
+    setSetting('llm.providers', JSON.stringify({ 'test-groq': { kind: 'groq' } }));
+    setSetting('llm.default', 'test-anthropic:claude-sonnet');
+    const config = structuredClone(DEFAULT_CONFIG);
+
+    mergeLLMSettingsIntoConfig(config, { persistMigrations: false });
+
+    expect(config.llm.default).toBeUndefined();
+    expect(getSetting('llm.default')).toBe('test-anthropic:claude-sonnet');
+  });
+
+  it('keeps refs to a configured provider that has no usable credentials', () => {
+    initDatabase(':memory:');
+    // Present in the providers map but not instantiable without a key. The
+    // user may still be about to paste one - the ref must survive.
+    setSetting('llm.providers', JSON.stringify({ 'test-anthropic': { kind: 'anthropic' } }));
+    setSetting('llm.default', 'test-anthropic:claude-sonnet');
+    const config = structuredClone(DEFAULT_CONFIG);
+
+    mergeLLMSettingsIntoConfig(config);
+
+    expect(config.llm.default).toBe('test-anthropic:claude-sonnet');
+    expect(getSetting('llm.default')).toBe('test-anthropic:claude-sonnet');
+  });
+
+  it('leaves everything alone when the providers row is corrupt', () => {
+    initDatabase(':memory:');
+    setSetting('llm.providers', '{not json');
+    setSetting('llm.default', 'test-groq:openai/gpt-oss-120b');
+    setSetting('llm.tiers.medium', 'test-groq:openai/gpt-oss-20b');
+    const config = structuredClone(DEFAULT_CONFIG);
+
+    mergeLLMSettingsIntoConfig(config);
+
+    // One bad row must not be read as "no providers exist" and wipe the routes.
+    expect(getSetting('llm.default')).toBe('test-groq:openai/gpt-oss-120b');
+    expect(getSetting('llm.tiers.medium')).toBe('test-groq:openai/gpt-oss-20b');
+  });
 });
 
 describe('LLM settings model migrations', () => {

--- a/src/daemon/llm-settings.ts
+++ b/src/daemon/llm-settings.ts
@@ -27,7 +27,7 @@ import {
 } from '../llm/config-binding.ts';
 import { isAnthropicCustomBaseUrl } from '../llm/anthropic.ts';
 import { GROQ_DEPRECATED_MODEL_REPLACEMENTS } from '../llm/groq-models.ts';
-import { TIERS, parseModelRef } from '../llm/tiers.ts';
+import { TIERS, type Tier, parseModelRef } from '../llm/tiers.ts';
 
 // ── DB keys ──────────────────────────────────────────────────────────────
 const SETTING_PROVIDERS = 'llm.providers';
@@ -38,6 +38,14 @@ const SETTING_TIER_HIGH = 'llm.tiers.high';
 const SETTING_TIER_MEDIUM = 'llm.tiers.medium';
 const SETTING_TIER_LOW = 'llm.tiers.low';
 const SETTING_PROMPT_CACHE = 'llm.prompt_cache';
+
+/** Settings key per tier. Single source so the read/write paths can't drift. */
+const SETTING_TIER_KEYS: Record<Tier, string> = {
+  conversation: SETTING_TIER_CONVERSATION,
+  high: SETTING_TIER_HIGH,
+  medium: SETTING_TIER_MEDIUM,
+  low: SETTING_TIER_LOW,
+};
 
 /** Keychain key for a provider's API key, by provider NAME (not kind). */
 function keychainKey(providerName: string): string {
@@ -333,6 +341,10 @@ export function mergeLLMSettingsIntoConfig(
 
   // 1. New shape: load providers JSON + default + tier strings.
   const providersJson = getSetting(SETTING_PROVIDERS);
+  // A parse failure means we don't actually know which providers exist, so the
+  // orphan prune below must not run - every ref would look dangling and we'd
+  // wipe a working config over one corrupt row.
+  let providersReadable = true;
   if (providersJson) {
     try {
       const parsed = JSON.parse(providersJson) as Record<string, LLMProviderEntry>;
@@ -340,6 +352,7 @@ export function mergeLLMSettingsIntoConfig(
         config.llm.providers[name] = entry;
       }
     } catch (err) {
+      providersReadable = false;
       console.warn('[LLM] Failed to parse stored providers JSON:', err);
     }
   }
@@ -347,13 +360,8 @@ export function mergeLLMSettingsIntoConfig(
   const dbDefault = getSetting(SETTING_DEFAULT);
   if (dbDefault) config.llm.default = dbDefault;
 
-  for (const [tier, key] of [
-    ['conversation', SETTING_TIER_CONVERSATION],
-    ['high', SETTING_TIER_HIGH],
-    ['medium', SETTING_TIER_MEDIUM],
-    ['low', SETTING_TIER_LOW],
-  ] as const) {
-    const value = getSetting(key);
+  for (const tier of TIERS) {
+    const value = getSetting(SETTING_TIER_KEYS[tier]);
     if (value) config.llm.tiers[tier] = value;
   }
 
@@ -372,6 +380,12 @@ export function mergeLLMSettingsIntoConfig(
   migrateLegacyDBSettings(config);
   migrateDeprecatedGroqModels(config, options.persistMigrations !== false);
 
+  // Repair installs dirtied before provider deletion cleaned up after itself.
+  // Runs after the legacy migration so refs it just revived still count.
+  if (providersReadable) {
+    pruneOrphanedModelRefs(config, options.persistMigrations !== false);
+  }
+
   // 3. Pull API keys from the keychain into provider entries. We do NOT
   // surface them in `config.llm.providers.<name>.api_key` (that would risk
   // saving them back to disk) - instead the config-binding module reads
@@ -386,6 +400,49 @@ export function mergeLLMSettingsIntoConfig(
       // persists secrets only to the keychain.
       config.llm.providers[name] = { ...config.llm.providers[name], api_key: key };
     }
+  }
+}
+
+/**
+ * Drop `default` / tier refs pointing at providers that are no longer
+ * configured. saveLLMSettings clears these when a provider is deleted, but
+ * installs dirtied before that landed still carry the dead refs: they load
+ * back in on every start, configureLLMTiers warns and skips them, and the
+ * affected tier silently falls up. Repairing on load makes those installs
+ * self-heal instead of needing the user to re-pick every tier.
+ *
+ * A provider that is configured but not instantiable (e.g. its API key is
+ * missing) is NOT an orphan - the entry still exists, so its refs stay put
+ * until the user removes the provider outright.
+ */
+function pruneOrphanedModelRefs(config: JarvisConfig, persist = true): void {
+  const orphanedOwner = (ref: string | undefined): string | null => {
+    const parsed = parseModelRef(ref);
+    if (!parsed || config.llm.providers?.[parsed.provider]) return null;
+    return parsed.provider;
+  };
+
+  const dropped: string[] = [];
+
+  const defaultOwner = orphanedOwner(config.llm.default);
+  if (defaultOwner) {
+    dropped.push(`default (${defaultOwner})`);
+    config.llm.default = undefined;
+    if (persist) setSetting(SETTING_DEFAULT, '');
+  }
+
+  for (const tier of TIERS) {
+    const owner = orphanedOwner(config.llm.tiers?.[tier]);
+    if (!owner) continue;
+    dropped.push(`${tier} (${owner})`);
+    delete config.llm.tiers?.[tier];
+    if (persist) setSetting(SETTING_TIER_KEYS[tier], '');
+  }
+
+  if (dropped.length > 0) {
+    console.warn(
+      `[LLM] Dropped model refs for providers that no longer exist: ${dropped.join(', ')}.`,
+    );
   }
 }
 

--- a/src/daemon/llm-settings.ts
+++ b/src/daemon/llm-settings.ts
@@ -27,6 +27,7 @@ import {
 } from '../llm/config-binding.ts';
 import { isAnthropicCustomBaseUrl } from '../llm/anthropic.ts';
 import { GROQ_DEPRECATED_MODEL_REPLACEMENTS } from '../llm/groq-models.ts';
+import { TIERS, parseModelRef } from '../llm/tiers.ts';
 
 // ── DB keys ──────────────────────────────────────────────────────────────
 const SETTING_PROVIDERS = 'llm.providers';
@@ -206,6 +207,18 @@ export function saveLLMSettings(
     for (const [name, update] of updates) {
       if (update === null) {
         delete config.llm.providers[name];
+        // Drop every model ref the provider owned. The manager prunes its own
+        // tier map on replaceProviders, but the settings table is a separate
+        // store - leaving the refs there resurrects the dead routes on the
+        // next cold start.
+        if (parseModelRef(config.llm.default)?.provider === name) {
+          config.llm.default = undefined;
+        }
+        for (const tier of TIERS) {
+          if (parseModelRef(config.llm.tiers[tier])?.provider === name) {
+            delete config.llm.tiers[tier];
+          }
+        }
         try { deleteSecret(keychainKey(name)); } catch { /* ignore */ }
         continue;
       }


### PR DESCRIPTION
## The bug

Deleting an LLM provider left its model references behind in the settings table.

`saveLLMSettings` removed the provider from `config.llm.providers` and dropped its keychain entry, but never touched `llm.default` or `llm.tiers.*`. The tail of the function then persisted those stale refs verbatim:

```ts
setSetting(SETTING_DEFAULT, config.llm.default ?? '');
setSetting(SETTING_TIER_CONVERSATION, config.llm.tiers.conversation ?? '');
```

The live daemon appeared healthy because `LLMManager.replaceProviders` prunes tier assignments pointing at providers that no longer exist. But that pruning happens only in memory, on the manager's own tier map — the settings table is a separate store and stayed dirty. On the next cold start `mergeLLMSettingsIntoConfig` read the dead refs back in, and `configureLLMTiers` logged `references unregistered provider '<name>' - skipping`, leaving those tiers unconfigured. A tier the user had explicitly configured silently fell up to another one, or the whole default disappeared, with nothing in the UI explaining why.

## The fix

Two halves — stop making the mess, and clean up the mess already made.

**1. On delete (`saveLLMSettings`)** — clear every model ref the provider owned before the settings are written:

```ts
if (parseModelRef(config.llm.default)?.provider === name) {
  config.llm.default = undefined;
}
for (const tier of TIERS) {
  if (parseModelRef(config.llm.tiers[tier])?.provider === name) {
    delete config.llm.tiers[tier];
  }
}
```

Refs owned by other providers are untouched. This reuses `parseModelRef` from `src/llm/tiers.ts` rather than a local string split, so it inherits the existing handling of edge cases like a trailing colon with an empty model id.

**2. On load (`mergeLLMSettingsIntoConfig`)** — the above only helps deletions from here on. Any install that already lost a provider still carries the dead refs and re-hits the exact symptom above on every single start, forever, until the user manually re-picks each tier. `pruneOrphanedModelRefs` drops refs whose provider is no longer in the providers map and persists the repair, following the same shape as the existing `migrateDeprecatedGroqModels` self-heal (including honouring `persistMigrations: false`).

Two deliberate boundaries on the prune:

- It skips entirely when the stored providers JSON fails to parse. Otherwise a single corrupt row reads as "no providers exist" and every ref looks dangling — turning a recoverable bad row into a wiped LLM config. There's a regression test pinning this.
- "Configured but not instantiable" is not an orphan. `instantiateProvider` returns null when e.g. an `anthropic` entry has no API key, but the entry still exists and the user may be about to paste one, so its refs stay put. The check is against `config.llm.providers`, not against what the manager managed to register.

## Provenance

The delete-path fix is cherry-picked from #320 (`fix(llm): clear stale provider assignments`), which was closed because its main feature — a separate `llm.default_provider` key — duplicated what the provider/model split already provides. See the closing comment on that PR for the full analysis. This tier cleanup was the one independent bug fix in it, so it is being landed on its own, rebuilt on current `main` and on `parseModelRef` instead of the helper that PR introduced. The load-path repair is new here: reviewing the cherry-pick surfaced that fixing only the write path leaves every already-affected install broken.

## Tests

Seven regression tests in `src/daemon/llm-settings.test.ts`, covering the deleted provider's refs being cleared from both the config object and the settings table, a sibling provider's refs surviving, a save→restart round-trip not resurrecting the dead routes, the load-path repair with and without persistence, credential-less providers keeping their refs, and the corrupt-JSON guard. Each was checked to fail with its corresponding fix reverted.

Full suite: 2097 pass, 22 skip, 0 fail. TypeScript clean.

## Also in here

`mergeLLMSettingsIntoConfig` had its tier→settings-key list inlined as a local literal while the write path used four separate `SETTING_TIER_*` constants. Both now read from one `SETTING_TIER_KEYS` map so the read and write paths can't drift.
