### PR TITLE
feat(tts): hosted speech

### DIFF
--- a/src/comms/index.ts
+++ b/src/comms/index.ts
@@ -14,6 +14,7 @@ export {
   createSTTProvider,
   createTTSProvider,
   listElevenLabsVoices,
+  sniffAudioFormat,
   splitIntoSentences,
   type STTProvider,
   type TTSProvider,

--- a/src/comms/index.ts
+++ b/src/comms/index.ts
@@ -8,6 +8,7 @@ export {
   GroqWhisperSTT,
   LocalWhisperSTT,
   UsejarvisSTT,
+  UsejarvisTTS,
   EdgeTTSProvider,
   ElevenLabsTTSProvider,
   createSTTProvider,

--- a/src/comms/voice.test.ts
+++ b/src/comms/voice.test.ts
@@ -678,6 +678,29 @@ describe('UsejarvisTTS', () => {
     await expect(tts.synthesize('hi')).rejects.toThrow(/Usejarvis AI TTS error \(429\)/);
   });
 
+  // A 200 that isn't audio is the same class as the STT no-transcript branch:
+  // without this guard the interstitial is returned AS the MP3, nothing
+  // throws, redaction never runs, and /api/tts/preview hands the browser a
+  // file with the per-account key inside it, labelled audio/mpeg.
+  test('rejects a 200 carrying a CDN interstitial instead of returning it as audio', async () => {
+    const key = 'sk-uj-LIFETIMEKEY0000000000';
+    const tts = new UsejarvisTTS('https://llm.usejarvis.host', key);
+    globalThis.fetch = mock(async () => new Response(
+      `<html><body>Access denied. token=${key} for llm.usejarvis.host</body></html>`,
+      { status: 200, headers: { 'Content-Type': 'text/html' } },
+    )) as any;
+    const err = await tts.synthesize('Hello.').then(() => null, (e: Error) => e);
+    expect(err).toBeInstanceOf(Error);
+    expect(err!.message).toContain('non-audio body');
+    expect(err!.message).not.toContain(key);
+  });
+
+  test('accepts real audio whose content-type a proxy stripped (magic-byte sniff)', async () => {
+    const tts = new UsejarvisTTS('https://llm.usejarvis.host', 'sk-uj-not-real');
+    globalThis.fetch = mock(async () => new Response(mp3Bytes, { headers: { 'Content-Type': 'application/octet-stream' } })) as any;
+    expect(Buffer.compare(await tts.synthesize('hi'), Buffer.from(mp3Bytes))).toBe(0);
+  });
+
   test('factory passes a non-Edge cfg voice through; Edge neural names fall back to alloy', async () => {
     const voices: string[] = [];
     globalThis.fetch = mock(async (_url: string, init: any) => {

--- a/src/comms/voice.test.ts
+++ b/src/comms/voice.test.ts
@@ -10,6 +10,7 @@ import {
   UsejarvisTTS,
   EdgeTTSProvider,
   SarvamTTSProvider,
+  sniffAudioFormat,
   splitIntoSentences,
   sniffAudioFormat,
 } from './voice.ts';
@@ -35,7 +36,7 @@ function makeWavBuffer(pcmBytes = 100): Buffer {
   return buf;
 }
 
-/** Build a buffer with an OGG page header (what Telegram voice notes carry). */
+/** Build a minimal OGG-page-prefixed buffer (Telegram voice-note container). */
 function makeOggBuffer(payloadBytes = 64): Buffer {
   const buf = Buffer.alloc(4 + payloadBytes);
   buf.write('OggS', 0, 'ascii');

--- a/src/comms/voice.test.ts
+++ b/src/comms/voice.test.ts
@@ -12,7 +12,6 @@ import {
   SarvamTTSProvider,
   sniffAudioFormat,
   splitIntoSentences,
-  sniffAudioFormat,
 } from './voice.ts';
 import type { STTConfig, TTSConfig } from '../config/types.ts';
 

--- a/src/comms/voice.test.ts
+++ b/src/comms/voice.test.ts
@@ -695,6 +695,30 @@ describe('UsejarvisTTS', () => {
     expect(err!.message).not.toContain(key);
   });
 
+  // Per-CHARACTER billing plus splitIntoSentences returning the whole text as
+  // one "sentence" when it cannot split = an unbounded billable request.
+  test('caps the input so an unsplittable reply cannot bill unbounded', async () => {
+    let sentLength = 0;
+    globalThis.fetch = mock(async (_url: string, init: any) => {
+      sentLength = String(JSON.parse(init.body as string).input).length;
+      return new Response(mp3Bytes);
+    }) as any;
+    const tts = new UsejarvisTTS('https://llm.usejarvis.host', 'sk-uj-not-real');
+    await tts.synthesize('x'.repeat(50_000));
+    expect(sentLength).toBeLessThanOrEqual(4_000);
+    expect(sentLength).toBeGreaterThan(0);
+  });
+
+  test('sends an abort signal so a hung proxy cannot wedge the sentence queue', async () => {
+    let hadSignal = false;
+    globalThis.fetch = mock(async (_url: string, init: any) => {
+      hadSignal = init.signal instanceof AbortSignal;
+      return new Response(mp3Bytes);
+    }) as any;
+    await new UsejarvisTTS('https://llm.usejarvis.host', 'sk-uj-not-real').synthesize('hi');
+    expect(hadSignal).toBe(true);
+  });
+
   test('accepts real audio whose content-type a proxy stripped (magic-byte sniff)', async () => {
     const tts = new UsejarvisTTS('https://llm.usejarvis.host', 'sk-uj-not-real');
     globalThis.fetch = mock(async () => new Response(mp3Bytes, { headers: { 'Content-Type': 'application/octet-stream' } })) as any;

--- a/src/comms/voice.test.ts
+++ b/src/comms/voice.test.ts
@@ -7,6 +7,7 @@ import {
   LocalWhisperSTT,
   SarvamSTT,
   UsejarvisSTT,
+  UsejarvisTTS,
   EdgeTTSProvider,
   SarvamTTSProvider,
   splitIntoSentences,
@@ -185,6 +186,27 @@ describe('createTTSProvider factory', () => {
   test('returns null when provider=sarvam and no key', () => {
     const config: TTSConfig = { enabled: true, provider: 'sarvam' };
     expect(createTTSProvider(config)).toBeNull();
+  });
+
+  test('returns UsejarvisTTS when provider=usejarvis and hosted creds passed', () => {
+    const config: TTSConfig = { enabled: true, provider: 'usejarvis' };
+    const provider = createTTSProvider(config, {
+      baseUrl: 'https://llm.usejarvis.host',
+      apiKey: 'sk-uj-not-real',
+    });
+    expect(provider).toBeInstanceOf(UsejarvisTTS);
+  });
+
+  test('returns null when provider=usejarvis and no hosted creds (self-hosted)', () => {
+    const config: TTSConfig = { enabled: true, provider: 'usejarvis' };
+    expect(createTTSProvider(config)).toBeNull();
+    expect(createTTSProvider(config, null)).toBeNull();
+    expect(createTTSProvider(config, { baseUrl: '', apiKey: 'sk-uj-not-real' })).toBeNull();
+  });
+
+  test('returns null for usejarvis when tts disabled, even with creds', () => {
+    const config: TTSConfig = { enabled: false, provider: 'usejarvis' };
+    expect(createTTSProvider(config, { baseUrl: 'https://llm.usejarvis.host', apiKey: 'k' })).toBeNull();
   });
 });
 
@@ -587,6 +609,87 @@ describe('sniffAudioFormat', () => {
     expect(sniffAudioFormat(Buffer.from('????garbage'))).toEqual({ filename: 'audio.wav', mimeType: 'audio/wav' });
     expect(sniffAudioFormat(Buffer.from([0x00]))).toEqual({ filename: 'audio.wav', mimeType: 'audio/wav' });
     expect(sniffAudioFormat(Buffer.alloc(0))).toEqual({ filename: 'audio.wav', mimeType: 'audio/wav' });
+  });
+});
+
+describe('UsejarvisTTS', () => {
+  const originalFetch = globalThis.fetch;
+  afterEach(() => { globalThis.fetch = originalFetch; });
+
+  const mp3Bytes = new Uint8Array([0x49, 0x44, 0x33, 0x04, 0x00, 0x00]); // ID3v4 header
+
+  test('POSTs JSON to <origin>/v1/audio/speech with bearer, uj-tts and mp3 format', async () => {
+    const tts = new UsejarvisTTS('https://llm.usejarvis.host', 'sk-uj-not-real');
+    let calledUrl = '';
+    let auth = '';
+    let contentType = '';
+    let sentBody: Record<string, unknown> = {};
+
+    globalThis.fetch = mock(async (url: string, init: any) => {
+      calledUrl = url;
+      auth = init.headers['Authorization'];
+      contentType = init.headers['Content-Type'];
+      sentBody = JSON.parse(init.body as string);
+      return new Response(mp3Bytes);
+    }) as any;
+
+    const audio = await tts.synthesize('Hello there.');
+    expect(calledUrl).toBe('https://llm.usejarvis.host/v1/audio/speech');
+    expect(auth).toBe('Bearer sk-uj-not-real');
+    expect(contentType).toBe('application/json');
+    expect(sentBody).toEqual({
+      model: 'uj-tts',
+      input: 'Hello there.',
+      voice: 'alloy', // constructor default
+      response_format: 'mp3',
+    });
+    expect(Buffer.compare(audio, Buffer.from(mp3Bytes))).toBe(0);
+  });
+
+  test('does not double the /v1 prefix when the base already carries it', async () => {
+    const tts = new UsejarvisTTS('https://llm.usejarvis.host/v1', 'sk-uj-not-real');
+    let calledUrl = '';
+    globalThis.fetch = mock(async (url: string) => { calledUrl = url; return new Response(mp3Bytes); }) as any;
+    await tts.synthesize('hi');
+    expect(calledUrl).toBe('https://llm.usejarvis.host/v1/audio/speech');
+  });
+
+  test('synthesizeStream yields the complete MP3 exactly once', async () => {
+    const tts = new UsejarvisTTS('https://llm.usejarvis.host', 'sk-uj-not-real');
+    globalThis.fetch = mock(async () => new Response(mp3Bytes)) as any;
+    const chunks: Buffer[] = [];
+    for await (const chunk of tts.synthesizeStream('Hello.')) chunks.push(chunk);
+    expect(chunks.length).toBe(1);
+    expect(Buffer.compare(chunks[0]!, Buffer.from(mp3Bytes))).toBe(0);
+  });
+
+  test('synthesizeStream yields nothing for empty audio', async () => {
+    const tts = new UsejarvisTTS('https://llm.usejarvis.host', 'sk-uj-not-real');
+    globalThis.fetch = mock(async () => new Response(new Uint8Array(0))) as any;
+    const chunks: Buffer[] = [];
+    for await (const chunk of tts.synthesizeStream('Hello.')) chunks.push(chunk);
+    expect(chunks.length).toBe(0);
+  });
+
+  test('throws with status on HTTP error', async () => {
+    const tts = new UsejarvisTTS('https://llm.usejarvis.host', 'sk-uj-not-real');
+    globalThis.fetch = mock(async () => new Response('budget exceeded', { status: 429 })) as any;
+    await expect(tts.synthesize('hi')).rejects.toThrow(/Usejarvis AI TTS error \(429\)/);
+  });
+
+  test('factory passes a non-Edge cfg voice through; Edge neural names fall back to alloy', async () => {
+    const voices: string[] = [];
+    globalThis.fetch = mock(async (_url: string, init: any) => {
+      voices.push(JSON.parse(init.body as string).voice);
+      return new Response(mp3Bytes);
+    }) as any;
+
+    const hosted = { baseUrl: 'https://llm.usejarvis.host', apiKey: 'sk-uj-not-real' };
+    await createTTSProvider({ enabled: true, provider: 'usejarvis', voice: 'nova' }, hosted)!.synthesize('hi');
+    // The persisted default 'en-US-AriaNeural' is Edge-specific — the
+    // OpenAI-compatible proxy would reject it, so it must not leak through.
+    await createTTSProvider({ enabled: true, provider: 'usejarvis', voice: 'en-US-AriaNeural' }, hosted)!.synthesize('hi');
+    expect(voices).toEqual(['nova', 'alloy']);
   });
 });
 

--- a/src/comms/voice.ts
+++ b/src/comms/voice.ts
@@ -505,6 +505,60 @@ export class ElevenLabsTTSProvider implements TTSProvider {
 }
 
 /**
+ * Hosted "Usejarvis AI" TTS — the platform proxy's OpenAI-compatible
+ * /audio/speech endpoint. `uj-tts` is the stable per-plan alias (resolution
+ * happens at the proxy, like uj-stt and the LLM tiers). Credentials come from
+ * the system-owned `usejarvis_ai` block via the factory's `hosted` argument —
+ * never from cfg.tts.
+ */
+export class UsejarvisTTS implements TTSProvider {
+  private baseUrl: string;
+  private apiKey: string;
+  private voice: string;
+
+  constructor(baseUrl: string, apiKey: string, voice: string = 'alloy') {
+    // Same origin→/v1 normalization as UsejarvisSTT / UsejarvisAIProvider.
+    const trimmed = baseUrl.replace(/\/+$/, '');
+    this.baseUrl = /\/v1$/.test(trimmed) ? trimmed : `${trimmed}/v1`;
+    this.apiKey = apiKey;
+    this.voice = voice;
+  }
+
+  async synthesize(text: string): Promise<Buffer> {
+    const response = await fetch(`${this.baseUrl}/audio/speech`, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${this.apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: 'uj-tts',
+        input: text,
+        voice: this.voice,
+        response_format: 'mp3',
+      }),
+    });
+
+    if (!response.ok) {
+      const err = await response.text();
+      throw new Error(`Usejarvis AI TTS error (${response.status}): ${err}`);
+    }
+
+    const arrayBuffer = await response.arrayBuffer();
+    return Buffer.from(arrayBuffer);
+  }
+
+  async *synthesizeStream(text: string): AsyncIterable<Buffer> {
+    // Same fake-streaming shape as the other providers: one complete MP3 per
+    // sentence, so the browser's decodeAudioData always gets a valid file.
+    const audio = await this.synthesize(text);
+    if (audio.length > 0) {
+      yield audio;
+    }
+  }
+}
+
+/**
  * Sarvam AI TTS Provider — high-quality Indian language voices via Sarvam AI.
  */
 export class SarvamTTSProvider implements TTSProvider {
@@ -587,9 +641,24 @@ export async function listElevenLabsVoices(apiKey: string): Promise<{
 /**
  * Factory: create the right TTS provider from config.
  * Returns null if TTS is disabled.
+ *
+ * `hosted` is the same separate credential channel as createSTTProvider's:
+ * cfg.tts only ever stores the string choice `provider: 'usejarvis'`.
  */
-export function createTTSProvider(config: TTSConfig): TTSProvider | null {
+export function createTTSProvider(
+  config: TTSConfig,
+  hosted?: HostedVoiceCredentials | null,
+): TTSProvider | null {
   if (!config.enabled) return null;
+
+  if (config.provider === 'usejarvis') {
+    if (!hosted?.baseUrl || !hosted?.apiKey) return null;
+    // Reuse a configured voice only when it isn't an Edge neural name:
+    // cfg.tts.voice defaults to 'en-US-AriaNeural' (Edge-specific), which the
+    // OpenAI-compatible proxy would reject — those fall back to 'alloy'.
+    const voice = config.voice && !/Neural$/i.test(config.voice) ? config.voice : undefined;
+    return new UsejarvisTTS(hosted.baseUrl, hosted.apiKey, voice ?? 'alloy');
+  }
 
   if (config.provider === 'elevenlabs') {
     if (!config.elevenlabs?.api_key) return null;

--- a/src/comms/voice.ts
+++ b/src/comms/voice.ts
@@ -541,7 +541,7 @@ export class UsejarvisTTS implements TTSProvider {
 
     if (!response.ok) {
       const err = await response.text();
-      throw new Error(`Usejarvis AI TTS error (${response.status}): ${err}`);
+      throw new Error(`Usejarvis AI TTS error (${response.status}): ${redactSecrets(err)}`);
     }
 
     const arrayBuffer = await response.arrayBuffer();

--- a/src/comms/voice.ts
+++ b/src/comms/voice.ts
@@ -511,6 +511,12 @@ export class ElevenLabsTTSProvider implements TTSProvider {
  * the system-owned `usejarvis_ai` block via the factory's `hosted` argument —
  * never from cfg.tts.
  */
+/** Per-request ceiling for hosted speech. Generous for a spoken sentence,
+ * bounded for a reply that never split. */
+const MAX_TTS_INPUT_CHARS = 4_000;
+/** Hard cap on one synthesis round-trip — see the call site. */
+const TTS_TIMEOUT_MS = 30_000;
+
 /** MP3 frame sniff: an ID3 tag, or an MPEG audio sync word (0xFF Ex). Used to
  * accept a correct response whose content-type header a proxy stripped or
  * rewrote, so the guard rejects interstitials without rejecting real audio. */
@@ -534,6 +540,13 @@ export class UsejarvisTTS implements TTSProvider {
   }
 
   async synthesize(text: string): Promise<Buffer> {
+    // Cap the input. splitIntoSentences returns the WHOLE text as one
+    // "sentence" when it cannot find a boundary (a long bullet list, a URL
+    // dump), and this endpoint is billed per CHARACTER — so an unsplittable
+    // reply would bill in one unbounded request. Truncating costs a clipped
+    // tail; not truncating costs real money on a runaway generation.
+    const input = text.length > MAX_TTS_INPUT_CHARS ? text.slice(0, MAX_TTS_INPUT_CHARS) : text;
+
     const response = await fetch(`${this.baseUrl}/audio/speech`, {
       method: 'POST',
       headers: {
@@ -542,10 +555,14 @@ export class UsejarvisTTS implements TTSProvider {
       },
       body: JSON.stringify({
         model: 'uj-tts',
-        input: text,
+        input,
         voice: this.voice,
         response_format: 'mp3',
       }),
+      // A hung proxy must not wedge the sentence queue: ws-service speaks
+      // sentences in sequence, so one stalled request silences everything
+      // after it with no error and no timeout of its own.
+      signal: AbortSignal.timeout(TTS_TIMEOUT_MS),
     });
 
     if (!response.ok) {

--- a/src/comms/voice.ts
+++ b/src/comms/voice.ts
@@ -550,7 +550,10 @@ export class UsejarvisTTS implements TTSProvider {
 
     if (!response.ok) {
       const err = await response.text();
-      throw new Error(`Usejarvis AI TTS error (${response.status}): ${redactSecrets(err).slice(0, 200)}`);
+      // Shared mapper, same reasoning as the STT branch: /api/tts/preview
+      // returns err.message straight to the settings toast, so budget and
+      // plan failures must read as copy, not as proxy JSON.
+      throw hostedProxyError('Usejarvis AI TTS', response.status, err);
     }
 
     const arrayBuffer = await response.arrayBuffer();

--- a/src/comms/voice.ts
+++ b/src/comms/voice.ts
@@ -511,6 +511,15 @@ export class ElevenLabsTTSProvider implements TTSProvider {
  * the system-owned `usejarvis_ai` block via the factory's `hosted` argument —
  * never from cfg.tts.
  */
+/** MP3 frame sniff: an ID3 tag, or an MPEG audio sync word (0xFF Ex). Used to
+ * accept a correct response whose content-type header a proxy stripped or
+ * rewrote, so the guard rejects interstitials without rejecting real audio. */
+function looksLikeMp3(buf: Buffer): boolean {
+  if (buf.length < 3) return false;
+  if (buf[0] === 0x49 && buf[1] === 0x44 && buf[2] === 0x33) return true; // "ID3"
+  return buf[0] === 0xff && (buf[1]! & 0xe0) === 0xe0;
+}
+
 export class UsejarvisTTS implements TTSProvider {
   private baseUrl: string;
   private apiKey: string;
@@ -541,11 +550,28 @@ export class UsejarvisTTS implements TTSProvider {
 
     if (!response.ok) {
       const err = await response.text();
-      throw new Error(`Usejarvis AI TTS error (${response.status}): ${redactSecrets(err)}`);
+      throw new Error(`Usejarvis AI TTS error (${response.status}): ${redactSecrets(err).slice(0, 200)}`);
     }
 
     const arrayBuffer = await response.arrayBuffer();
-    return Buffer.from(arrayBuffer);
+    const audio = Buffer.from(arrayBuffer);
+
+    // A 200 that isn't audio is the SAME class as UsejarvisSTT's
+    // no-transcript branch: a proxy or CDN interstitial is exactly where an
+    // echoed bearer shows up. Without this check the HTML would be returned
+    // AS the MP3 — nothing throws, so redaction never runs, and the preview
+    // route ships it to the browser labelled audio/mpeg with the key inside.
+    // Empty stays a no-op (callers already treat it as "nothing to speak");
+    // an interstitial always carries bytes, so the guard loses nothing.
+    const contentType = response.headers.get('content-type') ?? '';
+    if (audio.length > 0 && !contentType.toLowerCase().startsWith('audio/') && !looksLikeMp3(audio)) {
+      const body = audio.subarray(0, 2048).toString('utf8');
+      throw new Error(
+        `Usejarvis AI TTS returned a non-audio body (content-type: ${contentType || 'none'}): ` +
+          `${redactSecrets(body).slice(0, 200)}`,
+      );
+    }
+    return audio;
   }
 
   async *synthesizeStream(text: string): AsyncIterable<Buffer> {

--- a/src/comms/voice.ts
+++ b/src/comms/voice.ts
@@ -545,7 +545,16 @@ export class UsejarvisTTS implements TTSProvider {
     // dump), and this endpoint is billed per CHARACTER — so an unsplittable
     // reply would bill in one unbounded request. Truncating costs a clipped
     // tail; not truncating costs real money on a runaway generation.
-    const input = text.length > MAX_TTS_INPUT_CHARS ? text.slice(0, MAX_TTS_INPUT_CHARS) : text;
+    let input = text;
+    if (text.length > MAX_TTS_INPUT_CHARS) {
+      let cut = MAX_TTS_INPUT_CHARS;
+      // Never split a surrogate pair — a lone surrogate is invalid JSON string
+      // content for the proxy.
+      const last = text.charCodeAt(cut - 1);
+      if (last >= 0xd800 && last <= 0xdbff) cut -= 1;
+      input = text.slice(0, cut);
+      console.warn(`[UsejarvisTTS] Input truncated from ${text.length} to ${input.length} chars (per-request cap; the spoken reply will cut off)`);
+    }
 
     const response = await fetch(`${this.baseUrl}/audio/speech`, {
       method: 'POST',

--- a/src/config/README.md
+++ b/src/config/README.md
@@ -75,10 +75,20 @@ onboarding, ... — see `USER_OWNED_SECTIONS` in `types.ts`) persist to the
 vault DB settings store instead:
 
 ```typescript
-import { saveUserSection } from '../daemon/user-settings.ts';
+import { saveUserSection, persistUserPatch } from '../daemon/user-settings.ts';
 
+// Most sections: mutate in memory, then persist the section.
+config.personality = { ...config.personality, humor: 'dry' };
+saveUserSection('personality', config.personality);
+
+// stt/tts are the exception: persist the PATCH, never the merged in-memory
+// section — the in-memory value carries DEFAULT_CONFIG fills (provider
+// 'openai'/'edge'), and saving those records a provider choice the user never
+// made, which defeats the hosted "silent user gets the included voice"
+// default. persistUserPatch merges the patch over the stored row (hydrated
+// with keychain credentials) and saves that.
 config.tts = { ...config.tts, enabled: true };
-saveUserSection('tts', config.tts);
+persistUserPatch('tts', { enabled: true });
 ```
 
 A legacy `config.yaml` that still carries user sections seeds the DB once at

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -171,7 +171,12 @@ export type STTConfig = {
 
 export type TTSConfig = {
   enabled: boolean;
-  provider?: 'edge' | 'elevenlabs' | 'sarvam';  // default: 'edge'
+  /**
+   * Default: 'edge'. `usejarvis` is a pure string choice like the STT one:
+   * the hosted credentials ride the factory's separate `hosted` argument
+   * (never this persisted section).
+   */
+  provider?: 'edge' | 'elevenlabs' | 'sarvam' | 'usejarvis';
   voice?: string;       // e.g. 'en-US-AriaNeural' (edge)
   rate?: string;        // e.g. '+0%', '+10%' (edge)
   volume?: string;      // e.g. '+0%' (edge)

--- a/src/daemon/api-routes.ts
+++ b/src/daemon/api-routes.ts
@@ -12,7 +12,7 @@ import { SecretStorageError } from './section-secrets.ts';
 import type { AgentService } from './agent-service.ts';
 import type { JarvisConfig } from '../config/types.ts';
 import { resolveRealtimeVoice, DEFAULT_BLOCKED_CATEGORIES } from '../config/realtime.ts';
-import { hasUsejarvisAi, effectiveSttForBinding } from './usejarvis-ai.ts';
+import { hasUsejarvisAi, effectiveSttForBinding, effectiveTtsForBinding, usejarvisVoiceCredentials } from './usejarvis-ai.ts';
 import type { EntityType } from '../vault/entities.ts';
 import type { CommitmentPriority, CommitmentStatus } from '../vault/commitments.ts';
 import type { ObservationType } from '../vault/observations.ts';
@@ -1403,7 +1403,8 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
             try {
               if (ctx.config.tts && ctx.wsService) {
                 const { createTTSProvider } = await import('../comms/voice.ts');
-                const provider = await createTTSProvider(ctx.config.tts);
+                const ttsBinding = effectiveTtsForBinding(ctx.config) ?? ctx.config.tts;
+                const provider = createTTSProvider(ttsBinding, usejarvisVoiceCredentials(ctx.config));
                 if (provider) ctx.wsService.setTTSProvider(provider);
               }
             } catch (err) {
@@ -2539,9 +2540,14 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
     '/api/config/tts': {
       GET: () => {
         const tts = ctx.config.tts;
+        // Same shape as GET /api/config/stt: `provider` is the BINDING view
+        // (hosted installs with no recorded choice read 'usejarvis'), the
+        // persisted cfg.tts row stays pure user intent, no key material.
+        const effective = effectiveTtsForBinding(ctx.config);
         return json({
           enabled: tts?.enabled ?? false,
-          provider: tts?.provider ?? 'edge',
+          provider: effective?.provider ?? tts?.provider ?? 'edge',
+          usejarvis_available: hasUsejarvisAi(ctx.config),
           voice: tts?.voice ?? 'en-US-AriaNeural',
           rate: tts?.rate ?? '+0%',
           volume: tts?.volume ?? '+0%',
@@ -2574,7 +2580,12 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
           // Hot-reload TTS provider if wsService available
           if (ctx.wsService && merged) {
             const { createTTSProvider } = await import('../comms/voice.ts');
-            const provider = createTTSProvider(merged);
+            // Bind through the routing view: a hosted user who never chose a
+            // provider must get the included voice, not the DEFAULT_CONFIG
+            // 'edge' fill that `merged` carries. ctx.config.tts is already
+            // the post-save value (assigned above).
+            const ttsBinding = effectiveTtsForBinding(ctx.config) ?? merged;
+            const provider = createTTSProvider(ttsBinding, usejarvisVoiceCredentials(ctx.config));
             if (provider) {
               ctx.wsService.setTTSProvider(provider);
             }
@@ -2694,7 +2705,10 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
             provider?: string; voice?: string; api_key?: string; voice_id?: string; model?: string; text?: string;
           };
           const text = (typeof body.text === 'string' && body.text.trim() ? body.text.trim() : "Hi, I'm Jarvis. This is how I'll sound.").slice(0, 280);
-          const cfg: Record<string, unknown> = { enabled: true, provider: body.provider === 'elevenlabs' ? 'elevenlabs' : 'edge' };
+          const cfg: Record<string, unknown> = {
+            enabled: true,
+            provider: body.provider === 'elevenlabs' || body.provider === 'usejarvis' ? body.provider : 'edge',
+          };
           if (body.provider === 'elevenlabs') {
             if (!body.api_key) return error('ElevenLabs API key required.', 400);
             cfg.elevenlabs = {
@@ -2702,11 +2716,16 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
               voice_id: typeof body.voice_id === 'string' ? body.voice_id : undefined,
               model: typeof body.model === 'string' ? body.model : undefined,
             };
+          } else if (body.provider === 'usejarvis') {
+            // Hosted preview: no key in the body — the factory gets the
+            // system-owned proxy credentials as its separate argument below.
+            if (!hasUsejarvisAi(ctx.config)) return error('Usejarvis AI is not available on this install.', 400);
+            if (typeof body.voice === 'string' && body.voice) cfg.voice = body.voice;
           } else {
             cfg.voice = body.voice || 'en-US-AriaNeural';
           }
           const { createTTSProvider } = await import('../comms/voice.ts');
-          const provider = createTTSProvider(cfg as never);
+          const provider = createTTSProvider(cfg as never, usejarvisVoiceCredentials(ctx.config));
           if (!provider) return error('Could not build a TTS provider from those settings.', 400);
           const audio = await provider.synthesize(text);
           return new Response(new Uint8Array(audio), { headers: { 'Content-Type': 'audio/mpeg', 'Cache-Control': 'no-store' } });

--- a/src/daemon/api-routes.ts
+++ b/src/daemon/api-routes.ts
@@ -2581,6 +2581,22 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
       POST: async (req: Request) => {
         try {
           const body = await req.json() as Record<string, unknown>;
+
+          // Validate the provider before anything persists: an unknown string
+          // (or 'usejarvis' on a self-hosted install, where no hosted
+          // credentials exist to bind it) would be recorded as a choice that
+          // createTTSProvider can never construct — voice silently dead with
+          // an ok:true toast.
+          if (body.provider !== undefined) {
+            const VALID_TTS_PROVIDERS = ['edge', 'elevenlabs', 'sarvam', 'usejarvis'];
+            if (typeof body.provider !== 'string' || !VALID_TTS_PROVIDERS.includes(body.provider)) {
+              return json({ ok: false, error: `Unknown TTS provider: ${String(body.provider)}` }, 400);
+            }
+            if (body.provider === 'usejarvis' && !hasUsejarvisAi(ctx.config)) {
+              return json({ ok: false, error: 'The Usejarvis AI voice is only available on hosted installs; pick edge, elevenlabs or sarvam.' }, 400);
+            }
+          }
+
           const { persistUserPatch } = await import('./user-settings.ts');
           const { mergeTTSConfig } = await import('./config-merge.ts');
 
@@ -2598,8 +2614,16 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
             // the post-save value (assigned above).
             const ttsBinding = effectiveTtsForBinding(ctx.config) ?? merged;
             const provider = createTTSProvider(ttsBinding, usejarvisVoiceCredentials(ctx.config));
-            if (provider) {
-              ctx.wsService.setTTSProvider(provider);
+            // Always publish the result — including null. Leaving the previous
+            // provider live after a save that yields none (disabled, or a
+            // provider missing its key) keeps a stale voice speaking while the
+            // response claims the new config applied.
+            ctx.wsService.setTTSProvider(provider);
+            if (!provider) {
+              const reason = merged.enabled === false
+                ? 'TTS config saved; speech is off.'
+                : 'TTS config saved, but no voice is active yet (the selected provider has no usable credentials).';
+              return json({ ok: true, message: reason });
             }
           }
 

--- a/src/daemon/api-routes.ts
+++ b/src/daemon/api-routes.ts
@@ -1368,7 +1368,7 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
           //    daemon kill (or crash) between them persisted setup HALF-done
           //    — TTS saved but the completion flag lost — and the user was
           //    funneled back into onboarding on the next boot.
-          const { saveUserSection } = await import('./user-settings.ts');
+          const { saveUserSection, persistUserPatch } = await import('./user-settings.ts');
           const { mergeSTTConfig, mergeTTSConfig } = await import('./config-merge.ts');
           // Everything is merged into LOCALS and published to ctx.config only
           // after all three saves succeeded. saveUserSection throws when the
@@ -1390,8 +1390,14 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
           // keychain failure throws out of here, and the flag not being written
           // is what we want — setup did not succeed, so the wizard must run
           // again rather than leave the user with a "done" marker and no key.
-          if (stt) saveUserSection('stt', stt);
-          if (tts) saveUserSection('tts', tts);
+          //
+          // Persist the wizard's PATCHES over the stored rows (not the merged
+          // sections): a declined voice step ({enabled:false} with no
+          // provider) must not stamp the DEFAULT provider into the row, or
+          // every onboarded hosted install would read as "explicitly chose
+          // Edge" and never get the included Usejarvis AI default.
+          if (body.stt) persistUserPatch('stt', body.stt);
+          if (body.tts) persistUserPatch('tts', body.tts);
           saveUserSection('onboarding', onboarding);
           if (stt) ctx.config.stt = stt;
           if (tts) ctx.config.tts = tts;
@@ -2494,7 +2500,7 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
       POST: async (req: Request) => {
         try {
           const body = await req.json() as Record<string, unknown>;
-          const { saveUserSection } = await import('./user-settings.ts');
+          const { persistUserPatch } = await import('./user-settings.ts');
           const { mergeSTTConfig } = await import('./config-merge.ts');
 
           // Validate before anything persists: an unknown provider (or
@@ -2516,11 +2522,16 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
           // settings row, the exact leak the credential split exists to stop.
           delete body.usejarvis;
 
-          // Merged locally, published only once the save succeeded — see the
-          // channels route: a throwing keychain must not leave the live config
-          // holding a key the API reported as rejected.
+          // Merged locally and published only once the save succeeded (a
+          // throwing keychain must not leave the live config holding a key the
+          // API reported as rejected), but what gets PERSISTED is the request
+          // patch, not the merged section: the merge carries DEFAULT_CONFIG
+          // fills, and storing those would stamp a provider choice the user
+          // never made and permanently defeat the hosted-default silence
+          // detection. Appliers run on a scheduled tick, so they observe the
+          // published config below rather than this frame.
           const merged = mergeSTTConfig(ctx.config.stt, body);
-          saveUserSection('stt', merged);
+          persistUserPatch('stt', body);
           ctx.config.stt = merged;
 
           if (!ctx.settingsReload) {
@@ -2570,11 +2581,12 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
       POST: async (req: Request) => {
         try {
           const body = await req.json() as Record<string, unknown>;
-          const { saveUserSection } = await import('./user-settings.ts');
+          const { persistUserPatch } = await import('./user-settings.ts');
           const { mergeTTSConfig } = await import('./config-merge.ts');
 
+          // Same discipline as /api/config/stt POST above.
           const merged = mergeTTSConfig(ctx.config.tts, body);
-          saveUserSection('tts', merged);
+          persistUserPatch('tts', body);
           ctx.config.tts = merged;
 
           // Hot-reload TTS provider if wsService available
@@ -2720,7 +2732,15 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
             // Hosted preview: no key in the body — the factory gets the
             // system-owned proxy credentials as its separate argument below.
             if (!hasUsejarvisAi(ctx.config)) return error('Usejarvis AI is not available on this install.', 400);
-            if (typeof body.voice === 'string' && body.voice) cfg.voice = body.voice;
+            if (typeof body.voice === 'string' && body.voice) {
+              // Reject Edge neural names outright instead of letting the
+              // factory silently preview 'alloy' — the sample the user hears
+              // must be the voice they asked for.
+              if (/Neural$/i.test(body.voice)) {
+                return error(`"${body.voice}" is an Edge TTS voice — Usejarvis AI uses OpenAI-style voices (e.g. alloy).`, 400);
+              }
+              cfg.voice = body.voice;
+            }
           } else {
             cfg.voice = body.voice || 'en-US-AriaNeural';
           }

--- a/src/daemon/api-voice-config.test.ts
+++ b/src/daemon/api-voice-config.test.ts
@@ -80,7 +80,9 @@ describe('voice config routes: persistence stays silence-preserving', () => {
     });
     expect(res.status).toBe(200);
 
-    expect(loadUserSection('stt')).toEqual({ openai: { api_key: 'sk-user' } });
+    // Row is written stripped (credentials split to the keychain) — what this
+    // pins is the absence of a `provider`, not the key round-tripping.
+    expect(loadUserSection('stt')).toEqual({ openai: {} });
     expect(config.stt?.openai?.api_key).toBe('sk-user'); // runtime view
     expect(effectiveSttForBinding(config)?.provider).toBe('usejarvis'); // still silent
   });
@@ -93,7 +95,7 @@ describe('voice config routes: persistence stays silence-preserving', () => {
       groq: { api_key: 'gsk-user' },
     });
 
-    expect(loadUserSection('stt')).toEqual({ provider: 'groq', groq: { api_key: 'gsk-user' } });
+    expect(loadUserSection('stt')).toEqual({ provider: 'groq', groq: {} });
     expect(effectiveSttForBinding(config)?.provider).toBe('groq');
   });
 

--- a/src/daemon/api-voice-config.test.ts
+++ b/src/daemon/api-voice-config.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, test, beforeEach, afterEach } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { createApiRoutes, type ApiContext } from './api-routes.ts';
 import { initDatabase, closeDb } from '../vault/schema.ts';
 import { DEFAULT_CONFIG, type JarvisConfig } from '../config/types.ts';
@@ -52,11 +55,24 @@ function post(handler: Handler, url: string, body: unknown): Response | Promise<
 }
 
 describe('voice config routes: persistence stays silence-preserving', () => {
+  // These routes reach persistSectionSecrets — redirect the keychain to a
+  // throwaway dir so tests never touch the real store (same as user-settings.test.ts).
+  let secretsDir: string;
+  let prevSecretsDir: string | undefined;
+
   beforeEach(() => {
+    prevSecretsDir = process.env.JARVIS_SECRETS_DIR;
+    secretsDir = mkdtempSync(join(tmpdir(), 'jarvis-api-voice-'));
+    process.env.JARVIS_SECRETS_DIR = secretsDir;
     closeDb();
     initDatabase(':memory:');
   });
-  afterEach(() => { closeDb(); });
+  afterEach(() => {
+    closeDb();
+    if (prevSecretsDir === undefined) delete process.env.JARVIS_SECRETS_DIR;
+    else process.env.JARVIS_SECRETS_DIR = prevSecretsDir;
+    rmSync(secretsDir, { recursive: true, force: true });
+  });
 
   test('POST /api/config/tts {enabled:true} leaves the stored row provider-free (hosted default survives)', async () => {
     const config = hostedConfig();

--- a/src/daemon/api-voice-config.test.ts
+++ b/src/daemon/api-voice-config.test.ts
@@ -100,7 +100,10 @@ describe('voice config routes: persistence stays silence-preserving', () => {
     // pins is the absence of a `provider`, not the key round-tripping.
     expect(loadUserSection('stt')).toEqual({ openai: {} });
     expect(config.stt?.openai?.api_key).toBe('sk-user'); // runtime view
-    expect(effectiveSttForBinding(config)?.provider).toBe('usejarvis'); // still silent
+    // A row carrying a provider sub-block IS intent (storedProviderChoice):
+    // the user who pasted an OpenAI key gets their own provider, not the
+    // hosted default silently re-routing their audio past it.
+    expect(effectiveSttForBinding(config)?.provider).toBe('openai');
   });
 
   test('POST /api/config/stt with an explicit provider records intent and wins over the default', async () => {

--- a/src/daemon/api-voice-config.test.ts
+++ b/src/daemon/api-voice-config.test.ts
@@ -143,6 +143,34 @@ describe('voice config routes: persistence stays silence-preserving', () => {
     expect(effectiveTtsForBinding(config)?.provider).toBe('edge');
   });
 
+  test('POST /api/config/tts rejects provider usejarvis on a self-hosted install', async () => {
+    const config = structuredClone(DEFAULT_CONFIG); // no usejarvis_ai block
+    const routes = createApiRoutes(makeCtx(config));
+    const res = await post(getHandler(routes, '/api/config/tts', 'POST'), '/api/config/tts', { provider: 'usejarvis' }) as Response;
+    expect(res.status).toBe(400);
+    expect(loadUserSection('tts')).toBeUndefined(); // nothing persisted
+  });
+
+  test('POST /api/config/tts rejects an unknown provider string', async () => {
+    const config = hostedConfig();
+    const routes = createApiRoutes(makeCtx(config));
+    const res = await post(getHandler(routes, '/api/config/tts', 'POST'), '/api/config/tts', { provider: 'espeak' }) as Response;
+    expect(res.status).toBe(400);
+  });
+
+  test('POST /api/config/tts that yields no provider clears the live one instead of leaving it speaking', async () => {
+    const config = hostedConfig();
+    const setCalls: unknown[] = [];
+    const ctx = makeCtx(config);
+    (ctx as unknown as Record<string, unknown>).wsService = {
+      setTTSProvider: (p: unknown) => { setCalls.push(p); },
+    };
+    const routes = createApiRoutes(ctx);
+    const res = await post(getHandler(routes, '/api/config/tts', 'POST'), '/api/config/tts', { enabled: false }) as Response;
+    expect(res.status).toBe(200);
+    expect(setCalls).toEqual([null]); // published the null, not skipped it
+  });
+
   test('GET /api/config/tts reports the binding-view provider and availability, no key material', async () => {
     const config = hostedConfig();
     const routes = createApiRoutes(makeCtx(config));

--- a/src/daemon/api-voice-config.test.ts
+++ b/src/daemon/api-voice-config.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, test, beforeEach, afterEach } from 'bun:test';
+import { createApiRoutes, type ApiContext } from './api-routes.ts';
+import { initDatabase, closeDb } from '../vault/schema.ts';
+import { DEFAULT_CONFIG, type JarvisConfig } from '../config/types.ts';
+import { loadUserSection } from './user-settings.ts';
+import { effectiveSttForBinding, effectiveTtsForBinding } from './usejarvis-ai.ts';
+
+/**
+ * Route-level regressions for the voice-config persistence discipline.
+ *
+ * The hosted "Usejarvis AI" STT/TTS defaults key off SILENCE: a stored
+ * cfg.stt / cfg.tts row without a `provider` field. These routes used to
+ * persist the merged in-memory section (which carries DEFAULT_CONFIG fills
+ * like provider 'edge'), so a bare "Enable TTS" toggle or the onboarding
+ * "No voice" answer stamped a provider choice the user never made and
+ * permanently defeated the default. Every save path must instead persist the
+ * request PATCH over the stored row (persistUserPatch).
+ */
+
+type Handler = (req: Request) => Response | Promise<Response>;
+type MethodHandlers = { GET?: Handler; POST?: Handler };
+
+function getHandler(routes: Record<string, unknown>, path: string, method: 'GET' | 'POST'): Handler {
+  const route = routes[path] as MethodHandlers | undefined;
+  if (!route) throw new Error(`Route ${path} not registered`);
+  const handler = route[method];
+  if (!handler) throw new Error(`Method ${method} not registered for ${path}`);
+  return handler;
+}
+
+function hostedConfig(): JarvisConfig {
+  const config = structuredClone(DEFAULT_CONFIG);
+  config.usejarvis_ai = { base_url: 'https://llm.usejarvis.host', api_key: 'sk-uj-abc123' };
+  return config;
+}
+
+function makeCtx(config: JarvisConfig): ApiContext {
+  return {
+    daemonStartedAt: Date.now(),
+    healthMonitor: {} as ApiContext['healthMonitor'],
+    config,
+    agentService: {} as ApiContext['agentService'],
+  } as ApiContext;
+}
+
+function post(handler: Handler, url: string, body: unknown): Response | Promise<Response> {
+  return handler(new Request(`http://x${url}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  }));
+}
+
+describe('voice config routes: persistence stays silence-preserving', () => {
+  beforeEach(() => {
+    closeDb();
+    initDatabase(':memory:');
+  });
+  afterEach(() => { closeDb(); });
+
+  test('POST /api/config/tts {enabled:true} leaves the stored row provider-free (hosted default survives)', async () => {
+    const config = hostedConfig();
+    const routes = createApiRoutes(makeCtx(config));
+    const res = await post(getHandler(routes, '/api/config/tts', 'POST'), '/api/config/tts', { enabled: true });
+    expect(res.status).toBe(200);
+
+    // The row records exactly what was asked — no DEFAULT provider stamp.
+    expect(loadUserSection('tts')).toEqual({ enabled: true });
+    // Runtime view updated...
+    expect(config.tts?.enabled).toBe(true);
+    // ...and the hosted default still fires because the user is still silent.
+    expect(effectiveTtsForBinding(config)?.provider).toBe('usejarvis');
+  });
+
+  test('POST /api/config/stt with a key-only patch leaves the stored row provider-free', async () => {
+    const config = hostedConfig();
+    const routes = createApiRoutes(makeCtx(config));
+    const res = await post(getHandler(routes, '/api/config/stt', 'POST'), '/api/config/stt', {
+      openai: { api_key: 'sk-user' },
+    });
+    expect(res.status).toBe(200);
+
+    expect(loadUserSection('stt')).toEqual({ openai: { api_key: 'sk-user' } });
+    expect(config.stt?.openai?.api_key).toBe('sk-user'); // runtime view
+    expect(effectiveSttForBinding(config)?.provider).toBe('usejarvis'); // still silent
+  });
+
+  test('POST /api/config/stt with an explicit provider records intent and wins over the default', async () => {
+    const config = hostedConfig();
+    const routes = createApiRoutes(makeCtx(config));
+    await post(getHandler(routes, '/api/config/stt', 'POST'), '/api/config/stt', {
+      provider: 'groq',
+      groq: { api_key: 'gsk-user' },
+    });
+
+    expect(loadUserSection('stt')).toEqual({ provider: 'groq', groq: { api_key: 'gsk-user' } });
+    expect(effectiveSttForBinding(config)?.provider).toBe('groq');
+  });
+
+  test("onboarding 'No voice' ({enabled:false}, no provider) does not mark the user as having chosen", async () => {
+    const config = hostedConfig();
+    const routes = createApiRoutes(makeCtx(config));
+    const res = await post(getHandler(routes, '/api/onboarding/setup', 'POST'), '/api/onboarding/setup', {
+      tts: { enabled: false },
+    });
+    expect(res.status).toBe(200);
+
+    expect(loadUserSection('tts')).toEqual({ enabled: false });
+    const onboarding = loadUserSection('onboarding') as { setup_completed_at?: number };
+    expect(typeof onboarding?.setup_completed_at).toBe('number');
+    // When TTS is enabled later, the included hosted voice is the default.
+    expect(effectiveTtsForBinding(config)?.provider).toBe('usejarvis');
+  });
+
+  test('onboarding with a genuine provider choice persists it', async () => {
+    const config = hostedConfig();
+    const routes = createApiRoutes(makeCtx(config));
+    await post(getHandler(routes, '/api/onboarding/setup', 'POST'), '/api/onboarding/setup', {
+      tts: { enabled: true, provider: 'edge', voice: 'en-GB-SoniaNeural', rate: '+0%' },
+    });
+
+    expect(loadUserSection('tts')).toEqual({
+      enabled: true, provider: 'edge', voice: 'en-GB-SoniaNeural', rate: '+0%',
+    });
+    expect(effectiveTtsForBinding(config)?.provider).toBe('edge');
+  });
+
+  test('GET /api/config/tts reports the binding-view provider and availability, no key material', async () => {
+    const config = hostedConfig();
+    const routes = createApiRoutes(makeCtx(config));
+    const res = await getHandler(routes, '/api/config/tts', 'GET')(new Request('http://x/api/config/tts'));
+    const body = await (res as Response).json() as Record<string, unknown>;
+    expect(body.provider).toBe('usejarvis');
+    expect(body.usejarvis_available).toBe(true);
+    expect(JSON.stringify(body)).not.toContain('sk-uj-abc123');
+  });
+});

--- a/src/daemon/config-merge.ts
+++ b/src/daemon/config-merge.ts
@@ -104,11 +104,15 @@ function mergeCloudSubBlock(
   existing: AnyRec | undefined,
   incoming: AnyRec,
 ): AnyRec {
-  return {
-    ...existing,
-    ...incoming,
-    api_key: (incoming.api_key as string) || (existing?.api_key as string) || '',
-  };
+  const merged: AnyRec = { ...existing, ...incoming };
+  const key = (incoming.api_key as string) || (existing?.api_key as string) || '';
+  // Never materialize an explicit '' — persistSectionSecrets reads an empty
+  // credential as "delete the stored key", so a key-less merge writing '' into
+  // a touched sub-block would erase a keychain entry the caller never meant
+  // to clear.
+  if (key) merged.api_key = key;
+  else delete merged.api_key;
+  return merged;
 }
 
 /**

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -1536,23 +1536,17 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
       // hook then runs the stt/tts appliers (pebble + dashboard providers),
       // so the next response uses the new setting without a daemon restart.
       // Both appliers persist BEFORE mutating jarvisConfig and report failure
-      // instead of throwing: saveUserSection throws when the keychain refuses a
-      // credential, and an exception here would abort the whole response cycle
-      // — the user would get silence instead of an answer.
+      // instead of throwing: persistUserPatch throws when the keychain refuses
+      // a credential, and an exception here would abort the whole response
+      // cycle — the user would get silence instead of an answer.
       const applyTTSEnabled = async (enabled: boolean): Promise<boolean> => {
-        const { saveUserSection, loadUserSection } = await import('./user-settings.ts');
-        // Persist `enabled` over the STORED row, not the merged in-memory
-        // section: the boot merge layered DEFAULT_CONFIG.tts (provider
-        // 'edge', voice, rate) over the row, and persisting those defaults
-        // here would record a provider choice the user never made — which
-        // would pin hosted installs to Edge instead of the included
-        // Usejarvis AI voice (see effectiveTtsForBinding).
-        const storedTts = loadUserSection('tts');
-        const ttsRow = (typeof storedTts === 'object' && storedTts !== null && !Array.isArray(storedTts))
-          ? { ...(storedTts as Record<string, unknown>), enabled }
-          : { enabled };
+        const { persistUserPatch } = await import('./user-settings.ts');
+        // Patch-over-STORED-row (see persistUserPatch): persisting the merged
+        // in-memory section here would record the DEFAULT provider 'edge' as
+        // a choice the user never made, pinning hosted installs to Edge
+        // instead of the included Usejarvis AI voice.
         try {
-          saveUserSection('tts', ttsRow as typeof jarvisConfig.tts);
+          persistUserPatch('tts', { enabled });
         } catch (err) {
           console.error('[ambient-ui] Could not save the TTS setting:', err);
           return false;
@@ -1567,25 +1561,31 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
         return true;
       };
 
-      const applySTTProvider = async (provider: 'openai' | 'groq' | 'sarvam' | 'local'): Promise<boolean> => {
-        const { saveUserSection } = await import('./user-settings.ts');
+      const applySTTProvider = async (provider: 'openai' | 'groq' | 'sarvam' | 'local' | 'usejarvis'): Promise<boolean> => {
+        const { persistUserPatch } = await import('./user-settings.ts');
+        const { hasUsejarvisAi } = await import('./usejarvis-ai.ts');
         if (!jarvisConfig.stt) jarvisConfig.stt = { provider };
-        // Refuse the switch if the target provider has no API key
-        // configured — we don't want to silently break STT.
+        // Refuse the switch if the target provider has no credentials
+        // configured — we don't want to silently break STT. The hosted
+        // 'usejarvis' choice is gated on the system usejarvis_ai block
+        // (its key never lives in cfg.stt).
         const hasKey = (() => {
+          if (provider === 'usejarvis') return hasUsejarvisAi(jarvisConfig);
           if (provider === 'local') return !!jarvisConfig.stt!.local?.endpoint;
           const sub = (jarvisConfig.stt as unknown as Record<string, { api_key?: string } | undefined>)[provider];
           return !!sub?.api_key;
         })();
         if (!hasKey) return false;
-        const next = { ...jarvisConfig.stt, provider };
+        // Patch-over-STORED-row: the provider IS explicit intent here, but
+        // the rest of the merged in-memory section must not ride along.
         try {
-          saveUserSection('stt', next);
+          persistUserPatch('stt', { provider });
         } catch (err) {
           console.error('[ambient-ui] Could not save the STT provider:', err);
           return false;
         }
-        jarvisConfig.stt = next;
+        if (!jarvisConfig.stt) jarvisConfig.stt = { provider };
+        else jarvisConfig.stt.provider = provider;
         // Deterministic swap: the next transcription must already use the
         // new provider when we confirm the switch to the user.
         await settingsReload?.applyNow('stt');
@@ -1789,14 +1789,19 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
 
         // STT provider switch.
         const sttMatch =
-          /\b(switch|change)\s+(?:the\s+)?(stt|speech[- ]to[- ]text|transcription|speech recognition|listening)\s+(?:to|provider to)\s+(openai|whisper|groq|sarvam|local)\b/.exec(t) ||
-          /\buse\s+(openai|whisper|groq|sarvam|local)\s+(?:for\s+(?:stt|speech[- ]to[- ]text|transcription|speech recognition|listening|hearing))\b/.exec(t);
+          /\b(switch|change)\s+(?:the\s+)?(stt|speech[- ]to[- ]text|transcription|speech recognition|listening)\s+(?:to|provider to)\s+(openai|whisper|groq|sarvam|local|usejarvis|use jarvis|jarvis)\b/.exec(t) ||
+          /\buse\s+(openai|whisper|groq|sarvam|local|usejarvis|use jarvis|jarvis)\s+(?:for\s+(?:stt|speech[- ]to[- ]text|transcription|speech recognition|listening|hearing))\b/.exec(t);
         if (sttMatch) {
-          let target = (sttMatch[2] === 'whisper' ? 'openai' : sttMatch[2]) as 'openai' | 'groq' | 'sarvam' | 'local';
+          // 'whisper' → openai; 'jarvis' / 'use jarvis' (how STT typically
+          // transcribes the brand name) → the hosted usejarvis provider.
+          type SttTarget = 'openai' | 'groq' | 'sarvam' | 'local' | 'usejarvis';
+          const canonical = (name: string): SttTarget =>
+            (name === 'whisper' ? 'openai' : name === 'use jarvis' || name === 'jarvis' ? 'usejarvis' : name) as SttTarget;
+          let target = canonical(sttMatch[2]!);
           // The first capture group depends on which alternative matched.
           const candidate = (sttMatch[3] || sttMatch[1]) as string;
-          if (candidate && /^(openai|whisper|groq|sarvam|local)$/.test(candidate)) {
-            target = (candidate === 'whisper' ? 'openai' : candidate) as typeof target;
+          if (candidate && /^(openai|whisper|groq|sarvam|local|usejarvis|use jarvis|jarvis)$/.test(candidate)) {
+            target = canonical(candidate);
           }
           const ok = await applySTTProvider(target);
           await speakConfirmation(

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -894,9 +894,13 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
       if (jarvisConfig.tts?.enabled) {
         try {
           const { createTTSProvider } = await import('../comms/voice.ts');
-          pebbleTTS = createTTSProvider(jarvisConfig.tts);
+          const { effectiveTtsForBinding, usejarvisVoiceCredentials } = await import('./usejarvis-ai.ts');
+          const ttsBinding = effectiveTtsForBinding(jarvisConfig);
+          pebbleTTS = ttsBinding
+            ? createTTSProvider(ttsBinding, usejarvisVoiceCredentials(jarvisConfig))
+            : null;
           if (pebbleTTS) {
-            console.log(`[ambient-ui] TTS provider for pebble: ${jarvisConfig.tts.provider ?? 'edge-tts'}`);
+            console.log(`[ambient-ui] TTS provider for pebble: ${ttsBinding?.provider ?? 'edge-tts'}`);
           }
         } catch (err) {
           console.warn('[ambient-ui] failed to init TTS provider:', err);
@@ -918,7 +922,9 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
         pebbleTTS = null;
         if (cfg.tts?.enabled) {
           const { createTTSProvider } = await import('../comms/voice.ts');
-          pebbleTTS = createTTSProvider(cfg.tts);
+          const { effectiveTtsForBinding, usejarvisVoiceCredentials } = await import('./usejarvis-ai.ts');
+          const ttsBinding = effectiveTtsForBinding(cfg);
+          pebbleTTS = ttsBinding ? createTTSProvider(ttsBinding, usejarvisVoiceCredentials(cfg)) : null;
         }
         console.log(`[ambient-ui] TTS provider ${pebbleTTS ? 'rebuilt' : 'cleared'} (settings reload)`);
       });
@@ -933,6 +939,7 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
             return 'audio/wav';
           case 'elevenlabs':
           case 'edge':
+          case 'usejarvis': // proxy /audio/speech is asked for response_format: 'mp3'
           default:
             return 'audio/mp3';
         }
@@ -1533,17 +1540,25 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
       // credential, and an exception here would abort the whole response cycle
       // — the user would get silence instead of an answer.
       const applyTTSEnabled = async (enabled: boolean): Promise<boolean> => {
-        const { saveUserSection } = await import('./user-settings.ts');
-        const next = jarvisConfig.tts
-          ? { ...jarvisConfig.tts, enabled }
-          : { enabled, provider: 'edge' as const };
+        const { saveUserSection, loadUserSection } = await import('./user-settings.ts');
+        // Persist `enabled` over the STORED row, not the merged in-memory
+        // section: the boot merge layered DEFAULT_CONFIG.tts (provider
+        // 'edge', voice, rate) over the row, and persisting those defaults
+        // here would record a provider choice the user never made — which
+        // would pin hosted installs to Edge instead of the included
+        // Usejarvis AI voice (see effectiveTtsForBinding).
+        const storedTts = loadUserSection('tts');
+        const ttsRow = (typeof storedTts === 'object' && storedTts !== null && !Array.isArray(storedTts))
+          ? { ...(storedTts as Record<string, unknown>), enabled }
+          : { enabled };
         try {
-          saveUserSection('tts', next);
+          saveUserSection('tts', ttsRow as typeof jarvisConfig.tts);
         } catch (err) {
           console.error('[ambient-ui] Could not save the TTS setting:', err);
           return false;
         }
-        jarvisConfig.tts = next;
+        if (!jarvisConfig.tts) jarvisConfig.tts = { enabled };
+        else jarvisConfig.tts.enabled = enabled;
         // Await the applier (vs the save hook's scheduled run) so pebbleTTS
         // is already rebuilt when the confirmation reply is spoken — "turn
         // on text to speech" must be audible in the SAME response cycle.
@@ -3587,10 +3602,14 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
     // 8c. Wire TTS provider if configured
     if (jarvisConfig.tts?.enabled) {
       const { createTTSProvider } = await import('../comms/voice.ts');
-      const ttsProvider = createTTSProvider(jarvisConfig.tts);
+      const { effectiveTtsForBinding, usejarvisVoiceCredentials } = await import('./usejarvis-ai.ts');
+      const ttsBinding = effectiveTtsForBinding(jarvisConfig);
+      const ttsProvider = ttsBinding
+        ? createTTSProvider(ttsBinding, usejarvisVoiceCredentials(jarvisConfig))
+        : null;
       if (ttsProvider) {
         wsService.setTTSProvider(ttsProvider);
-        console.log(`[Daemon] TTS enabled: ${jarvisConfig.tts.voice ?? 'en-US-AriaNeural'}`);
+        console.log(`[Daemon] TTS enabled: ${ttsBinding?.provider ?? 'edge'} (${jarvisConfig.tts.voice ?? 'en-US-AriaNeural'})`);
       }
     }
 
@@ -3692,7 +3711,9 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
     // provider on disable.
     settingsReload.registerApplier('tts', async (cfg) => {
       const { createTTSProvider } = await import('../comms/voice.ts');
-      wsService.setTTSProvider(cfg.tts?.enabled ? createTTSProvider(cfg.tts) : null);
+      const { effectiveTtsForBinding, usejarvisVoiceCredentials } = await import('./usejarvis-ai.ts');
+      const ttsBinding = cfg.tts?.enabled ? effectiveTtsForBinding(cfg) : undefined;
+      wsService.setTTSProvider(ttsBinding ? createTTSProvider(ttsBinding, usejarvisVoiceCredentials(cfg)) : null);
     });
 
     // google — refresh the auth (disconnect unlinks the tokens file; the

--- a/src/daemon/usejarvis-ai.test.ts
+++ b/src/daemon/usejarvis-ai.test.ts
@@ -10,6 +10,7 @@ import {
   applyUsejarvisAi,
   effectiveLlmForBinding,
   effectiveSttForBinding,
+  effectiveTtsForBinding,
   hasUsejarvisAi,
   usejarvisVoiceCredentials,
   USEJARVIS_PROVIDER_NAME,
@@ -363,5 +364,55 @@ describe('effectiveSttForBinding (hosted STT default, persistence-pure)', () => 
     const view = effectiveSttForBinding(config, noRow)!;
     expect(JSON.stringify(view)).not.toContain('sk-uj-abc123');
     expect(view).toEqual({ ...config.stt!, provider: 'usejarvis' });
+  });
+});
+
+describe('effectiveTtsForBinding (hosted TTS default, explicit Edge respected)', () => {
+  const noRow = () => undefined;
+
+  test('self-hosted: returns cfg.tts untouched (same reference), DB never read', () => {
+    const config = base();
+    let reads = 0;
+    const spy = () => { reads += 1; return undefined; };
+    expect(effectiveTtsForBinding(config, spy)).toBe(config.tts);
+    expect(reads).toBe(0);
+  });
+
+  test('hosted + no stored tts row: binding view says usejarvis, enabled and config untouched', () => {
+    const config = hosted();
+    const view = effectiveTtsForBinding(config, noRow);
+    expect(view?.provider).toBe('usejarvis');
+    // The hosted default never switches speech ON — it only picks who
+    // speaks once the user enables TTS.
+    expect(view?.enabled).toBe(false);
+    // Persistence purity: the in-memory section still carries the stock
+    // default, so a later save records no choice the user never made.
+    expect(config.tts?.provider).toBe('edge');
+  });
+
+  test("hosted + stored row with provider 'edge': the EXPLICIT Edge choice wins", () => {
+    // The in-memory 'edge' alone is ambiguous (it is also DEFAULT_CONFIG's
+    // value) — the stored row's provider field is what makes it intent.
+    const config = hosted();
+    config.tts = { enabled: true, provider: 'edge', voice: 'en-GB-SoniaNeural' };
+    const view = effectiveTtsForBinding(config, (section) =>
+      section === 'tts' ? { enabled: true, provider: 'edge', voice: 'en-GB-SoniaNeural' } : undefined);
+    expect(view).toBe(config.tts); // same reference, untouched
+    expect(view?.provider).toBe('edge');
+  });
+
+  test('hosted + stored row WITHOUT a provider field (voice-command enable): still silent', () => {
+    const config = hosted();
+    config.tts = { ...config.tts!, enabled: true };
+    const view = effectiveTtsForBinding(config, () => ({ enabled: true }));
+    expect(view?.provider).toBe('usejarvis');
+    expect(view?.enabled).toBe(true);
+  });
+
+  test('the view never carries credentials', () => {
+    const config = hosted();
+    const view = effectiveTtsForBinding(config, noRow)!;
+    expect(JSON.stringify(view)).not.toContain('sk-uj-abc123');
+    expect(view).toEqual({ ...config.tts!, provider: 'usejarvis' });
   });
 });

--- a/src/daemon/usejarvis-ai.ts
+++ b/src/daemon/usejarvis-ai.ts
@@ -1,4 +1,4 @@
-import type { JarvisConfig, LLMConfig, STTConfig } from '../config/types.ts';
+import type { JarvisConfig, LLMConfig, STTConfig, TTSConfig } from '../config/types.ts';
 import type { HostedVoiceCredentials } from '../comms/voice.ts';
 import { loadUserSection } from './user-settings.ts';
 
@@ -170,7 +170,7 @@ export function validateHostedModelRef(model: string): string | null {
   return null;
 }
 
-// ── Hosted voice (STT) ──────────────────────────────────────────────────────
+// ── Hosted voice (STT + TTS) ────────────────────────────────────────────────
 
 /**
  * The proxy credentials for the voice provider factories, as a value SEPARATE
@@ -231,4 +231,23 @@ export function effectiveSttForBinding(
   if (!hasUsejarvisAi(config)) return config.stt;
   if (storedProviderChoice(loadStored('stt'))) return config.stt;
   return { ...config.stt, provider: 'usejarvis' };
+}
+
+/**
+ * The BINDING view of cfg.tts, same rules as effectiveSttForBinding. The one
+ * extra wrinkle: 'edge' is DEFAULT_CONFIG's provider value, so the in-memory
+ * section reading 'edge' cannot distinguish "explicitly chose Edge" from
+ * "never chose" — only a `provider` recorded in the stored `cfg.tts` DB row
+ * counts as choice (any dashboard TTS save writes one, so an explicit Edge
+ * selection sticks). `enabled` is passed through untouched — the hosted
+ * default never switches speech on, it only picks who speaks once the user
+ * turns it on.
+ */
+export function effectiveTtsForBinding(
+  config: JarvisConfig,
+  loadStored: (section: 'stt' | 'tts') => unknown = loadUserSection,
+): TTSConfig | undefined {
+  if (!hasUsejarvisAi(config)) return config.tts;
+  if (storedProviderChoice(loadStored('tts'))) return config.tts;
+  return { ...(config.tts ?? { enabled: false }), provider: 'usejarvis' };
 }

--- a/src/daemon/user-settings.test.ts
+++ b/src/daemon/user-settings.test.ts
@@ -255,17 +255,21 @@ describe('user-settings', () => {
     expect(loadUserSection('tts')).toEqual({ enabled: true });
 
     persistUserPatch('stt', { openai: { api_key: 'sk-user' } });
-    expect(loadUserSection('stt')).toEqual({ openai: { api_key: 'sk-user' } });
+    // The row is written STRIPPED — the credential is split out to the
+    // encrypted keychain on the way in — so what matters here is that no
+    // `provider` appeared, not that the key round-trips.
+    expect(loadUserSection('stt')).toEqual({ openai: {} });
   });
 
   test('persistUserPatch: merges over the STORED row, not the in-memory merged section', () => {
     saveUserSection('tts', { enabled: false, elevenlabs: { api_key: 'el-key' } });
-    // Patch omitting the key (GET redacts it) keeps the stored one; the
-    // DEFAULT_CONFIG fills (provider/voice/rate) never appear in the row.
+    // The point is the MERGE BASE: non-key fields of the stored row survive a
+    // partial patch, and the DEFAULT_CONFIG fills (provider/voice/rate) never
+    // appear. Credentials live in the keychain, so the row itself is stripped.
     persistUserPatch('tts', { enabled: true, elevenlabs: { voice_id: 'v-2' } });
     expect(loadUserSection('tts')).toEqual({
       enabled: true,
-      elevenlabs: { api_key: 'el-key', voice_id: 'v-2' },
+      elevenlabs: { voice_id: 'v-2' },
     });
   });
 

--- a/src/daemon/user-settings.test.ts
+++ b/src/daemon/user-settings.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { initDatabase, closeDb } from '../vault/schema.ts';
 import { getSetting, setSetting } from '../vault/settings.ts';
+import { getSecret } from '../vault/keychain.ts';
 import { loadConfig } from '../config/loader.ts';
 import { DEFAULT_CONFIG, type JarvisConfig } from '../config/types.ts';
 import {
@@ -287,6 +288,45 @@ describe('user-settings', () => {
     persistUserPatch('stt', { provider: 'groq' });
     persistUserPatch('tts', { enabled: true });
     expect(events).toEqual(['stt', 'tts']);
+  });
+
+  // ── keychain survival: the stored row is STRIPPED, so the merge base must be
+  // hydrated with the stored credentials before the save re-runs the secret
+  // split — otherwise every patch deletes the keys it does not carry. ──────────
+
+  test('persistUserPatch: keychain key survives an {enabled}-only patch', () => {
+    saveUserSection('tts', { enabled: true, provider: 'elevenlabs', elevenlabs: { api_key: 'el-secret', voice_id: 'v1' } });
+    expect(getSecret('tts.elevenlabs.api_key')).toBe('el-secret');
+
+    persistUserPatch('tts', { enabled: false });
+
+    expect(getSecret('tts.elevenlabs.api_key')).toBe('el-secret');
+    expect(loadUserSection('tts')).toEqual({
+      enabled: false, provider: 'elevenlabs', elevenlabs: { voice_id: 'v1' },
+    });
+  });
+
+  test('persistUserPatch: switching STT provider keeps BOTH stored keys', () => {
+    saveUserSection('stt', {
+      provider: 'openai',
+      openai: { api_key: 'sk-openai-secret' },
+      groq: { api_key: 'gsk-groq-secret' },
+    });
+
+    persistUserPatch('stt', { provider: 'groq' });
+
+    expect(getSecret('stt.openai.api_key')).toBe('sk-openai-secret');
+    expect(getSecret('stt.groq.api_key')).toBe('gsk-groq-secret');
+    expect(loadUserSection('stt')).toEqual({ provider: 'groq', openai: {}, groq: {} });
+  });
+
+  test('persistUserPatch: a patch touching one sub-block does not delete a sibling key', () => {
+    saveUserSection('stt', { provider: 'openai', openai: { api_key: 'sk-openai-secret' } });
+
+    persistUserPatch('stt', { groq: { api_key: 'gsk-new' } });
+
+    expect(getSecret('stt.openai.api_key')).toBe('sk-openai-secret');
+    expect(getSecret('stt.groq.api_key')).toBe('gsk-new');
   });
 
   test('end to end: legacy file -> import -> discard -> merge equals old behavior', async () => {

--- a/src/daemon/user-settings.test.ts
+++ b/src/daemon/user-settings.test.ts
@@ -11,6 +11,7 @@ import {
   loadUserSection,
   importLegacyUserSettings,
   mergeUserSettingsIntoConfig,
+  persistUserPatch,
   saveGoogleSettings,
   setSectionSavedListener,
 } from './user-settings.ts';
@@ -244,6 +245,44 @@ describe('user-settings', () => {
     hosted.google = { client_id: 'company-client', client_secret: 'company-secret' };
     mergeUserSettingsIntoConfig(hosted);
     expect(hosted.google.client_id).toBe('company-client');
+  });
+
+  test('persistUserPatch: a provider-less patch NEVER stamps a provider into the row', () => {
+    // The silence signal effectiveSttForBinding/effectiveTtsForBinding read
+    // is the row's provider field — an enable-toggle or key-only save must
+    // not turn silence into a recorded 'edge'/'openai' choice.
+    persistUserPatch('tts', { enabled: true });
+    expect(loadUserSection('tts')).toEqual({ enabled: true });
+
+    persistUserPatch('stt', { openai: { api_key: 'sk-user' } });
+    expect(loadUserSection('stt')).toEqual({ openai: { api_key: 'sk-user' } });
+  });
+
+  test('persistUserPatch: merges over the STORED row, not the in-memory merged section', () => {
+    saveUserSection('tts', { enabled: false, elevenlabs: { api_key: 'el-key' } });
+    // Patch omitting the key (GET redacts it) keeps the stored one; the
+    // DEFAULT_CONFIG fills (provider/voice/rate) never appear in the row.
+    persistUserPatch('tts', { enabled: true, elevenlabs: { voice_id: 'v-2' } });
+    expect(loadUserSection('tts')).toEqual({
+      enabled: true,
+      elevenlabs: { api_key: 'el-key', voice_id: 'v-2' },
+    });
+  });
+
+  test('persistUserPatch: an explicit provider in the patch is recorded as intent', () => {
+    persistUserPatch('tts', { enabled: true, provider: 'edge', voice: 'en-GB-SoniaNeural' });
+    expect(loadUserSection('tts')).toEqual({ enabled: true, provider: 'edge', voice: 'en-GB-SoniaNeural' });
+
+    persistUserPatch('stt', { provider: 'usejarvis' });
+    expect(loadUserSection('stt')).toEqual({ provider: 'usejarvis' });
+  });
+
+  test('persistUserPatch: notifies the section-saved listener (hot-reload choke point)', () => {
+    const events: string[] = [];
+    setSectionSavedListener((section) => events.push(section));
+    persistUserPatch('stt', { provider: 'groq' });
+    persistUserPatch('tts', { enabled: true });
+    expect(events).toEqual(['stt', 'tts']);
   });
 
   test('end to end: legacy file -> import -> discard -> merge equals old behavior', async () => {

--- a/src/daemon/user-settings.ts
+++ b/src/daemon/user-settings.ts
@@ -122,18 +122,22 @@ export function saveUserSection<K extends UserOwnedSection>(
  * saveUserSection with the merged in-memory section re-introduces the stamp.
  * Callers update the in-memory config separately for runtime use.
  *
- * Uses the shared mergeSTTConfig/mergeTTSConfig helpers, so api_keys stored
- * in the row survive patches that omit them (the GET endpoints redact keys).
+ * The stored row is STRIPPED (credentials live in the encrypted keychain), so
+ * the merge base is hydrated via injectSectionSecrets first — saveUserSection
+ * re-runs the secret split on the way out, and persistSectionSecrets treats an
+ * absent credential as "delete it". Merging over the bare stripped row would
+ * therefore destroy every stored key the patch does not carry (it did, once).
  */
 export function persistUserPatch(section: 'stt' | 'tts', patch: Record<string, unknown>): void {
   const stored = loadUserSection(section);
-  const base = (typeof stored === 'object' && stored !== null && !Array.isArray(stored))
-    ? stored
-    : {};
   // Cast, don't default: the merge helpers substitute a provider-carrying
   // default for an UNDEFINED base, which would stamp silence into the row.
   // A `{}` base merges cleanly and stays provider-free unless the patch
-  // itself carries a choice.
+  // itself carries a choice. Secrets are injected only when a row exists —
+  // same orphan rule as mergeUserSettingsIntoConfig.
+  const base = (typeof stored === 'object' && stored !== null && !Array.isArray(stored))
+    ? injectSectionSecrets(section, stored)
+    : {};
   if (section === 'stt') {
     saveUserSection('stt', mergeSTTConfig(base as STTConfig, patch));
   } else {

--- a/src/daemon/user-settings.ts
+++ b/src/daemon/user-settings.ts
@@ -27,6 +27,7 @@
 import { createHash } from 'node:crypto';
 import { getSetting, setSetting } from '../vault/settings.ts';
 import { deepMerge } from '../config/loader.ts';
+import { mergeSTTConfig, mergeTTSConfig } from './config-merge.ts';
 import {
   SECRET_SECTIONS,
   SecretStorageError,
@@ -41,6 +42,8 @@ import {
   USER_OWNED_SECTIONS,
   WORKFLOW_SYSTEM_KEYS,
   type JarvisConfig,
+  type STTConfig,
+  type TTSConfig,
   type UserOwnedSection,
 } from '../config/types.ts';
 
@@ -103,6 +106,39 @@ export function saveUserSection<K extends UserOwnedSection>(
   }
   setSetting(settingKey(section), JSON.stringify(stored ?? null));
   notifySectionSaved(section);
+}
+
+/**
+ * Persist a partial STT/TTS patch by merging it over the STORED row — never
+ * over the in-memory merged section. The in-memory value carries
+ * DEFAULT_CONFIG fills (stt provider 'openai'; tts provider 'edge', voice,
+ * rate, ...), and persisting those would stamp a provider choice the user
+ * never made into the DB row — the exact signal effectiveSttForBinding /
+ * effectiveTtsForBinding read to decide whether the user is "silent" (hosted
+ * installs default silent users to the included Usejarvis AI voice stack).
+ *
+ * EVERY save path for these two sections must go through here (dashboard
+ * routes, onboarding setup, voice commands): one path calling
+ * saveUserSection with the merged in-memory section re-introduces the stamp.
+ * Callers update the in-memory config separately for runtime use.
+ *
+ * Uses the shared mergeSTTConfig/mergeTTSConfig helpers, so api_keys stored
+ * in the row survive patches that omit them (the GET endpoints redact keys).
+ */
+export function persistUserPatch(section: 'stt' | 'tts', patch: Record<string, unknown>): void {
+  const stored = loadUserSection(section);
+  const base = (typeof stored === 'object' && stored !== null && !Array.isArray(stored))
+    ? stored
+    : {};
+  // Cast, don't default: the merge helpers substitute a provider-carrying
+  // default for an UNDEFINED base, which would stamp silence into the row.
+  // A `{}` base merges cleanly and stays provider-free unless the patch
+  // itself carries a choice.
+  if (section === 'stt') {
+    saveUserSection('stt', mergeSTTConfig(base as STTConfig, patch));
+  } else {
+    saveUserSection('tts', mergeTTSConfig(base as TTSConfig, patch));
+  }
 }
 
 /** Read one stored section; undefined when absent or unparseable. */

--- a/src/daemon/ws-service.ts
+++ b/src/daemon/ws-service.ts
@@ -663,14 +663,25 @@ export class WebSocketService implements Service {
       this.wsServer.broadcast(startMsg);
 
       let chunkCount = 0;
-      for await (const chunk of this.ttsProvider.synthesizeStream(text)) {
-        // Send binary audio to all connected clients
-        for (const ws of this.wsServer.getClients()) {
-          try {
-            ws.sendBinary(chunk);
-          } catch { /* client may have disconnected */ }
+      // Sentence-split like the reply path: proactive text goes to the
+      // provider whole otherwise, and the hosted provider truncates a single
+      // over-long input (billed per character, capped per request) — split
+      // sentences synthesize completely and fail independently.
+      const { splitIntoSentences } = await import('../comms/voice.ts');
+      for (const sentence of splitIntoSentences(text)) {
+        try {
+          for await (const chunk of this.ttsProvider.synthesizeStream(sentence)) {
+            // Send binary audio to all connected clients
+            for (const ws of this.wsServer.getClients()) {
+              try {
+                ws.sendBinary(chunk);
+              } catch { /* client may have disconnected */ }
+            }
+            chunkCount++;
+          }
+        } catch (err) {
+          console.error('[WSService] Proactive TTS sentence error:', err instanceof Error ? err.message : err);
         }
-        chunkCount++;
       }
 
       // Signal TTS end

--- a/src/vault/keychain.ts
+++ b/src/vault/keychain.ts
@@ -63,6 +63,13 @@ export function resolveKeychainDir(configured: string, legacy: string): string {
 
 /** Directory actually in use. Resolved per call, never cached. */
 export function keychainDir(): string {
+  // Guard: under `bun test` (bun sets NODE_ENV=test) with no explicit dir
+  // override, this would resolve to the developer's REAL keychain — a test
+  // file missing its JARVIS_SECRETS_DIR setup once deleted real keys. Fail
+  // loudly instead of touching it.
+  if (process.env.NODE_ENV === 'test' && !process.env.JARVIS_SECRETS_DIR && !process.env.JARVIS_HOME) {
+    throw new Error('Refusing to touch the real keychain under test: point JARVIS_SECRETS_DIR at a temp dir in your test setup (see user-settings.test.ts)');
+  }
   const configured = configuredDir();
   if (process.env.JARVIS_SECRETS_DIR) return configured;
   return resolveKeychainDir(configured, legacyDir());

--- a/ui/src/v2/onboarding/OnboardingWizard.tsx
+++ b/ui/src/v2/onboarding/OnboardingWizard.tsx
@@ -398,7 +398,12 @@ export function OnboardingWizard({
   const saveSetup = useCallback(async () => {
     setBusy(true); setError(null);
     try {
-      const ttsBlock: Record<string, unknown> = { enabled: tts !== "off", provider: tts === "off" ? "edge" : tts };
+      // "No voice" sends NO provider field: declining the voice step is not
+      // a provider choice, and stamping 'edge' would permanently mark the
+      // user as having chosen (hosted installs would then never default to
+      // the included Usejarvis AI voice when TTS is enabled later).
+      const ttsBlock: Record<string, unknown> = { enabled: tts !== "off" };
+      if (tts !== "off") ttsBlock.provider = tts;
       if (tts === "edge") { ttsBlock.voice = edgeVoice; ttsBlock.rate = "+0%"; }
       else if (tts === "elevenlabs") ttsBlock.elevenlabs = { api_key: elevenKey, voice_id: elevenVoice, model: elevenModel };
 

--- a/ui/src/v2/rooms/settings/tabs/ChannelsTab.tsx
+++ b/ui/src/v2/rooms/settings/tabs/ChannelsTab.tsx
@@ -5,6 +5,10 @@ import type {
   TTSProvider,
 } from "../useSettingsData";
 
+// OpenAI-style voices the hosted Usejarvis TTS accepts (see createTTSProvider:
+// Edge neural names are rejected there, so this list is the whole picker).
+const UJ_VOICES = ["alloy", "echo", "fable", "nova", "onyx", "shimmer"];
+
 const EDGE_VOICES = [
   { id: "en-US-AriaNeural", label: "Aria (US Female)" },
   { id: "en-US-GuyNeural", label: "Guy (US Male)" },
@@ -467,6 +471,50 @@ export function ChannelsTab({
             <option value="sarvam">Sarvam AI (Indian languages)</option>
           </select>
         </div>
+
+        {ttsCfg?.provider === "usejarvis" && (
+          <div className="v2-set__field">
+            <label className="v2-set__field-label">Voice</label>
+            <select
+              className="v2-set__select"
+              value={UJ_VOICES.includes(ttsCfg?.voice ?? "") ? (ttsCfg?.voice as string) : "alloy"}
+              onChange={async (e) => {
+                const r = await data.setTTS({ voice: e.target.value });
+                onToast(r.message, r.ok ? "ok" : "warn");
+              }}
+            >
+              {UJ_VOICES.map((v) => (
+                <option key={v} value={v}>
+                  {v.charAt(0).toUpperCase() + v.slice(1)}
+                </option>
+              ))}
+            </select>
+            <button
+              type="button"
+              className="v2-set__btn"
+              onClick={async () => {
+                const voice = UJ_VOICES.includes(ttsCfg?.voice ?? "") ? ttsCfg?.voice : "alloy";
+                const res = await fetch("/api/tts/preview", {
+                  method: "POST",
+                  headers: { "Content-Type": "application/json" },
+                  body: JSON.stringify({ provider: "usejarvis", voice }),
+                });
+                if (!res.ok) {
+                  const body = await res.json().catch(() => ({ error: "Preview failed" }));
+                  onToast((body as { error?: string }).error ?? "Preview failed", "warn");
+                  return;
+                }
+                const buf = await res.arrayBuffer();
+                const url = URL.createObjectURL(new Blob([buf], { type: "audio/mpeg" }));
+                const a = new Audio(url);
+                a.onended = () => URL.revokeObjectURL(url);
+                await a.play().catch(() => URL.revokeObjectURL(url));
+              }}
+            >
+              Listen
+            </button>
+          </div>
+        )}
 
         {ttsCfg?.provider === "edge" && (
           <>

--- a/ui/src/v2/rooms/settings/tabs/ChannelsTab.tsx
+++ b/ui/src/v2/rooms/settings/tabs/ChannelsTab.tsx
@@ -459,6 +459,9 @@ export function ChannelsTab({
               onToast(r.message, r.ok ? "ok" : "warn");
             }}
           >
+            {ttsCfg?.usejarvis_available && (
+              <option value="usejarvis">Usejarvis AI (included)</option>
+            )}
             <option value="edge">Edge TTS (free)</option>
             <option value="elevenlabs">ElevenLabs (API key)</option>
             <option value="sarvam">Sarvam AI (Indian languages)</option>

--- a/ui/src/v2/rooms/settings/useSettingsData.ts
+++ b/ui/src/v2/rooms/settings/useSettingsData.ts
@@ -116,7 +116,7 @@ export const LLM_PROVIDERS = LLM_PROVIDER_KINDS;
 export const LLM_PROVIDER_LABELS = LLM_PROVIDER_KIND_LABELS;
 
 export type STTProvider = "openai" | "groq" | "sarvam" | "local" | "usejarvis";
-export type TTSProvider = "edge" | "elevenlabs" | "sarvam";
+export type TTSProvider = "edge" | "elevenlabs" | "sarvam" | "usejarvis";
 
 /**
  * Per-provider summary returned by GET /api/config/llm. The credential value
@@ -212,6 +212,8 @@ export interface STTConfig {
 export interface TTSConfig {
   enabled: boolean;
   provider: string;
+  /** True on hosted installs: the "Usejarvis AI (included)" option applies. */
+  usejarvis_available?: boolean;
   voice: string;
   rate: string;
   volume: string;


### PR DESCRIPTION
UsejarvisTTS against the proxy's `/v1/audio/speech`. The request is bounded on both ends: the input is capped because the endpoint bills per character and the splitter can return a whole reply as one sentence, and the fetch has a timeout because sentences are spoken in sequence and one hung request silences everything after it.

Stack: **5/8** — base #357