### PR TITLE
fix(llm): carry assistant tool calls and result correlation through to Ollama

### DIFF
--- a/src/llm/ollama.test.ts
+++ b/src/llm/ollama.test.ts
@@ -1,7 +1,43 @@
 import { describe, expect, it, afterEach } from 'bun:test';
 import { OllamaProvider } from './ollama.ts';
+import type { LLMMessage } from './provider.ts';
 
 const originalFetch = globalThis.fetch;
+
+/**
+ * Stub /api/chat and hand back the request body the provider built. The
+ * assertions below are about the payload we put on the wire — a live Ollama
+ * isn't needed, and wasn't available when this regression was found.
+ */
+async function captureChatBody(
+  messages: LLMMessage[],
+): Promise<{ messages: OllamaWireMessage[] }> {
+  let captured: string | undefined;
+  globalThis.fetch = (async (_url: string, init: RequestInit) => {
+    captured = init.body as string;
+    return new Response(JSON.stringify({
+      model: 'qwen2.5:3b',
+      created_at: '',
+      message: { role: 'assistant', content: 'ok' },
+      done: true,
+    }), { status: 200 });
+  }) as unknown as typeof fetch;
+
+  await new OllamaProvider().chat(messages);
+  // Guards the diagnostic, not the provider: if chat() ever returns without
+  // reaching fetch, this says so instead of failing as a JSON parse error.
+  expect(captured).toBeDefined();
+  return JSON.parse(captured!);
+}
+
+type OllamaWireMessage = {
+  role: string;
+  content: string;
+  images?: string[];
+  tool_calls?: Array<{ function: { name: string; arguments: Record<string, unknown> } }>;
+  tool_name?: string;
+  tool_call_id?: string;
+};
 
 describe('OllamaProvider.listModels', () => {
   afterEach(() => {
@@ -34,5 +70,83 @@ describe('OllamaProvider.listModels', () => {
     }) as unknown as typeof fetch;
 
     expect(new OllamaProvider().listModels()).rejects.toThrow('Unable to connect');
+  });
+});
+
+describe('OllamaProvider tool-call round-trip', () => {
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  /** Assistant calls a tool, we answer it — the shape the orchestrator emits. */
+  const toolTurn: LLMMessage[] = [
+    { role: 'user', content: 'run hostnamectl on the linux box' },
+    {
+      role: 'assistant',
+      content: '',
+      tool_calls: [{
+        id: 'ollama_1_abc',
+        name: 'run_command',
+        arguments: { command: 'hostnamectl', target: 'linux-box' },
+      }],
+    },
+    { role: 'tool', content: 'Static hostname: linux-box', tool_call_id: 'ollama_1_abc' },
+  ];
+
+  it('sends the assistant tool calls back, with arguments as an object', async () => {
+    const body = await captureChatBody(toolTurn);
+    const assistant = body.messages[1]!;
+
+    expect(assistant.role).toBe('assistant');
+    expect(assistant.tool_calls).toEqual([{
+      function: {
+        name: 'run_command',
+        // Not a JSON string: Ollama's native API takes an object here.
+        arguments: { command: 'hostnamectl', target: 'linux-box' },
+      },
+    }]);
+  });
+
+  it('keeps the tool result addressed to the call it answers', async () => {
+    const body = await captureChatBody(toolTurn);
+    const result = body.messages[2]!;
+
+    expect(result.role).toBe('tool');
+    expect(result.content).toBe('Static hostname: linux-box');
+    // tool_name is the field Ollama reads; tool_call_id rides along in case a
+    // build does look for it. See the note on OllamaMessage.
+    expect(result.tool_name).toBe('run_command');
+    expect(result.tool_call_id).toBe('ollama_1_abc');
+  });
+
+  it('still passes a result through when its call fell outside the window', async () => {
+    const body = await captureChatBody([
+      { role: 'tool', content: 'orphaned output', tool_call_id: 'ollama_dropped' },
+    ]);
+    const result = body.messages[0]!;
+
+    expect(result.role).toBe('tool');
+    expect(result.content).toBe('orphaned output');
+    expect(result.tool_name).toBeUndefined();
+  });
+
+  it('leaves ordinary text and image messages untouched', async () => {
+    const body = await captureChatBody([
+      { role: 'system', content: 'be terse' },
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'what is this' },
+          { type: 'image', source: { type: 'base64', media_type: 'image/png', data: 'BASE64' } },
+        ],
+      },
+    ]);
+
+    expect(body.messages[0]).toEqual({ role: 'system', content: 'be terse' });
+    expect(body.messages[1]).toEqual({
+      role: 'user',
+      content: 'what is this',
+      images: ['BASE64'],
+    });
   });
 });

