### PR TITLE
fix(llm): clear tiers for removed providers

### DIFF
--- a/src/daemon/llm-settings.test.ts
+++ b/src/daemon/llm-settings.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it } from 'bun:test';
 import { initDatabase, closeDb } from '../vault/schema.ts';
 import { getSetting, setSetting } from '../vault/settings.ts';
 import { DEFAULT_CONFIG } from '../config/types.ts';
-import { mergeLLMSettingsIntoConfig } from './llm-settings.ts';
+import { mergeLLMSettingsIntoConfig, saveLLMSettings } from './llm-settings.ts';
 
 afterEach(() => closeDb());
 
@@ -32,5 +32,28 @@ describe('LLM settings model migrations', () => {
 
     expect(config.llm.default).toBe('groq:openai/gpt-oss-120b');
     expect(getSetting('llm.default')).toBe('groq:deepseek-r1-distill-llama-70b');
+  });
+});
+
+describe('LLM provider deletion', () => {
+  it('clears persisted tier assignments owned by the deleted provider', () => {
+    initDatabase(':memory:');
+    const config = structuredClone(DEFAULT_CONFIG);
+    config.llm.providers = {
+      anthropic: { kind: 'anthropic' },
+      omniroute: { kind: 'omniroute' },
+    };
+    config.llm.tiers = {
+      conversation: 'anthropic:claude-haiku',
+      high: 'omniroute:auto',
+      medium: 'anthropic:claude-sonnet',
+    };
+
+    saveLLMSettings(config, { providers: { anthropic: null } });
+
+    expect(config.llm.tiers).toEqual({ high: 'omniroute:auto' });
+    expect(getSetting('llm.tiers.conversation')).toBe('');
+    expect(getSetting('llm.tiers.medium')).toBe('');
+    expect(getSetting('llm.tiers.high')).toBe('omniroute:auto');
   });
 });

--- a/src/daemon/llm-settings.ts
+++ b/src/daemon/llm-settings.ts
@@ -27,6 +27,7 @@ import {
 } from '../llm/config-binding.ts';
 import { isAnthropicCustomBaseUrl } from '../llm/anthropic.ts';
 import { GROQ_DEPRECATED_MODEL_REPLACEMENTS } from '../llm/groq-models.ts';
+import { parseModelRef } from '../llm/tiers.ts';
 
 // ── DB keys ──────────────────────────────────────────────────────────────
 const SETTING_PROVIDERS = 'llm.providers';
@@ -206,6 +207,11 @@ export function saveLLMSettings(
     for (const [name, update] of updates) {
       if (update === null) {
         delete config.llm.providers[name];
+        for (const tier of ['conversation', 'high', 'medium', 'low'] as const) {
+          if (parseModelRef(config.llm.tiers[tier])?.provider === name) {
+            delete config.llm.tiers[tier];
+          }
+        }
         try { deleteSecret(keychainKey(name)); } catch { /* ignore */ }
         continue;
       }


### PR DESCRIPTION
## Summary

- clear saved tier assignments when their provider is removed
- preserve tiers that belong to other configured providers
- use the existing `parseModelRef` helper rather than adding parallel provider parsing or settings
- prevent stale conversation routes from returning after a daemon restart

## Verification

- `bun test src/daemon/llm-settings.test.ts` (3 passed)
- `bun x tsc --noEmit`
- `git diff --check`