### PR TITLE
ci: retry the transient test failures instead of re-running the job by hand

### DIFF
--- a/.github/actions/bun-setup/action.yml
+++ b/.github/actions/bun-setup/action.yml
@@ -1,0 +1,54 @@
+name: Bun setup
+description: Install Bun, restore the install cache, and run a retrying `bun install --frozen-lockfile`.
+
+inputs:
+  bun-version:
+    description: >-
+      Bun release to install. Pinned, not `latest`: with --frozen-lockfile a Bun
+      release that migrates the lockfile format would fail every PR ("lockfile
+      had changes, but lockfile is frozen") with no repo change to blame. Bump
+      deliberately, alongside a regenerated bun.lock.
+    required: false
+    default: "1.3.14"
+
+runs:
+  using: composite
+  steps:
+    - uses: oven-sh/setup-bun@v2
+      with:
+        bun-version: ${{ inputs.bun-version }}
+
+    # setup-bun does not cache the install cache, only the toolchain. Without
+    # this every run re-downloads the whole tree from npm.
+    - name: Cache bun install cache
+      uses: actions/cache@v4
+      with:
+        path: ~/.bun/install/cache
+        key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+        restore-keys: ${{ runner.os }}-bun-
+
+    # --frozen-lockfile: a package.json edit that never made it into bun.lock
+    # fails here instead of silently resolving something the lockfile has never
+    # seen.
+    #
+    # Retried because this step's observed CI failure is a NETWORK one, not a
+    # repo one: `prebuild-install` lost its socket fetching sharp's prebuilt
+    # binary, sharp fell back to compiling from source, and the runner has no
+    # libvips ("fatal error: vips/vips8: No such file or directory"). Install is
+    # idempotent, so re-running it is safe; a genuine lockfile or resolution
+    # error still fails all three attempts.
+    - name: Install dependencies
+      shell: bash
+      run: |
+        set -euo pipefail
+        for attempt in 1 2 3; do
+          if bun install --frozen-lockfile; then
+            exit 0
+          fi
+          if [ "$attempt" -eq 3 ]; then
+            echo "::error::bun install failed after 3 attempts"
+            exit 1
+          fi
+          echo "::warning::bun install failed (attempt $attempt/3), retrying"
+          sleep $((attempt * 15))
+        done

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,33 +58,31 @@ jobs:
               - 'src/daemon/pid.ts'
               - 'bin/**'
               - '.github/workflows/test.yml'
+              # This job's toolchain + install now live in a composite action;
+              # a change there must still re-run it.
+              - '.github/actions/bun-setup/**'
 
   test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: oven-sh/setup-bun@v2
-        with:
-          # Pinned, not `latest`: with --frozen-lockfile below, a Bun release
-          # that migrates the lockfile format would fail every PR ("lockfile had
-          # changes, but lockfile is frozen") with no repo change to blame.
-          # Bump deliberately, alongside a regenerated bun.lock.
-          bun-version: "1.3.14"
-      # setup-bun does not cache the install cache, only the toolchain. Without
-      # this every run re-downloads the whole tree from npm.
-      - name: Cache bun install cache
-        uses: actions/cache@v4
-        with:
-          path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
-          restore-keys: ${{ runner.os }}-bun-
-      # --frozen-lockfile: a package.json edit that never made it into bun.lock
-      # fails here instead of silently resolving something the lockfile has
-      # never seen.
-      - run: bun install --frozen-lockfile
+      - uses: ./.github/actions/bun-setup
       - run: bun run scripts/check-no-ee-imports.ts
       - run: bun run scripts/check-migrations.ts
-      - run: bun test
+      # --retry=2 (3 attempts per test), NOT a retry around the whole step.
+      # Every flake this suite has produced in CI is a per-test hook timing out
+      # on a loaded runner -- a headless Chromium slow to answer CDP
+      # (browser-primitives.test.ts) or a slow SQLite schema build
+      # (rotate-encryption-key.test.ts). Bun re-runs beforeEach/afterEach on
+      # each attempt, so those recover; a deterministic failure still fails all
+      # three. Retried tests print as "(attempt N)", so a flake stays visible in
+      # the log instead of silently disappearing.
+      #
+      # A step-level retry would re-run the whole ~130s suite on a runner still
+      # carrying the orphaned chrome processes the previous attempt leaked --
+      # slower, and less likely to pass.
+      - run: bun test --retry=2
+      # Not retried: deterministic.
       - run: bunx tsc --noEmit
 
   # ─── Daemon lifecycle on macOS (launchd) ───────────────────────
@@ -102,16 +100,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: "1.3.14"
-      - name: Cache bun install cache
-        uses: actions/cache@v4
-        with:
-          path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
-          restore-keys: ${{ runner.os }}-bun-
-      - run: bun install --frozen-lockfile
+      - uses: ./.github/actions/bun-setup
       # Scoped to the lifecycle + service-definition files, not all of src/cli.
       # This job exists for the macOS-only behaviour (launchd KeepAlive
       # relaunch, plist generation); the rest of src/cli is already covered on
@@ -124,7 +113,7 @@ jobs:
       # not because anything is known-broken.)
       - name: Daemon lifecycle tests (launchd paths active)
         run: |
-          bun test \
+          bun test --retry=2 \
             src/cli/daemon-control.test.ts \
             src/cli/daemon-control.launchd.test.ts \
             src/cli/daemon-control.systemd.test.ts \
@@ -142,6 +131,12 @@ jobs:
     needs: changes
     if: needs.changes.outputs.sidecar == 'true'
     runs-on: ubuntu-latest
+    # One literal for the `-skip`/`-run` pair below. They partition the package
+    # between an unretried step and a retried one, so they must stay in sync:
+    # drift would leave the flaky test running un-retried in the first step
+    # while the second matches nothing and passes vacuously.
+    env:
+      PARITY_TEST: '^TestBrowserHandlerParityIntegration$'
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v6
@@ -178,7 +173,43 @@ jobs:
           set -euo pipefail
           go vet ./...
           go build ./...
-          go test ./...
+          # The browser parity test is split out and retried; everything else
+          # runs once so a real regression still fails fast.
+          go test -skip "$PARITY_TEST" ./...
+
+      # TestBrowserHandlerParityIntegration drives a real headless Chromium over
+      # the CDP pipe, and on a loaded runner that races: the observed CI flakes
+      # are "attach to page: CDP timeout for Target.getTargets" (Chromium not
+      # answering CDP inside the 30s budget) and a profile-dir cleanup losing to
+      # a still-dying Chrome. Both clear on a re-run, so give it up to 3
+      # attempts. -count=1 keeps the test cache from returning the failure.
+      - name: Browser parity integration test (retried, cgo)
+        working-directory: sidecar
+        env:
+          CGO_ENABLED: "1"
+        run: |
+          set -euo pipefail
+          # Fail loudly if the pattern stops matching (a rename): `go test -run`
+          # with no match prints "no tests to run" and exits 0, which would turn
+          # this whole step into a no-op.
+          listed=$(go test -list "$PARITY_TEST" . | grep -c '^Test' || true)
+          if [ "$listed" -ne 1 ]; then
+            echo "::error::PARITY_TEST ($PARITY_TEST) matched $listed tests, expected 1"
+            exit 1
+          fi
+          for attempt in 1 2 3; do
+            if go test -count=1 -run "$PARITY_TEST" .; then
+              exit 0
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              echo "::error::browser parity test failed after 3 attempts"
+              exit 1
+            fi
+            # Settle before retrying: a previous attempt's Chromium may still be
+            # tearing down, which is one of the races this retry exists for.
+            echo "::warning::browser parity test failed (attempt $attempt/3), retrying"
+            sleep 10
+          done
 
       - name: Cross-build (windows/amd64, mingw)
         working-directory: sidecar


### PR DESCRIPTION
Across the last 300 `test.yml` runs, 10 of the 24 failures were flakes that a manual re-run turned green. Four signatures:

- `bun test` — `browser primitives (integration)`: `beforeEach` hook times out waiting on a headless Chromium slow to answer CDP.
- `bun test` — `rotate-encryption-key`: `beforeEach` SQLite schema build exceeds the default 5s hook budget.
- `go test` — `TestBrowserHandlerParityIntegration`: `CDP timeout for Target.getTargets`, and a profile-dir cleanup racing a still-dying Chrome.
- `bun install` — `prebuild-install` socket hang up fetching sharp's prebuilt binary, falling back to a source build with no libvips.

Four of the ten landed on `main`, leaving the branch red.

Changes:

- `bun test --retry=2` (3 attempts per test). Bun re-runs `beforeEach`/`afterEach` per attempt, so the hook timeouts recover; a deterministic failure still fails all three and retries print as `(attempt N)`, so flakes stay visible. Cheaper and likelier to pass than re-running the whole ~130s suite on a runner still carrying the leaked chrome processes.
- New `.github/actions/bun-setup` composite action: setup-bun + install cache + `bun install --frozen-lockfile` retried 3x with backoff. Replaces the block duplicated in `test` and `daemon-cli-darwin`.
- `sidecar-build`: the browser parity test is split out of `go test ./...` via `-skip` into its own step retried 3x. Everything else runs once so a real regression still fails fast. A guard fails the step if the name pattern stops matching, since `go test -run` with no match exits 0.

Only the `bun install` case is genuinely GitHub's fault; the rest are our own timing-sensitive tests losing a race on a loaded runner. Root-cause fixes for those follow separately.