### PR TITLE
fix(sidecar): stop panel spawn crashing after a close

### DIFF
--- a/scripts/vendor-webview.sh
+++ b/scripts/vendor-webview.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # Re-vendor github.com/webview/webview_go into sidecar/third_party/webview_go at
-# a given version and re-apply the jarvis SW_HIDE patch (jarvis.patch).
+# a given version and re-apply the jarvis patches (jarvis.patch).
 #
 # We vendor + patch webview_go because upstream's Win32 engine constructor shows
 # the window before WebView2 finishes initializing, producing a black flash. The
@@ -74,14 +74,23 @@ rm -rf "$STASH"
 # Re-apply our patch with GNU patch (no git-index awareness, unlike `git apply`,
 # which would see the committed header as already-patched and skip). Strict on
 # purpose: if upstream moved the win32 constructor this fails loudly and a human
-# must regenerate jarvis.patch (the SW_HIDE edit).
+# must regenerate jarvis.patch. Regenerate it by diffing pristine upstream
+# against the patched tree for EVERY file we touch, not just the header.
 echo "Applying jarvis.patch..."
 ( cd "$VENDOR_DIR" && patch -p1 --no-backup-if-mismatch -i "$PATCH_FILE" )
 
-# Sanity-check the patch actually landed.
+# Sanity-check the patch actually landed. One assertion PER patched behavior:
+# the re-copy above restores pristine upstream over every vendored file except
+# KEEP_FILES, so anything jarvis.patch stops carrying is silently reverted, the
+# build still passes, and the monthly update PR goes green having dropped it.
+# A grep that only covers some of the patches cannot tell that apart, so every
+# hunk gets a marker here.
 HEADER="$VENDOR_DIR/libs/webview/include/webview.h"
 grep -q "PATCHED (jarvis)" "$HEADER"
-grep -q "ShowWindow(m_window, SW_HIDE)" "$HEADER"
+grep -q "ShowWindow(m_window, SW_HIDE)" "$HEADER"           # win32: no open flash
+grep -q "isMainThread" "$HEADER"                            # cocoa: main-thread window
+grep -q "w->browser_controller()" "$HEADER"                 # reject half-built engines
+grep -q "PATCHED (jarvis)" "$VENDOR_DIR/webview.go"         # nil WebView on NULL handle
 
 # Record the pinned version (single source of truth for the update workflow).
 printf '%s\n' "$VERSION" > "$VENDOR_DIR/UPSTREAM_VERSION"

