### PR TITLE
fix(daemon): register the usage room everywhere it has to be listed

### DIFF
--- a/src/agents/voice-intent-classifier.ts
+++ b/src/agents/voice-intent-classifier.ts
@@ -34,6 +34,7 @@ const VALID_ROOMS: ReadonlySet<RoomKey> = new Set([
   'tasks',
   'content',
   'workspaces',
+  'usage',
   'settings',
 ]);
 

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -1885,6 +1885,7 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
         tasks:       { aliases: ['tasks', 'todos', 'task list', 'task'],    title: 'Tasks',       w: 500, h: 600 },
         content:     { aliases: ['content', 'content pipeline', 'notes'],   title: 'Content',     w: 800, h: 600 },
         workspaces:  { aliases: ['workspaces', 'workspace', 'sites'],       title: 'Workspaces',  w: 800, h: 600 },
+        usage:       { aliases: ['token usage', 'usage room'],              title: 'Usage',       w: 800, h: 600 },
       };
 
       // Match aliases longest-first so "tool catalog" wins over "tools" when

--- a/src/daemon/realtime-nav-tools.ts
+++ b/src/daemon/realtime-nav-tools.ts
@@ -15,7 +15,7 @@ import type { LLMTool } from '../llm/provider.ts';
 /** Room keys that map 1:1 to RoomKey in src/voice/intent.ts. */
 export const REALTIME_ROOM_KEYS = [
   'workflows', 'memory', 'tools', 'agents', 'authority', 'logs',
-  'calendar', 'goals', 'tasks', 'content', 'workspaces', 'settings',
+  'calendar', 'goals', 'tasks', 'content', 'workspaces', 'usage', 'settings',
 ] as const;
 
 export const REALTIME_NAV_TOOL_NAMES = new Set([

--- a/src/voice/intent.ts
+++ b/src/voice/intent.ts
@@ -133,6 +133,7 @@ export type RoomKey =
   | "tasks"
   | "content"
   | "workspaces"
+  | "usage"
   | "settings";
 
 export function intentToRoomKey(intent: Intent): RoomKey | null {

--- a/src/voice/window-control.ts
+++ b/src/voice/window-control.ts
@@ -57,6 +57,7 @@ const ROOM_ALIASES: Record<string, RoomKey> = {
   workspaces: "workspaces",
   project: "workspaces",
   projects: "workspaces",
+  usage: "usage",
   setting: "settings",
   settings: "settings",
 };

--- a/ui/src/v2/rooms/RoomShell.tsx
+++ b/ui/src/v2/rooms/RoomShell.tsx
@@ -17,6 +17,7 @@ const ROOM_KEYS = new Set<RoomKey>([
   "tasks",
   "content",
   "workspaces",
+  "usage",
   "settings",
 ]);
 


### PR DESCRIPTION
Picking Usage in the palette closed the palette and opened nothing — the daemon never dispatched `panel.spawn`.

Six registries each carry their own copy of the room set, and only the UI ones had `usage`. The daemon hit `if (!meta)` and returned before spawning. The same omission one layer over meant realtime voice could not express "open usage" in its tool enum, the classifier rejected a usage `room_action`, window control could not resolve "close the usage window", and `#/_room_usage` fell back to the Tools breadcrumb.

Voice aliases are `token usage` / `usage room`, deliberately not the bare word: `show` is an open verb, so `\busage\b` matches the tail of "show my cpu usage" and would confidently open the LLM-token panel while skipping the LLM for a question it should have answered. Falling through to the LLM is the better failure. The palette matches on key rather than alias, so it is unaffected either way.

Confirmed working on Windows. Worth noting the drift itself is untested — a parity assertion over the room registries would have caught this and would catch the next one.