### PR TITLE
feat(ux): hosted onboarding flow

### DIFF
--- a/src/daemon/api-onboarding-hosted.test.ts
+++ b/src/daemon/api-onboarding-hosted.test.ts
@@ -80,18 +80,35 @@ describe('POST /api/onboarding/setup on a hosted install', () => {
       conversation: 'usejarvis_ai:uj-chat',
       high: 'usejarvis_ai:uj-high',
     });
-    // No voice intent was recorded, so the included voice still applies.
+    // No voice PROVIDER intent was recorded, so the included voice applies…
     expect(loadUserSection('stt') ?? null).toBeNull();
-    expect(loadUserSection('tts') ?? null).toBeNull();
+    expect((loadUserSection('tts') as { provider?: string } | undefined)?.provider).toBeUndefined();
     expect(effectiveTtsForBinding(config)?.provider).toBe('usejarvis');
+    // …and the assistant actually SPEAKS. DEFAULT_CONFIG.tts.enabled is
+    // false, so dropping `enabled` along with the provider would ship a
+    // hosted install mute while the wizard promises voice is included.
+    expect(config.tts?.enabled).toBe(true);
   });
 
   test('still completes setup, so onboarding does not replay next launch', async () => {
     const config = hostedConfig();
     const handler = getHandler(createApiRoutes(makeCtx(config)), '/api/onboarding/setup', 'POST');
-    const res = await post(handler, { llm: { mode: 'multi-tier' } });
+    const res = await post(handler, { llm: { mode: 'multi-tier' }, tts: { enabled: true } });
     expect(res.status).toBe(200);
     expect(config.onboarding?.setup_completed_at).toBeGreaterThan(0);
+  });
+
+  test('the tts whitelist admits enabled ONLY — a smuggled provider is still dropped', async () => {
+    const config = hostedConfig();
+    const handler = getHandler(createApiRoutes(makeCtx(config)), '/api/onboarding/setup', 'POST');
+    await post(handler, { tts: { enabled: true, provider: 'edge', voice: 'en-GB-SoniaNeural' } });
+
+    expect(config.tts?.enabled).toBe(true);
+    const stored = loadUserSection('tts') as Record<string, unknown> | undefined;
+    expect(stored?.provider).toBeUndefined();
+    expect(stored?.voice).toBeUndefined();
+    // Still silent, so the plan's voice is what speaks.
+    expect(effectiveTtsForBinding(config)?.provider).toBe('usejarvis');
   });
 
   test('a self-hosted install is untouched by the guard', async () => {

--- a/src/daemon/api-onboarding-hosted.test.ts
+++ b/src/daemon/api-onboarding-hosted.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test, beforeEach, afterEach } from 'bun:test';
+import { createApiRoutes, type ApiContext } from './api-routes.ts';
+import { initDatabase, closeDb } from '../vault/schema.ts';
+import { DEFAULT_CONFIG, type JarvisConfig } from '../config/types.ts';
+import { loadUserSection } from './user-settings.ts';
+import { effectiveLlmForBinding, effectiveTtsForBinding } from './usejarvis-ai.ts';
+
+/**
+ * The hosted onboarding contract, enforced SERVER-side.
+ *
+ * The wizard hides brain/hearing/speaking on a hosted install and posts no
+ * provider config — but the UI cannot be the guarantee. A stale cached
+ * bundle, a replayed request, or curl would otherwise write:
+ *
+ *   - llm.default   → effectiveLlmForBinding bails out on it, disabling all
+ *                     four uj-* tiers so everything collapses onto uj-chat;
+ *   - tts.provider  → marks the user as having chosen, so the included
+ *                     hosted voice never applies again.
+ *
+ * Both are silent: the account keeps working, just off its own plan.
+ */
+
+type Handler = (req: Request) => Response | Promise<Response>;
+
+function getHandler(routes: Record<string, unknown>, path: string, method: 'POST'): Handler {
+  const route = routes[path] as { POST?: Handler } | undefined;
+  const handler = route?.[method];
+  if (!handler) throw new Error(`${method} ${path} not registered`);
+  return handler;
+}
+
+function makeCtx(config: JarvisConfig): ApiContext {
+  return {
+    daemonStartedAt: Date.now(),
+    healthMonitor: {} as ApiContext['healthMonitor'],
+    config,
+    // The hot-reload path calls a handful of manager methods whose identity is
+    // irrelevant here — what this file asserts is what gets PERSISTED. A
+    // permissive stub keeps the test from breaking every time that path grows
+    // a call.
+    agentService: {
+      getLLMManager: () => new Proxy({}, {
+        get: (_t, prop) => (prop === 'getProviderNames' ? () => [] : () => null),
+      }),
+    } as unknown as ApiContext['agentService'],
+  } as ApiContext;
+}
+
+const hostedConfig = (): JarvisConfig => {
+  const config = structuredClone(DEFAULT_CONFIG);
+  config.usejarvis_ai = { base_url: 'https://llm.usejarvis.host', api_key: 'sk-uj-abc123' };
+  return config;
+};
+
+const post = (handler: Handler, body: unknown) =>
+  handler(new Request('http://x/api/onboarding/setup', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  }));
+
+describe('POST /api/onboarding/setup on a hosted install', () => {
+  beforeEach(() => { closeDb(); initDatabase(':memory:'); });
+  afterEach(() => { closeDb(); });
+
+  test('drops provider config a bypassing client sends, and keeps the plan defaults live', async () => {
+    const config = hostedConfig();
+    const handler = getHandler(createApiRoutes(makeCtx(config)), '/api/onboarding/setup', 'POST');
+
+    const res = await post(handler, {
+      llm: { providers: { anthropic: { kind: 'anthropic', api_key: 'sk-ant-x' } }, default: 'anthropic:claude-x' },
+      stt: { provider: 'openai', openai: { api_key: 'sk-user' } },
+      tts: { enabled: true, provider: 'edge', voice: 'en-US-AriaNeural' },
+    });
+    expect(res.status).toBe(200);
+
+    // The tier wiring survives — this is what llm.default would have killed.
+    expect(config.llm.default).toBeUndefined();
+    expect(effectiveLlmForBinding(config).tiers).toMatchObject({
+      conversation: 'usejarvis_ai:uj-chat',
+      high: 'usejarvis_ai:uj-high',
+    });
+    // No voice intent was recorded, so the included voice still applies.
+    expect(loadUserSection('stt') ?? null).toBeNull();
+    expect(loadUserSection('tts') ?? null).toBeNull();
+    expect(effectiveTtsForBinding(config)?.provider).toBe('usejarvis');
+  });
+
+  test('still completes setup, so onboarding does not replay next launch', async () => {
+    const config = hostedConfig();
+    const handler = getHandler(createApiRoutes(makeCtx(config)), '/api/onboarding/setup', 'POST');
+    const res = await post(handler, { llm: { mode: 'multi-tier' } });
+    expect(res.status).toBe(200);
+    expect(config.onboarding?.setup_completed_at).toBeGreaterThan(0);
+  });
+
+  test('a self-hosted install is untouched by the guard', async () => {
+    const config = structuredClone(DEFAULT_CONFIG); // no usejarvis_ai block
+    const handler = getHandler(createApiRoutes(makeCtx(config)), '/api/onboarding/setup', 'POST');
+    const res = await post(handler, {
+      llm: { providers: { anthropic: { kind: 'anthropic', api_key: 'sk-ant-x' } }, default: 'anthropic:claude-x' },
+      tts: { enabled: true, provider: 'edge' },
+    });
+    expect(res.status).toBe(200);
+    // Configuring an LLM is mandatory here — it must persist exactly as sent.
+    expect(config.llm.default).toBe('anthropic:claude-x');
+    expect(loadUserSection('tts')).toMatchObject({ provider: 'edge' });
+  });
+});

--- a/src/daemon/api-onboarding-hosted.test.ts
+++ b/src/daemon/api-onboarding-hosted.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, test, beforeEach, afterEach } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { createApiRoutes, type ApiContext } from './api-routes.ts';
 import { initDatabase, closeDb } from '../vault/schema.ts';
 import { DEFAULT_CONFIG, type JarvisConfig } from '../config/types.ts';
