### PR TITLE
feat(ux): hosted tiers in the LLM settings tab

### DIFF
--- a/src/daemon/api-routes.ts
+++ b/src/daemon/api-routes.ts
@@ -1618,6 +1618,29 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
       },
     },
 
+    // Live Usejarvis AI catalog: the uj-* aliases THIS account's key may
+    // call (the proxy filters per key, so there is no hardcoded list). The
+    // provider is built from the system-owned config.yaml block — the route
+    // takes no credentials and never echoes the base_url or key back.
+    '/api/config/llm/usejarvis/models': {
+      GET: async () => {
+        const { hasUsejarvisAi } = await import('./usejarvis-ai.ts');
+        if (!hasUsejarvisAi(ctx.config)) {
+          return error('Usejarvis AI is only available on hosted installs.', 503);
+        }
+        try {
+          const { UsejarvisAIProvider } = await import('../llm/usejarvis.ts');
+          const block = ctx.config.usejarvis_ai!;
+          const provider = new UsejarvisAIProvider(block.base_url!.trim(), block.api_key!.trim());
+          const models = await provider.listModels();
+          return json({ ok: true, models });
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          return json({ ok: false, error: msg, models: [] });
+        }
+      },
+    },
+
     // Full OmniRoute catalog: provider models, free routes, automatic routes,
     // and user-defined combos. POST keeps an onboarding API key out of the URL
     // and also supports a saved provider by name from Settings.

--- a/src/daemon/api-routes.ts
+++ b/src/daemon/api-routes.ts
@@ -1630,10 +1630,16 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
         }
         try {
           const { UsejarvisAIProvider } = await import('../llm/usejarvis.ts');
+          const { noteHostedCatalog } = await import('./usejarvis-ai.ts');
           const block = ctx.config.usejarvis_ai!;
           const provider = new UsejarvisAIProvider(block.base_url!.trim(), block.api_key!.trim());
-          const models = await provider.listModels();
-          return json({ ok: true, models });
+          const { models, degraded } = await provider.listModelsDetailed();
+          // A live catalog feeds the save-time allowlist; a degraded one never
+          // does (it would shrink the allowlist to the fallback four). The
+          // flag lets the dashboard show "plan catalog unreachable — Retry"
+          // instead of presenting the fallback as the plan's truth.
+          noteHostedCatalog(models, degraded);
+          return json({ ok: true, models, degraded });
         } catch (err) {
           // listModels embeds the upstream response body in its errors, and a
           // CDN/proxy error page can echo the hosted base_url hostname this

--- a/src/daemon/api-routes.ts
+++ b/src/daemon/api-routes.ts
@@ -1635,8 +1635,14 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
           const models = await provider.listModels();
           return json({ ok: true, models });
         } catch (err) {
-          const msg = err instanceof Error ? err.message : String(err);
-          return json({ ok: false, error: msg, models: [] });
+          // listModels embeds the upstream response body in its errors, and a
+          // CDN/proxy error page can echo the hosted base_url hostname this
+          // surface deliberately hides — the detail stays in the server log.
+          console.warn(
+            '[LLM] Usejarvis AI catalog fetch failed:',
+            err instanceof Error ? err.message : err,
+          );
+          return json({ ok: false, error: 'Usejarvis AI catalog unavailable', models: [] });
         }
       },
     },

