### PR TITLE
feat(voice): hosted realtime

### DIFF
--- a/scripts/realtime-smoke.ts
+++ b/scripts/realtime-smoke.ts
@@ -19,7 +19,7 @@
  * can build on a verified protocol.
  */
 
-import { REALTIME_URL, buildSessionUpdate } from '../src/comms/realtime.ts';
+import { buildSessionUpdate } from '../src/comms/realtime.ts';
 import type { ResolvedRealtimeVoice } from '../src/config/realtime.ts';
 import type { RealtimeReasoningEffort } from '../src/config/types.ts';
 
@@ -29,7 +29,14 @@ if (!key) {
   process.exit(1);
 }
 
+// The URL now rides ON the resolved config (the hosted path repoints it to
+// the platform proxy), so this script states the OpenAI one explicitly rather
+// than importing a constant that no longer exists.
+const OPENAI_REALTIME_URL = 'wss://api.openai.com/v1/realtime';
+
 const resolved: ResolvedRealtimeVoice = {
+  provider: 'openai',
+  url: OPENAI_REALTIME_URL,
   apiKey: key,
   model: process.env.REALTIME_MODEL || 'gpt-realtime-2',
   voice: process.env.REALTIME_VOICE || 'marin',
@@ -39,7 +46,7 @@ const resolved: ResolvedRealtimeVoice = {
 };
 
 const prompt = process.argv.slice(2).join(' ') || 'Say hello and tell me you are working, in one short sentence.';
-const url = `${REALTIME_URL}?model=${encodeURIComponent(resolved.model)}`;
+const url = `${resolved.url}?model=${encodeURIComponent(resolved.model)}`;
 
 console.log(`→ Connecting: ${url}`);
 console.log(`→ Model=${resolved.model}  effort=${resolved.reasoningEffort}  voice=${resolved.voice}`);

--- a/src/comms/realtime.test.ts
+++ b/src/comms/realtime.test.ts
@@ -11,6 +11,8 @@ import type { LLMTool } from '../llm/provider.ts';
 import { BrowserAudioTransport } from './audio-transport.ts';
 
 const RESOLVED: ResolvedRealtimeVoice = {
+  provider: 'openai',
+  url: 'wss://api.openai.com/v1/realtime',
   apiKey: 'sk-test',
   model: 'gpt-realtime-2',
   voice: 'marin',

--- a/src/comms/realtime.test.ts
+++ b/src/comms/realtime.test.ts
@@ -12,7 +12,8 @@ import { BrowserAudioTransport } from './audio-transport.ts';
 
 const RESOLVED: ResolvedRealtimeVoice = {
   provider: 'openai',
-  url: 'wss://api.openai.com/v1/realtime',
+  // Distinct from the OpenAI constant so a re-hardcoded connect() FAILS.
+  url: 'wss://proxy.test/v1/realtime',
   apiKey: 'sk-test',
   model: 'gpt-realtime-2',
   voice: 'marin',
@@ -74,7 +75,11 @@ class FakeSocket implements RealtimeSocket {
 
 function makeSession() {
   const socket = new FakeSocket();
-  const factory: RealtimeSocketFactory = () => socket;
+  const dialed: string[] = [];
+  const factory: RealtimeSocketFactory = (url) => {
+    dialed.push(String(url));
+    return socket;
+  };
   const sentAudio: Buffer[] = [];
   const transport = new BrowserAudioTransport({
     sendAudio: (c) => sentAudio.push(c),
@@ -87,10 +92,16 @@ function makeSession() {
     transport,
     socketFactory: factory,
   });
-  return { socket, session, transport, sentAudio };
+  return { socket, session, transport, sentAudio, dialed };
 }
 
 describe('RealtimeSession lifecycle', () => {
+  test('dials resolved.url, not a hardcoded endpoint', async () => {
+    const { session, dialed } = makeSession();
+    await session.connect();
+    expect(dialed[0]).toBe('wss://proxy.test/v1/realtime?model=gpt-realtime-2');
+  });
+
   test('sends session.update on open', async () => {
     const { socket, session } = makeSession();
     await session.connect();

--- a/src/comms/realtime.ts
+++ b/src/comms/realtime.ts
@@ -19,9 +19,6 @@ import type { LLMTool } from '../llm/provider.ts';
 import type { ResolvedRealtimeVoice } from '../config/realtime.ts';
 import type { AudioTransport } from './audio-transport.ts';
 
-// Kept as a re-export for back-compat; sessions dial resolved.url so the
-// hosted proxy path (wss://llm.<host>/v1/realtime) uses the same machinery.
-export { OPENAI_REALTIME_URL as REALTIME_URL } from '../config/realtime.ts';
 
 /**
  * OpenAI realtime rejects an input audio rate below 24 kHz

--- a/src/comms/realtime.ts
+++ b/src/comms/realtime.ts
@@ -19,7 +19,9 @@ import type { LLMTool } from '../llm/provider.ts';
 import type { ResolvedRealtimeVoice } from '../config/realtime.ts';
 import type { AudioTransport } from './audio-transport.ts';
 
-export const REALTIME_URL = 'wss://api.openai.com/v1/realtime';
+// Kept as a re-export for back-compat; sessions dial resolved.url so the
+// hosted proxy path (wss://llm.<host>/v1/realtime) uses the same machinery.
+export { OPENAI_REALTIME_URL as REALTIME_URL } from '../config/realtime.ts';
 
 /**
  * OpenAI realtime rejects an input audio rate below 24 kHz
@@ -188,7 +190,7 @@ export class RealtimeSession {
   /** Connect, send session.update, and wire the transport's mic + playback. */
   async connect(): Promise<void> {
     const { resolved, safetyIdentifier, socketFactory, transport } = this.opts;
-    const url = `${REALTIME_URL}?model=${encodeURIComponent(resolved.model)}`;
+    const url = `${resolved.url}?model=${encodeURIComponent(resolved.model)}`;
     const headers: Record<string, string> = {
       Authorization: `Bearer ${resolved.apiKey}`,
     };

--- a/src/config/realtime.test.ts
+++ b/src/config/realtime.test.ts
@@ -131,6 +131,32 @@ describe('resolveRealtimeVoice', () => {
     }
   });
 
+  test('hosted block with realtime disabled stays off; partial block falls to no-key', () => {
+    const disabled = makeConfig();
+    disabled.usejarvis_ai = { base_url: 'https://llm.usejarvis.host', api_key: 'sk-uj-abc' };
+    disabled.voice!.realtime = { enabled: false };
+    expect(resolveRealtimeVoice(disabled).ok).toBe(false);
+
+    const partial = makeConfig();
+    partial.usejarvis_ai = { base_url: 'https://llm.usejarvis.host' }; // no key
+    partial.voice!.realtime = { enabled: true };
+    const res = resolveRealtimeVoice(partial);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toContain('no OpenAI key');
+  });
+
+  test('http dev proxy derives ws:// (not wss://)', () => {
+    const config = makeConfig();
+    config.usejarvis_ai = { base_url: 'http://dev-llm.usejarvis.dev:4000', api_key: 'sk-uj-abc' };
+    config.voice!.realtime = { enabled: true };
+    const res = resolveRealtimeVoice(config);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.resolved.url).toBe('ws://dev-llm.usejarvis.dev:4000/v1/realtime');
+      expect(res.resolved.modelsUrl).toBe('http://dev-llm.usejarvis.dev:4000/v1/models');
+    }
+  });
+
   test("a user's own OpenAI key still wins over the hosted path", () => {
     const config = withOpenAIProvider(makeConfig(), 'sk-user-own');
     config.usejarvis_ai = { base_url: 'https://llm.usejarvis.host', api_key: 'sk-uj-abc' };

--- a/src/config/realtime.test.ts
+++ b/src/config/realtime.test.ts
@@ -113,6 +113,20 @@ describe('resolveRealtimeVoice', () => {
     expect(r2.ok && r2.resolved.reasoningEffort).toBe('low');
   });
 
+  // The ws derivation is a prefix rewrite, so a case-SENSITIVE one turns
+  // HTTPS://… into HTTPS://…/realtime — never dialable, and the failure reads
+  // as "realtime is broken" rather than "the scheme is wrong".
+  test('an uppercase scheme in the provisioned block still yields a ws(s) URL', () => {
+    const config = makeConfig();
+    config.usejarvis_ai = { base_url: 'HTTPS://LLM.Usejarvis.Host', api_key: 'sk-uj-abc' };
+    config.voice!.realtime = { enabled: true, model: 'gpt-realtime-2' };
+    const res = resolveRealtimeVoice(config);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.resolved.url.startsWith('wss://')).toBe(true);
+    expect(res.resolved.modelsUrl!.startsWith('https://')).toBe(true);
+  });
+
   test('hosted fallback: no BYO key + usejarvis_ai block resolves the proxy session', () => {
     const config = makeConfig();
     config.usejarvis_ai = { base_url: 'https://llm.usejarvis.host', api_key: 'sk-uj-abc' };

--- a/src/config/realtime.test.ts
+++ b/src/config/realtime.test.ts
@@ -113,6 +113,37 @@ describe('resolveRealtimeVoice', () => {
     expect(r2.ok && r2.resolved.reasoningEffort).toBe('low');
   });
 
+  test('hosted fallback: no BYO key + usejarvis_ai block resolves the proxy session', () => {
+    const config = makeConfig();
+    config.usejarvis_ai = { base_url: 'https://llm.usejarvis.host', api_key: 'sk-uj-abc' };
+    config.voice!.realtime = { enabled: true, model: 'gpt-realtime-2', monthly_budget_usd: 25 };
+    const res = resolveRealtimeVoice(config);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.resolved.provider).toBe('usejarvis_ai');
+      expect(res.resolved.url).toBe('wss://llm.usejarvis.host/v1/realtime');
+      expect(res.resolved.modelsUrl).toBe('https://llm.usejarvis.host/v1/models');
+      // The alias is fixed regardless of the configured model — the proxy
+      // resolves the actual model per plan.
+      expect(res.resolved.model).toBe('uj-realtime');
+      // The LOCAL estimate guard must not double-block hosted sessions.
+      expect(res.resolved.monthlyBudgetUsd).toBeUndefined();
+    }
+  });
+
+  test("a user's own OpenAI key still wins over the hosted path", () => {
+    const config = withOpenAIProvider(makeConfig(), 'sk-user-own');
+    config.usejarvis_ai = { base_url: 'https://llm.usejarvis.host', api_key: 'sk-uj-abc' };
+    config.voice!.realtime = { enabled: true };
+    const res = resolveRealtimeVoice(config);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.resolved.provider).toBe('openai');
+      expect(res.resolved.apiKey).toBe('sk-user-own');
+      expect(res.resolved.url).toBe('wss://api.openai.com/v1/realtime');
+    }
+  });
+
   test('passes through blocked_categories and budget', () => {
     const config = withOpenAIProvider(makeConfig(), 'k');
     config.voice!.realtime = {

--- a/src/config/realtime.test.ts
+++ b/src/config/realtime.test.ts
@@ -127,6 +127,52 @@ describe('resolveRealtimeVoice', () => {
     expect(res.resolved.modelsUrl!.startsWith('https://')).toBe(true);
   });
 
+  // Provisioner typo classes the URL-based normalization must absorb: a
+  // scheme-less host previously left `replace(/^http/,'ws')` a no-op (the
+  // "URL" wasn't dialable at all), and an uppercase /V1 failed the
+  // case-sensitive suffix test, doubling into /V1/v1/realtime.
+  test('a scheme-less base_url reads as https and derives wss://', () => {
+    const config = makeConfig();
+    config.usejarvis_ai = { base_url: 'llm.usejarvis.host', api_key: 'sk-uj-abc' };
+    config.voice!.realtime = { enabled: true };
+    const res = resolveRealtimeVoice(config);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.resolved.url).toBe('wss://llm.usejarvis.host/v1/realtime');
+      expect(res.resolved.modelsUrl).toBe('https://llm.usejarvis.host/v1/models');
+    }
+  });
+
+  test('an uppercase /V1 suffix is recognized, not doubled', () => {
+    const config = makeConfig();
+    config.usejarvis_ai = { base_url: 'https://llm.usejarvis.host/V1', api_key: 'sk-uj-abc' };
+    config.voice!.realtime = { enabled: true };
+    const res = resolveRealtimeVoice(config);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.resolved.url).toBe('wss://llm.usejarvis.host/V1/realtime');
+      expect(res.resolved.modelsUrl).toBe('https://llm.usejarvis.host/V1/models');
+    }
+  });
+
+  test('trailing slashes are stripped before the /v1 suffix check', () => {
+    const config = makeConfig();
+    config.usejarvis_ai = { base_url: 'https://llm.usejarvis.host/v1///', api_key: 'sk-uj-abc' };
+    config.voice!.realtime = { enabled: true };
+    const res = resolveRealtimeVoice(config);
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.resolved.url).toBe('wss://llm.usejarvis.host/v1/realtime');
+  });
+
+  test('an unparseable or non-http base_url refuses instead of dialing garbage', () => {
+    const bad = makeConfig();
+    bad.usejarvis_ai = { base_url: 'ftp://llm.usejarvis.host', api_key: 'sk-uj-abc' };
+    bad.voice!.realtime = { enabled: true };
+    const res = resolveRealtimeVoice(bad);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toContain('scheme');
+  });
+
   test('hosted fallback: no BYO key + usejarvis_ai block resolves the proxy session', () => {
     const config = makeConfig();
     config.usejarvis_ai = { base_url: 'https://llm.usejarvis.host', api_key: 'sk-uj-abc' };

--- a/src/config/realtime.ts
+++ b/src/config/realtime.ts
@@ -98,13 +98,26 @@ export function resolveRealtimeVoice(
   const hosted = config.usejarvis_ai;
   const hostedReady = Boolean(hosted?.base_url?.trim() && hosted?.api_key?.trim());
   if (!apiKey && hostedReady) {
-    // Lowercase the SCHEME while normalizing: the ws(s) derivation below is a
-    // prefix rewrite, so a provisioner writing `HTTPS://…` would otherwise
-    // yield `HTTPS://…/realtime` — never a ws(s) URL — and the dial fails
-    // with an opaque error rather than a wrong-scheme one.
-    const origin = hosted!.base_url!.trim().replace(/\/+$/, '')
-      .replace(/^(https?):\/\//i, (_m, scheme: string) => `${scheme.toLowerCase()}://`);
-    const httpBase = /\/v1$/.test(origin) ? origin : `${origin}/v1`;
+    // Normalize through URL parsing rather than string surgery: the block is
+    // provisioner-written, and each of these typo classes previously derailed
+    // the ws(s) derivation into an undialable URL — an uppercase scheme
+    // (`HTTPS://…` → prefix rewrite misses), a missing scheme
+    // (`llm.usejarvis.host` → `llm.usejarvis.host/v1/realtime`, no ws://),
+    // trailing slashes, and an uppercase `/V1` suffix (`…/V1/v1/realtime`).
+    // A missing scheme reads as https — the only transport the proxy serves.
+    const raw = hosted!.base_url!.trim();
+    let httpBase: string;
+    try {
+      const url = new URL(/^[a-z][a-z0-9+.-]*:\/\//i.test(raw) ? raw : `https://${raw}`);
+      if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+        return { ok: false, reason: `usejarvis_ai.base_url has unsupported scheme: ${url.protocol}` };
+      }
+      const path = url.pathname.replace(/\/+$/, '');
+      const origin = `${url.protocol}//${url.host}${path}`;
+      httpBase = /\/v1$/i.test(origin) ? origin : `${origin}/v1`;
+    } catch {
+      return { ok: false, reason: `usejarvis_ai.base_url is not a valid URL: ${raw}` };
+    }
     return {
       ok: true,
       resolved: {

--- a/src/config/realtime.ts
+++ b/src/config/realtime.ts
@@ -17,8 +17,20 @@ export const DEFAULT_BLOCKED_CATEGORIES: ActionCategory[] = (Object.keys(IMPACT_
  * Resolved, ready-to-use realtime voice settings. Produced by
  * `resolveRealtimeVoice` once gating + key resolution have passed.
  */
+/** OpenAI's realtime websocket endpoint (the BYO-key path). */
+export const OPENAI_REALTIME_URL = 'wss://api.openai.com/v1/realtime';
+
 export type ResolvedRealtimeVoice = {
   apiKey: string;
+  /** Which backend serves the session — drives usage attribution and whether
+   * the LOCAL estimate-based budget applies (hosted spend is metered and
+   * enforced by the platform proxy, not the $/minute guess). */
+  provider: 'openai' | 'usejarvis_ai';
+  /** Websocket endpoint (model appended as a query param at connect). */
+  url: string;
+  /** Hosted only: the key-scoped catalog endpoint — the session starter
+   * pre-checks that uj-realtime is included in the plan before dialing. */
+  modelsUrl?: string;
   model: string;
   voice?: string;
   reasoningEffort: RealtimeReasoningEffort;
@@ -80,6 +92,42 @@ export function resolveRealtimeVoice(
 
   const apiKey = findOpenAIProviderKey(config).trim();
 
+  // Hosted fallback: no BYO OpenAI key, but the platform block is live — the
+  // proxy serves realtime under the plan-gated uj-realtime alias. A user's
+  // own OpenAI provider still wins (their explicit choice, their own spend).
+  const hosted = config.usejarvis_ai;
+  const hostedReady = Boolean(hosted?.base_url?.trim() && hosted?.api_key?.trim());
+  if (!apiKey && hostedReady) {
+    const origin = hosted!.base_url!.trim().replace(/\/+$/, '');
+    const httpBase = /\/v1$/.test(origin) ? origin : `${origin}/v1`;
+    return {
+      ok: true,
+      resolved: {
+        apiKey: hosted!.api_key!.trim(),
+        provider: 'usejarvis_ai',
+        url: `${httpBase.replace(/^http/, 'ws')}/realtime`,
+        modelsUrl: `${httpBase}/models`,
+        // The proxy resolves the actual model per plan; the alias is fixed.
+        model: 'uj-realtime',
+        voice: rt.voice,
+        reasoningEffort: VALID_EFFORTS.includes(rt.reasoning_effort as RealtimeReasoningEffort)
+          ? (rt.reasoning_effort as RealtimeReasoningEffort)
+          : DEFAULT_EFFORT,
+        maxSessionMinutes:
+          typeof rt.max_session_minutes === 'number' && rt.max_session_minutes > 0
+            ? rt.max_session_minutes
+            : DEFAULT_MAX_SESSION_MINUTES,
+        // Deliberately unset: the local $/minute ESTIMATE guard must not
+        // double-block hosted sessions — the proxy meters real spend and
+        // enforces the plan windows itself.
+        monthlyBudgetUsd: undefined,
+        blockedCategories: Array.isArray(rt.blocked_categories)
+          ? rt.blocked_categories
+          : DEFAULT_BLOCKED_CATEGORIES,
+      },
+    };
+  }
+
   if (!apiKey) {
     return {
       ok: false,
@@ -102,6 +150,8 @@ export function resolveRealtimeVoice(
     ok: true,
     resolved: {
       apiKey,
+      provider: 'openai',
+      url: OPENAI_REALTIME_URL,
       model: rt.model?.trim() || DEFAULT_MODEL,
       voice: rt.voice,
       reasoningEffort,

--- a/src/config/realtime.ts
+++ b/src/config/realtime.ts
@@ -98,7 +98,12 @@ export function resolveRealtimeVoice(
   const hosted = config.usejarvis_ai;
   const hostedReady = Boolean(hosted?.base_url?.trim() && hosted?.api_key?.trim());
   if (!apiKey && hostedReady) {
-    const origin = hosted!.base_url!.trim().replace(/\/+$/, '');
+    // Lowercase the SCHEME while normalizing: the ws(s) derivation below is a
+    // prefix rewrite, so a provisioner writing `HTTPS://…` would otherwise
+    // yield `HTTPS://…/realtime` — never a ws(s) URL — and the dial fails
+    // with an opaque error rather than a wrong-scheme one.
+    const origin = hosted!.base_url!.trim().replace(/\/+$/, '')
+      .replace(/^(https?):\/\//i, (_m, scheme: string) => `${scheme.toLowerCase()}://`);
     const httpBase = /\/v1$/.test(origin) ? origin : `${origin}/v1`;
     return {
       ok: true,

--- a/src/daemon/api-routes.ts
+++ b/src/daemon/api-routes.ts
@@ -13,6 +13,7 @@ import type { AgentService } from './agent-service.ts';
 import type { JarvisConfig } from '../config/types.ts';
 import { resolveRealtimeVoice, DEFAULT_BLOCKED_CATEGORIES } from '../config/realtime.ts';
 import { hasUsejarvisAi, effectiveSttForBinding, effectiveTtsForBinding, usejarvisVoiceCredentials } from './usejarvis-ai.ts';
+import { cachedRealtimeVerdict } from './realtime-gate.ts';
 import type { EntityType } from '../vault/entities.ts';
 import type { CommitmentPriority, CommitmentStatus } from '../vault/commitments.ts';
 import type { ObservationType } from '../vault/observations.ts';
@@ -2737,9 +2738,17 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
         const rt = voice?.realtime;
         // Surface whether realtime would actually resolve (BYO key cascade),
         // so the UI can show "active / no key" without exposing secrets.
+        // The plan gate is part of "available": this flag is what puts the
+        // browser into raw-PCM capture mode, so reporting true for a plan
+        // that excludes uj-realtime makes client and server disagree about
+        // the wire format for a whole utterance. Read the gate's CACHE only —
+        // the dashboard polls this route, and a fetching gate here would turn
+        // that poll into sustained catalog traffic. An unknown verdict stays
+        // available, matching the gate's own advisory-allow stance.
         let available = false;
         try {
-          available = resolveRealtimeVoice(ctx.config).ok;
+          const res = resolveRealtimeVoice(ctx.config);
+          available = res.ok && cachedRealtimeVerdict(res.resolved) !== false;
         } catch { available = false; }
         return json({
           wake_engine: voice?.wake_engine ?? 'openwakeword',

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -22,6 +22,7 @@ import { createObservation } from "../vault/observations.ts";
 import { ObserverService, mapEventType } from "./observer-service.ts";
 import { WebSocketService } from "./ws-service.ts";
 import { PebbleRealtimeManager } from "./pebble-realtime.ts";
+import { hostedRealtimeIncluded } from './realtime-gate.ts';
 import { resolveRealtimeVoice } from "../config/realtime.ts";
 import { REALTIME_NAV_TOOLS, REALTIME_NAV_TOOL_NAMES } from "./realtime-nav-tools.ts";
 import { EventReactor } from "./event-reactor.ts";
@@ -820,10 +821,12 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
 
       // Tell each pebble-capable sidecar whether realtime is available so its
       // summon hotkey knows to toggle a live session vs. the one-shot capture.
-      sidecarManager.onSidecarConnected((sidecar) => {
+      sidecarManager.onSidecarConnected(async (sidecar) => {
         if (!sidecar.capabilities.includes('pebble')) return;
         const res = resolveRealtimeVoice(agentService.getConfig());
-        const enabled = res.ok;
+        // The advertisement must agree with the starters' plan gate, or the
+        // summon hotkey opens sessions the plan refuses at dial.
+        const enabled = res.ok && (await hostedRealtimeIncluded(res.resolved));
         console.log(`[pebble-realtime] configure_realtime → ${sidecar.id} enabled=${enabled}${res.ok ? '' : ` (${res.reason})`}`);
         void sidecarManager.dispatchRPC(sidecar.id, 'pebble.configure_realtime', { enabled })
           .catch((err) => console.warn(`[pebble-realtime] configure_realtime dispatch failed (older sidecar?):`, err));

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -103,6 +103,10 @@ let workflowEngineShutdown: (() => Promise<void>) | null = null;
 let systemCron: import('./system-cron.ts').SystemCronService | null = null;
 let timerScheduler: TimerWaitpointScheduler | null = null;
 let settingsReload: import('./settings-reload.ts').SettingsReloadCoordinator | null = null;
+/** Set once the sidecar manager is up; re-pushes the pebble realtime
+ * capability after a settings reload (a plan change arrives that way, and the
+ * advertisement is otherwise computed only at connect). */
+let readvertiseRealtime: (() => Promise<void>) | null = null;
 /** Graceful-drain deadline (ms), set from config at boot. Default 75s. */
 let drainDeadlineMs = 75_000;
 
@@ -821,15 +825,33 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
 
       // Tell each pebble-capable sidecar whether realtime is available so its
       // summon hotkey knows to toggle a live session vs. the one-shot capture.
-      sidecarManager.onSidecarConnected(async (sidecar) => {
-        if (!sidecar.capabilities.includes('pebble')) return;
+      const advertiseRealtime = async (sidecarId: string) => {
         const res = resolveRealtimeVoice(agentService.getConfig());
         // The advertisement must agree with the starters' plan gate, or the
         // summon hotkey opens sessions the plan refuses at dial.
         const enabled = res.ok && (await hostedRealtimeIncluded(res.resolved));
-        console.log(`[pebble-realtime] configure_realtime → ${sidecar.id} enabled=${enabled}${res.ok ? '' : ` (${res.reason})`}`);
-        void sidecarManager.dispatchRPC(sidecar.id, 'pebble.configure_realtime', { enabled })
+        console.log(`[pebble-realtime] configure_realtime → ${sidecarId} enabled=${enabled}${res.ok ? '' : ` (${res.reason})`}`);
+        await sidecarManager.dispatchRPC(sidecarId, 'pebble.configure_realtime', { enabled })
           .catch((err) => console.warn(`[pebble-realtime] configure_realtime dispatch failed (older sidecar?):`, err));
+      };
+      // Re-advertise after a settings reload: the advertisement is otherwise
+      // computed once at CONNECT, so a sidecar that attached while the plan
+      // excluded realtime keeps its summon hotkey in one-shot mode until it
+      // reconnects — even after an upgrade. reloadAll clears the gate cache,
+      // so this re-asks the catalog rather than repeating a stale verdict.
+      readvertiseRealtime = async () => {
+        for (const s of sidecarManager.listConnected()) {
+          if (s.capabilities.includes('pebble')) await advertiseRealtime(s.id);
+        }
+      };
+      sidecarManager.onSidecarConnected((sidecar) => {
+        if (!sidecar.capabilities.includes('pebble')) return;
+        // The listener is typed `=> void` and the dispatch loop only catches
+        // SYNCHRONOUS throws, so an async body would surface a rejection as
+        // an unhandled one. Keep the contract: fire and swallow here.
+        void advertiseRealtime(sidecar.id).catch((err) =>
+          console.warn('[pebble-realtime] advertisement failed:', err),
+        );
       });
 
       // Sidecar → daemon realtime control + mic stream.
@@ -5195,9 +5217,14 @@ if (process.platform !== 'win32') {
     }
     console.log('[Daemon] SIGHUP — reloading settings from DB');
     settingsReload.reloadAll()
-      .then((r) => {
+      .then(async (r) => {
         const changed = r.changed.length > 0 ? r.changed.join(', ') : 'nothing';
         console.log(`[Daemon] SIGHUP reload done — changed: ${changed}${r.errors.length ? `, errors: ${r.errors.length}` : ''}`);
+        // A re-provisioned usejarvis_ai block (plan change) lands on SIGHUP,
+        // and it is not a user-owned section, so no per-section applier fires.
+        await readvertiseRealtime?.().catch((err: unknown) =>
+          console.warn('[pebble-realtime] re-advertisement after reload failed:', err),
+        );
       })
       .catch((err) => console.error('[Daemon] SIGHUP reload failed:', err));
   });

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -821,6 +821,14 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
           void sidecarManager.dispatchRPC(sidecarId, 'pebble.realtime_status', { state: status, detail: detail ?? '' })
             .catch(() => {/* sidecar may lack the handler / be gone */});
         },
+        // Plan-gate refusal → re-push configure_realtime with the now-cached
+        // definitive verdict so the summon key downgrades to one-shot capture.
+        // (advertiseRealtime is defined just below; only ever called at runtime.)
+        readvertise: (sidecarId) => {
+          void advertiseRealtime(sidecarId).catch((err) =>
+            console.warn('[pebble-realtime] post-refusal re-advertisement failed:', err),
+          );
+        },
       });
 
       // Tell each pebble-capable sidecar whether realtime is available so its
@@ -844,6 +852,13 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
           if (s.capabilities.includes('pebble')) await advertiseRealtime(s.id);
         }
       };
+      // Registered on the coordinator (not just the SIGHUP handler) so BOTH
+      // reload entry points — SIGHUP and POST /api/config/reload — re-push
+      // the advertisement; the route previously cleared the gate cache but
+      // left every connected pebble on its stale configure_realtime verdict.
+      settingsReload?.setPostReloadAll(async () => {
+        await readvertiseRealtime?.();
+      });
       sidecarManager.onSidecarConnected((sidecar) => {
         if (!sidecar.capabilities.includes('pebble')) return;
         // The listener is typed `=> void` and the dispatch loop only catches
@@ -5217,14 +5232,11 @@ if (process.platform !== 'win32') {
     }
     console.log('[Daemon] SIGHUP — reloading settings from DB');
     settingsReload.reloadAll()
-      .then(async (r) => {
+      .then((r) => {
         const changed = r.changed.length > 0 ? r.changed.join(', ') : 'nothing';
         console.log(`[Daemon] SIGHUP reload done — changed: ${changed}${r.errors.length ? `, errors: ${r.errors.length}` : ''}`);
-        // A re-provisioned usejarvis_ai block (plan change) lands on SIGHUP,
-        // and it is not a user-owned section, so no per-section applier fires.
-        await readvertiseRealtime?.().catch((err: unknown) =>
-          console.warn('[pebble-realtime] re-advertisement after reload failed:', err),
-        );
+        // The pebble realtime re-advertisement runs inside reloadAll's
+        // post-reload hook, shared with POST /api/config/reload.
       })
       .catch((err) => console.error('[Daemon] SIGHUP reload failed:', err));
   });

--- a/src/daemon/pebble-realtime.test.ts
+++ b/src/daemon/pebble-realtime.test.ts
@@ -1,5 +1,108 @@
-import { test, expect, describe } from 'bun:test';
-import { foldTranscript, newTranscriptAccumulator } from './pebble-realtime.ts';
+import { test, expect, describe, afterEach } from 'bun:test';
+import { PebbleRealtimeManager, foldTranscript, newTranscriptAccumulator } from './pebble-realtime.ts';
+import { clearRealtimeGateCache } from './realtime-gate.ts';
+import type { ResolvedRealtimeVoice } from '../config/realtime.ts';
+
+const originalFetch = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  clearRealtimeGateCache();
+});
+
+const hostedResolved = (): ResolvedRealtimeVoice => ({
+  provider: 'usejarvis_ai',
+  url: 'wss://llm.usejarvis.host/v1/realtime',
+  modelsUrl: 'https://llm.usejarvis.host/v1/models',
+  apiKey: 'sk-uj-abc',
+  model: 'uj-realtime',
+  reasoningEffort: 'low',
+  maxSessionMinutes: 10,
+  blockedCategories: [],
+});
+
+const makeManager = (over: Partial<ConstructorParameters<typeof PebbleRealtimeManager>[0]> = {}) =>
+  new PebbleRealtimeManager({
+    dispatchRPC: async () => undefined,
+    dispatchNotify: () => {},
+    getAudioChannel: () => null,
+    resolve: () => ({ ok: true, resolved: hostedResolved() }),
+    tools: () => [],
+    instructions: () => 'test',
+    executeToolCall: async () => 'ok',
+    ...over,
+  });
+
+describe('start/stop race across the plan gate', () => {
+  // pr6#2 regression: before the gate existed, the first await in start() came
+  // AFTER sessions.set(), so stop() always found the entry. The gate await
+  // opened a window where a stop (summon toggled off, sidecar disconnected)
+  // found nothing — and the start then opened a perpetual billed session for a
+  // peer that was already gone.
+  test('stop() during the gate window cancels the start — no session is opened', async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((r) => { release = r; });
+    globalThis.fetch = (async () => {
+      await gate;
+      return new Response(JSON.stringify({ data: [{ id: 'uj-realtime' }] }), {
+        status: 200, headers: { 'Content-Type': 'application/json' },
+      });
+    }) as unknown as typeof fetch;
+
+    const mgr = makeManager();
+    const started = mgr.start('sidecar-1');
+    mgr.stop('sidecar-1'); // arrives while start() is parked on the gate
+    release();
+    await started;
+    expect(mgr.isActive('sidecar-1')).toBe(false);
+  });
+
+  test('a quick stop→start toggle mid-gate is adopted by the parked start', async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((r) => { release = r; });
+    globalThis.fetch = (async () => {
+      await gate;
+      // Refuse the plan so the adopted start terminates before dialing a
+      // real websocket — the assertion is about the token, not the dial.
+      return new Response(JSON.stringify({ data: [{ id: 'uj-chat' }] }), {
+        status: 200, headers: { 'Content-Type': 'application/json' },
+      });
+    }) as unknown as typeof fetch;
+
+    const statuses: string[] = [];
+    const mgr = makeManager({ onStatus: (_id, status) => { statuses.push(status); } });
+    const started = mgr.start('sidecar-1');
+    mgr.stop('sidecar-1');
+    const second = mgr.start('sidecar-1'); // revives the parked start
+    release();
+    await Promise.all([started, second]);
+    // The refusal surfaced (the parked start ran to completion for the new
+    // request) rather than being silently swallowed by the cancelled token.
+    expect(statuses).toContain('closed');
+    expect(mgr.isActive('sidecar-1')).toBe(false);
+  });
+
+  // pr6#7: the summon key only reaches start() because configure_realtime said
+  // realtime was on. On a definitive plan refusal the sidecar must be told to
+  // downgrade to one-shot capture, not left to error on every summon press.
+  test('a plan refusal re-advertises so the sidecar falls back to one-shot', async () => {
+    globalThis.fetch = (async () => new Response(JSON.stringify({ data: [{ id: 'uj-chat' }] }), {
+      status: 200, headers: { 'Content-Type': 'application/json' },
+    })) as unknown as typeof fetch;
+
+    const readvertised: string[] = [];
+    const statuses: Array<{ status: string; detail?: string }> = [];
+    const mgr = makeManager({
+      readvertise: (id) => { readvertised.push(id); },
+      onStatus: (_id, status, detail) => { statuses.push({ status, detail }); },
+    });
+    await mgr.start('sidecar-1');
+    expect(mgr.isActive('sidecar-1')).toBe(false);
+    expect(readvertised).toEqual(['sidecar-1']);
+    // Surfaced as a lifecycle close (informative), not an error flash.
+    expect(statuses.some((s) => s.status === 'closed')).toBe(true);
+    expect(statuses.some((s) => s.status === 'error')).toBe(false);
+  });
+});
 
 describe('foldTranscript', () => {
   test('assistant deltas accumulate — fragments are not cumulative text', () => {

--- a/src/daemon/pebble-realtime.ts
+++ b/src/daemon/pebble-realtime.ts
@@ -48,6 +48,12 @@ export type PebbleRealtimeDeps = {
   onState?: (sidecarId: string, state: PebbleRealtimeState, text?: string) => void;
   /** Surface session lifecycle to logs / the sidecar. */
   onStatus?: (sidecarId: string, status: PebbleRealtimeStatus, detail?: string) => void;
+  /** Re-push the sidecar's `configure_realtime` advertisement. Called when the
+   *  plan gate refuses a start: the advertisement that let the summon key open
+   *  a live session was computed under an advisory-allow (or a stale verdict),
+   *  and re-advertising with the now-cached definitive verdict flips the
+   *  hotkey back to one-shot capture instead of an error dead-end. */
+  readvertise?: (sidecarId: string) => void;
 };
 
 type Entry = {
@@ -100,6 +106,12 @@ export function foldTranscript(
 
 export class PebbleRealtimeManager {
   private sessions = new Map<string, Entry>(); // sidecarId -> entry
+  /** Starts parked on the plan-gate await. `stop()` (summon toggled off, or
+   *  the sidecar disconnected) cancels the token; the start aborts instead of
+   *  opening a perpetual billed session for a peer that already left. Before
+   *  this existed the first await in start() came AFTER sessions.set(), so
+   *  stop() always found the entry — the gate await reopened that window. */
+  private pendingStarts = new Map<string, { cancelled: boolean }>();
 
   constructor(private deps: PebbleRealtimeDeps) {}
 
@@ -110,6 +122,13 @@ export class PebbleRealtimeManager {
   /** Open a perpetual realtime session for this sidecar (idempotent). */
   async start(sidecarId: string): Promise<void> {
     if (this.sessions.has(sidecarId)) return;
+    // A start already parked on the gate await adopts this request: un-cancel
+    // it (covers a quick stop→start toggle) rather than racing a second gate.
+    const parked = this.pendingStarts.get(sidecarId);
+    if (parked) {
+      parked.cancelled = false;
+      return;
+    }
 
     let resolved: ResolvedRealtimeVoice;
     try {
@@ -124,14 +143,26 @@ export class PebbleRealtimeManager {
       return;
     }
 
-    // Same plan gate as WSService.tryStartRealtimeVoice — without it a hosted
-    // plan that excludes realtime would dial and fail instead of the sidecar
-    // falling back to one-shot capture.
-    if (!(await hostedRealtimeIncluded(resolved))) {
-      this.deps.onStatus?.(sidecarId, 'error', 'Realtime voice is not included in this plan.');
-      return;
+    const pending = { cancelled: false };
+    this.pendingStarts.set(sidecarId, pending);
+    try {
+      // Same plan gate as WSService.tryStartRealtimeVoice — without it a hosted
+      // plan that excludes realtime would dial and fail instead of the sidecar
+      // falling back to one-shot capture.
+      if (!(await hostedRealtimeIncluded(resolved))) {
+        this.deps.onStatus?.(sidecarId, 'closed', 'Realtime voice is not included in this plan.');
+        // The summon key only got here because the advertisement said realtime
+        // was on (advisory-allow or a stale verdict). Re-advertise with the
+        // now-cached definitive verdict so the hotkey falls back to one-shot
+        // capture instead of erroring on every press.
+        this.deps.readvertise?.(sidecarId);
+        return;
+      }
+      if (pending.cancelled) return; // stop()/disconnect arrived mid-gate
+      if (this.sessions.has(sidecarId)) return; // re-check across the await
+    } finally {
+      this.pendingStarts.delete(sidecarId);
     }
-    if (this.sessions.has(sidecarId)) return; // re-check across the await
 
     const transport = new PebbleAudioTransport({
       // Output audio → the sidecar's streaming PCM player. Prefer the dedicated
@@ -206,6 +237,10 @@ export class PebbleRealtimeManager {
 
   /** Close the session and return the pebble to idle (idempotent). */
   stop(sidecarId: string): void {
+    // A start parked on the gate await has no session entry yet — cancel the
+    // token so it aborts instead of opening a session for a peer that's gone.
+    const pending = this.pendingStarts.get(sidecarId);
+    if (pending) pending.cancelled = true;
     const entry = this.sessions.get(sidecarId);
     if (!entry) return;
     this.sessions.delete(sidecarId);

--- a/src/daemon/pebble-realtime.ts
+++ b/src/daemon/pebble-realtime.ts
@@ -19,6 +19,7 @@
 import { PebbleAudioTransport } from '../comms/pebble-audio-transport.ts';
 import { RealtimeVoiceSession } from './realtime-voice.ts';
 import type { ResolvedRealtimeVoice } from '../config/realtime.ts';
+import { hostedRealtimeIncluded } from './realtime-gate.ts';
 import type { LLMTool } from '../llm/provider.ts';
 import type { SidecarAudioChannel } from '../sidecar/manager.ts';
 
@@ -122,6 +123,15 @@ export class PebbleRealtimeManager {
       this.deps.onStatus?.(sidecarId, 'error', `Realtime resolve failed: ${String(err)}`);
       return;
     }
+
+    // Same plan gate as WSService.tryStartRealtimeVoice — without it a hosted
+    // plan that excludes realtime would dial and fail instead of the sidecar
+    // falling back to one-shot capture.
+    if (!(await hostedRealtimeIncluded(resolved))) {
+      this.deps.onStatus?.(sidecarId, 'error', 'Realtime voice is not included in this plan.');
+      return;
+    }
+    if (this.sessions.has(sidecarId)) return; // re-check across the await
 
     const transport = new PebbleAudioTransport({
       // Output audio → the sidecar's streaming PCM player. Prefer the dedicated

--- a/src/daemon/realtime-gate.test.ts
+++ b/src/daemon/realtime-gate.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { cachedRealtimeVerdict, clearRealtimeGateCache, hostedRealtimeIncluded } from './realtime-gate.ts';
+import type { ResolvedRealtimeVoice } from '../config/realtime.ts';
+
+const originalFetch = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  clearRealtimeGateCache();
+});
+
+const hosted = (over: Partial<ResolvedRealtimeVoice> = {}): ResolvedRealtimeVoice => ({
+  provider: 'usejarvis_ai',
+  url: 'wss://llm.usejarvis.host/v1/realtime',
+  modelsUrl: 'https://llm.usejarvis.host/v1/models',
+  apiKey: 'sk-uj-abc',
+  model: 'uj-realtime',
+  maxSessionMinutes: 10,
+  ...over,
+} as ResolvedRealtimeVoice);
+
+const catalog = (...ids: string[]) =>
+  new Response(JSON.stringify({ data: ids.map((id) => ({ id })) }), {
+    status: 200, headers: { 'Content-Type': 'application/json' },
+  });
+
+describe('hostedRealtimeIncluded', () => {
+  test('BYO sessions (no modelsUrl) short-circuit without touching the network', async () => {
+    let called = 0;
+    globalThis.fetch = (async () => { called++; return catalog(); }) as unknown as typeof fetch;
+    expect(await hostedRealtimeIncluded(hosted({ modelsUrl: undefined, provider: 'openai' }))).toBe(true);
+    expect(called).toBe(0);
+  });
+
+  test('gates on the catalog verdict: alias present allows, absent refuses', async () => {
+    globalThis.fetch = (async () => catalog('uj-chat', 'uj-realtime')) as unknown as typeof fetch;
+    expect(await hostedRealtimeIncluded(hosted())).toBe(true);
+    clearRealtimeGateCache();
+    globalThis.fetch = (async () => catalog('uj-chat', 'uj-low')) as unknown as typeof fetch;
+    expect(await hostedRealtimeIncluded(hosted())).toBe(false);
+  });
+
+  test('caches the verdict so a session does not pay a catalog RTT per utterance', async () => {
+    let called = 0;
+    globalThis.fetch = (async () => { called++; return catalog('uj-realtime'); }) as unknown as typeof fetch;
+    await hostedRealtimeIncluded(hosted());
+    await hostedRealtimeIncluded(hosted());
+    await hostedRealtimeIncluded(hosted());
+    expect(called).toBe(1);
+  });
+
+  // The plan is enforced by the KEY's allowlist, so an upgrade rewrites the
+  // key while base_url and model stay put. Keying the cache on the URL alone
+  // would serve the stale "excluded" verdict after the user paid.
+  test('a new key is a new cache identity (plan upgrades take effect at once)', async () => {
+    globalThis.fetch = (async () => catalog('uj-chat')) as unknown as typeof fetch;
+    expect(await hostedRealtimeIncluded(hosted({ apiKey: 'sk-uj-old' }))).toBe(false);
+    globalThis.fetch = (async () => catalog('uj-chat', 'uj-realtime')) as unknown as typeof fetch;
+    expect(await hostedRealtimeIncluded(hosted({ apiKey: 'sk-uj-new' }))).toBe(true);
+  });
+
+  test('a hard timeout bounds the fetch, and a stall is advisory-allow', async () => {
+    globalThis.fetch = ((_url: string, init?: { signal?: AbortSignal }) => new Promise((_resolve, reject) => {
+      init?.signal?.addEventListener('abort', () => reject(new Error('aborted')));
+    })) as unknown as typeof fetch;
+    const started = Date.now();
+    expect(await hostedRealtimeIncluded(hosted())).toBe(true);
+    // Must not hang voice_start: the gate's own budget is 1.5s.
+    expect(Date.now() - started).toBeLessThan(4_000);
+  }, 10_000);
+
+  test('an unreachable catalog is advisory-allow and is not re-fetched per session', async () => {
+    let called = 0;
+    globalThis.fetch = (async () => { called++; throw new Error('ECONNREFUSED'); }) as unknown as typeof fetch;
+    expect(await hostedRealtimeIncluded(hosted())).toBe(true);
+    expect(await hostedRealtimeIncluded(hosted())).toBe(true);
+    expect(called).toBe(1); // advisory verdicts are cached (briefly)
+  });
+
+  test('a non-2xx catalog is advisory-allow — only a definitive catalog gates', async () => {
+    globalThis.fetch = (async () => new Response('bad gateway', { status: 502 })) as unknown as typeof fetch;
+    expect(await hostedRealtimeIncluded(hosted())).toBe(true);
+  });
+});
+
+describe('cachedRealtimeVerdict', () => {
+  test('never fetches, and reports unknown until the gate has run', async () => {
+    let called = 0;
+    globalThis.fetch = (async () => { called++; return catalog('uj-chat'); }) as unknown as typeof fetch;
+    expect(cachedRealtimeVerdict(hosted())).toBeNull();
+    expect(called).toBe(0);
+    await hostedRealtimeIncluded(hosted());
+    expect(cachedRealtimeVerdict(hosted())).toBe(false);
+    expect(called).toBe(1); // the cached read added no traffic
+  });
+
+  test('BYO is known-allowed without any catalog', () => {
+    expect(cachedRealtimeVerdict(hosted({ modelsUrl: undefined }))).toBe(true);
+  });
+});

--- a/src/daemon/realtime-gate.test.ts
+++ b/src/daemon/realtime-gate.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from 'bun:test';
-import { cachedRealtimeVerdict, clearRealtimeGateCache, hostedRealtimeIncluded } from './realtime-gate.ts';
+import { ageRealtimeGateCacheForTest, cachedRealtimeVerdict, clearRealtimeGateCache, hostedRealtimeIncluded } from './realtime-gate.ts';
 import type { ResolvedRealtimeVoice } from '../config/realtime.ts';
 
 const originalFetch = globalThis.fetch;
@@ -79,6 +79,79 @@ describe('hostedRealtimeIncluded', () => {
   test('a non-2xx catalog is advisory-allow — only a definitive catalog gates', async () => {
     globalThis.fetch = (async () => new Response('bad gateway', { status: 502 })) as unknown as typeof fetch;
     expect(await hostedRealtimeIncluded(hosted())).toBe(true);
+  });
+
+  // A rotated/revoked key is a definitive "not entitled", not a network blip:
+  // advisory-allow here re-dialed a session the proxy is certain to refuse,
+  // repeating the stall + failed dial every advisory window.
+  test('401/403 from the catalog is a definitive refusal, cached like one', async () => {
+    let called = 0;
+    globalThis.fetch = (async () => { called++; return new Response('unauthorized', { status: 401 }); }) as unknown as typeof fetch;
+    expect(await hostedRealtimeIncluded(hosted())).toBe(false);
+    expect(await hostedRealtimeIncluded(hosted())).toBe(false);
+    expect(called).toBe(1); // cached with the definitive TTL, not the advisory one
+    expect(cachedRealtimeVerdict(hosted())).toBe(false);
+  });
+
+  test('concurrent gate calls share one in-flight catalog fetch', async () => {
+    let called = 0;
+    let release!: () => void;
+    const gateOpen = new Promise<void>((r) => { release = r; });
+    globalThis.fetch = (async () => { called++; await gateOpen; return catalog('uj-realtime'); }) as unknown as typeof fetch;
+    const [a, b, c] = [hostedRealtimeIncluded(hosted()), hostedRealtimeIncluded(hosted()), hostedRealtimeIncluded(hosted())];
+    release();
+    expect(await Promise.all([a, b, c])).toEqual([true, true, true]);
+    expect(called).toBe(1);
+  });
+});
+
+// pr6#3 regression: a definitive "excluded" that merely EXPIRED must not read
+// as unknown/open — /api/config/voice maps unknown to available:true, which
+// flips the browser back into raw-PCM capture once per TTL window and costs
+// the user that utterance. Decay is a background re-fetch, not an open door.
+describe('expired definitive refusals', () => {
+  test('hostedRealtimeIncluded answers false immediately and refreshes in the background', async () => {
+    globalThis.fetch = (async () => catalog('uj-chat')) as unknown as typeof fetch;
+    expect(await hostedRealtimeIncluded(hosted())).toBe(false);
+    ageRealtimeGateCacheForTest(11 * 60_000);
+    // Refetch now hangs — the answer must come from the stale verdict, not the wire.
+    let refetches = 0;
+    globalThis.fetch = ((_url: string, init?: { signal?: AbortSignal }) => {
+      refetches++;
+      return new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => reject(new Error('aborted')));
+      });
+    }) as unknown as typeof fetch;
+    const started = Date.now();
+    expect(await hostedRealtimeIncluded(hosted())).toBe(false);
+    expect(Date.now() - started).toBeLessThan(500); // no stall on the stale-false path
+    expect(refetches).toBe(1); // the background refresh did go out
+  });
+
+  test('cachedRealtimeVerdict reads an expired refusal as false, never null', async () => {
+    globalThis.fetch = (async () => catalog('uj-chat')) as unknown as typeof fetch;
+    await hostedRealtimeIncluded(hosted());
+    ageRealtimeGateCacheForTest(11 * 60_000);
+    expect(cachedRealtimeVerdict(hosted())).toBe(false);
+  });
+
+  test('an upgrade still lands: the background refresh flips the verdict', async () => {
+    globalThis.fetch = (async () => catalog('uj-chat')) as unknown as typeof fetch;
+    expect(await hostedRealtimeIncluded(hosted())).toBe(false);
+    ageRealtimeGateCacheForTest(11 * 60_000);
+    globalThis.fetch = (async () => catalog('uj-chat', 'uj-realtime')) as unknown as typeof fetch;
+    expect(await hostedRealtimeIncluded(hosted())).toBe(false); // stale answer, refresh kicked off
+    await Bun.sleep(10); // let the background fetch settle
+    expect(await hostedRealtimeIncluded(hosted())).toBe(true);
+  });
+
+  test('an expired advisory verdict still decays to unknown (re-fetch, not false)', async () => {
+    globalThis.fetch = (async () => { throw new Error('ECONNREFUSED'); }) as unknown as typeof fetch;
+    expect(await hostedRealtimeIncluded(hosted())).toBe(true); // advisory
+    ageRealtimeGateCacheForTest(60_000);
+    expect(cachedRealtimeVerdict(hosted())).toBeNull();
+    globalThis.fetch = (async () => catalog('uj-realtime')) as unknown as typeof fetch;
+    expect(await hostedRealtimeIncluded(hosted())).toBe(true); // real fetch this time
   });
 });
 

--- a/src/daemon/realtime-gate.ts
+++ b/src/daemon/realtime-gate.ts
@@ -1,0 +1,46 @@
+import type { ResolvedRealtimeVoice } from '../config/realtime.ts';
+
+/**
+ * Hosted plan gate for realtime voice, shared by every session starter AND
+ * the sidecar capability advertisement (they must agree, or the pebble
+ * summon key opens sessions the plan will refuse at dial).
+ *
+ * Semantics: BYO sessions (no modelsUrl) are always allowed — the gate only
+ * asks the platform proxy's key-scoped catalog whether the plan includes the
+ * uj-realtime alias. Verdicts are cached (plans change rarely; without the
+ * cache every utterance on a gated plan would pay a catalog RTT and clip the
+ * start of the user's speech), and fetch failures are ADVISORY-allow with a
+ * hard timeout — a network blip must neither disable voice nor stall
+ * voice_start indefinitely.
+ */
+const cache = new Map<string, { verdict: boolean; at: number }>();
+const CACHE_TTL_MS = 10 * 60_000;
+const FETCH_TIMEOUT_MS = 1_500;
+
+export async function hostedRealtimeIncluded(resolved: ResolvedRealtimeVoice): Promise<boolean> {
+  if (!resolved.modelsUrl) return true;
+  const key = `${resolved.modelsUrl}|${resolved.model}`;
+  const hit = cache.get(key);
+  if (hit && Date.now() - hit.at < CACHE_TTL_MS) return hit.verdict;
+  try {
+    const res = await fetch(resolved.modelsUrl, {
+      headers: { Authorization: `Bearer ${resolved.apiKey}` },
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+    if (!res.ok) return true; // advisory: only a definitive catalog gates
+    const payload = await res.json() as { data?: Array<{ id?: unknown }> };
+    const ids = Array.isArray(payload.data)
+      ? payload.data.map((m) => m.id).filter((id): id is string => typeof id === 'string')
+      : [];
+    const verdict = ids.includes(resolved.model);
+    cache.set(key, { verdict, at: Date.now() });
+    return verdict;
+  } catch {
+    return true; // advisory
+  }
+}
+
+/** Test seam. */
+export function clearRealtimeGateCache(): void {
+  cache.clear();
+}

--- a/src/daemon/realtime-gate.ts
+++ b/src/daemon/realtime-gate.ts
@@ -12,8 +12,20 @@ import type { ResolvedRealtimeVoice } from '../config/realtime.ts';
  * start of the user's speech), and fetch failures are ADVISORY-allow with a
  * hard timeout — a network blip must neither disable voice nor stall
  * voice_start indefinitely.
+ *
+ * Decay is asymmetric: "unknown defaults open" applies only before any
+ * definitive verdict has been observed. An EXPIRED definitive "excluded"
+ * keeps reading as excluded while a background re-fetch runs — decaying it
+ * back to open would flip a known-excluded plan into raw-PCM capture once
+ * per TTL window, and that utterance would be refused and lost.
  */
-const cache = new Map<string, { verdict: boolean; at: number }>();
+type Entry = { verdict: boolean; at: number; advisory: boolean };
+const cache = new Map<string, Entry>();
+/** One catalog fetch per key at a time: concurrent starters (browser
+ * voice_start racing a pebble start, or a reconnect fan-out re-advertising
+ * over N sidecars) share the same in-flight promise instead of each paying
+ * their own RTT. */
+const inFlight = new Map<string, Promise<boolean>>();
 const CACHE_TTL_MS = 10 * 60_000;
 /** Advisory (fetch-failed) verdicts expire fast: they are a guess, and an
  * unreachable catalog must not cost a fresh 1.5s stall on every session. */
@@ -28,50 +40,97 @@ function cacheKey(resolved: ResolvedRealtimeVoice): string {
   return `${resolved.modelsUrl}|${resolved.model}|${resolved.apiKey ?? ''}`;
 }
 
+function isFresh(entry: Entry): boolean {
+  return Date.now() - entry.at < (entry.advisory ? ADVISORY_TTL_MS : CACHE_TTL_MS);
+}
+
 export async function hostedRealtimeIncluded(resolved: ResolvedRealtimeVoice): Promise<boolean> {
   if (!resolved.modelsUrl) return true;
   const key = cacheKey(resolved);
   const hit = cache.get(key);
-  if (hit && Date.now() - hit.at < CACHE_TTL_MS) return hit.verdict;
-  try {
-    const res = await fetch(resolved.modelsUrl, {
-      headers: { Authorization: `Bearer ${resolved.apiKey}` },
-      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
-    });
-    if (!res.ok) return advisoryAllow(key); // only a definitive catalog gates
-    const payload = await res.json() as { data?: Array<{ id?: unknown }> };
-    const ids = Array.isArray(payload.data)
-      ? payload.data.map((m) => m.id).filter((id): id is string => typeof id === 'string')
-      : [];
-    const verdict = ids.includes(resolved.model);
-    cache.set(key, { verdict, at: Date.now() });
-    return verdict;
-  } catch {
-    return advisoryAllow(key);
+  if (hit && isFresh(hit)) return hit.verdict;
+  // Stale definitive "excluded": answer excluded NOW (no per-utterance stall,
+  // no flap back to open) and refresh in the background so a plan upgrade
+  // still lands within one TTL.
+  if (hit && !hit.advisory && !hit.verdict) {
+    void fetchVerdict(key, resolved).catch(() => {});
+    return false;
   }
+  return fetchVerdict(key, resolved);
+}
+
+/** Deduped catalog fetch: one in-flight request per cache key. */
+function fetchVerdict(key: string, resolved: ResolvedRealtimeVoice): Promise<boolean> {
+  const existing = inFlight.get(key);
+  if (existing) return existing;
+  const p = (async () => {
+    try {
+      const res = await fetch(resolved.modelsUrl!, {
+        headers: { Authorization: `Bearer ${resolved.apiKey}` },
+        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      });
+      // 401/403 is not a blip — the key is revoked, rotated away, or scoped
+      // out. Advisory-allow here would dial a session the proxy is certain to
+      // refuse, and repeat the stall + failed dial every ADVISORY_TTL_MS.
+      if (res.status === 401 || res.status === 403) {
+        cache.set(key, { verdict: false, at: Date.now(), advisory: false });
+        return false;
+      }
+      if (!res.ok) return advisoryAllow(key); // only a definitive catalog gates
+      const payload = await res.json() as { data?: Array<{ id?: unknown }> };
+      const ids = Array.isArray(payload.data)
+        ? payload.data.map((m) => m.id).filter((id): id is string => typeof id === 'string')
+        : [];
+      const verdict = ids.includes(resolved.model);
+      cache.set(key, { verdict, at: Date.now(), advisory: false });
+      return verdict;
+    } catch {
+      return advisoryAllow(key);
+    }
+  })().finally(() => {
+    inFlight.delete(key);
+  });
+  inFlight.set(key, p);
+  return p;
 }
 
 /** Allow, but remember it only briefly — see ADVISORY_TTL_MS. */
 function advisoryAllow(key: string): boolean {
-  cache.set(key, { verdict: true, at: Date.now() - (CACHE_TTL_MS - ADVISORY_TTL_MS) });
+  cache.set(key, { verdict: true, at: Date.now(), advisory: true });
   return true;
 }
 
 /**
- * Cache-only read: the verdict if one is known, else null. Never fetches.
+ * Cache-only read: the verdict if one is known, else null. Never stalls.
  *
  * Exists for read-mostly surfaces like GET /api/config/voice, which the
  * dashboard polls every ~15s — routing that poll through the fetching gate
- * would turn a UI refresh into sustained catalog traffic.
+ * would turn a UI refresh into sustained catalog traffic. A stale definitive
+ * "excluded" still reads as excluded (with a background refresh) for the same
+ * reason as in hostedRealtimeIncluded: this flag is what flips the browser
+ * into raw-PCM capture, and a TTL flap would cost the user an utterance.
  */
 export function cachedRealtimeVerdict(resolved: ResolvedRealtimeVoice): boolean | null {
   if (!resolved.modelsUrl) return true;
-  const hit = cache.get(cacheKey(resolved));
-  if (!hit || Date.now() - hit.at >= CACHE_TTL_MS) return null;
-  return hit.verdict;
+  const key = cacheKey(resolved);
+  const hit = cache.get(key);
+  if (!hit) return null;
+  if (isFresh(hit)) return hit.verdict;
+  if (!hit.advisory && !hit.verdict) {
+    void fetchVerdict(key, resolved).catch(() => {});
+    return false;
+  }
+  return null;
 }
 
 /** Test seam. */
 export function clearRealtimeGateCache(): void {
   cache.clear();
+  inFlight.clear();
+}
+
+/** Test seam: age every cached verdict by `ms` so TTL decay is testable
+ * without an injectable clock. */
+export function ageRealtimeGateCacheForTest(ms: number): void {
+  for (const entry of cache.values()) entry.at -= ms;
 }

--- a/src/daemon/realtime-gate.ts
+++ b/src/daemon/realtime-gate.ts
@@ -15,11 +15,22 @@ import type { ResolvedRealtimeVoice } from '../config/realtime.ts';
  */
 const cache = new Map<string, { verdict: boolean; at: number }>();
 const CACHE_TTL_MS = 10 * 60_000;
+/** Advisory (fetch-failed) verdicts expire fast: they are a guess, and an
+ * unreachable catalog must not cost a fresh 1.5s stall on every session. */
+const ADVISORY_TTL_MS = 30_000;
 const FETCH_TIMEOUT_MS = 1_500;
+
+/** The KEY is part of the cache identity, not just the URL: the plan is
+ * enforced by the key's models allowlist, so an upgrade rewrites the key
+ * while base_url and model stay put. Keying on the URL alone would serve a
+ * stale "excluded" verdict for up to the full TTL after the user paid. */
+function cacheKey(resolved: ResolvedRealtimeVoice): string {
+  return `${resolved.modelsUrl}|${resolved.model}|${resolved.apiKey ?? ''}`;
+}
 
 export async function hostedRealtimeIncluded(resolved: ResolvedRealtimeVoice): Promise<boolean> {
   if (!resolved.modelsUrl) return true;
-  const key = `${resolved.modelsUrl}|${resolved.model}`;
+  const key = cacheKey(resolved);
   const hit = cache.get(key);
   if (hit && Date.now() - hit.at < CACHE_TTL_MS) return hit.verdict;
   try {
@@ -27,7 +38,7 @@ export async function hostedRealtimeIncluded(resolved: ResolvedRealtimeVoice): P
       headers: { Authorization: `Bearer ${resolved.apiKey}` },
       signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
     });
-    if (!res.ok) return true; // advisory: only a definitive catalog gates
+    if (!res.ok) return advisoryAllow(key); // only a definitive catalog gates
     const payload = await res.json() as { data?: Array<{ id?: unknown }> };
     const ids = Array.isArray(payload.data)
       ? payload.data.map((m) => m.id).filter((id): id is string => typeof id === 'string')
@@ -36,8 +47,28 @@ export async function hostedRealtimeIncluded(resolved: ResolvedRealtimeVoice): P
     cache.set(key, { verdict, at: Date.now() });
     return verdict;
   } catch {
-    return true; // advisory
+    return advisoryAllow(key);
   }
+}
+
+/** Allow, but remember it only briefly — see ADVISORY_TTL_MS. */
+function advisoryAllow(key: string): boolean {
+  cache.set(key, { verdict: true, at: Date.now() - (CACHE_TTL_MS - ADVISORY_TTL_MS) });
+  return true;
+}
+
+/**
+ * Cache-only read: the verdict if one is known, else null. Never fetches.
+ *
+ * Exists for read-mostly surfaces like GET /api/config/voice, which the
+ * dashboard polls every ~15s — routing that poll through the fetching gate
+ * would turn a UI refresh into sustained catalog traffic.
+ */
+export function cachedRealtimeVerdict(resolved: ResolvedRealtimeVoice): boolean | null {
+  if (!resolved.modelsUrl) return true;
+  const hit = cache.get(cacheKey(resolved));
+  if (!hit || Date.now() - hit.at >= CACHE_TTL_MS) return null;
+  return hit.verdict;
 }
 
 /** Test seam. */

--- a/src/daemon/realtime-voice.test.ts
+++ b/src/daemon/realtime-voice.test.ts
@@ -7,7 +7,7 @@ import { initDatabase, closeDb, getDb } from '../vault/schema.ts';
 import { setUsageDatabase } from '../llm/usage.ts';
 
 const RESOLVED: ResolvedRealtimeVoice = {
-  apiKey: 'k', provider: 'openai', url: 'wss://api.openai.com/v1/realtime', model: 'gpt-realtime-2', reasoningEffort: 'low', maxSessionMinutes: 10, blockedCategories: [],
+  apiKey: 'k', provider: 'usejarvis_ai', url: 'wss://proxy.test/v1/realtime', model: 'gpt-realtime-2', reasoningEffort: 'low', maxSessionMinutes: 10, blockedCategories: [],
 };
 
 /** Fake RealtimeSession capturing wired callbacks + outgoing results. */
@@ -132,7 +132,7 @@ describe('RealtimeVoiceSession usage tracking', () => {
     expect(rows[0]).toEqual({
       tier: 'conversation',
       subsystem: 'realtime_voice',
-      provider: 'openai',
+      provider: 'usejarvis_ai',
       model: 'gpt-realtime-2',
       input_tokens: 100,
       output_tokens: 25,

--- a/src/daemon/realtime-voice.test.ts
+++ b/src/daemon/realtime-voice.test.ts
@@ -7,7 +7,7 @@ import { initDatabase, closeDb, getDb } from '../vault/schema.ts';
 import { setUsageDatabase } from '../llm/usage.ts';
 
 const RESOLVED: ResolvedRealtimeVoice = {
-  apiKey: 'k', model: 'gpt-realtime-2', reasoningEffort: 'low', maxSessionMinutes: 10, blockedCategories: [],
+  apiKey: 'k', provider: 'openai', url: 'wss://api.openai.com/v1/realtime', model: 'gpt-realtime-2', reasoningEffort: 'low', maxSessionMinutes: 10, blockedCategories: [],
 };
 
 /** Fake RealtimeSession capturing wired callbacks + outgoing results. */

--- a/src/daemon/realtime-voice.ts
+++ b/src/daemon/realtime-voice.ts
@@ -71,14 +71,14 @@ export class RealtimeVoiceSession {
     // Fold realtime token usage into the shared llm_usage table so the Usage
     // room reports realtime spend alongside the text tiers. Tier is
     // 'conversation' (realtime is the conversational brain when active) and
-    // subsystem labels the source. Provider name is hardcoded since realtime
-    // only runs against OpenAI; the model id comes from the resolved session.
+    // subsystem labels the source; the provider comes from the resolved
+    // session (openai for BYO keys, usejarvis_ai for the hosted proxy).
     this.session.onUsage((u) => {
       recordUsage({
         tier: 'conversation',
         resolved_tier: 'conversation',
         subsystem: 'realtime_voice',
-        provider: 'openai',
+        provider: resolved.provider,
         model: resolved.model,
         input_tokens: u.input_tokens,
         output_tokens: u.output_tokens,

--- a/src/daemon/settings-reload.ts
+++ b/src/daemon/settings-reload.ts
@@ -166,6 +166,19 @@ export class SettingsReloadCoordinator {
   }
 
   /**
+   * Runs at the end of every reloadAll — SIGHUP and POST /api/config/reload
+   * take the same path, so cross-cutting refreshes that are NOT per-section
+   * appliers (the pebble realtime re-advertisement, whose trigger is the
+   * SYSTEM-owned usejarvis_ai block that no section applier watches) fire on
+   * both. Errors are logged, never allowed to fail the reload itself.
+   */
+  setPostReloadAll(fn: (() => Promise<void>) | null): void {
+    this.postReloadAll = fn;
+  }
+
+  private postReloadAll: (() => Promise<void>) | null = null;
+
+  /**
    * Fire-and-forget: schedule a coalesced apply for the section. No-op when
    * the section has no appliers. A repeat call while one is pending restarts
    * the debounce timer — appliers read live config, so latest state wins.
@@ -243,6 +256,11 @@ export class SettingsReloadCoordinator {
 
       if (changed.length > 0) {
         this.emitBroadcast({ sections: [...changed], ok: errors.length === 0, errors });
+      }
+      try {
+        await this.postReloadAll?.();
+      } catch (err) {
+        console.warn('[SettingsReload] post-reload hook failed:', err);
       }
       return { changed, applied, errors };
     });

--- a/src/daemon/settings-reload.ts
+++ b/src/daemon/settings-reload.ts
@@ -48,6 +48,7 @@ import { applyEnvOverrides } from '../config/loader.ts';
 import { googleTokensPath } from '../integrations/google-auth.ts';
 import { USER_OWNED_SECTIONS, type JarvisConfig, type UserOwnedSection } from '../config/types.ts';
 import { mergeLLMSettingsIntoConfig } from './llm-settings.ts';
+import { clearRealtimeGateCache } from './realtime-gate.ts';
 import { mergeUserSettingsIntoConfig } from './user-settings.ts';
 
 export type ReloadSection = UserOwnedSection | 'llm' | 'google';
@@ -219,6 +220,11 @@ export class SettingsReloadCoordinator {
       mergeLLMSettingsIntoConfig(this.config);
       mergeUserSettingsIntoConfig(this.config);
       applyEnvOverrides(this.config);
+
+      // A reload is the moment a re-provisioned usejarvis_ai block lands, so
+      // any cached realtime plan verdict is now suspect. Cheap to drop: the
+      // next voice_start re-asks the catalog once and re-caches.
+      clearRealtimeGateCache();
 
       const changed = RELOAD_SECTIONS.filter((s) => this.snapshot(s) !== before.get(s));
       // The hosted deliver/revoke ops write the tokens file and SIGHUP us; the

--- a/src/daemon/ws-service-voice-start.test.ts
+++ b/src/daemon/ws-service-voice-start.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { WebSocketService } from './ws-service.ts';
+import { clearRealtimeGateCache } from './realtime-gate.ts';
+import type { JarvisConfig } from '../config/types.ts';
+
+/**
+ * pr6#1 regression suite — the plan-gate refusal must never swallow the
+ * standard WAV voice pipeline. The service is constructed but never
+ * start()ed (no port bound); routeMessage/handleVoiceAudio are exercised
+ * directly, with the gate driven through a stubbed global fetch.
+ */
+
+const originalFetch = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  clearRealtimeGateCache();
+});
+
+const hostedConfig = () => ({
+  voice: { realtime: { enabled: true } },
+  usejarvis_ai: { base_url: 'https://llm.usejarvis.host', api_key: 'sk-uj-abc' },
+  llm: { providers: {} },
+}) as unknown as JarvisConfig;
+
+const makeService = (config: JarvisConfig = hostedConfig()) => {
+  const fakeAgent = {
+    setDelegationCallback: () => {},
+    getConfig: () => config,
+  } as never;
+  const svc = new WebSocketService(0, fakeAgent);
+  const sent: Array<Record<string, unknown>> = [];
+  const ws = {
+    send: (raw: string) => { sent.push(JSON.parse(raw) as Record<string, unknown>); },
+    sendBinary: () => {},
+  } as never;
+  // Liveness: the starter checks membership in the server's client set to
+  // detect a mid-gate disconnect. Register by default; tests remove to
+  // simulate a disconnect.
+  const internals = svc as unknown as {
+    wsServer: { getClients: () => Set<unknown> };
+    voiceSessions: Map<unknown, { chunks: Buffer[] }>;
+    realtimeSessions: Map<unknown, unknown>;
+    pendingVoiceFrames: Map<unknown, { chunks: Buffer[]; bytes: number; ended?: boolean }>;
+    routeMessage: (msg: unknown, ws: unknown) => Promise<unknown>;
+    handleVoiceAudio: (data: Buffer, ws: unknown) => Promise<void>;
+  };
+  internals.wsServer.getClients().add(ws);
+  return { svc, ws, sent, internals };
+};
+
+const refusingCatalog = () => {
+  globalThis.fetch = (async () => new Response(
+    JSON.stringify({ data: [{ id: 'uj-chat' }] }), // no uj-realtime → excluded
+    { status: 200, headers: { 'Content-Type': 'application/json' } },
+  )) as unknown as typeof fetch;
+};
+
+const voiceStart = (mode?: 'pcm' | 'wav') => ({
+  type: 'voice_start',
+  payload: { requestId: 'req-1', currentRoom: 'home', ...(mode ? { mode } : {}) },
+  timestamp: Date.now(),
+});
+
+describe('voice_start under a plan-excluded hosted realtime config', () => {
+  test('a WAV-mode utterance opens the standard accumulator without touching the gate', async () => {
+    let fetches = 0;
+    globalThis.fetch = (async () => { fetches++; return new Response('{}', { status: 200 }); }) as unknown as typeof fetch;
+    const { ws, internals } = makeService();
+    await internals.routeMessage(voiceStart('wav'), ws);
+    expect(internals.voiceSessions.has(ws)).toBe(true);
+    expect(internals.realtimeSessions.has(ws)).toBe(false);
+    expect(fetches).toBe(0); // wav never consults the realtime gate
+  });
+
+  test('a WAV utterance still transcribes AFTER a cached refusal (the pr6#1 outage)', async () => {
+    refusingCatalog();
+    const { ws, sent, internals } = makeService();
+    // Utterance 1 (pcm): refused, verdict now cached false.
+    await internals.routeMessage(voiceStart('pcm'), ws);
+    expect(sent.some((m) => (m.payload as { reason?: string })?.reason === 'plan')).toBe(true);
+    // Utterance 2 (wav — the client downgraded): must reach the accumulator,
+    // not be swallowed by the cached refusal.
+    await internals.routeMessage(voiceStart('wav'), ws);
+    expect(internals.voiceSessions.has(ws)).toBe(true);
+    const wav = Buffer.from('RIFFxxxxWAVE');
+    await internals.handleVoiceAudio(wav, ws);
+    expect(internals.voiceSessions.get(ws)!.chunks).toEqual([wav]);
+  });
+
+  test('a PCM refusal opens NO standard session (headerless frames are not WAV)', async () => {
+    refusingCatalog();
+    const { ws, sent, internals } = makeService();
+    await internals.routeMessage(voiceStart('pcm'), ws);
+    expect(internals.voiceSessions.has(ws)).toBe(false);
+    expect(internals.realtimeSessions.has(ws)).toBe(false);
+    expect(internals.pendingVoiceFrames.has(ws)).toBe(false);
+    const status = sent.find((m) => m.type === 'realtime_status');
+    expect((status?.payload as { state?: string; reason?: string })?.state).toBe('closed');
+    expect((status?.payload as { state?: string; reason?: string })?.reason).toBe('plan');
+  });
+
+  test('a mode-less (older client) voice_start fails OPEN to the standard pipeline', async () => {
+    refusingCatalog();
+    const { ws, internals } = makeService();
+    await internals.routeMessage(voiceStart(), ws);
+    expect(internals.voiceSessions.has(ws)).toBe(true);
+    expect(internals.realtimeSessions.has(ws)).toBe(false);
+  });
+
+  test('frames arriving mid-gate are buffered and seed the fallback accumulator', async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((r) => { release = r; });
+    globalThis.fetch = (async () => {
+      await gate;
+      return new Response(JSON.stringify({ data: [{ id: 'uj-chat' }] }), {
+        status: 200, headers: { 'Content-Type': 'application/json' },
+      });
+    }) as unknown as typeof fetch;
+    const { ws, internals } = makeService();
+    const routed = internals.routeMessage(voiceStart(), ws);
+    await Bun.sleep(1); // let the starter park on the gate
+    const frame = Buffer.from('RIFFdataWAVE');
+    await internals.handleVoiceAudio(frame, ws); // would previously warn-drop
+    release();
+    await routed;
+    expect(internals.voiceSessions.get(ws)!.chunks).toEqual([frame]);
+  });
+});
+
+describe('disconnect during the gate window', () => {
+  test('no realtime session is created for a socket that left mid-gate', async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((r) => { release = r; });
+    globalThis.fetch = (async () => {
+      await gate;
+      return new Response(JSON.stringify({ data: [{ id: 'uj-realtime' }] }), { // plan INCLUDES realtime
+        status: 200, headers: { 'Content-Type': 'application/json' },
+      });
+    }) as unknown as typeof fetch;
+    const { ws, internals } = makeService();
+    const routed = internals.routeMessage(voiceStart('pcm'), ws);
+    await Bun.sleep(1);
+    internals.wsServer.getClients().delete(ws); // the client disconnected
+    release();
+    await routed;
+    // Before the liveness re-check this dialed a live, billed session into a
+    // dead socket until max_session_minutes.
+    expect(internals.realtimeSessions.has(ws)).toBe(false);
+    expect(internals.pendingVoiceFrames.has(ws)).toBe(false);
+  });
+});

--- a/src/daemon/ws-service.ts
+++ b/src/daemon/ws-service.ts
@@ -878,7 +878,7 @@ export class WebSocketService implements Service {
         const { requestId, currentRoom } = msg.payload as { requestId: string; currentRoom?: string };
         // Premium path: if realtime voice is enabled + keyed, open (or reuse) a
         // full-duplex realtime session and skip the STT accumulator entirely.
-        if (this.tryStartRealtimeVoice(ws)) return undefined;
+        if (await this.tryStartRealtimeVoice(ws)) return undefined;
         this.voiceSessions.set(ws, {
           requestId,
           chunks: [],
@@ -1401,7 +1401,7 @@ CRITICAL — when in genuine doubt between "make in a new project" vs "add to th
    * realtime (OpenAI's semantic VAD detects turns), and the session is closed
    * on disconnect or after `max_session_minutes` (cost guard).
    */
-  private tryStartRealtimeVoice(ws: ServerWebSocket<unknown>): boolean {
+  private async tryStartRealtimeVoice(ws: ServerWebSocket<unknown>): Promise<boolean> {
     if (this.realtimeSessions.has(ws)) return true; // already streaming
 
     let resolved: ResolvedRealtimeVoice;
@@ -1421,6 +1421,31 @@ CRITICAL — when in genuine doubt between "make in a new project" vs "add to th
     // bare error flash. Falling through to the standard pipeline would be wrong:
     // the client is already streaming raw realtime PCM, which the WAV-based path
     // can't consume.
+    // Hosted plan gate: uj-realtime is absent from the key-scoped catalog on
+    // plans that don't include it — pre-check instead of dialing a websocket
+    // that will be refused, and fall back to the STT->LLM->TTS pipeline with
+    // a clear reason. Catalog fetch failures are ADVISORY (proceed and let
+    // the session attempt decide) — a network blip must not disable voice.
+    if (resolved.modelsUrl) {
+      try {
+        const res = await fetch(resolved.modelsUrl, {
+          headers: { Authorization: `Bearer ${resolved.apiKey}` },
+        });
+        if (res.ok) {
+          const payload = await res.json() as { data?: Array<{ id?: unknown }> };
+          const ids = Array.isArray(payload.data)
+            ? payload.data.map((m) => m.id).filter((id): id is string => typeof id === 'string')
+            : [];
+          if (!ids.includes(resolved.model)) {
+            console.warn('[WSService] realtime not included in this plan — using standard pipeline');
+            return false; // caller falls back to STT->LLM->TTS
+          }
+        }
+      } catch {
+        // advisory only
+      }
+    }
+
     if (resolved.monthlyBudgetUsd && !this.getRealtimeBudget().canStart(resolved.monthlyBudgetUsd)) {
       console.warn('[WSService] realtime monthly budget reached — refusing new session');
       this.wsServer.sendToClient(ws, {

--- a/src/daemon/ws-service.ts
+++ b/src/daemon/ws-service.ts
@@ -100,9 +100,20 @@ export function cleanupPerSocketMaps<W>(
   voiceSessions: Map<W, unknown>,
   interviewSessions: Map<W, unknown>,
   pendingVoiceConfirmations: Map<string, { ws: W }>,
+  realtimeSessions?: Map<W, unknown>,
+  pendingVoiceFrames?: Map<W, unknown>,
 ): { voiceRemoved: boolean; interviewRemoved: boolean; pendingRemoved: number } {
   const voiceRemoved = voiceSessions.delete(ws);
   const interviewRemoved = interviewSessions.delete(ws);
+  // Backstop only: closeRealtimeVoice runs first on disconnect and owns the
+  // real teardown (OpenAI WS + timer). If an entry still exists here, clear
+  // its timer before dropping it so the sweep doesn't leak the timeout.
+  if (realtimeSessions) {
+    const entry = realtimeSessions.get(ws) as { timeout?: ReturnType<typeof setTimeout> } | undefined;
+    if (entry?.timeout !== undefined) clearTimeout(entry.timeout);
+    realtimeSessions.delete(ws);
+  }
+  pendingVoiceFrames?.delete(ws);
   let pendingRemoved = 0;
   for (const [id, pending] of pendingVoiceConfirmations) {
     if (pending.ws === ws) {
@@ -199,6 +210,17 @@ export class WebSocketService implements Service {
        * session — see closeRealtimeVoice for why the local ledger is skipped. */
       hosted: boolean;
     }
+  >();
+  /**
+   * Mic frames that arrive while a realtime start is mid-gate (the plan-gate
+   * catalog fetch is the only await before a session exists). Without this
+   * buffer those frames hit handleVoiceAudio's "no active session" branch and
+   * the start of the first utterance is clipped. Bounded (PENDING_FRAMES_MAX_BYTES);
+   * flushed into whichever consumer materializes, dropped on refusal/teardown.
+   */
+  private pendingVoiceFrames = new Map<
+    ServerWebSocket<unknown>,
+    { chunks: Buffer[]; bytes: number; ended?: boolean }
   >();
   /**
    * Lazily-created monthly spend guard for realtime voice. Only used when a
@@ -373,6 +395,8 @@ export class WebSocketService implements Service {
             this.voiceSessions as unknown as Map<typeof ws, unknown>,
             this.interviewSessions as unknown as Map<typeof ws, unknown>,
             this.pendingVoiceConfirmations as unknown as Map<string, { ws: typeof ws }>,
+            this.realtimeSessions as unknown as Map<typeof ws, unknown>,
+            this.pendingVoiceFrames as unknown as Map<typeof ws, unknown>,
           );
           console.log('[WSService] Client disconnected');
         },
@@ -884,22 +908,55 @@ export class WebSocketService implements Service {
         return this.handleStatus();
 
       case 'voice_start': {
-        const { requestId, currentRoom } = msg.payload as { requestId: string; currentRoom?: string };
-        // Premium path: if realtime voice is enabled + keyed, open (or reuse) a
-        // full-duplex realtime session and skip the STT accumulator entirely.
-        if (await this.tryStartRealtimeVoice(ws)) return undefined;
-        this.voiceSessions.set(ws, {
+        const { requestId, currentRoom, mode } = msg.payload as {
+          requestId: string; currentRoom?: string; mode?: 'pcm' | 'wav';
+        };
+        // A WAV-mode client is uploading a finished recording — realtime is
+        // never the right consumer for it (the session would treat the WAV
+        // container bytes as raw PCM frames). Skip the realtime starter and
+        // its gate await entirely: the accumulator is created synchronously,
+        // so no frame can arrive before a session exists.
+        //
+        // Premium path (PCM, or an older client that sends no mode): if
+        // realtime voice is enabled + keyed, open (or reuse) a full-duplex
+        // realtime session and skip the STT accumulator.
+        if (mode !== 'wav' && await this.tryStartRealtimeVoice(ws, mode)) {
+          this.pendingVoiceFrames.delete(ws);
+          return undefined;
+        }
+        // Frames buffered during the realtime starter's gate window belong to
+        // this utterance — seed the accumulator with them (mode-less clients
+        // only: a PCM refusal drops its buffer inside tryStartRealtimeVoice,
+        // and the wav path above never buffers). Messages are NOT serialized
+        // behind the gate await, so voice_end may already have raced past; in
+        // that case the utterance is complete and processing starts now.
+        const buffered = this.pendingVoiceFrames.get(ws);
+        this.pendingVoiceFrames.delete(ws);
+        const session = {
           requestId,
-          chunks: [],
+          chunks: buffered?.chunks ?? [],
           startedAt: Date.now(),
           currentRoom,
-        });
+        };
+        if (buffered?.ended) {
+          this.handleVoiceSession(session, ws).catch(err =>
+            console.error('[WSService] Voice session error:', err)
+          );
+        } else {
+          this.voiceSessions.set(ws, session);
+        }
         return undefined;
       }
 
       case 'voice_end': {
         const session = this.voiceSessions.get(ws);
-        if (!session) return undefined;
+        if (!session) {
+          // voice_start may still be mid-gate (messages aren't serialized) —
+          // mark the buffered utterance complete so the starter processes it.
+          const pending = this.pendingVoiceFrames.get(ws);
+          if (pending) pending.ended = true;
+          return undefined;
+        }
         this.voiceSessions.delete(ws);
         // Fire-and-forget: transcribe → process → TTS response
         this.handleVoiceSession(session, ws).catch(err =>
@@ -1395,11 +1452,25 @@ CRITICAL — when in genuine doubt between "make in a new project" vs "add to th
     }
     const session = this.voiceSessions.get(ws);
     if (!session) {
+      // A realtime start is mid-gate: hold the frames (bounded) so the first
+      // utterance isn't clipped; they flush into whichever consumer wins.
+      const pending = this.pendingVoiceFrames.get(ws);
+      if (pending) {
+        if (pending.bytes < WebSocketService.PENDING_FRAMES_MAX_BYTES) {
+          pending.chunks.push(data);
+          pending.bytes += data.length;
+        }
+        return;
+      }
       console.warn('[WSService] Binary audio received with no active voice session');
       return;
     }
     session.chunks.push(data);
   }
+
+  /** ~2MB ≈ 40s of 24kHz s16 mono — far beyond any gate window; the cap only
+   * exists so a client misbehaving mid-gate cannot grow the buffer unbounded. */
+  private static readonly PENDING_FRAMES_MAX_BYTES = 2 * 1024 * 1024;
 
   /**
    * Open (or reuse) a premium realtime voice session for this socket. Returns
@@ -1410,7 +1481,7 @@ CRITICAL — when in genuine doubt between "make in a new project" vs "add to th
    * realtime (OpenAI's semantic VAD detects turns), and the session is closed
    * on disconnect or after `max_session_minutes` (cost guard).
    */
-  private async tryStartRealtimeVoice(ws: ServerWebSocket<unknown>): Promise<boolean> {
+  private async tryStartRealtimeVoice(ws: ServerWebSocket<unknown>, mode?: 'pcm' | 'wav'): Promise<boolean> {
     if (this.realtimeSessions.has(ws)) return true; // already streaming
 
     let resolved: ResolvedRealtimeVoice;
@@ -1423,19 +1494,35 @@ CRITICAL — when in genuine doubt between "make in a new project" vs "add to th
       return false;
     }
 
+    // Buffer mic frames that arrive during the gate await below — without
+    // this the first utterance after boot/cache-clear is clipped at exactly
+    // the moment the gate exists to protect.
+    if (!this.pendingVoiceFrames.has(ws)) {
+      this.pendingVoiceFrames.set(ws, { chunks: [], bytes: 0 });
+    }
+
     // Hosted plan gate (shared with the pebble starter + capability
     // advertisement): cached + hard-timeout, advisory on failure.
     //
-    // Refusal must NOT fall through to the standard pipeline. By the time we
-    // get here the client is already streaming raw 24kHz PCM, which the
-    // WAV-based path cannot consume: the accumulator would concatenate
-    // headerless frames, hand them to Whisper as audio.wav, and silently drop
-    // the turn — while the browser, never told to leave realtime mode, sits
-    // in `recording` forever. So report it the same way the budget guard
-    // does: `closed` + a reason, and return true so the caller opens no
-    // standard session.
+    // What refusal must NOT do depends on the client's capture format, which
+    // is why voice_start now carries `mode`:
+    //  - 'pcm': the client is streaming raw 24kHz PCM the WAV pipeline cannot
+    //    consume (the accumulator would concatenate headerless frames, hand
+    //    them to Whisper as audio.wav, and silently drop the turn). Report it
+    //    like the budget guard — `closed` + reason — and return true so no
+    //    standard session opens. The `plan` reason makes the client re-fetch
+    //    /api/config/voice at once, so the NEXT utterance really does go
+    //    through the standard pipeline.
+    //  - absent (older client, most likely uploading WAV): fail OPEN to the
+    //    standard pipeline. Returning true here would suppress the WAV
+    //    accumulator and silently drop every utterance for as long as the
+    //    verdict stays cached — a total voice outage, strictly worse than one
+    //    garbled transcript in the rare stale-PCM-client case.
+    //  ('wav' never reaches this method — the caller skips realtime.)
     if (!(await hostedRealtimeIncluded(resolved))) {
       console.warn('[WSService] realtime not included in this plan — refusing session');
+      if (mode !== 'pcm') return false; // caller seeds the accumulator with any buffered frames
+      this.pendingVoiceFrames.delete(ws); // raw PCM is useless to the WAV pipeline
       this.wsServer.sendToClient(ws, {
         type: 'realtime_status',
         payload: {
@@ -1448,9 +1535,18 @@ CRITICAL — when in genuine doubt between "make in a new project" vs "add to th
       });
       return true;
     }
-    // The await above opened a race a sync starter never had: a second
-    // voice_start arriving mid-gate would build a SECOND session and orphan
-    // the first (billed audio, teardown of the wrong one). First-in wins.
+    // The gate await opened windows a sync starter never had:
+    //  - the client may have DISCONNECTED mid-gate. onDisconnect found no
+    //    session entry to tear down, so building one now would stream a live,
+    //    billed session into a dead socket until max_session_minutes.
+    if (!this.wsServer.getClients().has(ws)) {
+      console.warn('[WSService] client disconnected during realtime gate — not starting session');
+      this.pendingVoiceFrames.delete(ws);
+      return true;
+    }
+    //  - a second voice_start arriving mid-gate would build a SECOND session
+    //    and orphan the first (billed audio, teardown of the wrong one).
+    //    First-in wins.
     if (this.realtimeSessions.has(ws)) return true;
 
     // Monthly spend guard: refuse new sessions once the estimated budget is
@@ -1521,6 +1617,11 @@ CRITICAL — when in genuine doubt between "make in a new project" vs "add to th
       session, transport, timeout, startedAt: Date.now(),
       hosted: resolved.provider === 'usejarvis_ai',
     });
+    // Frames that arrived mid-gate belong to this utterance; the transport
+    // buffers pre-connect frames itself, so pushing before connect is safe.
+    const gateBuffered = this.pendingVoiceFrames.get(ws);
+    this.pendingVoiceFrames.delete(ws);
+    if (gateBuffered) for (const frame of gateBuffered.chunks) transport.pushMicChunk(frame);
     session.connect().then(
       () => this.wsServer.sendToClient(ws, { type: 'realtime_status', payload: { state: 'live', model: resolved.model }, timestamp: Date.now() }),
       (err) => {

--- a/src/daemon/ws-service.ts
+++ b/src/daemon/ws-service.ts
@@ -43,6 +43,7 @@ import { BrowserAudioTransport } from '../comms/audio-transport.ts';
 import { RealtimeVoiceSession } from './realtime-voice.ts';
 import { REALTIME_NAV_TOOLS, REALTIME_NAV_TOOL_NAMES } from './realtime-nav-tools.ts';
 import { RealtimeBudgetTracker } from './realtime-budget.ts';
+import { hostedRealtimeIncluded } from './realtime-gate.ts';
 import { classifyErrorString } from '../llm/provider.ts';
 import { getOrCreateConversation, addMessage } from '../vault/conversations.ts';
 import { maybeCreateUserProfileFollowupPrompt, recordUserProfileTurn } from '../user/profile-followup.ts';
@@ -1421,30 +1422,16 @@ CRITICAL — when in genuine doubt between "make in a new project" vs "add to th
     // bare error flash. Falling through to the standard pipeline would be wrong:
     // the client is already streaming raw realtime PCM, which the WAV-based path
     // can't consume.
-    // Hosted plan gate: uj-realtime is absent from the key-scoped catalog on
-    // plans that don't include it — pre-check instead of dialing a websocket
-    // that will be refused, and fall back to the STT->LLM->TTS pipeline with
-    // a clear reason. Catalog fetch failures are ADVISORY (proceed and let
-    // the session attempt decide) — a network blip must not disable voice.
-    if (resolved.modelsUrl) {
-      try {
-        const res = await fetch(resolved.modelsUrl, {
-          headers: { Authorization: `Bearer ${resolved.apiKey}` },
-        });
-        if (res.ok) {
-          const payload = await res.json() as { data?: Array<{ id?: unknown }> };
-          const ids = Array.isArray(payload.data)
-            ? payload.data.map((m) => m.id).filter((id): id is string => typeof id === 'string')
-            : [];
-          if (!ids.includes(resolved.model)) {
-            console.warn('[WSService] realtime not included in this plan — using standard pipeline');
-            return false; // caller falls back to STT->LLM->TTS
-          }
-        }
-      } catch {
-        // advisory only
-      }
+    // Hosted plan gate (shared with the pebble starter + capability
+    // advertisement): cached + hard-timeout, advisory on failure.
+    if (!(await hostedRealtimeIncluded(resolved))) {
+      console.warn('[WSService] realtime not included in this plan — using standard pipeline');
+      return false; // caller falls back to STT->LLM->TTS
     }
+    // The await above opened a race a sync starter never had: a second
+    // voice_start arriving mid-gate would build a SECOND session and orphan
+    // the first (billed audio, teardown of the wrong one). First-in wins.
+    if (this.realtimeSessions.has(ws)) return true;
 
     if (resolved.monthlyBudgetUsd && !this.getRealtimeBudget().canStart(resolved.monthlyBudgetUsd)) {
       console.warn('[WSService] realtime monthly budget reached — refusing new session');

--- a/src/daemon/ws-service.ts
+++ b/src/daemon/ws-service.ts
@@ -190,7 +190,15 @@ export class WebSocketService implements Service {
    */
   private realtimeSessions = new Map<
     ServerWebSocket<unknown>,
-    { session: RealtimeVoiceSession; transport: BrowserAudioTransport; timeout: ReturnType<typeof setTimeout>; startedAt: number }
+    {
+      session: RealtimeVoiceSession;
+      transport: BrowserAudioTransport;
+      timeout: ReturnType<typeof setTimeout>;
+      startedAt: number;
+      /** True when the platform proxy is the billing authority for this
+       * session — see closeRealtimeVoice for why the local ledger is skipped. */
+      hosted: boolean;
+    }
   >();
   /**
    * Lazily-created monthly spend guard for realtime voice. Only used when a
@@ -1415,24 +1423,42 @@ CRITICAL — when in genuine doubt between "make in a new project" vs "add to th
       return false;
     }
 
-    // Monthly spend guard: refuse new sessions once the estimated budget is
-    // hit. Returns true (caller skips the standard accumulator) but opens no
-    // session. Sent as `closed` (not `error`) + a message so the client stops
-    // the mic via the normal close path and surfaces the reason, rather than a
-    // bare error flash. Falling through to the standard pipeline would be wrong:
-    // the client is already streaming raw realtime PCM, which the WAV-based path
-    // can't consume.
     // Hosted plan gate (shared with the pebble starter + capability
     // advertisement): cached + hard-timeout, advisory on failure.
+    //
+    // Refusal must NOT fall through to the standard pipeline. By the time we
+    // get here the client is already streaming raw 24kHz PCM, which the
+    // WAV-based path cannot consume: the accumulator would concatenate
+    // headerless frames, hand them to Whisper as audio.wav, and silently drop
+    // the turn — while the browser, never told to leave realtime mode, sits
+    // in `recording` forever. So report it the same way the budget guard
+    // does: `closed` + a reason, and return true so the caller opens no
+    // standard session.
     if (!(await hostedRealtimeIncluded(resolved))) {
-      console.warn('[WSService] realtime not included in this plan — using standard pipeline');
-      return false; // caller falls back to STT->LLM->TTS
+      console.warn('[WSService] realtime not included in this plan — refusing session');
+      this.wsServer.sendToClient(ws, {
+        type: 'realtime_status',
+        payload: {
+          state: 'closed',
+          reason: 'plan',
+          message: 'Live voice is not included in your plan, so this session was not started. '
+            + 'Say that again and it will go through the standard voice pipeline.',
+        },
+        timestamp: Date.now(),
+      });
+      return true;
     }
     // The await above opened a race a sync starter never had: a second
     // voice_start arriving mid-gate would build a SECOND session and orphan
     // the first (billed audio, teardown of the wrong one). First-in wins.
     if (this.realtimeSessions.has(ws)) return true;
 
+    // Monthly spend guard: refuse new sessions once the estimated budget is
+    // hit. Returns true (caller skips the standard accumulator) but opens no
+    // session. Sent as `closed` (not `error`) + a message so the client stops
+    // the mic via the normal close path and surfaces the reason, rather than a
+    // bare error flash. Falling through to the standard pipeline would be wrong
+    // for the same reason as the plan gate above.
     if (resolved.monthlyBudgetUsd && !this.getRealtimeBudget().canStart(resolved.monthlyBudgetUsd)) {
       console.warn('[WSService] realtime monthly budget reached — refusing new session');
       this.wsServer.sendToClient(ws, {
@@ -1491,7 +1517,10 @@ CRITICAL — when in genuine doubt between "make in a new project" vs "add to th
       this.closeRealtimeVoice(ws);
     }, resolved.maxSessionMinutes * 60_000);
 
-    this.realtimeSessions.set(ws, { session, transport, timeout, startedAt: Date.now() });
+    this.realtimeSessions.set(ws, {
+      session, transport, timeout, startedAt: Date.now(),
+      hosted: resolved.provider === 'usejarvis_ai',
+    });
     session.connect().then(
       () => this.wsServer.sendToClient(ws, { type: 'realtime_status', payload: { state: 'live', model: resolved.model }, timestamp: Date.now() }),
       (err) => {
@@ -1564,10 +1593,19 @@ CRITICAL — when in genuine doubt between "make in a new project" vs "add to th
     // Record estimated spend against the monthly budget (only meaningful when a
     // budget is set; recording always is cheap and keeps the cap honest if one
     // is added mid-month).
-    try {
-      this.getRealtimeBudget().recordSessionSeconds((Date.now() - entry.startedAt) / 1000);
-    } catch (err) {
-      console.warn('[WSService] failed to record realtime spend:', err);
+    //
+    // EXCEPT on the hosted path, where the proxy is the billing authority and
+    // the local $/min estimate is deliberately unset. Writing hosted minutes
+    // into this shared ledger would charge them to a BYO key later: a user who
+    // runs 90 hosted minutes and then adds their own OpenAI key with a $25 cap
+    // would find $27 of spend they never incurred, and realtime refused
+    // immediately.
+    if (!entry.hosted) {
+      try {
+        this.getRealtimeBudget().recordSessionSeconds((Date.now() - entry.startedAt) / 1000);
+      } catch (err) {
+        console.warn('[WSService] failed to record realtime spend:', err);
+      }
     }
     try { entry.session.close(); } catch { /* ignore */ }
     try {

--- a/src/llm/config-binding.ts
+++ b/src/llm/config-binding.ts
@@ -101,8 +101,8 @@ export function instantiateProvider(
     case 'usejarvis_ai':
       // Hosted platform proxy: both values come from the system-owned
       // config.yaml block (daemon/usejarvis-ai.ts) - nothing to guess.
-      if (!entry.base_url || !entry.api_key) return null;
-      provider = new UsejarvisAIProvider(entry.base_url, entry.api_key);
+      if (!entry.base_url?.trim() || !entry.api_key?.trim()) return null;
+      provider = new UsejarvisAIProvider(entry.base_url.trim(), entry.api_key.trim());
       break;
     default:
       console.warn(`[LLM] Unknown provider kind '${kind}' for '${name}' - skipping.`);

--- a/src/llm/usejarvis.test.ts
+++ b/src/llm/usejarvis.test.ts
@@ -68,6 +68,19 @@ describe('UsejarvisAIProvider', () => {
     );
   });
 
+  it('rewrites STREAM error events too (the base class yields, never throws)', async () => {
+    globalThis.fetch = (async () =>
+      jsonResponse(400, { error: { message: 'ExceededBudget: budget has been exceeded for this key' } })) as unknown as typeof fetch;
+    const provider = new UsejarvisAIProvider('https://llm.usejarvis.host', 'sk-uj-abc');
+    const events: Array<{ type: string; error?: string }> = [];
+    for await (const ev of provider.stream([{ role: 'user', content: 'hi' }], { model: 'uj-chat' })) {
+      events.push(ev as { type: string; error?: string });
+    }
+    const err = events.find((e) => e.type === 'error');
+    expect(err?.error).toMatch(/included AI usage is used up/);
+    expect(err?.error).toMatch(/\(400\)/);
+  });
+
   it('keeps retryable statuses recognizable (429 passes through with marker)', async () => {
     globalThis.fetch = (async () => jsonResponse(429, { error: { message: 'rate limited' } })) as unknown as typeof fetch;
     const provider = new UsejarvisAIProvider('https://llm.usejarvis.host', 'sk-uj-abc');

--- a/src/sidecar/manager.ts
+++ b/src/sidecar/manager.ts
@@ -395,6 +395,13 @@ export class SidecarManager implements Service {
   // --------------- Connection Tracking ---------------
 
   /** Register a connected sidecar (called after WS handshake + registration message) */
+  /** Currently CONNECTED sidecars (not merely enrolled — listSidecars() is
+   * the DB view). Exposed so callers can re-push a capability advertisement
+   * to live sidecars after config changes, rather than only at connect. */
+  listConnected(): ConnectedSidecar[] {
+    return [...this.connected.values()];
+  }
+
   registerConnection(sidecar: ConnectedSidecar): void {
     // The reported timezone is untrusted sidecar input headed for sensitive
     // sinks: `jarvis sidecars list --json` (read by the hosting server) and,

--- a/ui/src/hooks/useVoice.ts
+++ b/ui/src/hooks/useVoice.ts
@@ -265,8 +265,9 @@ export type UseVoiceReturn = {
   handleTTSContainsWake: (containsStop?: boolean) => void;
   handleTTSEnd: (requestId?: string, bargeIn?: boolean) => void;
   handleError: (message?: string) => void;
-  /** Realtime session closed server-side — stop the mic, return to idle. */
-  handleRealtimeClosed: () => void;
+  /** Realtime session closed server-side — stop the mic, return to idle.
+   *  `reason:"plan"` additionally forces an immediate availability re-check. */
+  handleRealtimeClosed: (reason?: string) => void;
   // v2 additions (Phase 4A)
   /** Mute the mic. While muted, wake-word is paused and `startRecording` is a no-op. */
   muted: boolean;
@@ -416,6 +417,9 @@ export function useVoice({ wsRef, wakeWordEnabled = true, wakeEngine = "openwake
   // --- Premium realtime voice availability ---
   // Poll the voice config so the recording/playback path can switch to the
   // realtime streaming flow. Cheap; mirrors the settings poll cadence.
+  // Kept in a ref as well so a server-side plan refusal can force an
+  // immediate re-check instead of waiting out the poll interval.
+  const refreshRealtimeAvailabilityRef = useRef<() => Promise<void>>(async () => {});
   useEffect(() => {
     let cancelled = false;
     const check = async () => {
@@ -428,6 +432,7 @@ export function useVoice({ wsRef, wakeWordEnabled = true, wakeEngine = "openwake
         }
       } catch { /* leave previous value; default false */ }
     };
+    refreshRealtimeAvailabilityRef.current = check;
     check();
     const id = window.setInterval(() => {
       if (typeof document !== "undefined" && document.hidden) return;
@@ -1050,7 +1055,12 @@ export function useVoice({ wsRef, wakeWordEnabled = true, wakeEngine = "openwake
   // mic streaming PCM into a session that no longer exists (the server silently
   // drops it). Distinct from handleError: a normal close returns to idle with
   // no error flash.
-  const handleRealtimeClosed = useCallback(() => {
+  const handleRealtimeClosed = useCallback((reason?: string) => {
+    // A plan refusal means the server will refuse every future PCM session:
+    // re-fetch availability NOW (it will come back false) so the very next
+    // utterance uses the standard WAV pipeline — "say that again" must work
+    // immediately, not after the next 15s poll tick.
+    if (reason === "plan") void refreshRealtimeAvailabilityRef.current();
     if (!realtimeActiveRef.current) return;
     realtimeCtrlRef.current?.stopStreaming();
     realtimeCtrlRef.current?.flushPlayback();
@@ -1142,9 +1152,12 @@ export function useVoice({ wsRef, wakeWordEnabled = true, wakeEngine = "openwake
     const wavBuffer = encodeWav(pcmChunksRef.current, sampleRateRef.current);
 
     // Signal start
+    // mode:"wav" tells the daemon this is a finished WAV upload, so it must
+    // never route the utterance into a realtime session (or refuse it when a
+    // hosted plan excludes realtime) — the standard STT pipeline handles it.
     ws.send(JSON.stringify({
       type: "voice_start",
-      payload: { requestId, currentRoom },
+      payload: { requestId, currentRoom, mode: "wav" },
       timestamp: Date.now(),
     }));
 

--- a/ui/src/hooks/useWebSocket.ts
+++ b/ui/src/hooks/useWebSocket.ts
@@ -210,7 +210,7 @@ export type VoiceCallbacks = {
   /** Realtime session ended server-side (max_session_minutes timeout or
    *  server close). The client must stop the mic — it's otherwise streaming
    *  into a session that no longer exists. */
-  onRealtimeClosed?: () => void;
+  onRealtimeClosed?: (reason?: string) => void;
 };
 
 export type WorkflowEvent = {
@@ -678,7 +678,7 @@ export function useWebSocket() {
           }
           if (state === "error") voiceCallbacksRef.current?.onError(msg.payload?.message);
           // Server tore the session down (timeout/close) — stop the hot mic.
-          else if (state === "closed") voiceCallbacksRef.current?.onRealtimeClosed?.();
+          else if (state === "closed") voiceCallbacksRef.current?.onRealtimeClosed?.(msg.payload?.reason);
           return;
         }
         if (msg.type === "realtime_transcript") {

--- a/ui/src/lib/RealtimeVoiceController.ts
+++ b/ui/src/lib/RealtimeVoiceController.ts
@@ -72,10 +72,13 @@ export class RealtimeVoiceController {
       this.worklet = new AudioWorkletNode(this.captureCtx, "pcm-capture-processor");
 
       this.requestId = uuid();
+      // mode:"pcm" tells the daemon raw realtime frames follow — if the plan
+      // gate refuses the session, the daemon must NOT open a WAV accumulator
+      // for them (headerless PCM is garbage to the standard pipeline).
       ws.send(
         JSON.stringify({
           type: "voice_start",
-          payload: { requestId: this.requestId, currentRoom: this.opts.getCurrentRoom?.() ?? "home" },
+          payload: { requestId: this.requestId, currentRoom: this.opts.getCurrentRoom?.() ?? "home", mode: "pcm" },
           timestamp: Date.now(),
         }),
       );


### PR DESCRIPTION
Realtime voice falls back to the platform proxy, with the capability re-advertised after a settings reload rather than only at connect. Closes a start/stop race across the plan-gate await, and normalizes the scheme so an uppercase base URL still derives a dialable wss URL.

Stack: **6/8** — base #355