@@ -60,8 +63,28 @@ const post = (handler: Handler, body: unknown) =>
   }));
 
 describe('POST /api/onboarding/setup on a hosted install', () => {
-  beforeEach(() => { closeDb(); initDatabase(':memory:'); });
-  afterEach(() => { closeDb(); });
+  // The setup route persists a user section, which writes section secrets to
+  // the keychain — and keychain.ts REFUSES to run under test without an
+  // explicit secrets dir, because a file that forgot this once wiped real
+  // keys. Without it every case here 500s on the write and the failure reads
+  // as a broken route rather than a missing fixture.
+  let secretsDir: string;
+  let prevSecretsDir: string | undefined;
+
+  beforeEach(() => {
+    prevSecretsDir = process.env.JARVIS_SECRETS_DIR;
+    secretsDir = mkdtempSync(join(tmpdir(), 'jarvis-onboarding-hosted-'));
+    process.env.JARVIS_SECRETS_DIR = secretsDir;
+    closeDb();
+    initDatabase(':memory:');
+  });
+
+  afterEach(() => {
+    closeDb();
+    if (prevSecretsDir === undefined) delete process.env.JARVIS_SECRETS_DIR;
+    else process.env.JARVIS_SECRETS_DIR = prevSecretsDir;
+    rmSync(secretsDir, { recursive: true, force: true });
+  });
 
   test('drops provider config a bypassing client sends, and keeps the plan defaults live', async () => {
     const config = hostedConfig();

--- a/src/daemon/api-onboarding-hosted.test.ts
+++ b/src/daemon/api-onboarding-hosted.test.ts
@@ -88,6 +88,19 @@ describe('POST /api/onboarding/setup on a hosted install', () => {
     // false, so dropping `enabled` along with the provider would ship a
     // hosted install mute while the wizard promises voice is included.
     expect(config.tts?.enabled).toBe(true);
+    // The guard REPORTS what it stripped: a wizard that raced the hosted
+    // probe collected this config, and a plain ok would let it print
+    // "✓ brain · Anthropic" for credentials that were never saved.
+    const body = await (res as Response).json() as { dropped?: string[] };
+    expect(body.dropped?.sort()).toEqual(['llm', 'stt', 'tts']);
+  });
+
+  test('a clean hosted payload (mode + enabled only) reports nothing dropped', async () => {
+    const config = hostedConfig();
+    const handler = getHandler(createApiRoutes(makeCtx(config)), '/api/onboarding/setup', 'POST');
+    const res = await post(handler, { llm: { mode: 'multi-tier' }, tts: { enabled: true } });
+    const body = await (res as Response).json() as { dropped?: string[] };
+    expect(body.dropped).toEqual([]);
   });
 
   test('still completes setup, so onboarding does not replay next launch', async () => {

--- a/src/daemon/api-routes.ts
+++ b/src/daemon/api-routes.ts
@@ -1369,11 +1369,18 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
           //    records the architecture choice without naming a provider or a
           //    model, and without it the settings tab misreports multi-tier
           //    as single. Everything else is dropped.
+          //    `tts.enabled` is likewise kept: whether the assistant SPEAKS is
+          //    not a provider choice, and dropping it would leave a hosted
+          //    install mute (DEFAULT_CONFIG has it false) while the wizard
+          //    promises the plan includes voice. The provider field is still
+          //    stripped, so the row stays silent and the included uj voice
+          //    applies.
           if (hasUsejarvisAi(ctx.config)) {
             const mode = (body.llm as { mode?: unknown } | undefined)?.mode;
             body.llm = mode === 'single' || mode === 'multi-tier' ? { mode } : undefined;
             body.stt = undefined;
-            body.tts = undefined;
+            const enabled = (body.tts as { enabled?: unknown } | undefined)?.enabled;
+            body.tts = typeof enabled === 'boolean' ? { enabled } : undefined;
           }
 
           // 1. LLM settings — same path as /api/config/llm POST.
@@ -2528,8 +2535,14 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
           // effectiveSttForBinding fills it with the included uj stack.
           // Writing 'usejarvis' instead would record a choice and pin them.
           // Runs BEFORE provider validation: null is a command, not a
-          // provider value.
+          // provider value. Hosted only: on a self-hosted install there is no
+          // plan default to fall back TO, so clearing the choice would leave
+          // createSTTProvider with nothing to build and silently kill
+          // transcription.
           if (body.provider === null) {
+            if (!hasUsejarvisAi(ctx.config)) {
+              return error('No plan default to reset to on a self-hosted install');
+            }
             clearProviderChoice('stt');
             if (ctx.config.stt) delete (ctx.config.stt as Record<string, unknown>).provider;
             if (!ctx.settingsReload) {
@@ -2624,6 +2637,9 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
           // `provider: null` resets to the plan default, mirroring the STT
           // route: a command, handled before provider validation.
           if (body.provider === null) {
+            if (!hasUsejarvisAi(ctx.config)) {
+              return error('No plan default to reset to on a self-hosted install');
+            }
             clearProviderChoice('tts');
             if (ctx.config.tts) delete (ctx.config.tts as Record<string, unknown>).provider;
             if (!ctx.settingsReload) {

--- a/src/daemon/api-routes.ts
+++ b/src/daemon/api-routes.ts
@@ -2437,9 +2437,14 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
     '/api/channels/status': {
       GET: () => {
         if (!ctx.channelService) return json({ channels: {}, stt: null });
+        // Binding view, like the /api/config/stt GET: after a provider reset
+        // on a hosted install the raw section has no (or an empty sentinel)
+        // provider while transcription runs happily on 'usejarvis' — the raw
+        // read blanked the Channels header on a working install.
+        const sttBinding = effectiveSttForBinding(ctx.config);
         return json({
           channels: ctx.channelService.getChannelStatus(),
-          stt: ctx.config.stt?.provider ?? null,
+          stt: sttBinding?.provider || ctx.config.stt?.provider || null,
         });
       },
     },

--- a/src/daemon/api-routes.ts
+++ b/src/daemon/api-routes.ts
@@ -1375,11 +1375,22 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
           //    promises the plan includes voice. The provider field is still
           //    stripped, so the row stays silent and the included uj voice
           //    applies.
+          // Whatever the guard strips is REPORTED back (`dropped`): a wizard
+          // that raced the hosted probe may have collected provider config
+          // the guard is about to discard — answering plain ok would let it
+          // print "✓ brain · Anthropic" for credentials that were never
+          // saved (review pr7#4).
+          const dropped: string[] = [];
           if (hasUsejarvisAi(ctx.config)) {
-            const mode = (body.llm as { mode?: unknown } | undefined)?.mode;
+            const llmBody = body.llm as { mode?: unknown; providers?: unknown; default?: unknown } | undefined;
+            const mode = llmBody?.mode;
+            if (llmBody && (llmBody.providers !== undefined || llmBody.default !== undefined)) dropped.push('llm');
             body.llm = mode === 'single' || mode === 'multi-tier' ? { mode } : undefined;
+            if (body.stt !== undefined) dropped.push('stt');
             body.stt = undefined;
-            const enabled = (body.tts as { enabled?: unknown } | undefined)?.enabled;
+            const ttsBody = body.tts as { enabled?: unknown; provider?: unknown } | undefined;
+            if (ttsBody && Object.keys(ttsBody).some((k) => k !== 'enabled')) dropped.push('tts');
+            const enabled = ttsBody?.enabled;
             body.tts = typeof enabled === 'boolean' ? { enabled } : undefined;
           }
 
@@ -1468,6 +1479,9 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
             ok: true,
             setup_completed_at: now,
             post_setup_services_started: postSetupStarted,
+            // Sections the hosted guard stripped from this request, so the
+            // wizard can tell the user instead of claiming they were saved.
+            dropped,
             message: 'Setup complete. Jarvis is ready.',
           });
         } catch (err) {

--- a/src/daemon/api-routes.ts
+++ b/src/daemon/api-routes.ts
@@ -1356,6 +1356,26 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
             tts?: Record<string, unknown>;
           };
 
+          // 0. Hosted installs answer LLM/STT/TTS from the platform, so the
+          //    wizard hides those steps and sends no provider config. Enforce
+          //    that HERE rather than trusting the client: a stale cached
+          //    bundle, a replayed request, or curl would otherwise pin the
+          //    account off its own plan — writing llm.default (which makes
+          //    effectiveLlmForBinding bail out and disables all four uj-*
+          //    tiers) or tts.provider (which marks the user as having chosen,
+          //    so the included voice never applies again).
+          //
+          //    `mode` is the one LLM field a hosted install may set: it
+          //    records the architecture choice without naming a provider or a
+          //    model, and without it the settings tab misreports multi-tier
+          //    as single. Everything else is dropped.
+          if (hasUsejarvisAi(ctx.config)) {
+            const mode = (body.llm as { mode?: unknown } | undefined)?.mode;
+            body.llm = mode === 'single' || mode === 'multi-tier' ? { mode } : undefined;
+            body.stt = undefined;
+            body.tts = undefined;
+          }
+
           // 1. LLM settings — same path as /api/config/llm POST.
           if (body.llm && Object.keys(body.llm).length > 0) {
             const { saveLLMSettings, hotReloadLLMProviders } = await import('./llm-settings.ts');
@@ -2500,8 +2520,26 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
       POST: async (req: Request) => {
         try {
           const body = await req.json() as Record<string, unknown>;
-          const { persistUserPatch } = await import('./user-settings.ts');
+          const { persistUserPatch, clearProviderChoice } = await import('./user-settings.ts');
           const { mergeSTTConfig } = await import('./config-merge.ts');
+
+          // `provider: null` means "reset to the plan default": drop the
+          // recorded choice so the row is silent again and
+          // effectiveSttForBinding fills it with the included uj stack.
+          // Writing 'usejarvis' instead would record a choice and pin them.
+          // Runs BEFORE provider validation: null is a command, not a
+          // provider value.
+          if (body.provider === null) {
+            clearProviderChoice('stt');
+            if (ctx.config.stt) delete (ctx.config.stt as Record<string, unknown>).provider;
+            if (!ctx.settingsReload) {
+              return json({ ok: true, message: 'Reset to your plan default. Restart to apply.' });
+            }
+            const resetErr = await ctx.settingsReload.applyNow('stt');
+            return json(resetErr
+              ? { ok: false, message: `Reset saved, but applying it failed: ${resetErr.error}` }
+              : { ok: true, message: 'Reset to your plan default.' });
+          }
 
           // Validate before anything persists: an unknown provider (or
           // 'usejarvis' on a self-hosted install, where createSTTProvider can
@@ -2581,6 +2619,21 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
       POST: async (req: Request) => {
         try {
           const body = await req.json() as Record<string, unknown>;
+          const { persistUserPatch, clearProviderChoice } = await import('./user-settings.ts');
+
+          // `provider: null` resets to the plan default, mirroring the STT
+          // route: a command, handled before provider validation.
+          if (body.provider === null) {
+            clearProviderChoice('tts');
+            if (ctx.config.tts) delete (ctx.config.tts as Record<string, unknown>).provider;
+            if (!ctx.settingsReload) {
+              return json({ ok: true, message: 'Reset to your plan default. Restart to apply.' });
+            }
+            const resetErr = await ctx.settingsReload.applyNow('tts');
+            return json(resetErr
+              ? { ok: false, message: `Reset saved, but applying it failed: ${resetErr.error}` }
+              : { ok: true, message: 'Reset to your plan default.' });
+          }
 
           // Validate the provider before anything persists: an unknown string
           // (or 'usejarvis' on a self-hosted install, where no hosted
@@ -2596,11 +2649,13 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
               return json({ ok: false, error: 'The Usejarvis AI voice is only available on hosted installs; pick edge, elevenlabs or sarvam.' }, 400);
             }
           }
-
-          const { persistUserPatch } = await import('./user-settings.ts');
           const { mergeTTSConfig } = await import('./config-merge.ts');
 
-          // Same discipline as /api/config/stt POST above.
+          // Same discipline as /api/config/stt POST above: single merge,
+          // persist the request patch over the STORED row, publish only after
+          // the persist succeeded. Without patch-over-row persistence, the
+          // "Enable TTS" toggle (whose body carries no explicit choice) would
+          // stamp the DEFAULT provider 'edge' into the row as user intent.
           const merged = mergeTTSConfig(ctx.config.tts, body);
           persistUserPatch('tts', body);
           ctx.config.tts = merged;

--- a/src/daemon/api-routes.ts
+++ b/src/daemon/api-routes.ts
@@ -2543,7 +2543,10 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
             if (!hasUsejarvisAi(ctx.config)) {
               return error('No plan default to reset to on a self-hosted install');
             }
-            clearProviderChoice('stt');
+            const cleared = clearProviderChoice('stt');
+            if (!cleared) {
+              return json({ ok: true, message: 'Nothing to reset — no transcription choice is recorded, so your plan default already applies.' });
+            }
             if (ctx.config.stt) delete (ctx.config.stt as Record<string, unknown>).provider;
             if (!ctx.settingsReload) {
               return json({ ok: true, message: 'Reset to your plan default. Restart to apply.' });
@@ -2640,7 +2643,10 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
             if (!hasUsejarvisAi(ctx.config)) {
               return error('No plan default to reset to on a self-hosted install');
             }
-            clearProviderChoice('tts');
+            const cleared = clearProviderChoice('tts');
+            if (!cleared) {
+              return json({ ok: true, message: 'Nothing to reset — no voice choice is recorded, so your plan default already applies.' });
+            }
             if (ctx.config.tts) delete (ctx.config.tts as Record<string, unknown>).provider;
             if (!ctx.settingsReload) {
               return json({ ok: true, message: 'Reset to your plan default. Restart to apply.' });

--- a/src/daemon/api-voice-config.test.ts
+++ b/src/daemon/api-voice-config.test.ts
@@ -217,8 +217,8 @@ describe('voice config routes: persistence stays silence-preserving', () => {
     await post(handler, '/api/config/stt', { provider: null });
     expect((loadUserSection('stt') as Record<string, unknown>).provider).toBeUndefined();
     expect(effectiveSttForBinding(config)?.provider).toBe('usejarvis');
-    // The row is stripped (main's credential split): what survives a reset in
-    // the ROW is the sub-block, not the key.
+    // The sub-block the user configured survives the reset (the credential
+    // itself lives in the encrypted keychain, so the row is stripped).
     expect((loadUserSection('stt') as any).groq).toBeDefined();
   });
 

--- a/src/daemon/api-voice-config.test.ts
+++ b/src/daemon/api-voice-config.test.ts
@@ -6,6 +6,7 @@ import { createApiRoutes, type ApiContext } from './api-routes.ts';
 import { initDatabase, closeDb } from '../vault/schema.ts';
 import { DEFAULT_CONFIG, type JarvisConfig } from '../config/types.ts';
 import { loadUserSection } from './user-settings.ts';
+import { getSecret } from '../vault/keychain.ts';
 import { effectiveSttForBinding, effectiveTtsForBinding } from './usejarvis-ai.ts';
 
 /**
@@ -179,6 +180,55 @@ describe('voice config routes: persistence stays silence-preserving', () => {
     const res = await post(getHandler(routes, '/api/config/tts', 'POST'), '/api/config/tts', { enabled: false }) as Response;
     expect(res.status).toBe(200);
     expect(setCalls).toEqual([null]); // published the null, not skipped it
+  });
+
+  // The Settings reset must restore SILENCE, never write 'usejarvis' — a
+  // recorded choice pins the account and the plan default stops applying.
+  test('POST /api/config/tts {provider:null} deletes the choice rather than recording usejarvis', async () => {
+    const config = hostedConfig();
+    const routes = createApiRoutes(makeCtx(config));
+    const handler = getHandler(routes, '/api/config/tts', 'POST');
+
+    // A real explicit choice first…
+    await post(handler, '/api/config/tts', { enabled: true, provider: 'edge', voice: 'en-GB-SoniaNeural' });
+    expect((loadUserSection('tts') as { provider?: string }).provider).toBe('edge');
+    expect(effectiveTtsForBinding(config)?.provider).toBe('edge');
+
+    // …then reset.
+    const res = await post(handler, '/api/config/tts', { provider: null });
+    expect(res.status).toBe(200);
+    const stored = loadUserSection('tts') as Record<string, unknown>;
+    expect(stored.provider).toBeUndefined();
+    expect(stored.provider).not.toBe('usejarvis'); // silence, not a choice
+    // Unrelated settings survive the reset.
+    expect(stored.enabled).toBe(true);
+    expect(stored.voice).toBe('en-GB-SoniaNeural');
+    // Runtime follows, so the plan's voice speaks without a restart.
+    expect(config.tts?.provider).toBeUndefined();
+    expect(effectiveTtsForBinding(config)?.provider).toBe('usejarvis');
+  });
+
+  test('POST /api/config/stt {provider:null} likewise restores the plan default', async () => {
+    const config = hostedConfig();
+    const handler = getHandler(createApiRoutes(makeCtx(config)), '/api/config/stt', 'POST');
+    await post(handler, '/api/config/stt', { provider: 'groq', groq: { api_key: 'gsk-user' } });
+    expect(effectiveSttForBinding(config)?.provider).toBe('groq');
+
+    await post(handler, '/api/config/stt', { provider: null });
+    expect((loadUserSection('stt') as Record<string, unknown>).provider).toBeUndefined();
+    expect(effectiveSttForBinding(config)?.provider).toBe('usejarvis');
+    // The row is stripped (main's credential split): what survives a reset in
+    // the ROW is the sub-block, not the key.
+    expect((loadUserSection('stt') as any).groq).toBeDefined();
+  });
+
+  // Self-hosted has no plan default to fall back to — clearing the choice
+  // would leave createSTTProvider with nothing and silently kill STT.
+  test('reset is refused on a self-hosted install', async () => {
+    const config = structuredClone(DEFAULT_CONFIG);
+    const handler = getHandler(createApiRoutes(makeCtx(config)), '/api/config/stt', 'POST');
+    const res = await post(handler, '/api/config/stt', { provider: null });
+    expect(res.status).toBeGreaterThanOrEqual(400);
   });
 
   test('GET /api/config/tts reports the binding-view provider and availability, no key material', async () => {

--- a/src/daemon/api-voice-config.test.ts
+++ b/src/daemon/api-voice-config.test.ts
@@ -118,8 +118,12 @@ describe('voice config routes: persistence stays silence-preserving', () => {
     expect(effectiveSttForBinding(config)?.provider).toBe('groq');
   });
 
+  // Self-hosted on purpose: on a HOSTED install the setup route now drops
+  // stt/tts entirely (the wizard never shows those steps — see
+  // api-onboarding-hosted.test.ts). The patch-over-stored-row discipline this
+  // pins still governs self-hosted onboarding, which does send them.
   test("onboarding 'No voice' ({enabled:false}, no provider) does not mark the user as having chosen", async () => {
-    const config = hostedConfig();
+    const config = structuredClone(DEFAULT_CONFIG);
     const routes = createApiRoutes(makeCtx(config));
     const res = await post(getHandler(routes, '/api/onboarding/setup', 'POST'), '/api/onboarding/setup', {
       tts: { enabled: false },
@@ -129,12 +133,15 @@ describe('voice config routes: persistence stays silence-preserving', () => {
     expect(loadUserSection('tts')).toEqual({ enabled: false });
     const onboarding = loadUserSection('onboarding') as { setup_completed_at?: number };
     expect(typeof onboarding?.setup_completed_at).toBe('number');
-    // When TTS is enabled later, the included hosted voice is the default.
-    expect(effectiveTtsForBinding(config)?.provider).toBe('usejarvis');
+    // The stored-row assertion above is the one that matters: it stays
+    // provider-free, so nothing is pinned and a later hosted provisioning
+    // would find no recorded choice. (effectiveTtsForBinding is not checked
+    // here — on a self-hosted config it returns the runtime view, which
+    // legitimately carries the DEFAULT_CONFIG 'edge' fill.)
   });
 
   test('onboarding with a genuine provider choice persists it', async () => {
-    const config = hostedConfig();
+    const config = structuredClone(DEFAULT_CONFIG); // self-hosted; see above
     const routes = createApiRoutes(makeCtx(config));
     await post(getHandler(routes, '/api/onboarding/setup', 'POST'), '/api/onboarding/setup', {
       tts: { enabled: true, provider: 'edge', voice: 'en-GB-SoniaNeural', rate: '+0%' },

--- a/src/daemon/api-voice-config.test.ts
+++ b/src/daemon/api-voice-config.test.ts
@@ -189,23 +189,41 @@ describe('voice config routes: persistence stays silence-preserving', () => {
     const routes = createApiRoutes(makeCtx(config));
     const handler = getHandler(routes, '/api/config/tts', 'POST');
 
-    // A real explicit choice first…
-    await post(handler, '/api/config/tts', { enabled: true, provider: 'edge', voice: 'en-GB-SoniaNeural' });
-    expect((loadUserSection('tts') as { provider?: string }).provider).toBe('edge');
-    expect(effectiveTtsForBinding(config)?.provider).toBe('edge');
+    // A real explicit choice first — with a credential, because the thing a
+    // reset must never do is delete it from the keychain (review pr7#1).
+    await post(handler, '/api/config/tts', {
+      enabled: true, provider: 'elevenlabs', elevenlabs: { api_key: 'el-user', voice_id: 'v1' },
+    });
+    expect((loadUserSection('tts') as { provider?: string }).provider).toBe('elevenlabs');
+    expect(effectiveTtsForBinding(config)?.provider).toBe('elevenlabs');
+    expect(getSecret('tts.elevenlabs.api_key')).toBe('el-user');
 
     // …then reset.
     const res = await post(handler, '/api/config/tts', { provider: null });
     expect(res.status).toBe(200);
     const stored = loadUserSection('tts') as Record<string, unknown>;
-    expect(stored.provider).toBeUndefined();
-    expect(stored.provider).not.toBe('usejarvis'); // silence, not a choice
+    // The explicit "cleared" sentinel — never 'usejarvis' (a recorded choice
+    // would pin the account), and not a bare deletion (the surviving
+    // sub-block would read as intent again via the import heuristic).
+    expect(stored.provider).toBe('');
     // Unrelated settings survive the reset.
     expect(stored.enabled).toBe(true);
-    expect(stored.voice).toBe('en-GB-SoniaNeural');
+    expect((stored.elevenlabs as Record<string, unknown>)?.voice_id).toBe('v1');
+    // The credential survives in the keychain — the one-click reset must
+    // never be the thing that destroys a key the user may not have anymore.
+    expect(getSecret('tts.elevenlabs.api_key')).toBe('el-user');
     // Runtime follows, so the plan's voice speaks without a restart.
     expect(config.tts?.provider).toBeUndefined();
     expect(effectiveTtsForBinding(config)?.provider).toBe('usejarvis');
+  });
+
+  test('reset with no stored row reports "nothing to reset" instead of a fake success', async () => {
+    const config = hostedConfig();
+    const handler = getHandler(createApiRoutes(makeCtx(config)), '/api/config/tts', 'POST');
+    const res = await post(handler, '/api/config/tts', { provider: null }) as Response;
+    expect(res.status).toBe(200);
+    const body = await res.json() as { message: string };
+    expect(body.message).toContain('Nothing to reset');
   });
 
   test('POST /api/config/stt {provider:null} likewise restores the plan default', async () => {
@@ -215,7 +233,7 @@ describe('voice config routes: persistence stays silence-preserving', () => {
     expect(effectiveSttForBinding(config)?.provider).toBe('groq');
 
     await post(handler, '/api/config/stt', { provider: null });
-    expect((loadUserSection('stt') as Record<string, unknown>).provider).toBeUndefined();
+    expect((loadUserSection('stt') as Record<string, unknown>).provider).toBe('');
     expect(effectiveSttForBinding(config)?.provider).toBe('usejarvis');
     // The sub-block the user configured survives the reset (the credential
     // itself lives in the encrypted keychain, so the row is stripped).

--- a/src/daemon/api-voice-config.test.ts
+++ b/src/daemon/api-voice-config.test.ts
@@ -235,9 +235,11 @@ describe('voice config routes: persistence stays silence-preserving', () => {
     await post(handler, '/api/config/stt', { provider: null });
     expect((loadUserSection('stt') as Record<string, unknown>).provider).toBe('');
     expect(effectiveSttForBinding(config)?.provider).toBe('usejarvis');
-    // The sub-block the user configured survives the reset (the credential
-    // itself lives in the encrypted keychain, so the row is stripped).
+    // The sub-block AND the credential survive the reset: the row keeps the
+    // stripped sub-block, and the key must still be in the encrypted keychain
+    // — a reset that deletes it is the pr7#1 critical, not a reset.
     expect((loadUserSection('stt') as any).groq).toBeDefined();
+    expect(getSecret('stt.groq.api_key')).toBe('gsk-user');
   });
 
   // Self-hosted has no plan default to fall back to — clearing the choice

--- a/src/daemon/llm-settings.ts
+++ b/src/daemon/llm-settings.ts
@@ -248,7 +248,8 @@ export function getLLMSettings(config: JarvisConfig): LLMSettingsResponse {
     prompt_cache: config.llm.prompt_cache !== false,
     effective,
     // Hosted installs: tells the dashboard to render the read-only
-    // "included with your plan" card (no base_url, no key material).
+    // "included with your plan" card (no base_url, no key material), and
+    // gates the onboarding steps the platform already answers.
     // Derived from the config.yaml block — the single source of hostedness —
     // never from provider-map key presence, which a legacy row can fake.
     hosted_llm: hasUsejarvisAi(config),

--- a/src/daemon/usejarvis-ai.ts
+++ b/src/daemon/usejarvis-ai.ts
@@ -185,7 +185,11 @@ export function usejarvisVoiceCredentials(config: JarvisConfig): HostedVoiceCred
 }
 
 /** Provider-specific sub-blocks a stored stt row can carry. */
-const STT_PROVIDER_BLOCKS = ['openai', 'groq', 'local', 'sarvam'] as const;
+// Sub-blocks that mark a row as provider intent. Shared by the stt AND tts
+// rows: openai/groq/local are STT-only, elevenlabs is TTS-only, sarvam is
+// both — a section can't contain the other section's blocks, so the union
+// has no false positives.
+const PROVIDER_INTENT_BLOCKS = ['openai', 'groq', 'local', 'sarvam', 'elevenlabs'] as const;
 
 /**
  * True when a stored user section records provider intent. An explicit
@@ -196,12 +200,19 @@ const STT_PROVIDER_BLOCKS = ['openai', 'groq', 'local', 'sarvam'] as const;
  * silently re-routed that user's audio to the hosted proxy past the key they
  * configured. (New imports also stamp `provider` explicitly; this keeps rows
  * imported before that fix honest.)
+ *
+ * The one shape that beats the sub-block heuristic: `provider: ''` — the
+ * explicit "cleared" sentinel clearProviderChoice writes. A reset click is a
+ * newer, stronger signal than a leftover sub-block, and without the sentinel
+ * the reset could never restore the plan default on a row that ever held a
+ * key (the sub-block survives the reset by design — deleting it would delete
+ * the keychain credential with it).
  */
 function storedProviderChoice(stored: unknown): boolean {
   if (typeof stored !== 'object' || stored === null || Array.isArray(stored)) return false;
   const rec = stored as Record<string, unknown>;
-  if (typeof rec.provider === 'string' && rec.provider.trim() !== '') return true;
-  return STT_PROVIDER_BLOCKS.some(
+  if (typeof rec.provider === 'string') return rec.provider.trim() !== '';
+  return PROVIDER_INTENT_BLOCKS.some(
     (block) => typeof rec[block] === 'object' && rec[block] !== null,
   );
 }

--- a/src/daemon/user-settings.ts
+++ b/src/daemon/user-settings.ts
@@ -145,6 +145,24 @@ export function persistUserPatch(section: 'stt' | 'tts', patch: Record<string, u
   }
 }
 
+/**
+ * Drop the user's explicit provider choice for a voice section, restoring
+ * SILENCE — which is what the hosted defaults key off (effectiveSttForBinding
+ * / effectiveTtsForBinding fill a provider-free row with the included uj
+ * stack). Deliberately a delete rather than a write of 'usejarvis': recording
+ * that as a choice would pin the account, so "reset to the plan default" has
+ * to leave no choice at all.
+ */
+export function clearProviderChoice(section: 'stt' | 'tts'): void {
+  const stored = loadUserSection(section);
+  if (typeof stored !== 'object' || stored === null || Array.isArray(stored)) return;
+  const { provider: _dropped, ...rest } = stored as Record<string, unknown>;
+  // The stored row is user intent, not a complete config — it legitimately
+  // lacks fields the runtime type requires (that is the whole point of
+  // silence), so the cast is the honest shape here.
+  saveUserSection(section, rest as unknown as STTConfig | TTSConfig);
+}
+
 /** Read one stored section; undefined when absent or unparseable. */
 export function loadUserSection(section: UserOwnedSection): unknown {
   const raw = getSetting(settingKey(section));

--- a/src/daemon/user-settings.ts
+++ b/src/daemon/user-settings.ts
@@ -152,15 +152,29 @@ export function persistUserPatch(section: 'stt' | 'tts', patch: Record<string, u
  * stack). Deliberately a delete rather than a write of 'usejarvis': recording
  * that as a choice would pin the account, so "reset to the plan default" has
  * to leave no choice at all.
+ *
+ * Same hydration rule as persistUserPatch: the stored row is STRIPPED, and
+ * saveUserSection re-runs the secret split treating an absent credential as
+ * "delete it" — forwarding the bare row would destroy every stored key on
+ * the one click sold as harmless (it did, once: review pr7#1).
+ *
+ * Returns false when there was no stored row to clear, so the routes can say
+ * "nothing to reset" instead of toasting a success that changed nothing.
  */
-export function clearProviderChoice(section: 'stt' | 'tts'): void {
+export function clearProviderChoice(section: 'stt' | 'tts'): boolean {
   const stored = loadUserSection(section);
-  if (typeof stored !== 'object' || stored === null || Array.isArray(stored)) return;
-  const { provider: _dropped, ...rest } = stored as Record<string, unknown>;
+  if (typeof stored !== 'object' || stored === null || Array.isArray(stored)) return false;
+  const hydrated = injectSectionSecrets(section, stored as Record<string, unknown>);
+  // `provider: ''` is the explicit "cleared" sentinel, not a deletion: a row
+  // that ever held a credential keeps its sub-block (dropping it would drop
+  // the keychain key on the way out), and a bare sub-block reads as intent
+  // (storedProviderChoice's import heuristic) — the sentinel is what makes
+  // the reset stick anyway.
   // The stored row is user intent, not a complete config — it legitimately
   // lacks fields the runtime type requires (that is the whole point of
   // silence), so the cast is the honest shape here.
-  saveUserSection(section, rest as unknown as STTConfig | TTSConfig);
+  saveUserSection(section, { ...hydrated, provider: '' } as unknown as STTConfig | TTSConfig);
+  return true;
 }
 
 /** Read one stored section; undefined when absent or unparseable. */

--- a/ui/src/v2/onboarding/OnboardingWizard.steps.test.ts
+++ b/ui/src/v2/onboarding/OnboardingWizard.steps.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { HOSTED_PROVISIONED, STEPS, stepsFor } from "./OnboardingWizard";
+import { HOSTED_PROVISIONED, STEPS, stepsFor, stepGatedOnProbe, resolveStepKey } from "./OnboardingWizard";
 
 /** Pure-function test (the LLMTab.models.test.ts precedent — this repo has no
  * DOM test infrastructure). The step list is the feature: on a hosted install
@@ -31,5 +31,39 @@ describe("stepsFor", () => {
       expect(stepsFor(true).map(([k]) => k)).toContain(target);
       expect(stepsFor(false).map(([k]) => k)).toContain(target);
     }
+  });
+});
+
+/** The tri-state hosted probe (review pr7#4 / pr3#10): while UNRESOLVED, the
+ * provisioned screens gate — a pending or failed probe must never read as
+ * self-hosted and collect credentials the server guard will discard. */
+describe("stepGatedOnProbe", () => {
+  test("unknown probe gates exactly the provisioned screens", () => {
+    for (const k of HOSTED_PROVISIONED) expect(stepGatedOnProbe("unknown", k)).toBe(true);
+    for (const k of ["welcome", "perms", "connect", "interview", "tour", "allset"] as const) {
+      expect(stepGatedOnProbe("unknown", k)).toBe(false);
+    }
+  });
+
+  test("a resolved probe gates nothing (either verdict)", () => {
+    for (const [k] of STEPS) {
+      expect(stepGatedOnProbe("hosted", k)).toBe(false);
+      expect(stepGatedOnProbe("self", k)).toBe(false);
+    }
+  });
+});
+
+describe("resolveStepKey", () => {
+  test("a key present in the list renders as itself", () => {
+    expect(resolveStepKey(stepsFor(true), "connect")).toBe("connect");
+    expect(resolveStepKey(stepsFor(false), "brain")).toBe("brain");
+  });
+
+  test("a hidden key resolves to Permissions, never the terminal screen", () => {
+    // Probe resolves to hosted while the user stands on Hearing: the key
+    // vanishes from the list. steps.length-1 here would mount "All set".
+    expect(resolveStepKey(stepsFor(true), "hear")).toBe("perms");
+    expect(resolveStepKey(stepsFor(true), "brain")).toBe("perms");
+    expect(resolveStepKey(stepsFor(true), "speak")).toBe("perms");
   });
 });

--- a/ui/src/v2/onboarding/OnboardingWizard.steps.test.ts
+++ b/ui/src/v2/onboarding/OnboardingWizard.steps.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+import { HOSTED_PROVISIONED, STEPS, stepsFor } from "./OnboardingWizard";
+
+/** Pure-function test (the LLMTab.models.test.ts precedent — this repo has no
+ * DOM test infrastructure). The step list is the feature: on a hosted install
+ * the platform already answers brain/hearing/speaking, and ASKING is not the
+ * only cost — answering writes intent that pins the account off its own plan. */
+describe("stepsFor", () => {
+  test("self-hosted keeps every screen (configuring an LLM is mandatory there)", () => {
+    expect(stepsFor(false)).toEqual(STEPS);
+    expect(stepsFor(false).map(([k]) => k)).toContain("brain");
+  });
+
+  test("hosted drops exactly brain, hearing and speaking — nothing else", () => {
+    const keys = stepsFor(true).map(([k]) => k);
+    expect(keys).toEqual(["welcome", "perms", "connect", "interview", "tour", "allset"]);
+    for (const hidden of HOSTED_PROVISIONED) expect(keys).not.toContain(hidden);
+  });
+
+  test("the steps that survive keep their original relative order", () => {
+    const all = STEPS.map(([k]) => k);
+    const kept = stepsFor(true).map(([k]) => k);
+    expect(kept).toEqual(all.filter((k) => kept.includes(k)));
+  });
+
+  // Guards the resume path: startKey returns a KEY ("interview"/"tour"/
+  // "allset"), and every one of those must exist in BOTH lists or a resuming
+  // hosted user lands on a dead index.
+  test("every resume target exists on both installs", () => {
+    for (const target of ["welcome", "interview", "tour", "allset"] as const) {
+      expect(stepsFor(true).map(([k]) => k)).toContain(target);
+      expect(stepsFor(false).map(([k]) => k)).toContain(target);
+    }
+  });
+});

--- a/ui/src/v2/onboarding/OnboardingWizard.tsx
+++ b/ui/src/v2/onboarding/OnboardingWizard.tsx
@@ -30,6 +30,29 @@ export function stepsFor(hosted: boolean): ReadonlyArray<[StepKey, string]> {
   return hosted ? STEPS.filter(([k]) => !HOSTED_PROVISIONED.has(k)) : STEPS;
 }
 
+export type HostedProbe = "unknown" | "hosted" | "self";
+
+/** True when a screen must show the probe-resolving gate instead of its
+ * content: the provisioned screens are exactly the ones whose answers the
+ * server guard drops on hosted installs, so they never render while the
+ * probe is unresolved — a slow/erroring probe used to read as self-hosted
+ * and walk a hosted user into typing credentials that were then silently
+ * discarded (review pr7#4 / pr3#10). */
+export function stepGatedOnProbe(probe: HostedProbe, key: StepKey): boolean {
+  return probe === "unknown" && HOSTED_PROVISIONED.has(key);
+}
+
+/** The key to render when the stored step key is momentarily absent from the
+ * current list (the probe resolved under a hidden screen): Permissions — the
+ * same target the repair effect commits — never the terminal screen (which
+ * mounted "All set" mid-flow) and never index 0 (which flashed Welcome). */
+export function resolveStepKey(
+  steps: ReadonlyArray<[StepKey, string]>,
+  stepKey: StepKey,
+): StepKey {
+  return steps.some(([k]) => k === stepKey) ? stepKey : "perms";
+}
+
 /** Steps that show the progress bar (everything between Welcome and the
  * interview). Key-based: an index range breaks the moment the list shrinks. */
 const PROGRESS_STEPS: ReadonlySet<StepKey> = new Set<StepKey>([
@@ -161,19 +184,34 @@ export function OnboardingWizard({
   // permissions
   // brain
   // Hosted install? GET /api/config/llm reports hosted_llm when the
-  // system-owned usejarvis_ai block is live. Until (and unless) it says so,
-  // the "Jarvis AI" card stays a disabled "Soon" — self-hosted default.
-  const [hosted, setHosted] = useState(false);
+  // system-owned usejarvis_ai block is live. TRI-state on purpose: a slow or
+  // erroring probe used to read as self-hosted, so a hosted user racing a
+  // booting daemon was walked through brain/hearing/speaking, typed three
+  // API keys, and the server guard then silently discarded all of them while
+  // the recap claimed success (review pr7#4 / pr3#10). While 'unknown', the
+  // provisioned screens gate on the probe and the setup POST refuses to fire.
+  const [hostedProbe, setHostedProbe] = useState<"unknown" | "hosted" | "self">("unknown");
+  const [probeAttempt, setProbeAttempt] = useState(0);
   useEffect(() => {
     let cancelled = false;
     fetch("/api/config/llm")
-      .then((r) => (r.ok ? r.json() : null))
+      .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))))
       .then((d: { hosted_llm?: boolean } | null) => {
-        if (!cancelled && d?.hosted_llm) setHosted(true);
+        if (!cancelled) setHostedProbe(d?.hosted_llm ? "hosted" : "self");
       })
-      .catch(() => { /* unreachable daemon reads as self-hosted */ });
+      .catch(() => {
+        // Unreachable daemon stays UNKNOWN (blocked + retryable), never
+        // silently self-hosted. Auto-retry with a short backoff — the common
+        // cause is the daemon still booting under the wizard.
+        if (cancelled) return;
+        setTimeout(() => { if (!cancelled) setProbeAttempt((n) => n + 1); }, 1500);
+      });
     return () => { cancelled = true; };
-  }, []);
+  }, [probeAttempt]);
+  const hosted = hostedProbe === "hosted";
+  // Sections the setup route's hosted guard reported as stripped from OUR
+  // request — the recap must not print them as saved.
+  const [droppedSections, setDroppedSections] = useState<string[]>([]);
   const provList = useMemo(
     () => PROVIDERS.map((p) => (p.id === "jarvis" ? { ...p, soon: !hosted } : p)),
     [hosted],
@@ -189,15 +227,14 @@ export function OnboardingWizard({
     () => stepsFor(hosted),
     [hosted],
   );
-  const found = steps.findIndex(([k]) => k === stepKey);
   // While the key is momentarily absent (the probe resolved under a hidden
   // screen, repaired below), resolve to Permissions DURING RENDER — the same
   // target the repair effect commits to. The previous `steps.length - 1`
   // fallback mounted the terminal "All set" screen (and its onComplete
   // wiring) for one pre-paint commit mid-flow; snapping to 0 would be no
   // better, flashing Welcome's "I'll do this later".
-  const key = found >= 0 ? steps[found]![0] : "perms";
-  const step = found >= 0 ? found : steps.findIndex(([k]) => k === "perms");
+  const key = resolveStepKey(steps, stepKey);
+  const step = steps.findIndex(([k]) => k === key);
 
   // If the probe resolves while the user is standing on a now-hidden screen,
   // send them BACK to Permissions, not forward. Permissions is where the
@@ -444,6 +481,14 @@ export function OnboardingWizard({
 
   /* — the setup POST: fires when leaving Speaking (llm + stt + tts) — */
   const saveSetup = useCallback(async () => {
+    // Never post while the hosted probe is unresolved: the server guard
+    // decides what to keep by hostedness, and a wrong guess here is how
+    // typed-in credentials get silently discarded. The gated screens make
+    // this unreachable in practice; this is the backstop.
+    if (hostedProbe === "unknown") {
+      setError("Still checking what your plan includes — one moment, then try again.");
+      return;
+    }
     setBusy(true); setError(null);
     try {
       // "No voice" sends NO provider field: declining the voice step is not
@@ -503,11 +548,16 @@ export function OnboardingWizard({
       }
       const r = await fetch("/api/onboarding/setup", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(payload) });
       if (!r.ok) throw new Error((await r.text().catch(() => "")) || `HTTP ${r.status}`);
+      // The server reports any sections its hosted guard stripped — keep
+      // them so the recap tells the truth instead of printing dropped
+      // provider config as saved.
+      const resBody = await r.json().catch(() => null) as { dropped?: string[] } | null;
+      setDroppedSections(resBody?.dropped ?? []);
       goKey("connect");
     } catch (e) {
       setError(e instanceof Error ? e.message : "Setup failed.");
     } finally { setBusy(false); }
-  }, [hosted, prov, provId, apiKey, baseUrl, customEndpoint, model, test, tts, edgeVoice, elevenKey, elevenVoice, elevenModel, stt, sttKey, sttEndpoint]);
+  }, [hosted, hostedProbe, prov, provId, apiKey, baseUrl, customEndpoint, model, test, tts, edgeVoice, elevenKey, elevenVoice, elevenModel, stt, sttKey, sttEndpoint]);
 
   const skipAll = useCallback(async () => {
     setBusy(true);
@@ -714,6 +764,27 @@ export function OnboardingWizard({
 
   /* ─────────── step renderers ─────────── */
   function renderStep() {
+    // The provisioned screens are exactly the ones whose answers the server
+    // guard drops on hosted installs — never show them (or the "Jarvis AI ·
+    // Soon" mislabel) until the probe has actually said which install this
+    // is. Blocking here also blocks the path to the setup POST.
+    if (stepGatedOnProbe(hostedProbe, key)) {
+      return (
+        <div className="obw-body mid"><div className="obw-wrap">
+          <h2>Checking what your plan includes…</h2>
+          <div className="obw-sub" style={{ maxWidth: "36ch", margin: "9px auto 0" }}>
+            One moment — confirming whether the AI and voice are already part
+            of your plan, so you aren’t asked to configure something you
+            already have.
+          </div>
+          <div style={{ marginTop: 22, display: "flex", justifyContent: "center" }}>
+            <button className="obw-btn" onClick={() => setProbeAttempt((n) => n + 1)}>
+              Check again
+            </button>
+          </div>
+        </div></div>
+      );
+    }
     switch (key) {
       case "welcome": return (
         <div className="obw-body mid"><div className="obw-wrap">
@@ -973,8 +1044,12 @@ export function OnboardingWizard({
               </>
             ) : configuredThisSession ? (
               <>
-                <div><span className="ok">✓</span> brain · {prov.name}</div>
-                <div><span className="ok">✓</span> voice · {tts === "off" ? "text only" : tts === "edge" ? `Edge (${EDGE_VOICES.find((v) => v.id === edgeVoice)?.label.split(" ")[0]})` : "ElevenLabs"}{stt !== "skip" ? " + Whisper" : ""}</div>
+                {droppedSections.includes("llm")
+                  ? <div><span className="ok">✓</span> brain · included with your plan (the {prov.name} config wasn’t needed and wasn’t saved)</div>
+                  : <div><span className="ok">✓</span> brain · {prov.name}</div>}
+                {droppedSections.includes("tts") || droppedSections.includes("stt")
+                  ? <div><span className="ok">✓</span> voice · included with your plan (your provider entries weren’t needed and weren’t saved)</div>
+                  : <div><span className="ok">✓</span> voice · {tts === "off" ? "text only" : tts === "edge" ? `Edge (${EDGE_VOICES.find((v) => v.id === edgeVoice)?.label.split(" ")[0]})` : "ElevenLabs"}{stt !== "skip" ? " + Whisper" : ""}</div>}
                 <div><span className="ok">✓</span> profile saved to your Vault</div>
               </>
             ) : (

--- a/ui/src/v2/onboarding/OnboardingWizard.tsx
+++ b/ui/src/v2/onboarding/OnboardingWizard.tsx
@@ -191,11 +191,13 @@ export function OnboardingWizard({
   );
   const found = steps.findIndex(([k]) => k === stepKey);
   // While the key is momentarily absent (the probe resolved under a hidden
-  // screen, repaired below), hold the LAST step rather than snapping to 0 —
-  // index 0 is Welcome, and flashing it would briefly re-offer "I'll do this
-  // later" mid-flow.
-  const step = found >= 0 ? found : steps.length - 1;
-  const key = steps[step]![0];
+  // screen, repaired below), resolve to Permissions DURING RENDER — the same
+  // target the repair effect commits to. The previous `steps.length - 1`
+  // fallback mounted the terminal "All set" screen (and its onComplete
+  // wiring) for one pre-paint commit mid-flow; snapping to 0 would be no
+  // better, flashing Welcome's "I'll do this later".
+  const key = found >= 0 ? steps[found]![0] : "perms";
+  const step = found >= 0 ? found : steps.findIndex(([k]) => k === "perms");
 
   // If the probe resolves while the user is standing on a now-hidden screen,
   // send them BACK to Permissions, not forward. Permissions is where the
@@ -723,7 +725,7 @@ export function OnboardingWizard({
           <h2>This is your Jarvis.</h2>
           <div className="obw-sub" style={{ maxWidth: "34ch", margin: "9px auto 0" }}>
             {hosted
-              ? "Let’s spend a couple of minutes setting it up: what it can touch, and a little about you. The AI and voice are included with your plan — already wired up, and yours to change in Settings whenever you like."
+              ? "Let’s spend a couple of minutes setting it up: what it can touch, and a little about you. The AI and voice are included with your plan — Jarvis will speak its replies out loud from the start, and you can change the voice or turn it off any time in Settings → Channels."
               : "Let’s spend about five minutes setting it up: what it can touch, the brain and voice it runs on, and a little about you. You can skip anything and finish later."}
           </div>
           <div style={{ marginTop: 22, display: "flex", flexDirection: "column", gap: 11, alignItems: "center" }}>

--- a/ui/src/v2/onboarding/OnboardingWizard.tsx
+++ b/ui/src/v2/onboarding/OnboardingWizard.tsx
@@ -14,11 +14,27 @@ import { modelForOnboardingTest, onboardingDefaultModelRef } from "./llm-setup";
 type StepKey =
   | "welcome" | "perms" | "brain" | "hear" | "speak" | "connect" | "interview" | "tour" | "allset";
 
-const STEPS: ReadonlyArray<[StepKey, string]> = [
+export const STEPS: ReadonlyArray<[StepKey, string]> = [
   ["welcome", "Welcome"], ["perms", "Permissions"], ["brain", "The brain"],
   ["hear", "Hearing"], ["speak", "Speaking"], ["connect", "Connect"],
   ["interview", "The interview"], ["tour", "The tour"], ["allset", "All set"],
 ];
+
+/** Steps the platform answers on a hosted install — hidden there, and the
+ * setup POST omits their config entirely (the daemon enforces that too). */
+export const HOSTED_PROVISIONED: ReadonlySet<StepKey> = new Set<StepKey>(["brain", "hear", "speak"]);
+
+/** The step list an install actually walks. Exported for tests: the
+ * hosted/self-hosted split is the whole point of this screen set. */
+export function stepsFor(hosted: boolean): ReadonlyArray<[StepKey, string]> {
+  return hosted ? STEPS.filter(([k]) => !HOSTED_PROVISIONED.has(k)) : STEPS;
+}
+
+/** Steps that show the progress bar (everything between Welcome and the
+ * interview). Key-based: an index range breaks the moment the list shrinks. */
+const PROGRESS_STEPS: ReadonlySet<StepKey> = new Set<StepKey>([
+  "perms", "brain", "hear", "speak", "connect",
+]);
 
 /* — inline SVG glyphs (design I{}) — */
 const SVG: Record<string, string> = {
@@ -116,19 +132,21 @@ export function OnboardingWizard({
   status: OnboardingStatus | null;
   onComplete: () => void;
 }) {
-  const startStep = useMemo<number>(() => {
-    if (!status?.setup_completed) return 0;
-    if (!status.profile_completed && !status.setup_skipped_profile) return 6;
-    if (!status.tutorial_completed && !status.tutorial_dismissed) return 7;
-    return 8;
+  const startKey = useMemo<StepKey>(() => {
+    if (!status?.setup_completed) return "welcome";
+    if (!status.profile_completed && !status.setup_skipped_profile) return "interview";
+    if (!status.tutorial_completed && !status.tutorial_dismissed) return "tour";
+    return "allset";
   }, [status]);
 
-  const [step, setStep] = useState(startStep);
-  const key = STEPS[step]![0];
+  // Position is tracked by KEY, not index. The step list shrinks when the
+  // hosted probe resolves (three steps disappear), and an index captured
+  // before that would silently point at a different screen afterwards.
+  const [stepKey, setStepKey] = useState<StepKey>(startKey);
   // True when the wizard is running the setup steps in this session (fresh
   // start) — a resume at the interview/tour never touched brain/voice state,
   // so the recap must not print those defaults as if they were saved.
-  const configuredThisSession = startStep === 0;
+  const configuredThisSession = startKey === "welcome";
 
   // welcome
   const [theme, setTheme] = useState<"light" | "dark">(
@@ -160,6 +178,25 @@ export function OnboardingWizard({
     () => PROVIDERS.map((p) => (p.id === "jarvis" ? { ...p, soon: !hosted } : p)),
     [hosted],
   );
+
+  // On a hosted install the platform already answers brain / hearing /
+  // speaking, so those screens are dropped: asking is noise, and — worse —
+  // answering WRITES intent (an llm.default that disables the uj-* tier
+  // wiring, a tts.provider that pins the account off its included voice).
+  // Self-hosted keeps all nine: there, configuring an LLM is mandatory or
+  // nothing works.
+  const steps = useMemo(
+    () => stepsFor(hosted),
+    [hosted],
+  );
+  const step = Math.max(0, steps.findIndex(([k]) => k === stepKey));
+  const key = steps[step]![0];
+
+  // If the probe resolves while the user is standing ON a now-hidden screen,
+  // move them forward rather than leaving them on a dead index.
+  useEffect(() => {
+    if (!steps.some(([k]) => k === stepKey)) setStepKey("connect");
+  }, [steps, stepKey]);
   const [provId, setProvId] = useState("anthropic");
   const prov = provList.find((p) => p.id === provId)!;
   const [apiKey, setApiKey] = useState("");
@@ -346,9 +383,10 @@ export function OnboardingWizard({
   }, []);
   useEffect(() => stopGooglePoll, [stopGooglePoll]);
 
-  const go = (n: number) => { setError(null); setStep(n); };
-  const next = () => go(Math.min(step + 1, STEPS.length - 1));
-  const back = () => go(Math.max(0, step - 1));
+  const goKey = (k: StepKey) => { setError(null); setStepKey(k); };
+  const go = (n: number) => goKey(steps[Math.min(Math.max(0, n), steps.length - 1)]![0]);
+  const next = () => go(step + 1);
+  const back = () => go(step - 1);
 
   /* — brain: test connection — */
   const runTest = useCallback(async () => {
@@ -407,8 +445,15 @@ export function OnboardingWizard({
       if (tts === "edge") { ttsBlock.voice = edgeVoice; ttsBlock.rate = "+0%"; }
       else if (tts === "elevenlabs") ttsBlock.elevenlabs = { api_key: elevenKey, voice_id: elevenVoice, model: elevenModel };
 
-      const payload: Record<string, unknown> = { tts: ttsBlock };
-      if (provId === "jarvis") {
+      // Hosted: send NOTHING but the architecture mode. The brain/hearing/
+      // speaking screens never ran, so this component's tts/stt state is
+      // untouched defaults — posting it would record choices the user was
+      // never shown, pinning them off their own plan. (The daemon drops
+      // these fields too; this keeps the request honest at the source.)
+      const payload: Record<string, unknown> = hosted ? {} : { tts: ttsBlock };
+      if (hosted) {
+        payload.llm = { mode: "multi-tier" };
+      } else if (provId === "jarvis") {
         // Hosted needs no provider or default — the daemon's carve-out injects
         // the provider, and the uj-* tier wiring lives in the routing view.
         //
@@ -431,7 +476,7 @@ export function OnboardingWizard({
           default: onboardingDefaultModelRef(provId, model, validatedModel),
         };
       }
-      if (stt !== "skip") {
+      if (!hosted && stt !== "skip") {
         const sttBlock: Record<string, unknown> = { provider: stt };
         if ((stt === "openai" || stt === "groq") && sttKey) sttBlock[stt] = { api_key: sttKey };
         else if (stt === "local") sttBlock.local = { endpoint: sttEndpoint.trim(), server_type: "whisper_cpp" };
@@ -439,11 +484,11 @@ export function OnboardingWizard({
       }
       const r = await fetch("/api/onboarding/setup", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(payload) });
       if (!r.ok) throw new Error((await r.text().catch(() => "")) || `HTTP ${r.status}`);
-      go(5);
+      goKey("connect");
     } catch (e) {
       setError(e instanceof Error ? e.message : "Setup failed.");
     } finally { setBusy(false); }
-  }, [prov, provId, apiKey, baseUrl, customEndpoint, model, test, tts, edgeVoice, elevenKey, elevenVoice, elevenModel, stt, sttKey, sttEndpoint]);
+  }, [hosted, prov, provId, apiKey, baseUrl, customEndpoint, model, test, tts, edgeVoice, elevenKey, elevenVoice, elevenModel, stt, sttKey, sttEndpoint]);
 
   const skipAll = useCallback(async () => {
     setBusy(true);
@@ -587,7 +632,7 @@ export function OnboardingWizard({
     try {
       const r = await fetch(endpoint, { method: "POST" });
       if (!r.ok) throw new Error(`HTTP ${r.status}`);
-      go(8);
+      goKey("allset");
     } catch {
       setError("Couldn't reach the daemon to save your progress — try again.");
     }
@@ -614,13 +659,13 @@ export function OnboardingWizard({
   const speakReady = tts !== "elevenlabs" || ttsTest.status === "ok";
 
   /* — progress bar (steps 1..5 only) — */
-  const showProgress = step >= 1 && step <= 5;
+  const showProgress = PROGRESS_STEPS.has(key);
   const progress = showProgress && (
     <>
       <div className="obw-steps">
-        {STEPS.map((_, i) => <i key={i} className={i < step ? "done" : i === step ? "cur" : ""} />)}
+        {steps.map((_, i) => <i key={i} className={i < step ? "done" : i === step ? "cur" : ""} />)}
       </div>
-      <div className="obw-steplab">Step {step + 1} of 9 · {STEPS[step]![1]}</div>
+      <div className="obw-steplab">Step {step + 1} of {steps.length} · {steps[step]![1]}</div>
     </>
   );
 
@@ -639,7 +684,7 @@ export function OnboardingWizard({
       {progress}
 
       {key === "interview" ? (
-        <InterviewStep ttsDisabled={tts === "off"} onComplete={() => go(7)} />
+        <InterviewStep ttsDisabled={tts === "off"} onComplete={() => goKey("tour")} />
       ) : key === "tour" ? (
         renderTour()
       ) : (
@@ -660,7 +705,9 @@ export function OnboardingWizard({
           <div className="obw-word" style={{ fontSize: 15, marginBottom: 11 }}><span className="u">use</span>jarvis</div>
           <h2>This is your Jarvis.</h2>
           <div className="obw-sub" style={{ maxWidth: "34ch", margin: "9px auto 0" }}>
-            Let’s spend about five minutes setting it up: what it can touch, the brain and voice it runs on, and a little about you. You can skip anything and finish later.
+            {hosted
+              ? "Let’s spend a couple of minutes setting it up: what it can touch, and a little about you. The AI and voice are included with your plan — already wired up, and yours to change in Settings whenever you like."
+              : "Let’s spend about five minutes setting it up: what it can touch, the brain and voice it runs on, and a little about you. You can skip anything and finish later."}
           </div>
           <div style={{ marginTop: 22, display: "flex", flexDirection: "column", gap: 11, alignItems: "center" }}>
             <div className="obw-themelab">Choose your look</div>
@@ -697,7 +744,21 @@ export function OnboardingWizard({
               ))}
             </div>
             <div className="obw-hint" style={{ marginTop: 12 }}>Review or revoke any of these anytime in {IS_MAC ? "System Settings → Privacy & Security" : "Windows Settings → Privacy & security"}, or from Settings → Permissions.</div>
-            <div className="obw-btnrow"><button className="obw-btn obw-btn-ghost" onClick={back}>Back</button><span className="grow" /><button className="obw-btn obw-btn-pri" onClick={next}>Continue</button></div>
+            <div className="obw-btnrow">
+              <button className="obw-btn obw-btn-ghost" onClick={back}>Back</button>
+              <span className="grow" />
+              {/* Hosted skips brain/hearing/speaking, so this is the last
+                  setup screen — the setup POST (which normally fires when
+                  leaving Speaking) has to run here instead, or onboarding is
+                  never marked complete and the wizard replays next launch. */}
+              <button
+                className="obw-btn obw-btn-pri"
+                disabled={busy}
+                onClick={hosted ? saveSetup : next}
+              >
+                {busy ? "Setting up…" : "Continue"}
+              </button>
+            </div>
           </div></div>
         );
       }
@@ -878,7 +939,14 @@ export function OnboardingWizard({
             {recapLine()} Bringing your dashboard online now.
           </div>
           <div className="obw-recap">
-            {configuredThisSession ? (
+            {configuredThisSession && hosted ? (
+              // Hosted never ran the brain/voice screens — report what the
+              // plan provides rather than this component's untouched state.
+              <>
+                <div><span className="ok">✓</span> AI &amp; voice · included with your plan</div>
+                <div><span className="ok">✓</span> profile saved to your Vault</div>
+              </>
+            ) : configuredThisSession ? (
               <>
                 <div><span className="ok">✓</span> brain · {prov.name}</div>
                 <div><span className="ok">✓</span> voice · {tts === "off" ? "text only" : tts === "edge" ? `Edge (${EDGE_VOICES.find((v) => v.id === edgeVoice)?.label.split(" ")[0]})` : "ElevenLabs"}{stt !== "skip" ? " + Whisper" : ""}</div>
@@ -900,6 +968,7 @@ export function OnboardingWizard({
 
   function recapLine() {
     if (!configuredThisSession) return "Your brain is wired up, and I know a little about you.";
+    if (hosted) return "Your plan's AI and voice are wired up, and I know a little about you.";
     return `${prov.name} is wired up${tts !== "off" ? ", voice is on" : ""}, and I know a little about you.`;
   }
 

--- a/ui/src/v2/onboarding/OnboardingWizard.tsx
+++ b/ui/src/v2/onboarding/OnboardingWizard.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { useInterviewSession } from "./useInterviewSession";
 import type { OnboardingStatus } from "./useOnboardingStatus";
 import "./OnboardingWizard.css";
@@ -189,13 +189,21 @@ export function OnboardingWizard({
     () => stepsFor(hosted),
     [hosted],
   );
-  const step = Math.max(0, steps.findIndex(([k]) => k === stepKey));
+  const found = steps.findIndex(([k]) => k === stepKey);
+  // While the key is momentarily absent (the probe resolved under a hidden
+  // screen, repaired below), hold the LAST step rather than snapping to 0 —
+  // index 0 is Welcome, and flashing it would briefly re-offer "I'll do this
+  // later" mid-flow.
+  const step = found >= 0 ? found : steps.length - 1;
   const key = steps[step]![0];
 
-  // If the probe resolves while the user is standing ON a now-hidden screen,
-  // move them forward rather than leaving them on a dead index.
-  useEffect(() => {
-    if (!steps.some(([k]) => k === stepKey)) setStepKey("connect");
+  // If the probe resolves while the user is standing on a now-hidden screen,
+  // send them BACK to Permissions, not forward. Permissions is where the
+  // hosted setup POST fires; repairing forward to `connect` would skip it
+  // silently, leaving onboarding never marked complete — the wizard then
+  // replays on the next launch and "Open Jarvis" appears to do nothing.
+  useLayoutEffect(() => {
+    if (!steps.some(([k]) => k === stepKey)) setStepKey("perms");
   }, [steps, stepKey]);
   const [provId, setProvId] = useState("anthropic");
   const prov = provList.find((p) => p.id === provId)!;
@@ -445,14 +453,23 @@ export function OnboardingWizard({
       if (tts === "edge") { ttsBlock.voice = edgeVoice; ttsBlock.rate = "+0%"; }
       else if (tts === "elevenlabs") ttsBlock.elevenlabs = { api_key: elevenKey, voice_id: elevenVoice, model: elevenModel };
 
-      // Hosted: send NOTHING but the architecture mode. The brain/hearing/
-      // speaking screens never ran, so this component's tts/stt state is
-      // untouched defaults — posting it would record choices the user was
-      // never shown, pinning them off their own plan. (The daemon drops
-      // these fields too; this keeps the request honest at the source.)
-      const payload: Record<string, unknown> = hosted ? {} : { tts: ttsBlock };
+      // Hosted: the brain/hearing/speaking screens never ran, so this
+      // component's provider state is untouched defaults — posting it would
+      // record choices the user was never shown, pinning them off their own
+      // plan. (The daemon drops those fields too; this keeps the request
+      // honest at the source.)
+      //
+      // `tts.enabled` is the exception and MUST be sent: it is not a provider
+      // choice, and DEFAULT_CONFIG has it false, so omitting it ships a
+      // hosted install mute — while Welcome and the recap both promise voice
+      // is included. Sending `{enabled:true}` alone keeps the row
+      // provider-free, so effectiveTtsForBinding still fills in the included
+      // uj voice.
+      const payload: Record<string, unknown> = hosted
+        ? { llm: { mode: "multi-tier" }, tts: { enabled: true } }
+        : { tts: ttsBlock };
       if (hosted) {
-        payload.llm = { mode: "multi-tier" };
+        // nothing further: provider config is the platform's job
       } else if (provId === "jarvis") {
         // Hosted needs no provider or default — the daemon's carve-out injects
         // the provider, and the uj-* tier wiring lives in the routing view.
@@ -759,6 +776,12 @@ export function OnboardingWizard({
                 {busy ? "Setting up…" : "Continue"}
               </button>
             </div>
+            {/* The hosted setup POST fires from THIS screen, so its failure
+                has to surface here — otherwise the button just settles back
+                to "Continue" with no explanation and onboarding replays. */}
+            {error && (
+              <div className="obw-hint" style={{ color: "var(--listen)", marginTop: 8 }}>{error}</div>
+            )}
           </div></div>
         );
       }

--- a/ui/src/v2/rooms/settings/SettingsRoom.css
+++ b/ui/src/v2/rooms/settings/SettingsRoom.css
@@ -463,6 +463,15 @@
   outline-offset: 2px;
 }
 
+/* Square-ish icon-only variant: a symbol next to the model dropdowns rather
+   than a word, so the control reads at a glance and stays out of the way of
+   the two selects it sits beside. */
+.v2-set__btn--icon {
+  padding: 6px;
+  width: 30px;
+  flex: 0 0 auto;
+}
+
 .v2-set__btn--primary {
   background: var(--ink);
   color: var(--paper);

--- a/ui/src/v2/rooms/settings/tabs/ChannelsTab.tsx
+++ b/ui/src/v2/rooms/settings/tabs/ChannelsTab.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import { RotateCcw } from "lucide-react";
 import type {
   STTProvider,
   SettingsHook,
@@ -294,22 +295,38 @@ export function ChannelsTab({
 
         <div className="v2-set__field">
           <label className="v2-set__field-label">Provider</label>
-          <select
-            className="v2-set__select"
-            value={sttCfg?.provider ?? "openai"}
-            onChange={async (e) => {
-              const r = await data.setSTTProvider(e.target.value as STTProvider);
-              onToast(r.message, r.ok ? "ok" : "warn");
-            }}
-          >
-            {sttCfg?.usejarvis_available && (
-              <option value="usejarvis">Usejarvis AI (included)</option>
+          <div style={{ display: "flex", gap: "var(--s-2)", alignItems: "center" }}>
+            <select
+              className="v2-set__select"
+              value={sttCfg?.provider ?? "openai"}
+              onChange={async (e) => {
+                const r = await data.setSTTProvider(e.target.value as STTProvider);
+                onToast(r.message, r.ok ? "ok" : "warn");
+              }}
+            >
+              {sttCfg?.usejarvis_available && (
+                <option value="usejarvis">Usejarvis AI (included)</option>
+              )}
+              <option value="openai">OpenAI Whisper</option>
+              <option value="groq">Groq Whisper</option>
+              <option value="sarvam">Sarvam AI</option>
+              <option value="local">Local Whisper (whisper.cpp)</option>
+            </select>
+            {sttCfg?.usejarvis_available && sttCfg?.provider !== "usejarvis" && (
+              <button
+                type="button"
+                className="v2-set__btn v2-set__btn--icon"
+                title="Reset to your plan's included voice"
+                aria-label="Reset to your plan's included voice"
+                onClick={async () => {
+                  const r = await data.resetVoiceProvider("stt");
+                  onToast(r.message, r.ok ? "ok" : "warn");
+                }}
+              >
+                <RotateCcw size={14} aria-hidden="true" />
+              </button>
             )}
-            <option value="openai">OpenAI Whisper</option>
-            <option value="groq">Groq Whisper</option>
-            <option value="sarvam">Sarvam AI</option>
-            <option value="local">Local Whisper (whisper.cpp)</option>
-          </select>
+          </div>
         </div>
 
         {sttCfg?.provider !== "sarvam" && (
@@ -455,21 +472,37 @@ export function ChannelsTab({
 
         <div className="v2-set__field">
           <label className="v2-set__field-label">Provider</label>
-          <select
-            className="v2-set__select"
-            value={ttsCfg?.provider ?? "edge"}
-            onChange={async (e) => {
-              const r = await data.setTTS({ provider: e.target.value as TTSProvider });
-              onToast(r.message, r.ok ? "ok" : "warn");
-            }}
-          >
-            {ttsCfg?.usejarvis_available && (
-              <option value="usejarvis">Usejarvis AI (included)</option>
+          <div style={{ display: "flex", gap: "var(--s-2)", alignItems: "center" }}>
+            <select
+              className="v2-set__select"
+              value={ttsCfg?.provider ?? "edge"}
+              onChange={async (e) => {
+                const r = await data.setTTS({ provider: e.target.value as TTSProvider });
+                onToast(r.message, r.ok ? "ok" : "warn");
+              }}
+            >
+              {ttsCfg?.usejarvis_available && (
+                <option value="usejarvis">Usejarvis AI (included)</option>
+              )}
+              <option value="edge">Edge TTS (free)</option>
+              <option value="elevenlabs">ElevenLabs (API key)</option>
+              <option value="sarvam">Sarvam AI (Indian languages)</option>
+            </select>
+            {ttsCfg?.usejarvis_available && ttsCfg?.provider !== "usejarvis" && (
+              <button
+                type="button"
+                className="v2-set__btn v2-set__btn--icon"
+                title="Reset to your plan's included voice"
+                aria-label="Reset to your plan's included voice"
+                onClick={async () => {
+                  const r = await data.resetVoiceProvider("tts");
+                  onToast(r.message, r.ok ? "ok" : "warn");
+                }}
+              >
+                <RotateCcw size={14} aria-hidden="true" />
+              </button>
             )}
-            <option value="edge">Edge TTS (free)</option>
-            <option value="elevenlabs">ElevenLabs (API key)</option>
-            <option value="sarvam">Sarvam AI (Indian languages)</option>
-          </select>
+          </div>
         </div>
 
         {ttsCfg?.provider === "usejarvis" && (

--- a/ui/src/v2/rooms/settings/tabs/LLMTab.tsx
+++ b/ui/src/v2/rooms/settings/tabs/LLMTab.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
-import { ChevronRight, Plus, Trash2 } from "lucide-react";
+import { ChevronRight, Plus, RotateCcw, Trash2 } from "lucide-react";
 import { confirmDialog } from "../../../ui/ConfirmDialog";
 import { Icon } from "../../../ui";
 import {
@@ -926,6 +926,13 @@ function MultiTierSection({
             allowClear
             preferredModel={USEJARVIS_TIER_ALIASES[t.id]}
             effectiveHint={llm.effective?.tiers[t.id]}
+            clearHint={
+              llm.default
+                ? { ref: llm.default, source: "default" }
+                : llm.hosted_llm
+                  ? { ref: `usejarvis_ai:${USEJARVIS_TIER_ALIASES[t.id]}`, source: "plan" }
+                  : undefined
+            }
             onChange={async (ref) => {
               const r = await data.setTierModel(t.id, ref);
               onToast(r.message, r.ok ? "ok" : "warn");
@@ -977,6 +984,7 @@ function ModelSelector({
   allowClear,
   preferredModel,
   effectiveHint,
+  clearHint,
   onChange,
 }: {
   label: string;
@@ -997,8 +1005,15 @@ function ModelSelector({
   preferredModel?: string;
   /** What the daemon actually routes this slot to (from llm.effective) —
    * rendered when no explicit ref is set, so an unset slot shows routing
-   * truth instead of a never-persisted `models[0]` (review pr3#7). */
+   * truth instead of a never-persisted `models[0]` (review pr3#7). Also
+   * drives the plan-default hint + reset affordance: `source === 'plan'` is
+   * the only state where "using your plan's default" is truthful (pr7#2). */
   effectiveHint?: { ref: string | null; source: "choice" | "default" | "plan" | null };
+  /** What clearing this slot resolves to (computed by the parent from
+   * llm.default / the plan alias), so the reset button's label states the
+   * actual post-clear routing instead of an unconditional "plan default"
+   * claim (review pr7#2). */
+  clearHint?: { ref: string; source: "default" | "plan" };
   onChange: (ref: string | null) => void;
 }) {
   const parsed = useMemo(() => parseModelRef(value), [value]);
@@ -1174,10 +1189,16 @@ function ModelSelector({
         {allowClear && value && (
           <button
             type="button"
-            className="v2-set__btn"
+            className="v2-set__btn v2-set__btn--icon"
             onClick={() => onChange(null)}
+            title={clearHint
+              ? `Reset — this slot returns to ${clearHint.source === "plan" ? "your plan's default" : "the fallback default"} (${clearHint.ref})`
+              : "Clear this model"}
+            aria-label={clearHint
+              ? `Reset to ${clearHint.source === "plan" ? "your plan's default" : "the fallback default"}, ${clearHint.ref}`
+              : "Clear this model"}
           >
-            Clear
+            <RotateCcw size={14} aria-hidden="true" />
           </button>
         )}
       </div>

--- a/ui/src/v2/rooms/settings/useSettingsData.ts
+++ b/ui/src/v2/rooms/settings/useSettingsData.ts
@@ -818,6 +818,32 @@ export function useSettingsData() {
     [refresh],
   );
 
+  /**
+   * Reset a voice provider to the plan default (hosted installs).
+   *
+   * Sends `provider: null`, which the daemon turns into a DELETE of the
+   * recorded choice — not a write of 'usejarvis'. The hosted defaults key off
+   * an absent provider, so recording one would pin the account off its own
+   * plan; only silence keeps the default applying.
+   */
+  const resetVoiceProvider = useCallback(
+    async (section: "stt" | "tts"): Promise<ActionResult> => {
+      try {
+        const r = await postJson<{ ok: boolean; message: string }>(
+          `/api/config/${section}`,
+          { provider: null },
+        );
+        await refresh();
+        return r.ok
+          ? { ok: true, message: r.message || "Reset to your plan default." }
+          : { ok: false, message: r.message || "Failed to reset." };
+      } catch (err) {
+        return { ok: false, message: err instanceof Error ? err.message : "Failed" };
+      }
+    },
+    [refresh],
+  );
+
   // ── TTS (hot-reloaded) ──────────────────────────────────────────────
   const setTTS = useCallback(
     async (input: {
@@ -1061,6 +1087,7 @@ export function useSettingsData() {
     setTelegram,
     setDiscord,
     setSTTProvider,
+    resetVoiceProvider,
     setSTTLanguage,
     setTTS,
     setVoiceConfig,


### PR DESCRIPTION
Onboarding path for a hosted install. The hosted probe is tri-state so a pending or failed probe gates provisioning instead of falling through, a shrinking step list repairs backwards rather than past the screen that fires the setup POST, and the provider-reset routes refuse on self-hosted installs where there is no plan default to fall back to.

Stack: **7/8** — base #358