### PR TITLE
feat(config): usejarvis_ai system-owned config block

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -20,6 +20,16 @@ daemon:
 # the server clock is not your local time (e.g. a UTC-hosted VPS).
 # timezone: "Europe/Rome"
 
+# HOSTED INSTALLS ONLY — written by the hosting provisioner, never by hand.
+# SYSTEM-owned and file-authoritative: the daemon re-reads it on SIGHUP /
+# POST /api/config/reload (key rotation without restart); removing the block
+# un-hosts the install. Keep the file root-owned / mode 0600 — the key is a
+# per-account credential. QUOTE both values (unquoted scalars can parse as
+# numbers/booleans and are ignored with a warning).
+# usejarvis_ai:
+#   base_url: "https://llm.usejarvis.host/v1"
+#   api_key: "sk-uj-..."
+
 # Set local: false on headless servers (no display): the brain never launches
 # a local Chromium; browser actions route to a connected sidecar's browser.
 # browser:

--- a/src/config/README.md
+++ b/src/config/README.md
@@ -39,8 +39,36 @@ console.log(config.personality.core_traits);  // string[]
 ### Saving Configuration
 
 There is intentionally **no `saveConfig`**. `config.yaml` is a read-only
-SYSTEM config (daemon.*, auth, google) that the brain never writes; in hosted
-mode it is root-owned and managed by the hosting server.
+SYSTEM config (daemon.*, auth, google, usejarvis_ai) that the brain never
+writes; in hosted mode it is root-owned and managed by the hosting server.
+
+### The `usejarvis_ai` block (hosted installs only)
+
+Written exclusively by the hosting provisioner — never by the daemon, the
+dashboard, or the user:
+
+```yaml
+usejarvis_ai:
+  base_url: "https://llm.usejarvis.host/v1"   # quote both values: unquoted
+  api_key: "sk-uj-..."                        # scalars parse as non-strings
+```
+
+Ownership and semantics:
+
+- **File-authoritative.** The block is re-read on SIGHUP and
+  `POST /api/config/reload` (`reloadUsejarvisAiBlock`), so a key rotation
+  takes effect without a restart. Removing the block un-hosts the install on
+  the next reload/boot; a corrupt file keeps the current in-memory value.
+- **File mode.** The block carries a per-account API key: the file should be
+  root-owned and not world-readable (`0600`, owner the daemon's service
+  account or root with a read grant).
+- **Never persisted.** The injected `usejarvis_ai` provider entry is excluded
+  from every DB write (`stripSecretsFromProviders`) and the dashboard cannot
+  edit or delete it (`saveLLMSettings` refuses the reserved name on hosted
+  installs).
+- **Malformed values** (non-string `base_url`/`api_key`, e.g. unquoted
+  scalars) are warned about and treated as an absent block — the daemon still
+  boots.
 
 All user-owned sections (personality, voice, stt/tts, authority, channels,
 onboarding, ... — see `USER_OWNED_SECTIONS` in `types.ts`) persist to the

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -48,6 +48,35 @@ describe('Config Loader', () => {
     expect(loaded.llm.providers).toEqual({});
   });
 
