### PR TITLE
fix(llm): split 403 permission failures out of the auth error bucket

### DIFF
--- a/src/actions/tools/workflow-composer.ts
+++ b/src/actions/tools/workflow-composer.ts
@@ -505,10 +505,13 @@ async function composeWithTools(
         // don't misdiagnose transient/auth failures as "no tool support":
         // classify the error and only fall back for bad-request / unknown
         // codes (the shapes a rejected-tools-param error takes). Clearly
-        // transient (rate_limit, network, server) or auth failures are surfaced
+        // transient (rate_limit, network, server) or auth/permission failures are surfaced
         // as-is -- dropping tools won't fix them and hides the real cause.
         const code = classifyErrorString(message);
-        if (code === "rate_limit" || code === "network" || code === "server" || code === "auth") {
+        if (
+          code === "rate_limit" || code === "network" || code === "server" ||
+          code === "auth" || code === "forbidden"
+        ) {
           logAttempt(turn, "tool-loop-error", `tool call failed (${code}); not falling back: ${message}`);
           return {
             ok: false,

--- a/src/llm/anthropic.ts
+++ b/src/llm/anthropic.ts
@@ -15,8 +15,9 @@ import { compactHistory, calculateHistoryBudget } from './history.ts';
 function classifyAnthropicErrorType(type: string): LLMErrorCode {
   switch (type) {
     case 'authentication_error':
-    case 'permission_error':
       return 'auth';
+    case 'permission_error':
+      return 'forbidden';
     case 'rate_limit_error':
       return 'rate_limit';
     case 'overloaded_error':

--- a/src/llm/provider.test.ts
+++ b/src/llm/provider.test.ts
@@ -1405,9 +1405,12 @@ describe('modelRejectsCustomTemperature', () => {
 });
 
 describe('classifyHttpStatus', () => {
-  test('401/403 → auth', () => {
+  test('401 → auth', () => {
     expect(classifyHttpStatus(401)).toBe('auth');
-    expect(classifyHttpStatus(403)).toBe('auth');
+  });
+
+  test('403 → forbidden, not auth — a working key without model access', () => {
+    expect(classifyHttpStatus(403)).toBe('forbidden');
   });
 
   test('429 → rate_limit', () => {
@@ -1449,6 +1452,34 @@ describe('classifyErrorString', () => {
     expect(classifyErrorString('HTTP 401 Unauthorized')).toBe('auth');
     expect(classifyErrorString('invalid x-api-key')).toBe('auth');
     expect(classifyErrorString('Incorrect API key provided')).toBe('auth');
+  });
+
+  test('forbidden via 403 / permission markers', () => {
+    expect(classifyErrorString('HTTP 403 Forbidden')).toBe('forbidden');
+    expect(classifyErrorString('permission_error: not allowed to use this model')).toBe('forbidden');
+    expect(classifyErrorString('You do not have access to model gpt-5')).toBe('forbidden');
+  });
+
+  test('403 wins over the auth keywords it ships with', () => {
+    // Providers word 403s with auth-adjacent language; the status decides.
+    expect(classifyErrorString('403: authentication succeeded but access is denied')).toBe('forbidden');
+  });
+
+  test('a stated 401 keeps permission wording in the auth bucket', () => {
+    expect(classifyErrorString('401 Unauthorized: you do not have access')).toBe('auth');
+  });
+
+  test('permission wording alone, with no status, is forbidden', () => {
+    expect(classifyErrorString('permission denied for this model')).toBe('forbidden');
+    // Both wordings providers use for a model the caller can't reach.
+    expect(classifyErrorString('You do not have access to model gpt-5')).toBe('forbidden');
+    expect(classifyErrorString('Project `proj_a` does not have access to model `o3`')).toBe('forbidden');
+    // Google's canonical status uses an underscore, not a space.
+    expect(classifyErrorString('PERMISSION_DENIED: the API is not enabled')).toBe('forbidden');
+  });
+
+  test('word-boundary: 4030 does not collide with 403', () => {
+    expect(classifyErrorString('prompt has 4030 tokens')).not.toBe('forbidden');
   });
 
   test('rate_limit via 429 / quota / rate limit', () => {

--- a/src/llm/provider.ts
+++ b/src/llm/provider.ts
@@ -43,7 +43,8 @@ export type LLMResponse = {
  * user-facing copy without string-matching the upstream error message.
  */
 export type LLMErrorCode =
-  | 'auth'         // invalid API key, unauthorized
+  | 'auth'         // 401, invalid or missing API key
+  | 'forbidden'    // 403, credentials accepted but this model/endpoint is not allowed
   | 'rate_limit'   // 429, quota exhausted
   | 'network'      // timeout, connection refused, 502/503/504
   | 'bad_request'  // 400/422, invalid parameters
@@ -83,7 +84,8 @@ export class LLMProviderError extends Error {
  * UI doesn't have to guess from the error string.
  */
 export function classifyHttpStatus(status: number): LLMErrorCode {
-  if (status === 401 || status === 403) return 'auth';
+  if (status === 401) return 'auth';
+  if (status === 403) return 'forbidden';
   if (status === 429) return 'rate_limit';
   // Some OpenAI-compatible gateways use non-standard 498 for an upstream
   // connection/token expiry and expect clients to retry it as a network fault.
@@ -103,12 +105,26 @@ export function classifyHttpStatus(status: number): LLMErrorCode {
 export function classifyErrorString(raw: string | undefined | null): LLMErrorCode {
   if (!raw) return 'unknown';
   const s = raw.toLowerCase();
+  // 403 and 401 need different advice (no model access vs. a bad key), so the
+  // authoritative markers for a permission failure are checked first. The
+  // softer permission wording is checked *after* auth, because providers mix
+  // it into 401 bodies too and a stated 401 is the better signal.
   if (
-    /\b401\b/.test(s) || /\b403\b/.test(s) ||
+    /\b403\b/.test(s) ||
+    s.includes('forbidden') ||
+    s.includes('permission_error') || s.includes('permission_denied')
+  ) return 'forbidden';
+  if (
+    /\b401\b/.test(s) ||
     s.includes('unauthorized') || s.includes('api key') ||
     s.includes('invalid_api_key') || s.includes('invalid x-api-key') ||
     s.includes('authentication')
   ) return 'auth';
+  // "not have access" covers both wordings providers use ("you do not have
+  // access to model X", "project ... does not have access to model X").
+  if (
+    s.includes('permission denied') || s.includes('not have access')
+  ) return 'forbidden';
   if (
     /\b429\b/.test(s) ||
     s.includes('rate limit') || s.includes('too many requests') ||

--- a/ui/src/hooks/useWebSocket.test.ts
+++ b/ui/src/hooks/useWebSocket.test.ts
@@ -32,6 +32,22 @@ describe("formatProviderErrorMessage — buckets", () => {
     expect(r.summary).toContain("API key");
   });
 
+  test("forbidden: 403 gets model-access copy, not the API-key copy", () => {
+    const r = formatProviderErrorMessage("OpenAI API error (403): model access denied");
+    expect(r.summary).toContain("won't allow this model");
+    expect(r.summary).not.toContain("Check your API key and model settings");
+  });
+
+  test("auth wins when a 401 body also carries permission wording", () => {
+    const r = formatProviderErrorMessage("401 Unauthorized: you do not have access");
+    expect(r.summary).toContain("Check your API key and model settings");
+  });
+
+  test("forbidden: model-access wording with no status code", () => {
+    const r = formatProviderErrorMessage("Project `proj_a` does not have access to model `o3`");
+    expect(r.summary).toContain("won't allow this model");
+  });
+
   test("auth: invalid x-api-key", () => {
     const r = formatProviderErrorMessage("authentication_error: invalid x-api-key");
     expect(r.summary).toContain("API key");
@@ -105,6 +121,24 @@ describe("formatProviderErrorMessage — structured code branching (Phase B)", (
     expect(r.summary).not.toContain("connection");
   });
 
+  test("forbidden code has its own copy, distinct from auth", () => {
+    const forbidden = formatProviderErrorMessage("permission denied", "forbidden");
+    const auth = formatProviderErrorMessage("invalid api key", "auth");
+    expect(forbidden.summary).toContain("won't allow this model");
+    expect(forbidden.summary).not.toBe(auth.summary);
+  });
+
+  test("structured code still outranks digits in the raw message", () => {
+    // A quota failure whose payload happens to carry a 403/401-looking token
+    // must stay in the rate-limit bucket.
+    const r = formatProviderErrorMessage(
+      '{"error":{"message":"quota exceeded"},"request_id":"req-403-xyz"}',
+      "rate_limit",
+    );
+    expect(r.summary).toContain("rate-limit");
+    expect(r.summary).not.toContain("won't allow this model");
+  });
+
   test("not_found has its own copy", () => {
     const r = formatProviderErrorMessage("model xyz does not exist", "not_found");
     expect(r.summary).toContain("couldn't find");
@@ -136,6 +170,11 @@ describe("formatProviderErrorMessage — status-code brittleness fix", () => {
     const r = formatProviderErrorMessage("context window exceeded at token 14018");
     // falls through to the generic fallback, not the auth-specific copy
     expect(r.summary).not.toContain("Check your API key and model settings");
+  });
+
+  test("does NOT match '403' embedded in unrelated digits", () => {
+    const r = formatProviderErrorMessage("prompt length was 4030 tokens");
+    expect(r.summary).not.toContain("won't allow this model");
   });
 
   test("does NOT match '429' embedded in unrelated digits", () => {

--- a/ui/src/hooks/useWebSocket.ts
+++ b/ui/src/hooks/useWebSocket.ts
@@ -265,6 +265,7 @@ function deriveImpactFromCategory(category: string): ApprovalImpact {
  */
 export type ProviderErrorCode =
   | "auth"
+  | "forbidden"
   | "rate_limit"
   | "network"
   | "bad_request"
@@ -272,10 +273,16 @@ export type ProviderErrorCode =
   | "server"
   | "unknown";
 
+/** Shared by the structured `forbidden` code and the keyword fallbacks below. */
+const FORBIDDEN_SUMMARY =
+  "Your AI provider accepted the API key but won't allow this model. Check that your plan or organization has access to it, or pick a different model.";
+
 function summaryForCode(code: ProviderErrorCode | undefined): string | null {
   switch (code) {
     case "auth":
       return "Couldn't reach your AI provider. Check your API key and model settings.";
+    case "forbidden":
+      return FORBIDDEN_SUMMARY;
     case "rate_limit":
       return "Your AI provider is rate-limiting requests. Wait a moment, or check your usage and billing.";
     case "network":
@@ -325,6 +332,20 @@ export function formatProviderErrorMessage(
 
   const lowered = normalized.toLowerCase();
 
+  // Mirrors classifyErrorString: authoritative 403 markers first, the softer
+  // permission wording after the auth bucket.
+  if (
+    lowered.includes("forbidden") ||
+    lowered.includes("permission_error") ||
+    lowered.includes("permission_denied") ||
+    /\b403\b/.test(lowered)
+  ) {
+    return {
+      summary: FORBIDDEN_SUMMARY,
+      detail: normalized,
+    };
+  }
+
   if (
     lowered.includes("api key") ||
     lowered.includes("authentication") ||
@@ -336,6 +357,13 @@ export function formatProviderErrorMessage(
   ) {
     return {
       summary: "Couldn't reach your AI provider. Check your API key and model settings.",
+      detail: normalized,
+    };
+  }
+
+  if (lowered.includes("permission denied") || lowered.includes("not have access")) {
+    return {
+      summary: FORBIDDEN_SUMMARY,
       detail: normalized,
     };
   }


### PR DESCRIPTION
## Summary

`classifyHttpStatus` collapsed 401 and 403 into a single `auth` code, so "your API key is wrong" and "your key is fine, but this model isn't in your plan" rendered the same chat message — and the second one sent users off to re-check a key that was never the problem.

Splits 403 into its own `forbidden` code, classified where the HTTP status is still available.

- `LLMErrorCode` gains `forbidden`; `classifyHttpStatus` maps 401 → `auth`, 403 → `forbidden`
- `classifyErrorString` grows a matching branch for transports with no status (Gemini, Anthropic SSE, aggregated failures)
- Anthropic's `permission_error` type maps to `forbidden`, split from `authentication_error`
- UI gets distinct copy for the new code, plus keyword parity for status-less errors

Two ordering details that carry the weight:

- A stated `401` beats permission wording, so `"401 Unauthorized: you do not have access"` stays `auth` — providers mix that phrasing into 401 bodies, and the explicit status is the better signal. Only the authoritative markers (`403`, `forbidden`, `permission_error`, `permission_denied`) are checked ahead of the auth bucket.
- Marker spellings follow what providers actually emit: `not have access` covers both "you do not have access to model X" and "project ... does not have access to model X", and `permission_denied` covers Google's underscored status enum.

`forbidden` is deliberately **not** added to `shouldFailOver` — it keeps `auth`'s existing no-retry, no-failover behavior. Routing a denied model to a second provider is arguable, but it's a routing change, not an error-copy change, and doesn't belong here.

## Context

Supersedes #339, which found this gap. That PR recovered the status by regex in the browser, ahead of the structured code and against the un-normalized payload, which put every other bucket behind a digit match — a `bad_request` whose body read "(500 in the messages)" surfaced as a 500, and a quota failure with a `403` in its request id surfaced as a permission error. Fixing it at the emission site leaves the other buckets untouched. Credit to @Yperbu9474 for the find; I'll close #339 against this.

## Verification

- `bun test` — 2179 tests, 0 fail
- `bun x tsc --noEmit` — clean
- Re-probed the four cases #339 regressed: `bad_request`, `network` and `rate_limit` all keep their original copy; only a real 403 gets the new message
