### PR TITLE
feat(llm): UsejarvisAIProvider against the platform proxy

### DIFF
--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -95,7 +95,13 @@ export async function runDoctor(): Promise<void> {
     if (llmProviderNames.length === 0) {
       results.push({ name: 'LLM Provider', status: 'fail', message: 'No providers configured. Add one in Settings > LLM (http://localhost:3142).' });
     } else {
-      const tiers = llmConfig.llm.tiers ?? {};
+      // The ROUTING view, not the persisted one: on a hosted install the
+      // uj-* tier defaults live only in the binding view (they are
+      // deliberately never written to config.llm, so silence stays silent).
+      // Reading config.llm.tiers directly would report "no model assigned"
+      // for an install that routes perfectly well.
+      const { effectiveLlmForBinding } = await import('../daemon/usejarvis-ai.ts');
+      const tiers = effectiveLlmForBinding(llmConfig).tiers ?? {};
       const tierSummary = Object.entries(tiers).map(([t, v]) => `${t}=${v}`).join(', ');
       const mode = tierSummary ? `tiers: ${tierSummary}` : (llmConfig.llm.default ? `default: ${llmConfig.llm.default}` : 'no model assigned');
       results.push({ name: 'LLM Provider', status: 'ok', message: `${llmProviderNames.length} provider(s): ${llmProviderNames.join(', ')} (${mode})` });
@@ -109,9 +115,11 @@ export async function runDoctor(): Promise<void> {
     try {
       const { LLMManager } = await import('../llm/index.ts');
       const { registerLLMProviders, configureLLMTiers } = await import('../llm/config-binding.ts');
+      const { effectiveLlmForBinding } = await import('../daemon/usejarvis-ai.ts');
       const manager = new LLMManager();
       registerLLMProviders(manager, llmConfig.llm.providers ?? {});
-      configureLLMTiers(manager, llmConfig.llm);
+      // Same routing view the daemon binds — see Check 4.
+      configureLLMTiers(manager, effectiveLlmForBinding(llmConfig));
       // manager.chat() routes through the medium tier (with fall-up) when a
       // tier/default is configured, else the first registered provider.
       const resp = await manager.chat(

--- a/src/daemon/api-routes.ts
+++ b/src/daemon/api-routes.ts
@@ -38,6 +38,7 @@ import { getOrCreateConversation, getMessages, getRecentConversation } from '../
 import { getRecentObservations, summarizeObservation } from '../vault/observations.ts';
 import { listAgentActivity, countAgentActivity } from '../vault/agent-activity.ts';
 import { getPersonality } from '../personality/model.ts';
+import { hasUsejarvisAi } from './usejarvis-ai.ts';
 import { clearUserProfile, getUserProfile, saveUserProfile } from '../vault/user-profile.ts';
 import {
   USER_PROFILE_QUESTIONS,
@@ -1451,7 +1452,12 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
           // canonical summary - provider names, single-LLM default, and the
           // tier map. The dedicated dashboard endpoint is /api/config/llm.
           llm: {
-            providers: Object.keys(config.llm.providers ?? {}),
+            // Hosted installs: hide the injected reserved provider, matching
+            // getLLMSettings — a client that round-trips this list into a
+            // save would hit the managed-provider 400 (pr2 review #9).
+            providers: Object.keys(config.llm.providers ?? {}).filter(
+              (name) => name !== 'usejarvis_ai' || !hasUsejarvisAi(config),
+            ),
             default: config.llm.default ?? null,
             tiers: config.llm.tiers ?? {},
           },

--- a/src/daemon/llm-settings.test.ts
+++ b/src/daemon/llm-settings.test.ts
@@ -1,8 +1,9 @@
-import { afterEach, describe, expect, it } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, it, test } from 'bun:test';
 import { initDatabase, closeDb } from '../vault/schema.ts';
 import { getSetting, setSetting } from '../vault/settings.ts';
 import { DEFAULT_CONFIG, type JarvisConfig } from '../config/types.ts';
-import { mergeLLMSettingsIntoConfig, saveLLMSettings } from './llm-settings.ts';
+import { getLLMSettings, mergeLLMSettingsIntoConfig, saveLLMSettings } from './llm-settings.ts';
+import { applyUsejarvisAi, USEJARVIS_PROVIDER_NAME } from './usejarvis-ai.ts';
 
 afterEach(() => closeDb());
 
@@ -158,69 +159,74 @@ describe('LLM settings model migrations', () => {
   });
 });
 
-/**
- * `auth_header` is the one part of a provider credential that is NOT a secret,
- * so it rides in the config rather than the keychain. These pin the boundary
- * rules: a legal name persists, a blank clears, and an illegal one is refused
- * before it can reach fetch.
- */
-describe('LLM settings auth header', () => {
-  const withDb = (fn: () => void) => { initDatabase(':memory:'); fn(); };
+function hostedConfig(): JarvisConfig {
+  const config = structuredClone(DEFAULT_CONFIG);
+  config.usejarvis_ai = { base_url: 'https://llm.usejarvis.host', api_key: 'sk-uj-LIFETIMEKEY0000000000' };
+  applyUsejarvisAi(config); // what boot / every merge does
+  return config;
+}
 
-  it('persists a valid header name and exposes it back', () => withDb(() => {
-    const config = structuredClone(DEFAULT_CONFIG);
-    saveLLMSettings(config, {
-      providers: { gw: { kind: 'litellm', base_url: 'http://gw.local/v1', auth_header: 'x-api-key' } },
-    });
+describe('saveLLMSettings: the hosted provider is not editable', () => {
+  beforeEach(() => { closeDb(); initDatabase(':memory:'); });
+  afterEach(() => { closeDb(); });
 
-    expect(config.llm.providers?.['gw']?.auth_header).toBe('x-api-key');
-    const stored = JSON.parse(getSetting('llm.providers') ?? '{}') as Record<string, { auth_header?: string }>;
-    expect(stored['gw']?.auth_header).toBe('x-api-key');
-  }));
-
-  it('trims surrounding whitespace', () => withDb(() => {
-    const config = structuredClone(DEFAULT_CONFIG);
-    saveLLMSettings(config, {
-      providers: { gw: { kind: 'litellm', base_url: 'http://gw.local/v1', auth_header: '  x-api-key  ' } },
-    });
-
-    expect(config.llm.providers?.['gw']?.auth_header).toBe('x-api-key');
-  }));
-
-  it('clears the field on a blank value so the provider default applies', () => withDb(() => {
-    const config = structuredClone(DEFAULT_CONFIG);
-    saveLLMSettings(config, {
-      providers: { gw: { kind: 'litellm', base_url: 'http://gw.local/v1', auth_header: 'x-api-key' } },
-    });
-    saveLLMSettings(config, { providers: { gw: { auth_header: '' } } });
-
-    expect(config.llm.providers?.['gw']?.auth_header).toBeUndefined();
-  }));
-
-  it('leaves the stored header alone when the update omits it', () => withDb(() => {
-    const config = structuredClone(DEFAULT_CONFIG);
-    saveLLMSettings(config, {
-      providers: { gw: { kind: 'litellm', base_url: 'http://gw.local/v1', auth_header: 'x-api-key' } },
-    });
-    saveLLMSettings(config, { providers: { gw: { base_url: 'http://gw.local/v1' } } });
-
-    expect(config.llm.providers?.['gw']?.auth_header).toBe('x-api-key');
-  }));
-
-  it('refuses a header name containing CRLF', () => withDb(() => {
-    const config = structuredClone(DEFAULT_CONFIG);
+  // Previously this silently `continue`d and still answered "saved and
+  // applied", so a delete appeared to succeed and the card reappeared on the
+  // next render — the API reported work it had not done.
+  test('refuses an edit rather than silently ignoring it', () => {
+    const config = hostedConfig();
     expect(() => saveLLMSettings(config, {
-      providers: { gw: { kind: 'litellm', base_url: 'http://gw.local/v1', auth_header: 'X-Bad\r\nX-Evil: 1' } },
-    })).toThrow(/invalid auth header name/);
-    expect(config.llm.providers?.['gw']).toBeUndefined();
-  }));
+      providers: { [USEJARVIS_PROVIDER_NAME]: { base_url: 'http://attacker/v1' } },
+    })).toThrow(/managed by your hosting plan/);
+    // The injected entry is untouched by the rejected write.
+    expect(config.llm.providers?.[USEJARVIS_PROVIDER_NAME]?.base_url).toBe('https://llm.usejarvis.host');
+  });
 
-  it('refuses a header name with spaces or a colon', () => withDb(() => {
-    const config = structuredClone(DEFAULT_CONFIG);
-    for (const bad of ['has space', 'has:colon']) {
-      expect(() => saveLLMSettings(config, {
-        providers: { gw: { kind: 'litellm', base_url: 'http://gw.local/v1', auth_header: bad } },
-      })).toThrow(/invalid auth header name/);
-    }
-  }));
+  test('refuses a delete too', () => {
+    const config = hostedConfig();
+    expect(() => saveLLMSettings(config, {
+      providers: { [USEJARVIS_PROVIDER_NAME]: null },
+    })).toThrow(/managed by your hosting plan/);
+    expect(config.llm.providers?.[USEJARVIS_PROVIDER_NAME]).toBeDefined();
+  });
+
+  test('an ordinary provider still saves normally', () => {
+    const config = hostedConfig();
+    // The key rides along with the base_url: main's credential-scoping rule
+    // refuses to let a STORED credential follow a provider to a new endpoint,
+    // so a URL change must re-supply it in the same request.
+    saveLLMSettings(config, {
+      providers: { anthropic: { kind: 'anthropic', base_url: 'https://api.anthropic.com', api_key: 'sk-ant-user' } },
+    });
+    expect(config.llm.providers?.anthropic?.kind).toBe('anthropic');
+  });
+
+  // The security invariant: the per-account key must never reach the DB.
+  test('a save on a hosted install leaves the reserved name out of the settings table', () => {
+    const config = hostedConfig();
+    saveLLMSettings(config, { prompt_cache: false });
+    const stored = getSetting('llm.providers') ?? '{}';
+    expect(stored).not.toContain(USEJARVIS_PROVIDER_NAME);
+    expect(stored).not.toContain('sk-uj-');
+    expect(stored).not.toContain('llm.usejarvis.host');
+  });
+});
+
+describe('getLLMSettings: the block is reported, never exposed', () => {
+  beforeEach(() => { closeDb(); initDatabase(':memory:'); });
+  afterEach(() => { closeDb(); });
+
+  test('reports hosted_llm without any credential or endpoint material', () => {
+    const view = getLLMSettings(hostedConfig());
+    expect(view.hosted_llm).toBe(true);
+    // Surfaced as a managed flag only — not as an editable provider entry.
+    expect(view.providers[USEJARVIS_PROVIDER_NAME]).toBeUndefined();
+    const serialized = JSON.stringify(view);
+    expect(serialized).not.toContain('sk-uj-');
+    expect(serialized).not.toContain('llm.usejarvis.host');
+  });
+
+  test('a self-hosted install reports hosted_llm false', () => {
+    expect(getLLMSettings(structuredClone(DEFAULT_CONFIG)).hosted_llm).toBe(false);
+  });
 });

--- a/src/daemon/llm-settings.test.ts
+++ b/src/daemon/llm-settings.test.ts
@@ -230,3 +230,60 @@ describe('getLLMSettings: the block is reported, never exposed', () => {
     expect(getLLMSettings(structuredClone(DEFAULT_CONFIG)).hosted_llm).toBe(false);
   });
 });
+
+describe('getLLMSettings.effective: the dashboard reads routing reality, not a re-derivation', () => {
+  beforeEach(() => { closeDb(); initDatabase(':memory:'); });
+  afterEach(() => { closeDb(); });
+
+  test('hosted + everything silent: router-first on the four plan aliases, sourced "plan"', () => {
+    const config = hostedConfig();
+    const { effective } = getLLMSettings(config);
+    expect(effective.mode).toBe('router-first');
+    expect(effective.tiers.conversation).toEqual({ ref: 'usejarvis_ai:uj-chat', source: 'plan' });
+    expect(effective.tiers.high).toEqual({ ref: 'usejarvis_ai:uj-high', source: 'plan' });
+    expect(effective.tiers.medium).toEqual({ ref: 'usejarvis_ai:uj-medium', source: 'plan' });
+    expect(effective.tiers.low).toEqual({ ref: 'usejarvis_ai:uj-low', source: 'plan' });
+    // ...while the persisted view stays pure user intent (all null).
+    expect(getLLMSettings(config).tiers.high).toBeNull();
+  });
+
+  test('hosted + llm.default set: per-slot D1 resolution, explicit choice wins its slot', () => {
+    const config = hostedConfig();
+    config.llm.default = 'anthropic:claude-x';
+    config.llm.tiers = { high: 'usejarvis_ai:uj-high' };
+    const { effective } = getLLMSettings(config);
+    expect(effective.tiers.high).toEqual({ ref: 'usejarvis_ai:uj-high', source: 'choice' });
+    expect(effective.tiers.medium).toEqual({ ref: 'anthropic:claude-x', source: 'default' });
+    expect(effective.tiers.conversation).toEqual({ ref: 'anthropic:claude-x', source: 'default' });
+  });
+
+  test('self-hosted: effective mirrors the persisted refs, silent slots stay empty', () => {
+    const config = structuredClone(DEFAULT_CONFIG);
+    config.llm.tiers = { high: 'anthropic:claude-x' };
+    const { effective } = getLLMSettings(config);
+    expect(effective.mode).toBe('single'); // no conversation tier bound
+    expect(effective.tiers.high).toEqual({ ref: 'anthropic:claude-x', source: 'choice' });
+    expect(effective.tiers.low).toEqual({ ref: null, source: null });
+  });
+});
+
+describe('self-hosted installs with a legacy provider literally named usejarvis_ai (W10)', () => {
+  beforeEach(() => { closeDb(); initDatabase(':memory:'); });
+  afterEach(() => { closeDb(); });
+
+  test('the entry survives an unrelated save, stays listed, and hosted_llm stays false', () => {
+    const config = structuredClone(DEFAULT_CONFIG);
+    config.llm.providers = { usejarvis_ai: { kind: 'openai_compatible', base_url: 'https://my.gw/v1' } };
+    saveLLMSettings(config, { prompt_cache: false });
+    // Persisted, not dropped:
+    expect(getSetting('llm.providers') ?? '').toContain('usejarvis_ai');
+    // Still visible to the dashboard, and the install does not read as hosted:
+    const view = getLLMSettings(config);
+    expect(view.providers.usejarvis_ai).toBeDefined();
+    expect(view.hosted_llm).toBe(false);
+    // Reload keeps it (no reserved-name skip on self-hosted):
+    const reloaded = structuredClone(DEFAULT_CONFIG);
+    mergeLLMSettingsIntoConfig(reloaded);
+    expect(reloaded.llm.providers?.usejarvis_ai?.base_url).toBe('https://my.gw/v1');
+  });
+});

