### PR TITLE
feat(stt): hosted transcription

### DIFF
--- a/src/agents/voice-intent-classifier.ts
+++ b/src/agents/voice-intent-classifier.ts
@@ -281,8 +281,9 @@ settings room ("room": "settings"):
 - "disable_telegram" — args: {}   matches "disable telegram", "turn off telegram"
 - "enable_discord" — args: {}     matches "enable discord", "turn on discord"
 - "disable_discord" — args: {}    matches "disable discord", "turn off discord"
-- "set_stt_provider" — args: { "provider": "openai"|"groq"|"sarvam"|"local" }
-   matches "use groq for transcription", "set stt to local whisper"
+- "set_stt_provider" — args: { "provider": "openai"|"groq"|"sarvam"|"local"|"usejarvis" }
+   matches "use groq for transcription", "set stt to local whisper",
+   "switch transcription to usejarvis" (the hosted plan's included STT)
 - "enable_tts" — args: {}    matches "turn on TTS", "enable text to speech"
 - "disable_tts" — args: {}   matches "turn off TTS", "disable text to speech"
 - "set_tts_provider" — args: { "provider": "edge"|"elevenlabs"|"sarvam" }

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -188,9 +188,15 @@ export async function runDoctor(): Promise<void> {
 
   if (config?.stt?.provider) {
     const sttProv = config.stt.provider;
+    const { hasUsejarvisAi } = await import('../daemon/usejarvis-ai.ts');
     const hasKey = sttProv === 'ollama' || sttProv === 'local'
       || (sttProv === 'openai' && config.stt.openai?.api_key)
-      || (sttProv === 'groq' && config.stt.groq?.api_key);
+      || (sttProv === 'groq' && config.stt.groq?.api_key)
+      || (sttProv === 'sarvam' && config.stt.sarvam?.api_key)
+      // Hosted STT rides the system-owned usejarvis_ai credentials, not a
+      // cfg.stt key — "API key missing" here was a false alarm on every
+      // working hosted install.
+      || (sttProv === 'usejarvis' && hasUsejarvisAi(config));
     results.push({
       name: 'STT',
       status: hasKey ? 'ok' : 'warn',

--- a/src/comms/index.ts
+++ b/src/comms/index.ts
@@ -7,6 +7,7 @@ export {
   OpenAIWhisperSTT,
   GroqWhisperSTT,
   LocalWhisperSTT,
+  UsejarvisSTT,
   EdgeTTSProvider,
   ElevenLabsTTSProvider,
   createSTTProvider,
@@ -15,6 +16,7 @@ export {
   splitIntoSentences,
   type STTProvider,
   type TTSProvider,
+  type HostedVoiceCredentials,
 } from './voice.ts';
 
 // Channel adapters

--- a/src/comms/voice.test.ts
+++ b/src/comms/voice.test.ts
@@ -639,3 +639,35 @@ describe('SarvamSTT.transcribe', () => {
     await expect(stt.transcribe(wav)).rejects.toThrow(/Sarvam STT error \(401\)/);
   });
 });
+
+describe('hosted STT error redaction', () => {
+  // This block stubs globalThis.fetch and MUST restore it: the file-level
+  // afterEach lives in another describe, and a leaked stub fails unrelated
+  // test files (websocket's health endpoint suddenly returns our 401 body).
+  const realFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  test('never lets key-shaped material out of either STT throw', async () => {
+    const leak = 'sk-uj-LIFETIMEKEY0000000000';
+    // error branch
+    globalThis.fetch = (async () =>
+      new Response(`Authentication Error: bearer ${leak} rejected`, { status: 401 })) as unknown as typeof fetch;
+    const stt = new UsejarvisSTT('https://llm.usejarvis.host', 'sk-uj-abc');
+    await expect(stt.transcribe(makeWavBuffer())).rejects.toThrow(/\(401\)/);
+    await stt.transcribe(makeWavBuffer()).catch((e: Error) => {
+      expect(e.message).not.toContain(leak);
+    });
+    // 200-with-no-transcript branch (a proxy/CDN interstitial)
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ note: `upstream said ${leak}` }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })) as unknown as typeof fetch;
+    await stt.transcribe(makeWavBuffer()).catch((e: Error) => {
+      expect(e.message).not.toContain(leak);
+      expect(e.message).toContain('***redacted***');
+    });
+  });
+});

--- a/src/comms/voice.test.ts
+++ b/src/comms/voice.test.ts
@@ -6,6 +6,7 @@ import {
   GroqWhisperSTT,
   LocalWhisperSTT,
   SarvamSTT,
+  UsejarvisSTT,
   EdgeTTSProvider,
   SarvamTTSProvider,
   splitIntoSentences,
@@ -112,6 +113,30 @@ describe('createSTTProvider factory', () => {
 
   test('returns null when provider=sarvam and no key', () => {
     const config: STTConfig = { provider: 'sarvam' };
+    expect(createSTTProvider(config)).toBeNull();
+  });
+
+  test('returns UsejarvisSTT when provider=usejarvis and hosted creds passed', () => {
+    const config: STTConfig = { provider: 'usejarvis' };
+    const provider = createSTTProvider(config, {
+      baseUrl: 'https://llm.usejarvis.host',
+      apiKey: 'sk-uj-not-real',
+    });
+    expect(provider).toBeInstanceOf(UsejarvisSTT);
+  });
+
+  test('returns null when provider=usejarvis and no hosted creds (self-hosted)', () => {
+    const config: STTConfig = { provider: 'usejarvis' };
+    expect(createSTTProvider(config)).toBeNull();
+    expect(createSTTProvider(config, null)).toBeNull();
+    expect(createSTTProvider(config, { baseUrl: '', apiKey: 'sk-uj-not-real' })).toBeNull();
+    expect(createSTTProvider(config, { baseUrl: 'https://llm.usejarvis.host', apiKey: '' })).toBeNull();
+  });
+
+  test('cfg.stt sub-blocks never feed the usejarvis case (key stays out of user config)', () => {
+    // Even a squatting sub-block in the persisted user section is ignored:
+    // only the separately-threaded hosted argument can supply credentials.
+    const config = { provider: 'usejarvis', usejarvis: { api_key: 'from-db-row' } } as unknown as STTConfig;
     expect(createSTTProvider(config)).toBeNull();
   });
 });
@@ -461,6 +486,95 @@ describe('LocalWhisperSTT.transcribe', () => {
       expect(err.message).toBe('Connection refused');
     }
   });