--- a/src/llm/ollama.ts
+++ b/src/llm/ollama.ts
@@ -10,10 +10,36 @@ import type {
 import { classifyHttpStatus } from './provider.ts';
 import { compactHistory, calculateHistoryBudget } from './history.ts';
 
+type OllamaToolCall = {
+  function: {
+    name: string;
+    // Object, not a JSON string — Ollama's native /api/chat differs from
+    // OpenAI's wire format here in both directions.
+    arguments: Record<string, unknown>;
+  };
+};
+
 type OllamaMessage = {
-  role: 'system' | 'user' | 'assistant';
+  role: 'system' | 'user' | 'assistant' | 'tool';
   content: string;
   images?: string[];
+  /**
+   * Present on assistant messages that called tools. Ollama's chat templates
+   * render a tool result relative to the call that produced it, so dropping
+   * these leaves the model looking at an orphan result.
+   */
+  tool_calls?: OllamaToolCall[];
+  /** Names the tool a result answers — the field Ollama's own message carries. */
+  tool_name?: string;
+  /**
+   * OpenAI's correlation field, sent speculatively and unverified against a
+   * live Ollama, which as far as we know ignores it. Harmless either way (the
+   * server drops unknown JSON fields) and free if some build does read it.
+   * Don't mistake it for what pairs a result with its call: that's position in
+   * the array. Two parallel calls to the SAME tool yield two identical
+   * `tool_name`s, and only their order tells them apart.
+   */
+  tool_call_id?: string;
 };
 
 type OllamaToolDef = {
@@ -31,12 +57,7 @@ type OllamaResponse = {
   message: {
     role: 'assistant';
     content: string;
-    tool_calls?: Array<{
-      function: {
-        name: string;
-        arguments: Record<string, unknown>;
-      };
-    }>;
+    tool_calls?: OllamaToolCall[];
   };
   done: boolean;
   total_duration?: number;
@@ -51,12 +72,7 @@ type OllamaStreamChunk = {
   message?: {
     role: 'assistant';
     content: string;
-    tool_calls?: Array<{
-      function: {
-        name: string;
-        arguments: Record<string, unknown>;
-      };
-    }>;
+    tool_calls?: OllamaToolCall[];
   };
   done: boolean;
   total_duration?: number;
@@ -263,35 +279,60 @@ export class OllamaProvider implements LLMProvider {
   }
 
   private convertMessages(messages: LLMMessage[]): OllamaMessage[] {
-    return messages.map(m => {
-      if (typeof m.content === 'string') {
-        return {
-          role: m.role as 'system' | 'user' | 'assistant',
-          content: m.content,
-        };
-      }
+    // An assistant's tool calls and the results answering them have to survive
+    // this conversion together. Ollama renders a tool result relative to the
+    // preceding assistant `tool_calls`; a result that arrives alone reads as an
+    // orphan, and the model re-guesses the call it already made.
+    //
+    // Sequential, not a .map, because resolving a result's `tool_name` depends
+    // on having already walked the assistant message that named it.
+    // `compactHistory` keeps each assistant + its results in one chunk, so
+    // compaction can't strand a result whose call was dropped.
+    const toolNamesById = new Map<string, string>();
+    const converted: OllamaMessage[] = [];
 
-      // ContentBlock[] — extract text and images separately
-      let text = '';
+    for (const m of messages) {
+      let text: string;
       const images: string[] = [];
 
-      for (const block of m.content) {
-        if (block.type === 'text') {
-          text += (text ? '\n' : '') + block.text;
-        } else if (block.type === 'image') {
-          images.push(block.source.data);
+      if (typeof m.content === 'string') {
+        text = m.content;
+      } else {
+        // ContentBlock[] — extract text and images separately
+        text = '';
+        for (const block of m.content) {
+          if (block.type === 'text') {
+            text += (text ? '\n' : '') + block.text;
+          } else if (block.type === 'image') {
+            images.push(block.source.data);
+          }
         }
       }
 
-      const msg: OllamaMessage = {
-        role: m.role as 'system' | 'user' | 'assistant',
-        content: text,
-      };
+      const msg: OllamaMessage = { role: m.role, content: text };
       if (images.length > 0) {
         msg.images = images;
       }
-      return msg;
-    });
+
+      if (m.tool_calls && m.tool_calls.length > 0) {
+        msg.tool_calls = m.tool_calls.map(tc => {
+          toolNamesById.set(tc.id, tc.name);
+          return { function: { name: tc.name, arguments: tc.arguments } };
+        });
+      }
+
+      if (m.role === 'tool' && m.tool_call_id) {
+        msg.tool_call_id = m.tool_call_id;
+        const name = toolNamesById.get(m.tool_call_id);
+        // Absent only if the matching call fell outside the window; the
+        // result still goes through so the model isn't left waiting on it.
+        if (name) msg.tool_name = name;
+      }
+
+      converted.push(msg);
+    }
+
+    return converted;
   }
 
   private convertTools(tools: LLMTool[]): OllamaToolDef[] {


### PR DESCRIPTION
`OllamaProvider.convertMessages` mapped only `role`, `content`, and `images`. It dropped `tool_calls` from assistant messages and `tool_call_id` from tool results, so the provider could *read* tool calls but never send them back.

Ollama renders a tool result relative to the preceding assistant `tool_calls`. Without it the model gets an orphan result with no record of the call it just made, so the first tool call works and the loop falls apart on turn 2 — the model re-guesses tool names, or reports a registered tool as unavailable. Reported against a local Ollama driving sidecar tools: asking for a `run_command` on a connected sidecar produced "run_command is unavailable" or a call to an unrelated tool, with authority never involved.

Not a deliberate limitation. `docs/LLM_PROVIDERS.md` lists Ollama as supporting Tools and `src/llm/README.md` claims function-calling parity; nothing documents a caveat. #87 ("Fix/llm tool calling clean") gave Groq's `convertMessages` exactly what's missing here — `'tool'` in the role union, `tool_calls` mapping, null-content handling — and touched `ollama.ts` in the same commit without changing its conversion. The plumbing was never present at any point in the file's history.

## Change

All of it in `convertMessages` and the type above it:

- `OllamaMessage.role` widened to include `'tool'`; the old `as` cast was laundering a runtime `'tool'` through a type that didn't admit it
- assistant `tool_calls` carried through, `arguments` as an **object** — Ollama's native `/api/chat` differs from OpenAI's JSON-string encoding in both directions
- tool results carry `tool_name`, resolved through an id→name map built while walking messages in order (hence a `for` loop rather than `.map`). `tool_call_id` is sent alongside it, unverified and probably ignored; the wire format is documented honestly on the type
- extracted `OllamaToolCall`, already duplicated verbatim in the two response types

No changes to `LLMMessage`, the orchestrators, or any other provider.

## Tests

Four cases in `ollama.test.ts` over a stubbed `/api/chat`, asserting the request body: tool calls round-trip with object arguments, results stay addressed to their call, an orphaned result still passes through without a `tool_name`, and text/image messages are unchanged (that branch was restructured). No provider-specific conversion had tool-round-trip coverage before, which is how this survived.

Full suite green, `tsc --noEmit` clean.

## Limits

The tests assert payload shape, not model behaviour — no live Ollama was reachable. The assistant-side `tool_calls` is the part with no ambiguity; whether any build reads `tool_call_id` is unconfirmed, which is why both fields go out.

Out of scope, worth a follow-up: `calculateHistoryBudget(32000)` asserts a context window nobody measured and excludes tool schemas from the accounting, while `num_ctx` is deliberately left unset so a user's own `OLLAMA_CONTEXT_LENGTH` isn't clobbered. Server-side truncation past the real window can drop the very `tool_calls` block this restores, so the fix holds only within the model's actual context. Detecting that via `prompt_eval_count` and warning would close it without overriding anyone's setup.