--- a/src/daemon/api-usejarvis-models.test.ts
+++ b/src/daemon/api-usejarvis-models.test.ts
@@ -79,24 +79,26 @@ describe('GET /api/config/llm/usejarvis/models', () => {
   it('returns the key-scoped catalog, sending the block key ONLY to the block base_url', async () => {
     const res = await callEndpoint({ base_url: HOSTED_BASE, api_key: HOSTED_KEY });
     expect(res.status).toBe(200);
-    const body = await res.json() as { ok: boolean; models: string[] };
+    const body = await res.json() as { ok: boolean; models: string[]; degraded: boolean };
     expect(body.ok).toBe(true);
     expect(body.models).toEqual(['uj-chat', 'uj-high']); // provider sorts + dedupes
+    expect(body.degraded).toBe(false);
     expect(upstream!.url).toBe(`${HOSTED_BASE}/v1/models`);
     expect(upstream!.auth).toBe(`Bearer ${HOSTED_KEY}`);
   });
 
-  it('maps upstream failures to a generic error that leaks neither the key nor the host', async () => {
+  it('degrades upstream failures to the fallback aliases, leaking neither the key nor the host', async () => {
     // A CDN fronting the proxy answers with an HTML error page that names
-    // the origin host — exactly what the ok:false body must not echo.
+    // the origin host — exactly what the response body must not echo. The
+    // provider degrades to the core aliases so the tier picker keeps working.
     upstreamResponse = () =>
       new Response(`<html>origin ${HOSTED_BASE} unreachable</html>`, { status: 502 });
     const res = await callEndpoint({ base_url: HOSTED_BASE, api_key: HOSTED_KEY });
     expect(res.status).toBe(200);
-    const body = await res.json() as { ok: boolean; error: string; models: string[] };
-    expect(body.ok).toBe(false);
-    expect(body.error).toBe('Usejarvis AI catalog unavailable');
-    expect(body.models).toEqual([]);
+    const body = await res.json() as { ok: boolean; models: string[]; degraded: boolean };
+    expect(body.ok).toBe(true);
+    expect(body.models).toEqual(['uj-chat', 'uj-high', 'uj-low', 'uj-medium']);
+    expect(body.degraded).toBe(true);
     const serialized = JSON.stringify(body);
     expect(serialized).not.toContain('llm.usejarvis.host');
     expect(serialized).not.toContain(HOSTED_KEY);

--- a/src/daemon/api-usejarvis-models.test.ts
+++ b/src/daemon/api-usejarvis-models.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, beforeEach, afterEach } from 'bun:test';
+import { createApiRoutes, type ApiContext } from './api-routes.ts';
+import type { JarvisConfig } from '../config/types.ts';
+
+/**
+ * Tests for GET /api/config/llm/usejarvis/models.
+ *
+ * The interesting parts of this handler are (1) availability: the catalog
+ * exists only on hosted installs (a complete system-owned usejarvis_ai
+ * block), 503 otherwise; and (2) secrecy: the block's key travels ONLY to
+ * the block's own base_url, and no error path may echo the base_url host or
+ * key material back to the client — the settings surface deliberately hides
+ * both, and an upstream CDN error page would otherwise leak them through
+ * the provider's rewritten error messages. We stub global fetch and assert
+ * on the exact outgoing request and on the response body's contents.
+ */
+
+const HOSTED_BASE = 'https://llm.usejarvis.host';
+const HOSTED_KEY = 'sk-uj-abc123';
+
+type Handler = (req: Request) => Response | Promise<Response>;
+type MethodHandlers = { GET?: Handler; POST?: Handler };
+
+function getHandler(routes: Record<string, unknown>, path: string, method: 'GET' | 'POST'): Handler {
+  const route = routes[path] as MethodHandlers | undefined;
+  if (!route) throw new Error(`Route ${path} not registered`);
+  const handler = route[method];
+  if (!handler) throw new Error(`Method ${method} not registered for ${path}`);
+  return handler;
+}
+
+function makeCtx(usejarvisAi?: { base_url?: string; api_key?: string }): ApiContext {
+  return {
+    daemonStartedAt: Date.now(),
+    healthMonitor: {} as ApiContext['healthMonitor'],
+    config: { llm: { providers: {} }, ...(usejarvisAi ? { usejarvis_ai: usejarvisAi } : {}) } as JarvisConfig,
+  } as ApiContext;
+}
+
+function callEndpoint(usejarvisAi?: { base_url?: string; api_key?: string }) {
+  const routes = createApiRoutes(makeCtx(usejarvisAi));
+  const handler = getHandler(routes, '/api/config/llm/usejarvis/models', 'GET');
+  return handler(new Request('http://x/api/config/llm/usejarvis/models'));
+}
+
+describe('GET /api/config/llm/usejarvis/models', () => {
+  const realFetch = globalThis.fetch;
+  let upstream: { url: string; auth: string | undefined } | null;
+  let upstreamResponse: () => Response;
+
+  beforeEach(() => {
+    upstream = null;
+    upstreamResponse = () =>
+      new Response(JSON.stringify({ data: [{ id: 'uj-high' }, { id: 'uj-chat' }] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      const headers = new Headers(init?.headers);
+      upstream = { url: String(input), auth: headers.get('Authorization') ?? undefined };
+      return upstreamResponse();
+    }) as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  it('answers 503 on self-hosted installs (block absent or incomplete) without probing anything', async () => {
+    for (const block of [undefined, { base_url: HOSTED_BASE }, { api_key: HOSTED_KEY }]) {
+      const res = await callEndpoint(block);
+      expect(res.status).toBe(503);
+      const body = await res.json() as { error: string };
+      expect(body.error).toBe('Usejarvis AI is only available on hosted installs.');
+      expect(upstream).toBeNull();
+    }
+  });
+
+  it('returns the key-scoped catalog, sending the block key ONLY to the block base_url', async () => {
+    const res = await callEndpoint({ base_url: HOSTED_BASE, api_key: HOSTED_KEY });
+    expect(res.status).toBe(200);
+    const body = await res.json() as { ok: boolean; models: string[] };
+    expect(body.ok).toBe(true);
+    expect(body.models).toEqual(['uj-chat', 'uj-high']); // provider sorts + dedupes
+    expect(upstream!.url).toBe(`${HOSTED_BASE}/v1/models`);
+    expect(upstream!.auth).toBe(`Bearer ${HOSTED_KEY}`);
+  });
+
+  it('maps upstream failures to a generic error that leaks neither the key nor the host', async () => {
+    // A CDN fronting the proxy answers with an HTML error page that names
+    // the origin host — exactly what the ok:false body must not echo.
+    upstreamResponse = () =>
+      new Response(`<html>origin ${HOSTED_BASE} unreachable</html>`, { status: 502 });
+    const res = await callEndpoint({ base_url: HOSTED_BASE, api_key: HOSTED_KEY });
+    expect(res.status).toBe(200);
+    const body = await res.json() as { ok: boolean; error: string; models: string[] };
+    expect(body.ok).toBe(false);
+    expect(body.error).toBe('Usejarvis AI catalog unavailable');
+    expect(body.models).toEqual([]);
+    const serialized = JSON.stringify(body);
+    expect(serialized).not.toContain('llm.usejarvis.host');
+    expect(serialized).not.toContain(HOSTED_KEY);
+  });
+});

--- a/src/daemon/llm-settings.test.ts
+++ b/src/daemon/llm-settings.test.ts
@@ -3,7 +3,12 @@ import { initDatabase, closeDb } from '../vault/schema.ts';
 import { getSetting, setSetting } from '../vault/settings.ts';
 import { DEFAULT_CONFIG, type JarvisConfig } from '../config/types.ts';
 import { getLLMSettings, mergeLLMSettingsIntoConfig, saveLLMSettings } from './llm-settings.ts';
-import { applyUsejarvisAi, USEJARVIS_PROVIDER_NAME } from './usejarvis-ai.ts';
+import {
+  applyUsejarvisAi,
+  clearHostedCatalogForTest,
+  noteHostedCatalog,
+  USEJARVIS_PROVIDER_NAME,
+} from './usejarvis-ai.ts';
 
 afterEach(() => closeDb());
 
@@ -165,6 +170,56 @@ function hostedConfig(): JarvisConfig {
   applyUsejarvisAi(config); // what boot / every merge does
   return config;
 }
+
+describe('saveLLMSettings: hosted model refs pass the server-side allowlist (W8)', () => {
+  beforeEach(() => { closeDb(); initDatabase(':memory:'); clearHostedCatalogForTest(); });
+  afterEach(() => { closeDb(); clearHostedCatalogForTest(); });
+
+  test('static rule (no catalog seen): non-chat aliases and raw upstream ids are refused, chat aliases save', () => {
+    const config = hostedConfig();
+    for (const model of ['uj-stt', 'uj-tts-hd', 'uj-realtime', 'gpt-5.5']) {
+      expect(() => saveLLMSettings(config, { tiers: { high: `usejarvis_ai:${model}` } }))
+        .toThrow(/not (in your plan|a chat alias)/);
+    }
+    expect(() => saveLLMSettings(config, { default: 'usejarvis_ai:gpt-5.5' })).toThrow();
+    saveLLMSettings(config, { tiers: { high: 'usejarvis_ai:uj-high' } });
+    expect(getSetting('llm.tiers.high')).toBe('usejarvis_ai:uj-high');
+  });
+
+  test('a live catalog narrows the allowlist to exactly the plan; a degraded one never does', () => {
+    const config = hostedConfig();
+    noteHostedCatalog(['uj-chat', 'uj-pro'], false);
+    saveLLMSettings(config, { tiers: { high: 'usejarvis_ai:uj-pro' } });
+    expect(getSetting('llm.tiers.high')).toBe('usejarvis_ai:uj-pro');
+    // uj-high passes the static rule but is not in THIS plan's catalog:
+    expect(() => saveLLMSettings(config, { tiers: { medium: 'usejarvis_ai:uj-high' } }))
+      .toThrow(/not in your plan/);
+    // Degraded fetches must not shrink the allowlist to the fallback four:
+    clearHostedCatalogForTest();
+    noteHostedCatalog(['uj-chat'], true);
+    saveLLMSettings(config, { tiers: { medium: 'usejarvis_ai:uj-high' } });
+    expect(getSetting('llm.tiers.medium')).toBe('usejarvis_ai:uj-high');
+  });
+
+  test('a rejected ref mutates nothing (validate-before-mutate)', () => {
+    const config = hostedConfig();
+    saveLLMSettings(config, { tiers: { high: 'usejarvis_ai:uj-high' } });
+    expect(() => saveLLMSettings(config, {
+      tiers: { high: 'usejarvis_ai:uj-stt' },
+      default: 'anthropic:claude-x',
+    })).toThrow();
+    expect(getSetting('llm.tiers.high')).toBe('usejarvis_ai:uj-high');
+    expect(config.llm.default).toBeUndefined();
+    expect(getSetting('llm.default') ?? '').toBe('');
+  });
+
+  test('self-hosted installs have no gate: a legacy provider named usejarvis_ai keeps free refs', () => {
+    const config = structuredClone(DEFAULT_CONFIG);
+    config.llm.providers = { usejarvis_ai: { kind: 'openai_compatible', base_url: 'https://my.gw/v1' } };
+    saveLLMSettings(config, { tiers: { high: 'usejarvis_ai:gpt-5.5' } });
+    expect(getSetting('llm.tiers.high')).toBe('usejarvis_ai:gpt-5.5');
+  });
+});
 
 describe('saveLLMSettings: the hosted provider is not editable', () => {
   beforeEach(() => { closeDb(); initDatabase(':memory:'); });

--- a/src/daemon/llm-settings.test.ts
+++ b/src/daemon/llm-settings.test.ts
@@ -231,6 +231,28 @@ describe('getLLMSettings: the block is reported, never exposed', () => {
   });
 });
 
+describe('getLLMSettings (hosted vs self-hosted surface)', () => {
+  beforeEach(() => { closeDb(); initDatabase(':memory:'); });
+  afterEach(() => { closeDb(); });
+
+  test('hosted: a user provider lists alone, the managed entry stays hidden', () => {
+    const config = hostedConfig();
+    config.llm.providers!.anthropic = { api_key: 'sk-ant-user' };
+    const out = getLLMSettings(config);
+    expect(out.hosted_llm).toBe(true);
+    expect(out.providers[USEJARVIS_PROVIDER_NAME]).toBeUndefined();
+    expect(Object.keys(out.providers)).toEqual(['anthropic']);
+  });
+
+  test('self-hosted: providers pass through in display shape', () => {
+    const config = structuredClone(DEFAULT_CONFIG);
+    config.llm.providers = { anthropic: { api_key: 'sk-ant-user' } };
+    const out = getLLMSettings(config);
+    expect(out.hosted_llm).toBe(false);
+    expect(out.providers.anthropic).toEqual({ kind: 'anthropic', has_api_key: true });
+  });
+});
+
 describe('getLLMSettings.effective: the dashboard reads routing reality, not a re-derivation', () => {
   beforeEach(() => { closeDb(); initDatabase(':memory:'); });
   afterEach(() => { closeDb(); });

--- a/src/daemon/llm-settings.ts
+++ b/src/daemon/llm-settings.ts
@@ -22,6 +22,7 @@ import {
   effectiveLlmForBinding,
   hasUsejarvisAi,
   USEJARVIS_PROVIDER_NAME,
+  validateHostedModelRef,
 } from './usejarvis-ai.ts';
 import { getSetting, setSetting } from '../vault/settings.ts';
 import { getSecret, setSecret, deleteSecret, hasSecret } from '../vault/keychain.ts';
@@ -267,6 +268,28 @@ export function saveLLMSettings(
 ): void {
   if (!config.llm.providers) config.llm.providers = {};
   if (!config.llm.tiers) config.llm.tiers = {};
+
+  // Server-side allowlist for hosted refs (validate-before-mutate: this runs
+  // before ANY provider/tier/default application). The UI hides free-text
+  // model entry for the managed provider, but the UI is not the gate — a
+  // hand-crafted POST carrying `usejarvis_ai:gpt-5.5` or `usejarvis_ai:uj-stt`
+  // must not reach the proxy under the account key (review pr3#1, pr1#9).
+  if (hasUsejarvisAi(config)) {
+    const candidateRefs: string[] = [];
+    if (typeof body.default === 'string' && body.default) candidateRefs.push(body.default);
+    if (body.tiers) {
+      for (const value of Object.values(body.tiers)) {
+        if (typeof value === 'string' && value) candidateRefs.push(value);
+      }
+    }
+    for (const ref of candidateRefs) {
+      const parsed = parseModelRef(ref);
+      if (parsed?.provider === USEJARVIS_PROVIDER_NAME) {
+        const problem = validateHostedModelRef(parsed.model ?? '');
+        if (problem) throw new Error(problem);
+      }
+    }
+  }
 
   // Apply provider updates (add / modify / remove).
   if (body.providers) {

--- a/src/daemon/usejarvis-ai.ts
+++ b/src/daemon/usejarvis-ai.ts
@@ -120,3 +120,50 @@ export function effectiveLlmForBinding(config: JarvisConfig): LLMConfig {
   }
   return { ...config.llm, tiers };
 }
+
+// ── Hosted model allowlist (server-side gate) ────────────────────────────
+//
+// The dashboard's picker restrictions are advisory; THIS is the gate. Refs
+// under the reserved provider are validated against the plan catalog when we
+// have seen one recently, and against a conservative static rule otherwise.
+// The cache is fed by the catalog route (the UI hits it whenever a hosted
+// tier picker renders), because saveLLMSettings is synchronous and must not
+// fetch. A degraded catalog (proxy unreachable → fallback aliases) never
+// enters the cache: it would shrink the allowlist to four entries and reject
+// plan-specific aliases the user legitimately holds.
+
+const CATALOG_TTL_MS = 5 * 60_000;
+let hostedCatalog: { models: ReadonlySet<string>; at: number } | null = null;
+
+/** Feed the allowlist cache from a live (non-degraded) catalog response. */
+export function noteHostedCatalog(models: string[], degraded: boolean): void {
+  if (degraded) return;
+  hostedCatalog = { models: new Set(models), at: Date.now() };
+}
+
+export function clearHostedCatalogForTest(): void {
+  hostedCatalog = null;
+}
+
+/** Aliases that resolve to non-chat endpoints; never valid as a tier/default
+ * ref even when the live catalog is unavailable. */
+const NON_CHAT_ALIAS = /^uj-(stt|tts|realtime)\b/;
+
+/**
+ * Validate the model half of a `usejarvis_ai:<model>` ref. Returns an error
+ * message for the 400, or null when the ref is acceptable.
+ */
+export function validateHostedModelRef(model: string): string | null {
+  const fresh = hostedCatalog && Date.now() - hostedCatalog.at < CATALOG_TTL_MS
+    ? hostedCatalog.models
+    : null;
+  if (fresh) {
+    return fresh.has(model)
+      ? null
+      : `Model '${model}' is not in your plan's catalog`;
+  }
+  if (!model.startsWith('uj-') || NON_CHAT_ALIAS.test(model)) {
+    return `Model '${model}' is not a chat alias of your plan`;
+  }
+  return null;
+}

--- a/src/llm/usejarvis.ts
+++ b/src/llm/usejarvis.ts
@@ -42,10 +42,18 @@ export class UsejarvisAIProvider extends OpenAIProvider {
    * pickers — which would break alias opacity and let a user select a model
    * whose per-plan resale price was never configured. */
   override async listModels(): Promise<string[]> {
-    // Never throws: the LLMProvider contract is degrade-to-fallback (every
-    // sibling catches), and the first caller — the tier-picker catalog route —
-    // must not turn a transient proxy 503 into an unhandled rejection. The
-    // fallback is the four core aliases every plan carries.
+    return (await this.listModelsDetailed()).models;
+  }
+
+  /** Like listModels, but reports whether the result is the live plan catalog
+   * or the degraded fallback — the catalog route forwards the flag so the
+   * dashboard can offer a retry instead of presenting the fallback as truth.
+   * Never throws: the LLMProvider contract is degrade-to-fallback (every
+   * sibling catches), and the first caller — the tier-picker catalog route —
+   * must not turn a transient proxy 503 into an unhandled rejection. The
+   * fallback is the four core aliases every plan carries. */
+  async listModelsDetailed(): Promise<{ models: string[]; degraded: boolean }> {
+    const fallback = { models: UsejarvisAIProvider.FALLBACK_MODELS.slice(), degraded: true };
     try {
       const response = await fetch(this.modelsUrl, {
         headers: { Authorization: `Bearer ${this.apiKey}` },
@@ -53,21 +61,22 @@ export class UsejarvisAIProvider extends OpenAIProvider {
       });
       if (!response.ok) {
         console.warn(`[usejarvis] model catalog unavailable (${response.status}); serving fallback aliases`);
-        return UsejarvisAIProvider.FALLBACK_MODELS.slice();
+        return fallback;
       }
       const payload = await response.json() as { data?: Array<{ id?: unknown }> };
       if (!Array.isArray(payload.data)) {
         console.warn(`[usejarvis] model catalog malformed; serving fallback aliases`);
-        return UsejarvisAIProvider.FALLBACK_MODELS.slice();
+        return fallback;
       }
-      return [...new Set(
+      const models = [...new Set(
         payload.data
           .map((entry) => entry.id)
           .filter((id): id is string => typeof id === 'string' && id.startsWith('uj-')),
       )].sort();
+      return { models, degraded: false };
     } catch (err) {
       console.warn('[usejarvis] model catalog fetch failed; serving fallback aliases:', err instanceof Error ? err.message : err);
-      return UsejarvisAIProvider.FALLBACK_MODELS.slice();
+      return fallback;
     }
   }
 

--- a/ui/src/v2/onboarding/OnboardingWizard.tsx
+++ b/ui/src/v2/onboarding/OnboardingWizard.tsx
@@ -45,7 +45,9 @@ type Provider = {
   keyLabel?: string; urlLabel?: string; urlPh?: string; models?: string[]; hint?: string;
 };
 const PROVIDERS: Provider[] = [
-  { id: "jarvis", name: "Jarvis AI", abbr: "JA", kind: "no key", soon: true, noConfig: true },
+  // Hosted brain. `soon: true` is the self-hosted default; the wizard flips
+  // it off when GET /api/config/llm reports hosted_llm (see provList below).
+  { id: "jarvis", name: "Jarvis AI", abbr: "JA", kind: "included", soon: true, noConfig: true },
   { id: "anthropic", name: "Anthropic", abbr: "A", kind: "API key", needsKey: true, optionalBaseUrl: true, keyLabel: "API key", urlLabel: "Custom endpoint URL", urlPh: "https://gateway.example.com", models: ["claude-fable-5", "claude-opus-4-8", "claude-sonnet-5", "claude-haiku-4-5-20251001"], hint: "Enable the custom endpoint option to use ANTHROPIC_BASE_URL and ANTHROPIC_AUTH_TOKEN-style authentication." },
   { id: "openai", name: "OpenAI", abbr: "O", kind: "API key", needsKey: true, models: ["gpt-5.5", "gpt-5.5-pro", "gpt-5.4", "gpt-5-mini", "o4-mini"] },
   { id: "groq", name: "Groq", abbr: "G", kind: "API key", needsKey: true, models: ["openai/gpt-oss-20b", "openai/gpt-oss-120b", "qwen/qwen3.6-27b"], hint: "Loads the current model catalog from Groq so decommissioned models are never suggested." },
@@ -140,8 +142,26 @@ export function OnboardingWizard({
 
   // permissions
   // brain
+  // Hosted install? GET /api/config/llm reports hosted_llm when the
+  // system-owned usejarvis_ai block is live. Until (and unless) it says so,
+  // the "Jarvis AI" card stays a disabled "Soon" — self-hosted default.
+  const [hosted, setHosted] = useState(false);
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/api/config/llm")
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d: { hosted_llm?: boolean } | null) => {
+        if (!cancelled && d?.hosted_llm) setHosted(true);
+      })
+      .catch(() => { /* unreachable daemon reads as self-hosted */ });
+    return () => { cancelled = true; };
+  }, []);
+  const provList = useMemo(
+    () => PROVIDERS.map((p) => (p.id === "jarvis" ? { ...p, soon: !hosted } : p)),
+    [hosted],
+  );
   const [provId, setProvId] = useState("anthropic");
-  const prov = PROVIDERS.find((p) => p.id === provId)!;
+  const prov = provList.find((p) => p.id === provId)!;
   const [apiKey, setApiKey] = useState("");
   const [baseUrl, setBaseUrl] = useState("");
   const [customEndpoint, setCustomEndpoint] = useState(false);
@@ -378,21 +398,25 @@ export function OnboardingWizard({
   const saveSetup = useCallback(async () => {
     setBusy(true); setError(null);
     try {
-      const entry: Record<string, unknown> = { kind: prov.kind === "no key" ? "jarvis" : provId };
-      if (prov.needsKey && apiKey) entry.api_key = apiKey;
-      if (prov.needsBaseUrl) entry.base_url = baseUrl.trim();
-      if (prov.optionalBaseUrl && customEndpoint && baseUrl.trim()) entry.base_url = baseUrl.trim();
-      const validatedModel = test.status === "ok" ? test.validatedModel : undefined;
-      const llm: Record<string, unknown> = {
-        providers: { [provId]: entry },
-        default: onboardingDefaultModelRef(provId, model, validatedModel),
-      };
-
       const ttsBlock: Record<string, unknown> = { enabled: tts !== "off", provider: tts === "off" ? "edge" : tts };
       if (tts === "edge") { ttsBlock.voice = edgeVoice; ttsBlock.rate = "+0%"; }
       else if (tts === "elevenlabs") ttsBlock.elevenlabs = { api_key: elevenKey, voice_id: elevenVoice, model: elevenModel };
 
-      const payload: Record<string, unknown> = { llm, tts: ttsBlock };
+      const payload: Record<string, unknown> = { tts: ttsBlock };
+      // Hosted "Jarvis AI" needs NO llm block: the daemon's carve-out already
+      // injected the provider and tier wiring, so setup simply omits it
+      // (/api/onboarding/setup treats llm as optional).
+      if (provId !== "jarvis") {
+        const entry: Record<string, unknown> = { kind: provId };
+        if (prov.needsKey && apiKey) entry.api_key = apiKey;
+        if (prov.needsBaseUrl) entry.base_url = baseUrl.trim();
+        if (prov.optionalBaseUrl && customEndpoint && baseUrl.trim()) entry.base_url = baseUrl.trim();
+        const validatedModel = test.status === "ok" ? test.validatedModel : undefined;
+        payload.llm = {
+          providers: { [provId]: entry },
+          default: onboardingDefaultModelRef(provId, model, validatedModel),
+        };
+      }
       if (stt !== "skip") {
         const sttBlock: Record<string, unknown> = { provider: stt };
         if ((stt === "openai" || stt === "groq") && sttKey) sttBlock[stt] = { api_key: sttKey };
@@ -667,9 +691,13 @@ export function OnboardingWizard({
       case "brain": return (
         <div className="obw-body"><div className="obw-wrap wide">
           <h2>Pick a brain for Jarvis.</h2>
-          <div className="obw-sub">Bring your own: Ollama runs locally with no key, or add an API key for Anthropic, OpenAI, and more. Jarvis AI, our hosted brain, is coming soon. Change it anytime in Settings.</div>
+          <div className="obw-sub">
+            {hosted
+              ? "Jarvis AI is included with your plan — nothing to configure. Prefer your own? Ollama runs locally with no key, or add an API key for Anthropic, OpenAI, and more. Change it anytime in Settings."
+              : "Bring your own: Ollama runs locally with no key, or add an API key for Anthropic, OpenAI, and more. Jarvis AI, our hosted brain, is coming soon. Change it anytime in Settings."}
+          </div>
           <div className="obw-provgrid" style={{ marginTop: 14 }}>
-            {PROVIDERS.map((p) => (
+            {provList.map((p) => (
               <button
                 key={p.id}
                 className={`obw-prov ${p.reco ? "reco" : ""} ${p.soon ? "soon" : ""} ${provId === p.id ? "on" : ""}`}

--- a/ui/src/v2/onboarding/OnboardingWizard.tsx
+++ b/ui/src/v2/onboarding/OnboardingWizard.tsx
@@ -403,10 +403,19 @@ export function OnboardingWizard({
       else if (tts === "elevenlabs") ttsBlock.elevenlabs = { api_key: elevenKey, voice_id: elevenVoice, model: elevenModel };
 
       const payload: Record<string, unknown> = { tts: ttsBlock };
-      // Hosted "Jarvis AI" needs NO llm block: the daemon's carve-out already
-      // injected the provider and tier wiring, so setup simply omits it
-      // (/api/onboarding/setup treats llm as optional).
-      if (provId !== "jarvis") {
+      if (provId === "jarvis") {
+        // Hosted needs no provider or default — the daemon's carve-out injects
+        // the provider, and the uj-* tier wiring lives in the routing view.
+        //
+        // But the MODE must still be persisted. Without it getLLMSettings
+        // INFERS "single" (no default, no tiers stored), so the LLM tab shows
+        // "Single LLM · default unset" for an install that is actually running
+        // four tiers. The user then picks a default to fill the blank, which
+        // sets config.llm.default — and effectiveLlmForBinding returns early
+        // on that, tearing down all four hosted tiers so everything collapses
+        // onto uj-chat. Recording the mode makes the tab tell the truth.
+        payload.llm = { mode: "multi-tier" };
+      } else {
         const entry: Record<string, unknown> = { kind: provId };
         if (prov.needsKey && apiKey) entry.api_key = apiKey;
         if (prov.needsBaseUrl) entry.base_url = baseUrl.trim();

--- a/ui/src/v2/rooms/settings/tabs/LLMTab.models.test.ts
+++ b/ui/src/v2/rooms/settings/tabs/LLMTab.models.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { providerModels, seedModelForProvider, USEJARVIS_TIER_ALIASES } from "./LLMTab";
+import { providerModels, seedModelForProvider, unsetSlotPlaceholder, USEJARVIS_TIER_ALIASES } from "./LLMTab";
 
 /** The hosted catalog is key-scoped across EVERY modality, so these pickers —
  * which choose chat tiers and the single-model default — must never offer a
@@ -69,5 +69,30 @@ describe("seedModelForProvider: per-tier seeding", () => {
       { usejarvis_ai: ["uj-chat", "uj-high", "uj-low", "uj-medium", "uj-stt"] },
     );
     for (const alias of Object.values(USEJARVIS_TIER_ALIASES)) expect(offered).toContain(alias);
+  });
+});
+
+/** An unset tier slot renders routing truth from llm.effective — never a
+ * never-persisted models[0] presented as if it were saved (review pr3#7). */
+describe("unsetSlotPlaceholder: unset slots show routing truth", () => {
+  test("plan-sourced fill names the plan default", () => {
+    expect(unsetSlotPlaceholder({ ref: "usejarvis_ai:uj-high", source: "plan" }))
+      .toBe("Plan default: uj-high");
+  });
+
+  test("default-sourced fill names the fallback default", () => {
+    expect(unsetSlotPlaceholder({ ref: "anthropic:claude-x", source: "default" }))
+      .toBe("Default: claude-x");
+  });
+
+  test("nothing bound (self-hosted, no default) prompts a choice", () => {
+    expect(unsetSlotPlaceholder({ ref: null, source: null })).toBe("Select a model…");
+    expect(unsetSlotPlaceholder(undefined)).toBe("Select a model…");
+  });
+
+  test("a choice-sourced ref is not a placeholder case", () => {
+    // The slot has an explicit ref; the select shows it as the value instead.
+    expect(unsetSlotPlaceholder({ ref: "usejarvis_ai:uj-pro", source: "choice" }))
+      .toBe("Select a model…");
   });
 });

--- a/ui/src/v2/rooms/settings/tabs/LLMTab.models.test.ts
+++ b/ui/src/v2/rooms/settings/tabs/LLMTab.models.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+import { providerModels } from "./LLMTab";
+
+/** The hosted catalog is key-scoped across EVERY modality, so these pickers —
+ * which choose chat tiers and the single-model default — must never offer a
+ * voice alias. Pure-function test (the tree.test.ts precedent). */
+describe("providerModels: hosted catalog filtering", () => {
+  const providers = { usejarvis_ai: { kind: "usejarvis_ai" as const, has_api_key: true } };
+  const catalogs = {
+    usejarvis_ai: ["uj-chat", "uj-high", "uj-low", "uj-medium", "uj-realtime", "uj-stt", "uj-tts"],
+  };
+
+  test("keeps the chat tiers and drops every voice alias", () => {
+    expect(providerModels(providers, "usejarvis_ai", null, catalogs)).toEqual([
+      "uj-chat",
+      "uj-high",
+      "uj-low",
+      "uj-medium",
+    ]);
+  });
+
+  test("an UNKNOWN future alias is excluded (allowlist fails closed)", () => {
+    // The platform can ship a new slot with no jarvis release. A denylist
+    // would let it through — and since the first entry is auto-committed on a
+    // provider switch, a voice alias sorting first would silently become the
+    // user's conversation model.
+    const withFuture = { usejarvis_ai: ["uj-audio", "uj-chat", "uj-vision"] };
+    expect(providerModels(providers, "usejarvis_ai", null, withFuture)).toEqual(["uj-chat"]);
+  });
+
+  test("non-hosted catalogs pass through untouched", () => {
+    const omni = {
+      kinds: { omni: { kind: "omniroute" as const, has_api_key: true } },
+      catalog: { omni: ["a/b", "c/d"] },
+    };
+    expect(providerModels(omni.kinds, "omni", null, omni.catalog)).toEqual(["a/b", "c/d"]);
+  });
+});

--- a/ui/src/v2/rooms/settings/tabs/LLMTab.models.test.ts
+++ b/ui/src/v2/rooms/settings/tabs/LLMTab.models.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { providerModels } from "./LLMTab";
+import { providerModels, seedModelForProvider, USEJARVIS_TIER_ALIASES } from "./LLMTab";
 
 /** The hosted catalog is key-scoped across EVERY modality, so these pickers —
  * which choose chat tiers and the single-model default — must never offer a
@@ -34,5 +34,40 @@ describe("providerModels: hosted catalog filtering", () => {
       catalog: { omni: ["a/b", "c/d"] },
     };
     expect(providerModels(omni.kinds, "omni", null, omni.catalog)).toEqual(["a/b", "c/d"]);
+  });
+});
+
+/** Switching a tier's provider auto-commits immediately, so WHICH model gets
+ * seeded is a persisted decision, not a display detail. */
+describe("seedModelForProvider: per-tier seeding", () => {
+  const hostedChatModels = ["uj-chat", "uj-high", "uj-low", "uj-medium"];
+
+  test("each tier seeds its OWN alias, not the alphabetically-first one", () => {
+    // The bug this pins: models[0] is always "uj-chat", so switching the
+    // High-intelligence picker to the hosted provider silently persisted the
+    // thin conversation model as the deep-reasoning tier.
+    expect(seedModelForProvider(hostedChatModels, USEJARVIS_TIER_ALIASES.high)).toBe("uj-high");
+    expect(seedModelForProvider(hostedChatModels, USEJARVIS_TIER_ALIASES.medium)).toBe("uj-medium");
+    expect(seedModelForProvider(hostedChatModels, USEJARVIS_TIER_ALIASES.low)).toBe("uj-low");
+    expect(seedModelForProvider(hostedChatModels, USEJARVIS_TIER_ALIASES.conversation)).toBe("uj-chat");
+  });
+
+  test("falls back to the first entry when the provider lacks the preferred model", () => {
+    // A BYO provider has no uj-* aliases — seeding must not invent one.
+    expect(seedModelForProvider(["claude-opus-5", "claude-haiku-4-5"], "uj-high")).toBe("claude-opus-5");
+  });
+
+  test("an empty catalog yields the custom sentinel, never a bogus commit", () => {
+    expect(seedModelForProvider([], "uj-high")).toBe("__custom__");
+  });
+
+  test("every tier alias is one the picker actually offers (no drift)", () => {
+    const offered = providerModels(
+      { usejarvis_ai: { kind: "usejarvis_ai" as const, has_api_key: true } },
+      "usejarvis_ai",
+      null,
+      { usejarvis_ai: ["uj-chat", "uj-high", "uj-low", "uj-medium", "uj-stt"] },
+    );
+    for (const alias of Object.values(USEJARVIS_TIER_ALIASES)) expect(offered).toContain(alias);
   });
 });

--- a/ui/src/v2/rooms/settings/tabs/LLMTab.tsx
+++ b/ui/src/v2/rooms/settings/tabs/LLMTab.tsx
@@ -20,6 +20,9 @@ import {
 
 /** Reserved hosted provider name (mirrors the daemon's usejarvis_ai carve-out). */
 const USEJARVIS_NAME = "usejarvis_ai";
+/** Hosted aliases that are NOT chat models: the key-scoped catalog lists every
+ * modality, but these pickers only ever choose chat tiers. */
+const NON_CHAT_USEJARVIS_ALIASES = new Set(["uj-stt", "uj-tts", "uj-realtime"]);
 
 /**
  * Providers offered by the model pickers: the user's editable entries plus,
@@ -1103,7 +1106,15 @@ function providerModels(
     (entry.kind === "omniroute" || entry.kind === "groq" || entry.kind === "usejarvis_ai")
     && providerCatalogs[name]?.length
   ) {
-    return providerCatalogs[name]!;
+    const catalog = providerCatalogs[name]!;
+    // The hosted catalog is key-scoped across ALL modalities, so it also
+    // carries the voice aliases. These pickers choose CHAT tiers (and the
+    // single-model default) — selecting uj-stt/uj-tts/uj-realtime there would
+    // point the conversation at a transcription or speech endpoint and break
+    // chat outright. Voice slots are chosen in Channels/Voice, not here.
+    return entry.kind === "usejarvis_ai"
+      ? catalog.filter((id) => !NON_CHAT_USEJARVIS_ALIASES.has(id))
+      : catalog;
   }
   return MODELS_BY_KIND[entry.kind] ?? [];
 }

--- a/ui/src/v2/rooms/settings/tabs/LLMTab.tsx
+++ b/ui/src/v2/rooms/settings/tabs/LLMTab.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { ChevronRight, Plus, Trash2 } from "lucide-react";
 import { confirmDialog } from "../../../ui/ConfirmDialog";
 import { Icon } from "../../../ui";
@@ -20,6 +20,11 @@ import {
 
 /** Reserved hosted provider name (mirrors the daemon's usejarvis_ai carve-out). */
 const USEJARVIS_NAME = "usejarvis_ai";
+/** The hosted provider's KIND (mirrors the daemon's USEJARVIS_KIND). Same
+ * literal as the name today, but a distinct constant: gates asking "is this
+ * entry the hosted provider" compare kinds against this, never kind-vs-name —
+ * the two coinciding is an implementation detail, not a contract. */
+const USEJARVIS_KIND = "usejarvis_ai";
 /** Hosted aliases that ARE chat models — an ALLOWLIST, mirroring the
  * platform's SLOTS_BY_MODALITY.chat. A denylist fails OPEN: the platform's
  * slots are data (a new alias ships without any jarvis release), and
@@ -59,7 +64,7 @@ export function seedModelForProvider(models: string[], preferredModel?: string):
 function pickerProviders(llm: LLMConfig): Record<string, LLMConfigProviderView> {
   if (!llm.hosted_llm) return llm.providers;
   return {
-    [USEJARVIS_NAME]: { kind: "usejarvis_ai", has_api_key: true },
+    [USEJARVIS_NAME]: { kind: USEJARVIS_KIND, has_api_key: true },
     ...llm.providers,
   };
 }
@@ -187,7 +192,8 @@ export function LLMTab({
   // The pickers see the editable providers PLUS the managed hosted one; the
   // live-catalog hook fetches for both (OmniRoute routes, uj-* aliases).
   const allProviders = useMemo(() => (llm ? pickerProviders(llm) : {}), [llm]);
-  const providerCatalogs = useLiveProviderCatalogs(allProviders);
+  const catalogState = useLiveProviderCatalogs(allProviders);
+  const providerCatalogs = catalogState.catalogs;
 
   if (!llm) return <div className="v2-set__empty">Loading LLM config...</div>;
 
@@ -241,9 +247,9 @@ export function LLMTab({
       </section>
 
       {mode === "single" ? (
-        <SingleModelSection data={data} onToast={onToast} providers={allProviders} ollamaModels={ollamaModels} providerCatalogs={providerCatalogs} />
+        <SingleModelSection data={data} onToast={onToast} providers={allProviders} ollamaModels={ollamaModels} providerCatalogs={providerCatalogs} catalogState={catalogState} />
       ) : (
-        <MultiTierSection data={data} onToast={onToast} providers={allProviders} ollamaModels={ollamaModels} providerCatalogs={providerCatalogs} />
+        <MultiTierSection data={data} onToast={onToast} providers={allProviders} ollamaModels={ollamaModels} providerCatalogs={providerCatalogs} catalogState={catalogState} />
       )}
     </div>
   );
@@ -813,12 +819,14 @@ function SingleModelSection({
   providers,
   ollamaModels,
   providerCatalogs,
+  catalogState,
 }: {
   data: SettingsHook;
   onToast: (text: string, tone?: "ok" | "warn") => void;
   providers: Record<string, LLMConfigProviderView>;
   ollamaModels: string[] | null;
   providerCatalogs: Record<string, string[]>;
+  catalogState: LiveCatalogState;
 }) {
   const llm = data.llm!;
 
@@ -839,6 +847,8 @@ function SingleModelSection({
         providers={providers}
         ollamaModels={ollamaModels}
         providerCatalogs={providerCatalogs}
+        catalogState={catalogState}
+        allowClear
         onChange={async (ref) => {
           const r = await data.setDefaultModel(ref);
           onToast(r.message, r.ok ? "ok" : "warn");
@@ -856,12 +866,14 @@ function MultiTierSection({
   providers,
   ollamaModels,
   providerCatalogs,
+  catalogState,
 }: {
   data: SettingsHook;
   onToast: (text: string, tone?: "ok" | "warn") => void;
   providers: Record<string, LLMConfigProviderView>;
   ollamaModels: string[] | null;
   providerCatalogs: Record<string, string[]>;
+  catalogState: LiveCatalogState;
 }) {
   const llm = data.llm!;
 
@@ -910,8 +922,10 @@ function MultiTierSection({
             providers={providers}
             ollamaModels={ollamaModels}
             providerCatalogs={providerCatalogs}
+            catalogState={catalogState}
             allowClear
             preferredModel={USEJARVIS_TIER_ALIASES[t.id]}
+            effectiveHint={llm.effective?.tiers[t.id]}
             onChange={async (ref) => {
               const r = await data.setTierModel(t.id, ref);
               onToast(r.message, r.ok ? "ok" : "warn");
@@ -923,7 +937,14 @@ function MultiTierSection({
       <div className="v2-set__field" style={{ marginTop: "var(--s-4)" }}>
         <h4 className="v2-set__section-title">Default (fallback)</h4>
         <div className="v2-set__section-sub" style={{ marginBottom: "var(--s-2)" }}>
-          Used when a tier has no explicit model and the fall-up chain has nothing either.
+          {llm.hosted_llm ? (
+            <>Fills any tier you leave empty — it takes that slot over your
+            plan&apos;s tier default. Clear it to give empty tiers back to the
+            plan defaults. Tiers you set explicitly always win.</>
+          ) : (
+            <>Used when a tier has no explicit model and the fall-up chain has
+            nothing either.</>
+          )}
         </div>
         <ModelSelector
           label=""
@@ -931,6 +952,7 @@ function MultiTierSection({
           providers={providers}
           ollamaModels={ollamaModels}
           providerCatalogs={providerCatalogs}
+          catalogState={catalogState}
           allowClear
           onChange={async (ref) => {
             const r = await data.setDefaultModel(ref);
@@ -951,8 +973,10 @@ function ModelSelector({
   providers,
   ollamaModels,
   providerCatalogs,
+  catalogState,
   allowClear,
   preferredModel,
+  effectiveHint,
   onChange,
 }: {
   label: string;
@@ -963,12 +987,18 @@ function ModelSelector({
   ollamaModels: string[] | null;
   /** Live model/route catalogs keyed by configured provider name. */
   providerCatalogs: Record<string, string[]>;
+  /** Load state of the live catalogs plus the retry affordance. */
+  catalogState?: LiveCatalogState;
   allowClear?: boolean;
   /** Model to seed when the provider changes, if the new provider offers it.
    * Without this the seed is `catalog[0]`, and the hosted catalog sorts
    * alphabetically — so every tier would auto-commit `uj-chat`, silently
    * running deep reasoning on the thin conversation model. */
   preferredModel?: string;
+  /** What the daemon actually routes this slot to (from llm.effective) —
+   * rendered when no explicit ref is set, so an unset slot shows routing
+   * truth instead of a never-persisted `models[0]` (review pr3#7). */
+  effectiveHint?: { ref: string | null; source: "choice" | "default" | "plan" | null };
   onChange: (ref: string | null) => void;
 }) {
   const parsed = useMemo(() => parseModelRef(value), [value]);
@@ -989,7 +1019,12 @@ function ModelSelector({
     if (parsed) {
       setSelectedProvider(parsed.provider);
       const known = providerModels(providers, parsed.provider, ollamaModels, providerCatalogs);
-      if (known.includes(parsed.model)) {
+      const hostedRef = providers[parsed.provider]?.kind === USEJARVIS_KIND;
+      if (known.includes(parsed.model) || hostedRef) {
+        // Hosted refs are never parked in the custom field: free-text entry is
+        // suppressed for the managed provider, and a saved plan alias missing
+        // from a degraded fallback catalog is still the saved truth — it
+        // renders as itself (an extra option) rather than as "Custom…".
         setSelectedModel(parsed.model);
         setCustomModel("");
       } else {
@@ -1010,16 +1045,19 @@ function ModelSelector({
 
   const models = providerModels(providers, selectedProvider, ollamaModels, providerCatalogs);
   // The hosted provider is opaque BY DESIGN: its aliases are the only valid
-  // refs and the allowlist above is what keeps a voice alias out of a chat
-  // slot. Falling back to a free-text box when the catalog is empty (still
-  // loading, or the proxy is unreachable) would hand the user a control that
-  // bypasses that allowlist entirely — `usejarvis_ai:uj-stt` typed there
-  // points chat at a transcription endpoint. Nothing validates model refs
-  // server-side, so this is the only gate.
-  const isHosted = providers[selectedProvider]?.kind === USEJARVIS_NAME;
+  // refs. saveLLMSettings enforces the allowlist server-side (the real gate);
+  // hiding free-text entry here keeps the UI honest about it — a "Custom…"
+  // escape hatch or a fallback text box while the catalog loads would offer a
+  // control whose every input the server rejects (review pr3#1/#2).
+  const isHosted = providers[selectedProvider]?.kind === USEJARVIS_KIND;
   const usesCustomOnly = models.length === 0 && !isHosted;
-  const hostedCatalogUnavailable = isHosted && models.length === 0;
+  const catalogStatus: CatalogStatus | undefined = catalogState?.status[selectedProvider];
+  const hostedCatalogPending = isHosted && models.length === 0 && catalogStatus !== "failed";
+  const hostedCatalogFailed = isHosted && (catalogStatus === "failed" || catalogStatus === "degraded");
   const effectiveModel = selectedModel === "__custom__" ? customModel.trim() : selectedModel;
+  // Routing truth for an unset slot: what the daemon binds (plan alias or the
+  // default), shown as a placeholder — never presented as a saved choice.
+  const unsetPlaceholder = value ? "Select a model…" : unsetSlotPlaceholder(effectiveHint);
 
   const commit = (provider: string, model: string) => {
     if (!provider || !model) return;
@@ -1067,9 +1105,11 @@ function ModelSelector({
           ))}
         </select>
 
-        {hostedCatalogUnavailable ? (
+        {isHosted && models.length === 0 && !selectedModel ? (
           <select className="v2-set__select" disabled value="" style={{ flex: "1 1 200px" }}>
-            <option value="">Loading your plan’s models…</option>
+            <option value="">
+              {hostedCatalogPending ? "Loading your plan’s models…" : "Plan catalog unavailable"}
+            </option>
           </select>
         ) : usesCustomOnly ? (
           <input
@@ -1084,9 +1124,10 @@ function ModelSelector({
         ) : (
           <select
             className="v2-set__select"
-            value={selectedModel || models[0] || "__custom__"}
+            value={selectedModel || ""}
             onChange={(e) => {
               const next = e.target.value;
+              if (!next) return;
               setSelectedModel(next);
               if (next !== "__custom__") {
                 commit(selectedProvider, next);
@@ -1094,14 +1135,21 @@ function ModelSelector({
             }}
             style={{ flex: "1 1 200px" }}
           >
+            {/* An unset slot shows routing truth as an inert placeholder — a
+                pre-selected models[0] here read as a saved choice and invited
+                the user to "confirm" a downgrade (review pr3#7). */}
+            {!selectedModel && <option value="" disabled>{unsetPlaceholder}</option>}
+            {selectedModel && selectedModel !== "__custom__" && !models.includes(selectedModel) && (
+              <option value={selectedModel}>{selectedModel}</option>
+            )}
             {models.map((m) => (
               <option key={m} value={m}>{m}</option>
             ))}
-            <option value="__custom__">Custom…</option>
+            {!isHosted && <option value="__custom__">Custom…</option>}
           </select>
         )}
 
-        {selectedModel === "__custom__" && !usesCustomOnly && (
+        {selectedModel === "__custom__" && !usesCustomOnly && !isHosted && (
           <input
             type="text"
             className="v2-set__input"
@@ -1111,6 +1159,16 @@ function ModelSelector({
             onBlur={() => customModel && commit(selectedProvider, customModel.trim())}
             style={{ flex: "1 1 200px" }}
           />
+        )}
+
+        {hostedCatalogFailed && catalogState && (
+          <button
+            type="button"
+            className="v2-set__btn"
+            onClick={() => catalogState.retry()}
+          >
+            Retry
+          </button>
         )}
 
         {allowClear && value && (
@@ -1123,13 +1181,41 @@ function ModelSelector({
           </button>
         )}
       </div>
-      {effectiveModel && (
+      {hostedCatalogFailed && (
+        <div className="v2-set__hint v2-set__hint--warn" style={{ marginTop: "var(--s-2)" }}>
+          {catalogStatus === "degraded"
+            ? "Showing the standard aliases — your plan’s model catalog is unreachable."
+            : "Your plan’s model catalog could not be loaded."}
+        </div>
+      )}
+      {effectiveModel && effectiveModel !== "__custom__" && (
         <div className="v2-set__hint" style={{ marginTop: "var(--s-2)" }}>
           Saved as <code>{selectedProvider}:{effectiveModel}</code>
         </div>
       )}
+      {!value && effectiveHint?.ref && effectiveHint.source !== "choice" && (
+        <div className="v2-set__hint" style={{ marginTop: "var(--s-2)" }}>
+          No explicit choice — currently running on{" "}
+          {effectiveHint.source === "plan" ? "your plan’s default" : "the fallback default"}{" "}
+          <code>{effectiveHint.ref}</code>.
+        </div>
+      )}
     </div>
   );
+}
+
+/**
+ * Placeholder text for a tier slot with no explicit ref: routing truth from
+ * `llm.effective` (plan alias or the fallback default), or a neutral prompt
+ * when the daemon reports nothing bound. Extracted so the "never display a
+ * never-persisted models[0] as if it were saved" rule is pinned by tests.
+ */
+export function unsetSlotPlaceholder(
+  effectiveHint?: { ref: string | null; source: "choice" | "default" | "plan" | null },
+): string {
+  if (!effectiveHint?.ref || effectiveHint.source === "choice") return "Select a model…";
+  const model = parseModelRef(effectiveHint.ref)?.model ?? effectiveHint.ref;
+  return `${effectiveHint.source === "plan" ? "Plan default" : "Default"}: ${model}`;
 }
 
 export function providerModels(
@@ -1192,13 +1278,23 @@ function useOllamaModels(enabled: boolean): string[] | null {
 /** Load volatile catalogs for gateways/providers whose IDs change frequently:
  * OmniRoute (user-defined routes/combos) and the hosted Usejarvis AI proxy
  * (key-scoped uj-* aliases). */
+export type CatalogStatus = "loading" | "ok" | "degraded" | "failed";
+
+export interface LiveCatalogState {
+  catalogs: Record<string, string[]>;
+  /** Per provider name; absent = that provider has no live catalog to fetch. */
+  status: Record<string, CatalogStatus>;
+  /** Re-fetch every live catalog on demand (the "Retry" affordance). */
+  retry: () => void;
+}
+
 function useLiveProviderCatalogs(
   providers: Record<string, LLMConfigProviderView>,
-): Record<string, string[]> {
+): LiveCatalogState {
   const targets = Object.entries(providers)
     .filter(([, entry]) =>
       entry.kind === "omniroute"
-      || entry.kind === "usejarvis_ai"
+      || entry.kind === USEJARVIS_KIND
       || (entry.kind === "groq" && entry.has_api_key))
     .map(([name, entry]) => ({
       name,
@@ -1209,18 +1305,25 @@ function useLiveProviderCatalogs(
     .sort((a, b) => a.name.localeCompare(b.name));
   const signature = JSON.stringify(targets);
   const [catalogs, setCatalogs] = useState<Record<string, string[]>>({});
+  const [status, setStatus] = useState<Record<string, CatalogStatus>>({});
+  // Bumping the attempt re-runs the effect with the same signature — a
+  // permanent "Loading…" with no way out was review finding pr3#5.
+  const [attempt, setAttempt] = useState(0);
+  const retry = useCallback(() => setAttempt((n) => n + 1), []);
 
   useEffect(() => {
     if (targets.length === 0) {
       setCatalogs({});
+      setStatus({});
       return;
     }
     let cancelled = false;
+    setStatus(Object.fromEntries(targets.map(({ name }) => [name, "loading" as const])));
     Promise.all(targets.map(async ({ name, kind }) => {
       try {
         // The hosted catalog needs no inputs (the daemon holds the system
         // credentials); Groq and OmniRoute are looked up by saved provider name.
-        const response = kind === "usejarvis_ai"
+        const response = kind === USEJARVIS_KIND
           ? await fetch("/api/config/llm/usejarvis/models")
           : await fetch(
               kind === "groq"
@@ -1232,16 +1335,22 @@ function useLiveProviderCatalogs(
                 body: JSON.stringify({ name }),
               },
             );
-        const data = await response.json() as { ok: boolean; models?: string[] };
-        return [name, data.ok && data.models ? data.models : []] as const;
+        const data = await response.json() as { ok: boolean; models?: string[]; degraded?: boolean };
+        if (!data.ok || !data.models) return [name, [] as string[], "failed"] as const;
+        // Degraded = the daemon served fallback aliases because the plan
+        // catalog was unreachable. The picker stays usable, but the state is
+        // surfaced (with Retry) instead of presented as the plan's truth.
+        return [name, data.models, data.degraded ? "degraded" : "ok"] as const;
       } catch {
-        return [name, []] as const;
+        return [name, [] as string[], "failed"] as const;
       }
     })).then((entries) => {
-      if (!cancelled) setCatalogs(Object.fromEntries(entries));
+      if (cancelled) return;
+      setCatalogs(Object.fromEntries(entries.map(([name, models]) => [name, models])));
+      setStatus(Object.fromEntries(entries.map(([name, , state]) => [name, state])));
     });
     return () => { cancelled = true; };
-  }, [signature]); // targets are represented by the stable signature
+  }, [signature, attempt]); // targets are represented by the stable signature
 
-  return catalogs;
+  return { catalogs, status, retry };
 }

--- a/ui/src/v2/rooms/settings/tabs/LLMTab.tsx
+++ b/ui/src/v2/rooms/settings/tabs/LLMTab.tsx
@@ -20,9 +20,14 @@ import {
 
 /** Reserved hosted provider name (mirrors the daemon's usejarvis_ai carve-out). */
 const USEJARVIS_NAME = "usejarvis_ai";
-/** Hosted aliases that are NOT chat models: the key-scoped catalog lists every
- * modality, but these pickers only ever choose chat tiers. */
-const NON_CHAT_USEJARVIS_ALIASES = new Set(["uj-stt", "uj-tts", "uj-realtime"]);
+/** Hosted aliases that ARE chat models — an ALLOWLIST, mirroring the
+ * platform's SLOTS_BY_MODALITY.chat. A denylist fails OPEN: the platform's
+ * slots are data (a new alias ships without any jarvis release), and
+ * `providerModels()[0]` is auto-committed when the provider dropdown changes,
+ * so an unknown `uj-*` sorting before `uj-chat` would silently become someone's
+ * conversation model. Missing a future CHAT tier here is harmless by
+ * comparison — it is simply absent until the next release. */
+const CHAT_USEJARVIS_ALIASES = new Set(["uj-chat", "uj-low", "uj-medium", "uj-high"]);
 
 /**
  * Providers offered by the model pickers: the user's editable entries plus,
@@ -1087,7 +1092,7 @@ function ModelSelector({
   );
 }
 
-function providerModels(
+export function providerModels(
   providers: Record<string, LLMConfigProviderView>,
   name: string,
   live?: string[] | null,
@@ -1113,7 +1118,7 @@ function providerModels(
     // point the conversation at a transcription or speech endpoint and break
     // chat outright. Voice slots are chosen in Channels/Voice, not here.
     return entry.kind === "usejarvis_ai"
-      ? catalog.filter((id) => !NON_CHAT_USEJARVIS_ALIASES.has(id))
+      ? catalog.filter((id) => CHAT_USEJARVIS_ALIASES.has(id))
       : catalog;
   }
   return MODELS_BY_KIND[entry.kind] ?? [];

--- a/ui/src/v2/rooms/settings/tabs/LLMTab.tsx
+++ b/ui/src/v2/rooms/settings/tabs/LLMTab.tsx
@@ -10,12 +10,31 @@ import {
   OPTIONAL_BASE_URL_KINDS,
   URL_BASED_KINDS,
   sendsAuthHeader,
+  type LLMConfig,
   type LLMConfigProviderView,
   type LLMProviderKind,
   type LLMTier,
   type SettingsHook,
   parseModelRef,
 } from "../useSettingsData";
+
+/** Reserved hosted provider name (mirrors the daemon's usejarvis_ai carve-out). */
+const USEJARVIS_NAME = "usejarvis_ai";
+
+/**
+ * Providers offered by the model pickers: the user's editable entries plus,
+ * on hosted installs, the system-owned Usejarvis AI provider. The backend
+ * hides it from `llm.providers` (its base_url must never reach the client),
+ * so the pickers synthesize a credential-free view here — refs like
+ * `usejarvis_ai:uj-high` stay selectable.
+ */
+function pickerProviders(llm: LLMConfig): Record<string, LLMConfigProviderView> {
+  if (!llm.hosted_llm) return llm.providers;
+  return {
+    [USEJARVIS_NAME]: { kind: "usejarvis_ai", has_api_key: true },
+    ...llm.providers,
+  };
+}
 
 /**
  * Curated model lists per provider class. Each key is a kind (not a name)
@@ -90,6 +109,9 @@ const MODELS_BY_KIND: Record<LLMProviderKind, string[]> = {
   openai_compatible: [],
   litellm: [],
   omniroute: [],
+  // Hosted proxy: the uj-* aliases are key-scoped (per plan), so the real
+  // list always comes from the live catalog endpoint.
+  usejarvis_ai: [],
 };
 
 const DEFAULT_BASE_URLS: Partial<Record<LLMProviderKind, string>> = {
@@ -134,7 +156,10 @@ export function LLMTab({
   const ollamaModels = useOllamaModels(
     Object.values(llm?.providers ?? {}).some((p) => p.kind === "ollama"),
   );
-  const providerCatalogs = useLiveProviderCatalogs(llm?.providers ?? {});
+  // The pickers see the editable providers PLUS the managed hosted one; the
+  // live-catalog hook fetches for both (OmniRoute routes, uj-* aliases).
+  const allProviders = useMemo(() => (llm ? pickerProviders(llm) : {}), [llm]);
+  const providerCatalogs = useLiveProviderCatalogs(allProviders);
 
   if (!llm) return <div className="v2-set__empty">Loading LLM config...</div>;
 
@@ -188,9 +213,9 @@ export function LLMTab({
       </section>
 
       {mode === "single" ? (
-        <SingleModelSection data={data} onToast={onToast} ollamaModels={ollamaModels} providerCatalogs={providerCatalogs} />
+        <SingleModelSection data={data} onToast={onToast} providers={allProviders} ollamaModels={ollamaModels} providerCatalogs={providerCatalogs} />
       ) : (
-        <MultiTierSection data={data} onToast={onToast} ollamaModels={ollamaModels} providerCatalogs={providerCatalogs} />
+        <MultiTierSection data={data} onToast={onToast} providers={allProviders} ollamaModels={ollamaModels} providerCatalogs={providerCatalogs} />
       )}
     </div>
   );
@@ -261,7 +286,9 @@ function ProvidersList({
 
   return (
     <div>
-      {names.length === 0 && !adding && (
+      {llm.hosted_llm && <ManagedUsejarvisRow />}
+
+      {names.length === 0 && !adding && !llm.hosted_llm && (
         <div className="v2-set__empty">No providers configured yet.</div>
       )}
 
@@ -302,6 +329,30 @@ function ProvidersList({
 
 /** Match the daemon's base_url comparison: trim plus trailing-slash strip. */
 const normalizeBaseUrl = (value: string) => value.trim().replace(/\/+$/, "");
+/**
+ * Read-only card for the system-owned hosted provider. Deliberately inert:
+ * no key field, no base-url field, no expand, no delete — its config lives
+ * in the platform's config.yaml carve-out, which the dashboard can neither
+ * see nor change, and nothing from this card ever enters a save POST (the
+ * daemon would refuse the reserved name anyway).
+ */
+function ManagedUsejarvisRow() {
+  return (
+    <div className="v2-set__row">
+      <div className="v2-set__row-head" style={{ cursor: "default" }}>
+        <span className="v2-set__row-name">
+          {LLM_PROVIDER_KIND_LABELS.usejarvis_ai}{" "}
+          <span className="v2-set__chip" style={{ marginLeft: 6 }}>
+            included with your plan
+          </span>
+        </span>
+        <span className="v2-set__row-state">
+          <span className="v2-set__chip v2-set__chip--ok">managed</span>
+        </span>
+      </div>
+    </div>
+  );
+}
 
 function ProviderRow({
   name,
@@ -726,11 +777,13 @@ function ProviderTestResult({
 function SingleModelSection({
   data,
   onToast,
+  providers,
   ollamaModels,
   providerCatalogs,
 }: {
   data: SettingsHook;
   onToast: (text: string, tone?: "ok" | "warn") => void;
+  providers: Record<string, LLMConfigProviderView>;
   ollamaModels: string[] | null;
   providerCatalogs: Record<string, string[]>;
 }) {
@@ -750,7 +803,7 @@ function SingleModelSection({
       <ModelSelector
         label="Default model"
         value={llm.default}
-        providers={llm.providers}
+        providers={providers}
         ollamaModels={ollamaModels}
         providerCatalogs={providerCatalogs}
         onChange={async (ref) => {
@@ -767,11 +820,13 @@ function SingleModelSection({
 function MultiTierSection({
   data,
   onToast,
+  providers,
   ollamaModels,
   providerCatalogs,
 }: {
   data: SettingsHook;
   onToast: (text: string, tone?: "ok" | "warn") => void;
+  providers: Record<string, LLMConfigProviderView>;
   ollamaModels: string[] | null;
   providerCatalogs: Record<string, string[]>;
 }) {
@@ -819,7 +874,7 @@ function MultiTierSection({
             label={t.label}
             sub={t.sub}
             value={llm.tiers[t.id]}
-            providers={llm.providers}
+            providers={providers}
             ollamaModels={ollamaModels}
             providerCatalogs={providerCatalogs}
             allowClear
@@ -839,7 +894,7 @@ function MultiTierSection({
         <ModelSelector
           label=""
           value={llm.default}
-          providers={llm.providers}
+          providers={providers}
           ollamaModels={ollamaModels}
           providerCatalogs={providerCatalogs}
           allowClear
@@ -1036,7 +1091,13 @@ function providerModels(
   // The curated list is untagged guesswork, so prefer the real catalog when
   // the daemon could read it; fall back to the guesses when it could not.
   if (entry.kind === "ollama" && live && live.length > 0) return live;
-  if ((entry.kind === "omniroute" || entry.kind === "groq") && providerCatalogs[name]?.length) {
+  // Live-only catalogs: OmniRoute routes include user-defined combos, Groq's
+  // list is account-scoped, and the hosted uj-* aliases are key-scoped — a
+  // curated list cannot know any of them.
+  if (
+    (entry.kind === "omniroute" || entry.kind === "groq" || entry.kind === "usejarvis_ai")
+    && providerCatalogs[name]?.length
+  ) {
     return providerCatalogs[name]!;
   }
   return MODELS_BY_KIND[entry.kind] ?? [];
@@ -1067,12 +1128,17 @@ function useOllamaModels(enabled: boolean): string[] | null {
   return models;
 }
 
-/** Load volatile catalogs for gateways/providers whose IDs change frequently. */
+/** Load volatile catalogs for gateways/providers whose IDs change frequently:
+ * OmniRoute (user-defined routes/combos) and the hosted Usejarvis AI proxy
+ * (key-scoped uj-* aliases). */
 function useLiveProviderCatalogs(
   providers: Record<string, LLMConfigProviderView>,
 ): Record<string, string[]> {
   const targets = Object.entries(providers)
-    .filter(([, entry]) => entry.kind === "omniroute" || (entry.kind === "groq" && entry.has_api_key))
+    .filter(([, entry]) =>
+      entry.kind === "omniroute"
+      || entry.kind === "usejarvis_ai"
+      || (entry.kind === "groq" && entry.has_api_key))
     .map(([name, entry]) => ({
       name,
       kind: entry.kind,
@@ -1091,14 +1157,20 @@ function useLiveProviderCatalogs(
     let cancelled = false;
     Promise.all(targets.map(async ({ name, kind }) => {
       try {
-        const endpoint = kind === "groq"
-          ? '/api/config/llm/groq/models'
-          : '/api/config/llm/omniroute/models';
-        const response = await fetch(endpoint, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ name }),
-        });
+        // The hosted catalog needs no inputs (the daemon holds the system
+        // credentials); Groq and OmniRoute are looked up by saved provider name.
+        const response = kind === "usejarvis_ai"
+          ? await fetch("/api/config/llm/usejarvis/models")
+          : await fetch(
+              kind === "groq"
+                ? "/api/config/llm/groq/models"
+                : "/api/config/llm/omniroute/models",
+              {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ name }),
+              },
+            );
         const data = await response.json() as { ok: boolean; models?: string[] };
         return [name, data.ok && data.models ? data.models : []] as const;
       } catch {

--- a/ui/src/v2/rooms/settings/tabs/LLMTab.tsx
+++ b/ui/src/v2/rooms/settings/tabs/LLMTab.tsx
@@ -27,7 +27,27 @@ const USEJARVIS_NAME = "usejarvis_ai";
  * so an unknown `uj-*` sorting before `uj-chat` would silently become someone's
  * conversation model. Missing a future CHAT tier here is harmless by
  * comparison — it is simply absent until the next release. */
-const CHAT_USEJARVIS_ALIASES = new Set(["uj-chat", "uj-low", "uj-medium", "uj-high"]);
+export const USEJARVIS_TIER_ALIASES: Record<LLMTier, string> = {
+  conversation: "uj-chat",
+  high: "uj-high",
+  medium: "uj-medium",
+  low: "uj-low",
+};
+/** Derived from the tier map so the two cannot drift: every alias a tier can
+ * be seeded with is, by construction, an alias the picker offers. */
+const CHAT_USEJARVIS_ALIASES = new Set(Object.values(USEJARVIS_TIER_ALIASES));
+
+/**
+ * Which model to auto-commit when the provider dropdown changes.
+ *
+ * Prefers the slot's own alias when the new provider offers it, else the
+ * first entry. Extracted so the choice is testable: the hosted catalog sorts
+ * alphabetically, so a bare `models[0]` seeds `uj-chat` into EVERY tier and
+ * deep reasoning silently runs on the thin conversation model.
+ */
+export function seedModelForProvider(models: string[], preferredModel?: string): string {
+  return (preferredModel && models.includes(preferredModel) ? preferredModel : models[0]) ?? "__custom__";
+}
 
 /**
  * Providers offered by the model pickers: the user's editable entries plus,
@@ -891,6 +911,7 @@ function MultiTierSection({
             ollamaModels={ollamaModels}
             providerCatalogs={providerCatalogs}
             allowClear
+            preferredModel={USEJARVIS_TIER_ALIASES[t.id]}
             onChange={async (ref) => {
               const r = await data.setTierModel(t.id, ref);
               onToast(r.message, r.ok ? "ok" : "warn");
@@ -931,6 +952,7 @@ function ModelSelector({
   ollamaModels,
   providerCatalogs,
   allowClear,
+  preferredModel,
   onChange,
 }: {
   label: string;
@@ -942,6 +964,11 @@ function ModelSelector({
   /** Live model/route catalogs keyed by configured provider name. */
   providerCatalogs: Record<string, string[]>;
   allowClear?: boolean;
+  /** Model to seed when the provider changes, if the new provider offers it.
+   * Without this the seed is `catalog[0]`, and the hosted catalog sorts
+   * alphabetically — so every tier would auto-commit `uj-chat`, silently
+   * running deep reasoning on the thin conversation model. */
+  preferredModel?: string;
   onChange: (ref: string | null) => void;
 }) {
   const parsed = useMemo(() => parseModelRef(value), [value]);
@@ -982,7 +1009,16 @@ function ModelSelector({
   }, [value, ollamaModels, providerCatalogs]);
 
   const models = providerModels(providers, selectedProvider, ollamaModels, providerCatalogs);
-  const usesCustomOnly = models.length === 0;
+  // The hosted provider is opaque BY DESIGN: its aliases are the only valid
+  // refs and the allowlist above is what keeps a voice alias out of a chat
+  // slot. Falling back to a free-text box when the catalog is empty (still
+  // loading, or the proxy is unreachable) would hand the user a control that
+  // bypasses that allowlist entirely — `usejarvis_ai:uj-stt` typed there
+  // points chat at a transcription endpoint. Nothing validates model refs
+  // server-side, so this is the only gate.
+  const isHosted = providers[selectedProvider]?.kind === USEJARVIS_NAME;
+  const usesCustomOnly = models.length === 0 && !isHosted;
+  const hostedCatalogUnavailable = isHosted && models.length === 0;
   const effectiveModel = selectedModel === "__custom__" ? customModel.trim() : selectedModel;
 
   const commit = (provider: string, model: string) => {
@@ -1015,7 +1051,7 @@ function ModelSelector({
             setSelectedProvider(next);
             // Reset model when provider changes - the model list is now different.
             const nextModels = providerModels(providers, next, ollamaModels, providerCatalogs);
-            const defaultModel = nextModels[0] ?? "__custom__";
+            const defaultModel = seedModelForProvider(nextModels, preferredModel);
             setSelectedModel(defaultModel);
             setCustomModel("");
             if (defaultModel !== "__custom__") {
@@ -1031,7 +1067,11 @@ function ModelSelector({
           ))}
         </select>
 
-        {usesCustomOnly ? (
+        {hostedCatalogUnavailable ? (
+          <select className="v2-set__select" disabled value="" style={{ flex: "1 1 200px" }}>
+            <option value="">Loading your plan’s models…</option>
+          </select>
+        ) : usesCustomOnly ? (
           <input
             type="text"
             className="v2-set__input"

--- a/ui/src/v2/rooms/settings/tabs/LLMTab.tsx
+++ b/ui/src/v2/rooms/settings/tabs/LLMTab.tsx
@@ -598,7 +598,10 @@ function NewProviderRow({
   const sendsHeader = sendsAuthHeader(kind, supportsUrl);
   // Suggest name = kind unless user typed something
   const effectiveName = name.trim() || kind;
-  const duplicate = existing.includes(effectiveName);
+  // The reserved hosted name is blocked like a duplicate: the daemon silently
+  // refuses to persist it, so accepting it here would toast a success for a no-op.
+  const reserved = effectiveName === USEJARVIS_NAME;
+  const duplicate = existing.includes(effectiveName) || reserved;
 
   return (
     <div className="v2-set__provider-row v2-set__provider-row--open">
@@ -637,7 +640,9 @@ function NewProviderRow({
           />
           {duplicate && (
             <div className="v2-set__hint v2-set__hint--warn">
-              A provider named &quot;{effectiveName}&quot; already exists. Pick a different name.
+              {reserved
+                ? <>&quot;{USEJARVIS_NAME}&quot; is reserved for the hosted provider. Pick a different name.</>
+                : <>A provider named &quot;{effectiveName}&quot; already exists. Pick a different name.</>}
             </div>
           )}
         </div>

--- a/ui/src/v2/rooms/settings/useSettingsData.ts
+++ b/ui/src/v2/rooms/settings/useSettingsData.ts
@@ -17,7 +17,12 @@ export type LLMProviderKind =
   | "nvidia"
   | "openai_compatible"
   | "litellm"
-  | "omniroute";
+  | "omniroute"
+  // Hosted platform proxy. SYSTEM-owned: injected by the daemon on hosted
+  // installs, never user-creatable, so it is deliberately absent from
+  // LLM_PROVIDER_KINDS (the "Add provider" dropdown) and from every one of
+  // the key/url field sets below (no credential inputs are ever shown).
+  | "usejarvis_ai";
 
 export const LLM_PROVIDER_KINDS: readonly LLMProviderKind[] = [
   "anthropic",
@@ -43,6 +48,7 @@ export const LLM_PROVIDER_KIND_LABELS: Record<LLMProviderKind, string> = {
   openai_compatible: "OpenAI-compatible",
   litellm: "LiteLLM",
   omniroute: "OmniRoute",
+  usejarvis_ai: "Usejarvis AI",
 };
 
 /**
@@ -148,6 +154,13 @@ export interface LLMConfig {
     low: string | null;
   };
   available_kinds: LLMProviderKind[];
+  /**
+   * True on hosted installs: the system-owned usejarvis_ai provider is
+   * injected into the running config (and hidden from `providers` above so
+   * its base_url never reaches the client). The tab renders a read-only
+   * "included with your plan" card and offers `usejarvis_ai:*` model refs.
+   */
+  hosted_llm?: boolean;
 }
 
 /** Helper: split a "provider:model" reference into its parts. */

--- a/ui/src/v2/rooms/settings/useSettingsData.ts
+++ b/ui/src/v2/rooms/settings/useSettingsData.ts
@@ -161,6 +161,16 @@ export interface LLMConfig {
    * "included with your plan" card and offers `usejarvis_ai:*` model refs.
    */
   hosted_llm?: boolean;
+  /**
+   * Routing reality, computed by the daemon from the SAME per-slot resolution
+   * the binding paths use (explicit ref → llm.default → plan alias). The UI
+   * renders THIS for "what will actually run", never a re-derivation — the
+   * persisted `tiers`/`default` above stay pure user intent.
+   */
+  effective?: {
+    mode: "single" | "router-first";
+    tiers: Record<LLMTier, { ref: string | null; source: "choice" | "default" | "plan" | null }>;
+  };
 }
 
 /** Helper: split a "provider:model" reference into its parts. */


### PR DESCRIPTION
Read-only "included with your plan" card keyed off the hosted flag, with the reserved provider kept out of the free-text branch that would otherwise bypass the chat allowlist. Each tier seeds its own uj-* alias rather than the alphabetically-first one.

Stack: **3/8** — base #355