--- a/src/daemon/llm-settings.ts
+++ b/src/daemon/llm-settings.ts
@@ -185,8 +185,10 @@ export function getLLMSettings(config: JarvisConfig): LLMSettingsResponse {
     if (!entry) continue;
     // The injected hosted provider is SYSTEM-owned: not editable, and its
     // base_url/key presence are none of the dashboard's business. It is
-    // surfaced separately as a managed flag below.
-    if (name === USEJARVIS_PROVIDER_NAME) continue;
+    // surfaced separately as a managed flag below. Hosted-gated: a
+    // self-hosted install whose user happened to name a provider
+    // `usejarvis_ai` before the reservation existed still owns that entry.
+    if (name === USEJARVIS_PROVIDER_NAME && hasUsejarvisAi(config)) continue;
     const kind = (entry.kind ?? name) as LLMProviderKind;
     providers[name] = {
       kind,
@@ -246,10 +248,9 @@ export function getLLMSettings(config: JarvisConfig): LLMSettingsResponse {
     effective,
     // Hosted installs: tells the dashboard to render the read-only
     // "included with your plan" card (no base_url, no key material).
-    hosted_llm: Object.prototype.hasOwnProperty.call(
-      config.llm.providers ?? {},
-      USEJARVIS_PROVIDER_NAME,
-    ),
+    // Derived from the config.yaml block — the single source of hostedness —
+    // never from provider-map key presence, which a legacy row can fake.
+    hosted_llm: hasUsejarvisAi(config),
   };
 }
 
@@ -277,15 +278,13 @@ export function saveLLMSettings(
       // SYSTEM-owned: on hosted installs an edit/delete of the reserved name
       // is refused loudly (a silent skip reported "saved" for a no-op). The
       // throw lives HERE in the validation loop so a rejected batch mutates
-      // nothing. On self-hosted installs (no block) the legacy silent-skip
-      // stands until the reservation is gated on hostedness.
-      if (name === USEJARVIS_PROVIDER_NAME) {
-        if (hasUsejarvisAi(config)) {
-          throw new Error(
-            `Provider '${USEJARVIS_PROVIDER_NAME}' is managed by your hosting plan and cannot be edited or deleted`,
-          );
-        }
-        continue;
+      // nothing. On self-hosted installs there is no reservation: a legacy
+      // provider that happens to carry the name falls through to the normal
+      // validation and save path like any other entry.
+      if (name === USEJARVIS_PROVIDER_NAME && hasUsejarvisAi(config)) {
+        throw new Error(
+          `Provider '${USEJARVIS_PROVIDER_NAME}' is managed by your hosting plan and cannot be edited or deleted`,
+        );
       }
       if (update === null) continue;
       const existing = config.llm.providers[name] ?? {};
@@ -317,17 +316,10 @@ export function saveLLMSettings(
       }
     }
     for (const [name, update] of updates) {
-      // The hosted provider is SYSTEM-owned (config.yaml carve-out): the
-      // dashboard can neither create, edit, nor delete it, and nothing under
-      // the reserved name may reach the DB or keychain.
-      //
-      // Refuse rather than silently skip. Skipping still answered "saved and
-      // applied", so a delete appeared to succeed and the card came back on
-      // the next render — the API contract lied about what it had done. The
-      // route maps this to a 400.
-      if (name === USEJARVIS_PROVIDER_NAME) {
-        throw new Error(`'${USEJARVIS_PROVIDER_NAME}' is managed by the platform and cannot be edited`);
-      }
+      // Hosted installs never reach here with the reserved name — the
+      // validation loop above already threw. Defensive skip in case the two
+      // loops ever drift apart; on self-hosted the entry is a normal provider.
+      if (name === USEJARVIS_PROVIDER_NAME && hasUsejarvisAi(config)) continue;
       if (update === null) {
         delete config.llm.providers[name];
         // Drop every model ref the provider owned. The manager prunes its own
@@ -401,7 +393,9 @@ export function saveLLMSettings(
   // provider entry before serializing - the in-memory entries carry secrets
   // injected from the keychain (see mergeLLMSettingsIntoConfig), and the
   // settings table is plaintext.
-  setSetting(SETTING_PROVIDERS, JSON.stringify(stripSecretsFromProviders(config.llm.providers)));
+  setSetting(SETTING_PROVIDERS, JSON.stringify(
+    stripSecretsFromProviders(config.llm.providers, { hosted: hasUsejarvisAi(config) }),
+  ));
   setSetting(SETTING_DEFAULT, config.llm.default ?? '');
   setSetting(SETTING_TIER_CONVERSATION, config.llm.tiers.conversation ?? '');
   setSetting(SETTING_TIER_HIGH, config.llm.tiers.high ?? '');
@@ -422,14 +416,18 @@ export function saveLLMSettings(
  */
 export function stripSecretsFromProviders(
   providers: Record<string, LLMProviderEntry> | undefined,
+  options: { hosted?: boolean } = {},
 ): Record<string, LLMProviderEntry> {
   const out: Record<string, LLMProviderEntry> = {};
   for (const [name, entry] of Object.entries(providers ?? {})) {
     if (!entry) continue;
-    // The hosted provider is INJECTED from config.yaml on every merge — it
-    // must never round-trip into the persisted DB shape (it would survive
-    // un-hosting and shadow the file as a stale copy).
-    if (name === USEJARVIS_PROVIDER_NAME) continue;
+    // On hosted installs the reserved provider is INJECTED from config.yaml
+    // on every merge — it must never round-trip into the persisted DB shape
+    // (it would survive un-hosting and shadow the file as a stale copy). On
+    // self-hosted installs a legacy provider carrying the name is user
+    // property and persists like any other (dropping it silently destroyed
+    // the entry plus its refs on the next boot).
+    if (name === USEJARVIS_PROVIDER_NAME && options.hosted !== false) continue;
     const { api_key: _omit, ...rest } = entry;
     void _omit;
     out[name] = rest;
@@ -471,6 +469,10 @@ export function mergeLLMSettingsIntoConfig(
     try {
       const parsed = JSON.parse(providersJson) as Record<string, LLMProviderEntry>;
       for (const [name, entry] of Object.entries(parsed)) {
+        // Hosted installs: a DB row squatting on the reserved name never
+        // loads (applyUsejarvisAi would overwrite it anyway; skipping keeps
+        // the invariant visible). Self-hosted legacy rows load normally.
+        if (name === USEJARVIS_PROVIDER_NAME && hasUsejarvisAi(config)) continue;
         config.llm.providers[name] = entry;
       }
     } catch (err) {
@@ -525,7 +527,8 @@ export function mergeLLMSettingsIntoConfig(
   for (const name of Object.keys(config.llm.providers)) {
     // The hosted provider's credential comes from the config.yaml block only;
     // a keychain entry squatting on the reserved name must not shadow it.
-    if (name === USEJARVIS_PROVIDER_NAME) continue;
+    // Self-hosted legacy providers hydrate from the keychain like any other.
+    if (name === USEJARVIS_PROVIDER_NAME && hasUsejarvisAi(config)) continue;
     const key = getSecret(keychainKey(name));
     if (key) {
       // Inject into the entry transiently so registerLLMProviders can
@@ -820,8 +823,10 @@ export async function testLLMProvider(
   if (!name) return { ok: false, error: 'provider name required' };
   // The hosted provider's key must never pass through user hands: a caller
   // could combine the inherited credential with a kind/base_url OVERRIDE and
-  // exfiltrate it to an arbitrary endpoint. It is system-tested, not user-tested.
-  if (name === USEJARVIS_PROVIDER_NAME) {
+  // exfiltrate it to an arbitrary endpoint. It is system-tested, not
+  // user-tested. (Self-hosted installs have no platform key to protect; a
+  // legacy provider carrying the name is testable like any other.)
+  if (name === USEJARVIS_PROVIDER_NAME && hasUsejarvisAi(config)) {
     return { ok: false, error: 'usejarvis_ai is system-managed and cannot be tested here' };
   }
 

--- a/src/daemon/llm-settings.ts
+++ b/src/daemon/llm-settings.ts
@@ -113,6 +113,8 @@ export type LLMSettingsResponse = {
   };
   /** Provider classes the system can instantiate. UI dropdowns use this. */
   available_kinds: LLMProviderKind[];
+  /** True on hosted installs (the system-owned usejarvis_ai block is live). */
+  hosted_llm?: boolean;
   /** Provider-side prompt caching. Defaults to true; only explicit false disables. */
   prompt_cache: boolean;
 };
@@ -155,6 +157,10 @@ export function getLLMSettings(config: JarvisConfig): LLMSettingsResponse {
   const providers: Record<string, LLMSettingsProviderView> = {};
   for (const [name, entry] of Object.entries(config.llm.providers ?? {})) {
     if (!entry) continue;
+    // The injected hosted provider is SYSTEM-owned: not editable, and its
+    // base_url/key presence are none of the dashboard's business. It is
+    // surfaced separately as a managed flag below.
+    if (name === USEJARVIS_PROVIDER_NAME) continue;
     const kind = (entry.kind ?? name) as LLMProviderKind;
     providers[name] = {
       kind,
@@ -190,6 +196,12 @@ export function getLLMSettings(config: JarvisConfig): LLMSettingsResponse {
     tiers,
     available_kinds: AVAILABLE_KINDS,
     prompt_cache: config.llm.prompt_cache !== false,
+    // Hosted installs: tells the dashboard to render the read-only
+    // "included with your plan" card (no base_url, no key material).
+    hosted_llm: Object.prototype.hasOwnProperty.call(
+      config.llm.providers ?? {},
+      USEJARVIS_PROVIDER_NAME,
+    ),
   };
 }
 
@@ -453,7 +465,8 @@ export function mergeLLMSettingsIntoConfig(
   // surface them in `config.llm.providers.<name>.api_key` (that would risk
   // saving them back to disk) - instead the config-binding module reads
   // from the keychain at provider-instantiation time. So this step only
-  // ensures entries exist for any name with a keychain secret.
+  // ensures entries exist for any name with a keychain secret. (There is no
+  // YAML write path: loader.ts deliberately has no saveConfig.)
   for (const name of Object.keys(config.llm.providers)) {
     // The hosted provider's credential comes from the config.yaml block only;
     // a keychain entry squatting on the reserved name must not shadow it.
@@ -750,6 +763,12 @@ export async function testLLMProvider(
   // Resolve effective name + kind. Legacy `provider` is treated as `name`.
   const name = opts.name ?? opts.provider ?? opts.kind;
   if (!name) return { ok: false, error: 'provider name required' };
+  // The hosted provider's key must never pass through user hands: a caller
+  // could combine the inherited credential with a kind/base_url OVERRIDE and
+  // exfiltrate it to an arbitrary endpoint. It is system-tested, not user-tested.
+  if (name === USEJARVIS_PROVIDER_NAME) {
+    return { ok: false, error: 'usejarvis_ai is system-managed and cannot be tested here' };
+  }
 
   // Look up config entry to inherit settings the caller didn't override.
   const configured = config.llm.providers?.[name];

--- a/src/daemon/llm-settings.ts
+++ b/src/daemon/llm-settings.ts
@@ -117,6 +117,32 @@ export type LLMSettingsResponse = {
   hosted_llm?: boolean;
   /** Provider-side prompt caching. Defaults to true; only explicit false disables. */
   prompt_cache: boolean;
+  /**
+   * What the daemon is ACTUALLY routing with, computed from the same
+   * effectiveLlmForBinding view the provider-binding paths consume. The
+   * `tiers`/`mode`/`default` fields above are persisted user intent; this is
+   * the resolved result after hosted per-slot filling. The dashboard renders
+   * hints and fallback labels from HERE, never by re-deriving the fill —
+   * re-derivation is how the UI and the daemon ended up contradicting each
+   * other (pr2 review #3B, pr7 review #2).
+   */
+  effective: LLMSettingsEffectiveView;
+};
+
+/** Where an effective tier ref came from. */
+export type EffectiveTierSource =
+  | 'choice'   // the user's explicit tier ref
+  | 'default'  // filled from llm.default (per-slot, hosted installs)
+  | 'plan';    // filled from the plan's uj-* alias
+
+export type LLMSettingsEffectiveView = {
+  /** Architecture actually bound: router-first iff the effective view has a
+   * conversation tier (the same rule configureLLMTiers applies). */
+  mode: 'single' | 'router-first';
+  tiers: Record<Tier, {
+    ref: string | null;
+    source: EffectiveTierSource | null;
+  }>;
 };
 
 /** Body shape accepted by saveLLMSettings - all fields optional/partial. */
@@ -189,6 +215,27 @@ export function getLLMSettings(config: JarvisConfig): LLMSettingsResponse {
         ? 'multi-tier'
         : 'single';
 
+  // The resolved routing view, from the same function the binding paths use.
+  const bound = effectiveLlmForBinding(config);
+  const effectiveTiers = {} as LLMSettingsEffectiveView['tiers'];
+  for (const tier of TIERS) {
+    const chosen = config.llm.tiers?.[tier];
+    if (chosen) {
+      effectiveTiers[tier] = { ref: chosen, source: 'choice' };
+      continue;
+    }
+    const resolved = bound.tiers?.[tier] ?? null;
+    effectiveTiers[tier] = resolved
+      ? { ref: resolved, source: config.llm.default ? 'default' : 'plan' }
+      : { ref: null, source: null };
+  }
+  const effective: LLMSettingsEffectiveView = {
+    // Same rule configureLLMTiers applies: a conversation tier in the BOUND
+    // view activates router-first, whatever the stored mode label says.
+    mode: effectiveTiers.conversation.ref ? 'router-first' : 'single',
+    tiers: effectiveTiers,
+  };
+
   return {
     providers,
     default: config.llm.default ?? null,
@@ -196,6 +243,7 @@ export function getLLMSettings(config: JarvisConfig): LLMSettingsResponse {
     tiers,
     available_kinds: AVAILABLE_KINDS,
     prompt_cache: config.llm.prompt_cache !== false,
+    effective,
     // Hosted installs: tells the dashboard to render the read-only
     // "included with your plan" card (no base_url, no key material).
     hosted_llm: Object.prototype.hasOwnProperty.call(

--- a/src/daemon/llm-settings.ts
+++ b/src/daemon/llm-settings.ts
@@ -272,7 +272,14 @@ export function saveLLMSettings(
       // The hosted provider is SYSTEM-owned (config.yaml carve-out): the
       // dashboard can neither create, edit, nor delete it, and nothing under
       // the reserved name may reach the DB or keychain.
-      if (name === USEJARVIS_PROVIDER_NAME) continue;
+      //
+      // Refuse rather than silently skip. Skipping still answered "saved and
+      // applied", so a delete appeared to succeed and the card came back on
+      // the next render — the API contract lied about what it had done. The
+      // route maps this to a 400.
+      if (name === USEJARVIS_PROVIDER_NAME) {
+        throw new Error(`'${USEJARVIS_PROVIDER_NAME}' is managed by the platform and cannot be edited`);
+      }
       if (update === null) {
         delete config.llm.providers[name];
         // Drop every model ref the provider owned. The manager prunes its own

--- a/src/daemon/usejarvis-ai.test.ts
+++ b/src/daemon/usejarvis-ai.test.ts
@@ -256,3 +256,33 @@ describe('DB round-trips (restart survival + fill never persists)', () => {
     expect(selfHosted.llm.providers[USEJARVIS_PROVIDER_NAME]).toEqual({ kind: 'openai' });
   });
 });
+
+describe('hasUsejarvisAi: malformed blocks read as NOT hosted, never fatal', () => {
+  const withBlock = (block: unknown): JarvisConfig => {
+    const config = structuredClone(DEFAULT_CONFIG);
+    (config as Record<string, unknown>).usejarvis_ai = block;
+    return config;
+  };
+
+  // YAML types its scalars: an unquoted `api_key: 1234567890` parses as a
+  // number, and `.trim()` on it threw out of here, through
+  // mergeLLMSettingsIntoConfig, into the boot try/catch → exit(1). A hand-
+  // edited config must degrade to self-hosted, not stop the daemon booting.
+  test('a numeric api_key or base_url does not throw', () => {
+    expect(() => hasUsejarvisAi(withBlock({ base_url: 'https://x', api_key: 1234567890 }))).not.toThrow();
+    expect(hasUsejarvisAi(withBlock({ base_url: 'https://x', api_key: 1234567890 }))).toBe(false);
+    expect(hasUsejarvisAi(withBlock({ base_url: 42, api_key: 'sk-uj-abc' }))).toBe(false);
+  });
+
+  test('other malformed shapes are also non-fatal and non-hosted', () => {
+    for (const block of [null, undefined, 'a string', [], { base_url: 'https://x' }, { api_key: 'sk-uj-a' },
+                         { base_url: '   ', api_key: 'sk-uj-a' }, { base_url: true, api_key: false }]) {
+      expect(() => hasUsejarvisAi(withBlock(block))).not.toThrow();
+      expect(hasUsejarvisAi(withBlock(block))).toBe(false);
+    }
+  });
+
+  test('a well-formed block still reads as hosted', () => {
+    expect(hasUsejarvisAi(withBlock({ base_url: 'https://llm.usejarvis.host', api_key: 'sk-uj-abc' }))).toBe(true);
+  });
+});

--- a/src/daemon/usejarvis-ai.test.ts
+++ b/src/daemon/usejarvis-ai.test.ts
@@ -88,6 +88,20 @@ describe('applyUsejarvisAi (provider injection only)', () => {
     applyUsejarvisAi(twice);
     expect(twice.llm).toEqual(once.llm);
   });
+
+  test('testLLMProvider refuses the reserved name (key-exfiltration guard)', async () => {
+    const { testLLMProvider } = await import('./llm-settings.ts');
+    const config = hosted();
+    applyUsejarvisAi(config);
+    // A kind/base_url override would otherwise inherit the hosted key and
+    // send it to an attacker-chosen endpoint.
+    const result = await testLLMProvider(
+      { name: USEJARVIS_PROVIDER_NAME, kind: 'openai_compatible', base_url: 'https://evil.example' },
+      config,
+    );
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain('system-managed');
+  });
 });
 
 describe('effectiveLlmForBinding (per-slot: explicit ref → llm.default → plan alias)', () => {
@@ -231,12 +245,14 @@ describe('DB round-trips (restart survival + fill never persists)', () => {
     expect(hasSecret('llm.provider.atomicity-probe.api_key')).toBe(false);
     expect(config.llm.providers!['atomicity-probe']).toEqual({ kind: 'anthropic' });
 
-    // Self-hosted installs keep the legacy silent skip (no block, no throw).
+    // Self-hosted installs have NO reservation: a provider that happens to
+    // carry the name is user property and saves like any other entry (the
+    // old silent skip destroyed legacy configs named usejarvis_ai).
     const selfHosted = base();
     selfHosted.llm.providers = {};
     expect(() =>
       saveLLMSettings(selfHosted, { providers: { [USEJARVIS_PROVIDER_NAME]: { kind: 'openai' } } }),
     ).not.toThrow();
-    expect(selfHosted.llm.providers[USEJARVIS_PROVIDER_NAME]).toBeUndefined();
+    expect(selfHosted.llm.providers[USEJARVIS_PROVIDER_NAME]).toEqual({ kind: 'openai' });
   });
 });

--- a/src/daemon/usejarvis-ai.ts
+++ b/src/daemon/usejarvis-ai.ts
@@ -24,8 +24,16 @@ import type { JarvisConfig, LLMConfig } from '../config/types.ts';
  * choices.
  */
 
-/** Reserved provider name: the map key, the kind, and the tier-ref prefix. */
+/** Reserved provider name: the map key and the tier-ref prefix. */
 export const USEJARVIS_PROVIDER_NAME = 'usejarvis_ai';
+
+/**
+ * The hosted provider's `kind`. Same literal as the name today, but a
+ * DISTINCT constant: gates that ask "is this entry the hosted provider"
+ * compare kinds against this, never kind-vs-name — the two coinciding is an
+ * implementation detail, not a contract (see pr3 review #11).
+ */
+export const USEJARVIS_KIND = 'usejarvis_ai';
 
 /** Default tier wiring: identical on every plan — per-plan model resolution
  * happens at the proxy via these aliases, never in this file. */

--- a/src/llm/config-binding.ts
+++ b/src/llm/config-binding.ts
@@ -27,6 +27,7 @@ import { NVIDIAProvider } from './nvidia.ts';
 import { OpenAICompatibleProvider } from './openai-compatible.ts';
 import { LiteLLMProvider } from './litellm.ts';
 import { OmniRouteProvider } from './omniroute.ts';
+import { UsejarvisAIProvider } from './usejarvis.ts';
 
 /**
  * Instantiate a provider class from a single entry. Returns null when the
@@ -96,6 +97,12 @@ export function instantiateProvider(
       break;
     case 'omniroute':
       provider = new OmniRouteProvider(entry.base_url?.trim() || undefined, undefined, entry.api_key, entry.auth_header);
+      break;
+    case 'usejarvis_ai':
+      // Hosted platform proxy: both values come from the system-owned
+      // config.yaml block (daemon/usejarvis-ai.ts) - nothing to guess.
+      if (!entry.base_url || !entry.api_key) return null;
+      provider = new UsejarvisAIProvider(entry.base_url, entry.api_key);
       break;
     default:
       console.warn(`[LLM] Unknown provider kind '${kind}' for '${name}' - skipping.`);

--- a/src/llm/index.ts
+++ b/src/llm/index.ts
@@ -19,6 +19,7 @@ export { OllamaProvider } from './ollama.ts';
 export { OpenRouterProvider } from './openrouter.ts';
 export { LiteLLMProvider } from './litellm.ts';
 export { OmniRouteProvider } from './omniroute.ts';
+export { UsejarvisAIProvider } from './usejarvis.ts';
 
 // Manager
 export { LLMManager } from './manager.ts';

--- a/src/llm/test.ts
+++ b/src/llm/test.ts
@@ -34,7 +34,11 @@ async function testProviders() {
     console.error('No providers configured.');
     return;
   }
-  configureLLMTiers(manager, config.llm);
+  // Routing view, not persisted intent — hosted tier defaults live only here
+  // (see effectiveLlmForBinding), so binding config.llm directly would leave
+  // this diagnostic with no tiers on a hosted install.
+  const { effectiveLlmForBinding } = await import('../daemon/usejarvis-ai.ts');
+  configureLLMTiers(manager, effectiveLlmForBinding(config));
 
   console.log(`Active providers: ${manager.getProviderNames().join(', ')}`);
   if (config.llm.default) console.log(`Default: ${config.llm.default}`);

--- a/src/llm/usejarvis.test.ts
+++ b/src/llm/usejarvis.test.ts
@@ -91,13 +91,31 @@ describe('UsejarvisAIProvider', () => {
     );
   });
 
-  it('carries the budget window and reset boundary in the copy', async () => {
-    globalThis.fetch = (async () => jsonResponse(429, {
-      error: {
-        message: 'ExceededBudget: Budget has been exceeded! Current cost: 0.0051, Max budget: 0.005, '
-          + 'budget_duration: 6h, budget_reset_at: 2026-08-13T12:00:00+00:00',
-      },
-    })) as unknown as typeof fetch;
+  // The 429 budget body carries NO reset field (platform team, 2026-08-19);
+  // the reset time lives on GET /key/info at the proxy ROOT, readable with
+  // the account's own key, as ISO-8601 with an explicit offset.
+  it('budget copy quotes the /key/info reset time and memoizes the lookup', async () => {
+    let infoCalls = 0;
+    let infoUrl = '';
+    let infoAuth: string | null = null;
+    globalThis.fetch = (async (input: any, init?: any) => {
+      const url = String(input);
+      if (url.endsWith('/key/info')) {
+        infoCalls++;
+        infoUrl = url;
+        infoAuth = new Headers(init?.headers).get('Authorization');
+        return jsonResponse(200, {
+          key: 'sk-uj-abc',
+          info: { budget_reset_at: '2026-08-19T12:00:00+00:00', max_budget: 0.005 },
+        });
+      }
+      return jsonResponse(429, {
+        error: {
+          message: 'ExceededBudget: Budget has been exceeded! Current cost: 0.0051, Max budget: 0.005',
+          code: 'budget_exceeded',
+        },
+      });
+    }) as unknown as typeof fetch;
     const provider = new UsejarvisAIProvider('https://llm.usejarvis.host', 'sk-uj-abc');
     const failed = async (): Promise<string> => {
       try {
@@ -107,14 +125,45 @@ describe('UsejarvisAIProvider', () => {
         return (e as Error).message;
       }
     };
-    expect(await failed()).toMatch(/for this 6h window \(resumes 12:00 UTC\)/);
-    // …and degrades rather than inventing a time when the proxy omits them.
-    globalThis.fetch = (async () => jsonResponse(429, {
-      error: { message: 'Budget has been exceeded!' },
-    })) as unknown as typeof fetch;
-    const bare = await failed();
-    expect(bare).toMatch(/for this window\./);
-    expect(bare).not.toMatch(/resumes \d/);
+    expect(await failed()).toMatch(/used up for this window \(resumes 12:00 UTC\)/);
+    // /key/info sits on the proxy ROOT, not under /v1, with the same bearer.
+    expect(infoUrl).toBe('https://llm.usejarvis.host/key/info');
+    expect(infoAuth ?? '').toBe('Bearer sk-uj-abc');
+    // A second budget error inside the memo window issues no second lookup.
+    expect(await failed()).toMatch(/resumes 12:00 UTC/);
+    expect(infoCalls).toBe(1);
+  });
+
+  it('budget copy degrades to time-less when /key/info fails, leaking nothing', async () => {
+    globalThis.fetch = (async (input: any) => {
+      if (String(input).endsWith('/key/info')) {
+        throw new Error('connect ETIMEDOUT llm.usejarvis.host:443');
+      }
+      return jsonResponse(429, { error: { message: 'Budget has been exceeded!' } });
+    }) as unknown as typeof fetch;
+    const provider = new UsejarvisAIProvider('https://llm.usejarvis.host', 'sk-uj-abc');
+    let message = '';
+    try {
+      await provider.chat([{ role: 'user', content: 'hi' }], { model: 'uj-chat' });
+    } catch (e) {
+      message = (e as Error).message;
+    }
+    expect(message).toMatch(/used up for this window\./);
+    expect(message).not.toMatch(/resumes \d/);
+    expect(message).not.toContain('llm.usejarvis.host');
+  });
+
+  it('403 maps to model-not-in-plan (team_model_access_denied), no /key/info lookup', async () => {
+    let infoCalls = 0;
+    globalThis.fetch = (async (input: any) => {
+      if (String(input).endsWith('/key/info')) { infoCalls++; return jsonResponse(200, {}); }
+      return jsonResponse(403, { error: { message: 'team_model_access_denied', code: 'team_model_access_denied' } });
+    }) as unknown as typeof fetch;
+    const provider = new UsejarvisAIProvider('https://llm.usejarvis.host', 'sk-uj-abc');
+    await expect(provider.chat([{ role: 'user', content: 'hi' }], { model: 'gpt-5.5' })).rejects.toThrow(
+      /\(403\).*not included in your plan/,
+    );
+    expect(infoCalls).toBe(0);
   });
 
   // The base class YIELDS {type:'error'} events instead of throwing, so a

--- a/src/llm/usejarvis.test.ts
+++ b/src/llm/usejarvis.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import { UsejarvisAIProvider } from './usejarvis.ts';
+import { instantiateProvider } from './config-binding.ts';
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+const jsonResponse = (status: number, body: unknown) =>
+  new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } });
+
+describe('UsejarvisAIProvider', () => {
+  it('normalizes the provisioner-written origin to a /v1 base', () => {
+    const bare = new UsejarvisAIProvider('https://llm.usejarvis.host', 'sk-uj-a');
+    expect((bare as any).apiUrl).toBe('https://llm.usejarvis.host/v1/chat/completions');
+    // Already-suffixed and trailing-slash forms stay stable.
+    const suffixed = new UsejarvisAIProvider('https://llm.usejarvis.host/v1/', 'sk-uj-a');
+    expect((suffixed as any).apiUrl).toBe('https://llm.usejarvis.host/v1/chat/completions');
+  });
+
+  it('is created by the canonical config binding only when fully configured', () => {
+    const provider = instantiateProvider('usejarvis_ai', {
+      kind: 'usejarvis_ai',
+      base_url: 'https://llm.usejarvis.host',
+      api_key: 'sk-uj-abc',
+    });
+    expect(provider).toBeInstanceOf(UsejarvisAIProvider);
+    expect(provider?.name).toBe('usejarvis_ai');
+    // System-owned config always carries both values; a partial entry is a
+    // broken render, not something to guess around.
+    expect(instantiateProvider('usejarvis_ai', { kind: 'usejarvis_ai', base_url: 'https://x' })).toBeNull();
+  });
+
+  it('listModels returns the key-scoped alias catalog, deduped + sorted', async () => {
+    let url = '';
+    let auth: string | null = null;
+    globalThis.fetch = (async (input: any, init?: any) => {
+      url = String(input);
+      auth = new Headers(init?.headers).get('Authorization');
+      return jsonResponse(200, { data: [{ id: 'uj-low' }, { id: 'uj-chat' }, { id: 'uj-low' }, { id: 42 }] });
+    }) as unknown as typeof fetch;
+    const provider = new UsejarvisAIProvider('https://llm.usejarvis.host', 'sk-uj-abc');
+    expect(await provider.listModels()).toEqual(['uj-chat', 'uj-low']);
+    expect(url).toBe('https://llm.usejarvis.host/v1/models');
+    expect(auth ?? '').toBe('Bearer sk-uj-abc');
+  });
+
+  it('rewrites budget-exceeded into actionable copy, keeping the (status) marker', async () => {
+    globalThis.fetch = (async () =>
+      jsonResponse(400, { error: { message: 'ExceededBudget: budget has been exceeded for this key' } })) as unknown as typeof fetch;
+    const provider = new UsejarvisAIProvider('https://llm.usejarvis.host', 'sk-uj-abc');
+    await expect(provider.chat([{ role: 'user', content: 'hi' }], { model: 'uj-chat' })).rejects.toThrow(
+      /\(400\).*included AI usage is used up/,
+    );
+  });
+
+  it('rewrites blocked/no-plan (401) and model-not-in-plan errors', async () => {
+    globalThis.fetch = (async () => jsonResponse(401, { error: { message: 'Authentication Error: key is blocked' } })) as unknown as typeof fetch;
+    const provider = new UsejarvisAIProvider('https://llm.usejarvis.host', 'sk-uj-abc');
+    await expect(provider.chat([{ role: 'user', content: 'hi' }], { model: 'uj-chat' })).rejects.toThrow(
+      /\(401\).*active plan is required/,
+    );
+    globalThis.fetch = (async () => jsonResponse(400, { error: { message: 'model uj-realtime not allowed for this key' } })) as unknown as typeof fetch;
+    await expect(provider.chat([{ role: 'user', content: 'hi' }], { model: 'uj-realtime' })).rejects.toThrow(
+      /\(400\).*not included in your plan/,
+    );
+  });
+
+  it('keeps retryable statuses recognizable (429 passes through with marker)', async () => {
+    globalThis.fetch = (async () => jsonResponse(429, { error: { message: 'rate limited' } })) as unknown as typeof fetch;
+    const provider = new UsejarvisAIProvider('https://llm.usejarvis.host', 'sk-uj-abc');
+    await expect(provider.chat([{ role: 'user', content: 'hi' }], { model: 'uj-chat' })).rejects.toThrow(/\(429\)/);
+  });
+});

--- a/src/llm/usejarvis.test.ts
+++ b/src/llm/usejarvis.test.ts
@@ -73,4 +73,81 @@ describe('UsejarvisAIProvider', () => {
     const provider = new UsejarvisAIProvider('https://llm.usejarvis.host', 'sk-uj-abc');
     await expect(provider.chat([{ role: 'user', content: 'hi' }], { model: 'uj-chat' })).rejects.toThrow(/\(429\)/);
   });
+
+  // LiteLLM denies an out-of-plan model with 401, NOT 403 — so the model
+  // branch has to outrank the auth branch. Pinned at 401 specifically: at
+  // 400 (the old fixture) the ordering bug cannot fire, and a paying user
+  // picking a model outside their plan gets told their account is inactive.
+  it('reports model-not-in-plan for a 401 denial, not "no active plan"', async () => {
+    globalThis.fetch = (async () => jsonResponse(401, {
+      error: {
+        message: "Authentication Error, key not allowed to access model. This key can only access "
+          + "models=['uj-chat','uj-low']. Tried to access uj-realtime",
+      },
+    })) as unknown as typeof fetch;
+    const provider = new UsejarvisAIProvider('https://llm.usejarvis.host', 'sk-uj-abc');
+    await expect(provider.chat([{ role: 'user', content: 'hi' }], { model: 'uj-realtime' })).rejects.toThrow(
+      /\(401\).*not included in your plan/,
+    );
+  });
+
+  it('carries the budget window and reset boundary in the copy', async () => {
+    globalThis.fetch = (async () => jsonResponse(429, {
+      error: {
+        message: 'ExceededBudget: Budget has been exceeded! Current cost: 0.0051, Max budget: 0.005, '
+          + 'budget_duration: 6h, budget_reset_at: 2026-08-13T12:00:00+00:00',
+      },
+    })) as unknown as typeof fetch;
+    const provider = new UsejarvisAIProvider('https://llm.usejarvis.host', 'sk-uj-abc');
+    const failed = async (): Promise<string> => {
+      try {
+        await provider.chat([{ role: 'user', content: 'hi' }], { model: 'uj-chat' });
+        throw new Error('expected the budget error to throw');
+      } catch (e) {
+        return (e as Error).message;
+      }
+    };
+    expect(await failed()).toMatch(/for this 6h window \(resumes 12:00 UTC\)/);
+    // …and degrades rather than inventing a time when the proxy omits them.
+    globalThis.fetch = (async () => jsonResponse(429, {
+      error: { message: 'Budget has been exceeded!' },
+    })) as unknown as typeof fetch;
+    const bare = await failed();
+    expect(bare).toMatch(/for this window\./);
+    expect(bare).not.toMatch(/resumes \d/);
+  });
+
+  // The base class YIELDS {type:'error'} events instead of throwing, so a
+  // try/catch around super.stream() is dead code — and this is the path
+  // every conversation turn takes. Without the event rewrite the raw proxy
+  // body (which echoes the bearer we presented) reaches the chat bubble.
+  it('rewrites stream error EVENTS, leaking neither the key nor the body', async () => {
+    const key = 'sk-uj-7Yb2QpLmN4vXzR1aTgKe0wUf';
+    globalThis.fetch = (async () => new Response(
+      `<html><title>401</title><body>Upstream rejected credential Bearer ${key} `
+        + 'for host llm.usejarvis.host. ' + 'x'.repeat(4000) + '</body></html>',
+      { status: 401, headers: { 'Content-Type': 'text/html' } },
+    )) as unknown as typeof fetch;
+    const provider = new UsejarvisAIProvider('https://llm.usejarvis.host', key);
+
+    const events: Array<{ type: string; error?: string }> = [];
+    for await (const event of provider.stream([{ role: 'user', content: 'hi' }], { model: 'uj-chat' })) {
+      events.push(event as { type: string; error?: string });
+    }
+    const errors = events.filter((e) => e.type === 'error');
+    expect(errors).toHaveLength(1);
+    const text = errors[0]!.error ?? '';
+    expect(text).not.toContain(key);
+    expect(text).not.toContain('llm.usejarvis.host');
+    expect(text).toMatch(/\(401\).*active plan is required/);
+    expect(text.length).toBeLessThan(300); // never the unbounded CDN page
+  });
+
+  it('filters the catalog to uj-* so a mis-scoped key cannot leak upstream ids', async () => {
+    globalThis.fetch = (async () => jsonResponse(200, {
+      data: [{ id: 'uj-chat' }, { id: 'claude-haiku-4-5-20251001' }, { id: 'gpt-4o-mini' }],
+    })) as unknown as typeof fetch;
+    const provider = new UsejarvisAIProvider('https://llm.usejarvis.host', 'sk-uj-abc');
+    expect(await provider.listModels()).toEqual(['uj-chat']);
+  });
 });

--- a/src/llm/usejarvis.test.ts
+++ b/src/llm/usejarvis.test.ts
@@ -150,4 +150,19 @@ describe('UsejarvisAIProvider', () => {
     const provider = new UsejarvisAIProvider('https://llm.usejarvis.host', 'sk-uj-abc');
     expect(await provider.listModels()).toEqual(['uj-chat']);
   });
+
+  it('listModels degrades to the fallback aliases instead of throwing (pr2 review #6)', async () => {
+    // Transient 503:
+    globalThis.fetch = (async () => jsonResponse(503, { error: 'upstream down' })) as unknown as typeof fetch;
+    const provider = new UsejarvisAIProvider('https://llm.usejarvis.host', 'sk-uj-abc');
+    expect(await provider.listModels()).toEqual(['uj-chat', 'uj-high', 'uj-low', 'uj-medium']);
+    // Network failure:
+    globalThis.fetch = (async () => { throw new Error('connect ECONNREFUSED'); }) as unknown as typeof fetch;
+    expect(await provider.listModels()).toEqual(['uj-chat', 'uj-high', 'uj-low', 'uj-medium']);
+  });
+
+  it('defaultModel is uj-medium so the manager model-less retry never posts an empty model (pr2 review #7)', () => {
+    const provider = new UsejarvisAIProvider('https://llm.usejarvis.host', 'sk-uj-abc');
+    expect((provider as unknown as { defaultModel: string }).defaultModel).toBe('uj-medium');
+  });
 });

--- a/src/llm/usejarvis.ts
+++ b/src/llm/usejarvis.ts
@@ -1,4 +1,5 @@
 import { OpenAIProvider } from './openai.ts';
+import { redactSecrets } from '../util/redact.ts';
 
 /**
  * Hosted "Usejarvis AI" provider: the platform's OpenAI-compatible LLM proxy.
@@ -70,7 +71,13 @@ export class UsejarvisAIProvider extends OpenAIProvider {
   /** Map proxy errors to actionable copy. The `(status)` marker is kept so
    * classifyErrorString still steers retries (429/503 retry; 400s do not). */
   private friendly(status: number, detail: string): Error {
-    const lower = detail.toLowerCase();
+    // Redact FIRST: proxy auth bodies can echo the bearer we presented, and
+    // this per-account key is deliberately hidden from every other surface
+    // (settings, catalog route, provider test). It also keeps a key whose
+    // random body happens to contain "429"/"503" from making a non-retryable
+    // error retry — shouldRetry substring-matches those.
+    const safe = redactSecrets(detail);
+    const lower = safe.toLowerCase();
     if (lower.includes('budget') && (lower.includes('exceed') || lower.includes('over'))) {
       return new Error(
         `${this.errorLabel} API error (${status}): your included AI usage is used up for this window. ` +
@@ -88,7 +95,9 @@ export class UsejarvisAIProvider extends OpenAIProvider {
         `${this.errorLabel} API error (${status}): that model is not included in your plan.`,
       );
     }
-    return new Error(`${this.errorLabel} API error (${status})${detail ? `: ${detail}` : ''}`);
+    // Truncated: an unbounded body is how a CDN error page (hostname
+    // included) reaches a chat bubble.
+    return new Error(`${this.errorLabel} API error (${status})${safe ? `: ${safe.slice(0, 120)}` : ''}`);
   }
 
   private rewrite(error: unknown): unknown {

--- a/src/llm/usejarvis.ts
+++ b/src/llm/usejarvis.ts
@@ -1,0 +1,102 @@
+import { OpenAIProvider } from './openai.ts';
+
+/**
+ * Hosted "Usejarvis AI" provider: the platform's OpenAI-compatible LLM proxy.
+ * Configured EXCLUSIVELY by the system-owned `usejarvis_ai` config.yaml block
+ * (daemon/usejarvis-ai.ts injects it over every DB merge) — never by the
+ * dashboard, which shows it read-only.
+ *
+ * The proxy exposes stable per-plan aliases (uj-chat / uj-low / uj-medium /
+ * uj-high, plus voice slots) whose resolution happens server-side, so this
+ * class stays plan-agnostic: `listModels()` returns exactly what this
+ * account's key may call, and errors are rewritten into messages a user can
+ * act on (limits, plan state) while preserving the `(status)` marker the
+ * retry classifier keys on.
+ */
+export class UsejarvisAIProvider extends OpenAIProvider {
+  override name = 'usejarvis_ai';
+
+  constructor(baseUrl: string, apiKey: string) {
+    // The provisioner writes the proxy ORIGIN (https://llm.example.host);
+    // OpenAIProvider expects the /v1 prefix to already be present.
+    const trimmed = baseUrl.replace(/\/+$/, '');
+    super(apiKey, '', /\/v1$/.test(trimmed) ? trimmed : `${trimmed}/v1`);
+  }
+
+  protected override get errorLabel(): string {
+    return 'Usejarvis AI';
+  }
+
+  /** The key-scoped catalog: the uj-* aliases this plan includes (the proxy
+   * filters per key, so tier pickers need no hardcoded list). */
+  override async listModels(): Promise<string[]> {
+    const response = await fetch(this.modelsUrl, {
+      headers: { Authorization: `Bearer ${this.apiKey}` },
+    });
+    if (!response.ok) {
+      throw this.friendly(response.status, await response.text().catch(() => ''));
+    }
+    const payload = await response.json() as { data?: Array<{ id?: unknown }> };
+    if (!Array.isArray(payload.data)) {
+      throw new Error(`${this.errorLabel} returned an invalid model catalog`);
+    }
+    return [...new Set(
+      payload.data
+        .map((entry) => entry.id)
+        .filter((id): id is string => typeof id === 'string' && id.length > 0),
+    )].sort();
+  }
+
+  override async chat(
+    ...args: Parameters<OpenAIProvider['chat']>
+  ): ReturnType<OpenAIProvider['chat']> {
+    try {
+      return await super.chat(...args);
+    } catch (error) {
+      throw this.rewrite(error);
+    }
+  }
+
+  override async *stream(
+    ...args: Parameters<OpenAIProvider['stream']>
+  ): ReturnType<OpenAIProvider['stream']> {
+    try {
+      yield* super.stream(...args);
+    } catch (error) {
+      throw this.rewrite(error);
+    }
+  }
+
+  /** Map proxy errors to actionable copy. The `(status)` marker is kept so
+   * classifyErrorString still steers retries (429/503 retry; 400s do not). */
+  private friendly(status: number, detail: string): Error {
+    const lower = detail.toLowerCase();
+    if (lower.includes('budget') && (lower.includes('exceed') || lower.includes('over'))) {
+      return new Error(
+        `${this.errorLabel} API error (${status}): your included AI usage is used up for this window. ` +
+          'It resumes automatically - the usage meter shows when.',
+      );
+    }
+    if (status === 401 || status === 403 || lower.includes('blocked')) {
+      return new Error(
+        `${this.errorLabel} API error (${status}): Usejarvis AI is not active on this account - ` +
+          'an active plan is required.',
+      );
+    }
+    if (lower.includes('model') && (lower.includes('not allowed') || lower.includes('invalid model'))) {
+      return new Error(
+        `${this.errorLabel} API error (${status}): that model is not included in your plan.`,
+      );
+    }
+    return new Error(`${this.errorLabel} API error (${status})${detail ? `: ${detail}` : ''}`);
+  }
+
+  private rewrite(error: unknown): unknown {
+    if (!(error instanceof Error)) return error;
+    // Base-class errors read "<label> API error (NNN): <body>" - re-map the
+    // ones users can act on; pass everything else (network, aborts) through.
+    const match = error.message.match(/API error \((\d+)\): ?([\s\S]*)$/);
+    if (!match) return error;
+    return this.friendly(Number(match[1]), match[2] ?? '');
+  }
+}

--- a/src/llm/usejarvis.ts
+++ b/src/llm/usejarvis.ts
@@ -1,5 +1,6 @@
 import { OpenAIProvider } from './openai.ts';
-import { hostedProxyError } from '../util/hosted-error.ts';
+import { hostedProxyError, isBudgetExhaustion } from '../util/hosted-error.ts';
+import { redactSecrets } from '../util/redact.ts';
 
 /**
  * Hosted "Usejarvis AI" provider: the platform's OpenAI-compatible LLM proxy.
@@ -80,7 +81,7 @@ export class UsejarvisAIProvider extends OpenAIProvider {
     try {
       return await super.chat(...args);
     } catch (error) {
-      throw this.rewrite(error);
+      throw await this.rewrite(error);
     }
   }
 
@@ -94,30 +95,84 @@ export class UsejarvisAIProvider extends OpenAIProvider {
     // the chat bubble on the very path users talk through.
     for await (const event of super.stream(...args)) {
       if (event.type === 'error' && typeof event.error === 'string') {
-        yield { ...event, error: this.rewriteText(event.error) };
+        yield { ...event, error: await this.rewriteText(event.error) };
       } else {
         yield event;
       }
     }
   }
 
+  /** Memoized `/key/info` result — success AND failure both count, so an
+   * exhausted-budget burst issues at most one lookup per window. */
+  private resetCache: { at: number; value: Date | null } | null = null;
+  private static readonly RESET_CACHE_MS = 60_000;
+
+  /** Reset-time lookup for the budget-exhaustion copy.
+   *
+   * The 429 budget body carries NO timestamp (confirmed by the platform team);
+   * the reset time lives on `GET /key/info` at the proxy ROOT (not under /v1),
+   * readable with this same account key, as ISO-8601 with an explicit offset
+   * (e.g. "2026-08-19T12:00:00+00:00" under `info.budget_reset_at`).
+   *
+   * Only the parsed Date ever leaves this method: the /key/info body follows
+   * the same discipline as every other proxy body and never reaches user copy.
+   * Any failure — timeout, non-200, missing field, unparseable date — degrades
+   * to a time-less budget message (never guess a time you were not told). */
+  private async budgetResetAt(): Promise<Date | null> {
+    const now = Date.now();
+    if (this.resetCache && now - this.resetCache.at < UsejarvisAIProvider.RESET_CACHE_MS) {
+      return this.resetCache.value;
+    }
+    let value: Date | null = null;
+    try {
+      const root = this.baseUrl.replace(/\/v1$/, '');
+      const response = await fetch(`${root}/key/info`, {
+        headers: { Authorization: `Bearer ${this.apiKey}` },
+        signal: AbortSignal.timeout(3000),
+      });
+      if (response.ok) {
+        const payload = await response.json() as {
+          info?: { budget_reset_at?: unknown };
+          budget_reset_at?: unknown;
+        };
+        const raw = payload.info?.budget_reset_at ?? payload.budget_reset_at;
+        if (typeof raw === 'string') {
+          const parsed = new Date(raw);
+          if (!Number.isNaN(parsed.getTime())) value = parsed;
+        }
+        if (!value) console.warn('[usejarvis] /key/info carried no parseable budget_reset_at; budget copy stays time-less');
+      } else {
+        console.warn(`[usejarvis] /key/info unavailable (${response.status}); budget copy stays time-less`);
+      }
+    } catch (err) {
+      console.warn(
+        '[usejarvis] /key/info lookup failed; budget copy stays time-less:',
+        redactSecrets(err instanceof Error ? err.message : String(err)),
+      );
+    }
+    this.resetCache = { at: now, value };
+    return value;
+  }
+
   /** Shared with the hosted STT/TTS providers — see util/hosted-error.ts for
    * the redaction, branch-order and no-body-in-copy rules. The "<label> API"
    * form keeps the exact `Usejarvis AI API error (NNN)` prefix that
-   * classifyErrorString and rewriteText both parse. */
-  private friendly(status: number, detail: string): Error {
-    return hostedProxyError(`${this.errorLabel} API`, status, detail);
+   * classifyErrorString and rewriteText both parse. Budget errors trigger the
+   * /key/info reset lookup so the copy can quote a real resume time. */
+  private async friendly(status: number, detail: string): Promise<Error> {
+    const resetAt = isBudgetExhaustion(detail) ? await this.budgetResetAt() : null;
+    return hostedProxyError(`${this.errorLabel} API`, status, detail, resetAt);
   }
 
   /** Text-shaped variant of `rewrite` for stream error EVENTS (the base class
    * yields these rather than throwing — see `stream`). */
-  private rewriteText(text: string): string {
+  private async rewriteText(text: string): Promise<string> {
     const match = text.match(/API error \((\d+)\): ?([\s\S]*)$/);
     if (!match) return text;
-    return this.friendly(Number(match[1]), match[2] ?? '').message;
+    return (await this.friendly(Number(match[1]), match[2] ?? '')).message;
   }
 
-  private rewrite(error: unknown): unknown {
+  private async rewrite(error: unknown): Promise<unknown> {
     if (!(error instanceof Error)) return error;
     // Base-class errors read "<label> API error (NNN): <body>" - re-map the
     // ones users can act on; pass everything else (network, aborts) through.

--- a/src/llm/usejarvis.ts
+++ b/src/llm/usejarvis.ts
@@ -21,7 +21,11 @@ export class UsejarvisAIProvider extends OpenAIProvider {
     // The provisioner writes the proxy ORIGIN (https://llm.example.host);
     // OpenAIProvider expects the /v1 prefix to already be present.
     const trimmed = baseUrl.replace(/\/+$/, '');
-    super(apiKey, '', /\/v1$/.test(trimmed) ? trimmed : `${trimmed}/v1`);
+    // uj-medium as the default model: the manager's failover path retries a
+    // provider WITHOUT a model assignment (chatTier deletes options.model),
+    // and an empty default posted `{"model":""}` — a guaranteed 400 that
+    // replaced the original error. Every plan carries the mid alias.
+    super(apiKey, 'uj-medium', /\/v1$/.test(trimmed) ? trimmed : `${trimmed}/v1`);
   }
 
   protected override get errorLabel(): string {
@@ -37,22 +41,38 @@ export class UsejarvisAIProvider extends OpenAIProvider {
    * pickers — which would break alias opacity and let a user select a model
    * whose per-plan resale price was never configured. */
   override async listModels(): Promise<string[]> {
-    const response = await fetch(this.modelsUrl, {
-      headers: { Authorization: `Bearer ${this.apiKey}` },
-    });
-    if (!response.ok) {
-      throw this.friendly(response.status, await response.text().catch(() => ''));
+    // Never throws: the LLMProvider contract is degrade-to-fallback (every
+    // sibling catches), and the first caller — the tier-picker catalog route —
+    // must not turn a transient proxy 503 into an unhandled rejection. The
+    // fallback is the four core aliases every plan carries.
+    try {
+      const response = await fetch(this.modelsUrl, {
+        headers: { Authorization: `Bearer ${this.apiKey}` },
+        signal: AbortSignal.timeout(10_000),
+      });
+      if (!response.ok) {
+        console.warn(`[usejarvis] model catalog unavailable (${response.status}); serving fallback aliases`);
+        return UsejarvisAIProvider.FALLBACK_MODELS.slice();
+      }
+      const payload = await response.json() as { data?: Array<{ id?: unknown }> };
+      if (!Array.isArray(payload.data)) {
+        console.warn(`[usejarvis] model catalog malformed; serving fallback aliases`);
+        return UsejarvisAIProvider.FALLBACK_MODELS.slice();
+      }
+      return [...new Set(
+        payload.data
+          .map((entry) => entry.id)
+          .filter((id): id is string => typeof id === 'string' && id.startsWith('uj-')),
+      )].sort();
+    } catch (err) {
+      console.warn('[usejarvis] model catalog fetch failed; serving fallback aliases:', err instanceof Error ? err.message : err);
+      return UsejarvisAIProvider.FALLBACK_MODELS.slice();
     }
-    const payload = await response.json() as { data?: Array<{ id?: unknown }> };
-    if (!Array.isArray(payload.data)) {
-      throw new Error(`${this.errorLabel} returned an invalid model catalog`);
-    }
-    return [...new Set(
-      payload.data
-        .map((entry) => entry.id)
-        .filter((id): id is string => typeof id === 'string' && id.startsWith('uj-')),
-    )].sort();
   }
+
+  /** The aliases every plan includes — served when the live catalog is
+   * unreachable so tier pickers degrade instead of hanging or throwing. */
+  static readonly FALLBACK_MODELS = ['uj-chat', 'uj-high', 'uj-low', 'uj-medium'] as const;
 
   override async chat(
     ...args: Parameters<OpenAIProvider['chat']>

--- a/src/llm/usejarvis.ts
+++ b/src/llm/usejarvis.ts
@@ -1,5 +1,5 @@
 import { OpenAIProvider } from './openai.ts';
-import { redactSecrets } from '../util/redact.ts';
+import { hostedProxyError } from '../util/hosted-error.ts';
 
 /**
  * Hosted "Usejarvis AI" provider: the platform's OpenAI-compatible LLM proxy.
@@ -81,47 +81,12 @@ export class UsejarvisAIProvider extends OpenAIProvider {
     }
   }
 
-  /** Map proxy errors to actionable copy. The `(status)` marker is kept so
-   * classifyErrorString still steers retries (429/503 retry; 400s do not).
-   *
-   * Branch ORDER matters: LiteLLM denies an out-of-plan model with a 401
-   * "not allowed to access model", so the model check MUST run before the
-   * generic auth branch — otherwise a paying user who picks a model outside
-   * their plan is told their subscription is inactive, the worst false
-   * message this feature can produce.
-   *
-   * The proxy's own body never rides along in the returned copy: it is not a
-   * log-only channel — this Error's message becomes the chat bubble — and an
-   * upstream body carries the hosted hostname that the settings surface and
-   * the catalog route both deliberately withhold. Operators get it via
-   * console.warn instead. */
+  /** Shared with the hosted STT/TTS providers — see util/hosted-error.ts for
+   * the redaction, branch-order and no-body-in-copy rules. The "<label> API"
+   * form keeps the exact `Usejarvis AI API error (NNN)` prefix that
+   * classifyErrorString and rewriteText both parse. */
   private friendly(status: number, detail: string): Error {
-    // Redact FIRST: proxy auth bodies can echo the bearer we presented, and
-    // this per-account key is deliberately hidden from every other surface
-    // (settings, catalog route, provider test).
-    const safe = redactSecrets(detail);
-    const lower = safe.toLowerCase();
-    if (safe) console.warn(`[usejarvis] proxy error (${status}): ${safe.slice(0, 200)}`);
-    if (lower.includes('budget') && (lower.includes('exceed') || lower.includes('over'))) {
-      return new Error(
-        `${this.errorLabel} API error (${status}): your included AI usage is used up ` +
-          `${describeBudgetWindow(safe)}. It resumes automatically - the usage meter shows when.`,
-      );
-    }
-    if (lower.includes('model') && (lower.includes('not allowed') || lower.includes('invalid model'))) {
-      return new Error(
-        `${this.errorLabel} API error (${status}): that model is not included in your plan.`,
-      );
-    }
-    if (status === 401 || status === 403) {
-      return new Error(
-        `${this.errorLabel} API error (${status}): Usejarvis AI is not active on this account - ` +
-          'an active plan is required.',
-      );
-    }
-    // Truncated: an unbounded body is how a CDN error page (hostname
-    // included) reaches a chat bubble.
-    return new Error(`${this.errorLabel} API error (${status})${safe ? `: ${safe.slice(0, 120)}` : ''}`);
+    return hostedProxyError(`${this.errorLabel} API`, status, detail);
   }
 
   /** Text-shaped variant of `rewrite` for stream error EVENTS (the base class
@@ -142,25 +107,3 @@ export class UsejarvisAIProvider extends OpenAIProvider {
   }
 }
 
-/**
- * Turn a proxy budget body into the window phrase the friendly copy promises.
- * LiteLLM reports `budget_duration` and `budget_reset_at` on an exhausted
- * key, and the reset lands on a FIXED clock boundary (a 6h window minted
- * mid-morning resets at 12:00:00+00:00), so "resumes at 12:00 UTC" is exact
- * rather than approximate. Degrades to the generic phrase when the proxy
- * omits the fields — never guesses a time it was not told.
- *
- * Only the duration and timestamp are lifted out; the rest of the body stays
- * out of user-facing copy (it can carry the hosted hostname).
- */
-function describeBudgetWindow(body: string): string {
-  const duration = body.match(/budget_duration["'\s:=]+([0-9]+[a-z]+)/i)?.[1];
-  const resetAt = body.match(/budget_reset_at["'\s:=]+([0-9T:.+\-]{10,40})/i)?.[1];
-  const window = duration ? `for this ${duration} window` : 'for this window';
-  if (!resetAt) return window;
-  const parsed = new Date(resetAt);
-  if (Number.isNaN(parsed.getTime())) return window;
-  const hh = String(parsed.getUTCHours()).padStart(2, '0');
-  const mm = String(parsed.getUTCMinutes()).padStart(2, '0');
-  return `${window} (resumes ${hh}:${mm} UTC)`;
-}

--- a/src/llm/usejarvis.ts
+++ b/src/llm/usejarvis.ts
@@ -166,19 +166,26 @@ export class UsejarvisAIProvider extends OpenAIProvider {
 
   /** Text-shaped variant of `rewrite` for stream error EVENTS (the base class
    * yields these rather than throwing — see `stream`). */
+  /** Base-class errors come in two shapes: the legacy "<label> API error
+   * (NNN): <body>" and the current "<label> API error: HTTP NNN: <body>"
+   * (formatOpenAIHttpError). Accept both so a base-class format change can
+   * never silently disable the hosted rewrites again. */
+  private static readonly BASE_ERROR_RE =
+    /API error(?: \((\d+)\):|: HTTP (\d+):?) ?([\s\S]*)$/;
+
   private async rewriteText(text: string): Promise<string> {
-    const match = text.match(/API error \((\d+)\): ?([\s\S]*)$/);
+    const match = text.match(UsejarvisAIProvider.BASE_ERROR_RE);
     if (!match) return text;
-    return (await this.friendly(Number(match[1]), match[2] ?? '')).message;
+    return (await this.friendly(Number(match[1] ?? match[2]), match[3] ?? '')).message;
   }
 
   private async rewrite(error: unknown): Promise<unknown> {
     if (!(error instanceof Error)) return error;
-    // Base-class errors read "<label> API error (NNN): <body>" - re-map the
-    // ones users can act on; pass everything else (network, aborts) through.
-    const match = error.message.match(/API error \((\d+)\): ?([\s\S]*)$/);
+    // Re-map the errors users can act on; pass everything else (network,
+    // aborts) through untouched.
+    const match = error.message.match(UsejarvisAIProvider.BASE_ERROR_RE);
     if (!match) return error;
-    return this.friendly(Number(match[1]), match[2] ?? '');
+    return this.friendly(Number(match[1] ?? match[2]), match[3] ?? '');
   }
 }
 

--- a/src/llm/usejarvis.ts
+++ b/src/llm/usejarvis.ts
@@ -28,8 +28,14 @@ export class UsejarvisAIProvider extends OpenAIProvider {
     return 'Usejarvis AI';
   }
 
-  /** The key-scoped catalog: the uj-* aliases this plan includes (the proxy
-   * filters per key, so tier pickers need no hardcoded list). */
+  /** The key-scoped catalog: the uj-* aliases this plan includes.
+   *
+   * The proxy filters per key, but that is REMOTE state, not an invariant we
+   * hold: a key minted with an empty `models` list and no team means the full
+   * catalog at LiteLLM, not an empty one. Filtering to `uj-` locally keeps a
+   * mis-scoped key from leaking raw upstream deployment ids into the tier
+   * pickers — which would break alias opacity and let a user select a model
+   * whose per-plan resale price was never configured. */
   override async listModels(): Promise<string[]> {
     const response = await fetch(this.modelsUrl, {
       headers: { Authorization: `Bearer ${this.apiKey}` },
@@ -44,7 +50,7 @@ export class UsejarvisAIProvider extends OpenAIProvider {
     return [...new Set(
       payload.data
         .map((entry) => entry.id)
-        .filter((id): id is string => typeof id === 'string' && id.length > 0),
+        .filter((id): id is string => typeof id === 'string' && id.startsWith('uj-')),
     )].sort();
   }
 
@@ -61,33 +67,45 @@ export class UsejarvisAIProvider extends OpenAIProvider {
   override async *stream(
     ...args: Parameters<OpenAIProvider['stream']>
   ): ReturnType<OpenAIProvider['stream']> {
-    try {
-      yield* super.stream(...args);
-    } catch (error) {
-      throw this.rewrite(error);
+    // The base class never THROWS HTTP failures on this path — it yields
+    // { type: 'error' } events (pre-stream 4xx and mid-stream alike), so the
+    // rewrite must intercept EVENTS; a try/catch here is dead code, and the
+    // raw proxy body — which can echo the bearer we presented — would reach
+    // the chat bubble on the very path users talk through.
+    for await (const event of super.stream(...args)) {
+      if (event.type === 'error' && typeof event.error === 'string') {
+        yield { ...event, error: this.rewriteText(event.error) };
+      } else {
+        yield event;
+      }
     }
   }
 
   /** Map proxy errors to actionable copy. The `(status)` marker is kept so
-   * classifyErrorString still steers retries (429/503 retry; 400s do not). */
+   * classifyErrorString still steers retries (429/503 retry; 400s do not).
+   *
+   * Branch ORDER matters: LiteLLM denies an out-of-plan model with a 401
+   * "not allowed to access model", so the model check MUST run before the
+   * generic auth branch — otherwise a paying user who picks a model outside
+   * their plan is told their subscription is inactive, the worst false
+   * message this feature can produce.
+   *
+   * The proxy's own body never rides along in the returned copy: it is not a
+   * log-only channel — this Error's message becomes the chat bubble — and an
+   * upstream body carries the hosted hostname that the settings surface and
+   * the catalog route both deliberately withhold. Operators get it via
+   * console.warn instead. */
   private friendly(status: number, detail: string): Error {
     // Redact FIRST: proxy auth bodies can echo the bearer we presented, and
     // this per-account key is deliberately hidden from every other surface
-    // (settings, catalog route, provider test). It also keeps a key whose
-    // random body happens to contain "429"/"503" from making a non-retryable
-    // error retry — shouldRetry substring-matches those.
+    // (settings, catalog route, provider test).
     const safe = redactSecrets(detail);
     const lower = safe.toLowerCase();
+    if (safe) console.warn(`[usejarvis] proxy error (${status}): ${safe.slice(0, 200)}`);
     if (lower.includes('budget') && (lower.includes('exceed') || lower.includes('over'))) {
       return new Error(
-        `${this.errorLabel} API error (${status}): your included AI usage is used up for this window. ` +
-          'It resumes automatically - the usage meter shows when.',
-      );
-    }
-    if (status === 401 || status === 403 || lower.includes('blocked')) {
-      return new Error(
-        `${this.errorLabel} API error (${status}): Usejarvis AI is not active on this account - ` +
-          'an active plan is required.',
+        `${this.errorLabel} API error (${status}): your included AI usage is used up ` +
+          `${describeBudgetWindow(safe)}. It resumes automatically - the usage meter shows when.`,
       );
     }
     if (lower.includes('model') && (lower.includes('not allowed') || lower.includes('invalid model'))) {
@@ -95,9 +113,23 @@ export class UsejarvisAIProvider extends OpenAIProvider {
         `${this.errorLabel} API error (${status}): that model is not included in your plan.`,
       );
     }
+    if (status === 401 || status === 403) {
+      return new Error(
+        `${this.errorLabel} API error (${status}): Usejarvis AI is not active on this account - ` +
+          'an active plan is required.',
+      );
+    }
     // Truncated: an unbounded body is how a CDN error page (hostname
     // included) reaches a chat bubble.
     return new Error(`${this.errorLabel} API error (${status})${safe ? `: ${safe.slice(0, 120)}` : ''}`);
+  }
+
+  /** Text-shaped variant of `rewrite` for stream error EVENTS (the base class
+   * yields these rather than throwing — see `stream`). */
+  private rewriteText(text: string): string {
+    const match = text.match(/API error \((\d+)\): ?([\s\S]*)$/);
+    if (!match) return text;
+    return this.friendly(Number(match[1]), match[2] ?? '').message;
   }
 
   private rewrite(error: unknown): unknown {
@@ -108,4 +140,27 @@ export class UsejarvisAIProvider extends OpenAIProvider {
     if (!match) return error;
     return this.friendly(Number(match[1]), match[2] ?? '');
   }
+}
+
+/**
+ * Turn a proxy budget body into the window phrase the friendly copy promises.
+ * LiteLLM reports `budget_duration` and `budget_reset_at` on an exhausted
+ * key, and the reset lands on a FIXED clock boundary (a 6h window minted
+ * mid-morning resets at 12:00:00+00:00), so "resumes at 12:00 UTC" is exact
+ * rather than approximate. Degrades to the generic phrase when the proxy
+ * omits the fields — never guesses a time it was not told.
+ *
+ * Only the duration and timestamp are lifted out; the rest of the body stays
+ * out of user-facing copy (it can carry the hosted hostname).
+ */
+function describeBudgetWindow(body: string): string {
+  const duration = body.match(/budget_duration["'\s:=]+([0-9]+[a-z]+)/i)?.[1];
+  const resetAt = body.match(/budget_reset_at["'\s:=]+([0-9T:.+\-]{10,40})/i)?.[1];
+  const window = duration ? `for this ${duration} window` : 'for this window';
+  if (!resetAt) return window;
+  const parsed = new Date(resetAt);
+  if (Number.isNaN(parsed.getTime())) return window;
+  const hh = String(parsed.getUTCHours()).padStart(2, '0');
+  const mm = String(parsed.getUTCMinutes()).padStart(2, '0');
+  return `${window} (resumes ${hh}:${mm} UTC)`;
 }

--- a/src/util/hosted-error.test.ts
+++ b/src/util/hosted-error.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from 'bun:test';
+import { describeBudgetWindow, hostedProxyError } from './hosted-error.ts';
+
+describe('describeBudgetWindow', () => {
+  test('a Postgres-style naive timestamp (space separator) quotes the REAL time', () => {
+    // Used to truncate at the space → parse as UTC midnight → "resumes 00:00
+    // UTC" for an 18:00 reset (pr2 review #4).
+    const body = 'budget_duration: 6h, budget_reset_at: 2026-08-18 18:00:00';
+    expect(describeBudgetWindow(body)).toBe('for this 6h window (resumes 18:00 UTC)');
+  });
+
+  test('an ISO-T timestamp still works', () => {
+    const body = '{"budget_duration":"24h","budget_reset_at":"2026-08-19T06:30:00+00:00"}';
+    expect(describeBudgetWindow(body)).toBe('for this 24h window (resumes 06:30 UTC)');
+  });
+
+  test('a date with no time-of-day is never quoted as a time', () => {
+    const body = 'budget_reset_at: 2026-08-18, budget_duration: 6h';
+    expect(describeBudgetWindow(body)).toBe('for this 6h window');
+  });
+
+  test('no fields at all degrades to the generic phrase', () => {
+    expect(describeBudgetWindow('exceeded budget')).toBe('for this window');
+  });
+});
+
+describe('hostedProxyError', () => {
+  test('the generic branch never carries the proxy body (hostname stays out of chat copy)', () => {
+    // Typical CDN 502 page: the hostname sits in the first line, so even a
+    // 120-char truncation leaked it (pr2 review #5).
+    const err = hostedProxyError(
+      'Usejarvis AI API',
+      502,
+      '<html><title>502 Bad Gateway</title>error at proxy host llm.usejarvis.host: upstream timeout</html>',
+    );
+    expect(err.message).toContain('(502)');
+    expect(err.message).not.toContain('llm.usejarvis.host');
+    expect(err.message).not.toContain('502 Bad Gateway');
+  });
+
+  test('the budget branch keeps its actionable copy', () => {
+    const err = hostedProxyError('Usejarvis AI API', 429, 'ExceededBudget: budget_duration: 6h, budget_reset_at: 2026-08-18 18:00:00');
+    expect(err.message).toContain('used up');
+    expect(err.message).toContain('resumes 18:00 UTC');
+  });
+
+  test('model denial precedes the generic auth branch (401 ordering)', () => {
+    const err = hostedProxyError('Usejarvis AI API', 401, 'key not allowed to access model uj-video');
+    expect(err.message).toContain('not included in your plan');
+  });
+});

--- a/src/util/hosted-error.test.ts
+++ b/src/util/hosted-error.test.ts
@@ -1,28 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { describeBudgetWindow, hostedProxyError } from './hosted-error.ts';
-
-describe('describeBudgetWindow', () => {
-  test('a Postgres-style naive timestamp (space separator) quotes the REAL time', () => {
-    // Used to truncate at the space → parse as UTC midnight → "resumes 00:00
-    // UTC" for an 18:00 reset (pr2 review #4).
-    const body = 'budget_duration: 6h, budget_reset_at: 2026-08-18 18:00:00';
-    expect(describeBudgetWindow(body)).toBe('for this 6h window (resumes 18:00 UTC)');
-  });
-
-  test('an ISO-T timestamp still works', () => {
-    const body = '{"budget_duration":"24h","budget_reset_at":"2026-08-19T06:30:00+00:00"}';
-    expect(describeBudgetWindow(body)).toBe('for this 24h window (resumes 06:30 UTC)');
-  });
-
-  test('a date with no time-of-day is never quoted as a time', () => {
-    const body = 'budget_reset_at: 2026-08-18, budget_duration: 6h';
-    expect(describeBudgetWindow(body)).toBe('for this 6h window');
-  });
-
-  test('no fields at all degrades to the generic phrase', () => {
-    expect(describeBudgetWindow('exceeded budget')).toBe('for this window');
-  });
-});
+import { hostedProxyError, isBudgetExhaustion } from './hosted-error.ts';
 
 describe('hostedProxyError', () => {
   test('the generic branch never carries the proxy body (hostname stays out of chat copy)', () => {
@@ -38,14 +15,60 @@ describe('hostedProxyError', () => {
     expect(err.message).not.toContain('502 Bad Gateway');
   });
 
-  test('the budget branch keeps its actionable copy', () => {
-    const err = hostedProxyError('Usejarvis AI API', 429, 'ExceededBudget: budget_duration: 6h, budget_reset_at: 2026-08-18 18:00:00');
-    expect(err.message).toContain('used up');
-    expect(err.message).toContain('resumes 18:00 UTC');
+  test('budget copy quotes a reset time ONLY when handed one (never parsed from the body)', () => {
+    // The 429 budget body carries no reset field (confirmed 2026-08-19); the
+    // caller fetches /key/info and passes the parsed Date in.
+    const timed = hostedProxyError(
+      'Usejarvis AI API',
+      429,
+      'ExceededBudget: Budget has been exceeded! Current cost: 0.0051, Max budget: 0.005',
+      new Date('2026-08-19T12:00:00+00:00'),
+    );
+    expect(timed.message).toContain('used up for this window (resumes 12:00 UTC)');
+
+    // No timestamp handed in → no time claimed, even if the body smuggles
+    // something date-shaped (the old parser would have quoted it).
+    const bare = hostedProxyError(
+      'Usejarvis AI API',
+      429,
+      'ExceededBudget: budget has been exceeded, budget_reset_at: 2026-08-18 18:00:00',
+    );
+    expect(bare.message).toContain('used up for this window.');
+    expect(bare.message).not.toMatch(/resumes \d/);
+
+    // An invalid Date degrades identically.
+    const invalid = hostedProxyError('Usejarvis AI API', 429, 'budget exceeded', new Date('nonsense'));
+    expect(invalid.message).not.toMatch(/resumes \d/);
   });
 
-  test('model denial precedes the generic auth branch (401 ordering)', () => {
+  test('403 maps to model-not-in-plan even without model text (team_model_access_denied)', () => {
+    const err = hostedProxyError('Usejarvis AI API', 403, '{"error":{"code":"team_model_access_denied"}}');
+    expect(err.message).toContain('(403)');
+    expect(err.message).toContain('not included in your plan');
+  });
+
+  test('model-denial TEXT still precedes the auth branch (historical 401 shape)', () => {
     const err = hostedProxyError('Usejarvis AI API', 401, 'key not allowed to access model uj-video');
     expect(err.message).toContain('not included in your plan');
+  });
+
+  test('401 without model text is the credential/plan copy', () => {
+    const err = hostedProxyError('Usejarvis AI API', 401, 'Authentication Error: key is blocked');
+    expect(err.message).toMatch(/\(401\).*active plan is required/);
+  });
+
+  test('an ordinary 429 rate limit is NOT budget copy (stays retryable-generic)', () => {
+    const err = hostedProxyError('Usejarvis AI API', 429, 'rate limited, retry shortly');
+    expect(err.message).toContain('(429)');
+    expect(err.message).not.toContain('used up');
+  });
+});
+
+describe('isBudgetExhaustion', () => {
+  test('matches the LiteLLM budget family and nothing else', () => {
+    expect(isBudgetExhaustion('ExceededBudget: budget has been exceeded for this key')).toBe(true);
+    expect(isBudgetExhaustion('{"error":{"code":"budget_exceeded","message":"over budget"}}')).toBe(true);
+    expect(isBudgetExhaustion('rate limited, retry shortly')).toBe(false);
+    expect(isBudgetExhaustion('model not allowed')).toBe(false);
   });
 });

--- a/src/util/hosted-error.ts
+++ b/src/util/hosted-error.ts
@@ -46,9 +46,11 @@ export function hostedProxyError(label: string, status: number, detail: string):
         'an active plan is required.',
     );
   }
-  // Truncated: an unbounded body is how a CDN error page (hostname included)
-  // reaches a chat bubble.
-  return new Error(`${label} error (${status})${safe ? `: ${safe.slice(0, 120)}` : ''}`);
+  // Invariant 2, enforced: the body NEVER rides along in user-facing copy —
+  // even truncated-and-redacted, a CDN 502 page puts the hosted hostname in
+  // its first line. Operators already have the full (redacted) body from the
+  // console.warn above.
+  return new Error(`${label} error (${status}): the AI service could not process this request. It usually recovers on its own - try again shortly.`);
 }
 
 /**
@@ -64,10 +66,20 @@ export function hostedProxyError(label: string, status: number, detail: string):
  */
 export function describeBudgetWindow(body: string): string {
   const duration = body.match(/budget_duration["'\s:=]+([0-9]+[a-z]+)/i)?.[1];
-  const resetAt = body.match(/budget_reset_at["'\s:=]+([0-9T:.+\-]{10,40})/i)?.[1];
+  // The timestamp must carry an explicit time-of-day to be quoted. A
+  // date-only match (LiteLLM's Postgres-style `2026-08-18 18:00:00` used to
+  // truncate at the space) would parse to UTC midnight and state a reset
+  // time the proxy never sent.
+  const resetAt = body.match(
+    /budget_reset_at["'\s:=]+(\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}(?::\d{2})?(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?)/i,
+  )?.[1];
   const window = duration ? `for this ${duration} window` : 'for this window';
   if (!resetAt) return window;
-  const parsed = new Date(resetAt);
+  // A naive timestamp (no zone suffix) is documented by LiteLLM as UTC;
+  // normalize the space separator and pin the zone before parsing so the
+  // local machine's timezone cannot skew the quoted time.
+  const normalized = resetAt.replace(' ', 'T') + (/(Z|[+-]\d{2}:?\d{2})$/.test(resetAt) ? '' : 'Z');
+  const parsed = new Date(normalized);
   if (Number.isNaN(parsed.getTime())) return window;
   const hh = String(parsed.getUTCHours()).padStart(2, '0');
   const mm = String(parsed.getUTCMinutes()).padStart(2, '0');

--- a/src/util/hosted-error.ts
+++ b/src/util/hosted-error.ts
@@ -1,0 +1,75 @@
+import { redactSecrets } from './redact.ts';
+
+/**
+ * Map a hosted-proxy error body into copy a user can act on.
+ *
+ * ONE definition for every hosted surface — chat, STT, TTS. They all talk to
+ * the same LiteLLM proxy, so they all get the same budget/plan/model answers,
+ * and a per-surface copy would drift (the voice providers shipped throwing
+ * raw proxy JSON while chat had this mapping).
+ *
+ * Two invariants live here:
+ *
+ * 1. Redact FIRST. Proxy auth bodies can echo the bearer we presented, and the
+ *    per-account key is deliberately hidden from every other surface.
+ * 2. The proxy's own body never rides along in the returned copy. This is not
+ *    a log-only channel — the message becomes a chat bubble or a settings
+ *    toast — and an upstream body carries the hosted hostname that the
+ *    settings surface and the catalog route both withhold. Operators get the
+ *    original via console.warn instead.
+ *
+ * Branch ORDER matters: LiteLLM denies an out-of-plan model with a 401 "not
+ * allowed to access model", so the model check MUST precede the generic auth
+ * branch — otherwise a paying user who picks a model outside their plan is
+ * told their subscription is inactive.
+ *
+ * The `(status)` marker is preserved because classifyErrorString keys retry
+ * behaviour on it (429/503 retry; 400s do not).
+ */
+export function hostedProxyError(label: string, status: number, detail: string): Error {
+  const safe = redactSecrets(detail);
+  const lower = safe.toLowerCase();
+  if (safe) console.warn(`[usejarvis] ${label} proxy error (${status}): ${safe.slice(0, 200)}`);
+
+  if (lower.includes('budget') && (lower.includes('exceed') || lower.includes('over'))) {
+    return new Error(
+      `${label} error (${status}): your included AI usage is used up ` +
+        `${describeBudgetWindow(safe)}. It resumes automatically - the usage meter shows when.`,
+    );
+  }
+  if (lower.includes('model') && (lower.includes('not allowed') || lower.includes('invalid model'))) {
+    return new Error(`${label} error (${status}): that model is not included in your plan.`);
+  }
+  if (status === 401 || status === 403) {
+    return new Error(
+      `${label} error (${status}): Usejarvis AI is not active on this account - ` +
+        'an active plan is required.',
+    );
+  }
+  // Truncated: an unbounded body is how a CDN error page (hostname included)
+  // reaches a chat bubble.
+  return new Error(`${label} error (${status})${safe ? `: ${safe.slice(0, 120)}` : ''}`);
+}
+
+/**
+ * Turn a proxy budget body into the window phrase the friendly copy promises.
+ * LiteLLM reports `budget_duration` and `budget_reset_at` on an exhausted key,
+ * and the reset lands on a FIXED clock boundary (a 6h window minted
+ * mid-morning resets at 12:00:00+00:00), so "resumes at 12:00 UTC" is exact
+ * rather than approximate. Degrades to the generic phrase when the proxy omits
+ * the fields — never guesses a time it was not told.
+ *
+ * Only the duration and timestamp are lifted out; the rest of the body stays
+ * out of user-facing copy (it can carry the hosted hostname).
+ */
+export function describeBudgetWindow(body: string): string {
+  const duration = body.match(/budget_duration["'\s:=]+([0-9]+[a-z]+)/i)?.[1];
+  const resetAt = body.match(/budget_reset_at["'\s:=]+([0-9T:.+\-]{10,40})/i)?.[1];
+  const window = duration ? `for this ${duration} window` : 'for this window';
+  if (!resetAt) return window;
+  const parsed = new Date(resetAt);
+  if (Number.isNaN(parsed.getTime())) return window;
+  const hh = String(parsed.getUTCHours()).padStart(2, '0');
+  const mm = String(parsed.getUTCMinutes()).padStart(2, '0');
+  return `${window} (resumes ${hh}:${mm} UTC)`;
+}

--- a/src/util/hosted-error.ts
+++ b/src/util/hosted-error.ts
@@ -18,29 +18,44 @@ import { redactSecrets } from './redact.ts';
  *    settings surface and the catalog route both withhold. Operators get the
  *    original via console.warn instead.
  *
- * Branch ORDER matters: LiteLLM denies an out-of-plan model with a 401 "not
- * allowed to access model", so the model check MUST precede the generic auth
- * branch — otherwise a paying user who picks a model outside their plan is
- * told their subscription is inactive.
+ * Status semantics, confirmed by the platform team (2026-08-19): 401 = bad or
+ * blocked key, 403 = model not allowed (`team_model_access_denied`), 429 with
+ * a budget_exceeded body = included usage exhausted. Some key shapes have
+ * historically denied out-of-plan models with a 401 "not allowed to access
+ * model" TEXT instead, so the model-text check still precedes the auth branch.
+ *
+ * The error body carries NO reset timestamp (confirmed — none is ever sent);
+ * the reset time lives on the proxy's `GET /key/info`, which the PROVIDER
+ * fetches and hands in as `resetAt`. This function never parses times out of
+ * bodies: it states a time only when explicitly given one.
  *
  * The `(status)` marker is preserved because classifyErrorString keys retry
  * behaviour on it (429/503 retry; 400s do not).
  */
-export function hostedProxyError(label: string, status: number, detail: string): Error {
+export function hostedProxyError(
+  label: string,
+  status: number,
+  detail: string,
+  resetAt?: Date | null,
+): Error {
   const safe = redactSecrets(detail);
   const lower = safe.toLowerCase();
   if (safe) console.warn(`[usejarvis] ${label} proxy error (${status}): ${safe.slice(0, 200)}`);
 
-  if (lower.includes('budget') && (lower.includes('exceed') || lower.includes('over'))) {
+  if (isBudgetExhaustion(safe)) {
+    const valid = resetAt && !Number.isNaN(resetAt.getTime());
+    const resumes = valid
+      ? ` (resumes ${String(resetAt.getUTCHours()).padStart(2, '0')}:${String(resetAt.getUTCMinutes()).padStart(2, '0')} UTC)`
+      : '';
     return new Error(
-      `${label} error (${status}): your included AI usage is used up ` +
-        `${describeBudgetWindow(safe)}. It resumes automatically - the usage meter shows when.`,
+      `${label} error (${status}): your included AI usage is used up for this window${resumes}. ` +
+        'It resumes automatically - the usage meter shows when.',
     );
   }
-  if (lower.includes('model') && (lower.includes('not allowed') || lower.includes('invalid model'))) {
+  if (status === 403 || (lower.includes('model') && (lower.includes('not allowed') || lower.includes('invalid model')))) {
     return new Error(`${label} error (${status}): that model is not included in your plan.`);
   }
-  if (status === 401 || status === 403) {
+  if (status === 401) {
     return new Error(
       `${label} error (${status}): Usejarvis AI is not active on this account - ` +
         'an active plan is required.',
@@ -54,34 +69,14 @@ export function hostedProxyError(label: string, status: number, detail: string):
 }
 
 /**
- * Turn a proxy budget body into the window phrase the friendly copy promises.
- * LiteLLM reports `budget_duration` and `budget_reset_at` on an exhausted key,
- * and the reset lands on a FIXED clock boundary (a 6h window minted
- * mid-morning resets at 12:00:00+00:00), so "resumes at 12:00 UTC" is exact
- * rather than approximate. Degrades to the generic phrase when the proxy omits
- * the fields — never guesses a time it was not told.
- *
- * Only the duration and timestamp are lifted out; the rest of the body stays
- * out of user-facing copy (it can carry the hosted hostname).
+ * Budget-exhaustion detector, shared with the provider layer (which uses it
+ * to decide whether a `/key/info` reset-time lookup is worth making before
+ * building the copy). Matches LiteLLM's `budget_exceeded` code and its
+ * "ExceededBudget" / "budget has been exceeded" message family; an ordinary
+ * rate limit ("rate limited") carries none of these words and stays on the
+ * retryable generic branch.
  */
-export function describeBudgetWindow(body: string): string {
-  const duration = body.match(/budget_duration["'\s:=]+([0-9]+[a-z]+)/i)?.[1];
-  // The timestamp must carry an explicit time-of-day to be quoted. A
-  // date-only match (LiteLLM's Postgres-style `2026-08-18 18:00:00` used to
-  // truncate at the space) would parse to UTC midnight and state a reset
-  // time the proxy never sent.
-  const resetAt = body.match(
-    /budget_reset_at["'\s:=]+(\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}(?::\d{2})?(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?)/i,
-  )?.[1];
-  const window = duration ? `for this ${duration} window` : 'for this window';
-  if (!resetAt) return window;
-  // A naive timestamp (no zone suffix) is documented by LiteLLM as UTC;
-  // normalize the space separator and pin the zone before parsing so the
-  // local machine's timezone cannot skew the quoted time.
-  const normalized = resetAt.replace(' ', 'T') + (/(Z|[+-]\d{2}:?\d{2})$/.test(resetAt) ? '' : 'Z');
-  const parsed = new Date(normalized);
-  if (Number.isNaN(parsed.getTime())) return window;
-  const hh = String(parsed.getUTCHours()).padStart(2, '0');
-  const mm = String(parsed.getUTCMinutes()).padStart(2, '0');
-  return `${window} (resumes ${hh}:${mm} UTC)`;
+export function isBudgetExhaustion(detail: string): boolean {
+  const lower = detail.toLowerCase();
+  return lower.includes('budget') && (lower.includes('exceed') || lower.includes('over'));
 }

--- a/src/util/redact.test.ts
+++ b/src/util/redact.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from 'bun:test';
+import { redactSecrets } from './redact.ts';
+
+describe('redactSecrets', () => {
+  test('consumes a real-shaped hosted key WHOLE (no surviving suffix)', () => {
+    // The platform mints sk-uj-<base64url(24 bytes)> — base64url's charset is
+    // exactly [A-Za-z0-9_-], so a partial match would leak the tail.
+    const key = `sk-uj-${Buffer.from(crypto.getRandomValues(new Uint8Array(24))).toString('base64url')}`;
+    const out = redactSecrets(`Authentication Error: bearer ${key} rejected`);
+    expect(out).not.toContain(key);
+    expect(out).not.toContain(key.slice(-8));
+    expect(out).toContain('***redacted***');
+  });
+
+  test('covers the upstream prefixes a proxied auth failure can echo', () => {
+    const text = [
+      'sk-ant-api03-abcdefghijklmnop',
+      'gsk_abcdefghijklmnopqrstuvwx',
+      'AIzaSyA1234567890abcdefghij',
+      'xai-abcdefghijklmnop',
+    ].join(' ');
+    const out = redactSecrets(text);
+    for (const frag of ['ant-api03', 'gsk_abc', 'AIzaSy', 'xai-abc']) expect(out).not.toContain(frag);
+  });
+
+  test('leaves ordinary text alone (no mangling of model ids or prose)', () => {
+    const text = 'model uj-chat is not included in your plan (sk is not a prefix here)';
+    expect(redactSecrets(text)).toBe(text);
+  });
+});

--- a/src/util/redact.test.ts
+++ b/src/util/redact.test.ts
@@ -27,4 +27,17 @@ describe('redactSecrets', () => {
     const text = 'model uj-chat is not included in your plan (sk is not a prefix here)';
     expect(redactSecrets(text)).toBe(text);
   });
+
+  test('Basic auth values are consumed, labelled or bare (pr2 review #8)', () => {
+    const b64 = Buffer.from('user:sk_uj-secret-material').toString('base64');
+    expect(redactSecrets(`Authorization: Basic ${b64}`)).not.toContain(b64);
+    expect(redactSecrets(`rejected credential Basic ${b64} at proxy`)).not.toContain(b64);
+  });
+
+  test('bare unlabelled JWTs are consumed (pr2 review #8)', () => {
+    const jwt = 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dBjftJeZ4CVPmB92K27uhbUJU1p1r_wW1gFWFOEjXk';
+    const out = redactSecrets(`upstream said: ${jwt} expired`);
+    expect(out).not.toContain(jwt.split('.')[1]);
+    expect(out).toContain('***redacted***');
+  });
 });

--- a/src/util/redact.ts
+++ b/src/util/redact.ts
@@ -10,9 +10,28 @@
  * rather than only ours.
  *
  * ONE definition on purpose: three copies drifted apart once already.
+ *
+ * Prefix matching alone is not enough. The proxy fronts several upstreams,
+ * and an auth failure echoed back from Bedrock, Vertex or Azure carries a
+ * credential with NO recognizable prefix (`AKIA…`, a bare JWT, a 32-hex
+ * api-key header). Those are caught by shape instead: an `Authorization:
+ * Bearer <opaque>` run, or an `api[-_]key`-labelled value. The labelled forms
+ * are matched before the bare-token form so the label itself is consumed.
  */
-const CREDENTIAL_RE = /\b(?:sk|gsk|xai|rk)[-_][A-Za-z0-9_-]{4,}|\bAIza[A-Za-z0-9_-]{10,}/g;
+const CREDENTIAL_PATTERNS: ReadonlyArray<readonly [RegExp, string]> = [
+  // Labelled secrets — keep the label so the message still says WHAT failed,
+  // drop the value. Runs first so the label is consumed with its value.
+  [/\b(api[-_]?key|authorization|x-api-key)(["'\s:=]+)(?:bearer\s+)?[A-Za-z0-9._~+/=-]{12,}/gi, '$1$2***redacted***'],
+  [/\bbearer\s+[A-Za-z0-9._~+/=-]{12,}/gi, 'Bearer ***redacted***'],
+  // Known prefixes (ours included — sk-uj-… must never escape).
+  [/\b(?:sk|gsk|xai|rk)[-_][A-Za-z0-9_-]{4,}/g, '***redacted***'],
+  [/\bAIza[A-Za-z0-9_-]{10,}/g, '***redacted***'],
+  [/\bAKIA[0-9A-Z]{12,}/g, '***redacted***'],
+  [/\bya29\.[A-Za-z0-9._-]{10,}/g, '***redacted***'],
+];
 
 export function redactSecrets(text: string): string {
-  return text.replace(CREDENTIAL_RE, '***redacted***');
+  let out = text;
+  for (const [pattern, replacement] of CREDENTIAL_PATTERNS) out = out.replace(pattern, replacement);
+  return out;
 }

--- a/src/util/redact.ts
+++ b/src/util/redact.ts
@@ -21,8 +21,11 @@
 const CREDENTIAL_PATTERNS: ReadonlyArray<readonly [RegExp, string]> = [
   // Labelled secrets — keep the label so the message still says WHAT failed,
   // drop the value. Runs first so the label is consumed with its value.
-  [/\b(api[-_]?key|authorization|x-api-key)(["'\s:=]+)(?:bearer\s+)?[A-Za-z0-9._~+/=-]{12,}/gi, '$1$2***redacted***'],
-  [/\bbearer\s+[A-Za-z0-9._~+/=-]{12,}/gi, 'Bearer ***redacted***'],
+  [/\b(api[-_]?key|authorization|x-api-key)(["'\s:=]+)(?:(?:bearer|basic|token)\s+)?[A-Za-z0-9._~+/=-]{12,}/gi, '$1$2***redacted***'],
+  [/\b(?:bearer|basic|token)\s+[A-Za-z0-9._~+/=-]{12,}/gi, '***redacted***'],
+  // Bare JWTs (three base64url segments) with no label at all — Vertex/Azure
+  // bodies echo these unlabelled.
+  [/\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{4,}/g, '***redacted***'],
   // Known prefixes (ours included — sk-uj-… must never escape).
   [/\b(?:sk|gsk|xai|rk)[-_][A-Za-z0-9_-]{4,}/g, '***redacted***'],
   [/\bAIza[A-Za-z0-9_-]{10,}/g, '***redacted***'],

--- a/src/util/redact.ts
+++ b/src/util/redact.ts
@@ -1,0 +1,18 @@
+/**
+ * Redact credential-shaped material from text that is about to reach a log,
+ * an API response, or a chat bubble.
+ *
+ * Why this exists: the hosted proxy's error bodies can echo the bearer we
+ * presented, and that per-account key is deliberately hidden from every other
+ * surface (settings responses, the catalog route, the provider test
+ * endpoint). Upstream providers' own auth errors can likewise echo THEIR
+ * keys back through the proxy, so the pattern covers the common prefixes
+ * rather than only ours.
+ *
+ * ONE definition on purpose: three copies drifted apart once already.
+ */
+const CREDENTIAL_RE = /\b(?:sk|gsk|xai|rk)[-_][A-Za-z0-9_-]{4,}|\bAIza[A-Za-z0-9_-]{10,}/g;
+
+export function redactSecrets(text: string): string {
+  return text.replace(CREDENTIAL_RE, '***redacted***');
+}


### PR DESCRIPTION
An OpenAIProvider subclass pointed at the platform proxy, with a key-scoped `listModels` so tier pickers only ever offer what the plan includes. Budget reset time is read from `GET /key/info` (the 429 body carries no reset field), memoized with a short timeout and a time-less degrade; 403 maps to model-not-in-plan.

Stack: **2/8** — base #354