+});
+
+describe('UsejarvisSTT.transcribe', () => {
+  const originalFetch = globalThis.fetch;
+  afterEach(() => { globalThis.fetch = originalFetch; });
+
+  test('POSTs multipart WAV to <origin>/v1/audio/transcriptions with bearer + uj-stt', async () => {
+    const stt = new UsejarvisSTT('https://llm.usejarvis.host', 'sk-uj-not-real');
+    const wav = makeWavBuffer();
+    let calledUrl = '';
+    let auth = '';
+    let model = '';
+    let file: File | null = null;
+
+    globalThis.fetch = mock(async (url: string, init: any) => {
+      calledUrl = url;
+      auth = init.headers['Authorization'];
+      const body = init.body as FormData;
+      model = String(body.get('model'));
+      file = body.get('file') as File;
+      return new Response(JSON.stringify({ text: 'hosted transcript' }), {
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as any;
+
+    expect(await stt.transcribe(wav)).toBe('hosted transcript');
+    expect(calledUrl).toBe('https://llm.usejarvis.host/v1/audio/transcriptions');
+    expect(auth).toBe('Bearer sk-uj-not-real');
+    expect(model).toBe('uj-stt');
+    // The browser mic sends WAV — the form must say so (the audio.webm
+    // mislabel made strict servers reject the part).
+    expect(file!.name).toBe('audio.wav');
+    expect(file!.type).toBe('audio/wav');
+  });
+
+  test('does not double the /v1 prefix when the base already carries it', async () => {
+    const stt = new UsejarvisSTT('https://llm.usejarvis.host/v1/', 'sk-uj-not-real');
+    let calledUrl = '';
+
+    globalThis.fetch = mock(async (url: string) => {
+      calledUrl = url;
+      return new Response(JSON.stringify({ text: 'ok' }), {
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as any;
+
+    await stt.transcribe(makeWavBuffer());
+    expect(calledUrl).toBe('https://llm.usejarvis.host/v1/audio/transcriptions');
+  });
+
+  test('throws with status on HTTP error', async () => {
+    const stt = new UsejarvisSTT('https://llm.usejarvis.host', 'sk-uj-not-real');
+    globalThis.fetch = mock(async () => new Response('no active plan', { status: 403 })) as any;
+    await expect(stt.transcribe(makeWavBuffer())).rejects.toThrow(/Usejarvis AI STT error \(403\)/);
+  });
+
+  test('throws when the response carries no text field', async () => {
+    const stt = new UsejarvisSTT('https://llm.usejarvis.host', 'sk-uj-not-real');
+    globalThis.fetch = mock(async () =>
+      new Response(JSON.stringify({ unexpected: 'shape' }), {
+        headers: { 'content-type': 'application/json' },
+      })
+    ) as any;
+    await expect(stt.transcribe(makeWavBuffer())).rejects.toThrow('Usejarvis AI STT returned no transcript');
+  });
+});
+
+describe('WAV labeling of the shared browser-mic buffer', () => {
+  const originalFetch = globalThis.fetch;
+  afterEach(() => { globalThis.fetch = originalFetch; });
+
+  for (const [label, make] of [
+    ['OpenAIWhisperSTT', () => new OpenAIWhisperSTT('test-key-not-real')],
+    ['GroqWhisperSTT', () => new GroqWhisperSTT('test-key-not-real')],
+  ] as const) {
+    test(`${label} sends audio.wav with audio/wav type`, async () => {
+      let file: File | null = null;
+      globalThis.fetch = mock(async (_url: string, init: any) => {
+        file = (init.body as FormData).get('file') as File;
+        return new Response(JSON.stringify({ text: 'ok' }), {
+          headers: { 'content-type': 'application/json' },
+        });
+      }) as any;
+
+      await make().transcribe(makeWavBuffer());
+      expect(file!.name).toBe('audio.wav');
+      expect(file!.type).toBe('audio/wav');
+    });
+  }
 });
 
 describe('SarvamSTT.transcribe', () => {

--- a/src/comms/voice.test.ts
+++ b/src/comms/voice.test.ts
@@ -671,3 +671,25 @@ describe('hosted STT error redaction', () => {
     });
   });
 });
+
+describe('UsejarvisSTT non-JSON 200', () => {
+  const originalFetch = globalThis.fetch;
+  afterEach(() => { globalThis.fetch = originalFetch; });
+
+  // response.json() rejects with "Failed to parse JSON" — no provider, no
+  // status, no body — so a CDN interstitial served with a 200 used to leave
+  // nothing to correlate. Still redacted and capped.
+  test('reports the provider and a redacted body instead of a bare parse error', async () => {
+    const key = 'sk-uj-LIFETIMEKEY0000000000';
+    globalThis.fetch = mock(async () => new Response(
+      `<html><body>Access denied. token=${key}</body></html>`,
+      { status: 200, headers: { 'Content-Type': 'text/html' } },
+    )) as any;
+    const stt = new UsejarvisSTT('https://llm.usejarvis.host', key);
+    const err = await stt.transcribe(makeWavBuffer()).then(() => null, (e: Error) => e);
+    expect(err).toBeInstanceOf(Error);
+    expect(err!.message).toContain('non-JSON body');
+    expect(err!.message).toContain('Usejarvis AI STT');
+    expect(err!.message).not.toContain(key);
+  });
+});

--- a/src/comms/voice.test.ts
+++ b/src/comms/voice.test.ts
@@ -10,6 +10,7 @@ import {
   EdgeTTSProvider,
   SarvamTTSProvider,
   splitIntoSentences,
+  sniffAudioFormat,
 } from './voice.ts';
 import type { STTConfig, TTSConfig } from '../config/types.ts';
 
@@ -30,6 +31,13 @@ function makeWavBuffer(pcmBytes = 100): Buffer {
   buf.writeUInt16LE(16, 34);       // bits per sample
   buf.write('data', 36, 'ascii');
   buf.writeUInt32LE(dataSize, 40);
+  return buf;
+}
+
+/** Build a buffer with an OGG page header (what Telegram voice notes carry). */
+function makeOggBuffer(payloadBytes = 64): Buffer {
+  const buf = Buffer.alloc(4 + payloadBytes);
+  buf.write('OggS', 0, 'ascii');
   return buf;
 }
 
@@ -349,7 +357,7 @@ describe('LocalWhisperSTT.transcribe', () => {
     expect(calledUrl).toBe('http://localhost:8080/v1/audio/transcriptions');
   });
 
-  test('openai_compatible: sends model and language fields', async () => {
+  test('openai_compatible: sends model, omits language unless configured', async () => {
     const stt = new LocalWhisperSTT('http://localhost:8080/v1/audio/transcriptions', 'whisper-1', 'openai_compatible');
     const wav = makeWavBuffer();
 
@@ -357,7 +365,8 @@ describe('LocalWhisperSTT.transcribe', () => {
       const body = init.body as FormData;
       expect(body.has('model')).toBe(true);
       expect(body.get('model')).toBe('whisper-1');
-      expect(body.has('language')).toBe(true);
+      // Unset language = auto-detect: the param is omitted entirely.
+      expect(body.has('language')).toBe(false);
       expect(body.has('response_format')).toBe(false);
       return new Response(JSON.stringify({ text: 'ok' }), {
         headers: { 'content-type': 'application/json' },
@@ -365,6 +374,15 @@ describe('LocalWhisperSTT.transcribe', () => {
     }) as any;
 
     await stt.transcribe(wav);
+
+    globalThis.fetch = mock(async (_url: string, init: any) => {
+      expect((init.body as FormData).get('language')).toBe('it');
+      return new Response(JSON.stringify({ text: 'ok' }), {
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as any;
+    const withLang = new LocalWhisperSTT('http://localhost:8080/v1/audio/transcriptions', 'whisper-1', 'openai_compatible', 'it');
+    await withLang.transcribe(wav);
   });
 
   // -- Response shape parsing ---------------------------------------------
@@ -553,26 +571,53 @@ describe('UsejarvisSTT.transcribe', () => {
   });
 });
 
-describe('WAV labeling of the shared browser-mic buffer', () => {
+describe('sniffAudioFormat', () => {
+  test('detects the containers the STT paths actually see', () => {
+    expect(sniffAudioFormat(makeWavBuffer())).toEqual({ filename: 'audio.wav', mimeType: 'audio/wav' });
+    expect(sniffAudioFormat(makeOggBuffer())).toEqual({ filename: 'audio.ogg', mimeType: 'audio/ogg' });
+    expect(sniffAudioFormat(Buffer.from([0x1a, 0x45, 0xdf, 0xa3, 0x00, 0x00])))
+      .toEqual({ filename: 'audio.webm', mimeType: 'audio/webm' });
+    expect(sniffAudioFormat(Buffer.from('ID3\x04\x00\x00', 'latin1')))
+      .toEqual({ filename: 'audio.mp3', mimeType: 'audio/mpeg' });
+    expect(sniffAudioFormat(Buffer.from([0xff, 0xfb, 0x90, 0x00]))) // bare MPEG frame sync
+      .toEqual({ filename: 'audio.mp3', mimeType: 'audio/mpeg' });
+  });
+
+  test('falls back to WAV (the dashboard-mic format) for unknown or tiny buffers', () => {
+    expect(sniffAudioFormat(Buffer.from('????garbage'))).toEqual({ filename: 'audio.wav', mimeType: 'audio/wav' });
+    expect(sniffAudioFormat(Buffer.from([0x00]))).toEqual({ filename: 'audio.wav', mimeType: 'audio/wav' });
+    expect(sniffAudioFormat(Buffer.alloc(0))).toEqual({ filename: 'audio.wav', mimeType: 'audio/wav' });
+  });
+});
+
+describe('magic-byte labeling of the shared STT upload buffer', () => {
   const originalFetch = globalThis.fetch;
   afterEach(() => { globalThis.fetch = originalFetch; });
 
+  // One provider instance serves the dashboard mic (WAV), Telegram voice
+  // notes (OGG/Opus) and Discord attachments — the declared part must track
+  // the buffer, not a hardcoded container.
   for (const [label, make] of [
     ['OpenAIWhisperSTT', () => new OpenAIWhisperSTT('test-key-not-real')],
     ['GroqWhisperSTT', () => new GroqWhisperSTT('test-key-not-real')],
+    ['UsejarvisSTT', () => new UsejarvisSTT('https://llm.usejarvis.host', 'sk-uj-not-real')],
   ] as const) {
-    test(`${label} sends audio.wav with audio/wav type`, async () => {
-      let file: File | null = null;
+    test(`${label} labels a WAV buffer audio.wav and an OGG buffer audio.ogg`, async () => {
+      const files: File[] = [];
       globalThis.fetch = mock(async (_url: string, init: any) => {
-        file = (init.body as FormData).get('file') as File;
+        files.push((init.body as FormData).get('file') as File);
         return new Response(JSON.stringify({ text: 'ok' }), {
           headers: { 'content-type': 'application/json' },
         });
       }) as any;
 
-      await make().transcribe(makeWavBuffer());
-      expect(file!.name).toBe('audio.wav');
-      expect(file!.type).toBe('audio/wav');
+      const provider = make();
+      await provider.transcribe(makeWavBuffer());
+      await provider.transcribe(makeOggBuffer());
+      expect(files.map((f) => [f.name, f.type])).toEqual([
+        ['audio.wav', 'audio/wav'],
+        ['audio.ogg', 'audio/ogg'],
+      ]);
     });
   }
 });
@@ -698,10 +743,11 @@ describe('STT language is configurable (was hardcoded to en everywhere)', () => 
   const originalFetch = globalThis.fetch;
   afterEach(() => { globalThis.fetch = originalFetch; });
 
-  const languageSentBy = async (config: STTConfig, hosted?: { baseUrl: string; apiKey: string }) => {
-    let sent = '';
+  const languageSentBy = async (config: STTConfig, hosted?: { baseUrl: string; apiKey: string }): Promise<string | null> => {
+    let sent: string | null = null;
     globalThis.fetch = mock(async (_url: string, init: any) => {
-      sent = String((init.body as FormData).get('language'));
+      const value = (init.body as FormData).get('language');
+      sent = value === null ? null : String(value);
       return new Response(JSON.stringify({ text: 'ok' }), {
         status: 200, headers: { 'Content-Type': 'application/json' },
       });
@@ -710,8 +756,13 @@ describe('STT language is configurable (was hardcoded to en everywhere)', () => 
     return sent;
   };
 
-  test('defaults to en, preserving the previous hardcoded behaviour', async () => {
-    expect(await languageSentBy({ provider: 'openai', openai: { api_key: 'k' } })).toBe('en');
+  test('unset language omits the param entirely — Whisper auto-detects', async () => {
+    const hosted = { baseUrl: 'https://llm.usejarvis.host', apiKey: 'sk-uj-not-real' };
+    // Forcing 'en' made an Italian hosted user's speech decode (or translate)
+    // as English; absence is the documented auto-detect switch.
+    expect(await languageSentBy({ provider: 'openai', openai: { api_key: 'k' } })).toBeNull();
+    expect(await languageSentBy({ provider: 'groq', groq: { api_key: 'k' } })).toBeNull();
+    expect(await languageSentBy({ provider: 'usejarvis' }, hosted)).toBeNull();
   });
 
   test('a configured language reaches every Whisper-shaped provider', async () => {

--- a/src/comms/voice.test.ts
+++ b/src/comms/voice.test.ts
@@ -693,3 +693,31 @@ describe('UsejarvisSTT non-JSON 200', () => {
     expect(err!.message).not.toContain(key);
   });
 });
+
+describe('STT language is configurable (was hardcoded to en everywhere)', () => {
+  const originalFetch = globalThis.fetch;
+  afterEach(() => { globalThis.fetch = originalFetch; });
+
+  const languageSentBy = async (config: STTConfig, hosted?: { baseUrl: string; apiKey: string }) => {
+    let sent = '';
+    globalThis.fetch = mock(async (_url: string, init: any) => {
+      sent = String((init.body as FormData).get('language'));
+      return new Response(JSON.stringify({ text: 'ok' }), {
+        status: 200, headers: { 'Content-Type': 'application/json' },
+      });
+    }) as any;
+    await createSTTProvider(config, hosted)!.transcribe(makeWavBuffer());
+    return sent;
+  };
+
+  test('defaults to en, preserving the previous hardcoded behaviour', async () => {
+    expect(await languageSentBy({ provider: 'openai', openai: { api_key: 'k' } })).toBe('en');
+  });
+
+  test('a configured language reaches every Whisper-shaped provider', async () => {
+    const hosted = { baseUrl: 'https://llm.usejarvis.host', apiKey: 'sk-uj-not-real' };
+    expect(await languageSentBy({ provider: 'openai', language: 'it', openai: { api_key: 'k' } })).toBe('it');
+    expect(await languageSentBy({ provider: 'groq', language: 'it', groq: { api_key: 'k' } })).toBe('it');
+    expect(await languageSentBy({ provider: 'usejarvis', language: 'it' }, hosted)).toBe('it');
+  });
+});

--- a/src/comms/voice.ts
+++ b/src/comms/voice.ts
@@ -135,7 +135,20 @@ export class UsejarvisSTT implements STTProvider {
       throw hostedProxyError('Usejarvis AI STT', response.status, err);
     }
 
-    const result = await response.json() as { text?: string };
+    // Read as TEXT first: response.json() rejects before the shape check
+    // below, and its rejection ("Failed to parse JSON") carries no provider,
+    // no status and none of the body — so an HTML interstitial served with a
+    // 200 produced a bare parse error with nothing to correlate. Reading the
+    // body ourselves keeps the diagnostic, still redacted and still capped.
+    const raw = await response.text();
+    let result: { text?: string };
+    try {
+      result = JSON.parse(raw) as { text?: string };
+    } catch {
+      throw new Error(
+        `Usejarvis AI STT returned a non-JSON body: ${redactSecrets(raw).slice(0, 200)}`,
+      );
+    }
     if (typeof result.text !== 'string') {
       // Same class as the error branch: a 200 carrying a proxy/CDN
       // interstitial is exactly where an echoed bearer shows up.

--- a/src/comms/voice.ts
+++ b/src/comms/voice.ts
@@ -22,14 +22,40 @@ export interface TTSProvider {
 export type HostedVoiceCredentials = { baseUrl: string; apiKey: string };
 
 /**
+ * Sniff the audio container from magic bytes so multipart uploads declare
+ * what the buffer actually IS. The same STT provider instance receives
+ * dashboard-mic WAV (ui useVoice encodeWav writes a RIFF header), Telegram
+ * voice notes (OGG/Opus), and arbitrary Discord attachments — any hardcoded
+ * label is wrong for at least one of them, and strict servers (including the
+ * hosted proxy) may trust the declared container. Falls back to WAV, the
+ * dashboard-mic format, when nothing matches.
+ */
+export function sniffAudioFormat(audio: Buffer): { filename: string; mimeType: string } {
+  if (audio.length >= 4) {
+    const magic = audio.toString('latin1', 0, 4);
+    if (magic === 'RIFF') return { filename: 'audio.wav', mimeType: 'audio/wav' };
+    if (magic === 'OggS') return { filename: 'audio.ogg', mimeType: 'audio/ogg' };
+    // EBML header: WebM/Matroska (MediaRecorder output on some browsers).
+    if (audio[0] === 0x1a && audio[1] === 0x45 && audio[2] === 0xdf && audio[3] === 0xa3) {
+      return { filename: 'audio.webm', mimeType: 'audio/webm' };
+    }
+    // ID3v2 tag or a bare MPEG frame sync (0xFFEx).
+    if (magic.startsWith('ID3') || (audio[0] === 0xff && (audio[1]! & 0xe0) === 0xe0)) {
+      return { filename: 'audio.mp3', mimeType: 'audio/mpeg' };
+    }
+  }
+  return { filename: 'audio.wav', mimeType: 'audio/wav' };
+}
+
+/**
  * OpenAI Whisper STT — uses the OpenAI /v1/audio/transcriptions endpoint.
  */
 export class OpenAIWhisperSTT implements STTProvider {
   private apiKey: string;
   private model: string;
-  private language: string;
+  private language?: string;
 
-  constructor(apiKey: string, model: string = 'whisper-1', language: string = 'en') {
+  constructor(apiKey: string, model: string = 'whisper-1', language?: string) {
     this.apiKey = apiKey;
     this.model = model;
     this.language = language;
@@ -37,12 +63,14 @@ export class OpenAIWhisperSTT implements STTProvider {
 
   async transcribe(audio: Buffer): Promise<string> {
     const formData = new FormData();
-    // The browser mic encodes PCM to WAV before sending (ui useVoice
-    // encodeWav writes a RIFF header) — label it truthfully like the local
-    // and Sarvam providers already do; 'audio.webm' was a mislabel.
-    formData.append('file', new Blob([new Uint8Array(audio)], { type: 'audio/wav' }), 'audio.wav');
+    // Label the part from the buffer's magic bytes (dashboard mic sends WAV,
+    // Telegram voice notes are OGG/Opus); 'audio.webm' was a mislabel.
+    const { filename, mimeType } = sniffAudioFormat(audio);
+    formData.append('file', new Blob([new Uint8Array(audio)], { type: mimeType }), filename);
     formData.append('model', this.model);
-    formData.append('language', this.language);
+    // Unset language = let Whisper auto-detect; forcing 'en' made non-English
+    // speech decode (or translate) as English on a hosted product.
+    if (this.language) formData.append('language', this.language);
 
     const response = await fetch('https://api.openai.com/v1/audio/transcriptions', {
       method: 'POST',
@@ -66,9 +94,9 @@ export class OpenAIWhisperSTT implements STTProvider {
 export class GroqWhisperSTT implements STTProvider {
   private apiKey: string;
   private model: string;
-  private language: string;
+  private language?: string;
 
-  constructor(apiKey: string, model: string = 'whisper-large-v3-turbo', language: string = 'en') {
+  constructor(apiKey: string, model: string = 'whisper-large-v3-turbo', language?: string) {
     this.apiKey = apiKey;
     this.model = model;
     this.language = language;
@@ -76,10 +104,11 @@ export class GroqWhisperSTT implements STTProvider {
 
   async transcribe(audio: Buffer): Promise<string> {
     const formData = new FormData();
-    // Same WAV-mislabel fix as OpenAIWhisperSTT: the audio really is WAV.
-    formData.append('file', new Blob([new Uint8Array(audio)], { type: 'audio/wav' }), 'audio.wav');
+    // Same magic-byte labeling as OpenAIWhisperSTT.
+    const { filename, mimeType } = sniffAudioFormat(audio);
+    formData.append('file', new Blob([new Uint8Array(audio)], { type: mimeType }), filename);
     formData.append('model', this.model);
-    formData.append('language', this.language);
+    if (this.language) formData.append('language', this.language);
 
     const response = await fetch('https://api.groq.com/openai/v1/audio/transcriptions', {
       method: 'POST',
@@ -108,9 +137,20 @@ export class UsejarvisSTT implements STTProvider {
   private baseUrl: string;
   private apiKey: string;
   private model: string;
-  private language: string;
+  private language?: string;
 
-  constructor(baseUrl: string, apiKey: string, model: string = 'uj-stt', language: string = 'en') {
+  /** Bound on how long one hosted transcription round-trip may take. */
+  static readonly TIMEOUT_MS = 30_000;
+  /** Bound on how much of an ERROR body is read into memory (the caps below
+   * truncate to 200 chars AFTER the read — an unbounded read of a
+   * multi-megabyte interstitial would buffer it whole first, per request,
+   * on a memory-capped multi-tenant host). */
+  static readonly MAX_ERROR_BODY_BYTES = 8_192;
+  /** Bound on a SUCCESS body: generous (a transcript of hours of speech fits
+   * easily), but still a ceiling a misbehaving CDN cannot exceed. */
+  static readonly MAX_BODY_BYTES = 1_048_576;
+
+  constructor(baseUrl: string, apiKey: string, model: string = 'uj-stt', language?: string) {
     // The provisioner writes the proxy ORIGIN; normalize to the /v1 prefix
     // exactly like UsejarvisAIProvider (src/llm/usejarvis.ts) does.
     const trimmed = baseUrl.replace(/\/+$/, '');
@@ -120,20 +160,46 @@ export class UsejarvisSTT implements STTProvider {
     this.language = language;
   }
 
+  /** Read at most maxBytes from the response body. */
+  private static async boundedText(response: Response, maxBytes: number): Promise<string> {
+    const reader = response.body?.getReader();
+    if (!reader) return '';
+    const chunks: Uint8Array[] = [];
+    let total = 0;
+    try {
+      while (total < maxBytes) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        chunks.push(value);
+        total += value.byteLength;
+      }
+    } finally {
+      await reader.cancel().catch(() => {});
+    }
+    return Buffer.concat(chunks).toString('utf8').slice(0, maxBytes);
+  }
+
   async transcribe(audio: Buffer): Promise<string> {
     const formData = new FormData();
-    formData.append('file', new Blob([new Uint8Array(audio)], { type: 'audio/wav' }), 'audio.wav');
+    // Magic-byte labeling matters most here: the hosted proxy may trust the
+    // declared container, and this instance sees dashboard WAV and Telegram
+    // OGG/Opus alike.
+    const { filename, mimeType } = sniffAudioFormat(audio);
+    formData.append('file', new Blob([new Uint8Array(audio)], { type: mimeType }), filename);
     formData.append('model', this.model);
-    formData.append('language', this.language);
+    if (this.language) formData.append('language', this.language);
 
+    // Timeout: a hung proxy/CDN left Telegram and WS transcribe calls pending
+    // forever with no user-visible failure.
     const response = await fetch(`${this.baseUrl}/audio/transcriptions`, {
       method: 'POST',
       headers: { 'Authorization': `Bearer ${this.apiKey}` },
       body: formData,
+      signal: AbortSignal.timeout(UsejarvisSTT.TIMEOUT_MS),
     });
 
     if (!response.ok) {
-      const err = await response.text();
+      const err = await UsejarvisSTT.boundedText(response, UsejarvisSTT.MAX_ERROR_BODY_BYTES);
       // Shared mapper: budgets block audio endpoints too, so a hosted user
       // WILL hit this — they should get "your included usage is used up …",
       // not the raw proxy JSON (or, behind a CDN, a whole HTML page carrying
@@ -146,7 +212,9 @@ export class UsejarvisSTT implements STTProvider {
     // no status and none of the body — so an HTML interstitial served with a
     // 200 produced a bare parse error with nothing to correlate. Reading the
     // body ourselves keeps the diagnostic, still redacted and still capped.
-    const raw = await response.text();
+    // Bounded: a real transcript fits well under the cap; an interstitial
+    // does not deserve more memory than the cap.
+    const raw = await UsejarvisSTT.boundedText(response, UsejarvisSTT.MAX_BODY_BYTES);
     let result: { text?: string };
     try {
       result = JSON.parse(raw) as { text?: string };
@@ -175,13 +243,13 @@ export class LocalWhisperSTT implements STTProvider {
   private endpoint: string;
   private model: string;
   private serverType: LocalWhisperServerType;
-  private language: string;
+  private language?: string;
 
   constructor(
     endpoint: string = 'http://localhost:8080',
     model?: string,
     serverType: LocalWhisperServerType = 'whisper_cpp',
-    language: string = 'en',
+    language?: string,
   ) {
     this.endpoint = endpoint;
     this.model = model ?? 'base';
@@ -208,7 +276,7 @@ export class LocalWhisperSTT implements STTProvider {
     } else {
       formData.append('file', new Blob([new Uint8Array(audio)], { type: 'audio/wav' }), 'audio.wav');
       formData.append('model', this.model);
-      formData.append('language', this.language);
+      if (this.language) formData.append('language', this.language);
     }
     return formData;
   }

--- a/src/comms/voice.ts
+++ b/src/comms/voice.ts
@@ -1,4 +1,5 @@
 import type { STTConfig, TTSConfig } from '../config/types.ts';
+import { redactSecrets } from '../util/redact.ts';
 
 export interface STTProvider {
   transcribe(audio: Buffer): Promise<string>;
@@ -126,12 +127,16 @@ export class UsejarvisSTT implements STTProvider {
 
     if (!response.ok) {
       const err = await response.text();
-      throw new Error(`Usejarvis AI STT error (${response.status}): ${err}`);
+      throw new Error(`Usejarvis AI STT error (${response.status}): ${redactSecrets(err)}`);
     }
 
     const result = await response.json() as { text?: string };
     if (typeof result.text !== 'string') {
-      throw new Error(`Usejarvis AI STT returned no transcript: ${JSON.stringify(result).slice(0, 200)}`);
+      // Same class as the error branch: a 200 carrying a proxy/CDN
+      // interstitial is exactly where an echoed bearer shows up.
+      throw new Error(
+        `Usejarvis AI STT returned no transcript: ${redactSecrets(JSON.stringify(result)).slice(0, 200)}`,
+      );
     }
     return result.text;
   }

--- a/src/comms/voice.ts
+++ b/src/comms/voice.ts
@@ -10,6 +10,16 @@ export interface TTSProvider {
 }
 
 /**
+ * Hosted "Usejarvis AI" credentials for the voice factories. Sourced from the
+ * SYSTEM-owned `usejarvis_ai` config.yaml block at the call sites (see
+ * daemon/usejarvis-ai.ts) and passed as a separate argument on purpose:
+ * cfg.stt / cfg.tts persist as plaintext JSON in the DB settings store and
+ * round-trip through the /api/config routes, so the per-user proxy key must
+ * never live inside them.
+ */
+export type HostedVoiceCredentials = { baseUrl: string; apiKey: string };
+
+/**
  * OpenAI Whisper STT — uses the OpenAI /v1/audio/transcriptions endpoint.
  */
 export class OpenAIWhisperSTT implements STTProvider {
@@ -23,7 +33,10 @@ export class OpenAIWhisperSTT implements STTProvider {
 
   async transcribe(audio: Buffer): Promise<string> {
     const formData = new FormData();
-    formData.append('file', new Blob([new Uint8Array(audio)], { type: 'audio/webm' }), 'audio.webm');
+    // The browser mic encodes PCM to WAV before sending (ui useVoice
+    // encodeWav writes a RIFF header) — label it truthfully like the local
+    // and Sarvam providers already do; 'audio.webm' was a mislabel.
+    formData.append('file', new Blob([new Uint8Array(audio)], { type: 'audio/wav' }), 'audio.wav');
     formData.append('model', this.model);
     formData.append('language', 'en');
 
@@ -57,7 +70,8 @@ export class GroqWhisperSTT implements STTProvider {
 
   async transcribe(audio: Buffer): Promise<string> {
     const formData = new FormData();
-    formData.append('file', new Blob([new Uint8Array(audio)], { type: 'audio/webm' }), 'audio.webm');
+    // Same WAV-mislabel fix as OpenAIWhisperSTT: the audio really is WAV.
+    formData.append('file', new Blob([new Uint8Array(audio)], { type: 'audio/wav' }), 'audio.wav');
     formData.append('model', this.model);
     formData.append('language', 'en');
 
@@ -73,6 +87,52 @@ export class GroqWhisperSTT implements STTProvider {
     }
 
     const result = await response.json() as any;
+    return result.text;
+  }
+}
+
+/**
+ * Hosted "Usejarvis AI" STT — the platform proxy's OpenAI-compatible
+ * /audio/transcriptions endpoint. `uj-stt` is a stable per-plan alias the
+ * proxy resolves server-side (same scheme as the uj-* LLM tiers). Credentials
+ * come from the system-owned `usejarvis_ai` block via the factory's `hosted`
+ * argument — never from cfg.stt.
+ */
+export class UsejarvisSTT implements STTProvider {
+  private baseUrl: string;
+  private apiKey: string;
+  private model: string;
+
+  constructor(baseUrl: string, apiKey: string, model: string = 'uj-stt') {
+    // The provisioner writes the proxy ORIGIN; normalize to the /v1 prefix
+    // exactly like UsejarvisAIProvider (src/llm/usejarvis.ts) does.
+    const trimmed = baseUrl.replace(/\/+$/, '');
+    this.baseUrl = /\/v1$/.test(trimmed) ? trimmed : `${trimmed}/v1`;
+    this.apiKey = apiKey;
+    this.model = model;
+  }
+
+  async transcribe(audio: Buffer): Promise<string> {
+    const formData = new FormData();
+    formData.append('file', new Blob([new Uint8Array(audio)], { type: 'audio/wav' }), 'audio.wav');
+    formData.append('model', this.model);
+    formData.append('language', 'en');
+
+    const response = await fetch(`${this.baseUrl}/audio/transcriptions`, {
+      method: 'POST',
+      headers: { 'Authorization': `Bearer ${this.apiKey}` },
+      body: formData,
+    });
+
+    if (!response.ok) {
+      const err = await response.text();
+      throw new Error(`Usejarvis AI STT error (${response.status}): ${err}`);
+    }
+
+    const result = await response.json() as { text?: string };
+    if (typeof result.text !== 'string') {
+      throw new Error(`Usejarvis AI STT returned no transcript: ${JSON.stringify(result).slice(0, 200)}`);
+    }
     return result.text;
   }
 }
@@ -200,9 +260,20 @@ export class SarvamSTT implements STTProvider {
 /**
  * Factory: create the right STT provider from config.
  * Returns null if the selected provider lacks required credentials.
+ *
+ * `hosted` carries the Usejarvis AI proxy credentials as a SEPARATE argument
+ * (see HostedVoiceCredentials): cfg.stt only ever stores the string choice
+ * `provider: 'usejarvis'`, so the key can never leak into the persisted
+ * plaintext settings row.
  */
-export function createSTTProvider(config: STTConfig): STTProvider | null {
+export function createSTTProvider(
+  config: STTConfig,
+  hosted?: HostedVoiceCredentials | null,
+): STTProvider | null {
   switch (config.provider) {
+    case 'usejarvis':
+      if (!hosted?.baseUrl || !hosted?.apiKey) return null;
+      return new UsejarvisSTT(hosted.baseUrl, hosted.apiKey);
     case 'openai':
       if (!config.openai?.api_key) return null;
       return new OpenAIWhisperSTT(config.openai.api_key, config.openai.model);

--- a/src/comms/voice.ts
+++ b/src/comms/voice.ts
@@ -1,5 +1,6 @@
 import type { STTConfig, TTSConfig } from '../config/types.ts';
 import { redactSecrets } from '../util/redact.ts';
+import { hostedProxyError } from '../util/hosted-error.ts';
 
 export interface STTProvider {
   transcribe(audio: Buffer): Promise<string>;
@@ -127,7 +128,11 @@ export class UsejarvisSTT implements STTProvider {
 
     if (!response.ok) {
       const err = await response.text();
-      throw new Error(`Usejarvis AI STT error (${response.status}): ${redactSecrets(err)}`);
+      // Shared mapper: budgets block audio endpoints too, so a hosted user
+      // WILL hit this — they should get "your included usage is used up …",
+      // not the raw proxy JSON (or, behind a CDN, a whole HTML page carrying
+      // the hosted hostname) in a browser toast.
+      throw hostedProxyError('Usejarvis AI STT', response.status, err);
     }
 
     const result = await response.json() as { text?: string };

--- a/src/comms/voice.ts
+++ b/src/comms/voice.ts
@@ -27,10 +27,12 @@ export type HostedVoiceCredentials = { baseUrl: string; apiKey: string };
 export class OpenAIWhisperSTT implements STTProvider {
   private apiKey: string;
   private model: string;
+  private language: string;
 
-  constructor(apiKey: string, model: string = 'whisper-1') {
+  constructor(apiKey: string, model: string = 'whisper-1', language: string = 'en') {
     this.apiKey = apiKey;
     this.model = model;
+    this.language = language;
   }
 
   async transcribe(audio: Buffer): Promise<string> {
@@ -40,7 +42,7 @@ export class OpenAIWhisperSTT implements STTProvider {
     // and Sarvam providers already do; 'audio.webm' was a mislabel.
     formData.append('file', new Blob([new Uint8Array(audio)], { type: 'audio/wav' }), 'audio.wav');
     formData.append('model', this.model);
-    formData.append('language', 'en');
+    formData.append('language', this.language);
 
     const response = await fetch('https://api.openai.com/v1/audio/transcriptions', {
       method: 'POST',
@@ -64,10 +66,12 @@ export class OpenAIWhisperSTT implements STTProvider {
 export class GroqWhisperSTT implements STTProvider {
   private apiKey: string;
   private model: string;
+  private language: string;
 
-  constructor(apiKey: string, model: string = 'whisper-large-v3-turbo') {
+  constructor(apiKey: string, model: string = 'whisper-large-v3-turbo', language: string = 'en') {
     this.apiKey = apiKey;
     this.model = model;
+    this.language = language;
   }
 
   async transcribe(audio: Buffer): Promise<string> {
@@ -75,7 +79,7 @@ export class GroqWhisperSTT implements STTProvider {
     // Same WAV-mislabel fix as OpenAIWhisperSTT: the audio really is WAV.
     formData.append('file', new Blob([new Uint8Array(audio)], { type: 'audio/wav' }), 'audio.wav');
     formData.append('model', this.model);
-    formData.append('language', 'en');
+    formData.append('language', this.language);
 
     const response = await fetch('https://api.groq.com/openai/v1/audio/transcriptions', {
       method: 'POST',
@@ -104,21 +108,23 @@ export class UsejarvisSTT implements STTProvider {
   private baseUrl: string;
   private apiKey: string;
   private model: string;
+  private language: string;
 
-  constructor(baseUrl: string, apiKey: string, model: string = 'uj-stt') {
+  constructor(baseUrl: string, apiKey: string, model: string = 'uj-stt', language: string = 'en') {
     // The provisioner writes the proxy ORIGIN; normalize to the /v1 prefix
     // exactly like UsejarvisAIProvider (src/llm/usejarvis.ts) does.
     const trimmed = baseUrl.replace(/\/+$/, '');
     this.baseUrl = /\/v1$/.test(trimmed) ? trimmed : `${trimmed}/v1`;
     this.apiKey = apiKey;
     this.model = model;
+    this.language = language;
   }
 
   async transcribe(audio: Buffer): Promise<string> {
     const formData = new FormData();
     formData.append('file', new Blob([new Uint8Array(audio)], { type: 'audio/wav' }), 'audio.wav');
     formData.append('model', this.model);
-    formData.append('language', 'en');
+    formData.append('language', this.language);
 
     const response = await fetch(`${this.baseUrl}/audio/transcriptions`, {
       method: 'POST',
@@ -169,15 +175,18 @@ export class LocalWhisperSTT implements STTProvider {
   private endpoint: string;
   private model: string;
   private serverType: LocalWhisperServerType;
+  private language: string;
 
   constructor(
     endpoint: string = 'http://localhost:8080',
     model?: string,
     serverType: LocalWhisperServerType = 'whisper_cpp',
+    language: string = 'en',
   ) {
     this.endpoint = endpoint;
     this.model = model ?? 'base';
     this.serverType = serverType;
+    this.language = language;
   }
 
   private resolveUrl(): string {
@@ -199,7 +208,7 @@ export class LocalWhisperSTT implements STTProvider {
     } else {
       formData.append('file', new Blob([new Uint8Array(audio)], { type: 'audio/wav' }), 'audio.wav');
       formData.append('model', this.model);
-      formData.append('language', 'en');
+      formData.append('language', this.language);
     }
     return formData;
   }
@@ -296,15 +305,20 @@ export function createSTTProvider(
   switch (config.provider) {
     case 'usejarvis':
       if (!hosted?.baseUrl || !hosted?.apiKey) return null;
-      return new UsejarvisSTT(hosted.baseUrl, hosted.apiKey);
+      return new UsejarvisSTT(hosted.baseUrl, hosted.apiKey, undefined, config.language);
     case 'openai':
       if (!config.openai?.api_key) return null;
-      return new OpenAIWhisperSTT(config.openai.api_key, config.openai.model);
+      return new OpenAIWhisperSTT(config.openai.api_key, config.openai.model, config.language);
     case 'groq':
       if (!config.groq?.api_key) return null;
-      return new GroqWhisperSTT(config.groq.api_key, config.groq.model);
+      return new GroqWhisperSTT(config.groq.api_key, config.groq.model, config.language);
     case 'local':
-      return new LocalWhisperSTT(config.local?.endpoint, config.local?.model, config.local?.server_type);
+      return new LocalWhisperSTT(
+        config.local?.endpoint,
+        config.local?.model,
+        config.local?.server_type,
+        config.language,
+      );
     case 'sarvam':
       if (!config.sarvam?.api_key) return null;
       return new SarvamSTT(config.sarvam.api_key, config.sarvam.model, config.sarvam.language);

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -155,6 +155,13 @@ export type STTConfig = {
    * section persists as plaintext JSON in the DB settings store).
    */
   provider: 'openai' | 'groq' | 'local' | 'sarvam' | 'usejarvis';
+  /**
+   * ISO-639-1 hint sent to the Whisper-shaped providers (openai / groq /
+   * local / usejarvis). Defaults to 'en' — the value they were all hardcoded
+   * to — so behaviour is unchanged until someone sets it. Sarvam keeps its
+   * own `sarvam.language` (different API, different codes).
+   */
+  language?: string;
   openai?: { api_key: string; model?: string };
   groq?: { api_key: string; model?: string };
   local?: { endpoint: string; model?: string; server_type?: 'whisper_cpp' | 'openai_compatible' };

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -148,7 +148,13 @@ export type VoiceConfig = {
 };
 
 export type STTConfig = {
-  provider: 'openai' | 'groq' | 'local' | 'sarvam';
+  /**
+   * `usejarvis` is a pure string choice: the hosted "Usejarvis AI" STT rides
+   * the system-owned `usejarvis_ai` credentials, which are threaded to
+   * createSTTProvider as a separate argument and NEVER stored here (this
+   * section persists as plaintext JSON in the DB settings store).
+   */
+  provider: 'openai' | 'groq' | 'local' | 'sarvam' | 'usejarvis';
   openai?: { api_key: string; model?: string };
   groq?: { api_key: string; model?: string };
   local?: { endpoint: string; model?: string; server_type?: 'whisper_cpp' | 'openai_compatible' };

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -157,9 +157,10 @@ export type STTConfig = {
   provider: 'openai' | 'groq' | 'local' | 'sarvam' | 'usejarvis';
   /**
    * ISO-639-1 hint sent to the Whisper-shaped providers (openai / groq /
-   * local / usejarvis). Defaults to 'en' — the value they were all hardcoded
-   * to — so behaviour is unchanged until someone sets it. Sarvam keeps its
-   * own `sarvam.language` (different API, different codes).
+   * local / usejarvis). Unset = auto-detect (the `language` param is omitted
+   * from the request entirely) — a hosted product cannot assume its users
+   * speak English, and Whisper detects reliably. Sarvam keeps its own
+   * `sarvam.language` (different API, different codes).
    */
   language?: string;
   openai?: { api_key: string; model?: string };

--- a/src/daemon/api-routes.ts
+++ b/src/daemon/api-routes.ts
@@ -12,6 +12,7 @@ import { SecretStorageError } from './section-secrets.ts';
 import type { AgentService } from './agent-service.ts';
 import type { JarvisConfig } from '../config/types.ts';
 import { resolveRealtimeVoice, DEFAULT_BLOCKED_CATEGORIES } from '../config/realtime.ts';
+import { hasUsejarvisAi, effectiveSttForBinding } from './usejarvis-ai.ts';
 import type { EntityType } from '../vault/entities.ts';
 import type { CommitmentPriority, CommitmentStatus } from '../vault/commitments.ts';
 import type { ObservationType } from '../vault/observations.ts';
@@ -2470,8 +2471,14 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
     '/api/config/stt': {
       GET: () => {
         const stt = ctx.config.stt;
+        // `provider` reports the BINDING view: on hosted installs where the
+        // user never chose, it reads 'usejarvis' (what actually transcribes)
+        // while the persisted cfg.stt row stays untouched. No key material —
+        // the hosted credentials live only in the system config.
+        const effective = effectiveSttForBinding(ctx.config);
         return json({
-          provider: stt?.provider ?? 'openai',
+          provider: effective?.provider ?? stt?.provider ?? 'openai',
+          usejarvis_available: hasUsejarvisAi(ctx.config),
           has_openai_key: !!stt?.openai?.api_key,
           has_groq_key: !!stt?.groq?.api_key,
           has_sarvam_key: !!stt?.sarvam?.api_key,

--- a/src/daemon/api-routes.ts
+++ b/src/daemon/api-routes.ts
@@ -2479,6 +2479,10 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
         return json({
           provider: effective?.provider ?? stt?.provider ?? 'openai',
           usejarvis_available: hasUsejarvisAi(ctx.config),
+          // Empty string = auto-detect (the language param is omitted from
+          // provider requests). Surfaced so hosted users — who have no shell
+          // access to config.yaml — can change it from the dashboard.
+          language: stt?.language ?? '',
           has_openai_key: !!stt?.openai?.api_key,
           has_groq_key: !!stt?.groq?.api_key,
           has_sarvam_key: !!stt?.sarvam?.api_key,
@@ -2492,6 +2496,25 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
           const body = await req.json() as Record<string, unknown>;
           const { saveUserSection } = await import('./user-settings.ts');
           const { mergeSTTConfig } = await import('./config-merge.ts');
+
+          // Validate before anything persists: an unknown provider (or
+          // 'usejarvis' on a self-hosted install, where createSTTProvider can
+          // never construct it) previously saved fine and answered ok:true —
+          // then STT was silently dead on every surface with only a console
+          // line to show for it.
+          const STT_PROVIDERS = ['openai', 'groq', 'local', 'sarvam', 'usejarvis'];
+          if (body.provider !== undefined) {
+            if (typeof body.provider !== 'string' || !STT_PROVIDERS.includes(body.provider)) {
+              return json({ ok: false, message: `Unknown STT provider: ${String(body.provider)}` }, 400);
+            }
+            if (body.provider === 'usejarvis' && !hasUsejarvisAi(ctx.config)) {
+              return json({ ok: false, message: 'Usejarvis AI transcription is only available on hosted installs.' }, 400);
+            }
+          }
+          // The hosted credentials never live in cfg.stt — a 'usejarvis'
+          // sub-block in the patch would persist a key into the plaintext
+          // settings row, the exact leak the credential split exists to stop.
+          delete body.usejarvis;
 
           // Merged locally, published only once the save succeeded — see the
           // channels route: a throwing keychain must not leave the live config

--- a/src/daemon/api-routes.ts
+++ b/src/daemon/api-routes.ts
@@ -39,7 +39,6 @@ import { getOrCreateConversation, getMessages, getRecentConversation } from '../
 import { getRecentObservations, summarizeObservation } from '../vault/observations.ts';
 import { listAgentActivity, countAgentActivity } from '../vault/agent-activity.ts';
 import { getPersonality } from '../personality/model.ts';
-import { hasUsejarvisAi } from './usejarvis-ai.ts';
 import { clearUserProfile, getUserProfile, saveUserProfile } from '../vault/user-profile.ts';
 import {
   USER_PROFILE_QUESTIONS,

--- a/src/daemon/api-stt-validation.test.ts
+++ b/src/daemon/api-stt-validation.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createApiRoutes, type ApiContext } from './api-routes.ts';
+import { initDatabase, closeDb } from '../vault/schema.ts';
+import { loadUserSection } from './user-settings.ts';
+import type { JarvisConfig } from '../config/types.ts';
+
+type Handler = (req: Request) => Response | Promise<Response>;
+
+function post(config: JarvisConfig, body: Record<string, unknown>): Response | Promise<Response> {
+  const ctx = {
+    daemonStartedAt: Date.now(),
+    healthMonitor: {} as ApiContext['healthMonitor'],
+    config,
+  } as ApiContext;
+  const route = createApiRoutes(ctx)['/api/config/stt'] as { POST: Handler };
+  return route.POST(new Request('http://x/api/config/stt', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  }));
+}
+
+const selfHosted = (): JarvisConfig => ({ stt: { provider: 'openai' } } as JarvisConfig);
+const hosted = (): JarvisConfig => ({
+  stt: { provider: 'openai' },
+  usejarvis_ai: { base_url: 'https://llm.usejarvis.host', api_key: 'sk-uj-not-real' },
+} as JarvisConfig);
+
+describe('POST /api/config/stt validation', () => {
+  // NEVER touch the real keychain at ~/.jarvis: point the secrets store at a
+  // throwaway dir for every test in this file.
+  let secretsDir: string;
+  let prevSecretsDir: string | undefined;
+
+  beforeEach(() => {
+    prevSecretsDir = process.env.JARVIS_SECRETS_DIR;
+    secretsDir = mkdtempSync(join(tmpdir(), 'jarvis-stt-test-'));
+    process.env.JARVIS_SECRETS_DIR = secretsDir;
+    initDatabase(':memory:');
+  });
+
+  afterEach(() => {
+    closeDb();
+    rmSync(secretsDir, { recursive: true, force: true });
+    if (prevSecretsDir === undefined) delete process.env.JARVIS_SECRETS_DIR;
+    else process.env.JARVIS_SECRETS_DIR = prevSecretsDir;
+  });
+
+  it('rejects an unknown provider with a 400, not ok:true', async () => {
+    const res = await post(selfHosted(), { provider: 'whispersync' });
+    expect(res.status).toBe(400);
+    const body = await res.json() as { ok: boolean };
+    expect(body.ok).toBe(false);
+  });
+
+  it('rejects usejarvis on a self-hosted install where it can never bind', async () => {
+    const res = await post(selfHosted(), { provider: 'usejarvis' });
+    expect(res.status).toBe(400);
+    const body = await res.json() as { ok: boolean; message: string };
+    expect(body.ok).toBe(false);
+    expect(body.message).toContain('hosted');
+  });
+
+  it('accepts usejarvis on a hosted install', async () => {
+    const res = await post(hosted(), { provider: 'usejarvis' });
+    const body = await res.json() as { ok: boolean };
+    expect(body.ok).toBe(true);
+  });
+
+  it('strips a usejarvis credential sub-block before anything persists', async () => {
+    // The hosted key must never land in the plaintext cfg.stt row — that is
+    // the exact leak the credential split exists to prevent.
+    const res = await post(hosted(), {
+      provider: 'usejarvis',
+      usejarvis: { api_key: 'sk-uj-should-never-persist' },
+    });
+    const body = await res.json() as { ok: boolean };
+    expect(body.ok).toBe(true);
+    const row = JSON.stringify(loadUserSection('stt') ?? {});
+    expect(row).not.toContain('sk-uj-should-never-persist');
+    expect(row).not.toContain('usejarvis_ai');
+  });
+});

--- a/src/daemon/channel-service.ts
+++ b/src/daemon/channel-service.ts
@@ -16,6 +16,7 @@ import type { STTProvider } from '../comms/voice.ts';
 import { ChannelManager } from '../comms/index.ts';
 import { TelegramAdapter } from '../comms/channels/telegram.ts';
 import { createSTTProvider } from '../comms/voice.ts';
+import { effectiveSttForBinding, usejarvisVoiceCredentials } from './usejarvis-ai.ts';
 import { getOrCreateConversation, addMessage } from '../vault/conversations.ts';
 import { getSettingsByPrefix, setSetting } from '../vault/settings.ts';
 import { classifyErrorString } from '../llm/provider.ts';
@@ -78,11 +79,15 @@ export class ChannelService implements Service {
       //    empty until the user re-messages each bot).
       this.loadPersistedRecipients();
 
-      // 1. Create STT provider if configured
-      if (this.config.stt) {
-        this.sttProvider = createSTTProvider(this.config.stt);
+      // 1. Create STT provider if configured. The binding view (not the raw
+      // user section) picks the hosted Usejarvis AI default when the user
+      // never chose a provider; the proxy credentials ride as a separate
+      // argument so they never touch the persisted cfg.stt.
+      const sttBinding = effectiveSttForBinding(this.config);
+      if (sttBinding) {
+        this.sttProvider = createSTTProvider(sttBinding, usejarvisVoiceCredentials(this.config));
         if (this.sttProvider) {
-          console.log(`[ChannelService] STT provider: ${this.config.stt.provider}`);
+          console.log(`[ChannelService] STT provider: ${sttBinding.provider}`);
         } else {
           console.log('[ChannelService] STT configured but no valid credentials — voice messages disabled');
         }

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -877,9 +877,13 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
       if (jarvisConfig.stt) {
         try {
           const { createSTTProvider } = await import('../comms/voice.ts');
-          pebbleSTT = createSTTProvider(jarvisConfig.stt);
+          const { effectiveSttForBinding, usejarvisVoiceCredentials } = await import('./usejarvis-ai.ts');
+          const sttBinding = effectiveSttForBinding(jarvisConfig);
+          pebbleSTT = sttBinding
+            ? createSTTProvider(sttBinding, usejarvisVoiceCredentials(jarvisConfig))
+            : null;
           if (pebbleSTT) {
-            console.log(`[ambient-ui] STT provider for pebble: ${jarvisConfig.stt.provider}`);
+            console.log(`[ambient-ui] STT provider for pebble: ${sttBinding!.provider}`);
           }
         } catch (err) {
           console.warn('[ambient-ui] failed to init STT provider:', err);
@@ -903,8 +907,10 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
       // the main registration block.
       settingsReload?.registerApplier('stt', async (cfg) => {
         const { createSTTProvider } = await import('../comms/voice.ts');
-        pebbleSTT = cfg.stt ? createSTTProvider(cfg.stt) : null;
-        console.log(`[ambient-ui] STT provider ${pebbleSTT ? `set to ${cfg.stt?.provider}` : 'cleared'} (settings reload)`);
+        const { effectiveSttForBinding, usejarvisVoiceCredentials } = await import('./usejarvis-ai.ts');
+        const sttBinding = effectiveSttForBinding(cfg);
+        pebbleSTT = sttBinding ? createSTTProvider(sttBinding, usejarvisVoiceCredentials(cfg)) : null;
+        console.log(`[ambient-ui] STT provider ${pebbleSTT ? `set to ${sttBinding?.provider}` : 'cleared'} (settings reload)`);
       });
       settingsReload?.registerApplier('tts', async (cfg) => {
         pebbleTTS = null;
@@ -3589,10 +3595,14 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
     // 8d. Wire STT provider for voice input via dashboard
     if (jarvisConfig.stt) {
       const { createSTTProvider } = await import('../comms/voice.ts');
-      const sttProvider = createSTTProvider(jarvisConfig.stt);
+      const { effectiveSttForBinding, usejarvisVoiceCredentials } = await import('./usejarvis-ai.ts');
+      const sttBinding = effectiveSttForBinding(jarvisConfig);
+      const sttProvider = sttBinding
+        ? createSTTProvider(sttBinding, usejarvisVoiceCredentials(jarvisConfig))
+        : null;
       if (sttProvider) {
         wsService.setSTTProvider(sttProvider);
-        console.log(`[Daemon] STT for voice input: ${jarvisConfig.stt.provider}`);
+        console.log(`[Daemon] STT for voice input: ${sttBinding!.provider}`);
       }
     }
 
@@ -3665,7 +3675,9 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
     // restart when any channel is connected.
     settingsReload.registerApplier('stt', async (cfg) => {
       const { createSTTProvider } = await import('../comms/voice.ts');
-      wsService.setSTTProvider(cfg.stt ? createSTTProvider(cfg.stt) : null);
+      const { effectiveSttForBinding, usejarvisVoiceCredentials } = await import('./usejarvis-ai.ts');
+      const sttBinding = effectiveSttForBinding(cfg);
+      wsService.setSTTProvider(sttBinding ? createSTTProvider(sttBinding, usejarvisVoiceCredentials(cfg)) : null);
       if (Object.values(channelService.getChannelStatus()).some(Boolean)) {
         settingsReload!.sectionChanged('channels');
       }

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -874,20 +874,22 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
       // edge-tts / ElevenLabs / Sarvam for TTS) carry over.
       let pebbleSTT: import('../comms/voice.ts').STTProvider | null = null;
       let pebbleTTS: import('../comms/voice.ts').TTSProvider | null = null;
-      if (jarvisConfig.stt) {
-        try {
-          const { createSTTProvider } = await import('../comms/voice.ts');
-          const { effectiveSttForBinding, usejarvisVoiceCredentials } = await import('./usejarvis-ai.ts');
-          const sttBinding = effectiveSttForBinding(jarvisConfig);
-          pebbleSTT = sttBinding
-            ? createSTTProvider(sttBinding, usejarvisVoiceCredentials(jarvisConfig))
-            : null;
-          if (pebbleSTT) {
-            console.log(`[ambient-ui] STT provider for pebble: ${sttBinding!.provider}`);
-          }
-        } catch (err) {
-          console.warn('[ambient-ui] failed to init STT provider:', err);
+      // Guard on the BINDING result, not on config.stt existing (like
+      // channel-service): the hosted default applies even when the section
+      // is absent, and an outer config.stt check would leave pebble STT
+      // dead on a surface where Telegram/Discord transcribe fine.
+      try {
+        const { createSTTProvider } = await import('../comms/voice.ts');
+        const { effectiveSttForBinding, usejarvisVoiceCredentials } = await import('./usejarvis-ai.ts');
+        const sttBinding = effectiveSttForBinding(jarvisConfig);
+        pebbleSTT = sttBinding
+          ? createSTTProvider(sttBinding, usejarvisVoiceCredentials(jarvisConfig))
+          : null;
+        if (pebbleSTT) {
+          console.log(`[ambient-ui] STT provider for pebble: ${sttBinding!.provider}`);
         }
+      } catch (err) {
+        console.warn('[ambient-ui] failed to init STT provider:', err);
       }
       if (jarvisConfig.tts?.enabled) {
         try {
@@ -3592,8 +3594,10 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
       }
     }
 
-    // 8d. Wire STT provider for voice input via dashboard
-    if (jarvisConfig.stt) {
+    // 8d. Wire STT provider for voice input via dashboard. Guard on the
+    // BINDING result, not on config.stt existing (like channel-service):
+    // the hosted default applies even when the section is absent.
+    {
       const { createSTTProvider } = await import('../comms/voice.ts');
       const { effectiveSttForBinding, usejarvisVoiceCredentials } = await import('./usejarvis-ai.ts');
       const sttBinding = effectiveSttForBinding(jarvisConfig);

--- a/src/daemon/usejarvis-ai.test.ts
+++ b/src/daemon/usejarvis-ai.test.ts
@@ -9,7 +9,9 @@ import { hasSecret } from '../vault/keychain.ts';
 import {
   applyUsejarvisAi,
   effectiveLlmForBinding,
+  effectiveSttForBinding,
   hasUsejarvisAi,
+  usejarvisVoiceCredentials,
   USEJARVIS_PROVIDER_NAME,
 } from './usejarvis-ai.ts';
 import { mergeLLMSettingsIntoConfig, saveLLMSettings } from './llm-settings.ts';
@@ -284,5 +286,71 @@ describe('hasUsejarvisAi: malformed blocks read as NOT hosted, never fatal', () 
 
   test('a well-formed block still reads as hosted', () => {
     expect(hasUsejarvisAi(withBlock({ base_url: 'https://llm.usejarvis.host', api_key: 'sk-uj-abc' }))).toBe(true);
+  });
+});
+
+describe('usejarvisVoiceCredentials (the SEPARATE credential channel)', () => {
+  test('null on self-hosted installs', () => {
+    expect(usejarvisVoiceCredentials(base())).toBeNull();
+    const partial = base();
+    partial.usejarvis_ai = { base_url: 'https://llm.usejarvis.host' }; // no key
+    expect(usejarvisVoiceCredentials(partial)).toBeNull();
+  });
+
+  test('returns trimmed proxy origin + key when hosted', () => {
+    const config = hosted();
+    config.usejarvis_ai = { base_url: ' https://llm.usejarvis.host ', api_key: ' sk-uj-abc123 ' };
+    expect(usejarvisVoiceCredentials(config)).toEqual({
+      baseUrl: 'https://llm.usejarvis.host',
+      apiKey: 'sk-uj-abc123',
+    });
+  });
+});
+
+describe('effectiveSttForBinding (hosted STT default, persistence-pure)', () => {
+  const noRow = () => undefined;
+
+  test('self-hosted: returns cfg.stt untouched (same reference), DB never read', () => {
+    const config = base();
+    let reads = 0;
+    const spy = () => { reads += 1; return undefined; };
+    expect(effectiveSttForBinding(config, spy)).toBe(config.stt);
+    expect(reads).toBe(0);
+  });
+
+  test('hosted + no stored stt row: binding view says usejarvis, config is NOT mutated', () => {
+    const config = hosted();
+    const view = effectiveSttForBinding(config, noRow);
+    expect(view?.provider).toBe('usejarvis');
+    // Persistence purity: the in-memory section every /api/config/stt save
+    // round-trips must still carry only user intent (the stock default).
+    expect(config.stt?.provider).toBe('openai');
+  });
+
+  test('hosted + stored row WITH a provider: the explicit user choice wins', () => {
+    const config = hosted();
+    config.stt = { provider: 'groq', groq: { api_key: 'gsk-user' } };
+    const view = effectiveSttForBinding(config, (section) =>
+      section === 'stt' ? { provider: 'groq', groq: { api_key: 'gsk-user' } } : undefined);
+    expect(view).toBe(config.stt); // untouched, same reference
+    expect(view?.provider).toBe('groq');
+  });
+
+  test('hosted + stored row WITHOUT a provider field: still silent, defaults to usejarvis', () => {
+    const config = hosted();
+    // What boot produces when the row only carries a key: the merge layered
+    // it over DEFAULT_CONFIG.stt, so provider 'openai' here is NOT intent.
+    config.stt = { provider: 'openai', openai: { api_key: 'sk-user' } };
+    const view = effectiveSttForBinding(config, () => ({ openai: { api_key: 'sk-user' } }));
+    expect(view?.provider).toBe('usejarvis');
+    // ...and the user's sub-blocks survive in the view untouched.
+    expect((view as { openai?: { api_key?: string } }).openai).toEqual({ api_key: 'sk-user' });
+  });
+
+  test('the view never carries credentials: only the provider string differs', () => {
+    const config = hosted();
+    const view = effectiveSttForBinding(config, noRow)!;
+    expect(JSON.stringify(view)).not.toContain('sk-uj-abc123');
+    expect(view).toEqual({ ...config.stt!, provider: 'usejarvis' });
   });
 });

--- a/src/daemon/usejarvis-ai.test.ts
+++ b/src/daemon/usejarvis-ai.test.ts
@@ -336,15 +336,26 @@ describe('effectiveSttForBinding (hosted STT default, persistence-pure)', () => 
     expect(view?.provider).toBe('groq');
   });
 
-  test('hosted + stored row WITHOUT a provider field: still silent, defaults to usejarvis', () => {
+  test('hosted + stored row with a sub-block but no provider: configuration, not silence', () => {
     const config = hosted();
-    // What boot produces when the row only carries a key: the merge layered
-    // it over DEFAULT_CONFIG.stt, so provider 'openai' here is NOT intent.
+    // What the legacy import wrote for a config.yaml that had
+    // `stt: { openai: {...} }` and relied on DEFAULT_CONFIG for the provider
+    // line: a stripped row with no `provider`. That user configured a key —
+    // re-routing their audio to the hosted proxy past it would bypass an
+    // explicit setup, so the sub-block reads as intent and the merged
+    // in-memory section (provider 'openai') binds.
     config.stt = { provider: 'openai', openai: { api_key: 'sk-user' } };
-    const view = effectiveSttForBinding(config, () => ({ openai: { api_key: 'sk-user' } }));
+    const view = effectiveSttForBinding(config, () => ({ openai: {} }));
+    expect(view).toBe(config.stt);
+    expect(view?.provider).toBe('openai');
+  });
+
+  test('hosted + stored row with only unknown fields: still silent, defaults to usejarvis', () => {
+    const config = hosted();
+    // A row carrying no provider AND no provider sub-block (e.g. just a
+    // language preference) records no routing intent.
+    const view = effectiveSttForBinding(config, () => ({ language: 'it' }));
     expect(view?.provider).toBe('usejarvis');
-    // ...and the user's sub-blocks survive in the view untouched.
-    expect((view as { openai?: { api_key?: string } }).openai).toEqual({ api_key: 'sk-user' });
   });
 
   test('the view never carries credentials: only the provider string differs', () => {

--- a/src/daemon/usejarvis-ai.ts
+++ b/src/daemon/usejarvis-ai.ts
@@ -184,12 +184,25 @@ export function usejarvisVoiceCredentials(config: JarvisConfig): HostedVoiceCred
   return { baseUrl: block.base_url!.trim(), apiKey: block.api_key!.trim() };
 }
 
-/** True when a stored user section records an explicit provider choice. */
+/** Provider-specific sub-blocks a stored stt row can carry. */
+const STT_PROVIDER_BLOCKS = ['openai', 'groq', 'local', 'sarvam'] as const;
+
+/**
+ * True when a stored user section records provider intent. An explicit
+ * `provider` string is intent — but so is a row that carries any
+ * provider-specific sub-block without one: importLegacyUserSettings writes
+ * exactly that shape for a config.yaml that had `stt: { openai: {...} }` and
+ * relied on DEFAULT_CONFIG for the provider line. Treating it as silence
+ * silently re-routed that user's audio to the hosted proxy past the key they
+ * configured. (New imports also stamp `provider` explicitly; this keeps rows
+ * imported before that fix honest.)
+ */
 function storedProviderChoice(stored: unknown): boolean {
-  return (
-    typeof stored === 'object' && stored !== null && !Array.isArray(stored) &&
-    typeof (stored as { provider?: unknown }).provider === 'string' &&
-    ((stored as { provider: string }).provider.trim() !== '')
+  if (typeof stored !== 'object' || stored === null || Array.isArray(stored)) return false;
+  const rec = stored as Record<string, unknown>;
+  if (typeof rec.provider === 'string' && rec.provider.trim() !== '') return true;
+  return STT_PROVIDER_BLOCKS.some(
+    (block) => typeof rec[block] === 'object' && rec[block] !== null,
   );
 }
 

--- a/src/daemon/usejarvis-ai.ts
+++ b/src/daemon/usejarvis-ai.ts
@@ -1,4 +1,6 @@
-import type { JarvisConfig, LLMConfig } from '../config/types.ts';
+import type { JarvisConfig, LLMConfig, STTConfig } from '../config/types.ts';
+import type { HostedVoiceCredentials } from '../comms/voice.ts';
+import { loadUserSection } from './user-settings.ts';
 
 /**
  * Hosted "Usejarvis AI" wiring (the platform's LLM proxy).
@@ -166,4 +168,54 @@ export function validateHostedModelRef(model: string): string | null {
     return `Model '${model}' is not a chat alias of your plan`;
   }
   return null;
+}
+
+// ── Hosted voice (STT) ──────────────────────────────────────────────────────
+
+/**
+ * The proxy credentials for the voice provider factories, as a value SEPARATE
+ * from cfg.stt/cfg.tts: those sections persist as plaintext JSON rows in the
+ * DB settings store and round-trip through the /api/config routes, so the
+ * per-account key must never be written into them. Null when self-hosted.
+ */
+export function usejarvisVoiceCredentials(config: JarvisConfig): HostedVoiceCredentials | null {
+  if (!hasUsejarvisAi(config)) return null;
+  const block = config.usejarvis_ai!;
+  return { baseUrl: block.base_url!.trim(), apiKey: block.api_key!.trim() };
+}
+
+/** True when a stored user section records an explicit provider choice. */
+function storedProviderChoice(stored: unknown): boolean {
+  return (
+    typeof stored === 'object' && stored !== null && !Array.isArray(stored) &&
+    typeof (stored as { provider?: unknown }).provider === 'string' &&
+    ((stored as { provider: string }).provider.trim() !== '')
+  );
+}
+
+/**
+ * The BINDING view of cfg.stt: hosted installs where the user never chose an
+ * STT provider default to the included Usejarvis AI transcription.
+ *
+ * Same persistence-purity rule as effectiveLlmForBinding: the default is
+ * never assigned back onto config.stt, because that object is persisted
+ * verbatim by every /api/config/stt save (mergeSTTConfig merges the patch
+ * over the IN-MEMORY section) and by the voice-command provider switch — a
+ * mutated fill would be recorded as user intent on the next unrelated save.
+ * Consume this at provider-construction time only.
+ *
+ * "User is silent" is judged by the DB row, not by the in-memory value:
+ * after mergeUserSettingsIntoConfig, config.stt.provider === 'openai' could
+ * be either the DEFAULT_CONFIG value or an explicit dashboard choice — only
+ * the presence of a `provider` in the stored `cfg.stt` row distinguishes the
+ * two. `loadStored` is injectable for tests; the default reads the vault DB
+ * (open in every runtime caller: boot, reload appliers, API routes).
+ */
+export function effectiveSttForBinding(
+  config: JarvisConfig,
+  loadStored: (section: 'stt' | 'tts') => unknown = loadUserSection,
+): STTConfig | undefined {
+  if (!hasUsejarvisAi(config)) return config.stt;
+  if (storedProviderChoice(loadStored('stt'))) return config.stt;
+  return { ...config.stt, provider: 'usejarvis' };
 }

--- a/src/daemon/user-settings.test.ts
+++ b/src/daemon/user-settings.test.ts
@@ -132,6 +132,25 @@ describe('user-settings', () => {
     expect(config.active_role).toBe('villain');
   });
 
+  test('import: a provider-less stt row is stamped with the effective provider', () => {
+    // A config.yaml that had `stt: { openai: {...} }` relied on
+    // DEFAULT_CONFIG for the provider line. The stored row must record that
+    // effective choice explicitly: a provider-less row reads as "user never
+    // chose" downstream, and on a hosted plan that silently re-routes audio
+    // to the platform proxy past the key this import just moved to the
+    // keychain.
+    importLegacyUserSettings({ stt: { openai: { api_key: 'sk-user' } } });
+    const row = loadUserSection('stt') as { provider?: string; openai?: object };
+    expect(row.provider).toBe('openai');
+    expect(row.openai).toBeDefined();
+  });
+
+  test('import: an explicit stt provider in the file is imported unchanged', () => {
+    importLegacyUserSettings({ stt: { provider: 'groq', groq: { api_key: 'gsk-user' } } });
+    const row = loadUserSection('stt') as { provider?: string };
+    expect(row.provider).toBe('groq');
+  });
+
   test('import: an EDITED file value applies over the DB (editor-less sections stay tunable)', () => {
     // Review finding: heartbeat/cron/goals/... have no dashboard editor, so
     // write-once import made the file a lie. A changed file value is intent.

--- a/src/daemon/user-settings.ts
+++ b/src/daemon/user-settings.ts
@@ -163,6 +163,22 @@ function loadImportState(): Record<string, string> {
  *
  * Returns the imported section names (for boot logging).
  */
+/**
+ * For the provider-choice sections (stt/tts): if the imported file value has
+ * sub-blocks but no `provider` line, stamp the DEFAULT_CONFIG provider that
+ * the merge layer would have supplied anyway — so the stored row records the
+ * effective choice instead of a shape that reads as "user never chose".
+ */
+function stampImplicitProvider(section: string, fileValue: unknown): unknown {
+  if (section !== 'stt' && section !== 'tts') return fileValue;
+  if (typeof fileValue !== 'object' || fileValue === null || Array.isArray(fileValue)) return fileValue;
+  const rec = fileValue as Record<string, unknown>;
+  if (typeof rec.provider === 'string' && rec.provider.trim() !== '') return fileValue;
+  const fallback = (DEFAULT_CONFIG[section] as { provider?: string } | undefined)?.provider;
+  if (!fallback) return fileValue;
+  return { ...rec, provider: fallback };
+}
+
 export function importLegacyUserSettings(rawYaml: Record<string, unknown> | null): string[] {
   const imported: string[] = [];
   const state = loadImportState();
@@ -211,7 +227,14 @@ export function importLegacyUserSettings(rawYaml: Record<string, unknown> | null
         console.error(`[UserSettings] Keychain write failed — skipping the ${section} import from config.yaml (will retry on the next boot)`);
         continue;
       }
-      setSetting(settingKey(section), JSON.stringify(stripSectionSecrets(section, fileValue)));
+      // Stamp the provider the file relied on DEFAULT_CONFIG for: a row
+      // holding `{ openai: {...} }` with no `provider` line reads as user
+      // silence downstream (effectiveSttForBinding), and on a hosted plan
+      // silence re-routes audio to the platform proxy — past the key this
+      // very import just moved to the keychain. The file's implicit choice
+      // becomes explicit at the moment it is recorded.
+      const stamped = stampImplicitProvider(section, fileValue);
+      setSetting(settingKey(section), JSON.stringify(stripSectionSecrets(section, stamped)));
       if (hasInlineSecret(section, fileValue)) {
         console.log(`[UserSettings] Imported ${section} credential(s) from config.yaml into the encrypted keychain — the plaintext value can be removed from the file`);
       }

--- a/ui/src/v2/rooms/settings/SettingsRoom.tsx
+++ b/ui/src/v2/rooms/settings/SettingsRoom.tsx
@@ -207,7 +207,7 @@ export function SettingsRoomBody({ mode }: { mode: RoomBodyMode }) {
       }
       case "set_stt_provider": {
         const provider = String(args.provider).toLowerCase();
-        if (!["openai", "groq", "sarvam", "local"].includes(provider)) return false;
+        if (!["openai", "groq", "sarvam", "local", "usejarvis"].includes(provider)) return false;
         setTab("channels");
         (async () => {
           const r = await data.setSTTProvider(provider as any);

--- a/ui/src/v2/rooms/settings/tabs/ChannelsTab.tsx
+++ b/ui/src/v2/rooms/settings/tabs/ChannelsTab.tsx
@@ -308,6 +308,41 @@ export function ChannelsTab({
           </select>
         </div>
 
+        {sttCfg?.provider !== "sarvam" && (
+          <div className="v2-set__field">
+            <label className="v2-set__field-label">Spoken language</label>
+            <select
+              className="v2-set__select"
+              value={sttCfg?.language ?? ""}
+              onChange={async (e) => {
+                const r = await data.setSTTLanguage(e.target.value);
+                onToast(r.message, r.ok ? "ok" : "warn");
+              }}
+            >
+              <option value="">Auto-detect</option>
+              <option value="en">English</option>
+              <option value="it">Italiano</option>
+              <option value="es">Español</option>
+              <option value="fr">Français</option>
+              <option value="de">Deutsch</option>
+              <option value="pt">Português</option>
+              <option value="nl">Nederlands</option>
+              <option value="pl">Polski</option>
+              <option value="tr">Türkçe</option>
+              <option value="ru">Русский</option>
+              <option value="ar">العربية</option>
+              <option value="hi">हिन्दी</option>
+              <option value="ja">日本語</option>
+              <option value="ko">한국어</option>
+              <option value="zh">中文</option>
+            </select>
+            <p className="v2-set__hint">
+              Auto-detect works well; pick a language only if transcripts come
+              out wrong.
+            </p>
+          </div>
+        )}
+
         {(sttCfg?.provider === "openai" ||
           sttCfg?.provider === "groq" ||
           sttCfg?.provider === "sarvam") && (

--- a/ui/src/v2/rooms/settings/tabs/ChannelsTab.tsx
+++ b/ui/src/v2/rooms/settings/tabs/ChannelsTab.tsx
@@ -298,6 +298,9 @@ export function ChannelsTab({
               onToast(r.message, r.ok ? "ok" : "warn");
             }}
           >
+            {sttCfg?.usejarvis_available && (
+              <option value="usejarvis">Usejarvis AI (included)</option>
+            )}
             <option value="openai">OpenAI Whisper</option>
             <option value="groq">Groq Whisper</option>
             <option value="sarvam">Sarvam AI</option>

--- a/ui/src/v2/rooms/settings/useSettingsData.ts
+++ b/ui/src/v2/rooms/settings/useSettingsData.ts
@@ -200,6 +200,8 @@ export interface STTConfig {
   provider: string;
   /** True on hosted installs: the "Usejarvis AI (included)" option applies. */
   usejarvis_available?: boolean;
+  /** ISO-639-1 hint for the Whisper-shaped providers; '' = auto-detect. */
+  language?: string;
   has_openai_key: boolean;
   has_groq_key: boolean;
   has_sarvam_key: boolean;
@@ -761,6 +763,25 @@ export function useSettingsData() {
     [refresh],
   );
 
+  const setSTTLanguage = useCallback(
+    async (language: string): Promise<ActionResult> => {
+      try {
+        // '' = auto-detect; the daemon omits the param from provider requests.
+        const r = await postJson<{ ok: boolean; message: string }>(
+          "/api/config/stt",
+          { language },
+        );
+        await refresh();
+        return r.ok
+          ? { ok: true, message: r.message || "Transcription language saved." }
+          : { ok: false, message: r.message || "Failed to save transcription language." };
+      } catch (err) {
+        return { ok: false, message: err instanceof Error ? err.message : "Failed" };
+      }
+    },
+    [refresh],
+  );
+
   const setSTTProvider = useCallback(
     async (
       provider: STTProvider,
@@ -1038,6 +1059,7 @@ export function useSettingsData() {
     setTelegram,
     setDiscord,
     setSTTProvider,
+    setSTTLanguage,
     setTTS,
     setVoiceConfig,
     setHeartbeatInterval,

--- a/ui/src/v2/rooms/settings/useSettingsData.ts
+++ b/ui/src/v2/rooms/settings/useSettingsData.ts
@@ -115,7 +115,7 @@ export type LLMProvider = LLMProviderKind;
 export const LLM_PROVIDERS = LLM_PROVIDER_KINDS;
 export const LLM_PROVIDER_LABELS = LLM_PROVIDER_KIND_LABELS;
 
-export type STTProvider = "openai" | "groq" | "sarvam" | "local";
+export type STTProvider = "openai" | "groq" | "sarvam" | "local" | "usejarvis";
 export type TTSProvider = "edge" | "elevenlabs" | "sarvam";
 
 /**
@@ -198,6 +198,8 @@ export interface ChannelConfig {
 
 export interface STTConfig {
   provider: string;
+  /** True on hosted installs: the "Usejarvis AI (included)" option applies. */
+  usejarvis_available?: boolean;
   has_openai_key: boolean;
   has_groq_key: boolean;
   has_sarvam_key: boolean;


### PR DESCRIPTION
UsejarvisSTT against the proxy's `/v1/audio/transcriptions`. Also makes the STT language configurable across the Whisper-shaped providers instead of hardcoding `en`, defaulting to `en` so nothing changes until it is set.

Stack: **4/8** — base #355