+  test('reloadUsejarvisAiBlock: rotation lands, removal un-hosts, corruption keeps the current value', async () => {
+    const { writeFile } = await import('node:fs/promises');
+    const { reloadUsejarvisAiBlock } = await import('./loader.ts');
+    await writeFile(
+      TEST_CONFIG_PATH,
+      'usejarvis_ai:\n  base_url: https://llm.usejarvis.host\n  api_key: sk-uj-old\n',
+    );
+    const config = await loadConfig(TEST_CONFIG_PATH);
+    expect(config.usejarvis_ai?.api_key).toBe('sk-uj-old');
+
+    // Provisioner rotates the key: SIGHUP re-read must pick it up.
+    await writeFile(
+      TEST_CONFIG_PATH,
+      'usejarvis_ai:\n  base_url: https://llm.usejarvis.host\n  api_key: sk-uj-rotated\n',
+    );
+    await reloadUsejarvisAiBlock(config, TEST_CONFIG_PATH);
+    expect(config.usejarvis_ai?.api_key).toBe('sk-uj-rotated');
+
+    // Corrupt file: keep the current value (a write race must not un-host).
+    await writeFile(TEST_CONFIG_PATH, 'usejarvis_ai: [unclosed\n  broken');
+    await reloadUsejarvisAiBlock(config, TEST_CONFIG_PATH);
+    expect(config.usejarvis_ai?.api_key).toBe('sk-uj-rotated');
+
+    // Block removed: the install is no longer hosted.
+    await writeFile(TEST_CONFIG_PATH, 'daemon:\n  port: 8788\n');
+    await reloadUsejarvisAiBlock(config, TEST_CONFIG_PATH);
+    expect(config.usejarvis_ai).toBeUndefined();
+  });
+
   test('workflows SYSTEM path keys survive the user-section discard; user fields do not', async () => {
     // A hosted/system config carries only the ready-made artifact paths;
     // any user-tunable workflow fields in the FILE have no authority (they

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -22,6 +22,32 @@ describe('Config Loader', () => {
     await rm(TEST_CONFIG_DIR, { recursive: true, force: true });
   });
 
+  test('usejarvis_ai survives the load intact while llm: is discarded', async () => {
+    const { writeFile } = await import('node:fs/promises');
+    await writeFile(
+      TEST_CONFIG_PATH,
+      [
+        'usejarvis_ai:',
+        '  base_url: https://llm.usejarvis.host',
+        '  api_key: sk-uj-test0123456789abcdef',
+        // The llm block MUST stay ignored — DB is the sole authority there.
+        'llm:',
+        '  default: "openai:gpt-x"',
+        '  providers:',
+        '    evil: { kind: openai, api_key: sneaky }',
+        '',
+      ].join('\n'),
+    );
+    const loaded = await loadConfig(TEST_CONFIG_PATH);
+    expect(loaded.usejarvis_ai).toEqual({
+      base_url: 'https://llm.usejarvis.host',
+      api_key: 'sk-uj-test0123456789abcdef',
+    });
+    // llm from the file contributed NOTHING (existing rule, still true).
+    expect(loaded.llm.default).toBeUndefined();
+    expect(loaded.llm.providers).toEqual({});
+  });
+
   test('workflows SYSTEM path keys survive the user-section discard; user fields do not', async () => {
     // A hosted/system config carries only the ready-made artifact paths;
     // any user-tunable workflow fields in the FILE have no authority (they

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -208,6 +208,36 @@ export async function readRawConfigFile(
 }
 
 
+/**
+ * Re-read ONLY the SYSTEM-owned `usejarvis_ai` block from config.yaml into
+ * the live config. Backs SIGHUP / POST /api/config/reload so a provisioner
+ * key rotation (or un-hosting) takes effect without a daemon restart.
+ *
+ * File-authoritative semantics: a missing file or absent block clears the
+ * block (the install is no longer hosted). An unreadable/corrupt file keeps
+ * the current in-memory value and warns — a transient write race must not
+ * un-host a running install.
+ */
+export async function reloadUsejarvisAiBlock(
+  config: JarvisConfig,
+  configPath?: string,
+): Promise<void> {
+  try {
+    const raw = await readRawConfigFile(configPath);
+    const block = raw?.usejarvis_ai;
+    if (block && typeof block === 'object' && !Array.isArray(block)) {
+      config.usejarvis_ai = block as { base_url?: string; api_key?: string };
+    } else {
+      delete config.usejarvis_ai;
+    }
+  } catch (err) {
+    console.warn(
+      '[Config] Could not re-read the usejarvis_ai block from config.yaml; keeping the current value:',
+      err instanceof Error ? err.message : err,
+    );
+  }
+}
+
 // NOTE: there is intentionally no saveConfig here. The brain treats
 // config.yaml as READ-ONLY system configuration (network/hosting keys,
 // root-owned in hosted mode). All user-chosen settings persist to the vault

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -344,7 +344,10 @@ export type LLMProviderKind =
   | 'nvidia'
   | 'openai_compatible'
   | 'litellm'
-  | 'omniroute';
+  | 'omniroute'
+  // Hosted "Usejarvis AI": the platform's LLM proxy, configured exclusively
+  // by the root-owned config.yaml `usejarvis_ai` block (never the dashboard).
+  | 'usejarvis_ai';
 
 /**
  * Credentials + endpoint for one provider instance. The `kind` field is
@@ -416,6 +419,14 @@ export type LLMConfig = {
 };
 
 export type JarvisConfig = {
+  /**
+   * Hosted-LLM access (SYSTEM-owned, file-authoritative): written by the
+   * hosting provisioner into the root-owned config.yaml, never by the brain
+   * or dashboard. Survives the user-section discard (not listed in
+   * USER_OWNED_SECTIONS) and is re-applied over every DB merge by
+   * applyUsejarvisAi (daemon/usejarvis-ai.ts). Absent on self-hosted installs.
+   */
+  usejarvis_ai?: { base_url?: string; api_key?: string };
   user?: UserConfig;
   onboarding?: OnboardingConfig;
   telemetry?: TelemetryConfig;

--- a/src/daemon/agent-service.ts
+++ b/src/daemon/agent-service.ts
@@ -16,6 +16,7 @@ import type { PersonalityModel } from '../personality/model.ts';
 import { LLMManager } from '../llm/manager.ts';
 import { activeTurns, DrainingError } from './active-turns.ts';
 import { registerLLMProviders, configureLLMTiers } from '../llm/config-binding.ts';
+import { effectiveLlmForBinding } from './usejarvis-ai.ts';
 
 /** Wrap a turn's stream so the in-flight count is released when it settles
  *  (exhausted, errored, or the consumer breaks). `endTurn` is idempotent. */
@@ -629,7 +630,10 @@ export class AgentService implements Service, IAgentService {
   // --- Private methods ---
 
   private registerProviders(): void {
-    const { llm } = this.config;
+    // Bind through the effective view: hosted tier defaults live only in this
+    // per-bind copy (explicit ref → llm.default → plan alias), never in
+    // config.llm, so they can never leak into a persistence path.
+    const llm = effectiveLlmForBinding(this.config);
     const hasProvider = registerLLMProviders(this.llmManager, llm.providers ?? {}, {
       promptCache: llm.prompt_cache !== false,
     });

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -501,7 +501,13 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
     // voice intent, pebble toggle — schedule the section's appliers.
     const { SettingsReloadCoordinator } = await import('./settings-reload.ts');
     const { setSectionSavedListener } = await import('./user-settings.ts');
-    settingsReload = new SettingsReloadCoordinator(jarvisConfig);
+    const { reloadUsejarvisAiBlock } = await import('../config/loader.ts');
+    settingsReload = new SettingsReloadCoordinator(jarvisConfig, {
+      // File-authoritative SYSTEM sections are re-read on every reloadAll so
+      // a provisioner rotation of the usejarvis_ai key (or un-hosting) takes
+      // effect on SIGHUP / POST /api/config/reload without a restart.
+      reloadSystemSections: (cfg) => reloadUsejarvisAiBlock(cfg),
+    });
     setSectionSavedListener((section) => settingsReload?.sectionChanged(section));
 
     // 3b. Anonymous usage telemetry (opt-out). Constructed here so it can be

--- a/src/daemon/llm-settings.ts
+++ b/src/daemon/llm-settings.ts
@@ -17,6 +17,7 @@
  */
 
 import type { JarvisConfig, LLMProviderEntry, LLMProviderKind } from '../config/types.ts';
+import { applyUsejarvisAi, USEJARVIS_PROVIDER_NAME } from './usejarvis-ai.ts';
 import { getSetting, setSetting } from '../vault/settings.ts';
 import { getSecret, setSecret, deleteSecret, hasSecret } from '../vault/keychain.ts';
 import type { LLMManager } from '../llm/manager.ts';
@@ -208,6 +209,11 @@ export function saveLLMSettings(
     // would otherwise leave earlier entries applied in memory but never
     // persisted by the setSetting() block at the end of this function.
     for (const [name, update] of updates) {
+      // SYSTEM-owned: never validated and never mutated (see the loop below),
+      // so the credential-scoping checks must not speak for it either — they
+      // would report a base_url/kind problem for an entry the dashboard has
+      // no business sending at all.
+      if (name === USEJARVIS_PROVIDER_NAME) continue;
       if (update === null) continue;
       const existing = config.llm.providers[name] ?? {};
       const nextBaseUrl = normalizeBaseUrl(update.base_url);
@@ -238,6 +244,10 @@ export function saveLLMSettings(
       }
     }
     for (const [name, update] of updates) {
+      // The hosted provider is SYSTEM-owned (config.yaml carve-out): the
+      // dashboard can neither create, edit, nor delete it, and nothing under
+      // the reserved name may reach the DB or keychain.
+      if (name === USEJARVIS_PROVIDER_NAME) continue;
       if (update === null) {
         delete config.llm.providers[name];
         // Drop every model ref the provider owned. The manager prunes its own
@@ -336,6 +346,10 @@ export function stripSecretsFromProviders(
   const out: Record<string, LLMProviderEntry> = {};
   for (const [name, entry] of Object.entries(providers ?? {})) {
     if (!entry) continue;
+    // The hosted provider is INJECTED from config.yaml on every merge — it
+    // must never round-trip into the persisted DB shape (it would survive
+    // un-hosting and shadow the file as a stale copy).
+    if (name === USEJARVIS_PROVIDER_NAME) continue;
     const { api_key: _omit, ...rest } = entry;
     void _omit;
     out[name] = rest;
@@ -429,6 +443,11 @@ export function mergeLLMSettingsIntoConfig(
       config.llm.providers[name] = { ...config.llm.providers[name], api_key: key };
     }
   }
+
+  // 4. Hosted installs: the usejarvis_ai config.yaml block is re-applied over
+  // every DB merge (this function REPLACES config.llm wholesale, and it runs
+  // on boot, SIGHUP reload, and around dashboard saves).
+  applyUsejarvisAi(config);
 }
 
 /**
@@ -585,6 +604,9 @@ function migrateLegacyDBSettings(config: JarvisConfig): void {
  * underlying replaceProviders/setTierMap operations are atomic.
  */
 export function hotReloadLLMProviders(config: JarvisConfig, llmManager: LLMManager): void {
+  // Idempotent: a dashboard save rebuilds config.llm from the request before
+  // calling this — the hosted provider must survive that too.
+  applyUsejarvisAi(config);
   // Build enriched entries with keychain secrets injected so providers can
   // instantiate. The injection is transient - only the in-memory entries
   // see it; persisted forms (DB / YAML) get stripped via

--- a/src/daemon/llm-settings.ts
+++ b/src/daemon/llm-settings.ts
@@ -17,7 +17,12 @@
  */
 
 import type { JarvisConfig, LLMProviderEntry, LLMProviderKind } from '../config/types.ts';
-import { applyUsejarvisAi, USEJARVIS_PROVIDER_NAME } from './usejarvis-ai.ts';
+import {
+  applyUsejarvisAi,
+  effectiveLlmForBinding,
+  hasUsejarvisAi,
+  USEJARVIS_PROVIDER_NAME,
+} from './usejarvis-ai.ts';
 import { getSetting, setSetting } from '../vault/settings.ts';
 import { getSecret, setSecret, deleteSecret, hasSecret } from '../vault/keychain.ts';
 import type { LLMManager } from '../llm/manager.ts';
@@ -209,11 +214,19 @@ export function saveLLMSettings(
     // would otherwise leave earlier entries applied in memory but never
     // persisted by the setSetting() block at the end of this function.
     for (const [name, update] of updates) {
-      // SYSTEM-owned: never validated and never mutated (see the loop below),
-      // so the credential-scoping checks must not speak for it either — they
-      // would report a base_url/kind problem for an entry the dashboard has
-      // no business sending at all.
-      if (name === USEJARVIS_PROVIDER_NAME) continue;
+      // SYSTEM-owned: on hosted installs an edit/delete of the reserved name
+      // is refused loudly (a silent skip reported "saved" for a no-op). The
+      // throw lives HERE in the validation loop so a rejected batch mutates
+      // nothing. On self-hosted installs (no block) the legacy silent-skip
+      // stands until the reservation is gated on hostedness.
+      if (name === USEJARVIS_PROVIDER_NAME) {
+        if (hasUsejarvisAi(config)) {
+          throw new Error(
+            `Provider '${USEJARVIS_PROVIDER_NAME}' is managed by your hosting plan and cannot be edited or deleted`,
+          );
+        }
+        continue;
+      }
       if (update === null) continue;
       const existing = config.llm.providers[name] ?? {};
       const nextBaseUrl = normalizeBaseUrl(update.base_url);
@@ -416,7 +429,15 @@ export function mergeLLMSettingsIntoConfig(
     config.llm.prompt_cache = storedPromptCache !== 'false';
   }
 
-  // 2. Legacy shape: migrate per-provider DB keys + KEY_* secrets if any
+  // 2. Hosted installs: inject the usejarvis_ai provider from the config.yaml
+  // block BEFORE the legacy migration and the orphan prune below. The prune
+  // decides "orphan" by looking the ref's provider up in config.llm.providers;
+  // injecting afterwards made every persisted usejarvis_ai:* ref look dangling
+  // and PERSISTED its deletion — a hosted user's explicit tier/default choices
+  // were erased on every boot.
+  applyUsejarvisAi(config);
+
+  // 3. Legacy shape: migrate per-provider DB keys + KEY_* secrets if any
   // are present and no new-shape providers exist for them. This is the
   // upgrade path for installs that pre-date the provider/model split.
   migrateLegacyDBSettings(config);
@@ -428,12 +449,15 @@ export function mergeLLMSettingsIntoConfig(
     pruneOrphanedModelRefs(config, options.persistMigrations !== false);
   }
 
-  // 3. Pull API keys from the keychain into provider entries. We do NOT
+  // 4. Pull API keys from the keychain into provider entries. We do NOT
   // surface them in `config.llm.providers.<name>.api_key` (that would risk
   // saving them back to disk) - instead the config-binding module reads
   // from the keychain at provider-instantiation time. So this step only
   // ensures entries exist for any name with a keychain secret.
   for (const name of Object.keys(config.llm.providers)) {
+    // The hosted provider's credential comes from the config.yaml block only;
+    // a keychain entry squatting on the reserved name must not shadow it.
+    if (name === USEJARVIS_PROVIDER_NAME) continue;
     const key = getSecret(keychainKey(name));
     if (key) {
       // Inject into the entry transiently so registerLLMProviders can
@@ -443,11 +467,6 @@ export function mergeLLMSettingsIntoConfig(
       config.llm.providers[name] = { ...config.llm.providers[name], api_key: key };
     }
   }
-
-  // 4. Hosted installs: the usejarvis_ai config.yaml block is re-applied over
-  // every DB merge (this function REPLACES config.llm wholesale, and it runs
-  // on boot, SIGHUP reload, and around dashboard saves).
-  applyUsejarvisAi(config);
 }
 
 /**
@@ -628,7 +647,9 @@ export function hotReloadLLMProviders(config: JarvisConfig, llmManager: LLMManag
   if (built.length === 0) {
     console.warn('[LLM] Hot-reload: no providers registered (all entries missing credentials).');
   }
-  configureLLMTiers(llmManager, config.llm);
+  // Bind through the effective view: hosted tier defaults exist ONLY here,
+  // never in config.llm, so no save path can accidentally persist them.
+  configureLLMTiers(llmManager, effectiveLlmForBinding(config));
 
   console.log(`[LLM] Providers active after hot-reload: ${built.map((p) => p.name).join(', ') || 'none'}`);
 }

--- a/src/daemon/settings-reload.ts
+++ b/src/daemon/settings-reload.ts
@@ -117,19 +117,30 @@ export class SettingsReloadCoordinator {
   private readonly googleTokensFile: string;
   /** Fingerprint of the tokens file as of the last look; see googleTokensChanged. */
   private lastGoogleTokens: string;
+  /** Optional pre-hydration hook that re-reads file-authoritative SYSTEM
+   * sections (e.g. the usejarvis_ai block) before the DB merge. Injected by
+   * the daemon so tests stay hermetic (no config.yaml reads). */
+  private readonly reloadSystemSections: ((config: JarvisConfig) => Promise<void>) | null;
 
   /**
    * `googleTokensPath` is injectable for the same reason GoogleAuth's is: the
    * default resolves through os.homedir(), which Bun fixes at process start and
    * does NOT re-read from $HOME, so a test cannot redirect it any other way.
    */
-  constructor(config: JarvisConfig, opts?: { googleTokensPath?: string }) {
+  constructor(
+    config: JarvisConfig,
+    opts?: {
+      googleTokensPath?: string;
+      reloadSystemSections?: (config: JarvisConfig) => Promise<void>;
+    },
+  ) {
     this.config = config;
     this.googleTokensFile = opts?.googleTokensPath ?? googleTokensPath();
     // Baseline at construction, which is boot: whatever is on disk now is what
     // the daemon's own GoogleAuth was just built from, so the first reload must
     // not report a change and pointlessly restart the observers.
     this.lastGoogleTokens = googleTokensFingerprint(this.googleTokensFile);
+    this.reloadSystemSections = opts?.reloadSystemSections ?? null;
   }
 
   /**
@@ -190,6 +201,17 @@ export class SettingsReloadCoordinator {
       const before = new Map<ReloadSection, string>();
       for (const section of RELOAD_SECTIONS) {
         before.set(section, this.snapshot(section));
+      }
+
+      // SYSTEM sections are file-authoritative: re-read them first so a
+      // provisioner key rotation (or removal of the usejarvis_ai block)
+      // lands on SIGHUP / POST /api/config/reload without a daemon restart.
+      if (this.reloadSystemSections) {
+        try {
+          await this.reloadSystemSections(this.config);
+        } catch (err) {
+          console.warn('[SettingsReload] System-section re-read failed:', err);
+        }
       }
 
       // Exact boot hydration order (daemon/index.ts): LLM, then user

--- a/src/daemon/usejarvis-ai.test.ts
+++ b/src/daemon/usejarvis-ai.test.ts
@@ -1,6 +1,18 @@
-import { test, expect, describe } from 'bun:test';
+import { test, expect, describe, beforeEach, afterEach } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { DEFAULT_CONFIG, type JarvisConfig } from '../config/types.ts';
-import { applyUsejarvisAi, hasUsejarvisAi, USEJARVIS_PROVIDER_NAME } from './usejarvis-ai.ts';
+import { initDatabase, closeDb } from '../vault/schema.ts';
+import { getSetting, setSetting } from '../vault/settings.ts';
+import { hasSecret } from '../vault/keychain.ts';
+import {
+  applyUsejarvisAi,
+  effectiveLlmForBinding,
+  hasUsejarvisAi,
+  USEJARVIS_PROVIDER_NAME,
+} from './usejarvis-ai.ts';
+import { mergeLLMSettingsIntoConfig, saveLLMSettings } from './llm-settings.ts';
 
 const base = (): JarvisConfig => structuredClone(DEFAULT_CONFIG);
 
@@ -10,7 +22,7 @@ const hosted = (): JarvisConfig => {
   return config;
 };
 
-describe('applyUsejarvisAi (fill-if-silent over every DB merge)', () => {
+describe('applyUsejarvisAi (provider injection only)', () => {
   test('no-op on self-hosted installs (block absent or incomplete)', () => {
     const config = base();
     applyUsejarvisAi(config);
@@ -23,7 +35,7 @@ describe('applyUsejarvisAi (fill-if-silent over every DB merge)', () => {
     expect(partial.llm.providers?.[USEJARVIS_PROVIDER_NAME]).toBeUndefined();
   });
 
-  test('injects the provider and fills every silent tier with uj-* aliases', () => {
+  test('injects the provider and NEVER touches config.llm.tiers', () => {
     const config = hosted();
     applyUsejarvisAi(config);
     expect(config.llm.providers![USEJARVIS_PROVIDER_NAME]).toEqual({
@@ -31,31 +43,28 @@ describe('applyUsejarvisAi (fill-if-silent over every DB merge)', () => {
       base_url: 'https://llm.usejarvis.host',
       api_key: 'sk-uj-abc123',
     });
-    expect(config.llm.tiers).toEqual({
-      conversation: 'usejarvis_ai:uj-chat',
-      low: 'usejarvis_ai:uj-low',
-      medium: 'usejarvis_ai:uj-medium',
-      high: 'usejarvis_ai:uj-high',
-    });
-  });
-
-  test("a user's dashboard tier choice wins for THAT slot; the rest default", () => {
-    const config = hosted();
-    config.llm.providers = { anthropic: { api_key: 'sk-ant-user' } };
-    config.llm.tiers = { high: 'anthropic:claude-x' };
-    applyUsejarvisAi(config);
-    expect(config.llm.tiers!.high).toBe('anthropic:claude-x'); // user wins
-    expect(config.llm.tiers!.low).toBe('usejarvis_ai:uj-low'); // silence filled
-    expect(config.llm.providers!.anthropic).toEqual({ api_key: 'sk-ant-user' }); // untouched
-  });
-
-  test('single-model mode (llm.default) disables tier-filling entirely', () => {
-    const config = hosted();
-    config.llm.default = 'anthropic:claude-x';
-    applyUsejarvisAi(config);
+    // Tier defaults live ONLY in the binding view — the config object stays
+    // exactly what the DB (here: nothing) provided, so no save path can
+    // ever persist a fabricated tier as a user choice.
     expect(config.llm.tiers ?? {}).toEqual({});
-    // ...but the provider is still injected (it must always exist).
-    expect(config.llm.providers![USEJARVIS_PROVIDER_NAME]).toBeDefined();
+    expect(config.llm.default).toBeUndefined();
+  });
+
+  test('a malformed block (unquoted YAML scalars) is ignored, never throws', () => {
+    const config = base();
+    config.usejarvis_ai = { base_url: 'https://llm.usejarvis.host', api_key: 1234567890 } as never;
+    expect(hasUsejarvisAi(config)).toBe(false);
+    expect(() => applyUsejarvisAi(config)).not.toThrow();
+    expect(config.llm.providers?.[USEJARVIS_PROVIDER_NAME]).toBeUndefined();
+  });
+
+  test('base_url is normalized: trailing slashes never reach the provider entry', () => {
+    const config = base();
+    config.usejarvis_ai = { base_url: 'https://llm.usejarvis.host/v1/', api_key: 'sk-uj-abc123' };
+    applyUsejarvisAi(config);
+    expect(config.llm.providers![USEJARVIS_PROVIDER_NAME]!.base_url).toBe(
+      'https://llm.usejarvis.host/v1',
+    );
   });
 
   test('a DB row squatting on the reserved name is overwritten, not merged', () => {
@@ -78,5 +87,156 @@ describe('applyUsejarvisAi (fill-if-silent over every DB merge)', () => {
     applyUsejarvisAi(twice);
     applyUsejarvisAi(twice);
     expect(twice.llm).toEqual(once.llm);
+  });
+});
+
+describe('effectiveLlmForBinding (per-slot: explicit ref → llm.default → plan alias)', () => {
+  test('self-hosted: returns config.llm untouched', () => {
+    const config = base();
+    config.llm.tiers = { high: 'anthropic:claude-x' };
+    expect(effectiveLlmForBinding(config)).toBe(config.llm);
+  });
+
+  test('hosted, all silent: every slot resolves to its uj-* alias', () => {
+    const config = hosted();
+    expect(effectiveLlmForBinding(config).tiers).toEqual({
+      conversation: 'usejarvis_ai:uj-chat',
+      low: 'usejarvis_ai:uj-low',
+      medium: 'usejarvis_ai:uj-medium',
+      high: 'usejarvis_ai:uj-high',
+    });
+    // ...without mutating the underlying config.
+    expect(config.llm.tiers ?? {}).toEqual({});
+  });
+
+  test("a user's explicit tier choice wins for THAT slot; the rest default", () => {
+    const config = hosted();
+    config.llm.tiers = { high: 'anthropic:claude-x' };
+    const effective = effectiveLlmForBinding(config);
+    expect(effective.tiers!.high).toBe('anthropic:claude-x');
+    expect(effective.tiers!.low).toBe('usejarvis_ai:uj-low');
+    expect(config.llm.tiers).toEqual({ high: 'anthropic:claude-x' }); // untouched
+  });
+
+  test('llm.default narrows the fallback for unset slots instead of disabling the others', () => {
+    // The old all-or-nothing bail meant setting a default silently tore down
+    // every hosted tier. Per-slot resolution: explicit ref → default → alias.
+    const config = hosted();
+    config.llm.default = 'anthropic:claude-x';
+    config.llm.tiers = { high: 'usejarvis_ai:uj-high' };
+    const effective = effectiveLlmForBinding(config);
+    expect(effective.tiers!.high).toBe('usejarvis_ai:uj-high'); // explicit wins
+    expect(effective.tiers!.conversation).toBe('anthropic:claude-x'); // default beats alias
+    expect(effective.tiers!.low).toBe('anthropic:claude-x');
+  });
+});
+
+describe('DB round-trips (restart survival + fill never persists)', () => {
+  // Isolated keychain per test: these paths touch getSecret/setSecret and must
+  // never read from — or write to — the machine's real ~/.jarvis keychain.
+  let secretsDir: string;
+  let prevSecretsDir: string | undefined;
+
+  beforeEach(() => {
+    prevSecretsDir = process.env.JARVIS_SECRETS_DIR;
+    secretsDir = mkdtempSync(join(tmpdir(), 'jarvis-usejarvis-ai-'));
+    process.env.JARVIS_SECRETS_DIR = secretsDir;
+  });
+
+  afterEach(() => {
+    closeDb();
+    if (prevSecretsDir === undefined) delete process.env.JARVIS_SECRETS_DIR;
+    else process.env.JARVIS_SECRETS_DIR = prevSecretsDir;
+    rmSync(secretsDir, { recursive: true, force: true });
+  });
+
+  test('persisted usejarvis_ai:* refs survive a boot merge (never pruned as orphans)', () => {
+    initDatabase(':memory:');
+    setSetting('llm.providers', '{}');
+    setSetting('llm.default', 'usejarvis_ai:uj-high');
+    setSetting('llm.tiers.high', 'usejarvis_ai:uj-high');
+
+    const config = hosted();
+    mergeLLMSettingsIntoConfig(config);
+
+    // In memory AND in the settings table: the refs must survive the restart.
+    expect(config.llm.default).toBe('usejarvis_ai:uj-high');
+    expect(config.llm.tiers!.high).toBe('usejarvis_ai:uj-high');
+    expect(getSetting('llm.default')).toBe('usejarvis_ai:uj-high');
+    expect(getSetting('llm.tiers.high')).toBe('usejarvis_ai:uj-high');
+  });
+
+  test('un-hosting still prunes the now-dangling usejarvis_ai refs', () => {
+    initDatabase(':memory:');
+    setSetting('llm.providers', '{}');
+    setSetting('llm.tiers.high', 'usejarvis_ai:uj-high');
+
+    const config = base(); // no usejarvis_ai block
+    mergeLLMSettingsIntoConfig(config);
+
+    expect(config.llm.tiers!.high).toBeUndefined();
+    expect(getSetting('llm.tiers.high')).toBe('');
+  });
+
+  test('the hosted fill is never promoted to persisted user state by a save', () => {
+    initDatabase(':memory:');
+    const config = hosted();
+    mergeLLMSettingsIntoConfig(config);
+
+    // Reproduces pr1's defaults-become-choices bug: switch to single mode,
+    // then pick a default — before the fix the refilled uj-* tiers were
+    // written to the DB and outranked the model the user just chose.
+    saveLLMSettings(config, { mode: 'single', tiers: { conversation: null, high: null, medium: null, low: null } });
+    saveLLMSettings(config, { default: 'anthropic:claude-x' });
+
+    expect(getSetting('llm.default')).toBe('anthropic:claude-x');
+    expect(getSetting('llm.tiers.conversation')).toBe('');
+    expect(getSetting('llm.tiers.high')).toBe('');
+    expect(getSetting('llm.tiers.medium')).toBe('');
+    expect(getSetting('llm.tiers.low')).toBe('');
+    expect(config.llm.tiers ?? {}).toEqual({});
+  });
+
+  test('clearing a tier persists the clear (no same-request refill)', () => {
+    initDatabase(':memory:');
+    const config = hosted();
+    mergeLLMSettingsIntoConfig(config);
+
+    saveLLMSettings(config, { tiers: { high: 'usejarvis_ai:uj-high' } });
+    expect(getSetting('llm.tiers.high')).toBe('usejarvis_ai:uj-high');
+
+    saveLLMSettings(config, { tiers: { high: null } });
+    expect(getSetting('llm.tiers.high')).toBe('');
+    expect(config.llm.tiers!.high).toBeUndefined();
+    // The binding view falls back to the plan alias; the persisted state does not.
+    expect(effectiveLlmForBinding(config).tiers!.high).toBe('usejarvis_ai:uj-high');
+  });
+
+  test('editing/deleting the managed provider is refused atomically on hosted installs', () => {
+    initDatabase(':memory:');
+    const config = hosted();
+    mergeLLMSettingsIntoConfig(config);
+    config.llm.providers!['atomicity-probe'] = { kind: 'anthropic' };
+
+    // The throw must come from the VALIDATION loop: a mixed batch rejects
+    // without writing the sibling's key to the keychain or mutating config.
+    expect(() =>
+      saveLLMSettings(config, {
+        providers: {
+          'atomicity-probe': { api_key: 'sk-ant-NEW' },
+          [USEJARVIS_PROVIDER_NAME]: null,
+        },
+      }),
+    ).toThrow(/managed by your hosting plan/);
+    expect(hasSecret('llm.provider.atomicity-probe.api_key')).toBe(false);
+    expect(config.llm.providers!['atomicity-probe']).toEqual({ kind: 'anthropic' });
+
+    // Self-hosted installs keep the legacy silent skip (no block, no throw).
+    const selfHosted = base();
+    selfHosted.llm.providers = {};
+    expect(() =>
+      saveLLMSettings(selfHosted, { providers: { [USEJARVIS_PROVIDER_NAME]: { kind: 'openai' } } }),
+    ).not.toThrow();
+    expect(selfHosted.llm.providers[USEJARVIS_PROVIDER_NAME]).toBeUndefined();
   });
 });

--- a/src/daemon/usejarvis-ai.test.ts
+++ b/src/daemon/usejarvis-ai.test.ts
@@ -1,0 +1,82 @@
+import { test, expect, describe } from 'bun:test';
+import { DEFAULT_CONFIG, type JarvisConfig } from '../config/types.ts';
+import { applyUsejarvisAi, hasUsejarvisAi, USEJARVIS_PROVIDER_NAME } from './usejarvis-ai.ts';
+
+const base = (): JarvisConfig => structuredClone(DEFAULT_CONFIG);
+
+const hosted = (): JarvisConfig => {
+  const config = base();
+  config.usejarvis_ai = { base_url: 'https://llm.usejarvis.host', api_key: 'sk-uj-abc123' };
+  return config;
+};
+
+describe('applyUsejarvisAi (fill-if-silent over every DB merge)', () => {
+  test('no-op on self-hosted installs (block absent or incomplete)', () => {
+    const config = base();
+    applyUsejarvisAi(config);
+    expect(config.llm.providers?.[USEJARVIS_PROVIDER_NAME]).toBeUndefined();
+    expect(hasUsejarvisAi(config)).toBe(false);
+
+    const partial = base();
+    partial.usejarvis_ai = { base_url: 'https://llm.usejarvis.host' }; // no key
+    applyUsejarvisAi(partial);
+    expect(partial.llm.providers?.[USEJARVIS_PROVIDER_NAME]).toBeUndefined();
+  });
+
+  test('injects the provider and fills every silent tier with uj-* aliases', () => {
+    const config = hosted();
+    applyUsejarvisAi(config);
+    expect(config.llm.providers![USEJARVIS_PROVIDER_NAME]).toEqual({
+      kind: 'usejarvis_ai',
+      base_url: 'https://llm.usejarvis.host',
+      api_key: 'sk-uj-abc123',
+    });
+    expect(config.llm.tiers).toEqual({
+      conversation: 'usejarvis_ai:uj-chat',
+      low: 'usejarvis_ai:uj-low',
+      medium: 'usejarvis_ai:uj-medium',
+      high: 'usejarvis_ai:uj-high',
+    });
+  });
+
+  test("a user's dashboard tier choice wins for THAT slot; the rest default", () => {
+    const config = hosted();
+    config.llm.providers = { anthropic: { api_key: 'sk-ant-user' } };
+    config.llm.tiers = { high: 'anthropic:claude-x' };
+    applyUsejarvisAi(config);
+    expect(config.llm.tiers!.high).toBe('anthropic:claude-x'); // user wins
+    expect(config.llm.tiers!.low).toBe('usejarvis_ai:uj-low'); // silence filled
+    expect(config.llm.providers!.anthropic).toEqual({ api_key: 'sk-ant-user' }); // untouched
+  });
+
+  test('single-model mode (llm.default) disables tier-filling entirely', () => {
+    const config = hosted();
+    config.llm.default = 'anthropic:claude-x';
+    applyUsejarvisAi(config);
+    expect(config.llm.tiers ?? {}).toEqual({});
+    // ...but the provider is still injected (it must always exist).
+    expect(config.llm.providers![USEJARVIS_PROVIDER_NAME]).toBeDefined();
+  });
+
+  test('a DB row squatting on the reserved name is overwritten, not merged', () => {
+    const config = hosted();
+    config.llm.providers = {
+      [USEJARVIS_PROVIDER_NAME]: { kind: 'openai', base_url: 'https://evil.example' },
+    };
+    applyUsejarvisAi(config);
+    expect(config.llm.providers[USEJARVIS_PROVIDER_NAME]).toEqual({
+      kind: 'usejarvis_ai',
+      base_url: 'https://llm.usejarvis.host',
+      api_key: 'sk-uj-abc123',
+    });
+  });
+
+  test('idempotent: applying twice equals applying once', () => {
+    const once = hosted();
+    applyUsejarvisAi(once);
+    const twice = hosted();
+    applyUsejarvisAi(twice);
+    applyUsejarvisAi(twice);
+    expect(twice.llm).toEqual(once.llm);
+  });
+});

--- a/src/daemon/usejarvis-ai.ts
+++ b/src/daemon/usejarvis-ai.ts
@@ -1,0 +1,63 @@
+import type { JarvisConfig } from '../config/types.ts';
+
+/**
+ * Hosted "Usejarvis AI" wiring (the platform's LLM proxy).
+ *
+ * The `usejarvis_ai` config.yaml block (base_url + the user's per-account
+ * key) is SYSTEM-owned and file-authoritative: the provisioner writes it,
+ * the brain never does, and the dashboard cannot touch it. But `config.llm`
+ * is rebuilt WHOLESALE from the DB by mergeLLMSettingsIntoConfig on boot,
+ * on SIGHUP reload, and around every dashboard save — so this hook re-applies
+ * the hosted provider over every one of those merges. It must be called
+ * after ANY code path that replaces `config.llm`.
+ *
+ * Semantics (fill-if-silent):
+ * - The provider itself is ALWAYS injected (users cannot delete it).
+ * - Tier assignments are defaults only: each unset tier slot is pointed at
+ *   the matching uj-* alias, but any tier the user chose in the dashboard
+ *   wins for that slot, and a user who configured single-model mode
+ *   (llm.default) keeps it untouched.
+ */
+
+/** Reserved provider name: the map key, the kind, and the tier-ref prefix. */
+export const USEJARVIS_PROVIDER_NAME = 'usejarvis_ai';
+
+/** Default tier wiring: identical on every plan — per-plan model resolution
+ * happens at the proxy via these aliases, never in this file. */
+const TIER_DEFAULTS = {
+  conversation: `${USEJARVIS_PROVIDER_NAME}:uj-chat`,
+  low: `${USEJARVIS_PROVIDER_NAME}:uj-low`,
+  medium: `${USEJARVIS_PROVIDER_NAME}:uj-medium`,
+  high: `${USEJARVIS_PROVIDER_NAME}:uj-high`,
+} as const;
+
+/** True when this install is hosted (a complete usejarvis_ai block exists). */
+export function hasUsejarvisAi(config: JarvisConfig): boolean {
+  const block = config.usejarvis_ai;
+  return Boolean(block?.base_url?.trim() && block?.api_key?.trim());
+}
+
+export function applyUsejarvisAi(config: JarvisConfig): void {
+  if (!hasUsejarvisAi(config)) return;
+  const block = config.usejarvis_ai!;
+
+  config.llm.providers ??= {};
+  // Unconditional: whatever the DB merge brought in, the hosted provider
+  // exists afterwards. A DB row squatting on the reserved name is overwritten
+  // (saveLLMSettings also refuses to persist one).
+  config.llm.providers[USEJARVIS_PROVIDER_NAME] = {
+    kind: USEJARVIS_PROVIDER_NAME,
+    base_url: block.base_url!.trim(),
+    api_key: block.api_key!.trim(),
+  };
+
+  // Defaults only where the user is silent: an explicit single-model choice
+  // (llm.default) disables tier-filling entirely; otherwise each unset slot
+  // gets its uj-* alias while user-chosen slots stay untouched.
+  if (!config.llm.default) {
+    const tiers = (config.llm.tiers ??= {});
+    for (const [tier, ref] of Object.entries(TIER_DEFAULTS)) {
+      (tiers as Record<string, string>)[tier] ||= ref;
+    }
+  }
+}

--- a/src/daemon/usejarvis-ai.ts
+++ b/src/daemon/usejarvis-ai.ts
@@ -1,4 +1,4 @@
-import type { JarvisConfig } from '../config/types.ts';
+import type { JarvisConfig, LLMConfig } from '../config/types.ts';
 
 /**
  * Hosted "Usejarvis AI" wiring (the platform's LLM proxy).
@@ -7,16 +7,21 @@ import type { JarvisConfig } from '../config/types.ts';
  * key) is SYSTEM-owned and file-authoritative: the provisioner writes it,
  * the brain never does, and the dashboard cannot touch it. But `config.llm`
  * is rebuilt WHOLESALE from the DB by mergeLLMSettingsIntoConfig on boot,
- * on SIGHUP reload, and around every dashboard save — so this hook re-applies
- * the hosted provider over every one of those merges. It must be called
- * after ANY code path that replaces `config.llm`.
+ * on SIGHUP reload, and around every dashboard save — so the provider is
+ * re-injected over every one of those merges (BEFORE the orphan prune, so
+ * persisted usejarvis_ai:* refs are never treated as dangling).
  *
- * Semantics (fill-if-silent):
- * - The provider itself is ALWAYS injected (users cannot delete it).
- * - Tier assignments are defaults only: each unset tier slot is pointed at
- *   the matching uj-* alias, but any tier the user chose in the dashboard
- *   wins for that slot, and a user who configured single-model mode
- *   (llm.default) keeps it untouched.
+ * Tier defaults are NEVER written into config.llm. They exist only in the
+ * binding view returned by effectiveLlmForBinding, which the provider
+ * registration paths consume. This keeps runtime defaults out of every
+ * persistence path by construction: saveLLMSettings can only ever write
+ * back what the DB or the request body contained.
+ *
+ * Per-slot resolution (decision D1): a tier slot resolves
+ *   explicit user ref → llm.default → plan uj-* alias.
+ * There is no all-or-nothing bail on llm.default; setting a default narrows
+ * the fallback for unset slots, it does not disable the other slots' explicit
+ * choices.
  */
 
 /** Reserved provider name: the map key, the kind, and the tier-ref prefix. */
@@ -24,22 +29,57 @@ export const USEJARVIS_PROVIDER_NAME = 'usejarvis_ai';
 
 /** Default tier wiring: identical on every plan — per-plan model resolution
  * happens at the proxy via these aliases, never in this file. */
-const TIER_DEFAULTS = {
+export const USEJARVIS_TIER_DEFAULTS = {
   conversation: `${USEJARVIS_PROVIDER_NAME}:uj-chat`,
   low: `${USEJARVIS_PROVIDER_NAME}:uj-low`,
   medium: `${USEJARVIS_PROVIDER_NAME}:uj-medium`,
   high: `${USEJARVIS_PROVIDER_NAME}:uj-high`,
 } as const;
 
-/** True when this install is hosted (a complete usejarvis_ai block exists). */
-export function hasUsejarvisAi(config: JarvisConfig): boolean {
-  const block = config.usejarvis_ai;
-  return Boolean(block?.base_url?.trim() && block?.api_key?.trim());
+/** Trailing-slash-stripped, trimmed URL (mirrors llm-settings normalizeBaseUrl;
+ * duplicated here because importing llm-settings would create a cycle). */
+function normalizeBlockUrl(value: string): string {
+  return value.trim().replace(/\/+$/, '');
 }
 
+/**
+ * Read and validate the SYSTEM block. A malformed block (non-string values —
+ * e.g. an unquoted YAML scalar parsed as number/boolean) is reported once per
+ * read and treated as absent rather than throwing from inside the boot merge.
+ */
+function readUsejarvisAiBlock(
+  config: JarvisConfig,
+): { base_url: string; api_key: string } | null {
+  const block = config.usejarvis_ai;
+  if (!block || typeof block !== 'object') return null;
+  const { base_url, api_key } = block as Record<string, unknown>;
+  if (
+    (base_url !== undefined && typeof base_url !== 'string')
+    || (api_key !== undefined && typeof api_key !== 'string')
+  ) {
+    console.warn(
+      '[UsejarvisAI] Ignoring malformed usejarvis_ai config block: base_url and api_key must be strings (quote them in config.yaml).',
+    );
+    return null;
+  }
+  const url = typeof base_url === 'string' ? normalizeBlockUrl(base_url) : '';
+  const key = typeof api_key === 'string' ? api_key.trim() : '';
+  if (!url || !key) return null;
+  return { base_url: url, api_key: key };
+}
+
+/** True when this install is hosted (a complete, well-formed usejarvis_ai block exists). */
+export function hasUsejarvisAi(config: JarvisConfig): boolean {
+  return readUsejarvisAiBlock(config) !== null;
+}
+
+/**
+ * Inject the hosted provider entry. Providers only — tier defaults live in
+ * effectiveLlmForBinding and never touch the config object.
+ */
 export function applyUsejarvisAi(config: JarvisConfig): void {
-  if (!hasUsejarvisAi(config)) return;
-  const block = config.usejarvis_ai!;
+  const block = readUsejarvisAiBlock(config);
+  if (!block) return;
 
   config.llm.providers ??= {};
   // Unconditional: whatever the DB merge brought in, the hosted provider
@@ -47,17 +87,28 @@ export function applyUsejarvisAi(config: JarvisConfig): void {
   // (saveLLMSettings also refuses to persist one).
   config.llm.providers[USEJARVIS_PROVIDER_NAME] = {
     kind: USEJARVIS_PROVIDER_NAME,
-    base_url: block.base_url!.trim(),
-    api_key: block.api_key!.trim(),
+    base_url: block.base_url,
+    api_key: block.api_key,
   };
+}
 
-  // Defaults only where the user is silent: an explicit single-model choice
-  // (llm.default) disables tier-filling entirely; otherwise each unset slot
-  // gets its uj-* alias while user-chosen slots stay untouched.
-  if (!config.llm.default) {
-    const tiers = (config.llm.tiers ??= {});
-    for (const [tier, ref] of Object.entries(TIER_DEFAULTS)) {
-      (tiers as Record<string, string>)[tier] ||= ref;
+/**
+ * The LLM config the provider-binding paths (boot registration, hot reload)
+ * must consume instead of config.llm. On self-hosted installs it IS
+ * config.llm. On hosted installs it is a copy whose tier slots are resolved
+ * per-slot: explicit user ref → llm.default → plan uj-* alias.
+ *
+ * Never mutates config and its result must never be persisted — the fill
+ * exists only for the duration of a bind.
+ */
+export function effectiveLlmForBinding(config: JarvisConfig): LLMConfig {
+  if (!hasUsejarvisAi(config)) return config.llm;
+
+  const tiers: Record<string, string> = { ...(config.llm.tiers ?? {}) };
+  for (const [tier, alias] of Object.entries(USEJARVIS_TIER_DEFAULTS)) {
+    if (!tiers[tier]) {
+      tiers[tier] = config.llm.default || alias;
     }
   }
+  return { ...config.llm, tiers };
 }


### PR DESCRIPTION
Adds a `usejarvis_ai` block to config.yaml (base_url, api_key, cache_salt) that the platform writes and the brain never does. It survives the user-section discard and is re-applied over every wholesale rebuild of `config.llm` — boot merge, SIGHUP reload, dashboard save. The reserved provider name cannot be persisted to the DB shape or edited through settings.

Base of the Usejarvis AI stack. The platform side that writes this block is already implemented.

Stack: **1/8** → #355