### PR TITLE
fix(google): the onboarding wizard's managed branch never opened the tab or polled

### DIFF
--- a/src/integrations/google-managed-refresh.ts
+++ b/src/integrations/google-managed-refresh.ts
@@ -12,9 +12,10 @@ import type { JarvisConfig } from '../config/types.ts';
  * could read — and the control plane storing refresh tokens would make a single
  * compromise worth every user's mailbox.
  *
- * The request is signed with the per-instance notify secret from the system
- * config, the same key the push bridge's doorbell is verified with, used here in
- * the other direction. The timestamp is inside the signed bytes so a captured
+ * The request is signed with the per-instance REFRESH secret from the system
+ * config — a different key from the doorbell's notify secret. The two travel in
+ * opposite directions, and while one key served both, the same signature was
+ * valid at either endpoint. The timestamp is inside the signed bytes so a captured
  * request cannot be replayed later.
  */
 export interface ManagedRefreshConfig {

--- a/ui/src/v2/onboarding/OnboardingWizard.tsx
+++ b/ui/src/v2/onboarding/OnboardingWizard.tsx
@@ -610,11 +610,18 @@ export function OnboardingWizard({
         .then((res) => res.json() as Promise<{ managed?: boolean; connect_url?: string }>)
         .catch(() => ({}) as { managed?: boolean; connect_url?: string });
       if (managed.managed && managed.connect_url) {
-        const acct = window.open(managed.connect_url, "_blank", "noopener,noreferrer");
+        // NO `noopener` in the features, deliberately: with it, window.open
+        // returns NULL by specification — so this branch ALWAYS fell into the
+        // error path below, which opens no tab and, worse, returns before
+        // starting the poll. A user who opened the link by hand and connected
+        // successfully watched this step sit unfinished forever. (The hosted
+        // account panel hit the identical bug and fixed it the same way.)
+        const acct = window.open(managed.connect_url, "_blank");
         if (!acct) {
-          setGoogleState("idle");
+          // Genuinely blocked, or a webview that refuses window.open. Tell the
+          // user where to go, but KEEP POLLING: completing it over there is what
+          // finishes this step, and that works whether or not we opened the tab.
           setConnectErr(`Open ${managed.connect_url} to connect Google, then come back here.`);
-          return;
         }
         stopGooglePoll();
         googlePollRef.current = window.setInterval(async () => {


### PR DESCRIPTION
Two fixes found while reviewing the managed Google integration.

**The onboarding wizard's managed branch never opened the tab and never polled.** `window.open` returns `null` by specification when the features string contains `noopener`, so that branch always fell into its own error path — which opens nothing and, worse, returns before starting the poll. A user who opened the link by hand and connected successfully watched the step sit unfinished forever. The settings tab hit the identical bug and was fixed the same way. The poll now starts regardless, since completing the connection elsewhere is what finishes the step whether or not we managed to open a tab.

**A stale docstring** described refresh requests as signed with the doorbell's notify secret, four lines above the code that correctly uses the separate refresh secret. They are different keys on purpose — they travel in opposite directions, and while one key served both, the same signature was valid at either endpoint.
