### PR TITLE
fix(sidecar): record runtime panics instead of writing them to a dead handle

### DIFF
--- a/sidecar/logging.go
+++ b/sidecar/logging.go
@@ -31,6 +31,15 @@ func setupLogging() {
 	if err != nil {
 		return
 	}
+	// Runtime panics never reach the log package — the runtime writes them to
+	// fd 2 directly — so on Windows point the process's stderr handle at this
+	// file too. Without it, a panic under -H windowsgui kills the process with
+	// nothing written anywhere. When the swap succeeds os.Stderr IS f, so the
+	// tee below would double-write every line.
+	if redirectStderrToLog(f) {
+		log.SetOutput(f)
+		return
+	}
 	// File first so it always receives output even when stderr is a dead handle
 	// (the Windows GUI subsystem has no console). MultiWriter stops on the first
 	// error, so ordering matters.

--- a/sidecar/logging_other.go
+++ b/sidecar/logging_other.go
@@ -1,0 +1,10 @@
+//go:build !windows
+
+package main
+
+import "os"
+
+// redirectStderrToLog is a no-op off Windows: stderr is a live terminal when
+// run from a shell, and the launchd/systemd cases already capture it. See the
+// Windows implementation for why that platform needs the handle swapped.
+func redirectStderrToLog(*os.File) bool { return false }

--- a/sidecar/logging_windows.go
+++ b/sidecar/logging_windows.go
@@ -1,0 +1,34 @@
+//go:build windows
+
+package main
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+// redirectStderrToLog points the process's STD_ERROR_HANDLE at the log file.
+//
+// The log package never sees a runtime panic: the Go runtime writes its
+// traceback straight to fd 2, and on Windows that resolves through
+// GetStdHandle(STD_ERROR_HANDLE) on EVERY write (runtime/os_windows.go
+// write1). Under -H windowsgui there is no console, so that handle is dead
+// and a panic — or any fatal runtime error — leaves NO trace anywhere: the
+// process simply disappears while sidecar.log ends mid-sentence, which reads
+// as "it crashed with no error" when in fact the error was written to a
+// handle that goes nowhere.
+//
+// Because the runtime re-resolves the handle per write rather than caching it
+// at startup, replacing it here is enough to capture tracebacks that have not
+// happened yet. Returns false if the swap failed, so the caller can keep the
+// normal stderr tee rather than losing output entirely.
+func redirectStderrToLog(f *os.File) bool {
+	if err := windows.SetStdHandle(windows.STD_ERROR_HANDLE, windows.Handle(f.Fd())); err != nil {
+		return false
+	}
+	// Keep Go-level writers (os.Stderr) pointed at the same place as the
+	// runtime's fd 2, so the two cannot diverge.
+	os.Stderr = f
+	return true
+}

--- a/sidecar/main.go
+++ b/sidecar/main.go
@@ -99,15 +99,18 @@ Usage:
 		// wrong-URL token used to be saved blind and fail invisibly in the
 		// reconnect loop. Errors go to stderr as well as the log — --token is
 		// typically run from a terminal, and logs already go to the file.
+		// On Windows setupLogging has pointed stderr AT the log file, so the
+		// two land together there (the same line twice, once timestamped).
 		tok := trimToken(*token)
 		if err := verifyBrainToken(context.Background(), tok, cfg.Brain); err != nil {
 			log.Printf("[sidecar] enrollment token check failed: %v", err)
 			fmt.Fprintf(os.Stderr, "Error: %v\nThe token was not saved.\n", err)
-			// The Windows build is a GUI-subsystem binary — stderr goes
-			// nowhere — so surface the failure in a native message box there
-			// (MessageBoxW blocks until dismissed). Elsewhere this logs
-			// (Linux) or no-ops before exit (macOS, no run loop yet); the
-			// stderr line above covers those terminals.
+			// The Windows build is a GUI-subsystem binary with no console, so
+			// the line above reaches the log file but no human — surface the
+			// failure in a native message box there (MessageBoxW blocks until
+			// dismissed). Elsewhere this logs (Linux) or no-ops before exit
+			// (macOS, no run loop yet); the stderr line above covers those
+			// terminals.
 			platformShowAlert("JARVIS Sidecar", fmt.Sprintf("%v\n\nThe token was not saved.", err))
 			os.Exit(1)
 		}


### PR DESCRIPTION
A panic on Windows killed the sidecar with `sidecar.log` ending mid-sentence and the traceback nowhere to be found.

`setupLogging` tees the `log` package to the file, but the runtime writes tracebacks straight to fd 2. On Windows that resolves through `GetStdHandle(STD_ERROR_HANDLE)` on every write, and under `-H windowsgui` there is no console, so the output went to a dead handle.

The process stderr handle now points at the log file. That works precisely because the runtime re-resolves it per write rather than caching it at startup, so the swap catches tracebacks that have not happened yet. `os.Stderr` is reassigned to match so the two cannot diverge, and the old `MultiWriter` tee is kept if the swap fails.

No behavior change beyond what gets recorded — this only stops crashes from being silent. It is what made #366 diagnosable.