### PR TITLE
fix(chat): recover text from completion frames

### DIFF
--- a/src/daemon/ws-service.ts
+++ b/src/daemon/ws-service.ts
@@ -1132,7 +1132,7 @@ CRITICAL — when in genuine doubt between "make in a new project" vs "add to th
       let ttsSentenceQueue: string[] = [];
       let ttsSpeaking = false;
       let ttsStartSent = false;
-      let ttsStreamFullyDone = false; // set AFTER relayStream returns, not per-turn 'done'
+      let ttsStreamFullyDone = false; // set AFTER relayStream returns, not on the 'done' event
       let ttsSentenceCount = 0;
       let ttsChunkCount = 0;
 
@@ -1213,8 +1213,13 @@ CRITICAL — when in genuine doubt between "make in a new project" vs "add to th
 
       // Relay stream to all WebSocket clients, collect full text.
       // onSentence fires for each complete sentence during streaming.
-      // NOTE: onTextDone fires per LLM turn (tool loop), NOT once at the end.
-      // We ignore onTextDone and use the relayStream return to mark stream completion.
+      // NOTE: exactly one 'done' event reaches the relay per request — the
+      // orchestrator swallows its per-iteration done events and yields a single
+      // terminal one after the tool loop settles. The dashboard relies on that:
+      // it keys the assistant message on `assistant:<requestId>` and rebuilds it
+      // from the done frame's fullText, so a second done frame for the same
+      // request would render a duplicate message under a duplicate React key.
+      // We still use the relayStream return (not onTextDone) to mark completion.
       const fullText = await this.streamRelay.relayStream(stream, requestId, {
         signal: activeChat?.controller.signal,
         // Voice enters "thinking" after STT-final. Flip it off as soon as

--- a/ui/src/hooks/useWebSocket.test.ts
+++ b/ui/src/hooks/useWebSocket.test.ts
@@ -1,5 +1,47 @@
 import { describe, expect, test } from "bun:test";
-import { extractNestedMessage, formatProviderErrorMessage } from "./useWebSocket.ts";
+import { extractNestedMessage, finalizeStreamMessage, formatProviderErrorMessage } from "./useWebSocket.ts";
+
+describe("finalizeStreamMessage", () => {
+  test("recovers text from the done frame when every stream chunk was missed", () => {
+    const messages = finalizeStreamMessage([], {
+      id: "assistant:req-1",
+      fullText: "This was spoken aloud.",
+      timestamp: 123,
+      toolCalls: [],
+      subAgentEvents: [],
+    });
+    expect(messages).toEqual([{
+      id: "assistant:req-1",
+      role: "assistant",
+      content: "This was spoken aloud.",
+      timestamp: 123,
+      isStreaming: false,
+    }]);
+  });
+
+  test("repairs partial streamed text with authoritative completed text", () => {
+    const messages = finalizeStreamMessage([{
+      id: "assistant:req-1", role: "assistant", content: "This was", timestamp: 100, isStreaming: true,
+    }], {
+      id: "assistant:req-1",
+      fullText: "This was spoken aloud.",
+      timestamp: 123,
+      toolCalls: [],
+      subAgentEvents: [],
+    });
+    expect(messages[0]?.content).toBe("This was spoken aloud.");
+    expect(messages[0]?.isStreaming).toBe(false);
+  });
+
+  test("does not duplicate a response when completion is handled twice", () => {
+    const existing = [{
+      id: "assistant:req-1", role: "assistant" as const, content: "OK", timestamp: 100, isStreaming: false,
+    }];
+    expect(finalizeStreamMessage(existing, {
+      id: "assistant:req-1", fullText: "OK", timestamp: 123, toolCalls: [], subAgentEvents: [],
+    })).toHaveLength(1);
+  });
+});
 
 describe("extractNestedMessage", () => {
   test("returns null for non-objects and empty values", () => {

--- a/ui/src/hooks/useWebSocket.test.ts
+++ b/ui/src/hooks/useWebSocket.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { extractNestedMessage, finalizeStreamMessage, formatProviderErrorMessage } from "./useWebSocket.ts";
+import { extractNestedMessage, finalizeStreamMessage, formatProviderErrorMessage, mergeRestoredHistory } from "./useWebSocket.ts";
 
 describe("finalizeStreamMessage", () => {
   test("recovers text from the done frame when every stream chunk was missed", () => {
@@ -40,6 +40,50 @@ describe("finalizeStreamMessage", () => {
     expect(finalizeStreamMessage(existing, {
       id: "assistant:req-1", fullText: "OK", timestamp: 123, toolCalls: [], subAgentEvents: [],
     })).toHaveLength(1);
+  });
+});
+
+describe("mergeRestoredHistory", () => {
+  const restored = [
+    { id: "vault-1", role: "user" as const, content: "hello", timestamp: 1 },
+    { id: "vault-2", role: "assistant" as const, content: "hi there", timestamp: 2 },
+  ];
+
+  test("returns history untouched when nothing raced in", () => {
+    expect(mergeRestoredHistory(restored, [])).toEqual(restored);
+  });
+
+  test("keeps a message that landed while the history fetch was in flight", () => {
+    const live = [{
+      id: "assistant:req-1", role: "assistant" as const, content: "recovered", timestamp: 3,
+    }];
+    expect(mergeRestoredHistory(restored, live)).toEqual([...restored, ...live]);
+  });
+
+  test("drops the live copy of a message the vault already has", () => {
+    const live = [{
+      id: "assistant:req-1", role: "assistant" as const, content: "hi there ", timestamp: 3,
+    }];
+    expect(mergeRestoredHistory(restored, live)).toEqual(restored);
+  });
+
+  test("does not collapse a genuinely repeated answer", () => {
+    const twice = [
+      ...restored,
+      { id: "vault-3", role: "assistant" as const, content: "hi there", timestamp: 3 },
+    ];
+    const live = [
+      { id: "a", role: "assistant" as const, content: "hi there", timestamp: 4 },
+      { id: "b", role: "assistant" as const, content: "hi there", timestamp: 5 },
+      { id: "c", role: "assistant" as const, content: "hi there", timestamp: 6 },
+    ];
+    // Two vault copies absorb two live copies; the third survives.
+    expect(mergeRestoredHistory(twice, live)).toHaveLength(4);
+  });
+
+  test("does not match across roles", () => {
+    const live = [{ id: "x", role: "user" as const, content: "hi there", timestamp: 3 }];
+    expect(mergeRestoredHistory(restored, live)).toHaveLength(3);
   });
 });
 

--- a/ui/src/hooks/useWebSocket.ts
+++ b/ui/src/hooks/useWebSocket.ts
@@ -28,6 +28,44 @@ export type ChatMessage = {
   detail?: string; // raw error/debug payload, rendered collapsed in the chat
 };
 
+/**
+ * Merge vault history into whatever already landed in the chat list.
+ *
+ * `ws.onopen` awaits the history fetch, but `ws.onmessage` keeps firing during
+ * that await — a turn that completes inside the fetch window appends its
+ * message first. Replacing the list would drop that message; skipping the
+ * restore because the list is "not empty" would drop the entire conversation.
+ * So restored history goes first and only the live messages it does not
+ * already account for are kept after it.
+ *
+ * Vault rows carry their own ids, so the live copy of a persisted message
+ * never matches by id — role + text is the only usable identity here. Matches
+ * are consumed one-for-one so a genuinely repeated answer keeps both copies.
+ */
+export function mergeRestoredHistory(
+  restored: ChatMessage[],
+  live: ChatMessage[],
+): ChatMessage[] {
+  if (live.length === 0) return restored;
+
+  const key = (message: ChatMessage) => `${message.role}\u0000${message.content.trim()}`;
+  const available = new Map<string, number>();
+  for (const message of restored) {
+    const messageKey = key(message);
+    available.set(messageKey, (available.get(messageKey) ?? 0) + 1);
+  }
+
+  const unmatched = live.filter((message) => {
+    const messageKey = key(message);
+    const remaining = available.get(messageKey) ?? 0;
+    if (remaining === 0) return true;
+    available.set(messageKey, remaining - 1);
+    return false;
+  });
+
+  return [...restored, ...unmatched];
+}
+
 export function finalizeStreamMessage(
   messages: ChatMessage[],
   options: {
@@ -435,6 +473,10 @@ export function useWebSocket() {
   } | null>(null);
   const wsRef = useRef<WebSocket | null>(null);
   const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // History is authoritative only for the first successful load. After that the
+  // client holds messages the vault never persists (system notices, errors,
+  // workflow lines), so a reconnect must not re-seed from the vault.
+  const historyHydratedRef = useRef(false);
   const streamBufferRef = useRef<string>("");
   const streamIdRef = useRef<string | null>(null);
   const toolCallsRef = useRef<ToolCall[]>([]);
@@ -456,24 +498,27 @@ export function useWebSocket() {
     ws.onopen = async () => {
       setIsConnected(true);
       console.log("[WS] Connected");
-      // Load chat history from backend on connect
-      try {
-        const resp = await fetch("/api/vault/conversations/active?channel=websocket");
-        if (resp.ok) {
-          const data = await resp.json();
-          if (data.messages && data.messages.length > 0) {
-            const restored: ChatMessage[] = data.messages.map((m: any) => ({
-              id: m.id,
-              role: m.role as MessageRole,
-              content: m.content,
-              timestamp: m.created_at,
-              toolCalls: m.tool_calls ?? undefined,
-            }));
-            setMessages((prev) => prev.length === 0 ? restored : prev);
+      // Load chat history from backend on the first connect that gets an answer.
+      if (!historyHydratedRef.current) {
+        try {
+          const resp = await fetch("/api/vault/conversations/active?channel=websocket");
+          if (resp.ok) {
+            const data = await resp.json();
+            historyHydratedRef.current = true;
+            if (data.messages && data.messages.length > 0) {
+              const restored: ChatMessage[] = data.messages.map((m: any) => ({
+                id: m.id,
+                role: m.role as MessageRole,
+                content: m.content,
+                timestamp: m.created_at,
+                toolCalls: m.tool_calls ?? undefined,
+              }));
+              setMessages((prev) => mergeRestoredHistory(restored, prev));
+            }
           }
+        } catch (err) {
+          console.warn("[WS] Failed to load history:", err);
         }
-      } catch (err) {
-        console.warn("[WS] Failed to load history:", err);
       }
 
       // Rehydrate any pending approval requests so a daemon restart (or a

--- a/ui/src/hooks/useWebSocket.ts
+++ b/ui/src/hooks/useWebSocket.ts
@@ -28,6 +28,41 @@ export type ChatMessage = {
   detail?: string; // raw error/debug payload, rendered collapsed in the chat
 };
 
+export function finalizeStreamMessage(
+  messages: ChatMessage[],
+  options: {
+    id: string;
+    fullText?: string;
+    timestamp: number;
+    toolCalls: ToolCall[];
+    subAgentEvents: SubAgentEvent[];
+  },
+): ChatMessage[] {
+  const index = messages.findIndex((message) => message.id === options.id);
+  if (index < 0) {
+    if (!options.fullText) return messages;
+    return [...messages, {
+      id: options.id,
+      role: "assistant",
+      content: options.fullText,
+      timestamp: options.timestamp,
+      isStreaming: false,
+      ...(options.toolCalls.length ? { toolCalls: options.toolCalls } : {}),
+      ...(options.subAgentEvents.length ? { subAgentEvents: options.subAgentEvents } : {}),
+    }];
+  }
+
+  return messages.map((message, messageIndex) => messageIndex === index
+    ? {
+        ...message,
+        content: options.fullText || message.content,
+        isStreaming: false,
+        toolCalls: options.toolCalls.length ? options.toolCalls : message.toolCalls,
+        subAgentEvents: options.subAgentEvents.length ? options.subAgentEvents : message.subAgentEvents,
+      }
+    : message);
+}
+
 export type TaskEvent = {
   action: "created" | "updated" | "deleted";
   task: {
@@ -697,7 +732,7 @@ export function useWebSocket() {
 
         if (!streamIdRef.current) {
           // Start a new assistant message
-          const id = uuid();
+          const id = requestId ? `assistant:${requestId}` : uuid();
           streamIdRef.current = id;
           setMessages((prev) => [
             ...prev,
@@ -732,26 +767,16 @@ export function useWebSocket() {
       ) return;
       // Stream complete or explicitly stopped. Keep partial text visible but
       // remove its speaking/streaming state immediately.
-      if (streamIdRef.current) {
-        const finalId = streamIdRef.current;
-        const finalToolCalls = toolCallsRef.current;
-        const finalSubAgentEvents = subAgentEventsRef.current;
-        setMessages((prev) =>
-          prev.map((m) =>
-            m.id === finalId
-              ? {
-                  ...m,
-                  isStreaming: false,
-                  toolCalls:
-                    finalToolCalls.length > 0 ? finalToolCalls : m.toolCalls,
-                  subAgentEvents:
-                    finalSubAgentEvents.length > 0
-                      ? finalSubAgentEvents
-                      : m.subAgentEvents,
-                }
-              : m
-          )
-        );
+      const finalId = streamIdRef.current || (requestId ? `assistant:${requestId}` : "");
+      if (finalId) {
+        const fullText = typeof msg.payload?.fullText === "string" ? msg.payload.fullText : undefined;
+        setMessages((prev) => finalizeStreamMessage(prev, {
+          id: finalId,
+          fullText,
+          timestamp: msg.timestamp || Date.now(),
+          toolCalls: toolCallsRef.current,
+          subAgentEvents: subAgentEventsRef.current,
+        }));
       }
       // Reset stream state
       streamBufferRef.current = "";


### PR DESCRIPTION
## Summary

- give each streamed assistant response a stable ID derived from its request
- treat the completion frame `fullText` as the authoritative final response
- create the assistant message from completion data when earlier stream chunks were missed
- repair partial text and deduplicate repeated completion handling

This fixes cases where Jarvis speaks a completed answer through TTS but the dashboard shows no text.

## Verification

- `bun test ui/src/hooks/useWebSocket.test.ts` (30 passed)
- `bun x tsc --noEmit`
- `bun run build:ui`
- `git diff --check`