--- a/sidecar/internal/webviewui/run.go
+++ b/sidecar/internal/webviewui/run.go
@@ -26,11 +26,14 @@ func RunWindow(title string, width, height int, hint webview.Hint, build func(we
 	// to one OS thread past the window's life is not intended.
 	defer runtime.UnlockOSThread()
 	wv := webview.New(false)
-	// NOT `wv == nil`: webview.New always returns a non-nil interface value,
-	// even when the underlying webview_t is NULL, so that check never fires and
-	// the code proceeds to drive a NULL handle. Under -H windowsgui the symptom
-	// is the installer doing nothing at all when double-clicked, with no
-	// message anywhere. Window() exposes the real handle.
+	// `wv == nil` is the real guard: the vendored binding returns a nil
+	// interface when webview_create returned NULL (third_party/webview_go,
+	// JARVIS_PATCH.md). It MUST come first — Window() is not NULL-safe either
+	// (webview_get_window dereferences the handle), so it would fault on the
+	// very case being checked. It stays as a second condition for a handle
+	// that is null without create having reported failure. Under -H windowsgui
+	// the symptom of getting this wrong is the installer doing nothing at all
+	// when double-clicked, with no message anywhere.
 	if wv == nil || wv.Window() == nil {
 		log.Printf("[ui] could not open %q (webview runtime missing or failed to start?)", title)
 		return false

--- a/sidecar/panels_runtime.go
+++ b/sidecar/panels_runtime.go
@@ -39,12 +39,12 @@ func uiSync(wv webview.WebView, fn func()) {
 // panelImpl wraps a single webview window and the channel used to control it.
 type panelImpl struct {
 	spec       PanelSpec
-	wvVal      atomic.Value    // webview.WebView; set once by the runner goroutine, read by close-watcher / hotkey / service methods
-	ready      chan struct{}   // closed once wv is set + flags applied
-	done       chan struct{}   // closed when Run() returns
-	following  atomic.Bool     // when true, cursor-tracker actively moves window
-	followStop chan struct{}   // closed by Close()/Stop() to halt the tracker
-	hotkeyStop func()          // unregister + stop the hotkey listener
+	wvVal      atomic.Value  // webview.WebView; set once by the runner goroutine, read by close-watcher / hotkey / service methods
+	ready      chan struct{} // closed once wv is set + flags applied
+	done       chan struct{} // closed when Run() returns
+	following  atomic.Bool   // when true, cursor-tracker actively moves window
+	followStop chan struct{} // closed by Close()/Stop() to halt the tracker
+	hotkeyStop func()        // unregister + stop the hotkey listener
 	// macOS shared-loop teardown: uiClosed is closed (once) when the window is
 	// gone so the spawn goroutine, which does not run its own loop there, can
 	// return. Unused on Windows/Linux (those block in wv.Run()).
@@ -158,7 +158,7 @@ func (s *panelService) Spawn(spec PanelSpec) (PanelID, error) {
 		debug := false
 		wv = webview.New(debug)
 		if wv == nil {
-			log.Printf("[panels] spawn(%s): webview.New returned nil — WebView2 runtime missing?", spec.ID)
+			log.Printf("[panels] spawn(%s): webview.New returned nil — WebView2 runtime missing, or its init failed", spec.ID)
 			close(impl.ready)
 			return
 		}
@@ -618,7 +618,41 @@ func (s *panelService) Close(id PanelID) error {
 		if err := platformDestroyWindow(wv.Window()); err != nil {
 			log.Printf("[panels] platformDestroyWindow(%s): %v (falling back to wv.Terminate)", id, err)
 		}
-		wv.Terminate()
+		// Terminate MUST run on the webview's own thread. terminate_impl() is
+		// PostQuitMessage(0) (win32), which posts WM_QUIT to the CALLING
+		// thread — and this runs on whatever goroutine served the close RPC.
+		// So the bare call never reached the panel's loop, and left a WM_QUIT
+		// sitting on a random runtime M that nothing would ever consume.
+		//
+		// That stray message is not inert. The next webview created on that M
+		// (panel goroutines LockOSThread, so they inherit one) pumps the queue
+		// while waiting for WebView2 to initialize, treats the queued WM_QUIT
+		// as "give up" (embed() -> got_quit_msg -> return false), and leaves
+		// m_webview NULL. webview_create validated only the WINDOW, so it handed
+		// back that browserless engine happily and the first Bind dereferenced
+		// NULL — an access violation, which is why the crash always followed a
+		// panel.close + panel.spawn pair and never reproduced on a fresh start.
+		//
+		// Dispatch hands the call to the engine's own message window, so the
+		// quit lands in the loop it is meant to stop.
+		//
+		// The impl.done check is not redundant. If the panel was ALREADY
+		// tearing down when this ran (user closed the window, or the daemon
+		// called Close in response to the closed event), the loop is gone and
+		// the WM_APP sits unread until ~win32_edge_engine's
+		// deplete_run_loop_event_queue drains it mid-destruction — running
+		// this closure and posting the very WM_QUIT the dispatch exists to
+		// avoid, onto an M about to be unlocked and reused. done is closed
+		// before Destroy in the spawn goroutine's defer chain, so by then this
+		// sees it and does nothing.
+		wv.Dispatch(func() {
+			select {
+			case <-impl.done:
+				return
+			default:
+			}
+			wv.Terminate()
+		})
 	}
 	return nil
 }

--- a/sidecar/third_party/webview_go/JARVIS_PATCH.md
+++ b/sidecar/third_party/webview_go/JARVIS_PATCH.md
@@ -2,8 +2,17 @@
 
 This is a local copy of `github.com/webview/webview_go` (the pinned version is
 in `UPSTREAM_VERSION`), wired in via a `replace` directive in `sidecar/go.mod`,
-with **two patches** (`jarvis.patch`): a Win32 one (no open flash) and a Cocoa
-one (create the window on the main thread).
+with **four patches**, all carried by `jarvis.patch`: a Win32 one for the open
+flash, a Cocoa one to create the window on the main thread, a `webview_create`
+check that rejects a half-built engine, and a NULL-handle guard in `webview.go`.
+
+`jarvis.patch` must carry EVERY vendored edit. `vendor-webview.sh` deletes the
+vendor directory and copies pristine upstream over it, keeping only
+`JARVIS_PATCH.md`, `jarvis.patch` and `.gitattributes` — so an edit made
+directly to a vendored file, `webview.go` included, is reverted on the next
+re-vendor with the build still green. Regenerate the patch by diffing pristine
+upstream against the patched tree for every file we touch, and give each
+behavior its own sanity grep in the script.
 
 ## Why
 
@@ -64,8 +73,10 @@ Upgrades are automated. `.github/workflows/update-webview.yml` runs monthly: it
 checks the Go module proxy for a newer version, re-vendors via
 `scripts/vendor-webview.sh`, re-applies `jarvis.patch`, and -- only if the patch
 still applies and the sidecar still builds (linux-native cgo + windows-cross
-mingw) -- opens a PR. A green run means the bump is safe to merge, but the PR is
-always left for a human to review and merge (no auto-merge).
+mingw) -- opens a PR. The script also asserts one marker per patched behavior
+after re-applying, so a patch that silently stopped carrying one of them fails
+the run instead of shipping a green PR that reverts it. The PR is always left
+for a human to review and merge (no auto-merge).
 
 To bump manually (or pin a specific version):
 
@@ -78,3 +89,55 @@ If upstream moves the win32 constructor, `patch` (and the workflow) will fail.
 Regenerate `jarvis.patch`: diff a pristine copy of the new
 `libs/webview/include/webview.h` against the `SW_HIDE` edit above (search for
 `PATCHED (jarvis)`), update the hunk, and re-run the script.
+
+## The NULL-handle patch (`webview.go`)
+
+`webview_create` returns `nullptr` when the window could not be created — it
+deletes the instance and returns null (`webview.h`, `webview_create`). Upstream's
+Go binding wrapped that null in a non-nil `*webview` and returned it anyway:
+
+```go
+w := &webview{}
+w.w = C.webview_create(boolToInt(debug), window)
+return w        // never nil, even when w.w is NULL
+```
+
+So the `if wv == nil` guard at every call site (`local_webview_other.go`,
+`local_webview_darwin.go`, `panels_runtime.go`, `hosted_window.go`,
+`internal/webviewui/run.go`) was dead code, and the next call through the interface dereferenced NULL inside C++.
+That is an access violation, not a Go panic: the process dies instantly with
+nothing in the log — the failure mode looks like "the sidecar just vanishes when
+a window opens".
+
+The check cannot live at the call site, because none of the C entry points are
+NULL-safe — `webview_get_window` included (`static_cast<webview *>(w)->window()`),
+so even `wv.Window() == nil` faults. `NewWindow` now returns a nil interface
+instead, which makes the guard every caller already has do what it says.
+
+## The half-built-engine patch (`webview_create`)
+
+`embed()` pumps the message loop while WebView2 initializes, and bails if it
+sees a WM_QUIT:
+
+```cpp
+while (flag.test_and_set() && GetMessageW(&msg, nullptr, 0, 0) >= 0) {
+  if (msg.message == WM_QUIT) { got_quit_msg = true; break; }
+  ...
+}
+if (got_quit_msg) { return false; }
+```
+
+The window was created before that point, so a thread with a stray WM_QUIT
+already queued produces an engine with a valid `m_window` and a NULL
+`m_webview`/`m_controller`. Upstream's `webview_create` only checked
+`w->window()`, so it returned that engine and the first `bind()`/`navigate()`
+faulted on NULL — a 0xC0000005 that no Go `recover` can catch.
+
+It now requires `browser_controller()` as well, so a failed init is a failed
+create. Combined with the NULL-handle patch above, callers get a nil `WebView`
+and their existing `wv == nil` guard logs and degrades.
+
+The stray WM_QUIT that made this reachable came from the sidecar calling
+`Terminate()` (`PostQuitMessage(0)`, which targets the *calling* thread) from
+a foreign goroutine; `panels_runtime.go` now dispatches it onto the engine's
+own thread. This patch is the backstop for any other source.

--- a/sidecar/third_party/webview_go/jarvis.patch
+++ b/sidecar/third_party/webview_go/jarvis.patch
@@ -1,4 +1,3 @@
-diff --git a/libs/webview/include/webview.h b/libs/webview/include/webview.h
 --- a/libs/webview/include/webview.h
 +++ b/libs/webview/include/webview.h
 @@ -1471,6 +1471,7 @@
@@ -94,3 +93,40 @@ diff --git a/libs/webview/include/webview.h b/libs/webview/include/webview.h
      }
  
      auto cb =
+@@ -3500,7 +3516,16 @@
+ 
+ WEBVIEW_API webview_t webview_create(int debug, void *wnd) {
+   auto w = new webview::webview(debug, wnd);
+-  if (!w->window()) {
++  // PATCHED (jarvis): require the BROWSER, not just the window. embed() gives
++  // up and returns false when a WM_QUIT is already queued on this thread (or
++  // WebView2 init fails outright), leaving m_webview/m_controller NULL while
++  // m_window is perfectly valid. Upstream's window-only check then returns
++  // that half-built engine, and the first call that touches the browser —
++  // bind(), navigate(), eval() — dereferences NULL and takes the process down
++  // with an access violation no Go recover can see. Fail the create instead;
++  // the Go binding turns a nullptr into a nil WebView (see JARVIS_PATCH.md)
++  // and callers already log and degrade on that.
++  if (!w->window() || !w->browser_controller()) {
+     delete w;
+     return nullptr;
+   }
+--- a/webview.go
++++ b/webview.go
+@@ -155,6 +155,16 @@
+ func NewWindow(debug bool, window unsafe.Pointer) WebView {
+ 	w := &webview{}
+ 	w.w = C.webview_create(boolToInt(debug), window)
++	// PATCHED (jarvis): webview_create returns NULL when the window could not be
++	// created (see webview.h: it deletes the instance and returns nullptr).
++	// Upstream wrapped that NULL in a non-nil *webview anyway, so the callers'
++	// `wv == nil` guard could never fire and the next C call dereferenced NULL
++	// inside C++ — an access violation that kills the process with no Go panic
++	// and nothing in the log. None of the C entry points are NULL-safe,
++	// webview_get_window included, so the check cannot live at the call site.
++	if w.w == nil {
++		return nil
++	}
+ 	return w
+ }
+ 

--- a/sidecar/third_party/webview_go/libs/webview/include/webview.h
+++ b/sidecar/third_party/webview_go/libs/webview/include/webview.h
@@ -3516,7 +3516,16 @@ using webview = browser_engine;
 
 WEBVIEW_API webview_t webview_create(int debug, void *wnd) {
   auto w = new webview::webview(debug, wnd);
-  if (!w->window()) {
+  // PATCHED (jarvis): require the BROWSER, not just the window. embed() gives
+  // up and returns false when a WM_QUIT is already queued on this thread (or
+  // WebView2 init fails outright), leaving m_webview/m_controller NULL while
+  // m_window is perfectly valid. Upstream's window-only check then returns
+  // that half-built engine, and the first call that touches the browser —
+  // bind(), navigate(), eval() — dereferences NULL and takes the process down
+  // with an access violation no Go recover can see. Fail the create instead;
+  // the Go binding turns a nullptr into a nil WebView (see JARVIS_PATCH.md)
+  // and callers already log and degrade on that.
+  if (!w->window() || !w->browser_controller()) {
     delete w;
     return nullptr;
   }

--- a/sidecar/third_party/webview_go/webview.go
+++ b/sidecar/third_party/webview_go/webview.go
@@ -155,6 +155,16 @@ func New(debug bool) WebView { return NewWindow(debug, nil) }
 func NewWindow(debug bool, window unsafe.Pointer) WebView {
 	w := &webview{}
 	w.w = C.webview_create(boolToInt(debug), window)
+	// PATCHED (jarvis): webview_create returns NULL when the window could not be
+	// created (see webview.h: it deletes the instance and returns nullptr).
+	// Upstream wrapped that NULL in a non-nil *webview anyway, so the callers'
+	// `wv == nil` guard could never fire and the next C call dereferenced NULL
+	// inside C++ — an access violation that kills the process with no Go panic
+	// and nothing in the log. None of the C entry points are NULL-safe,
+	// webview_get_window included, so the check cannot live at the call site.
+	if w.w == nil {
+		return nil
+	}
 	return w
 }
 


### PR DESCRIPTION
Opening a room right after the palette closed killed the sidecar with an access violation and no Go panic.

`Close()` called `wv.Terminate()` from the RPC goroutine. On win32 that is `PostQuitMessage(0)`, which targets the **calling** thread — so it never reached the panel loop and left a WM_QUIT on an arbitrary runtime M. Panel goroutines `LockOSThread`, so a later spawn could inherit it; the webview constructor pumps that queue while WebView2 initialises, treats the WM_QUIT as "give up", and returns an engine with a valid window but a NULL browser. `webview_create` only checked the window, so it accepted it, and the first `Bind` dereferenced NULL.

- `Terminate` now goes through `Dispatch`, skipping the quit if the panel already tore down (the destructor drains that queue, and running the closure there would repost the same WM_QUIT).
- `webview_create` requires the browser too, so a half-built engine is a failed create rather than a NULL deref later.
- The Go binding returns a nil `WebView` on a NULL handle, making the `wv == nil` guard all five call sites already had reachable — it was dead code.

Both vendored edits go into `jarvis.patch`, not the files alone: `vendor-webview.sh` restores pristine upstream over everything outside `KEEP_FILES`, so the monthly bump would have reverted them with the build still green. The script now asserts one marker per patched behavior.

Verified: a simulated re-vendor (pristine + patch) reproduces the vendored tree byte-identically and all five assertions pass. Windows cross-build clean, suite 2421 pass / 0 fail. Confirmed on Windows against the original repro.