### PR TITLE
fix(chat): rebuild the stream buffer from the relay's accumulated total

### DIFF
--- a/ui/src/hooks/useWebSocket.test.ts
+++ b/ui/src/hooks/useWebSocket.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { extractNestedMessage, finalizeStreamMessage, formatProviderErrorMessage, mergeRestoredHistory } from "./useWebSocket.ts";
+import { extractNestedMessage, finalizeStreamMessage, formatProviderErrorMessage, mergeRestoredHistory, nextStreamBuffer } from "./useWebSocket.ts";
 
 describe("finalizeStreamMessage", () => {
   test("recovers text from the done frame when every stream chunk was missed", () => {
@@ -84,6 +84,33 @@ describe("mergeRestoredHistory", () => {
   test("does not match across roles", () => {
     const live = [{ id: "x", role: "user" as const, content: "hi there", timestamp: 3 }];
     expect(mergeRestoredHistory(restored, live)).toHaveLength(3);
+  });
+});
+
+describe("nextStreamBuffer", () => {
+  test("adopts the relay's running total so a late client is not left truncated", () => {
+    // First chunk this client sees; everything before it was broadcast while
+    // the socket was still connecting.
+    expect(nextStreamBuffer("", { text: " world", accumulated: "hello world" }))
+      .toBe("hello world");
+  });
+
+  test("stays in step with local accumulation on a healthy stream", () => {
+    expect(nextStreamBuffer("hello", { text: " world", accumulated: "hello world" }))
+      .toBe("hello world");
+  });
+
+  test("falls back to appending when the chunk carries no accumulated total", () => {
+    expect(nextStreamBuffer("hello", { text: " world" })).toBe("hello world");
+  });
+
+  test("ignores a non-string accumulated value", () => {
+    expect(nextStreamBuffer("hello", { text: " world", accumulated: 42 }))
+      .toBe("hello world");
+  });
+
+  test("keeps the buffer intact when a chunk has no text at all", () => {
+    expect(nextStreamBuffer("hello", {})).toBe("hello");
   });
 });
 

--- a/ui/src/hooks/useWebSocket.ts
+++ b/ui/src/hooks/useWebSocket.ts
@@ -101,6 +101,28 @@ export function finalizeStreamMessage(
     : message);
 }
 
+/**
+ * Next value of the local stream buffer for an incoming text chunk.
+ *
+ * Chunks are broadcast to every dashboard, so a client that opens, reloads, or
+ * reconnects mid-turn starts with an empty buffer and would render the answer
+ * with its opening cut off. The relay stamps every chunk with `accumulated` —
+ * its own running total for the request, already including this chunk — so the
+ * first chunk a late client sees carries everything it missed. Prefer it and
+ * the answer is whole from the first render instead of staying truncated until
+ * the terminal frame repairs it.
+ *
+ * Falls back to local accumulation when `accumulated` is absent, so a daemon
+ * that predates the field still streams correctly.
+ */
+export function nextStreamBuffer(
+  buffer: string,
+  payload: { text?: string; accumulated?: unknown },
+): string {
+  if (typeof payload.accumulated === "string") return payload.accumulated;
+  return buffer + (payload.text ?? "");
+}
+
 export type TaskEvent = {
   action: "created" | "updated" | "deleted";
   task: {
@@ -801,7 +823,7 @@ export function useWebSocket() {
         }
       } else if (msg.payload?.text) {
         // Text chunk
-        streamBufferRef.current += msg.payload.text;
+        streamBufferRef.current = nextStreamBuffer(streamBufferRef.current, msg.payload);
 
         if (!streamIdRef.current) {
           // Start a new assistant message


### PR DESCRIPTION
## Summary

Follow-up to #348. That PR made the terminal `done` frame authoritative, which repairs a truncated answer once the turn ends. This closes the same gap while the turn is still streaming.

Stream chunks are broadcast to every dashboard, so a client that opens, reloads, or reconnects mid-turn starts with an empty buffer and renders the answer with its opening cut off until the `done` frame arrives. The relay already stamps every chunk with `accumulated` (`src/comms/streaming.ts`) — its own running total for the request, including the current chunk — so the first chunk a late client sees already carries everything it missed. The UI now prefers that value over local `+=` accumulation.

- add `nextStreamBuffer(buffer, payload)` and use it for the text-chunk branch
- fall back to appending when `accumulated` is absent, so an older daemon still streams correctly

The two mechanisms are complementary, not redundant: `accumulated` covers a client that sees *some* chunks, the `done` frame still covers one that sees *none*.

## Verification

- `bun test` (2170 pass, 0 fail)
- `bun x tsc --noEmit`
- `bun run build:ui`
- `git diff --check`
