### PR TITLE
feat(google): managed Google integration — hosted connect flow and remote token refresh

### DIFF
--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -51,6 +51,16 @@ export type GoogleConfig = {
    * VPS move does not break it).
    */
   connect_url?: string;
+  /**
+   * Where this instance asks the control plane to refresh its access token.
+   *
+   * Present INSTEAD of client_id/client_secret on a managed instance: the
+   * control plane holds those and applies them on our behalf, so no shared
+   * credential sits in a file this daemon's own (tenant-owned) user can read.
+   */
+  refresh_url?: string;
+  /** This instance's control-plane id, used to name itself when refreshing. */
+  instance_id?: string;
 };
 
 export type ChannelConfig = {

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -15,8 +15,13 @@ export type SystemCronConfig = {
 };
 
 export type GoogleConfig = {
-  client_id: string;
-  client_secret: string;
+  /**
+   * SELF-HOSTED ONLY. Absent on a control-plane managed instance, which holds no
+   * Google client credentials at all — see `refresh_url`. Optional so the
+   * compiler makes every reader face that case instead of trusting a `''`.
+   */
+  client_id?: string;
+  client_secret?: string;
   /**
    * HOSTED ONLY (usejarvis, GOOGLE.md "Push bridging"). Present when the control
    * plane runs a push bridge: Google notifies it, and it rings this instance's
@@ -43,8 +48,8 @@ export type GoogleConfig = {
   /**
    * Where the user connects Google, on the hosted account page.
    *
-   * Its PRESENCE means this instance is control-plane MANAGED: the credentials
-   * below were rendered by the server, the tokens are delivered rather than
+   * Its PRESENCE means this instance is control-plane MANAGED: there are no
+   * client credentials in this file at all, the tokens are delivered rather than
    * obtained here, and this daemon's own OAuth flow must not run — its redirect
    * URI is this instance's own hostname, which is not registered with Google and
    * cannot be (there is one registered URI, on the control plane, precisely so a

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -17,6 +17,29 @@ export type SystemCronConfig = {
 export type GoogleConfig = {
   client_id: string;
   client_secret: string;
+  /**
+   * HOSTED ONLY (usejarvis, GOOGLE.md "Push bridging"). Present when the control
+   * plane runs a push bridge: Google notifies it, and it rings this instance's
+   * doorbell so a change reflects in seconds instead of on the next poll.
+   *
+   * All three absent = self-hosted, or a deployment with no bridge. Polling then
+   * covers everything, which is the designed fallback rather than a degraded
+   * mode — so nothing here is required and nothing fails without it.
+   */
+  /** HMAC key the inbound doorbell is verified with (per instance). */
+  notify_secret?: string;
+  /** Pub/Sub topic to point Gmail's users.watch at. */
+  pubsub_topic?: string;
+  /** The bridge's public URL, for Calendar's events.watch callback. */
+  push_callback?: string;
+  /**
+   * The token to set on the Calendar watch, which Google echoes back to the
+   * bridge so it can tell which instance a notification belongs to. Rendered
+   * whole by the control plane rather than built here from notify_secret — the
+   * derivation would then live in two codebases, and a drifted token is a
+   * notification the bridge refuses without anything looking wrong.
+   */
+  channel_token?: string;
 };
 
 export type ChannelConfig = {

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -40,6 +40,17 @@ export type GoogleConfig = {
    * notification the bridge refuses without anything looking wrong.
    */
   channel_token?: string;
+  /**
+   * Where the user connects Google, on the hosted account page.
+   *
+   * Its PRESENCE means this instance is control-plane MANAGED: the credentials
+   * below were rendered by the server, the tokens are delivered rather than
+   * obtained here, and this daemon's own OAuth flow must not run — its redirect
+   * URI is this instance's own hostname, which is not registered with Google and
+   * cannot be (there is one registered URI, on the control plane, precisely so a
+   * VPS move does not break it).
+   */
+  connect_url?: string;
 };
 
 export type ChannelConfig = {

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -57,6 +57,15 @@ export type GoogleConfig = {
    */
   connect_url?: string;
   /**
+   * HMAC key this instance SIGNS its refresh requests with (hosted only).
+   *
+   * A different key from notify_secret, which the DOORBELL is verified with. The
+   * two travel in opposite directions, and while one key served both, the same
+   * signature was valid at either endpoint — safe only because the two body
+   * shapes happen to be disjoint. Both are rendered whole by the control plane.
+   */
+  refresh_secret?: string;
+  /**
    * Where this instance asks the control plane to refresh its access token.
    *
    * Present INSTEAD of client_id/client_secret on a managed instance: the

--- a/src/daemon/api-google-managed.test.ts
+++ b/src/daemon/api-google-managed.test.ts
@@ -17,6 +17,18 @@ type Handler = (req: Request) => Response | Promise<Response>;
  */
 const CONNECT_URL = 'https://app.usejarvis.dev/account';
 
+/**
+ * A REAL managed block: no client_id, no client_secret. Fixtures that carried
+ * them let every "is this managed?" branch pass on the credentials clause
+ * instead of the hosted one — the exact confusion this mode exists to end.
+ */
+const MANAGED = {
+  refresh_url: 'https://app.usejarvis.dev/api/integrations/google/refresh',
+  instance_id: 'inst-1',
+  notify_secret: 'a'.repeat(64),
+  connect_url: CONNECT_URL,
+};
+
 function routes(google: Record<string, string> | undefined) {
   return createApiRoutes({
     daemonStartedAt: Date.now(),
@@ -30,12 +42,7 @@ function routes(google: Record<string, string> | undefined) {
 
 describe('managed (hosted) Google mode', () => {
   it('status reports managed + where to connect', async () => {
-    const r = routes({
-      client_id: 'cid',
-      client_secret: 'sec',
-      notify_secret: 'a'.repeat(64),
-      connect_url: CONNECT_URL,
-    });
+    const r = routes(MANAGED);
     const body = (await (await r['/api/auth/google/status']!.GET!(
       new Request('http://localhost/api/auth/google/status'),
     )).json()) as {
@@ -43,9 +50,12 @@ describe('managed (hosted) Google mode', () => {
       connect_url: string;
       status: string;
       is_authenticated: boolean;
+      has_credentials: boolean;
     };
     expect(body.managed).toBe(true);
     expect(body.connect_url).toBe(CONNECT_URL);
+    // Configured WITHOUT any credentials in the file — the whole point.
+    expect(body.has_credentials).toBe(true);
     // The MAPPING is the assertion, relative to whatever token file this machine
     // happens to have: unauthenticated + managed must read "not_connected", NOT
     // "credentials_saved" — there are no credentials for the user to save here,
@@ -66,11 +76,7 @@ describe('managed (hosted) Google mode', () => {
   });
 
   it('the daemon OAuth flow is refused when managed, and points at the account page', async () => {
-    const r = routes({
-      client_id: 'cid',
-      client_secret: 'sec',
-      connect_url: CONNECT_URL,
-    });
+    const r = routes(MANAGED);
     const res = await r['/api/auth/google/init']!.POST!(
       new Request('http://localhost/api/auth/google/init', { method: 'POST' }),
     );
@@ -87,5 +93,49 @@ describe('managed (hosted) Google mode', () => {
     );
     // The hosted change must not break the self-hosted product.
     expect(res.status).not.toBe(409);
+  });
+
+  it('a partial managed block disables Google rather than using the file credentials', async () => {
+    // A config carrying refresh_url but not instance_id/notify_secret is one we
+    // mis-rendered. Falling through to the client_id/client_secret also present
+    // would silently put a hosted instance back on the shared secret — and
+    // nothing would look wrong, because Google would keep working.
+    const r = routes({
+      refresh_url: MANAGED.refresh_url,
+      client_id: 'cid',
+      client_secret: 'sec',
+    });
+    const body = (await (await r['/api/auth/google/status']!.GET!(
+      new Request('http://localhost/api/auth/google/status'),
+    )).json()) as { status: string; has_credentials: boolean };
+    expect(body.has_credentials).toBe(false);
+    expect(body.status).toBe('not_configured');
+  });
+
+  it('POST /api/config/google is refused when managed', async () => {
+    // It REPLACES the whole google section, so one call from a stale tab used to
+    // drop refresh_url, instance_id and notify_secret from the running config —
+    // refresh dead, doorbell 404, hosted UI gone, no error anywhere.
+    const r = routes(MANAGED);
+    const res = await r['/api/config/google']!.POST!(
+      new Request('http://localhost/api/config/google', {
+        method: 'POST',
+        body: JSON.stringify({ client_id: 'cid', client_secret: 'sec' }),
+      }),
+    );
+    expect(res.status).toBe(409);
+  });
+
+  it('POST /api/config/google still works for a self-hosted instance', async () => {
+    const r = routes({ client_id: 'old', client_secret: 'old' });
+    const res = await r['/api/config/google']!.POST!(
+      new Request('http://localhost/api/config/google', {
+        method: 'POST',
+        body: JSON.stringify({ client_id: '', client_secret: '' }),
+      }),
+    );
+    // Rejected for its EMPTY body (400), not for being managed (409) — the
+    // guard must not have swallowed the self-hosted path with it.
+    expect(res.status).toBe(400);
   });
 });

--- a/src/daemon/api-google-managed.test.ts
+++ b/src/daemon/api-google-managed.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'bun:test';
+import { createApiRoutes, type ApiContext } from './api-routes.ts';
+import type { JarvisConfig } from '../config/types.ts';
+
+type Handler = (req: Request) => Response | Promise<Response>;
+
+/**
+ * Hosted ("managed") mode for the daemon's own Google surface (GOOGLE.md).
+ *
+ * The point of the hosted integration is that it REPLACES the self-hosted one in
+ * this UI. That means two things have to be true here: the status endpoint has to
+ * say so (the settings tab keys its whole rendering off it), and the daemon's own
+ * OAuth flow has to refuse — its redirect URI is this instance's own hostname,
+ * which is not registered with Google and cannot be, since there is exactly one
+ * registered URI on the control plane so that moving hosts never breaks it. A
+ * user who reached that flow would get a redirect_uri_mismatch error page.
+ */
+const CONNECT_URL = 'https://app.usejarvis.dev/account';
+
+function routes(google: Record<string, string> | undefined) {
+  return createApiRoutes({
+    daemonStartedAt: Date.now(),
+    healthMonitor: {} as ApiContext['healthMonitor'],
+    config: {
+      daemon: { port: 3142, data_dir: '/tmp/jarvis', db_path: '/tmp/jarvis/jarvis.db' },
+      ...(google ? { google } : {}),
+    } as JarvisConfig,
+  } as ApiContext) as Record<string, { GET?: Handler; POST?: Handler }>;
+}
+
+describe('managed (hosted) Google mode', () => {
+  it('status reports managed + where to connect', async () => {
+    const r = routes({
+      client_id: 'cid',
+      client_secret: 'sec',
+      notify_secret: 'a'.repeat(64),
+      connect_url: CONNECT_URL,
+    });
+    const body = (await (await r['/api/auth/google/status']!.GET!(
+      new Request('http://localhost/api/auth/google/status'),
+    )).json()) as {
+      managed: boolean;
+      connect_url: string;
+      status: string;
+      is_authenticated: boolean;
+    };
+    expect(body.managed).toBe(true);
+    expect(body.connect_url).toBe(CONNECT_URL);
+    // The MAPPING is the assertion, relative to whatever token file this machine
+    // happens to have: unauthenticated + managed must read "not_connected", NOT
+    // "credentials_saved" — there are no credentials for the user to save here,
+    // and telling them to would be the old self-hosted story. Written this way
+    // because GoogleAuth resolves its path through os.homedir(), which Bun fixes
+    // at process start and no test can redirect.
+    expect(body.status).toBe(body.is_authenticated ? 'connected' : 'not_connected');
+  });
+
+  it('a self-hosted instance is NOT managed', async () => {
+    const r = routes({ client_id: 'cid', client_secret: 'sec' });
+    const body = (await (await r['/api/auth/google/status']!.GET!(
+      new Request('http://localhost/api/auth/google/status'),
+    )).json()) as { managed: boolean; status: string; is_authenticated: boolean };
+    // Its own credentials form and OAuth flow are the RIGHT ui there.
+    expect(body.managed).toBe(false);
+    expect(body.status).toBe(body.is_authenticated ? 'connected' : 'credentials_saved');
+  });
+
+  it('the daemon OAuth flow is refused when managed, and points at the account page', async () => {
+    const r = routes({
+      client_id: 'cid',
+      client_secret: 'sec',
+      connect_url: CONNECT_URL,
+    });
+    const res = await r['/api/auth/google/init']!.POST!(
+      new Request('http://localhost/api/auth/google/init', { method: 'POST' }),
+    );
+    // Refused at the API, not merely hidden in the UI: otherwise a stale tab or a
+    // direct call still starts a flow that can only end in redirect_uri_mismatch.
+    expect(res.status).toBe(409);
+    expect(JSON.stringify(await res.json())).toContain(CONNECT_URL);
+  });
+
+  it('the daemon OAuth flow still works for a self-hosted instance', async () => {
+    const r = routes({ client_id: 'cid', client_secret: 'sec' });
+    const res = await r['/api/auth/google/init']!.POST!(
+      new Request('http://localhost/api/auth/google/init', { method: 'POST' }),
+    );
+    // The hosted change must not break the self-hosted product.
+    expect(res.status).not.toBe(409);
+  });
+});

--- a/src/daemon/api-google-managed.test.ts
+++ b/src/daemon/api-google-managed.test.ts
@@ -147,7 +147,7 @@ describe('managed (hosted) Google mode', () => {
     expect(res.status).toBe(409);
   });
 
-  it('POST /api/config/google still works for a self-hosted instance', async () => {
+  it('POST /api/config/google is NOT swallowed by the managed guard when self-hosted', async () => {
     const r = routes({ client_id: 'old', client_secret: 'old' });
     const res = await r['/api/config/google']!.POST!(
       new Request('http://localhost/api/config/google', {

--- a/src/daemon/api-google-managed.test.ts
+++ b/src/daemon/api-google-managed.test.ts
@@ -1,4 +1,8 @@
 import { describe, expect, it } from 'bun:test';
+import { createHash } from 'node:crypto';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { createApiRoutes, type ApiContext } from './api-routes.ts';
 import type { JarvisConfig } from '../config/types.ts';
 
@@ -25,14 +29,18 @@ const CONNECT_URL = 'https://app.usejarvis.dev/account';
 const MANAGED = {
   refresh_url: 'https://app.usejarvis.dev/api/integrations/google/refresh',
   instance_id: 'inst-1',
+  // The doorbell key and the refresh key: different derivations, so a mix-up of
+  // the two cannot pass a test that uses this fixture.
   notify_secret: 'a'.repeat(64),
+  refresh_secret: 'c'.repeat(64),
   connect_url: CONNECT_URL,
 };
 
-function routes(google: Record<string, string> | undefined) {
+function routes(google: Record<string, string> | undefined, googleTokensPath?: string) {
   return createApiRoutes({
     daemonStartedAt: Date.now(),
     healthMonitor: {} as ApiContext['healthMonitor'],
+    googleTokensPath,
     config: {
       daemon: { port: 3142, data_dir: '/tmp/jarvis', db_path: '/tmp/jarvis/jarvis.db' },
       ...(google ? { google } : {}),
@@ -40,39 +48,47 @@ function routes(google: Record<string, string> | undefined) {
   } as ApiContext) as Record<string, { GET?: Handler; POST?: Handler }>;
 }
 
+async function status(r: Record<string, { GET?: Handler }>) {
+  return (await (await r['/api/auth/google/status']!.GET!(
+    new Request('http://localhost/api/auth/google/status'),
+  )).json()) as {
+    managed: boolean;
+    connect_url: string;
+    status: string;
+    is_authenticated: boolean;
+    configured: boolean;
+    reconnect_reason?: string;
+    reason?: string;
+  };
+}
+
 describe('managed (hosted) Google mode', () => {
   it('status reports managed + where to connect', async () => {
-    const r = routes(MANAGED);
-    const body = (await (await r['/api/auth/google/status']!.GET!(
-      new Request('http://localhost/api/auth/google/status'),
-    )).json()) as {
-      managed: boolean;
-      connect_url: string;
-      status: string;
-      is_authenticated: boolean;
-      has_credentials: boolean;
-    };
+    const dir = await mkdtemp(join(tmpdir(), 'jarvis-google-status-'));
+    const body = await status(routes(MANAGED, join(dir, 'google-tokens.json')));
     expect(body.managed).toBe(true);
     expect(body.connect_url).toBe(CONNECT_URL);
-    // Configured WITHOUT any credentials in the file — the whole point.
-    expect(body.has_credentials).toBe(true);
-    // The MAPPING is the assertion, relative to whatever token file this machine
-    // happens to have: unauthenticated + managed must read "not_connected", NOT
+    // Configured WITHOUT any credentials in the file — the whole point, and the
+    // reason the field is no longer called has_credentials.
+    expect(body.configured).toBe(true);
+    // Managed and unauthenticated must read "not_connected", NOT
     // "credentials_saved" — there are no credentials for the user to save here,
-    // and telling them to would be the old self-hosted story. Written this way
-    // because GoogleAuth resolves its path through os.homedir(), which Bun fixes
-    // at process start and no test can redirect.
-    expect(body.status).toBe(body.is_authenticated ? 'connected' : 'not_connected');
+    // and telling them to would be the old self-hosted story. Asserted against an
+    // empty tokens directory rather than as a mapping over "whatever this machine
+    // happens to have".
+    expect(body.status).toBe('not_connected');
+    expect(body.is_authenticated).toBe(false);
   });
 
   it('a self-hosted instance is NOT managed', async () => {
-    const r = routes({ client_id: 'cid', client_secret: 'sec' });
-    const body = (await (await r['/api/auth/google/status']!.GET!(
-      new Request('http://localhost/api/auth/google/status'),
-    )).json()) as { managed: boolean; status: string; is_authenticated: boolean };
+    const dir = await mkdtemp(join(tmpdir(), 'jarvis-google-self-'));
+    const body = await status(
+      routes({ client_id: 'cid', client_secret: 'sec' }, join(dir, 'google-tokens.json')),
+    );
     // Its own credentials form and OAuth flow are the RIGHT ui there.
     expect(body.managed).toBe(false);
-    expect(body.status).toBe(body.is_authenticated ? 'connected' : 'credentials_saved');
+    expect(body.is_authenticated).toBe(false);
+    expect(body.status).toBe('credentials_saved');
   });
 
   it('the daemon OAuth flow is refused when managed, and points at the account page', async () => {
@@ -102,14 +118,19 @@ describe('managed (hosted) Google mode', () => {
     // nothing would look wrong, because Google would keep working.
     const r = routes({
       refresh_url: MANAGED.refresh_url,
+      instance_id: MANAGED.instance_id,
+      // ...but no refresh_secret, so nothing here could sign a refresh request.
       client_id: 'cid',
       client_secret: 'sec',
     });
     const body = (await (await r['/api/auth/google/status']!.GET!(
       new Request('http://localhost/api/auth/google/status'),
-    )).json()) as { status: string; has_credentials: boolean };
-    expect(body.has_credentials).toBe(false);
+    )).json()) as { status: string; configured: boolean; reason?: string };
+    expect(body.configured).toBe(false);
     expect(body.status).toBe('not_configured');
+    // ...and it says WHY, because this shape is a config we refused rather than a
+    // deployment that simply does not run Google.
+    expect(body.reason).toContain('refresh_url');
   });
 
   it('POST /api/config/google is refused when managed', async () => {
@@ -137,5 +158,56 @@ describe('managed (hosted) Google mode', () => {
     // Rejected for its EMPTY body (400), not for being managed (409) — the
     // guard must not have swallowed the self-hosted path with it.
     expect(res.status).toBe(400);
+  });
+
+  it('a connected instance reads connected; a REVOKED grant reads reconnect_required', async () => {
+    // Previously untestable, and so untested: the route resolved the tokens path
+    // through os.homedir(), which Bun fixes at process start — the older test in
+    // this file even says so and asserts a mapping instead. With the path injected
+    // both branches can be driven, which matters because "tokens on disk" and
+    // "Google works" are exactly the two things this endpoint must stop
+    // conflating: a revoked grant leaves the file untouched.
+    const dir = await mkdtemp(join(tmpdir(), 'jarvis-google-status-'));
+    const tokensPath = join(dir, 'google-tokens.json');
+    try {
+      await Bun.write(
+        tokensPath,
+        JSON.stringify({
+          access_token: 'a',
+          refresh_token: '1//r',
+          expiry_date: Date.now() + 3_600_000,
+          token_type: 'Bearer',
+        }),
+      );
+      const connected = await status(routes(MANAGED, tokensPath));
+      expect(connected).toMatchObject({
+        managed: true,
+        configured: true,
+        is_authenticated: true,
+        status: 'connected',
+      });
+
+      // The verdict the refresh path records when the control plane says the
+      // grant is gone. Same tokens on disk; opposite answer.
+      await Bun.write(
+        `${tokensPath}.reconnect`,
+        JSON.stringify({
+          tokenHash: createHash('sha256').update('1//r').digest('hex'),
+          message: 'Google access is no longer valid — connect Google again',
+        }),
+      );
+      const revoked = await status(routes(MANAGED, tokensPath));
+      expect(revoked).toMatchObject({
+        managed: true,
+        // NOT authenticated, which is what puts the Connect button back in front
+        // of the user instead of a green chip over a dead integration.
+        is_authenticated: false,
+        status: 'reconnect_required',
+        connect_url: CONNECT_URL,
+      });
+      expect(revoked.reconnect_reason).toContain('connect Google again');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/src/daemon/api-google-notify.test.ts
+++ b/src/daemon/api-google-notify.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from 'bun:test';
+import { createHmac } from 'node:crypto';
+import { createApiRoutes, type ApiContext } from './api-routes.ts';
+import type { JarvisConfig } from '../config/types.ts';
+
+type Handler = (req: Request) => Response | Promise<Response>;
+
+/**
+ * The hosted push bridge's doorbell (GOOGLE.md "Push bridging").
+ *
+ * This route is PUBLIC — it has to be, since the caller is the control plane and
+ * holds no enrolled-device token — so the HMAC is the entire access control. It
+ * lives under `/api/webhooks/`, which is already the signature-verified public
+ * prefix (see isPublicRoute in comms/websocket.ts), rather than adding a bespoke
+ * exception that would widen the unauthenticated surface.
+ */
+const SECRET = 'a'.repeat(64);
+
+function makeRoutes(opts?: {
+  secret?: string | null;
+  onSync?: (source: 'gmail' | 'calendar') => Promise<string[]>;
+}) {
+  const secret = opts?.secret === undefined ? SECRET : opts.secret;
+  const config = {
+    daemon: { port: 3142, data_dir: '/tmp/jarvis', db_path: '/tmp/jarvis/jarvis.db' },
+    google: {
+      client_id: 'client-id',
+      client_secret: 'client-secret',
+      ...(secret ? { notify_secret: secret } : {}),
+    },
+  } as JarvisConfig;
+  const synced: Array<'gmail' | 'calendar'> = [];
+  const routes = createApiRoutes({
+    daemonStartedAt: Date.now(),
+    healthMonitor: {} as ApiContext['healthMonitor'],
+    config,
+    ...(opts?.onSync === null
+      ? {}
+      : {
+          observerService: {
+            syncNow: async (source: 'gmail' | 'calendar') => {
+              synced.push(source);
+              return opts?.onSync ? opts.onSync(source) : [source === 'gmail' ? 'email' : 'calendar'];
+            },
+          },
+        }),
+  } as ApiContext) as Record<string, { POST?: Handler }>;
+  return { post: routes['/api/webhooks/google/notify']!.POST!, synced };
+}
+
+const signed = (body: string, secret = SECRET) =>
+  new Request('http://localhost/api/webhooks/google/notify', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-jarvis-signature': createHmac('sha256', secret).update(body).digest('hex'),
+    },
+    body,
+  });
+
+const doorbell = (source = 'gmail', at = new Date().toISOString()) =>
+  JSON.stringify({ source, at });
+
+describe('POST /api/webhooks/google/notify', () => {
+  it('syncs the named integration when the signature is valid', async () => {
+    const { post, synced } = makeRoutes();
+    const body = doorbell('gmail');
+    const res = await post(signed(body));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, synced: ['email'] });
+    expect(synced).toEqual(['gmail']);
+
+    const cal = await post(signed(doorbell('calendar')));
+    expect(cal.status).toBe(200);
+    expect(synced).toEqual(['gmail', 'calendar']);
+  });
+
+  it('rejects a wrong, missing or truncated signature', async () => {
+    const { post, synced } = makeRoutes();
+    const body = doorbell('gmail');
+
+    // Signed with the wrong key: the whole access control of a public route.
+    const wrongKey = await post(signed(body, 'b'.repeat(64)));
+    expect(wrongKey.status).toBe(401);
+
+    const missing = await post(
+      new Request('http://localhost/api/webhooks/google/notify', { method: 'POST', body }),
+    );
+    expect(missing.status).toBe(401);
+
+    // A prefix of the real signature must not pass a lazy comparison.
+    const real = createHmac('sha256', SECRET).update(body).digest('hex');
+    const truncated = await post(
+      new Request('http://localhost/api/webhooks/google/notify', {
+        method: 'POST',
+        headers: { 'x-jarvis-signature': real.slice(0, 16) },
+        body,
+      }),
+    );
+    expect(truncated.status).toBe(401);
+    expect(synced).toEqual([]);
+  });
+
+  it('rejects a body whose bytes differ from what was signed', async () => {
+    const { post, synced } = makeRoutes();
+    // Signature over one body, sent with another: the check must cover the exact
+    // bytes, not merely be present.
+    const req = new Request('http://localhost/api/webhooks/google/notify', {
+      method: 'POST',
+      headers: {
+        'x-jarvis-signature': createHmac('sha256', SECRET).update(doorbell('gmail')).digest('hex'),
+      },
+      body: doorbell('calendar'),
+    });
+    expect((await post(req)).status).toBe(401);
+    expect(synced).toEqual([]);
+  });
+
+  it('rejects a stale or undated doorbell', async () => {
+    const { post, synced } = makeRoutes();
+    // The timestamp is inside the signed bytes, so a REPLAYED notification can be
+    // refused without keeping a nonce store — and anything genuinely missed is
+    // covered by the poll timer.
+    const old = doorbell('gmail', new Date(Date.now() - 60 * 60 * 1000).toISOString());
+    expect((await post(signed(old))).status).toBe(400);
+    const undated = JSON.stringify({ source: 'gmail' });
+    expect((await post(signed(undated))).status).toBe(400);
+    const gibberishDate = JSON.stringify({ source: 'gmail', at: 'not-a-date' });
+    expect((await post(signed(gibberishDate))).status).toBe(400);
+    expect(synced).toEqual([]);
+  });
+
+  it('rejects an unknown source and a malformed body', async () => {
+    const { post, synced } = makeRoutes();
+    expect((await post(signed(JSON.stringify({ source: 'drive', at: new Date().toISOString() })))).status).toBe(400);
+    expect((await post(signed('not json'))).status).toBe(400);
+    expect(synced).toEqual([]);
+  });
+
+  it('404s when no notify secret is configured', async () => {
+    // Self-hosted, or a hosted config predating the bridge: there is nothing to
+    // verify against, so nothing may be accepted. Notably it must NOT fall
+    // through to syncing.
+    const { post, synced } = makeRoutes({ secret: null });
+    const res = await post(signed(doorbell('gmail')));
+    expect(res.status).toBe(404);
+    expect(synced).toEqual([]);
+  });
+
+  it('answers honestly when the observers are not running', async () => {
+    const routes = createApiRoutes({
+      daemonStartedAt: Date.now(),
+      healthMonitor: {} as ApiContext['healthMonitor'],
+      config: {
+        daemon: { port: 3142, data_dir: '/tmp/jarvis', db_path: '/tmp/jarvis/jarvis.db' },
+        google: { client_id: 'c', client_secret: 's', notify_secret: SECRET },
+      } as JarvisConfig,
+    } as ApiContext) as Record<string, { POST?: Handler }>;
+    const res = await routes['/api/webhooks/google/notify']!.POST!(signed(doorbell('gmail')));
+    // 200 with an empty list, not a lie about having synced: the bridge logs the
+    // difference, and the tokens may simply not be delivered yet.
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, synced: [] });
+  });
+
+  it('reports an empty sync when the observer could not run', async () => {
+    // An observer that threw, or one with no syncNow. The doorbell is
+    // best-effort by design, so this is a 200 with nothing synced rather than an
+    // error that would make the bridge log a delivery failure.
+    const { post } = makeRoutes({ onSync: async () => [] });
+    const res = await post(signed(doorbell('gmail')));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, synced: [] });
+  });
+});

--- a/src/daemon/api-google-notify.test.ts
+++ b/src/daemon/api-google-notify.test.ts
@@ -98,6 +98,20 @@ describe('POST /api/webhooks/google/notify', () => {
       }),
     );
     expect(truncated.status).toBe(401);
+
+    // A 64-CHARACTER signature that is not 64 BYTES. This is the one that used
+    // to escape: String.length counts UTF-16 units, so it passed the length gate
+    // and then made timingSafeEqual throw — a 500 with a stack trace instead of
+    // a 401, from an unauthenticated caller, on a route that is public by design
+    // and sits under a Bun.serve with no error handler above it.
+    const nonAscii = await post(
+      new Request('http://localhost/api/webhooks/google/notify', {
+        method: 'POST',
+        headers: { 'x-jarvis-signature': 'é'.repeat(64) },
+        body,
+      }),
+    );
+    expect(nonAscii.status).toBe(401);
     expect(synced).toEqual([]);
   });
 

--- a/src/daemon/api-routes.ts
+++ b/src/daemon/api-routes.ts
@@ -2098,14 +2098,14 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
     '/api/auth/google/status': {
       GET: async () => {
         const googleConfig = ctx.config.google;
+        const { classifyGoogle, makeGoogleAuth, googleReconnectRequired } =
+          await import('../integrations/google-managed-refresh.ts');
         // A MANAGED instance has no client credentials by design — the control
         // plane holds them and refreshes on its behalf — so "configured" cannot
         // mean "has credentials" any more, or hosted would always read as
-        // not_configured.
-        const hasCredentials = !!(
-          (googleConfig?.client_id && googleConfig?.client_secret) ||
-          googleConfig?.refresh_url
-        );
+        // not_configured. Asked of the same classifier the auth builder uses, so
+        // this cannot claim a config is usable that makeGoogleAuth then refuses.
+        const hasCredentials = classifyGoogle(ctx.config).mode !== 'none';
         // Control-plane managed (GOOGLE.md): the settings UI must show the
         // hosted Connect button instead of the credentials form, because the
         // account is connected THROUGH the control plane and this daemon's own
@@ -2120,18 +2120,30 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
         }
 
         try {
-          const { makeGoogleAuth } = await import('../integrations/google-managed-refresh.ts');
           const auth = makeGoogleAuth(ctx.config);
-          const authenticated = auth?.isAuthenticated() ?? false;
           const tokens = auth?.loadTokens() ?? null;
+          // A revoked or expired grant leaves the tokens file exactly where it
+          // was, so "we have tokens" is not "Google works". When the control
+          // plane has told us the grant is gone, report NOT authenticated —
+          // that is what puts the Connect button back in front of the user
+          // instead of a green "connected" chip over a dead integration.
+          const reconnect = googleReconnectRequired(auth);
+          const authenticated = !reconnect && (auth?.isAuthenticated() ?? false);
 
           return json({
             // Managed and not yet authenticated is "waiting for the control
             // plane to deliver", not "save your credentials" — there are none to
             // save here.
-            status: authenticated ? 'connected' : managed ? 'not_connected' : 'credentials_saved',
+            status: reconnect
+              ? 'reconnect_required'
+              : authenticated
+                ? 'connected'
+                : managed
+                  ? 'not_connected'
+                  : 'credentials_saved',
             has_credentials: true,
             is_authenticated: authenticated,
+            ...(reconnect ? { reconnect_reason: reconnect } : {}),
             scopes: ['gmail.readonly', 'calendar.readonly'],
             token_expiry: tokens?.expiry_date ?? null,
             ...managedFields,
@@ -2145,12 +2157,23 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
     '/api/config/google': {
       POST: async (req: Request) => {
         try {
+          // MANAGED instances must not accept credentials here (GOOGLE.md).
+          // The sibling /api/auth/google/init already refuses; this one did not,
+          // and it REPLACES the whole google section — so one POST from a stale
+          // tab or a curl dropped refresh_url, instance_id and notify_secret
+          // from the running config and persisted a row that then won on every
+          // reload: refresh dead, doorbell 404, managed UI gone. Silently.
+          if (ctx.config.google?.connect_url || ctx.config.google?.refresh_url) {
+            return error(
+              'This instance is managed by usejarvis — its Google credentials are held by the control plane and cannot be set here.',
+              409,
+            );
+          }
           const body = await req.json() as { client_id: string; client_secret: string };
           if (!body.client_id || !body.client_secret) {
             return error('Missing client_id or client_secret');
           }
 
-          const { saveUserSection } = await import('./user-settings.ts');
           const freshConfig = ctx.config;
           freshConfig.google = { client_id: body.client_id, client_secret: body.client_secret };
           const { saveGoogleSettings } = await import('./user-settings.ts');

--- a/src/daemon/api-routes.ts
+++ b/src/daemon/api-routes.ts
@@ -2098,7 +2098,14 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
     '/api/auth/google/status': {
       GET: async () => {
         const googleConfig = ctx.config.google;
-        const hasCredentials = !!(googleConfig?.client_id && googleConfig?.client_secret);
+        // A MANAGED instance has no client credentials by design — the control
+        // plane holds them and refreshes on its behalf — so "configured" cannot
+        // mean "has credentials" any more, or hosted would always read as
+        // not_configured.
+        const hasCredentials = !!(
+          (googleConfig?.client_id && googleConfig?.client_secret) ||
+          googleConfig?.refresh_url
+        );
         // Control-plane managed (GOOGLE.md): the settings UI must show the
         // hosted Connect button instead of the credentials form, because the
         // account is connected THROUGH the control plane and this daemon's own
@@ -2113,10 +2120,10 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
         }
 
         try {
-          const { GoogleAuth } = await import('../integrations/google-auth.ts');
-          const auth = new GoogleAuth(googleConfig!.client_id, googleConfig!.client_secret);
-          const authenticated = auth.isAuthenticated();
-          const tokens = auth.loadTokens();
+          const { makeGoogleAuth } = await import('../integrations/google-managed-refresh.ts');
+          const auth = makeGoogleAuth(ctx.config);
+          const authenticated = auth?.isAuthenticated() ?? false;
+          const tokens = auth?.loadTokens() ?? null;
 
           return json({
             // Managed and not yet authenticated is "waiting for the control

--- a/src/daemon/api-routes.ts
+++ b/src/daemon/api-routes.ts
@@ -5,6 +5,7 @@
  * Returns a routes object for Bun.serve().
  */
 
+import { createHmac, timingSafeEqual } from 'node:crypto';
 import type { HealthMonitor } from './health.ts';
 import { applyApprovalDecision } from './approval-decision.ts';
 import { SecretStorageError } from './section-secrets.ts';
@@ -168,7 +169,21 @@ export type ApiContext = {
    * observers, ...) apply to the running process without a restart.
    */
   settingsReload?: import('./settings-reload.ts').SettingsReloadCoordinator;
+  /**
+   * Observer service, for the hosted push bridge's doorbell to poll on demand.
+   * Absent when observers are not running, which the webhook reports honestly
+   * rather than pretending to have synced.
+   */
+  observerService?: { syncNow(source: 'gmail' | 'calendar'): Promise<string[]> };
 };
+
+/**
+ * How far out of date a push doorbell may be. Generous, because it is bounded by
+ * Pub/Sub's retry window and clock skew between two machines, not by anything
+ * precise — the point is to reject a captured notification replayed hours later,
+ * not to police seconds.
+ */
+const NOTIFY_MAX_SKEW_MS = 5 * 60 * 1000;
 
 // CORS headers — scoped to the dashboard origin, not wildcard
 let CORS: Record<string, string> = {
@@ -2159,6 +2174,68 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
           const msg = err instanceof Error ? err.message : String(err);
           return error(`Failed to generate auth URL: ${msg}`, 500);
         }
+      },
+    },
+
+
+    /**
+     * The push bridge's doorbell (GOOGLE.md "Push bridging"). HOSTED ONLY.
+     *
+     * PUBLIC route, deliberately, and it has to be: the caller is the control
+     * plane, which holds no enrolled-device token and must not. It lives under
+     * `/api/webhooks/` because that prefix is already the public, signature-
+     * verified machine-to-machine surface (see isPublicRoute) — inventing a new
+     * exception for one route would widen the unauthenticated surface for no
+     * reason. Two path segments so it cannot be confused with the workflow
+     * webhook ingress at `/api/webhooks/:flowId`.
+     *
+     * Authentication is the HMAC over the exact body, keyed by the per-instance
+     * notify_secret from the system config. Constant-time compared: this is a MAC
+     * check on attacker-supplied input, and a byte-by-byte early exit is what a
+     * forgery attempt measures.
+     *
+     * The body is a DOORBELL — `{source, at}`, no data — so the worst a forged
+     * one achieves is an early poll. That is why the answer is deliberately
+     * uninformative about which instance or address exists.
+     */
+    '/api/webhooks/google/notify': {
+      POST: async (req: Request) => {
+        const secret = ctx.config.google?.notify_secret;
+        // No secret configured = self-hosted, or a hosted instance whose config
+        // predates the bridge. Nothing can be verified, so nothing is accepted.
+        if (!secret) return error('not configured', 404);
+
+        const raw = await req.text();
+        const provided = req.headers.get('x-jarvis-signature') ?? '';
+        const expected = createHmac('sha256', secret).update(raw).digest('hex');
+        if (
+          provided.length !== expected.length ||
+          !timingSafeEqual(Buffer.from(provided), Buffer.from(expected))
+        ) {
+          return error('bad signature', 401);
+        }
+
+        let source: 'gmail' | 'calendar' | null = null;
+        let at = 0;
+        try {
+          const body = JSON.parse(raw) as { source?: unknown; at?: unknown };
+          if (body.source === 'gmail' || body.source === 'calendar') source = body.source;
+          if (typeof body.at === 'string') at = Date.parse(body.at);
+        } catch {
+          return error('bad body', 400);
+        }
+        if (!source) return error('bad body', 400);
+        // The timestamp is INSIDE the signed bytes, so a replayed doorbell can be
+        // rejected without keeping a nonce store: an old one is either a retry
+        // long past being useful or a capture being replayed, and the poll timer
+        // covers anything genuinely missed.
+        if (!Number.isFinite(at) || Math.abs(Date.now() - at) > NOTIFY_MAX_SKEW_MS) {
+          return error('stale', 400);
+        }
+
+        if (!ctx.observerService) return json({ ok: true, synced: [] });
+        const synced = await ctx.observerService.syncNow(source);
+        return json({ ok: true, synced });
       },
     },
 

--- a/src/daemon/api-routes.ts
+++ b/src/daemon/api-routes.ts
@@ -2099,9 +2099,17 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
       GET: async () => {
         const googleConfig = ctx.config.google;
         const hasCredentials = !!(googleConfig?.client_id && googleConfig?.client_secret);
+        // Control-plane managed (GOOGLE.md): the settings UI must show the
+        // hosted Connect button instead of the credentials form, because the
+        // account is connected THROUGH the control plane and this daemon's own
+        // OAuth flow cannot work here.
+        const managed = !!googleConfig?.connect_url;
+        const managedFields = managed
+          ? { managed: true as const, connect_url: googleConfig!.connect_url }
+          : { managed: false as const };
 
         if (!hasCredentials) {
-          return json({ status: 'not_configured', has_credentials: false, is_authenticated: false, scopes: [], token_expiry: null });
+          return json({ status: 'not_configured', has_credentials: false, is_authenticated: false, scopes: [], token_expiry: null, ...managedFields });
         }
 
         try {
@@ -2111,11 +2119,15 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
           const tokens = auth.loadTokens();
 
           return json({
-            status: authenticated ? 'connected' : 'credentials_saved',
+            // Managed and not yet authenticated is "waiting for the control
+            // plane to deliver", not "save your credentials" — there are none to
+            // save here.
+            status: authenticated ? 'connected' : managed ? 'not_connected' : 'credentials_saved',
             has_credentials: true,
             is_authenticated: authenticated,
             scopes: ['gmail.readonly', 'calendar.readonly'],
             token_expiry: tokens?.expiry_date ?? null,
+            ...managedFields,
           });
         } catch {
           return json({ status: 'credentials_saved', has_credentials: true, is_authenticated: false, scopes: [], token_expiry: null });
@@ -2151,6 +2163,18 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
     '/api/auth/google/init': {
       POST: async () => {
         const googleConfig = ctx.config.google;
+        // MANAGED instances must not run this flow (GOOGLE.md). Its redirect URI
+        // is this instance's own hostname, which is not registered with Google —
+        // there is exactly ONE registered URI, on the control plane, precisely so
+        // that moving to another host does not break it. Starting the flow here
+        // therefore ends at a redirect_uri_mismatch error page, so it is refused
+        // at the API rather than only hidden in the UI.
+        if (googleConfig?.connect_url) {
+          return error(
+            `This instance is managed by usejarvis — connect Google from ${googleConfig.connect_url}`,
+            409,
+          );
+        }
         if (!googleConfig?.client_id || !googleConfig?.client_secret) {
           return error('Google credentials not configured. Save client_id and client_secret first.', 400);
         }

--- a/src/daemon/api-routes.ts
+++ b/src/daemon/api-routes.ts
@@ -134,6 +134,15 @@ export type ApiContext = {
   healthMonitor: HealthMonitor;
   agentService: AgentService;
   config: JarvisConfig;
+  /**
+   * Where the Google tokens live. Only set by tests.
+   *
+   * GoogleAuth otherwise resolves this through os.homedir(), which Bun fixes at
+   * process start and no test can redirect — so without this seam the Google
+   * status endpoint reads whatever tokens the machine running the tests happens
+   * to have, and its reconnect/authenticated branches cannot be exercised at all.
+   */
+  googleTokensPath?: string;
   wsService?: WebSocketService;
   channelService?: ChannelService;
   authorityEngine?: AuthorityEngine;
@@ -2098,36 +2107,54 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
     '/api/auth/google/status': {
       GET: async () => {
         const googleConfig = ctx.config.google;
-        const { classifyGoogle, makeGoogleAuth, googleReconnectRequired } =
-          await import('../integrations/google-managed-refresh.ts');
+        const { classifyGoogle, makeGoogleAuth } = await import(
+          '../integrations/google-managed-refresh.ts'
+        );
+        const shape = classifyGoogle(ctx.config);
         // A MANAGED instance has no client credentials by design — the control
         // plane holds them and refreshes on its behalf — so "configured" cannot
         // mean "has credentials" any more, or hosted would always read as
-        // not_configured. Asked of the same classifier the auth builder uses, so
-        // this cannot claim a config is usable that makeGoogleAuth then refuses.
-        const hasCredentials = classifyGoogle(ctx.config).mode !== 'none';
-        // Control-plane managed (GOOGLE.md): the settings UI must show the
-        // hosted Connect button instead of the credentials form, because the
-        // account is connected THROUGH the control plane and this daemon's own
-        // OAuth flow cannot work here.
-        const managed = !!googleConfig?.connect_url;
+        // not_configured.
+        const configured = shape.mode !== 'none';
+        // Control-plane managed (GOOGLE.md): the settings UI must show the hosted
+        // Connect button instead of the credentials form, because the account is
+        // connected THROUGH the control plane and this daemon's own OAuth flow
+        // cannot work here.
+        //
+        // From the CLASSIFIER, not from connect_url. Keyed on connect_url alone
+        // this disagreed with `configured` whenever a config had refresh_url and
+        // no connect_url: the instance was managed, refresh and the doorbell
+        // worked, and the tab still rendered the credentials form — whose save
+        // then 409s from the managed guard and whose OAuth button 400s. The
+        // control plane now refuses to boot without the link, and this reads the
+        // same source of truth the auth builder does.
+        const managed = shape.mode === 'managed';
         const managedFields = managed
-          ? { managed: true as const, connect_url: googleConfig!.connect_url }
+          ? { managed: true as const, connect_url: googleConfig?.connect_url ?? null }
           : { managed: false as const };
 
-        if (!hasCredentials) {
-          return json({ status: 'not_configured', has_credentials: false, is_authenticated: false, scopes: [], token_expiry: null, ...managedFields });
+        if (!configured) {
+          return json({
+            status: 'not_configured',
+            configured: false,
+            is_authenticated: false,
+            scopes: [],
+            token_expiry: null,
+            // A config we REFUSED says why; "no Google here" says nothing.
+            ...(shape.reason ? { reason: shape.reason } : {}),
+            ...managedFields,
+          });
         }
 
         try {
-          const auth = makeGoogleAuth(ctx.config);
+          const auth = makeGoogleAuth(ctx.config, undefined, ctx.googleTokensPath);
           const tokens = auth?.loadTokens() ?? null;
           // A revoked or expired grant leaves the tokens file exactly where it
-          // was, so "we have tokens" is not "Google works". When the control
-          // plane has told us the grant is gone, report NOT authenticated —
-          // that is what puts the Connect button back in front of the user
-          // instead of a green "connected" chip over a dead integration.
-          const reconnect = googleReconnectRequired(auth);
+          // was, so "we have tokens" is not "Google works". When the grant is
+          // known to be gone, report NOT authenticated — that is what puts the
+          // Connect button back in front of the user instead of a green
+          // "connected" chip over a dead integration.
+          const reconnect = auth?.reconnectRequired() ?? null;
           const authenticated = !reconnect && (auth?.isAuthenticated() ?? false);
 
           return json({
@@ -2141,7 +2168,7 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
                 : managed
                   ? 'not_connected'
                   : 'credentials_saved',
-            has_credentials: true,
+            configured: true,
             is_authenticated: authenticated,
             ...(reconnect ? { reconnect_reason: reconnect } : {}),
             scopes: ['gmail.readonly', 'calendar.readonly'],
@@ -2149,7 +2176,17 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
             ...managedFields,
           });
         } catch {
-          return json({ status: 'credentials_saved', has_credentials: true, is_authenticated: false, scopes: [], token_expiry: null });
+          // managedFields is carried here too: dropping it answered
+          // `credentials_saved` with no `managed`, i.e. the self-hosted
+          // credentials form on a hosted box — the same wrong UI as above.
+          return json({
+            status: managed ? 'not_connected' : 'credentials_saved',
+            configured: true,
+            is_authenticated: false,
+            scopes: [],
+            token_expiry: null,
+            ...managedFields,
+          });
         }
       },
     },
@@ -2163,7 +2200,8 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
           // tab or a curl dropped refresh_url, instance_id and notify_secret
           // from the running config and persisted a row that then won on every
           // reload: refresh dead, doorbell 404, managed UI gone. Silently.
-          if (ctx.config.google?.connect_url || ctx.config.google?.refresh_url) {
+          const { classifyGoogle } = await import('../integrations/google-managed-refresh.ts');
+          if (classifyGoogle(ctx.config).mode === 'managed' || ctx.config.google?.refresh_url) {
             return error(
               'This instance is managed by usejarvis — its Google credentials are held by the control plane and cannot be set here.',
               409,
@@ -2260,12 +2298,14 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
         if (!secret) return error('not configured', 404);
 
         const raw = await req.text();
-        const provided = req.headers.get('x-jarvis-signature') ?? '';
-        const expected = createHmac('sha256', secret).update(raw).digest('hex');
-        if (
-          provided.length !== expected.length ||
-          !timingSafeEqual(Buffer.from(provided), Buffer.from(expected))
-        ) {
+        const { INSTANCE_SIGNATURE_HEADER, verifyWithSecret } = await import(
+          '../integrations/google-signature.ts'
+        );
+        // Byte-length compare, via the shared helper: the hand-rolled version
+        // here gated on String.length, so a 64-CHARACTER non-ASCII signature got
+        // past it and made timingSafeEqual throw — a 500 with a stack instead of
+        // a 401, from any unauthenticated caller, on a deliberately public route.
+        if (!verifyWithSecret(secret, raw, req.headers.get(INSTANCE_SIGNATURE_HEADER))) {
           return error('bad signature', 401);
         }
 

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -30,7 +30,7 @@ import { CommitmentExecutor } from "./commitment-executor.ts";
 import { classifyEvent } from "./event-classifier.ts";
 import { createApiRoutes, setCorsOrigin } from "./api-routes.ts";
 import { GoogleAuth } from "../integrations/google-auth.ts";
-import { googleIdentity, makeGoogleAuth } from "../integrations/google-managed-refresh.ts";
+import { classifyGoogle, googleIdentity, makeGoogleAuth } from "../integrations/google-managed-refresh.ts";
 import { ResearchQueue } from "./research-queue.ts";
 import { researchQueueTool, setResearchQueueRef } from "../actions/tools/research.ts";
 import { spawnPersistentAgent, assignPersistentAgentTask } from "../actions/tools/agents.ts";
@@ -524,6 +524,13 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
     // them — so this cannot key on their presence or hosted Google would never
     // start.
     googleAuth = makeGoogleAuth(jarvisConfig);
+    // A config we REFUSED (a mis-rendered managed block) is logged HERE, once,
+    // rather than by the classifier: that runs on every status poll too, and
+    // logging inside it printed the same line twice per poll forever.
+    const googleShape = classifyGoogle(jarvisConfig);
+    if (googleShape.mode === 'none' && googleShape.reason) {
+      console.error(`[Daemon] Google is disabled: ${googleShape.reason}`);
+    }
     if (googleAuth) {
       if (googleAuth.isAuthenticated()) {
         console.log('[Daemon] Google OAuth: authenticated (Gmail + Calendar observers enabled)');

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -539,6 +539,13 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
     const observerService = config.noLocalTools
       ? null
       : new ObserverService(reactor, coalescer, googleAuth ?? undefined, config.dataDir);
+    // Hosted push bridge targets (GOOGLE.md). All absent on self-hosted, where
+    // the observers' own poll timers are the whole story.
+    observerService?.setPushTargets({
+      pubsubTopic: jarvisConfig.google?.pubsub_topic,
+      pushCallback: jarvisConfig.google?.push_callback,
+      channelToken: jarvisConfig.google?.channel_token,
+    });
     // Hosted mode: daemon.listen = unix:/run/jarvis/u_<id>.sock binds a unix
     // socket and no TCP port at all (Caddy is the only way in). `listen` was
     // resolved (and validated) once, before the lockfile write above.
@@ -3674,6 +3681,15 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
       lastGoogleCreds = creds;
       if (observerService) {
         observerService.setGoogleAuth(googleAuth);
+        // Re-read alongside the auth: a migrate re-renders the config, and the
+        // notify secret and channel token are per-instance, so a moved instance
+        // must arm its watches with the NEW values rather than the ones it
+        // booted with.
+        observerService.setPushTargets({
+          pubsubTopic: cfg.google?.pubsub_topic,
+          pushCallback: cfg.google?.push_callback,
+          channelToken: cfg.google?.channel_token,
+        });
         await registry!.stopService('observers');
         await registry!.startService('observers');
       }
@@ -4015,6 +4031,10 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
       goalService: undefined,
       sidecarManager,
       settingsReload,
+      // Lets the hosted push bridge's doorbell poll on demand. `?? undefined`
+      // rather than a cast: when observers are not running there is genuinely
+      // nothing to sync, and the webhook says so.
+      observerService: observerService ?? undefined,
     };
     setCorsOrigin(externalOrigin.httpOrigin);
     wsService.getServer().setCorsOrigin(externalOrigin.httpOrigin);

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -3681,10 +3681,11 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
       lastGoogleCreds = creds;
       if (observerService) {
         observerService.setGoogleAuth(googleAuth);
-        // Re-read alongside the auth: a migrate re-renders the config, and the
-        // notify secret and channel token are per-instance, so a moved instance
-        // must arm its watches with the NEW values rather than the ones it
-        // booted with.
+        // Re-read alongside the auth so the watches are armed from the live
+        // config rather than whatever booted. (The notify secret and channel
+        // token are keyed by the INSTANCE id, which a migration preserves, so
+        // those two do not actually change on a move — the topic and callback
+        // can, if the deployment's config did.)
         observerService.setPushTargets({
           pubsubTopic: cfg.google?.pubsub_topic,
           pushCallback: cfg.google?.push_callback,

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -30,6 +30,7 @@ import { CommitmentExecutor } from "./commitment-executor.ts";
 import { classifyEvent } from "./event-classifier.ts";
 import { createApiRoutes, setCorsOrigin } from "./api-routes.ts";
 import { GoogleAuth } from "../integrations/google-auth.ts";
+import { googleIdentity, makeGoogleAuth } from "../integrations/google-managed-refresh.ts";
 import { ResearchQueue } from "./research-queue.ts";
 import { researchQueueTool, setResearchQueueRef } from "../actions/tools/research.ts";
 import { spawnPersistentAgent, assignPersistentAgentTask } from "../actions/tools/agents.ts";
@@ -519,8 +520,11 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
 
     // 4b. Create GoogleAuth if configured
     let googleAuth: GoogleAuth | null = null;
-    if (jarvisConfig.google?.client_id && jarvisConfig.google?.client_secret) {
-      googleAuth = new GoogleAuth(jarvisConfig.google.client_id, jarvisConfig.google.client_secret);
+    // Managed instances have NO client credentials — the control plane holds
+    // them — so this cannot key on their presence or hosted Google would never
+    // start.
+    googleAuth = makeGoogleAuth(jarvisConfig);
+    if (googleAuth) {
       if (googleAuth.isAuthenticated()) {
         console.log('[Daemon] Google OAuth: authenticated (Gmail + Calendar observers enabled)');
       } else {
@@ -3665,18 +3669,15 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
     // google — refresh the auth (disconnect unlinks the tokens file; the
     // null-first reload drops the stale in-memory tokens), hand it to the
     // observers and restart them so EmailSync/CalendarSync re-capture it.
-    let lastGoogleCreds = jarvisConfig.google?.client_id && jarvisConfig.google?.client_secret
-      ? `${jarvisConfig.google.client_id}\n${jarvisConfig.google.client_secret}`
-      : null;
+    let lastGoogleCreds = googleIdentity(jarvisConfig);
     settingsReload.registerApplier('google', async (cfg) => {
-      const g = cfg.google;
-      const creds = g?.client_id && g?.client_secret ? `${g.client_id}\n${g.client_secret}` : null;
+      const creds = googleIdentity(cfg);
       if (!creds) {
         googleAuth = null;
       } else if (googleAuth && creds === lastGoogleCreds) {
         googleAuth.reloadTokensFromDisk();
       } else {
-        googleAuth = new GoogleAuth(g!.client_id!, g!.client_secret!);
+        googleAuth = makeGoogleAuth(cfg);
       }
       lastGoogleCreds = creds;
       if (observerService) {

--- a/src/daemon/observer-service.ts
+++ b/src/daemon/observer-service.ts
@@ -19,6 +19,8 @@ import type { ObservationType } from '../vault/observations.ts';
 import type { EventReactor } from './event-reactor.ts';
 import type { EventCoalescer } from './event-coalescer.ts';
 import type { GoogleAuth } from '../integrations/google-auth.ts';
+import { GoogleWatchManager } from '../integrations/google-watch-manager.ts';
+import type { WatchTargets } from '../integrations/google-watch.ts';
 
 import { homedir } from 'node:os';
 import { ObserverManager } from '../observers/index.ts';
@@ -64,6 +66,8 @@ export class ObserverService implements Service {
   name = 'observers';
   private _status: ServiceStatus = 'stopped';
   private manager: ObserverManager;
+  private watches: GoogleWatchManager;
+  private pushTargets: WatchTargets = {};
   private reactor: EventReactor | null;
   private coalescer: EventCoalescer | null;
   private googleAuth: GoogleAuth | null;
@@ -83,6 +87,7 @@ export class ObserverService implements Service {
     dataDir?: string,
   ) {
     this.manager = new ObserverManager();
+    this.watches = new GoogleWatchManager();
     this.reactor = reactor ?? null;
     this.coalescer = coalescer ?? null;
     this.googleAuth = googleAuth ?? null;
@@ -105,6 +110,14 @@ export class ObserverService implements Service {
    */
   setGoogleAuth(auth: GoogleAuth | null): void {
     this.googleAuth = auth;
+  }
+
+  /**
+   * Hosted push targets from the system config (GOOGLE.md). Absent = no bridge,
+   * and the observers' own poll timers cover everything — the designed fallback.
+   */
+  setPushTargets(targets: WatchTargets): void {
+    this.pushTargets = targets;
   }
 
   async start(): Promise<void> {
@@ -170,6 +183,17 @@ export class ObserverService implements Service {
       // Start all observers (individual failures don't crash the service)
       await this.manager.startAll();
 
+      // Arm the push watches, if this deployment has a bridge. Deliberately
+      // AFTER the observers are up: a notification that arrives the instant a
+      // watch is registered should find something able to answer it.
+      this.watches.configure(this.googleAuth, this.pushTargets);
+      if (this.watches.enabled) {
+        // Not awaited: registering two watches is two round trips to Google, and
+        // nothing about starting observation should wait on a latency
+        // optimisation. Failures are logged inside.
+        void this.watches.start();
+      }
+
       this._status = 'running';
       console.log('[ObserverService] Started');
     } catch (error) {
@@ -178,8 +202,33 @@ export class ObserverService implements Service {
     }
   }
 
+  /**
+   * Make the named integration poll now — the push bridge's doorbell
+   * (GOOGLE.md). Returns which observers actually ran, so the webhook can answer
+   * honestly rather than claiming a sync that never happened.
+   *
+   * Errors are swallowed per observer: a notification is best-effort by design
+   * (the poll timer is the fallback), and one failing integration must not make
+   * the webhook look broken for the other.
+   */
+  async syncNow(source: 'gmail' | 'calendar'): Promise<string[]> {
+    const name = source === 'gmail' ? 'email' : 'calendar';
+    const observer = this.manager.get(name);
+    if (!observer?.syncNow) return [];
+    try {
+      await observer.syncNow();
+      return [name];
+    } catch (err) {
+      console.error(`[ObserverService] syncNow(${name}) failed:`, err);
+      return [];
+    }
+  }
+
   async stop(): Promise<void> {
     this._status = 'stopping';
+    // Before the observers: once they are down there is nothing to answer a
+    // notification, so Google should stop being told to send them.
+    await this.watches.stop();
     await this.manager.stopAll();
     this._status = 'stopped';
     console.log('[ObserverService] Stopped');

--- a/src/daemon/settings-reload.test.ts
+++ b/src/daemon/settings-reload.test.ts
@@ -1,5 +1,5 @@
 import { test, expect, describe, beforeEach, afterEach } from 'bun:test';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, statSync, utimesSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { initDatabase, closeDb } from '../vault/schema.ts';
@@ -178,6 +178,63 @@ describe('settings-reload', () => {
     const second = await coordinator.reloadAll();
     expect(second.changed).toEqual([]);
     expect(second.applied).toEqual([]);
+  });
+
+  test('reloadAll notices the Google TOKENS FILE, not just the config section', async () => {
+    // In hosted mode the tokens file is written and deleted by the control plane
+    // from OUTSIDE this process (the deliver/revoke ops), while the client creds
+    // in config never change. A section-only diff therefore saw nothing and left
+    // a freshly delivered connection inert until the next restart — and left the
+    // observers running after a revoke. Same wart self-hosted: delete the file
+    // by hand, SIGHUP, and the observers carried on.
+    const home = mkdtempSync(join(tmpdir(), 'jarvis-google-home-'));
+    const tokens = join(home, '.jarvis', 'google-tokens.json');
+    mkdirSync(join(home, '.jarvis'), { recursive: true });
+    try {
+      const config = freshConfig();
+      config.google = { client_id: 'id', client_secret: 'secret' };
+      // Injected rather than redirected via $HOME: Bun fixes os.homedir() at
+      // process start and does not re-read the env, so there is no other way.
+      const coordinator = new SettingsReloadCoordinator(config, { googleTokensPath: tokens });
+      const applied: string[] = [];
+      coordinator.registerApplier('google', () => {
+        applied.push('google');
+      });
+
+      // Nothing delivered yet.
+      expect((await coordinator.reloadAll()).changed).not.toContain('google');
+      expect(applied).toEqual([]);
+
+      // Delivery: the applier must run, because it is what constructs GoogleAuth
+      // and (re)starts the observers.
+      writeFileSync(tokens, JSON.stringify({ access_token: 'a', refresh_token: 'r' }));
+      expect((await coordinator.reloadAll()).changed).toContain('google');
+      expect(applied).toEqual(['google']);
+
+      // A re-delivery whose token differs but whose LENGTH and MTIME are
+      // identical. This is why the fingerprint hashes content: size+mtime would
+      // compare equal here and skip the reload, leaving the observers on the
+      // stale token. Forced with utimesSync rather than hoped for — two plain
+      // writes land on different mtimes, so without this the test passes either
+      // way and proves nothing (it did, until a mutation showed it).
+      const before = statSync(tokens);
+      writeFileSync(tokens, JSON.stringify({ access_token: 'b', refresh_token: 'r' }));
+      expect(statSync(tokens).size).toBe(before.size);
+      utimesSync(tokens, before.atime, before.mtime);
+      expect((await coordinator.reloadAll()).changed).toContain('google');
+      expect(applied).toEqual(['google', 'google']);
+
+      // Stable when nothing moved (appliers restart observers — no churn).
+      expect((await coordinator.reloadAll()).changed).not.toContain('google');
+
+      // Revoke removes the file: the observers must STOP, which needs the same
+      // detection in reverse.
+      rmSync(tokens);
+      expect((await coordinator.reloadAll()).changed).toContain('google');
+      expect(applied).toHaveLength(3);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
   });
 
   test('reloadAll cancels a pending scheduled apply for a changed section', async () => {

--- a/src/daemon/settings-reload.test.ts
+++ b/src/daemon/settings-reload.test.ts
@@ -232,6 +232,16 @@ describe('settings-reload', () => {
       rmSync(tokens);
       expect((await coordinator.reloadAll()).changed).toContain('google');
       expect(applied).toHaveLength(3);
+
+      // An apply the daemon did ITSELF (the in-daemon disconnect route deletes
+      // the file and calls applyNow) must re-baseline too, or the next SIGHUP
+      // would see a change that has already been applied and restart the
+      // observers for nothing.
+      writeFileSync(tokens, JSON.stringify({ access_token: 'c', refresh_token: 'r' }));
+      await coordinator.applyNow('google');
+      expect(applied).toHaveLength(4);
+      expect((await coordinator.reloadAll()).changed).not.toContain('google');
+      expect(applied).toHaveLength(4);
     } finally {
       rmSync(home, { recursive: true, force: true });
     }

--- a/src/daemon/settings-reload.ts
+++ b/src/daemon/settings-reload.ts
@@ -32,14 +32,20 @@
  * workflows, ...) keep today's behavior: new values are visible to live
  * config readers, construction-time snapshots stay until restart.
  *
- * Known limitation: reloadAll() detects changes to CONFIG SECTIONS only.
- * State living outside the settings table — e.g. the Google tokens file —
- * doesn't show up in the diff, so deleting google-tokens.json externally
- * and sending SIGHUP won't deactivate observers (the in-daemon disconnect
- * route handles that case via applyNow('google')).
+ * reloadAll() otherwise detects changes to CONFIG SECTIONS only, so state
+ * living outside the settings table does not show up in the diff. The one
+ * exception is the Google TOKENS FILE, which is folded into the `google`
+ * snapshot (see googleTokensFingerprint): it is written and deleted from
+ * outside this process — by hand when self-hosted, by the control plane's
+ * deliver/revoke ops when hosted — and without that, SIGHUP would compare
+ * identical client creds and leave the observers running on a token that is
+ * gone, or inert while a fresh one sits on disk.
  */
 
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
 import { applyEnvOverrides } from '../config/loader.ts';
+import { googleTokensPath } from '../integrations/google-auth.ts';
 import { USER_OWNED_SECTIONS, type JarvisConfig, type UserOwnedSection } from '../config/types.ts';
 import { mergeLLMSettingsIntoConfig } from './llm-settings.ts';
 import { mergeUserSettingsIntoConfig } from './user-settings.ts';
@@ -68,6 +74,30 @@ export interface SettingsAppliedPayload {
 
 const RELOAD_SECTIONS: readonly ReloadSection[] = [...USER_OWNED_SECTIONS, 'llm', 'google'];
 
+/**
+ * Content hash of the Google tokens file, or 'absent'.
+ *
+ * A CONTENT hash rather than size+mtime on purpose: a re-delivery replaces one
+ * access token with another of the same length, and two writes inside the same
+ * millisecond are entirely possible on the hosted path (deliver then revoke, or
+ * a retried delivery). Size+mtime would compare equal and the reload would be
+ * skipped — a missed change here means the observers never pick the new token
+ * up, which is the exact failure this fingerprint exists to prevent. Hashing a
+ * ~500-byte file on a reload is not worth optimising.
+ *
+ * Only the hash is kept, never the contents: snapshots are held in memory and
+ * compared, and a token must not sit in a diff string.
+ */
+function googleTokensFingerprint(file: string): string {
+  try {
+    return createHash('sha256').update(readFileSync(file)).digest('hex').slice(0, 32);
+  } catch {
+    // Unreadable and absent are the same thing for the observers: no usable
+    // credential. Distinguishing them would only add a state nothing acts on.
+    return 'absent';
+  }
+}
+
 interface RegisteredApplier {
   fn: SectionApplier;
   debounceMs: number;
@@ -84,9 +114,22 @@ export class SettingsReloadCoordinator {
   /** Single-flight chain: no two appliers ever run concurrently. */
   private queue: Promise<unknown> = Promise.resolve();
   private broadcast: ((payload: SettingsAppliedPayload) => void) | null = null;
+  private readonly googleTokensFile: string;
+  /** Fingerprint of the tokens file as of the last look; see googleTokensChanged. */
+  private lastGoogleTokens: string;
 
-  constructor(config: JarvisConfig) {
+  /**
+   * `googleTokensPath` is injectable for the same reason GoogleAuth's is: the
+   * default resolves through os.homedir(), which Bun fixes at process start and
+   * does NOT re-read from $HOME, so a test cannot redirect it any other way.
+   */
+  constructor(config: JarvisConfig, opts?: { googleTokensPath?: string }) {
     this.config = config;
+    this.googleTokensFile = opts?.googleTokensPath ?? googleTokensPath();
+    // Baseline at construction, which is boot: whatever is on disk now is what
+    // the daemon's own GoogleAuth was just built from, so the first reload must
+    // not report a change and pointlessly restart the observers.
+    this.lastGoogleTokens = googleTokensFingerprint(this.googleTokensFile);
   }
 
   /**
@@ -156,6 +199,9 @@ export class SettingsReloadCoordinator {
       applyEnvOverrides(this.config);
 
       const changed = RELOAD_SECTIONS.filter((s) => this.snapshot(s) !== before.get(s));
+      // The hosted deliver/revoke ops write the tokens file and SIGHUP us; the
+      // creds in config are untouched, so the section diff above sees nothing.
+      if (this.googleTokensChanged() && !changed.includes('google')) changed.push('google');
       const applied: ReloadSection[] = [];
       const errors: ApplyError[] = [];
       for (const section of changed) {
@@ -186,6 +232,25 @@ export class SettingsReloadCoordinator {
 
   private snapshot(section: ReloadSection): string {
     return JSON.stringify((this.config as Record<string, unknown>)[section] ?? null);
+  }
+
+  /**
+   * Has the Google tokens FILE changed since we last looked?
+   *
+   * Deliberately not folded into snapshot(): reloadAll's per-section diff
+   * compares before/after WITHIN one call, so it answers "did re-hydration
+   * change this?" — and the tokens file changes BETWEEN calls, which such a
+   * diff can never see. This keeps the last-seen fingerprint on the instance
+   * instead, which is the only way to notice an external write.
+   *
+   * Stateful on purpose, and it updates on read: a change must be reported
+   * exactly once, or every subsequent reload would restart the observers.
+   */
+  private googleTokensChanged(): boolean {
+    const fp = googleTokensFingerprint(this.googleTokensFile);
+    if (fp === this.lastGoogleTokens) return false;
+    this.lastGoogleTokens = fp;
+    return true;
   }
 
   /** Drop a scheduled apply (reloadAll runs the section's appliers itself). */

--- a/src/daemon/settings-reload.ts
+++ b/src/daemon/settings-reload.ts
@@ -266,6 +266,12 @@ export class SettingsReloadCoordinator {
 
     return this.enqueue(async () => {
       const errors = await this.runAppliers(section);
+      // Re-baseline the tokens fingerprint whenever the google appliers run,
+      // whatever triggered them. The in-daemon disconnect route deletes the file
+      // and calls applyNow('google') itself; without this the fingerprint would
+      // still hold the deleted token's hash, and the next SIGHUP would report a
+      // change and restart the observers for a disconnect already applied.
+      if (section === 'google') this.lastGoogleTokens = googleTokensFingerprint(this.googleTokensFile);
       this.emitBroadcast({ sections: [section], ok: errors.length === 0, errors });
       return errors[0] ?? null;
     });

--- a/src/daemon/user-settings.ts
+++ b/src/daemon/user-settings.ts
@@ -330,13 +330,22 @@ export function saveGoogleSettings(value: JarvisConfig['google']): void {
 function googleIsFileProvided(google: JarvisConfig['google']): boolean {
   // NOT `client_id` alone: a managed instance has no client credentials at all
   // — that is the entire point of hosted mode — so keying on them let the stored
-  // row replace refresh_url, instance_id and notify_secret, breaking refresh and
-  // the push doorbell and turning the managed UI back into the credentials form.
+  // row replace refresh_url, instance_id and the two derived keys, breaking
+  // refresh and the push doorbell and turning the managed UI back into the
+  // credentials form.
+  //
+  // Every key the SERVER writes counts, including the push-only ones: the
+  // renderer emits them together, so any of them present means this section came
+  // from the file, and a stored row must not win over it.
   return !!(
     google?.client_id ||
     google?.refresh_url ||
+    google?.refresh_secret ||
     google?.notify_secret ||
-    google?.connect_url
+    google?.connect_url ||
+    google?.pubsub_topic ||
+    google?.push_callback ||
+    google?.channel_token
   );
 }
 

--- a/src/daemon/user-settings.ts
+++ b/src/daemon/user-settings.ts
@@ -312,9 +312,11 @@ function migratePlaintextSectionSecrets(): void {
 
 // ── google: system-owned when the FILE provides it ─────────────────────────
 //
-// `google` is the one section with dual ownership. In hosted mode the system
-// config carries the shared company OAuth client (server-written), so the
-// file must win. Self-hosters without a file entry configure their own
+// `google` is the one section with dual ownership. When the system config
+// provides it, the file must win: on a hosted instance that section carries the
+// control-plane wiring (refresh_url, instance_id, notify_secret, connect_url)
+// and letting a stored row replace it would silently revert the instance to
+// self-hosted behaviour. Self-hosters without a file entry configure their own
 // client from the dashboard, which persists here in the DB as a fallback.
 
 const GOOGLE_KEY = `${CFG_PREFIX}google`;
@@ -324,8 +326,22 @@ export function saveGoogleSettings(value: JarvisConfig['google']): void {
   notifySectionSaved('google');
 }
 
+/** Did the FILE provide a google section? Any server-written key counts. */
+function googleIsFileProvided(google: JarvisConfig['google']): boolean {
+  // NOT `client_id` alone: a managed instance has no client credentials at all
+  // — that is the entire point of hosted mode — so keying on them let the stored
+  // row replace refresh_url, instance_id and notify_secret, breaking refresh and
+  // the push doorbell and turning the managed UI back into the credentials form.
+  return !!(
+    google?.client_id ||
+    google?.refresh_url ||
+    google?.notify_secret ||
+    google?.connect_url
+  );
+}
+
 function mergeGoogleSettingsIntoConfig(config: JarvisConfig): void {
-  if (config.google?.client_id) return; // file-provided: system-owned, file wins
+  if (googleIsFileProvided(config.google)) return; // system-owned, file wins
   const raw = getSetting(GOOGLE_KEY);
   if (raw === null) return;
   try {

--- a/src/integrations/google-auth.test.ts
+++ b/src/integrations/google-auth.test.ts
@@ -163,6 +163,74 @@ describe('GoogleAuth managed refresh', () => {
     }
   });
 
+  test('a disconnect mid-flight does NOT re-create the tokens file', async () => {
+    // THE case: a refresh is in the air (managed refreshes are bounded at 20s)
+    // when the user hits Disconnect. revoke-google unlinks the tokens file and
+    // the reload applier calls reloadTokensFromDisk(), nulling the cache. The
+    // flight then resolved and wrote the file BACK — containing a live access
+    // token for the account that was just revoked, and no refresh token at all,
+    // because `{...null}` spreads nothing. It also bumped the settings-reload
+    // fingerprint into a spurious observer restart.
+    let release: () => void = () => {};
+    const gate = new Promise<void>((r) => { release = r; });
+    const { auth, dir, tokensPath } = await staleAuth(async () => {
+      await gate;
+      return { access_token: 'fresh-access', expires_in: 3600 };
+    });
+
+    try {
+      const inFlight = auth.getAccessToken();
+      await Bun.sleep(0);
+      // The disconnect.
+      await rm(tokensPath, { force: true });
+      expect(auth.reloadTokensFromDisk()).toBe(false);
+      release();
+
+      await expect(inFlight).rejects.toThrow(/in flight/);
+      expect(existsSync(tokensPath)).toBe(false);
+      expect(auth.getTokens()).toBeNull();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('a reconnect mid-flight does not clobber the new grant', async () => {
+    // The other direction: a new grant is delivered while an old-token refresh is
+    // in the air. Writing that result would keep the NEW refresh token but pair it
+    // with an access token minted from the OLD grant, and stamp an hour's expiry
+    // on it. Nothing refreshes on a 401 — the observers only log — so if the old
+    // grant is then revoked, every poll fails for that whole hour.
+    let release: () => void = () => {};
+    const gate = new Promise<void>((r) => { release = r; });
+    const { auth, dir, tokensPath } = await staleAuth(async () => {
+      await gate;
+      return { access_token: 'from-the-OLD-grant', expires_in: 3600 };
+    });
+
+    try {
+      const inFlight = auth.getAccessToken();
+      await Bun.sleep(0);
+      await Bun.write(
+        tokensPath,
+        JSON.stringify({
+          access_token: 'delivered-access',
+          refresh_token: 'refresh-2-delivered',
+          expiry_date: Date.now() + 3_600_000,
+          token_type: 'Bearer',
+        }),
+      );
+      expect(auth.reloadTokensFromDisk()).toBe(true);
+      release();
+
+      await expect(inFlight).rejects.toThrow(/in flight/);
+      const after = JSON.parse(await Bun.file(tokensPath).text()) as Record<string, string>;
+      expect(after.access_token).toBe('delivered-access');
+      expect(after.refresh_token).toBe('refresh-2-delivered');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   test('a rotated refresh token is persisted, not dropped', async () => {
     // Google does not normally rotate, but dropping one it DID return strands
     // the instance at its next refresh — and the control plane binds on the

--- a/src/integrations/google-auth.test.ts
+++ b/src/integrations/google-auth.test.ts
@@ -89,3 +89,96 @@ describe('GoogleAuth token storage', () => {
     }
   });
 });
+
+describe('GoogleAuth managed refresh', () => {
+  const realFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  /** An auth whose token on disk is already past the 5-minute expiry buffer. */
+  async function staleAuth(refreshVia: (t: string) => Promise<any>) {
+    const dir = await mkdtemp(join(tmpdir(), 'jarvis-google-auth-managed-'));
+    const tokensPath = join(dir, 'google-tokens.json');
+    const auth = new GoogleAuth('', '', { tokensPath, refreshVia });
+    await auth.saveTokens({
+      access_token: 'stale-access',
+      refresh_token: 'refresh-1',
+      expiry_date: Date.now() - 60_000,
+      token_type: 'Bearer',
+    });
+    return { auth, dir, tokensPath };
+  }
+
+  test('concurrent callers share ONE refresh', async () => {
+    // Six independent callers cross the expiry buffer together at boot (both
+    // observers, both watch registrations, the suggestion engine, the workflow
+    // credential source). Six refreshes used to go out; the control plane's
+    // minimum-interval limiter now 429s five of them, and a watch that fails
+    // to arm reports as a broken sync.
+    globalThis.fetch = (() => {
+      throw new Error('a managed refresh must not call Google directly');
+    }) as unknown as typeof fetch;
+
+    let calls = 0;
+    let release: () => void = () => {};
+    const gate = new Promise<void>((r) => { release = r; });
+    const { auth, dir } = await staleAuth(async () => {
+      calls += 1;
+      await gate;
+      return { access_token: 'fresh-access', expires_in: 3600 };
+    });
+
+    try {
+      const all = Promise.all(Array.from({ length: 6 }, () => auth.getAccessToken()));
+      await Bun.sleep(0);
+      release();
+      expect(await all).toEqual(Array(6).fill('fresh-access'));
+      expect(calls).toBe(1);
+
+      // And the flight is released afterwards: a later expiry refreshes again
+      // rather than serving the first result forever.
+      await auth.saveTokens({ ...auth.getTokens()!, expiry_date: Date.now() - 60_000 });
+      await auth.getAccessToken();
+      expect(calls).toBe(2);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('a failed refresh does not wedge the single-flight slot', async () => {
+    let calls = 0;
+    const { auth, dir } = await staleAuth(async () => {
+      calls += 1;
+      if (calls === 1) throw new Error('control plane unreachable');
+      return { access_token: 'fresh-access', expires_in: 3600 };
+    });
+
+    try {
+      await expect(auth.getAccessToken()).rejects.toThrow('control plane unreachable');
+      expect(await auth.getAccessToken()).toBe('fresh-access');
+      expect(calls).toBe(2);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('a rotated refresh token is persisted, not dropped', async () => {
+    // Google does not normally rotate, but dropping one it DID return strands
+    // the instance at its next refresh — and the control plane binds on the
+    // token's hash, so a stale token there is a hard reconnect.
+    const { auth, dir, tokensPath } = await staleAuth(async () => ({
+      access_token: 'fresh-access',
+      refresh_token: 'refresh-2',
+      expires_in: 3600,
+    }));
+
+    try {
+      await auth.getAccessToken();
+      expect(auth.getTokens()!.refresh_token).toBe('refresh-2');
+      expect(JSON.parse(await Bun.file(tokensPath).text()).refresh_token).toBe('refresh-2');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/integrations/google-auth.ts
+++ b/src/integrations/google-auth.ts
@@ -214,7 +214,26 @@ export class GoogleAuth {
   /**
    * Refresh the access token using the refresh token.
    */
-  private async refreshAccessToken(): Promise<void> {
+  /** In-flight refresh, so concurrent callers share one round trip. */
+  private refreshing: Promise<void> | null = null;
+
+  private refreshAccessToken(): Promise<void> {
+    // SINGLE-FLIGHT. Six independent callers can ask for a token at once (both
+    // observers' initial polls, both watch registrations, the suggestion engine,
+    // the workflow credential source) and they all cross the 5-minute expiry
+    // buffer together — most visibly right after a restart or a restore, when
+    // the tokens on disk are already old. Without this they each refresh: for a
+    // self-hosted instance that was merely wasteful, but a managed one now meets
+    // the control plane's minimum-interval limiter and all but one get a 429
+    // they report as a failed sync.
+    if (this.refreshing) return this.refreshing;
+    this.refreshing = this.doRefresh().finally(() => {
+      this.refreshing = null;
+    });
+    return this.refreshing;
+  }
+
+  private async doRefresh(): Promise<void> {
     if (!this.tokens?.refresh_token) {
       throw new Error('No refresh token available');
     }

--- a/src/integrations/google-auth.ts
+++ b/src/integrations/google-auth.ts
@@ -8,7 +8,8 @@
 
 import path from 'node:path';
 import os from 'node:os';
-import { readFileSync, existsSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { readFileSync, existsSync, rmSync } from 'node:fs';
 import { secureParentDirectory, secureWriteFile } from '../util/fs-secure.ts';
 
 const TOKEN_ENDPOINT = 'https://oauth2.googleapis.com/token';
@@ -63,6 +64,25 @@ export class GoogleAuth {
    */
   private refreshVia: ((refreshToken: string) => Promise<ManagedRefresh>) | null;
 
+  /**
+   * Where a "this grant is gone" verdict is remembered, beside the tokens it is
+   * about.
+   *
+   * PERSISTED, because the alternative is a lie with a timer on it: a revoked
+   * grant leaves the tokens file exactly where it was, so after every restart the
+   * settings tab would show a green "connected" chip over an integration where
+   * every sync fails, until something happened to attempt a refresh — up to an
+   * hour, since refreshes only run on the expiry clock.
+   *
+   * Keyed by a hash of the refresh token it applies to — never the token — so it
+   * self-clears the moment a new one is delivered, with no cross-module reset for
+   * anyone to forget to call. Beside the tokens file rather than at a fixed path
+   * so that redirecting one in a test redirects both.
+   */
+  private get reconnectPath(): string {
+    return `${this.tokensPath}.reconnect`;
+  }
+
   constructor(
     clientId: string,
     clientSecret: string,
@@ -78,6 +98,22 @@ export class GoogleAuth {
     this.tokensPath = opts?.tokensPath ?? path.join(os.homedir(), '.jarvis', 'google-tokens.json');
     this.redirectUri = opts?.redirectUri ?? 'http://localhost:3142/api/auth/google/callback';
     this.loadTokens();
+  }
+
+  /**
+   * A HOSTED instance's auth: no client credentials at all, refreshing through
+   * the control plane.
+   *
+   * A named constructor because the empty strings are a lie the type system would
+   * otherwise carry around — the credential arguments are meaningless on this
+   * path, and confining them to one line here is what lets every reader of
+   * `clientId` treat "empty" as "there is no such thing here".
+   */
+  static managed(
+    refreshVia: (refreshToken: string) => Promise<ManagedRefresh>,
+    opts: { tokensPath?: string } = {},
+  ): GoogleAuth {
+    return new GoogleAuth('', '', { ...opts, refreshVia });
   }
 
   /**
@@ -233,34 +269,92 @@ export class GoogleAuth {
     return this.refreshing;
   }
 
+  /**
+   * The reason this instance must connect Google again, or null.
+   *
+   * Tokens on disk are NOT proof of a live grant, which is the whole point:
+   * reported by /api/auth/google/status so the settings tab offers Connect
+   * instead of a green chip over an integration that cannot work.
+   */
+  reconnectRequired(): string | null {
+    const token = this.tokens?.refresh_token;
+    if (!token) return null;
+    try {
+      const saved = JSON.parse(readFileSync(this.reconnectPath, 'utf-8')) as {
+        tokenHash?: unknown;
+        message?: unknown;
+      };
+      if (typeof saved.tokenHash !== 'string' || typeof saved.message !== 'string') return null;
+      // A DIFFERENT token means a reconnect already happened, and the verdict on
+      // the old grant says nothing about the new one.
+      return saved.tokenHash === sha256(token) ? saved.message : null;
+    } catch {
+      return null;
+    }
+  }
+
+  private async markReconnectRequired(refreshToken: string, message: string): Promise<void> {
+    try {
+      await secureParentDirectory(this.reconnectPath);
+      await secureWriteFile(
+        this.reconnectPath,
+        JSON.stringify({ tokenHash: sha256(refreshToken), message: clampReason(message) }),
+        0o600,
+        'GoogleAuth',
+      );
+    } catch (err) {
+      // Losing this only costs a stale "connected" chip until the next attempt;
+      // it must never turn a refresh failure into an unhandled one.
+      console.warn(
+        '[GoogleAuth] could not record the reconnect state:',
+        err instanceof Error ? err.message : err,
+      );
+    }
+  }
+
+  private clearReconnect(): void {
+    try {
+      rmSync(this.reconnectPath, { force: true });
+    } catch {
+      // Same reasoning as above.
+    }
+  }
+
   private async doRefresh(): Promise<void> {
     if (!this.tokens?.refresh_token) {
       throw new Error('No refresh token available');
     }
+    // The token this flight is FOR. Everything below awaits — a managed refresh
+    // for up to 20s — and the tokens on disk can change underneath it: a
+    // disconnect deletes the file and reloadTokensFromDisk() nulls this cache, a
+    // reconnect replaces it with a different grant. Without this binding the
+    // merge below reads `this.tokens` again after the await and would either
+    // RE-CREATE the file the user just revoked (with a live access token for the
+    // account they revoked, since `{...null}` spreads nothing and drops the
+    // refresh token silently) or overwrite a freshly delivered grant's access
+    // token with one minted from the old one — and nothing refreshes on a 401,
+    // so that costs up to an hour of failing polls.
+    const bound = this.tokens.refresh_token;
 
     let data: { access_token: string; expires_in?: number; refresh_token?: string };
 
-    if (this.refreshVia) {
-      // Managed: the control plane holds the secret and applies it for us.
-      data = await this.refreshVia(this.tokens.refresh_token);
-    } else {
-      const resp = await fetch(TOKEN_ENDPOINT, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-        body: new URLSearchParams({
-          refresh_token: this.tokens.refresh_token,
-          client_id: this.clientId,
-          client_secret: this.clientSecret,
-          grant_type: 'refresh_token',
-        }),
-      });
+    // ONE recorder for both paths: a gone grant is a gone grant whether the
+    // control plane told us or Google did, and the settings tab has to say so
+    // either way.
+    try {
+      data = await this.fetchRefreshed(bound);
+    } catch (err) {
+      if (err instanceof GoogleReconnectRequired) await this.markReconnectRequired(bound, err.message);
+      throw err;
+    }
 
-      if (!resp.ok) {
-        const err = await resp.text();
-        throw new Error(`Token refresh failed: ${err}`);
-      }
-
-      data = await resp.json() as any;
+    // The grant moved while we were waiting: this result belongs to a token that
+    // is no longer ours. Discard it rather than write it — see `bound` above.
+    if (this.tokens?.refresh_token !== bound) {
+      console.warn(
+        '[GoogleAuth] discarding a refresh whose token was replaced while it was in flight',
+      );
+      throw new Error('the refresh token changed while the refresh was in flight');
     }
 
     this.tokens = {
@@ -273,6 +367,65 @@ export class GoogleAuth {
     };
 
     await this.saveTokens(this.tokens);
+    // A refresh that worked says the grant is alive, whatever we thought before.
+    this.clearReconnect();
     console.log('[GoogleAuth] Token refreshed successfully');
   }
+
+  /** The exchange itself: through the control plane when managed, else Google. */
+  private async fetchRefreshed(
+    refreshToken: string,
+  ): Promise<{ access_token: string; expires_in?: number; refresh_token?: string }> {
+    if (this.refreshVia) {
+      // Managed: the control plane holds the secret and applies it for us.
+      return await this.refreshVia(refreshToken);
+    } else {
+      const resp = await fetch(TOKEN_ENDPOINT, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({
+          refresh_token: refreshToken,
+          client_id: this.clientId,
+          client_secret: this.clientSecret,
+          grant_type: 'refresh_token',
+        }),
+      });
+
+      if (!resp.ok) {
+        const err = await resp.text();
+        // `invalid_grant` is Google's answer for a revoked, expired, or
+        // password-change-invalidated token — permanent, and fixed only by the
+        // user connecting again. Classified here too, not just on the managed
+        // path, or a self-hosted instance shows a green "connected" chip over a
+        // dead grant forever.
+        if (err.includes('invalid_grant')) {
+          throw new GoogleReconnectRequired(
+            'Google access is no longer valid — connect Google again',
+          );
+        }
+        throw new Error(`Token refresh failed: ${clampReason(err)}`);
+      }
+
+      return (await resp.json()) as { access_token: string; expires_in?: number };
+    }
+  }
+}
+
+/** sha256 hex. Used to key the reconnect state without storing a token. */
+function sha256(value: string): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+/**
+ * Bound and de-control-character an untrusted reason before it is stored or
+ * shown.
+ *
+ * The managed path's message comes from whatever answers `refresh_url`, and it is
+ * rendered to the user as this daemon's own explanation — so an unbounded or
+ * newline-bearing string would be someone else's text in our voice, and in our
+ * logs. Not XSS (React escapes it), but not ours to pass through either.
+ */
+export function clampReason(message: string): string {
+  const flat = message.replace(/[\u0000-\u001f\u007f]+/g, ' ').trim();
+  return flat.length > 200 ? `${flat.slice(0, 197)}...` : flat;
 }

--- a/src/integrations/google-auth.ts
+++ b/src/integrations/google-auth.ts
@@ -14,6 +14,15 @@ import { secureParentDirectory, secureWriteFile } from '../util/fs-secure.ts';
 const TOKEN_ENDPOINT = 'https://oauth2.googleapis.com/token';
 const AUTH_ENDPOINT = 'https://accounts.google.com/o/oauth2/v2/auth';
 
+/**
+ * Where the tokens live. Exported so a caller that needs to notice this file
+ * changing (settings-reload's per-section diff) cannot drift from the path this
+ * class actually reads.
+ */
+export function googleTokensPath(): string {
+  return path.join(os.homedir(), '.jarvis', 'google-tokens.json');
+}
+
 export type GoogleTokens = {
   access_token: string;
   refresh_token: string;

--- a/src/integrations/google-auth.ts
+++ b/src/integrations/google-auth.ts
@@ -23,6 +23,21 @@ export function googleTokensPath(): string {
   return path.join(os.homedir(), '.jarvis', 'google-tokens.json');
 }
 
+export interface ManagedRefresh {
+  access_token: string;
+  expires_in?: number;
+  /** Passed through if the control plane ever reports a rotated token. */
+  refresh_token?: string;
+}
+
+/**
+ * A refresh that will not succeed by waiting: the grant is gone (revoked, or
+ * expired — Google revokes Gmail-scoped tokens on a password change and expires
+ * them after 7 days while an app is in Testing). The user must connect again,
+ * and callers must not treat it as a transient failure to retry forever.
+ */
+export class GoogleReconnectRequired extends Error {}
+
 export type GoogleTokens = {
   access_token: string;
   refresh_token: string;
@@ -37,13 +52,29 @@ export class GoogleAuth {
   private tokensPath: string;
   private redirectUri: string;
 
+  /**
+   * HOSTED: refresh through the control plane instead of calling Google here.
+   *
+   * Set when the system config carries `google.refresh_url`. The instance keeps
+   * its refresh token; the control plane holds the client secret and applies it.
+   * That is what lets a managed config carry no Google credentials at all — this
+   * daemon runs as the tenant's own user, so a secret it could use would be a
+   * secret the tenant could read.
+   */
+  private refreshVia: ((refreshToken: string) => Promise<ManagedRefresh>) | null;
+
   constructor(
     clientId: string,
     clientSecret: string,
-    opts?: { tokensPath?: string; redirectUri?: string }
+    opts?: {
+      tokensPath?: string;
+      redirectUri?: string;
+      refreshVia?: (refreshToken: string) => Promise<ManagedRefresh>;
+    }
   ) {
     this.clientId = clientId;
     this.clientSecret = clientSecret;
+    this.refreshVia = opts?.refreshVia ?? null;
     this.tokensPath = opts?.tokensPath ?? path.join(os.homedir(), '.jarvis', 'google-tokens.json');
     this.redirectUri = opts?.redirectUri ?? 'http://localhost:3142/api/auth/google/callback';
     this.loadTokens();
@@ -188,27 +219,37 @@ export class GoogleAuth {
       throw new Error('No refresh token available');
     }
 
-    const resp = await fetch(TOKEN_ENDPOINT, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-      body: new URLSearchParams({
-        refresh_token: this.tokens.refresh_token,
-        client_id: this.clientId,
-        client_secret: this.clientSecret,
-        grant_type: 'refresh_token',
-      }),
-    });
+    let data: { access_token: string; expires_in?: number; refresh_token?: string };
 
-    if (!resp.ok) {
-      const err = await resp.text();
-      throw new Error(`Token refresh failed: ${err}`);
+    if (this.refreshVia) {
+      // Managed: the control plane holds the secret and applies it for us.
+      data = await this.refreshVia(this.tokens.refresh_token);
+    } else {
+      const resp = await fetch(TOKEN_ENDPOINT, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({
+          refresh_token: this.tokens.refresh_token,
+          client_id: this.clientId,
+          client_secret: this.clientSecret,
+          grant_type: 'refresh_token',
+        }),
+      });
+
+      if (!resp.ok) {
+        const err = await resp.text();
+        throw new Error(`Token refresh failed: ${err}`);
+      }
+
+      data = await resp.json() as any;
     }
-
-    const data = await resp.json() as any;
 
     this.tokens = {
       ...this.tokens,
       access_token: data.access_token,
+      // Google does not normally rotate refresh tokens, but dropping one it DID
+      // return would strand this instance at its next refresh.
+      ...(data.refresh_token ? { refresh_token: data.refresh_token } : {}),
       expiry_date: Date.now() + (data.expires_in ?? 3600) * 1000,
     };
 

--- a/src/integrations/google-managed-refresh.test.ts
+++ b/src/integrations/google-managed-refresh.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, test } from 'bun:test';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createHmac } from 'node:crypto';
+import { GoogleAuth, GoogleReconnectRequired } from './google-auth.ts';
+import { googleIdentity, makeGoogleAuth, makeManagedRefresh } from './google-managed-refresh.ts';
+import type { JarvisConfig } from '../config/types.ts';
+
+/**
+ * Refreshing through the control plane (GOOGLE.md).
+ *
+ * The property being protected is that a HOSTED instance holds no Google client
+ * credentials — this daemon runs as the tenant's own user, so a secret it could
+ * use is a secret the tenant could read. Everything here checks that the managed
+ * path works without them, and that the self-hosted path is untouched.
+ */
+const MANAGED: JarvisConfig['google'] = {
+  client_id: '',
+  client_secret: '',
+  refresh_url: 'https://app.example.com/api/integrations/google/refresh',
+  instance_id: 'inst-1',
+  notify_secret: 'a'.repeat(64),
+};
+
+function tokensFile(tokens: Record<string, unknown>): string {
+  const dir = mkdtempSync(join(tmpdir(), 'jarvis-managed-'));
+  const p = join(dir, 'google-tokens.json');
+  writeFileSync(p, JSON.stringify(tokens));
+  return p;
+}
+
+describe('makeManagedRefresh', () => {
+  const cfg = {
+    refreshUrl: MANAGED!.refresh_url!,
+    instanceId: MANAGED!.instance_id!,
+    notifySecret: MANAGED!.notify_secret!,
+  };
+
+  test('signs the exact body it sends, and never sends a client secret', async () => {
+    let seen: { url: string; body: string; signature: string | null } | null = null;
+    const refresh = makeManagedRefresh(cfg, (async (url: string, init: RequestInit) => {
+      seen = {
+        url,
+        body: String(init.body),
+        signature: new Headers(init.headers).get('x-jarvis-signature'),
+      };
+      return new Response(JSON.stringify({ access_token: 'ya29.fresh', expires_in: 3599 }), {
+        status: 200,
+      });
+    }) as unknown as typeof fetch);
+
+    const out = await refresh('1//token');
+    expect(out.access_token).toBe('ya29.fresh');
+    // The signature must cover the bytes actually sent — re-serialising would
+    // change them and the control plane would reject every request.
+    const expected = createHmac('sha256', cfg.notifySecret).update(seen!.body).digest('hex');
+    expect(seen!.signature).toBe(expected);
+    const sent = JSON.parse(seen!.body) as { instanceId: string; refreshToken: string; at: string };
+    expect(sent).toMatchObject({ instanceId: 'inst-1', refreshToken: '1//token' });
+    // A timestamp inside the signed bytes is what bounds replay.
+    expect(Number.isFinite(Date.parse(sent.at))).toBe(true);
+    // THE property: no credential of ours crosses the wire.
+    expect(seen!.body).not.toContain('client_secret');
+  });
+
+  test('a gone grant is permanent; everything else is transient', async () => {
+    const reconnect = makeManagedRefresh(cfg, (async () =>
+      new Response(JSON.stringify({ error: 'expired', reconnect: true }), { status: 409 })) as unknown as typeof fetch);
+    await expect(reconnect('1//t')).rejects.toBeInstanceOf(GoogleReconnectRequired);
+
+    // 404 = the control plane has no connected record any more. Also only fixed
+    // by connecting again, so it must not read as a retryable blip.
+    const gone = makeManagedRefresh(cfg, (async () =>
+      new Response('{}', { status: 404 })) as unknown as typeof fetch);
+    await expect(gone('1//t')).rejects.toBeInstanceOf(GoogleReconnectRequired);
+
+    // A 500, or an unreachable control plane, is transient: the next poll
+    // retries, and telling the user to reconnect over a blip would be wrong.
+    const down = makeManagedRefresh(cfg, (async () =>
+      new Response('{}', { status: 500 })) as unknown as typeof fetch);
+    await expect(down('1//t')).rejects.not.toBeInstanceOf(GoogleReconnectRequired);
+    const unreachable = makeManagedRefresh(cfg, (async () => {
+      throw new Error('ECONNREFUSED');
+    }) as unknown as typeof fetch);
+    await expect(unreachable('1//t')).rejects.not.toBeInstanceOf(GoogleReconnectRequired);
+  });
+});
+
+describe('makeGoogleAuth', () => {
+  test('a managed config produces an auth with NO credentials that refreshes remotely', async () => {
+    const path = tokensFile({
+      access_token: 'old',
+      refresh_token: '1//r',
+      // Already expired, so the very next getAccessToken must refresh.
+      expiry_date: Date.now() - 1000,
+      token_type: 'Bearer',
+    });
+    let calledControlPlane = false;
+    const auth = new GoogleAuth('', '', {
+      tokensPath: path,
+      refreshVia: async () => {
+        calledControlPlane = true;
+        return { access_token: 'ya29.viaControlPlane', expires_in: 3599 };
+      },
+    });
+    expect(await auth.getAccessToken()).toBe('ya29.viaControlPlane');
+    expect(calledControlPlane).toBe(true);
+  });
+
+  test('MANAGED WINS over credentials that are also present', async () => {
+    // A config carrying both (a transitional render, or a mistake) must take the
+    // managed path: the whole point is that a hosted instance never uses the
+    // shared secret, and preferring credentials would silently keep the old
+    // behaviour alive on exactly the instances this protects.
+    const path = tokensFile({
+      access_token: 'old',
+      refresh_token: '1//r',
+      expiry_date: Date.now() - 1000,
+      token_type: 'Bearer',
+    });
+    const seen: string[] = [];
+    const auth = makeGoogleAuth(
+      { google: { ...MANAGED, client_id: 'cid', client_secret: 'leaked-secret' } },
+      (async (url: string) => {
+        seen.push(String(url));
+        return new Response(JSON.stringify({ access_token: 'ya29.managed', expires_in: 3599 }), {
+          status: 200,
+        });
+      }) as unknown as typeof fetch,
+    )!;
+    // Force a refresh through whichever path was chosen. The injected fetch is
+    // wired ONLY to the managed client, so reaching it proves the choice.
+    (auth as unknown as { tokensPath: string }).tokensPath = path;
+    auth.reloadTokensFromDisk();
+    expect(await auth.getAccessToken()).toBe('ya29.managed');
+    expect(seen[0]).toBe(MANAGED!.refresh_url);
+  });
+
+  test('managed is chosen over credentials, and self-hosted still works', () => {
+    expect(makeGoogleAuth({ google: MANAGED })).not.toBeNull();
+    // Nothing configured at all.
+    expect(makeGoogleAuth({})).toBeNull();
+    expect(makeGoogleAuth({ google: { client_id: '', client_secret: '' } })).toBeNull();
+    // Self-hosted keeps its own credentials path.
+    expect(makeGoogleAuth({ google: { client_id: 'cid', client_secret: 'sec' } })).not.toBeNull();
+  });
+
+  test('the reload identity distinguishes both shapes', () => {
+    // The settings-reload applier decides "rebuild or just reload tokens?" from
+    // this. Keying it on credentials alone (as it once did) means a managed
+    // instance never constructs an auth at all.
+    expect(googleIdentity({ google: MANAGED })).toContain('managed');
+    expect(googleIdentity({ google: { client_id: 'cid', client_secret: 'sec' } })).toContain('self');
+    expect(googleIdentity({})).toBeNull();
+    // A moved instance keeps its id, so its identity is stable — no needless
+    // rebuild, and the tokens are simply re-read.
+    expect(googleIdentity({ google: MANAGED })).toBe(googleIdentity({ google: { ...MANAGED } }));
+  });
+});

--- a/src/integrations/google-managed-refresh.test.ts
+++ b/src/integrations/google-managed-refresh.test.ts
@@ -4,7 +4,13 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { createHmac } from 'node:crypto';
 import { GoogleAuth, GoogleReconnectRequired } from './google-auth.ts';
-import { googleIdentity, makeGoogleAuth, makeManagedRefresh } from './google-managed-refresh.ts';
+import {
+  classifyGoogle,
+  googleIdentity,
+  googleReconnectRequired,
+  makeGoogleAuth,
+  makeManagedRefresh,
+} from './google-managed-refresh.ts';
 import type { JarvisConfig } from '../config/types.ts';
 
 /**
@@ -156,5 +162,84 @@ describe('makeGoogleAuth', () => {
     // A moved instance keeps its id, so its identity is stable — no needless
     // rebuild, and the tokens are simply re-read.
     expect(googleIdentity({ google: MANAGED })).toBe(googleIdentity({ google: { ...MANAGED } }));
+  });
+});
+
+describe('a grant the control plane says is gone', () => {
+  const cfg = {
+    refreshUrl: MANAGED!.refresh_url!,
+    instanceId: MANAGED!.instance_id!,
+    notifySecret: MANAGED!.notify_secret!,
+  };
+
+  function authWith(refreshToken: string): GoogleAuth {
+    return new GoogleAuth('', '', {
+      tokensPath: tokensFile({
+        access_token: 'a',
+        refresh_token: refreshToken,
+        expiry_date: Date.now() + 60_000,
+        token_type: 'Bearer',
+      }),
+    });
+  }
+
+  test('is remembered, and clears itself when a new token arrives', async () => {
+    // Without this the classification is inert: a revoked grant leaves the
+    // tokens file untouched, so the settings tab keeps showing a green
+    // "connected" chip over an integration where every sync fails, and never
+    // offers the one action that fixes it.
+    const dead = makeManagedRefresh(cfg, (async () =>
+      new Response(JSON.stringify({ error: 'connect Google again', reconnect: true }), {
+        status: 409,
+      })) as unknown as typeof fetch);
+    await expect(dead('1//dead')).rejects.toBeInstanceOf(GoogleReconnectRequired);
+
+    expect(googleReconnectRequired(authWith('1//dead'))).toContain('connect Google again');
+    // Keyed on the token that actually failed: a DIFFERENT one is a reconnect
+    // that already happened, and must not inherit the old verdict.
+    expect(googleReconnectRequired(authWith('1//fresh-after-reconnect'))).toBeNull();
+    expect(googleReconnectRequired(null)).toBeNull();
+
+    // A refresh that succeeds says the grant is alive again.
+    const ok = makeManagedRefresh(cfg, (async () =>
+      new Response(JSON.stringify({ access_token: 'ya29.fresh', expires_in: 3599 }), {
+        status: 200,
+      })) as unknown as typeof fetch);
+    await ok('1//dead');
+    expect(googleReconnectRequired(authWith('1//dead'))).toBeNull();
+  });
+
+  test('a transient failure does NOT mark the grant dead', async () => {
+    const down = makeManagedRefresh(cfg, (async () =>
+      new Response('{}', { status: 500 })) as unknown as typeof fetch);
+    await expect(down('1//alive')).rejects.toThrow();
+    expect(googleReconnectRequired(authWith('1//alive'))).toBeNull();
+  });
+});
+
+describe('classifyGoogle', () => {
+  test('a partial managed block is none, not a fallback to the file credentials', () => {
+    expect(classifyGoogle({ google: MANAGED }).mode).toBe('managed');
+    expect(classifyGoogle({ google: { client_id: 'cid', client_secret: 'sec' } }).mode).toBe('self');
+    expect(classifyGoogle({}).mode).toBe('none');
+    // refresh_url without its companions: a config we mis-rendered. Using the
+    // credentials that happen to sit beside it would put a hosted instance back
+    // on the shared secret, invisibly, because Google would keep working.
+    for (const partial of [
+      { refresh_url: MANAGED!.refresh_url, client_id: 'cid', client_secret: 'sec' },
+      { refresh_url: MANAGED!.refresh_url, instance_id: 'inst-1', client_id: 'cid', client_secret: 'sec' },
+      { refresh_url: MANAGED!.refresh_url, notify_secret: 'a'.repeat(64) },
+    ]) {
+      expect(classifyGoogle({ google: partial }).mode).toBe('none');
+      expect(makeGoogleAuth({ google: partial })).toBeNull();
+      expect(googleIdentity({ google: partial })).toBeNull();
+    }
+    // notify_secret alone is the push doorbell's key — legitimate on a
+    // self-hosted instance, and must not disable it.
+    expect(
+      classifyGoogle({
+        google: { client_id: 'cid', client_secret: 'sec', notify_secret: 'a'.repeat(64) },
+      }).mode,
+    ).toBe('self');
   });
 });

--- a/src/integrations/google-managed-refresh.test.ts
+++ b/src/integrations/google-managed-refresh.test.ts
@@ -7,7 +7,6 @@ import { GoogleAuth, GoogleReconnectRequired } from './google-auth.ts';
 import {
   classifyGoogle,
   googleIdentity,
-  googleReconnectRequired,
   makeGoogleAuth,
   makeManagedRefresh,
 } from './google-managed-refresh.ts';
@@ -21,12 +20,20 @@ import type { JarvisConfig } from '../config/types.ts';
  * use is a secret the tenant could read. Everything here checks that the managed
  * path works without them, and that the self-hosted path is untouched.
  */
+/**
+ * A REAL managed block: no client credentials at all. Carrying empty strings
+ * here (as this fixture used to) made every "is this managed?" branch pass on
+ * the credentials clause instead of the hosted one, and made a
+ * `not.toContain('client_secret')` assertion vacuous twice over.
+ *
+ * notify_secret is the DOORBELL key and refresh_secret the one used here; they
+ * are deliberately different values so a mix-up cannot pass.
+ */
 const MANAGED: JarvisConfig['google'] = {
-  client_id: '',
-  client_secret: '',
   refresh_url: 'https://app.example.com/api/integrations/google/refresh',
   instance_id: 'inst-1',
   notify_secret: 'a'.repeat(64),
+  refresh_secret: 'c'.repeat(64),
 };
 
 function tokensFile(tokens: Record<string, unknown>): string {
@@ -40,7 +47,7 @@ describe('makeManagedRefresh', () => {
   const cfg = {
     refreshUrl: MANAGED!.refresh_url!,
     instanceId: MANAGED!.instance_id!,
-    notifySecret: MANAGED!.notify_secret!,
+    refreshSecret: MANAGED!.refresh_secret!,
   };
 
   test('signs the exact body it sends, and never sends a client secret', async () => {
@@ -60,7 +67,7 @@ describe('makeManagedRefresh', () => {
     expect(out.access_token).toBe('ya29.fresh');
     // The signature must cover the bytes actually sent — re-serialising would
     // change them and the control plane would reject every request.
-    const expected = createHmac('sha256', cfg.notifySecret).update(seen!.body).digest('hex');
+    const expected = createHmac('sha256', cfg.refreshSecret).update(seen!.body).digest('hex');
     expect(seen!.signature).toBe(expected);
     const sent = JSON.parse(seen!.body) as { instanceId: string; refreshToken: string; at: string };
     expect(sent).toMatchObject({ instanceId: 'inst-1', refreshToken: '1//token' });
@@ -75,11 +82,22 @@ describe('makeManagedRefresh', () => {
       new Response(JSON.stringify({ error: 'expired', reconnect: true }), { status: 409 })) as unknown as typeof fetch);
     await expect(reconnect('1//t')).rejects.toBeInstanceOf(GoogleReconnectRequired);
 
-    // 404 = the control plane has no connected record any more. Also only fixed
-    // by connecting again, so it must not read as a retryable blip.
+    // The control plane having no connected record any more is ALSO a reconnect,
+    // and it says so with the flag — it is a 404 that carries `reconnect`. Taken
+    // from the flag rather than inferred from the status, because a BARE 404 is
+    // what a wrong origin path, a rollback that drops the route, or a CDN
+    // answering for an unknown path returns; treating those as a gone grant would
+    // tell the user to reconnect over a misconfiguration and stop refreshing a
+    // token that was fine.
     const gone = makeManagedRefresh(cfg, (async () =>
-      new Response('{}', { status: 404 })) as unknown as typeof fetch);
+      new Response(JSON.stringify({ error: 'no connected instance', reconnect: true }), {
+        status: 404,
+      })) as unknown as typeof fetch);
     await expect(gone('1//t')).rejects.toBeInstanceOf(GoogleReconnectRequired);
+
+    const routing = makeManagedRefresh(cfg, (async () =>
+      new Response('not found', { status: 404 })) as unknown as typeof fetch);
+    await expect(routing('1//t')).rejects.not.toBeInstanceOf(GoogleReconnectRequired);
 
     // A 500, or an unreachable control plane, is transient: the next poll
     // retries, and telling the user to reconnect over a blip would be wrong.
@@ -159,61 +177,122 @@ describe('makeGoogleAuth', () => {
     expect(googleIdentity({ google: MANAGED })).toContain('managed');
     expect(googleIdentity({ google: { client_id: 'cid', client_secret: 'sec' } })).toContain('self');
     expect(googleIdentity({})).toBeNull();
-    // A moved instance keeps its id, so its identity is stable — no needless
-    // rebuild, and the tokens are simply re-read.
-    expect(googleIdentity({ google: MANAGED })).toBe(googleIdentity({ google: { ...MANAGED } }));
+    // A moved instance keeps its id, and the push targets can change on a move
+    // without the AUTH needing a rebuild — so the identity must ignore those.
+    // (Comparing MANAGED to a spread of itself proved nothing: identical values
+    // through a pure function.)
+    expect(googleIdentity({ google: { ...MANAGED, pubsub_topic: 'projects/p/topics/t' } })).toBe(
+      googleIdentity({ google: MANAGED }),
+    );
+
+    // ...but the REFRESH SECRET is part of it. It is the one value that
+    // authenticates every refresh, and the refresher closes over it: an identity
+    // that ignored it would tell the applier "same Google, just re-read the
+    // tokens" after a master-key rotation and leave every refresh signing with a
+    // key the control plane no longer accepts — 401ing forever, until a restart
+    // nobody knows to perform.
+    expect(googleIdentity({ google: { ...MANAGED, refresh_secret: 'd'.repeat(64) } })).not.toBe(
+      googleIdentity({ google: MANAGED }),
+    );
   });
 });
 
-describe('a grant the control plane says is gone', () => {
+describe('a grant that is gone', () => {
   const cfg = {
     refreshUrl: MANAGED!.refresh_url!,
     instanceId: MANAGED!.instance_id!,
-    notifySecret: MANAGED!.notify_secret!,
+    refreshSecret: MANAGED!.refresh_secret!,
   };
 
-  function authWith(refreshToken: string): GoogleAuth {
-    return new GoogleAuth('', '', {
-      tokensPath: tokensFile({
+  /** A managed auth whose token on disk is already past the expiry buffer. */
+  function staleAuth(refreshToken: string, fetchImpl: typeof fetch) {
+    const path = tokensFile({
+      access_token: 'old',
+      refresh_token: refreshToken,
+      expiry_date: Date.now() - 1000,
+      token_type: 'Bearer',
+    });
+    return {
+      path,
+      auth: GoogleAuth.managed(makeManagedRefresh(cfg, fetchImpl), { tokensPath: path }),
+    };
+  }
+
+  const respond = (status: number, body: unknown) =>
+    (async () => new Response(JSON.stringify(body), { status })) as unknown as typeof fetch;
+
+  test('is remembered ACROSS A RESTART, and clears when a new token arrives', async () => {
+    // Without this the classification is inert: a revoked grant leaves the tokens
+    // file untouched, so the settings tab shows a green "connected" chip over an
+    // integration where every sync fails, and never offers the one action that
+    // helps. Persisted rather than held in memory because refreshes only run on
+    // the expiry clock — after a restart the lie would stand for up to an hour.
+    const { auth, path } = staleAuth('1//dead', respond(409, { error: 'connect Google again', reconnect: true }));
+    await expect(auth.getAccessToken()).rejects.toBeInstanceOf(GoogleReconnectRequired);
+    expect(auth.reconnectRequired()).toContain('connect Google again');
+
+    // A fresh process reading the same files — the restart case.
+    const restarted = GoogleAuth.managed(makeManagedRefresh(cfg, respond(200, {})), {
+      tokensPath: path,
+    });
+    expect(restarted.reconnectRequired()).toContain('connect Google again');
+
+    // Keyed on the token that actually FAILED, so a delivered token clears it
+    // with no reset call for anyone to forget: this is the reconnect case.
+    await Bun.write(
+      path,
+      JSON.stringify({
         access_token: 'a',
-        refresh_token: refreshToken,
+        refresh_token: '1//after-reconnect',
         expiry_date: Date.now() + 60_000,
         token_type: 'Bearer',
       }),
+    );
+    const reconnected = GoogleAuth.managed(makeManagedRefresh(cfg, respond(200, {})), {
+      tokensPath: path,
     });
-  }
+    expect(reconnected.reconnectRequired()).toBeNull();
+  });
 
-  test('is remembered, and clears itself when a new token arrives', async () => {
-    // Without this the classification is inert: a revoked grant leaves the
-    // tokens file untouched, so the settings tab keeps showing a green
-    // "connected" chip over an integration where every sync fails, and never
-    // offers the one action that fixes it.
-    const dead = makeManagedRefresh(cfg, (async () =>
-      new Response(JSON.stringify({ error: 'connect Google again', reconnect: true }), {
-        status: 409,
-      })) as unknown as typeof fetch);
-    await expect(dead('1//dead')).rejects.toBeInstanceOf(GoogleReconnectRequired);
+  test('a successful refresh says the grant is alive again', async () => {
+    const { auth } = staleAuth('1//dead', respond(409, { reconnect: true }));
+    await expect(auth.getAccessToken()).rejects.toBeInstanceOf(GoogleReconnectRequired);
+    expect(auth.reconnectRequired()).not.toBeNull();
 
-    expect(googleReconnectRequired(authWith('1//dead'))).toContain('connect Google again');
-    // Keyed on the token that actually failed: a DIFFERENT one is a reconnect
-    // that already happened, and must not inherit the old verdict.
-    expect(googleReconnectRequired(authWith('1//fresh-after-reconnect'))).toBeNull();
-    expect(googleReconnectRequired(null)).toBeNull();
-
-    // A refresh that succeeds says the grant is alive again.
-    const ok = makeManagedRefresh(cfg, (async () =>
-      new Response(JSON.stringify({ access_token: 'ya29.fresh', expires_in: 3599 }), {
-        status: 200,
-      })) as unknown as typeof fetch);
-    await ok('1//dead');
-    expect(googleReconnectRequired(authWith('1//dead'))).toBeNull();
+    const revived = GoogleAuth.managed(
+      makeManagedRefresh(cfg, respond(200, { access_token: 'ya29.fresh', expires_in: 3599 })),
+      { tokensPath: (auth as unknown as { tokensPath: string }).tokensPath },
+    );
+    expect(await revived.getAccessToken()).toBe('ya29.fresh');
+    expect(revived.reconnectRequired()).toBeNull();
   });
 
   test('a transient failure does NOT mark the grant dead', async () => {
-    const down = makeManagedRefresh(cfg, (async () =>
-      new Response('{}', { status: 500 })) as unknown as typeof fetch);
-    await expect(down('1//alive')).rejects.toThrow();
-    expect(googleReconnectRequired(authWith('1//alive'))).toBeNull();
+    // Asserted against a state that is already DEAD for another token, so this
+    // cannot pass merely because nothing was ever written.
+    const { auth } = staleAuth('1//alive', respond(500, {}));
+    await expect(auth.getAccessToken()).rejects.toThrow(/refused the refresh/);
+    expect(auth.reconnectRequired()).toBeNull();
+
+    // A bare 404 is transient too: it is also what a wrong origin path or a
+    // rollback that drops the route returns, and telling the user to reconnect
+    // over a misconfiguration would stop a perfectly good token being refreshed.
+    const { auth: routing } = staleAuth('1//alive', respond(404, {}));
+    await expect(routing.getAccessToken()).rejects.not.toBeInstanceOf(GoogleReconnectRequired);
+    expect(routing.reconnectRequired()).toBeNull();
+  });
+
+  test("someone else's text does not become our voice, unbounded", async () => {
+    // The reason is rendered to the user as this daemon's own explanation, so
+    // whatever answers refresh_url must not be able to put newlines, control
+    // characters or a wall of text into a log line and a settings panel.
+    const hostile = `line-one\nline-two\u0007${'x'.repeat(500)}`;
+    const { auth } = staleAuth('1//dead', respond(409, { error: hostile, reconnect: true }));
+    await expect(auth.getAccessToken()).rejects.toBeInstanceOf(GoogleReconnectRequired);
+    const shown = auth.reconnectRequired()!;
+    expect(shown.length).toBeLessThanOrEqual(200);
+    expect(shown).not.toContain('\n');
+    expect(shown).not.toContain('\u0007');
   });
 });
 

--- a/src/integrations/google-managed-refresh.ts
+++ b/src/integrations/google-managed-refresh.ts
@@ -1,4 +1,4 @@
-import { createHmac } from 'node:crypto';
+import { createHash, createHmac } from 'node:crypto';
 import { GoogleAuth, GoogleReconnectRequired, type ManagedRefresh } from './google-auth.ts';
 import type { JarvisConfig } from '../config/types.ts';
 
@@ -25,6 +25,31 @@ export interface ManagedRefreshConfig {
 
 /** How long to wait on the control plane. The caller is blocked on this. */
 const TIMEOUT_MS = 20_000;
+
+/**
+ * The last grant we were told is GONE, remembered so the settings UI can say so.
+ *
+ * Without this the classification is inert: a revoked grant leaves the tokens
+ * file in place, so status keeps reading "connected" while every sync quietly
+ * fails, and the one action that fixes it (connect again) is never offered.
+ *
+ * Keyed by a hash of the refresh token that failed — never the token — so it
+ * self-clears the moment the control plane delivers a new one, with no
+ * cross-module reset to forget to call.
+ */
+let deadGrant: { tokenHash: string; message: string } | null = null;
+
+const tokenHash = (t: string) => createHash('sha256').update(t).digest('hex');
+
+/**
+ * The reason this instance must connect Google again, or null. Reported by
+ * /api/auth/google/status; tokens on disk are NOT proof of a live grant.
+ */
+export function googleReconnectRequired(auth: GoogleAuth | null): string | null {
+  const token = auth?.getTokens()?.refresh_token;
+  if (!token || !deadGrant) return null;
+  return deadGrant.tokenHash === tokenHash(token) ? deadGrant.message : null;
+}
 
 export function makeManagedRefresh(
   cfg: ManagedRefreshConfig,
@@ -57,6 +82,7 @@ export function makeManagedRefresh(
     if (res.status === 200) {
       const data = (await res.json()) as ManagedRefresh;
       if (!data?.access_token) throw new Error('control plane returned no access token');
+      deadGrant = null;
       return data;
     }
 
@@ -68,12 +94,64 @@ export function makeManagedRefresh(
     // by connecting again. Both are permanent — retrying either forever would
     // bury the one action that helps.
     if (detail?.reconnect || res.status === 404) {
-      throw new GoogleReconnectRequired(
-        detail?.error ?? 'Google access is no longer valid — connect Google again',
-      );
+      const message = detail?.error ?? 'Google access is no longer valid — connect Google again';
+      deadGrant = { tokenHash: tokenHash(refreshToken), message };
+      throw new GoogleReconnectRequired(message);
     }
     throw new Error(`control plane refused the refresh (${res.status})`);
   };
+}
+
+/**
+ * Build the right GoogleAuth for this deployment, or null when Google is not
+ * configured at all.
+ *
+ * MANAGED (hosted) instances carry `refresh_url` and no credentials: the control
+ * plane holds the client id and secret and applies them on the instance's
+ * behalf. SELF-HOSTED instances carry their own credentials and talk to Google
+ * directly. Both shapes are legitimate; what must never happen is a hosted
+ * instance holding the shared secret, which is why the managed branch is checked
+ * FIRST and constructs with no credentials at all.
+ */
+/**
+ * Which Google shape this config is — and, with it, the validated fields that
+ * shape needs. Decided in ONE place so the daemon's status endpoint, the auth
+ * builder and the reload applier cannot disagree about whether an instance is
+ * hosted. `none` covers both "no Google" and a config too broken to use.
+ */
+export type GoogleShape =
+  | { mode: 'managed'; refreshUrl: string; instanceId: string; notifySecret: string }
+  | { mode: 'self'; clientId: string; clientSecret: string }
+  | { mode: 'none' };
+
+export function classifyGoogle(config: { google?: JarvisConfig['google'] }): GoogleShape {
+  const g = config.google;
+  if (!g) return { mode: 'none' };
+  if (g.refresh_url) {
+    // MANAGED, or a managed block we mis-rendered. Refuse a partial one rather
+    // than falling through to any client_id/client_secret also present: that
+    // would put a hosted instance back on the path this whole design exists to
+    // remove, and do it invisibly, since everything would keep working. The
+    // control plane's own googleAppCredsFromEnv refuses a half-set pair for the
+    // same reason.
+    if (!g.instance_id || !g.notify_secret) {
+      console.error(
+        '[google] the config carries refresh_url but not instance_id and notify_secret — ' +
+          'Google is disabled rather than falling back to any credentials in this file.',
+      );
+      return { mode: 'none' };
+    }
+    return {
+      mode: 'managed',
+      refreshUrl: g.refresh_url,
+      instanceId: g.instance_id,
+      notifySecret: g.notify_secret,
+    };
+  }
+  if (g.client_id && g.client_secret) {
+    return { mode: 'self', clientId: g.client_id, clientSecret: g.client_secret };
+  }
+  return { mode: 'none' };
 }
 
 /**
@@ -91,18 +169,12 @@ export function makeGoogleAuth(
   config: { google?: JarvisConfig['google'] },
   fetchImpl: typeof fetch = fetch,
 ): GoogleAuth | null {
-  const g = config.google;
-  if (!g) return null;
-  if (g.refresh_url && g.instance_id && g.notify_secret) {
-    return new GoogleAuth('', '', {
-      refreshVia: makeManagedRefresh(
-        { refreshUrl: g.refresh_url, instanceId: g.instance_id, notifySecret: g.notify_secret },
-        fetchImpl,
-      ),
-    });
+  const shape = classifyGoogle(config);
+  if (shape.mode === 'none') return null;
+  if (shape.mode === 'managed') {
+    return new GoogleAuth('', '', { refreshVia: makeManagedRefresh(shape, fetchImpl) });
   }
-  if (g.client_id && g.client_secret) return new GoogleAuth(g.client_id, g.client_secret);
-  return null;
+  return new GoogleAuth(shape.clientId, shape.clientSecret);
 }
 
 /**
@@ -112,11 +184,8 @@ export function makeGoogleAuth(
  * every reload, or worse, never constructing at all.
  */
 export function googleIdentity(config: { google?: JarvisConfig['google'] }): string | null {
-  const g = config.google;
-  if (!g) return null;
-  if (g.refresh_url && g.instance_id && g.notify_secret) {
-    return `managed\n${g.refresh_url}\n${g.instance_id}`;
-  }
-  if (g.client_id && g.client_secret) return `self\n${g.client_id}\n${g.client_secret}`;
+  const shape = classifyGoogle(config);
+  if (shape.mode === 'managed') return `managed\n${shape.refreshUrl}\n${shape.instanceId}`;
+  if (shape.mode === 'self') return `self\n${shape.clientId}\n${shape.clientSecret}`;
   return null;
 }

--- a/src/integrations/google-managed-refresh.ts
+++ b/src/integrations/google-managed-refresh.ts
@@ -1,5 +1,5 @@
-import { createHash, createHmac } from 'node:crypto';
-import { GoogleAuth, GoogleReconnectRequired, type ManagedRefresh } from './google-auth.ts';
+import { GoogleAuth, GoogleReconnectRequired, clampReason, type ManagedRefresh } from './google-auth.ts';
+import { INSTANCE_SIGNATURE_HEADER, signWithSecret } from './google-signature.ts';
 import type { JarvisConfig } from '../config/types.ts';
 
 /**
@@ -20,36 +20,15 @@ import type { JarvisConfig } from '../config/types.ts';
 export interface ManagedRefreshConfig {
   refreshUrl: string;
   instanceId: string;
-  notifySecret: string;
+  /**
+   * The REFRESH key, not the doorbell's. They are separate derivations because
+   * they travel in opposite directions; see google-signature.ts.
+   */
+  refreshSecret: string;
 }
 
 /** How long to wait on the control plane. The caller is blocked on this. */
 const TIMEOUT_MS = 20_000;
-
-/**
- * The last grant we were told is GONE, remembered so the settings UI can say so.
- *
- * Without this the classification is inert: a revoked grant leaves the tokens
- * file in place, so status keeps reading "connected" while every sync quietly
- * fails, and the one action that fixes it (connect again) is never offered.
- *
- * Keyed by a hash of the refresh token that failed — never the token — so it
- * self-clears the moment the control plane delivers a new one, with no
- * cross-module reset to forget to call.
- */
-let deadGrant: { tokenHash: string; message: string } | null = null;
-
-const tokenHash = (t: string) => createHash('sha256').update(t).digest('hex');
-
-/**
- * The reason this instance must connect Google again, or null. Reported by
- * /api/auth/google/status; tokens on disk are NOT proof of a live grant.
- */
-export function googleReconnectRequired(auth: GoogleAuth | null): string | null {
-  const token = auth?.getTokens()?.refresh_token;
-  if (!token || !deadGrant) return null;
-  return deadGrant.tokenHash === tokenHash(token) ? deadGrant.message : null;
-}
 
 export function makeManagedRefresh(
   cfg: ManagedRefreshConfig,
@@ -61,13 +40,13 @@ export function makeManagedRefresh(
       refreshToken,
       at: new Date().toISOString(),
     });
-    const signature = createHmac('sha256', cfg.notifySecret).update(body).digest('hex');
+    const signature = signWithSecret(cfg.refreshSecret, body);
 
     let res: Response;
     try {
       res = await fetchImpl(cfg.refreshUrl, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json', 'x-jarvis-signature': signature },
+        headers: { 'Content-Type': 'application/json', [INSTANCE_SIGNATURE_HEADER]: signature },
         body,
         signal: AbortSignal.timeout(TIMEOUT_MS),
       });
@@ -82,21 +61,28 @@ export function makeManagedRefresh(
     if (res.status === 200) {
       const data = (await res.json()) as ManagedRefresh;
       if (!data?.access_token) throw new Error('control plane returned no access token');
-      deadGrant = null;
       return data;
     }
 
     const detail = (await res.json().catch(() => null)) as
       | { error?: string; reconnect?: boolean }
       | null;
-    // 409+reconnect is the grant being gone; 404 means the control plane no
-    // longer has a connected record for this instance, which the user also fixes
-    // by connecting again. Both are permanent — retrying either forever would
-    // bury the one action that helps.
-    if (detail?.reconnect || res.status === 404) {
-      const message = detail?.error ?? 'Google access is no longer valid — connect Google again';
-      deadGrant = { tokenHash: tokenHash(refreshToken), message };
-      throw new GoogleReconnectRequired(message);
+    // `reconnect` is the control plane saying the grant is gone — 409 when the
+    // token is not the one bound to this instance, 404 when there is no connected
+    // record any more. Both are permanent, and retrying either forever would bury
+    // the one action that helps.
+    //
+    // Taken from the FLAG, never inferred from the status: a bare 404 is also what
+    // a wrong origin path, a rollback that drops the route, or a CDN answering for
+    // an unknown path returns, and treating those as a dead grant would tell the
+    // user to reconnect over a misconfiguration — then stop refreshing a token
+    // that was fine.
+    if (detail?.reconnect) {
+      throw new GoogleReconnectRequired(
+        // Someone else's text, shown to the user in our voice, so it is bounded
+        // and stripped of control characters before it goes anywhere.
+        detail.error ? clampReason(detail.error) : 'Google access is no longer valid — connect Google again',
+      );
     }
     throw new Error(`control plane refused the refresh (${res.status})`);
   };
@@ -120,9 +106,10 @@ export function makeManagedRefresh(
  * hosted. `none` covers both "no Google" and a config too broken to use.
  */
 export type GoogleShape =
-  | { mode: 'managed'; refreshUrl: string; instanceId: string; notifySecret: string }
+  | { mode: 'managed'; refreshUrl: string; instanceId: string; refreshSecret: string }
   | { mode: 'self'; clientId: string; clientSecret: string }
-  | { mode: 'none' };
+  /** `reason` is set only when a config was REFUSED, not when there is no Google. */
+  | { mode: 'none'; reason?: string };
 
 export function classifyGoogle(config: { google?: JarvisConfig['google'] }): GoogleShape {
   const g = config.google;
@@ -134,18 +121,24 @@ export function classifyGoogle(config: { google?: JarvisConfig['google'] }): Goo
     // remove, and do it invisibly, since everything would keep working. The
     // control plane's own googleAppCredsFromEnv refuses a half-set pair for the
     // same reason.
-    if (!g.instance_id || !g.notify_secret) {
-      console.error(
-        '[google] the config carries refresh_url but not instance_id and notify_secret — ' +
-          'Google is disabled rather than falling back to any credentials in this file.',
-      );
-      return { mode: 'none' };
+    //
+    // The reason is RETURNED, not logged: this function is called on every status
+    // poll as well as at construction, and logging here printed the same line
+    // twice per poll forever. The boot/reload edge logs it once, and the status
+    // endpoint can show it to whoever has to fix it.
+    if (!g.instance_id || !g.refresh_secret) {
+      return {
+        mode: 'none',
+        reason:
+          'the config carries refresh_url but not instance_id and refresh_secret, so Google ' +
+          'is disabled rather than falling back to any credentials in this file',
+      };
     }
     return {
       mode: 'managed',
       refreshUrl: g.refresh_url,
       instanceId: g.instance_id,
-      notifySecret: g.notify_secret,
+      refreshSecret: g.refresh_secret,
     };
   }
   if (g.client_id && g.client_secret) {
@@ -168,13 +161,15 @@ export function classifyGoogle(config: { google?: JarvisConfig['google'] }): Goo
 export function makeGoogleAuth(
   config: { google?: JarvisConfig['google'] },
   fetchImpl: typeof fetch = fetch,
+  /** Test seam — see ApiContext.googleTokensPath. */
+  tokensPath?: string,
 ): GoogleAuth | null {
   const shape = classifyGoogle(config);
   if (shape.mode === 'none') return null;
   if (shape.mode === 'managed') {
-    return new GoogleAuth('', '', { refreshVia: makeManagedRefresh(shape, fetchImpl) });
+    return GoogleAuth.managed(makeManagedRefresh(shape, fetchImpl), { tokensPath });
   }
-  return new GoogleAuth(shape.clientId, shape.clientSecret);
+  return new GoogleAuth(shape.clientId, shape.clientSecret, { tokensPath });
 }
 
 /**
@@ -185,7 +180,16 @@ export function makeGoogleAuth(
  */
 export function googleIdentity(config: { google?: JarvisConfig['google'] }): string | null {
   const shape = classifyGoogle(config);
-  if (shape.mode === 'managed') return `managed\n${shape.refreshUrl}\n${shape.instanceId}`;
+  // The refresh SECRET is part of the identity, not just the URL and the id: it is
+  // the one value that authenticates every refresh, and the managed refresher
+  // closes over it. If it ever changed without the URL changing (a master-key
+  // rotation on the control plane), an identity that ignored it would tell the
+  // reload applier "same Google, just re-read the tokens" and leave the refresher
+  // signing with a key the control plane no longer accepts — every refresh 401ing,
+  // forever, until a restart nobody knows to perform.
+  if (shape.mode === 'managed') {
+    return `managed\n${shape.refreshUrl}\n${shape.instanceId}\n${shape.refreshSecret}`;
+  }
   if (shape.mode === 'self') return `self\n${shape.clientId}\n${shape.clientSecret}`;
   return null;
 }

--- a/src/integrations/google-managed-refresh.ts
+++ b/src/integrations/google-managed-refresh.ts
@@ -1,0 +1,122 @@
+import { createHmac } from 'node:crypto';
+import { GoogleAuth, GoogleReconnectRequired, type ManagedRefresh } from './google-auth.ts';
+import type { JarvisConfig } from '../config/types.ts';
+
+/**
+ * Ask the control plane to refresh this instance's Google access token
+ * (GOOGLE.md "Refresh"). HOSTED ONLY.
+ *
+ * The instance holds the refresh token; the control plane holds the client
+ * secret. Neither side has both, which is the point: this daemon runs as the
+ * tenant's own Linux user, so a secret it could use would be one the tenant
+ * could read — and the control plane storing refresh tokens would make a single
+ * compromise worth every user's mailbox.
+ *
+ * The request is signed with the per-instance notify secret from the system
+ * config, the same key the push bridge's doorbell is verified with, used here in
+ * the other direction. The timestamp is inside the signed bytes so a captured
+ * request cannot be replayed later.
+ */
+export interface ManagedRefreshConfig {
+  refreshUrl: string;
+  instanceId: string;
+  notifySecret: string;
+}
+
+/** How long to wait on the control plane. The caller is blocked on this. */
+const TIMEOUT_MS = 20_000;
+
+export function makeManagedRefresh(
+  cfg: ManagedRefreshConfig,
+  fetchImpl: typeof fetch = fetch,
+): (refreshToken: string) => Promise<ManagedRefresh> {
+  return async (refreshToken: string) => {
+    const body = JSON.stringify({
+      instanceId: cfg.instanceId,
+      refreshToken,
+      at: new Date().toISOString(),
+    });
+    const signature = createHmac('sha256', cfg.notifySecret).update(body).digest('hex');
+
+    let res: Response;
+    try {
+      res = await fetchImpl(cfg.refreshUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'x-jarvis-signature': signature },
+        body,
+        signal: AbortSignal.timeout(TIMEOUT_MS),
+      });
+    } catch (err) {
+      // Unreachable control plane is TRANSIENT: the next poll tries again, and
+      // telling the user to reconnect over a network blip would be wrong.
+      throw new Error(
+        `could not reach the control plane to refresh: ${err instanceof Error ? err.message : err}`,
+      );
+    }
+
+    if (res.status === 200) {
+      const data = (await res.json()) as ManagedRefresh;
+      if (!data?.access_token) throw new Error('control plane returned no access token');
+      return data;
+    }
+
+    const detail = (await res.json().catch(() => null)) as
+      | { error?: string; reconnect?: boolean }
+      | null;
+    // 409+reconnect is the grant being gone; 404 means the control plane no
+    // longer has a connected record for this instance, which the user also fixes
+    // by connecting again. Both are permanent — retrying either forever would
+    // bury the one action that helps.
+    if (detail?.reconnect || res.status === 404) {
+      throw new GoogleReconnectRequired(
+        detail?.error ?? 'Google access is no longer valid — connect Google again',
+      );
+    }
+    throw new Error(`control plane refused the refresh (${res.status})`);
+  };
+}
+
+/**
+ * Build the right GoogleAuth for this deployment, or null when Google is not
+ * configured at all.
+ *
+ * MANAGED (hosted) instances carry `refresh_url` and no credentials: the control
+ * plane holds the client id and secret and applies them on the instance's
+ * behalf. SELF-HOSTED instances carry their own credentials and talk to Google
+ * directly. Both shapes are legitimate; what must never happen is a hosted
+ * instance holding the shared secret, which is why the managed branch is checked
+ * FIRST and constructs with no credentials at all.
+ */
+export function makeGoogleAuth(
+  config: { google?: JarvisConfig['google'] },
+  fetchImpl: typeof fetch = fetch,
+): GoogleAuth | null {
+  const g = config.google;
+  if (!g) return null;
+  if (g.refresh_url && g.instance_id && g.notify_secret) {
+    return new GoogleAuth('', '', {
+      refreshVia: makeManagedRefresh(
+        { refreshUrl: g.refresh_url, instanceId: g.instance_id, notifySecret: g.notify_secret },
+        fetchImpl,
+      ),
+    });
+  }
+  if (g.client_id && g.client_secret) return new GoogleAuth(g.client_id, g.client_secret);
+  return null;
+}
+
+/**
+ * A value that changes when the Google IDENTITY changes, for the settings-reload
+ * applier's "rebuild or just reload the tokens?" decision. Covers both shapes —
+ * keying it on credentials alone would leave a managed instance rebuilding on
+ * every reload, or worse, never constructing at all.
+ */
+export function googleIdentity(config: { google?: JarvisConfig['google'] }): string | null {
+  const g = config.google;
+  if (!g) return null;
+  if (g.refresh_url && g.instance_id && g.notify_secret) {
+    return `managed\n${g.refresh_url}\n${g.instance_id}`;
+  }
+  if (g.client_id && g.client_secret) return `self\n${g.client_id}\n${g.client_secret}`;
+  return null;
+}

--- a/src/integrations/google-signature.ts
+++ b/src/integrations/google-signature.ts
@@ -1,0 +1,45 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
+
+/**
+ * The HMAC seam between this instance and the control plane (GOOGLE.md).
+ *
+ * Two directions, two keys, and they are NOT interchangeable:
+ *
+ * - the DOORBELL comes in (the control plane signs with `notify_secret`, we
+ *   verify) and carries `{source, at}` — no data, so the worst a forged one
+ *   achieves is an early poll;
+ * - a REFRESH request goes out (we sign with `refresh_secret`, the control plane
+ *   verifies) and carries the refresh token, so it is the one that matters.
+ *
+ * They were one key once, which made `HMAC(S, body)` a valid signature at either
+ * endpoint — safe only because the two body shapes happen to be disjoint. The
+ * control plane derives both from its master key under separate labels and
+ * renders them whole into the system config, so nothing here derives anything and
+ * there is no literal to drift between the two codebases.
+ *
+ * This mirrors packages/orchestration/src/google-app.ts on the control plane.
+ * The duplication is deliberate: the repos do not share code, and the SHAPE
+ * (hex sha256 over the exact bytes, in one header) is the contract.
+ */
+export const INSTANCE_SIGNATURE_HEADER = 'x-jarvis-signature';
+
+/** Sign the exact bytes being sent. The timestamp is inside them, bounding replay. */
+export function signWithSecret(secret: string, body: string): string {
+  return createHmac('sha256', secret).update(body).digest('hex');
+}
+
+/**
+ * Verify a signature over the exact bytes received.
+ *
+ * Compares by BYTES. `String.length` counts UTF-16 units while `Buffer` counts
+ * utf8 bytes, so a 64-CHARACTER non-ASCII signature passed a `.length` gate and
+ * then made timingSafeEqual THROW — which, on a public route with no error
+ * handler above it, turned an unauthenticated 401 into a 500 with a stack trace,
+ * at will. The lengths compared here are the buffers' own.
+ */
+export function verifyWithSecret(secret: string, body: string, signature: string | null): boolean {
+  if (!signature) return false;
+  const provided = Buffer.from(signature);
+  const expected = Buffer.from(signWithSecret(secret, body));
+  return provided.length === expected.length && timingSafeEqual(provided, expected);
+}

--- a/src/integrations/google-watch-manager.test.ts
+++ b/src/integrations/google-watch-manager.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, test } from 'bun:test';
+import { GoogleWatchManager, type WatchApi } from './google-watch-manager.ts';
+import type { GoogleAuth } from './google-auth.ts';
+import { GMAIL_WATCH_RENEW_MS, type CalendarChannel } from './google-watch.ts';
+
+/**
+ * The watch lifecycle (GOOGLE.md "Push bridging").
+ *
+ * Everything here is invisible in production until it is wrong, and then it is
+ * wrong quietly: push simply stops working while polling keeps the product
+ * looking fine. The two rules that matter most are that a Calendar
+ * re-registration STOPS the previous channel (Google fans every change out to
+ * every live channel, so leaking them multiplies the traffic for one instance),
+ * and that a FAILED attempt still re-arms (otherwise one transient refusal
+ * disables push until the next daemon restart).
+ */
+const TOPIC = 'projects/p/topics/gmail-push';
+const CALLBACK = 'https://app.example.com/api/integrations/google/push';
+const CHANNEL_TOKEN = 'inst-1.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
+function fakeAuth(authenticated = true): GoogleAuth {
+  return {
+    isAuthenticated: () => authenticated,
+    getAccessToken: async () => 'ya29.token',
+  } as unknown as GoogleAuth;
+}
+
+/** Records every call, and hands back the scheduled renewals to fire by hand. */
+function fakeApi(over: Partial<WatchApi> = {}) {
+  const calls: string[] = [];
+  const scheduled: Array<{ fn: () => void; ms: number }> = [];
+  let channelSeq = 0;
+  const stoppedChannels: string[] = [];
+  const api: WatchApi = {
+    registerGmail: async (_t, topic) => {
+      calls.push(`registerGmail:${topic}`);
+      return { expiration: undefined };
+    },
+    stopGmail: async () => {
+      calls.push('stopGmail');
+    },
+    registerCalendar: async (_t, input) => {
+      channelSeq += 1;
+      calls.push(`registerCalendar:${input.channelToken}`);
+      return { id: `chan-${channelSeq}`, resourceId: `res-${channelSeq}` } as CalendarChannel;
+    },
+    stopCalendar: async (_t, channel) => {
+      calls.push(`stopCalendar:${channel.id}`);
+      stoppedChannels.push(channel.id);
+    },
+    schedule: (fn, ms) => {
+      scheduled.push({ fn, ms });
+      return { cancel: () => {} };
+    },
+    ...over,
+  };
+  return { api, calls, scheduled, stoppedChannels };
+}
+
+const allTargets = { pubsubTopic: TOPIC, pushCallback: CALLBACK, channelToken: CHANNEL_TOKEN };
+
+describe('GoogleWatchManager', () => {
+  test('arms both watches when everything is configured', async () => {
+    const { api, calls, scheduled } = fakeApi();
+    const m = new GoogleWatchManager(api);
+    m.configure(fakeAuth(), allTargets);
+    expect(m.enabled).toBe(true);
+    await m.start();
+
+    expect(calls).toContain(`registerGmail:${TOPIC}`);
+    expect(calls).toContain(`registerCalendar:${CHANNEL_TOKEN}`);
+    // Both re-arm themselves; a watch registered once and never renewed silently
+    // stops working within days.
+    expect(scheduled).toHaveLength(2);
+    expect(scheduled[0]!.ms).toBe(GMAIL_WATCH_RENEW_MS);
+  });
+
+  test('nothing is armed without auth, or without any target', async () => {
+    const { api, calls } = fakeApi();
+
+    const noAuth = new GoogleWatchManager(api);
+    noAuth.configure(fakeAuth(false), allTargets);
+    expect(noAuth.enabled).toBe(false);
+    await noAuth.start();
+
+    // Self-hosted: no bridge at all. Polling covers everything, so this must be
+    // silent rather than an error.
+    const noTargets = new GoogleWatchManager(api);
+    noTargets.configure(fakeAuth(), {});
+    expect(noTargets.enabled).toBe(false);
+    await noTargets.start();
+
+    expect(calls).toEqual([]);
+  });
+
+  test('a topic alone arms Gmail; a callback alone arms Calendar', async () => {
+    const gmailOnly = fakeApi();
+    const g = new GoogleWatchManager(gmailOnly.api);
+    g.configure(fakeAuth(), { pubsubTopic: TOPIC });
+    await g.start();
+    expect(gmailOnly.calls).toEqual([`registerGmail:${TOPIC}`]);
+
+    const calOnly = fakeApi();
+    const c = new GoogleWatchManager(calOnly.api);
+    c.configure(fakeAuth(), { pushCallback: CALLBACK, channelToken: CHANNEL_TOKEN });
+    await c.start();
+    expect(calOnly.calls).toEqual([`registerCalendar:${CHANNEL_TOKEN}`]);
+
+    // A callback with no channel token cannot be routed back by the bridge, so
+    // registering it would produce notifications nobody can attribute.
+    const halfCal = fakeApi();
+    const h = new GoogleWatchManager(halfCal.api);
+    h.configure(fakeAuth(), { pushCallback: CALLBACK });
+    expect(h.enabled).toBe(false);
+    await h.start();
+    expect(halfCal.calls).toEqual([]);
+  });
+
+  test('a Calendar RENEWAL stops the previous channel first', async () => {
+    const { api, calls, scheduled } = fakeApi();
+    const m = new GoogleWatchManager(api);
+    m.configure(fakeAuth(), { pushCallback: CALLBACK, channelToken: CHANNEL_TOKEN });
+    await m.start();
+    expect(calls).toEqual([`registerCalendar:${CHANNEL_TOKEN}`]);
+
+    // Fire the scheduled renewal by hand. Each registration creates a NEW
+    // channel, so without stopping the old one Google ends up delivering every
+    // change to a growing pile of channels that all point at this one instance.
+    const renew = scheduled.at(-1)!;
+    renew.fn();
+    await Bun.sleep(0);
+
+    expect(calls).toEqual([
+      `registerCalendar:${CHANNEL_TOKEN}`,
+      'stopCalendar:chan-1',
+      `registerCalendar:${CHANNEL_TOKEN}`,
+    ]);
+  });
+
+  test('a FAILED registration still re-arms', async () => {
+    const { api, calls, scheduled } = fakeApi({
+      registerGmail: async () => {
+        calls.push('registerGmail:refused');
+        return null;
+      },
+    });
+    const m = new GoogleWatchManager(api);
+    m.configure(fakeAuth(), { pubsubTopic: TOPIC });
+    await m.start();
+
+    // The timer IS the retry. Giving up here would disable push until the next
+    // daemon restart, for what may have been a transient refusal.
+    expect(scheduled).toHaveLength(1);
+    expect(scheduled[0]!.ms).toBe(GMAIL_WATCH_RENEW_MS);
+    scheduled[0]!.fn();
+    await Bun.sleep(0);
+    expect(calls.filter((c) => c === 'registerGmail:refused')).toHaveLength(2);
+  });
+
+  test('stop() cancels the renewals and tells Google to stop', async () => {
+    const { api, calls, scheduled } = fakeApi();
+    let cancelled = 0;
+    const m = new GoogleWatchManager({
+      ...api,
+      schedule: (fn, ms) => {
+        scheduled.push({ fn, ms });
+        return { cancel: () => { cancelled += 1; } };
+      },
+    });
+    m.configure(fakeAuth(), allTargets);
+    await m.start();
+    await m.stop();
+
+    expect(cancelled).toBe(2);
+    expect(calls).toContain('stopGmail');
+    expect(calls).toContain('stopCalendar:chan-1');
+
+    // And a renewal that fires AFTER stop must do nothing — a cancelled timer
+    // that still runs (or a queued callback already in flight) must not
+    // resurrect a watch for observers that are no longer running.
+    const before = calls.length;
+    scheduled.at(-1)!.fn();
+    await Bun.sleep(0);
+    expect(calls).toHaveLength(before);
+  });
+
+  test('stop() is silent when the tokens are already gone', async () => {
+    // THE disconnect path: revoke-google deletes the tokens file before the
+    // reload applier stops the observers, so there is no access token left to
+    // call Google with. Nothing to do, and nothing to throw about — the bridge
+    // dropping unroutable notifications is the real backstop.
+    const { api, calls } = fakeApi();
+    const m = new GoogleWatchManager(api);
+    m.configure(fakeAuth(), allTargets);
+    await m.start();
+    calls.length = 0;
+    m.configure(fakeAuth(false), allTargets); // tokens gone
+    await m.stop();
+    expect(calls).toEqual([]);
+  });
+
+  test('start() twice does not double-register', async () => {
+    // The reload applier stops and starts the observer service on every google
+    // change; a second start without a stop must not arm a second set of
+    // watches (which for Calendar would mean a duplicate channel).
+    const { api, calls } = fakeApi();
+    const m = new GoogleWatchManager(api);
+    m.configure(fakeAuth(), allTargets);
+    await m.start();
+    const after = calls.length;
+    await m.start();
+    expect(calls).toHaveLength(after);
+  });
+});

--- a/src/integrations/google-watch-manager.test.ts
+++ b/src/integrations/google-watch-manager.test.ts
@@ -49,8 +49,17 @@ function fakeApi(over: Partial<WatchApi> = {}) {
       stoppedChannels.push(channel.id);
     },
     schedule: (fn, ms) => {
-      scheduled.push({ fn, ms });
-      return { cancel: () => {} };
+      const entry = { fn, ms };
+      scheduled.push(entry);
+      // cancel() really removes it, so `scheduled` is the set of timers that
+      // would ACTUALLY fire. A no-op cancel would let a leaked or provisional
+      // timer pass unnoticed, which is half of what these tests are for.
+      return {
+        cancel: () => {
+          const i = scheduled.indexOf(entry);
+          if (i >= 0) scheduled.splice(i, 1);
+        },
+      };
     },
     ...over,
   };
@@ -157,21 +166,49 @@ describe('GoogleWatchManager', () => {
     expect(calls.filter((c) => c === 'registerGmail:refused')).toHaveLength(2);
   });
 
+  test('a failed TOKEN re-arms too, not just a failed registration', async () => {
+    // The regression this pins: the retry used to be scheduled only AFTER the
+    // token was in hand, so "could not get an access token" returned early and
+    // scheduled nothing — push off until the next daemon restart. Under managed
+    // refresh the control plane is a hard dependency, so a momentary failure
+    // here is ordinary, and it is likeliest at boot when this first runs.
+    const { api, calls, scheduled } = fakeApi();
+    let working = false;
+    const auth = {
+      isAuthenticated: () => true,
+      getAccessToken: async () => {
+        if (!working) throw new Error('control plane unreachable');
+        return 'ya29.token';
+      },
+    } as unknown as GoogleAuth;
+
+    const m = new GoogleWatchManager(api);
+    m.configure(auth, allTargets);
+    await m.start();
+
+    expect(calls).toHaveLength(0);
+    expect(scheduled).toHaveLength(2);
+
+    working = true;
+    for (const t of scheduled.slice()) t.fn();
+    await Bun.sleep(0);
+    expect(calls).toContain(`registerGmail:${TOPIC}`);
+    expect(calls).toContain(`registerCalendar:${CHANNEL_TOKEN}`);
+  });
+
   test('stop() cancels the renewals and tells Google to stop', async () => {
     const { api, calls, scheduled } = fakeApi();
-    let cancelled = 0;
-    const m = new GoogleWatchManager({
-      ...api,
-      schedule: (fn, ms) => {
-        scheduled.push({ fn, ms });
-        return { cancel: () => { cancelled += 1; } };
-      },
-    });
+    const m = new GoogleWatchManager(api);
     m.configure(fakeAuth(), allTargets);
     await m.start();
+    const live = scheduled.slice();
     await m.stop();
 
-    expect(cancelled).toBe(2);
+    // Counting cancel() calls would pass on a manager that cancelled the same
+    // timer twice and leaked the other; what matters is that NO timer is left
+    // live.
+    expect(live).toHaveLength(2);
+    expect(scheduled).toHaveLength(0);
     expect(calls).toContain('stopGmail');
     expect(calls).toContain('stopCalendar:chan-1');
 
@@ -179,7 +216,7 @@ describe('GoogleWatchManager', () => {
     // that still runs (or a queued callback already in flight) must not
     // resurrect a watch for observers that are no longer running.
     const before = calls.length;
-    scheduled.at(-1)!.fn();
+    live.at(-1)!.fn();
     await Bun.sleep(0);
     expect(calls).toHaveLength(before);
   });

--- a/src/integrations/google-watch-manager.test.ts
+++ b/src/integrations/google-watch-manager.test.ts
@@ -196,6 +196,81 @@ describe('GoogleWatchManager', () => {
     expect(calls).toContain(`registerCalendar:${CHANNEL_TOKEN}`);
   });
 
+  test('a stop during an in-flight registration undoes the watch it created', async () => {
+    // THE leak: start() does not await the manager (observer-service fires it
+    // with `void`), so an arm can still be inside registerCalendar when the user
+    // disconnects. It then assigned the channel and armed a timer on a stopped
+    // manager — and no later stop() could cancel that channel, because a
+    // disconnect deletes the tokens file first, so there is no token left to call
+    // Google with. Google kept pushing that user's calendar for the channel's
+    // whole TTL.
+    let release: () => void = () => {};
+    const gate = new Promise<void>((r) => { release = r; });
+    const { api, calls, scheduled } = fakeApi();
+    const m = new GoogleWatchManager({
+      ...api,
+      registerCalendar: async (t, input) => {
+        await gate;
+        return api.registerCalendar(t, input);
+      },
+      registerGmail: async (t, topic) => {
+        await gate;
+        return api.registerGmail(t, topic);
+      },
+    });
+    m.configure(fakeAuth(), allTargets);
+
+    const starting = m.start();
+    await Bun.sleep(0);
+    await m.stop();
+    release();
+    await starting;
+
+    // Whatever was registered was stopped again, and nothing is left armed.
+    expect(calls).toContain('registerCalendar:' + CHANNEL_TOKEN);
+    expect(calls).toContain('stopCalendar:chan-1');
+    expect(calls.filter((c) => c === 'stopGmail')).not.toHaveLength(0);
+    expect(scheduled).toHaveLength(0);
+  });
+
+  test('a stop/start race leaves exactly one live channel and one live timer', async () => {
+    // The daemon's google applier stops then starts the observers without
+    // awaiting the manager, so two arms can overlap. The older one used to assign
+    // its channel over the newer one's — orphaning a channel nothing holds a
+    // reference to, so Google fanned every change out to two channels for one
+    // instance — and to overwrite the newer one's timer field, leaving a live but
+    // unreachable timer re-arming forever.
+    let gate1: () => void = () => {};
+    const first = new Promise<void>((r) => { gate1 = r; });
+    let seen = 0;
+    const { api, calls, scheduled, stoppedChannels } = fakeApi();
+    const m = new GoogleWatchManager({
+      ...api,
+      registerCalendar: async (t, input) => {
+        seen += 1;
+        if (seen === 1) await first;
+        return api.registerCalendar(t, input);
+      },
+    });
+    m.configure(fakeAuth(), allTargets);
+
+    const firstStart = m.start();
+    await Bun.sleep(0);
+    await m.stop();
+    await m.start();
+    gate1();
+    await firstStart;
+
+    // Two registrations happened, and exactly one channel was stopped: the one
+    // belonging to the arm that lost. WHICH id that is depends on the order the
+    // two arms reached Google, which is not the point — the point is that no
+    // channel is left with nobody holding a reference to it.
+    expect(calls.filter((c) => c.startsWith('registerCalendar')).length).toBe(2);
+    expect(stoppedChannels).toHaveLength(1);
+    // One Gmail timer + one Calendar timer, from the surviving generation only.
+    expect(scheduled).toHaveLength(2);
+  });
+
   test('stop() cancels the renewals and tells Google to stop', async () => {
     const { api, calls, scheduled } = fakeApi();
     const m = new GoogleWatchManager(api);

--- a/src/integrations/google-watch-manager.ts
+++ b/src/integrations/google-watch-manager.ts
@@ -63,6 +63,23 @@ export class GoogleWatchManager {
   private calendarTimer: { cancel(): void } | null = null;
   private calendarChannel: CalendarChannel | null = null;
   private running = false;
+  /**
+   * Bumped by every stop(). An arm carries the generation it began in and does
+   * nothing once that generation is over.
+   *
+   * The awaits in an arm are long (a token fetch that may go to the control
+   * plane, then a registration bounded at 15s) and the daemon's own google
+   * applier does `stopService('observers')` then `startService('observers')`
+   * without awaiting the manager — so an arm from before the stop can resolve
+   * after a new one has already begun. Two things went wrong then: a Calendar
+   * channel got REGISTERED after the user disconnected (and no later stop could
+   * ever cancel it, because the tokens file was already gone, so Google kept
+   * pushing that user's calendar for the channel's whole TTL), and two arms
+   * writing one timer field left the displaced one live but unreachable, each
+   * re-arming forever. The shared single-flight refresh made this likelier, not
+   * less: both arms now await the SAME promise and resume together.
+   */
+  private generation = 0;
   private readonly api: WatchApi;
 
   constructor(api: Partial<WatchApi> = {}) {
@@ -88,11 +105,13 @@ export class GoogleWatchManager {
     if (this.running) return;
     if (!this.enabled) return;
     this.running = true;
-    await Promise.all([this.armGmail(), this.armCalendar()]);
+    const gen = this.generation;
+    await Promise.all([this.armGmail(gen), this.armCalendar(gen)]);
   }
 
   async stop(): Promise<void> {
     this.running = false;
+    this.generation += 1;
     this.gmailTimer?.cancel();
     this.calendarTimer?.cancel();
     this.gmailTimer = null;
@@ -112,6 +131,19 @@ export class GoogleWatchManager {
     }
   }
 
+  /**
+   * Has this arm been overtaken? Either the manager stopped, or a later start()
+   * began a new generation.
+   *
+   * A stale arm returns WITHOUT touching the timer fields: whoever made it stale
+   * already cancelled what was there (stop()) or will cancel-then-replace it (the
+   * new generation's own arm), so reaching in here could only kill a live timer
+   * that belongs to somebody else.
+   */
+  private stale(gen: number): boolean {
+    return !this.running || gen !== this.generation;
+  }
+
   private async accessToken(): Promise<string | null> {
     if (!this.auth?.isAuthenticated()) return null;
     try {
@@ -125,51 +157,70 @@ export class GoogleWatchManager {
     }
   }
 
-  private async armGmail(): Promise<void> {
-    if (!this.running || !this.targets.pubsubTopic) return;
+  /** Cancel this generation's renewal and schedule the next one. */
+  private rearmGmail(gen: number, delay: number): void {
+    if (this.stale(gen)) return;
+    this.gmailTimer?.cancel();
+    this.gmailTimer = this.api.schedule(() => void this.armGmail(gen), delay);
+  }
+
+  private rearmCalendar(gen: number, delay: number): void {
+    if (this.stale(gen)) return;
+    this.calendarTimer?.cancel();
+    this.calendarTimer = this.api.schedule(() => void this.armCalendar(gen), delay);
+  }
+
+  private async armGmail(gen: number): Promise<void> {
+    if (this.stale(gen) || !this.targets.pubsubTopic) return;
     // Armed BEFORE anything that can fail. "Re-arm even when this attempt
     // failed" only ever covered a failed registration: a token that could not
     // be fetched returned early and scheduled nothing, so push stayed off until
     // the next daemon restart. Under managed refresh that is no longer a rare
     // path — "the control plane was briefly unreachable" is an ordinary
     // transient, and it is likeliest at boot, which is exactly when this runs.
-    this.gmailTimer = this.api.schedule(() => void this.armGmail(), GMAIL_WATCH_RENEW_MS);
+    this.rearmGmail(gen, GMAIL_WATCH_RENEW_MS);
     const token = await this.accessToken();
-    if (!this.running) return this.gmailTimer?.cancel();
-    if (!token) return;
+    if (this.stale(gen) || !token) return;
     const result = await this.api.registerGmail(token, this.targets.pubsubTopic);
+    if (this.stale(gen)) {
+      // Stopped while this registration was in flight. We still hold a token —
+      // which stop() itself may not have had, since a disconnect deletes the
+      // tokens file first — so UNDO the watch we just created instead of leaving
+      // Google publishing at a bridge that will drop everything.
+      if (result) await this.api.stopGmail(token).catch(() => {});
+      return;
+    }
     // Replace the provisional timer with one derived from the real expiry.
-    this.gmailTimer?.cancel();
-    const delay = renewDelayMs(result?.expiration, Date.now(), GMAIL_WATCH_RENEW_MS);
-    this.gmailTimer = this.api.schedule(() => void this.armGmail(), delay);
+    this.rearmGmail(gen, renewDelayMs(result?.expiration, Date.now(), GMAIL_WATCH_RENEW_MS));
   }
 
-  private async armCalendar(): Promise<void> {
-    if (!this.running || !this.targets.pushCallback || !this.targets.channelToken) return;
+  private async armCalendar(gen: number): Promise<void> {
+    if (this.stale(gen) || !this.targets.pushCallback || !this.targets.channelToken) return;
     // Provisional re-arm before the fallible work — see armGmail.
-    this.calendarTimer = this.api.schedule(
-      () => void this.armCalendar(),
-      CALENDAR_WATCH_FALLBACK_MS,
-    );
+    this.rearmCalendar(gen, CALENDAR_WATCH_FALLBACK_MS);
     const token = await this.accessToken();
-    if (!this.running) return this.calendarTimer?.cancel();
-    if (!token) return;
+    if (this.stale(gen) || !token) return;
     // Each registration creates a NEW channel, so the old one has to go or Google
     // fans every change out to a growing pile of channels for one instance.
     if (this.calendarChannel) {
       await this.api.stopCalendar(token, this.calendarChannel);
       this.calendarChannel = null;
     }
-    this.calendarChannel = await this.api.registerCalendar(token, {
+    const channel = await this.api.registerCalendar(token, {
       callbackUrl: this.targets.pushCallback,
       channelToken: this.targets.channelToken,
     });
-    this.calendarTimer?.cancel();
-    const delay = renewDelayMs(
-      this.calendarChannel?.expiration,
-      Date.now(),
-      CALENDAR_WATCH_FALLBACK_MS,
+    if (this.stale(gen)) {
+      // See armGmail. Assigning `channel` here would also ORPHAN whatever the new
+      // generation had already registered, leaving a channel nothing holds a
+      // reference to and no stop() can ever cancel.
+      if (channel) await this.api.stopCalendar(token, channel).catch(() => {});
+      return;
+    }
+    this.calendarChannel = channel;
+    this.rearmCalendar(
+      gen,
+      renewDelayMs(channel?.expiration, Date.now(), CALENDAR_WATCH_FALLBACK_MS),
     );
-    this.calendarTimer = this.api.schedule(() => void this.armCalendar(), delay);
   }
 }

--- a/src/integrations/google-watch-manager.ts
+++ b/src/integrations/google-watch-manager.ts
@@ -1,0 +1,125 @@
+import type { GoogleAuth } from './google-auth.ts';
+import {
+  CALENDAR_WATCH_FALLBACK_MS,
+  GMAIL_WATCH_RENEW_MS,
+  registerCalendarWatch,
+  registerGmailWatch,
+  renewDelayMs,
+  stopCalendarWatch,
+  stopGmailWatch,
+  type CalendarChannel,
+  type WatchTargets,
+} from './google-watch.ts';
+
+/**
+ * Keeps the Google push watches armed for as long as the observers run
+ * (GOOGLE.md "Push bridging"). HOSTED ONLY — self-hosted has no bridge to notify.
+ *
+ * Owns two things and nothing else: registering each watch once auth is
+ * available, and re-arming it before it expires. It deliberately does NOT own
+ * what happens when a notification arrives (that is the webhook → observer
+ * syncNow path), so a broken watch degrades to polling instead of breaking
+ * observation.
+ *
+ * Every failure is soft and logged. There is no retry loop: the renewal timer IS
+ * the retry, and a tighter one would hammer Google while an instance is
+ * misconfigured — for a latency optimisation.
+ */
+export class GoogleWatchManager {
+  private auth: GoogleAuth | null = null;
+  private targets: WatchTargets = {};
+  private gmailTimer: ReturnType<typeof setTimeout> | null = null;
+  private calendarTimer: ReturnType<typeof setTimeout> | null = null;
+  private calendarChannel: CalendarChannel | null = null;
+  private running = false;
+
+  configure(auth: GoogleAuth | null, targets: WatchTargets): void {
+    this.auth = auth;
+    this.targets = targets;
+  }
+
+  /** True when there is anything to arm at all. */
+  get enabled(): boolean {
+    return Boolean(
+      this.auth?.isAuthenticated() &&
+        ((this.targets.pubsubTopic ?? null) !== null ||
+          ((this.targets.pushCallback ?? null) !== null &&
+            (this.targets.channelToken ?? null) !== null)),
+    );
+  }
+
+  async start(): Promise<void> {
+    if (this.running) return;
+    if (!this.enabled) return;
+    this.running = true;
+    await Promise.all([this.armGmail(), this.armCalendar()]);
+  }
+
+  async stop(): Promise<void> {
+    this.running = false;
+    if (this.gmailTimer) clearTimeout(this.gmailTimer);
+    if (this.calendarTimer) clearTimeout(this.calendarTimer);
+    this.gmailTimer = null;
+    this.calendarTimer = null;
+    // Tell Google to stop pushing. Not strictly required — the watches expire,
+    // and the bridge drops anything it cannot route — but leaving them armed
+    // means Google keeps publishing for a disconnected account for up to a week.
+    const token = await this.accessToken();
+    if (!token) return;
+    if (this.targets.pubsubTopic) await stopGmailWatch(token);
+    if (this.calendarChannel) {
+      await stopCalendarWatch(token, this.calendarChannel);
+      this.calendarChannel = null;
+    }
+  }
+
+  private async accessToken(): Promise<string | null> {
+    if (!this.auth?.isAuthenticated()) return null;
+    try {
+      return await this.auth.getAccessToken();
+    } catch (err) {
+      console.warn(
+        '[google-watch] could not get an access token:',
+        err instanceof Error ? err.message : err,
+      );
+      return null;
+    }
+  }
+
+  private async armGmail(): Promise<void> {
+    if (!this.running || !this.targets.pubsubTopic) return;
+    const token = await this.accessToken();
+    if (!token) return;
+    const result = await registerGmailWatch(token, this.targets.pubsubTopic);
+    // Re-arm even when this attempt failed: the timer is the retry, and a
+    // transient refusal must not disable push until the next daemon restart.
+    const delay = renewDelayMs(result?.expiration, Date.now(), GMAIL_WATCH_RENEW_MS);
+    this.gmailTimer = setTimeout(() => void this.armGmail(), delay);
+    // Node/Bun keep the process alive for pending timers; a renewal must never
+    // be the reason a daemon will not exit.
+    this.gmailTimer.unref?.();
+  }
+
+  private async armCalendar(): Promise<void> {
+    if (!this.running || !this.targets.pushCallback || !this.targets.channelToken) return;
+    const token = await this.accessToken();
+    if (!token) return;
+    // Each registration creates a NEW channel, so the old one has to go or Google
+    // fans every change out to a growing pile of channels for one instance.
+    if (this.calendarChannel) {
+      await stopCalendarWatch(token, this.calendarChannel);
+      this.calendarChannel = null;
+    }
+    this.calendarChannel = await registerCalendarWatch(token, {
+      callbackUrl: this.targets.pushCallback,
+      channelToken: this.targets.channelToken,
+    });
+    const delay = renewDelayMs(
+      this.calendarChannel?.expiration,
+      Date.now(),
+      CALENDAR_WATCH_FALLBACK_MS,
+    );
+    this.calendarTimer = setTimeout(() => void this.armCalendar(), delay);
+    this.calendarTimer.unref?.();
+  }
+}

--- a/src/integrations/google-watch-manager.ts
+++ b/src/integrations/google-watch-manager.ts
@@ -61,9 +61,12 @@ export class GoogleWatchManager {
     if (this.calendarTimer) clearTimeout(this.calendarTimer);
     this.gmailTimer = null;
     this.calendarTimer = null;
-    // Tell Google to stop pushing. Not strictly required — the watches expire,
-    // and the bridge drops anything it cannot route — but leaving them armed
-    // means Google keeps publishing for a disconnected account for up to a week.
+    // Try to tell Google to stop pushing. Best effort, and often IMPOSSIBLE by
+    // design: on a disconnect the tokens file is deleted before this runs, so
+    // there is no access token left to call with and Google keeps publishing
+    // until the watch expires (up to a week for Gmail). The bridge dropping
+    // notifications it cannot route is the actual backstop — this only shortens
+    // the window when a token still happens to be available.
     const token = await this.accessToken();
     if (!token) return;
     if (this.targets.pubsubTopic) await stopGmailWatch(token);

--- a/src/integrations/google-watch-manager.ts
+++ b/src/integrations/google-watch-manager.ts
@@ -25,13 +25,49 @@ import {
  * the retry, and a tighter one would hammer Google while an instance is
  * misconfigured — for a latency optimisation.
  */
+/**
+ * The Google-facing calls and the scheduler, injectable.
+ *
+ * Not for purity's sake: the two behaviours worth pinning here are "a Calendar
+ * re-registration stops the previous channel first" and "a failed attempt still
+ * re-arms", and both are only observable through these. Without the seams the
+ * only way to exercise them would be to wait hours for a real timer.
+ */
+export interface WatchApi {
+  registerGmail: typeof registerGmailWatch;
+  stopGmail: typeof stopGmailWatch;
+  registerCalendar: typeof registerCalendarWatch;
+  stopCalendar: typeof stopCalendarWatch;
+  /** Defaults to setTimeout; a test captures the callback and fires it itself. */
+  schedule: (fn: () => void, ms: number) => { cancel(): void };
+}
+
+const defaultApi: WatchApi = {
+  registerGmail: registerGmailWatch,
+  stopGmail: stopGmailWatch,
+  registerCalendar: registerCalendarWatch,
+  stopCalendar: stopCalendarWatch,
+  schedule: (fn, ms) => {
+    const t = setTimeout(fn, ms);
+    // Node/Bun keep the process alive for pending timers; a renewal must never
+    // be the reason a daemon will not exit.
+    t.unref?.();
+    return { cancel: () => clearTimeout(t) };
+  },
+};
+
 export class GoogleWatchManager {
   private auth: GoogleAuth | null = null;
   private targets: WatchTargets = {};
-  private gmailTimer: ReturnType<typeof setTimeout> | null = null;
-  private calendarTimer: ReturnType<typeof setTimeout> | null = null;
+  private gmailTimer: { cancel(): void } | null = null;
+  private calendarTimer: { cancel(): void } | null = null;
   private calendarChannel: CalendarChannel | null = null;
   private running = false;
+  private readonly api: WatchApi;
+
+  constructor(api: Partial<WatchApi> = {}) {
+    this.api = { ...defaultApi, ...api };
+  }
 
   configure(auth: GoogleAuth | null, targets: WatchTargets): void {
     this.auth = auth;
@@ -57,8 +93,8 @@ export class GoogleWatchManager {
 
   async stop(): Promise<void> {
     this.running = false;
-    if (this.gmailTimer) clearTimeout(this.gmailTimer);
-    if (this.calendarTimer) clearTimeout(this.calendarTimer);
+    this.gmailTimer?.cancel();
+    this.calendarTimer?.cancel();
     this.gmailTimer = null;
     this.calendarTimer = null;
     // Try to tell Google to stop pushing. Best effort, and often IMPOSSIBLE by
@@ -69,9 +105,9 @@ export class GoogleWatchManager {
     // the window when a token still happens to be available.
     const token = await this.accessToken();
     if (!token) return;
-    if (this.targets.pubsubTopic) await stopGmailWatch(token);
+    if (this.targets.pubsubTopic) await this.api.stopGmail(token);
     if (this.calendarChannel) {
-      await stopCalendarWatch(token, this.calendarChannel);
+      await this.api.stopCalendar(token, this.calendarChannel);
       this.calendarChannel = null;
     }
   }
@@ -93,14 +129,11 @@ export class GoogleWatchManager {
     if (!this.running || !this.targets.pubsubTopic) return;
     const token = await this.accessToken();
     if (!token) return;
-    const result = await registerGmailWatch(token, this.targets.pubsubTopic);
+    const result = await this.api.registerGmail(token, this.targets.pubsubTopic);
     // Re-arm even when this attempt failed: the timer is the retry, and a
     // transient refusal must not disable push until the next daemon restart.
     const delay = renewDelayMs(result?.expiration, Date.now(), GMAIL_WATCH_RENEW_MS);
-    this.gmailTimer = setTimeout(() => void this.armGmail(), delay);
-    // Node/Bun keep the process alive for pending timers; a renewal must never
-    // be the reason a daemon will not exit.
-    this.gmailTimer.unref?.();
+    this.gmailTimer = this.api.schedule(() => void this.armGmail(), delay);
   }
 
   private async armCalendar(): Promise<void> {
@@ -110,10 +143,10 @@ export class GoogleWatchManager {
     // Each registration creates a NEW channel, so the old one has to go or Google
     // fans every change out to a growing pile of channels for one instance.
     if (this.calendarChannel) {
-      await stopCalendarWatch(token, this.calendarChannel);
+      await this.api.stopCalendar(token, this.calendarChannel);
       this.calendarChannel = null;
     }
-    this.calendarChannel = await registerCalendarWatch(token, {
+    this.calendarChannel = await this.api.registerCalendar(token, {
       callbackUrl: this.targets.pushCallback,
       channelToken: this.targets.channelToken,
     });
@@ -122,7 +155,6 @@ export class GoogleWatchManager {
       Date.now(),
       CALENDAR_WATCH_FALLBACK_MS,
     );
-    this.calendarTimer = setTimeout(() => void this.armCalendar(), delay);
-    this.calendarTimer.unref?.();
+    this.calendarTimer = this.api.schedule(() => void this.armCalendar(), delay);
   }
 }

--- a/src/integrations/google-watch-manager.ts
+++ b/src/integrations/google-watch-manager.ts
@@ -127,18 +127,32 @@ export class GoogleWatchManager {
 
   private async armGmail(): Promise<void> {
     if (!this.running || !this.targets.pubsubTopic) return;
+    // Armed BEFORE anything that can fail. "Re-arm even when this attempt
+    // failed" only ever covered a failed registration: a token that could not
+    // be fetched returned early and scheduled nothing, so push stayed off until
+    // the next daemon restart. Under managed refresh that is no longer a rare
+    // path — "the control plane was briefly unreachable" is an ordinary
+    // transient, and it is likeliest at boot, which is exactly when this runs.
+    this.gmailTimer = this.api.schedule(() => void this.armGmail(), GMAIL_WATCH_RENEW_MS);
     const token = await this.accessToken();
+    if (!this.running) return this.gmailTimer?.cancel();
     if (!token) return;
     const result = await this.api.registerGmail(token, this.targets.pubsubTopic);
-    // Re-arm even when this attempt failed: the timer is the retry, and a
-    // transient refusal must not disable push until the next daemon restart.
+    // Replace the provisional timer with one derived from the real expiry.
+    this.gmailTimer?.cancel();
     const delay = renewDelayMs(result?.expiration, Date.now(), GMAIL_WATCH_RENEW_MS);
     this.gmailTimer = this.api.schedule(() => void this.armGmail(), delay);
   }
 
   private async armCalendar(): Promise<void> {
     if (!this.running || !this.targets.pushCallback || !this.targets.channelToken) return;
+    // Provisional re-arm before the fallible work — see armGmail.
+    this.calendarTimer = this.api.schedule(
+      () => void this.armCalendar(),
+      CALENDAR_WATCH_FALLBACK_MS,
+    );
     const token = await this.accessToken();
+    if (!this.running) return this.calendarTimer?.cancel();
     if (!token) return;
     // Each registration creates a NEW channel, so the old one has to go or Google
     // fans every change out to a growing pile of channels for one instance.
@@ -150,6 +164,7 @@ export class GoogleWatchManager {
       callbackUrl: this.targets.pushCallback,
       channelToken: this.targets.channelToken,
     });
+    this.calendarTimer?.cancel();
     const delay = renewDelayMs(
       this.calendarChannel?.expiration,
       Date.now(),

--- a/src/integrations/google-watch.test.ts
+++ b/src/integrations/google-watch.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  CALENDAR_WATCH_FALLBACK_MS,
+  GMAIL_WATCH_RENEW_MS,
+  RENEW_MARGIN_MS,
+  renewDelayMs,
+} from './google-watch.ts';
+
+/**
+ * Renewal arithmetic for the Google push watches (GOOGLE.md "Push bridging").
+ *
+ * Worth its own tests because every mistake here is invisible: a delay that is
+ * too long leaves a gap where Google has stopped pushing and nobody notices
+ * (polling still works, so nothing looks broken), and a delay of zero or less
+ * turns the renewal into a spin against Google's API.
+ */
+describe('renewDelayMs', () => {
+  const now = 1_760_000_000_000;
+
+  test('no stated expiry falls back to the caller default', () => {
+    expect(renewDelayMs(undefined, now, GMAIL_WATCH_RENEW_MS)).toBe(GMAIL_WATCH_RENEW_MS);
+    // Google returns expiration as a string; a non-numeric one must not become
+    // NaN and schedule a timer that never fires.
+    expect(renewDelayMs(Number.NaN, now, CALENDAR_WATCH_FALLBACK_MS)).toBe(
+      CALENDAR_WATCH_FALLBACK_MS,
+    );
+  });
+
+  test('renews a margin BEFORE the stated expiry', () => {
+    // Expires in 6 hours -> renew in 5, so a slow renewal is not a gap in
+    // coverage.
+    const sixHours = 6 * 60 * 60 * 1000;
+    expect(renewDelayMs(now + sixHours, now, CALENDAR_WATCH_FALLBACK_MS)).toBe(
+      sixHours - RENEW_MARGIN_MS,
+    );
+  });
+
+  test('an expiry already past, or inside the margin, still waits a full minute', () => {
+    // A zero or negative delay would spin: setTimeout fires immediately, the
+    // renewal fails or returns the same expiry, and it fires again.
+    expect(renewDelayMs(now - 1000, now, CALENDAR_WATCH_FALLBACK_MS)).toBe(60_000);
+    expect(renewDelayMs(now + 1000, now, CALENDAR_WATCH_FALLBACK_MS)).toBe(60_000);
+    expect(renewDelayMs(now + RENEW_MARGIN_MS, now, CALENDAR_WATCH_FALLBACK_MS)).toBe(60_000);
+  });
+
+  test('a far-future expiry is capped at the fallback interval', () => {
+    // Gmail's watch lasts 7 days but Google asks for a DAILY re-arm; honouring
+    // the stated expiry literally would re-arm weekly and race it.
+    const sevenDays = 7 * 24 * 60 * 60 * 1000;
+    expect(renewDelayMs(now + sevenDays, now, GMAIL_WATCH_RENEW_MS)).toBe(GMAIL_WATCH_RENEW_MS);
+  });
+});

--- a/src/integrations/google-watch.ts
+++ b/src/integrations/google-watch.ts
@@ -1,0 +1,176 @@
+/**
+ * Google push watches (GOOGLE.md "Push bridging"). HOSTED ONLY.
+ *
+ * The BRAIN registers these, not the control plane, and that is the whole point:
+ * registering a watch requires the user's access token, and the control plane
+ * deliberately does not have one (deliver-and-forget, D22). So the instance —
+ * which does — asks Google to notify the bridge, and the bridge relays the
+ * doorbell back. The token never leaves the instance.
+ *
+ * Both watches EXPIRE and must be renewed:
+ *  - Gmail's `users.watch` lasts 7 days and Google explicitly expects a daily
+ *    re-arm, so a weekly timer would be racing the expiry rather than beating it.
+ *  - a Calendar channel's TTL is whatever Google returns in `expiration`.
+ *
+ * Everything here fails SOFT. A watch that cannot be registered means push does
+ * not work for this instance, which costs latency only: the observers keep
+ * polling on their own timers regardless. Nothing in this file should ever be
+ * able to stop an instance from observing.
+ */
+
+import { randomUUID } from 'node:crypto';
+
+const GMAIL_BASE = 'https://gmail.googleapis.com/gmail/v1/users/me';
+const CALENDAR_BASE = 'https://www.googleapis.com/calendar/v3/calendars';
+
+/** Re-arm Gmail daily — the watch lasts 7 days, but Google asks for daily. */
+export const GMAIL_WATCH_RENEW_MS = 24 * 60 * 60 * 1000;
+/** Fall back to this when Google returns no usable Calendar expiry. */
+export const CALENDAR_WATCH_FALLBACK_MS = 24 * 60 * 60 * 1000;
+/** Renew this far BEFORE the stated expiry, so a slow renewal is not a gap. */
+export const RENEW_MARGIN_MS = 60 * 60 * 1000;
+
+export interface WatchTargets {
+  /** Gmail's Pub/Sub topic; absent = no Gmail push. */
+  pubsubTopic?: string | undefined;
+  /** The bridge's callback URL; absent = no Calendar push. */
+  pushCallback?: string | undefined;
+  /**
+   * Self-describing token the bridge maps back to this instance
+   * (`<instanceId>.<mac>`). Google echoes it in X-Goog-Channel-Token, which is
+   * what lets the bridge route with no channel table of its own.
+   */
+  channelToken?: string | undefined;
+}
+
+/**
+ * Ask Gmail to publish this account's changes to the topic. Idempotent: calling
+ * it again extends the existing watch rather than creating a second one.
+ */
+export async function registerGmailWatch(
+  accessToken: string,
+  topicName: string,
+): Promise<{ historyId?: string; expiration?: number } | null> {
+  try {
+    const resp = await fetch(`${GMAIL_BASE}/watch`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'Content-Type': 'application/json',
+      },
+      // INBOX only: the doorbell exists for incoming mail, and every label
+      // change in the mailbox would otherwise ring it.
+      body: JSON.stringify({ topicName, labelIds: ['INBOX'], labelFilterBehavior: 'INCLUDE' }),
+    });
+    if (!resp.ok) {
+      const detail = await resp.text().catch(() => '');
+      // The overwhelmingly likely cause is the topic's IAM: Gmail publishes as
+      // gmail-api-push@system.gserviceaccount.com and needs Publisher on it.
+      // Saying so here saves an hour of looking at the wrong thing.
+      console.warn(
+        `[google-watch] Gmail watch refused (${resp.status}): ${detail.slice(0, 200)} — ` +
+          'check that gmail-api-push@system.gserviceaccount.com has Pub/Sub Publisher on the topic',
+      );
+      return null;
+    }
+    const body = (await resp.json()) as { historyId?: string; expiration?: string };
+    return {
+      historyId: body.historyId,
+      expiration: body.expiration ? Number(body.expiration) : undefined,
+    };
+  } catch (err) {
+    console.warn('[google-watch] Gmail watch failed:', err instanceof Error ? err.message : err);
+    return null;
+  }
+}
+
+export async function stopGmailWatch(accessToken: string): Promise<void> {
+  try {
+    await fetch(`${GMAIL_BASE}/stop`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+  } catch {
+    // Best effort. An abandoned watch expires by itself in 7 days, and the
+    // bridge drops notifications it cannot route.
+  }
+}
+
+export interface CalendarChannel {
+  id: string;
+  resourceId: string;
+  expiration?: number;
+}
+
+/**
+ * Ask Calendar to POST the bridge when this calendar changes.
+ *
+ * Unlike Gmail this is NOT idempotent — each call creates a new channel — so the
+ * caller must stop the previous one, or Google ends up fanning every change out
+ * to a growing pile of channels that all resolve to the same instance.
+ */
+export async function registerCalendarWatch(
+  accessToken: string,
+  input: { calendarId?: string; callbackUrl: string; channelToken: string },
+): Promise<CalendarChannel | null> {
+  const calendarId = encodeURIComponent(input.calendarId ?? 'primary');
+  try {
+    const resp = await fetch(`${CALENDAR_BASE}/${calendarId}/events/watch`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        id: randomUUID(),
+        type: 'web_hook',
+        address: input.callbackUrl,
+        token: input.channelToken,
+      }),
+    });
+    if (!resp.ok) {
+      const detail = await resp.text().catch(() => '');
+      console.warn(
+        `[google-watch] Calendar watch refused (${resp.status}): ${detail.slice(0, 200)}`,
+      );
+      return null;
+    }
+    const body = (await resp.json()) as { id?: string; resourceId?: string; expiration?: string };
+    if (!body.id || !body.resourceId) return null;
+    return {
+      id: body.id,
+      resourceId: body.resourceId,
+      expiration: body.expiration ? Number(body.expiration) : undefined,
+    };
+  } catch (err) {
+    console.warn('[google-watch] Calendar watch failed:', err instanceof Error ? err.message : err);
+    return null;
+  }
+}
+
+export async function stopCalendarWatch(
+  accessToken: string,
+  channel: CalendarChannel,
+): Promise<void> {
+  try {
+    await fetch('https://www.googleapis.com/calendar/v3/channels/stop', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ id: channel.id, resourceId: channel.resourceId }),
+    });
+  } catch {
+    // Best effort; the channel expires on its own.
+  }
+}
+
+/** When to renew, given whatever expiry Google stated. */
+export function renewDelayMs(expiration: number | undefined, now: number, fallbackMs: number): number {
+  if (!expiration || !Number.isFinite(expiration)) return fallbackMs;
+  const untilExpiry = expiration - now;
+  // Renew a margin early so a slow renewal is not a gap in coverage; never
+  // schedule zero or negative, which would spin.
+  return Math.max(60_000, Math.min(fallbackMs, untilExpiry - RENEW_MARGIN_MS));
+}

--- a/src/integrations/google-watch.ts
+++ b/src/integrations/google-watch.ts
@@ -20,6 +20,19 @@
 
 import { randomUUID } from 'node:crypto';
 
+/**
+ * Every call here is bounded, and the stop calls especially.
+ *
+ * They are awaited from ObserverService.stop(), which the settings-reload
+ * coordinator awaits on its SINGLE-FLIGHT queue — so one hanging request to
+ * Google would wedge not just this shutdown but every subsequent settings
+ * apply. An unbounded fetch on a shutdown path is a daemon that will not
+ * shut down.
+ */
+const REGISTER_TIMEOUT_MS = 15_000;
+/** Shorter: best-effort, and nothing downstream depends on the answer. */
+const STOP_TIMEOUT_MS = 5_000;
+
 const GMAIL_BASE = 'https://gmail.googleapis.com/gmail/v1/users/me';
 const CALENDAR_BASE = 'https://www.googleapis.com/calendar/v3/calendars';
 
@@ -61,6 +74,7 @@ export async function registerGmailWatch(
       // INBOX only: the doorbell exists for incoming mail, and every label
       // change in the mailbox would otherwise ring it.
       body: JSON.stringify({ topicName, labelIds: ['INBOX'], labelFilterBehavior: 'INCLUDE' }),
+      signal: AbortSignal.timeout(REGISTER_TIMEOUT_MS),
     });
     if (!resp.ok) {
       const detail = await resp.text().catch(() => '');
@@ -89,6 +103,7 @@ export async function stopGmailWatch(accessToken: string): Promise<void> {
     await fetch(`${GMAIL_BASE}/stop`, {
       method: 'POST',
       headers: { Authorization: `Bearer ${accessToken}` },
+      signal: AbortSignal.timeout(STOP_TIMEOUT_MS),
     });
   } catch {
     // Best effort. An abandoned watch expires by itself in 7 days, and the
@@ -127,6 +142,7 @@ export async function registerCalendarWatch(
         address: input.callbackUrl,
         token: input.channelToken,
       }),
+      signal: AbortSignal.timeout(REGISTER_TIMEOUT_MS),
     });
     if (!resp.ok) {
       const detail = await resp.text().catch(() => '');
@@ -160,6 +176,7 @@ export async function stopCalendarWatch(
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({ id: channel.id, resourceId: channel.resourceId }),
+      signal: AbortSignal.timeout(STOP_TIMEOUT_MS),
     });
   } catch {
     // Best effort; the channel expires on its own.

--- a/src/observers/calendar.ts
+++ b/src/observers/calendar.ts
@@ -64,6 +64,15 @@ export class CalendarSync implements Observer {
     this.handler = handler;
   }
 
+  /**
+   * Poll immediately (the push bridge's doorbell). No-op while stopped, so a
+   * notification that races a disconnect cannot resurrect a dead observer.
+   */
+  async syncNow(): Promise<void> {
+    if (!this.running) return;
+    await this.poll();
+  }
+
   private async poll(): Promise<void> {
     if (!this.googleAuth || !this.handler) return;
 

--- a/src/observers/email.ts
+++ b/src/observers/email.ts
@@ -62,6 +62,15 @@ export class EmailSync implements Observer {
     this.handler = handler;
   }
 
+  /**
+   * Poll immediately (the push bridge's doorbell). No-op while stopped, so a
+   * notification that races a disconnect cannot resurrect a dead observer.
+   */
+  async syncNow(): Promise<void> {
+    if (!this.running) return;
+    await this.poll();
+  }
+
   private async poll(): Promise<void> {
     if (!this.googleAuth || !this.handler) return;
 

--- a/src/observers/index.ts
+++ b/src/observers/index.ts
@@ -19,6 +19,16 @@ export interface Observer {
   stop(): Promise<void>;
   isRunning(): boolean;
   onEvent(handler: ObserverEventHandler): void;
+  /**
+   * Poll RIGHT NOW, out of band, and resolve when done.
+   *
+   * Optional because only the observers behind a push feed have anything to
+   * answer here. It is deliberately the same poll the timer runs rather than a
+   * separate incremental path: the notification that triggers it is a doorbell
+   * carrying no data, the observers already de-duplicate what they have seen,
+   * and one code path means push and polling cannot drift in behaviour.
+   */
+  syncNow?(): Promise<void>;
 }
 
 // Account-level integration observers. Host-sensing observers (file watcher,
@@ -46,6 +56,11 @@ export class ObserverManager {
     }
 
     console.log(`[ObserverManager] Registered observer: ${observer.name}`);
+  }
+
+  /** One registered observer by name, if present. */
+  get(name: string): Observer | undefined {
+    return this.observers.get(name);
   }
 
   /**

--- a/ui/src/v2/onboarding/OnboardingWizard.tsx
+++ b/ui/src/v2/onboarding/OnboardingWizard.tsx
@@ -448,6 +448,36 @@ export function OnboardingWizard({
     setConnectErr(null);
     setGoogleState("pending");
     try {
+      // HOSTED (managed) instances connect through the control plane, never here:
+      // this daemon's OAuth redirect URI is its own hostname, which is not
+      // registered with Google and cannot be. Send the user to their account
+      // page instead. The poll below still finishes the job, because completing
+      // it there DELIVERS the tokens to this instance, which is exactly what the
+      // poll watches for.
+      const managed = await fetch("/api/auth/google/status")
+        .then((res) => res.json() as Promise<{ managed?: boolean; connect_url?: string }>)
+        .catch(() => ({}) as { managed?: boolean; connect_url?: string });
+      if (managed.managed && managed.connect_url) {
+        const acct = window.open(managed.connect_url, "_blank", "noopener,noreferrer");
+        if (!acct) {
+          setGoogleState("idle");
+          setConnectErr(`Open ${managed.connect_url} to connect Google, then come back here.`);
+          return;
+        }
+        stopGooglePoll();
+        googlePollRef.current = window.setInterval(async () => {
+          try {
+            const s = await fetch("/api/auth/google/status");
+            const d = (await s.json()) as { status?: string; is_authenticated?: boolean };
+            if (d.is_authenticated || d.status === "connected") {
+              stopGooglePoll();
+              setGoogleState("connected");
+              setConnected((c) => new Set(c).add("google").add("gmail"));
+            }
+          } catch { /* ignore */ }
+        }, 2000);
+        return;
+      }
       const r = await fetch("/api/auth/google/init", { method: "POST" });
       const d = (await r.json().catch(() => ({}))) as { auth_url?: string; error?: string };
       if (!r.ok || !d.auth_url) {

--- a/ui/src/v2/rooms/settings/tabs/IntegrationsTab.tsx
+++ b/ui/src/v2/rooms/settings/tabs/IntegrationsTab.tsx
@@ -140,7 +140,7 @@ export function IntegrationsTab({
                 "v2-set__chip " +
                 (g.status === "connected"
                   ? "v2-set__chip--ok"
-                  : g.status === "credentials_saved"
+                  : g.status === "credentials_saved" || g.status === "reconnect_required"
                     ? "v2-set__chip--warn"
                     : "")
               }
@@ -181,8 +181,10 @@ export function IntegrationsTab({
             ) : (
               <>
                 <p className="v2-set__hint">
-                  Connect your Google account to let Jarvis read your Gmail and Calendar. Nothing is
-                  sent or changed — access is read-only, and you can disconnect at any time.
+                  {g.status === "reconnect_required"
+                    ? (g.reconnect_reason ??
+                      "Google access is no longer valid — connect your account again.")
+                    : "Connect your Google account to let Jarvis read your Gmail and Calendar. Nothing is sent or changed — access is read-only, and you can disconnect at any time."}
                 </p>
                 <div style={{ display: "flex", justifyContent: "flex-end" }}>
                   <a

--- a/ui/src/v2/rooms/settings/tabs/IntegrationsTab.tsx
+++ b/ui/src/v2/rooms/settings/tabs/IntegrationsTab.tsx
@@ -129,7 +129,9 @@ export function IntegrationsTab({
           <div>
             <h3 className="v2-set__section-title">Google</h3>
             <div className="v2-set__section-sub">
-              Connect Gmail and Google Calendar (read-only). Restart-required after connect/disconnect.
+              {g?.managed
+                ? "Connect Gmail and Google Calendar (read-only), managed by usejarvis."
+                : "Connect Gmail and Google Calendar (read-only). Restart-required after connect/disconnect."}
             </div>
           </div>
           {g && (
@@ -150,6 +152,51 @@ export function IntegrationsTab({
 
         {!g ? (
           <div className="v2-set__empty">Loading Google status…</div>
+        ) : g.managed ? (
+          /* HOSTED. The credentials form and this daemon's own OAuth flow do not
+             belong here: the account is connected through the control plane,
+             which owns the one redirect URI Google knows about. Connecting needs
+             a signed-in session this UI does not have (it authenticates to the
+             daemon with a device token, not the account), so the button hands
+             off to the account page — which then opens the system browser,
+             because Google refuses OAuth inside an embedded webview. */
+          <>
+            {g.is_authenticated ? (
+              <>
+                <p className="v2-set__hint">
+                  Gmail and Google Calendar are connected, read-only. Jarvis never sends mail or
+                  edits events.
+                </p>
+                <div style={{ display: "flex", justifyContent: "flex-end" }}>
+                  <a
+                    className="v2-set__btn"
+                    href={g.connect_url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Manage in your account
+                  </a>
+                </div>
+              </>
+            ) : (
+              <>
+                <p className="v2-set__hint">
+                  Connect your Google account to let Jarvis read your Gmail and Calendar. Nothing is
+                  sent or changed — access is read-only, and you can disconnect at any time.
+                </p>
+                <div style={{ display: "flex", justifyContent: "flex-end" }}>
+                  <a
+                    className="v2-set__btn v2-set__btn--primary"
+                    href={g.connect_url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Connect Google account
+                  </a>
+                </div>
+              </>
+            )}
+          </>
         ) : g.status === "not_configured" && phase !== "saving" ? (
           <>
             <p className="v2-set__hint">

--- a/ui/src/v2/rooms/settings/useSettingsData.ts
+++ b/ui/src/v2/rooms/settings/useSettingsData.ts
@@ -286,7 +286,12 @@ export interface GoogleStatus {
     | "not_connected"
     /** The grant is gone (revoked, or expired). Tokens may still be on disk. */
     | "reconnect_required";
-  has_credentials: boolean;
+  /**
+   * Google is usable on this instance. NOT "credentials are present": a managed
+   * instance has none by design — the control plane holds them — so the old name
+   * was false for exactly the mode it most had to describe.
+   */
+  configured: boolean;
   is_authenticated: boolean;
   scopes: string[];
   token_expiry: number | null;

--- a/ui/src/v2/rooms/settings/useSettingsData.ts
+++ b/ui/src/v2/rooms/settings/useSettingsData.ts
@@ -279,11 +279,20 @@ export interface RoleInfo {
 }
 
 export interface GoogleStatus {
-  status: "not_configured" | "credentials_saved" | "connected";
+  status: "not_configured" | "credentials_saved" | "connected" | "not_connected";
   has_credentials: boolean;
   is_authenticated: boolean;
   scopes: string[];
   token_expiry: number | null;
+  /**
+   * Control-plane MANAGED (hosted). The credentials came from the system config
+   * and the account is connected through the control plane, so this daemon's own
+   * OAuth flow does not apply — its redirect URI is this instance's hostname,
+   * which is not registered with Google.
+   */
+  managed?: boolean;
+  /** Where the user connects, when managed. */
+  connect_url?: string;
 }
 
 export interface SidecarInfo {

--- a/ui/src/v2/rooms/settings/useSettingsData.ts
+++ b/ui/src/v2/rooms/settings/useSettingsData.ts
@@ -279,7 +279,13 @@ export interface RoleInfo {
 }
 
 export interface GoogleStatus {
-  status: "not_configured" | "credentials_saved" | "connected" | "not_connected";
+  status:
+    | "not_configured"
+    | "credentials_saved"
+    | "connected"
+    | "not_connected"
+    /** The grant is gone (revoked, or expired). Tokens may still be on disk. */
+    | "reconnect_required";
   has_credentials: boolean;
   is_authenticated: boolean;
   scopes: string[];
@@ -291,6 +297,8 @@ export interface GoogleStatus {
    * which is not registered with Google.
    */
   managed?: boolean;
+  /** Why a reconnect is needed, when `status` is "reconnect_required". */
+  reconnect_reason?: string;
   /** Where the user connects, when managed. */
   connect_url?: string;
 }


### PR DESCRIPTION
Makes the Google integration work when the instance is centrally managed, instead of only when the operator brings their own OAuth app.

## What changes

**The Integrations tab becomes the managed one.** When the system config carries `connect_url`, the credentials form is replaced by a Connect button that hands off to the account page, and the daemon's own OAuth flow is refused at the API — not merely hidden — because its redirect URI is the instance's own hostname, which is not registered with Google. `POST /api/config/google` refuses too: it replaces the whole `google` section, so one call from a stale tab used to drop the managed wiring and silently revert the instance. The onboarding wizard follows the same rule, since first run is where this matters most.

**Refresh happens remotely, and the instance holds no client credentials.** Google's refresh grant needs the client secret, and this daemon runs as the tenant's own Linux user — so a secret it could use is a secret they could read. A managed config carries `refresh_url` + `instance_id` + `refresh_secret` instead: the instance keeps its refresh token and asks for the exchange, HMAC-signed with its own per-instance key. Neither side holds both halves. `GoogleAuth` gains an optional `refreshVia` delegate; the self-hosted path is untouched and still talks to Google directly.

- Refreshes are **single-flight**. Six callers cross the 5-minute expiry buffer together at boot, and remotely they meet a minimum-interval limiter, so all but one got a 429 they reported as a failed sync.
- A refresh in flight is **bound to the token it started with**. Reading the token cache again after the await could re-create a tokens file a disconnect had just deleted, or pair a freshly delivered grant with an access token minted from the old one.
- A gone grant (revoked, or expired — Google revokes Gmail-scoped tokens on a password change) raises a distinct error and is **persisted**, so status reports `reconnect_required` and offers Connect instead of a green chip over a dead integration. It covers self-hosted `invalid_grant` as well, and survives a restart. An unreachable peer stays transient and is retried.
- A partial managed block **disables Google and says why** rather than falling back to any credentials beside it.

**Push bridging.** The instance registers and renews the Gmail (Pub/Sub) and Calendar watches — it holds the token, so only it can — and answers a signed `/api/webhooks/google/notify` doorbell with an immediate sync. Polling remains the fallback, so a lost notification costs latency and never data.

- A Calendar re-registration stops the previous channel, or Google fans every change out to a growing pile of channels for one instance.
- The arms re-arm before the fallible work: a token that could not be fetched used to schedule nothing, leaving push off until the next daemon restart.
- The arms carry a generation, so a stop during an in-flight registration undoes the watch it just created. Nothing else could — a disconnect deletes the tokens file first, so there is no token left to call Google with, and Google would keep pushing for the channel's full TTL.
- The doorbell's signature comparison was byte-length-blind: `String.length` counts UTF-16 units, so a 64-character non-ASCII signature passed the gate and made `timingSafeEqual` throw — an unauthenticated 401 became a 500 with a stack trace, on a deliberately public route.

**Settings reload.** A `google` section provided by the file wins over any stored row, and the tokens fingerprint is re-baselined on every apply, so credentials written from outside the daemon are noticed and a disconnect is not undone by the next reload.

## Notes

- Nothing here changes the self-hosted product: with no managed fields present, every path behaves as before, and that is covered by tests alongside each change.
- The two per-instance HMAC keys are separate derivations on purpose. While one key served both directions, the same signature was valid at either endpoint — safe only because the two body shapes happen to be disjoint, which is an accident rather than a guarantee.
- Verified with the full suite plus `build:ui`, and by parsing a real rendered config end to end. The remaining verification is a live run against Google.
