### PR TITLE
fix(ci): remove the two slow-runner races behind the test flakes

### DIFF
--- a/scripts/rotate-encryption-key.test.ts
+++ b/scripts/rotate-encryption-key.test.ts
@@ -34,6 +34,17 @@ let keyFile: string;
 let dbPath: string;
 let originalKey: Buffer;
 
+// Explicit budget: this hook builds a real schema'd SQLite DB and writes two
+// encrypted rows. That is ~140ms on a dev box, but it timed out CI against
+// bun's 5s default on a loaded shared runner. The work is fast; it just needs
+// headroom when the runner is throttled.
+const HOOK_TIMEOUT_MS = 30_000;
+
+// Same reasoning for the tests themselves: every one of them shells out to
+// `bun run scripts/rotate-encryption-key.ts`, and a cold subprocess start plus
+// a full rotation does not reliably fit in bun's 5s default on a loaded runner.
+const TEST_TIMEOUT_MS = 30_000;
+
 beforeEach(() => {
   dataDir = mkdtempSync(join(tmpdir(), "jarvis-rotate-"));
   keyFile = join(dataDir, "cache", "workflow-encryption.key");
@@ -68,13 +79,13 @@ beforeEach(() => {
   closeWorkflowDb();
   // Reset in-memory key state so the spawned script doesn't inherit it.
   setEncryptionKey(null);
-});
+}, HOOK_TIMEOUT_MS);
 
 afterEach(() => {
   closeWorkflowDb();
   setEncryptionKey(null);
   rmSync(dataDir, { recursive: true, force: true });
-});
+}, HOOK_TIMEOUT_MS);
 
 function runScript(opts: {
   env?: Record<string, string | undefined>;
@@ -138,7 +149,7 @@ describe("rotate-encryption-key", () => {
       .get() as { value: string };
     expect(() => decryptJson(row.value, "conn_a")).toThrow();
     db2.close();
-  });
+  }, TEST_TIMEOUT_MS);
 
   test("refuses to run when a daemon currently holds the pid lock for the same data dir", async () => {
     // Acquire a flock at the *test data dir's* pid path -- that's what the
@@ -158,7 +169,7 @@ describe("rotate-encryption-key", () => {
     } finally {
       handle.release();
     }
-  });
+  }, TEST_TIMEOUT_MS);
 
   test("--allow-running-daemon bypasses the lock check", async () => {
     const { acquireLockAt, lockPathFor } = await import("../src/daemon/pid");
@@ -171,7 +182,7 @@ describe("rotate-encryption-key", () => {
     } finally {
       handle.release();
     }
-  });
+  }, TEST_TIMEOUT_MS);
 
   test("ignores a daemon holding the default lock when --data-dir points elsewhere", async () => {
     // Regression: previously the script called isLocked() without honoring
@@ -184,7 +195,7 @@ describe("rotate-encryption-key", () => {
     const res = runScript({ allowDaemon: false });
     expect(res.status).toBe(0);
     expect(res.stderr).not.toMatch(/Daemon is running/);
-  });
+  }, TEST_TIMEOUT_MS);
 
   test("refuses to run when JARVIS_WORKFLOW_ENCRYPTION_KEY is set", () => {
     const res = runScript({
@@ -194,7 +205,7 @@ describe("rotate-encryption-key", () => {
     expect(res.stderr).toMatch(/JARVIS_WORKFLOW_ENCRYPTION_KEY/);
     // Keychain unchanged.
     expect(readFileSync(keyFile, "utf8").trim()).toBe(originalKey.toString("hex"));
-  });
+  }, TEST_TIMEOUT_MS);
 
   test("refuses to run when a `.new` sidecar already exists", () => {
     writeFileSync(`${keyFile}.new`, randomBytes(32).toString("hex") + "\n");
@@ -203,12 +214,12 @@ describe("rotate-encryption-key", () => {
     expect(res.stderr).toMatch(/sidecar/i);
     // Keychain unchanged.
     expect(readFileSync(keyFile, "utf8").trim()).toBe(originalKey.toString("hex"));
-  });
+  }, TEST_TIMEOUT_MS);
 
   test("noop when no keychain exists", () => {
     rmSync(keyFile);
     const res = runScript();
     expect(res.status).toBe(0);
     expect(res.stderr).toMatch(/nothing to rotate/i);
-  });
+  }, TEST_TIMEOUT_MS);
 });

--- a/sidecar/browser.go
+++ b/sidecar/browser.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -150,6 +151,12 @@ func chromiumLaunchArgs(profileDir string, headless bool) []string {
 	return args
 }
 
+// browserReadyTimeout bounds how long a freshly-spawned browser may take to
+// start answering CDP at all. Generous on purpose: it is a ceiling for a cold
+// start on a throttled CI runner, not a latency budget -- waitForBrowserReady
+// returns as soon as the browser replies.
+const browserReadyTimeout = 30 * time.Second
+
 // launchCDP finds a Chromium-based browser, starts it with the CDP pipe, and
 // attaches to a page target.
 func launchCDP(cfg *SidecarConfig, headless bool) (*cdpClient, error) {
@@ -183,6 +190,14 @@ func launchCDP(cfg *SidecarConfig, headless bool) (*cdpClient, error) {
 		pending:  make(map[int64]chan cdpReply),
 	}
 	go c.readLoop(proc.read)
+
+	// Wait for the process to actually be answering CDP before asking it for
+	// anything, so a slow start reads as "still booting" rather than as a
+	// timed-out Target.getTargets.
+	if err := c.waitForBrowserReady(browserReadyTimeout); err != nil {
+		c.shutdown()
+		return nil, fmt.Errorf("launch browser %q: %w", exe, err)
+	}
 
 	if err := c.attachToPage(); err != nil {
 		c.shutdown()
@@ -305,8 +320,24 @@ func (c *cdpClient) send(method string, params map[string]any) (json.RawMessage,
 	return c.sendOn(c.sessionID, method, params)
 }
 
+// cdpDefaultTimeout bounds a single CDP round-trip once the browser is known
+// to be answering. The launch handshake uses a shorter, retried budget instead
+// -- see waitForBrowserReady.
+const cdpDefaultTimeout = 30 * time.Second
+
+// errCDPTimeout marks a command that got no reply inside its budget. It is the
+// one failure worth retrying: the browser may simply not be listening yet. A
+// transport error means the pipe is gone and no retry can help, so callers that
+// poll must tell the two apart.
+var errCDPTimeout = errors.New("CDP timeout")
+
 // sendOn issues a command on a specific session ("" = browser-level).
 func (c *cdpClient) sendOn(sessionID, method string, params map[string]any) (json.RawMessage, error) {
+	return c.sendOnTimeout(sessionID, method, params, cdpDefaultTimeout)
+}
+
+// sendOnTimeout is sendOn with an explicit reply deadline.
+func (c *cdpClient) sendOnTimeout(sessionID, method string, params map[string]any, timeout time.Duration) (json.RawMessage, error) {
 	if c.closed.Load() {
 		return nil, fmt.Errorf("browser connection closed")
 	}
@@ -343,11 +374,54 @@ func (c *cdpClient) sendOn(sessionID, method string, params map[string]any) (jso
 			return nil, fmt.Errorf("CDP %s: %s", method, string(reply.errMsg))
 		}
 		return reply.result, nil
-	case <-time.After(30 * time.Second):
+	case <-time.After(timeout):
 		c.pendMu.Lock()
 		delete(c.pending, id)
 		c.pendMu.Unlock()
-		return nil, fmt.Errorf("CDP timeout for %s", method)
+		return nil, fmt.Errorf("%w for %s", errCDPTimeout, method)
+	}
+}
+
+// waitForBrowserReady blocks until the freshly-spawned browser answers a
+// browser-level CDP command, or the deadline passes.
+//
+// A cold Chromium on a loaded machine can take many seconds before it reads the
+// CDP pipe at all. Firing the first real command straight at it spends the full
+// 30s round-trip budget on a browser that simply had not started yet, then fails
+// the whole launch -- the "attach to page: CDP timeout for Target.getTargets"
+// flake seen on CI runners. Polling with a short per-attempt budget instead
+// turns that into a wait: each probe that finds nobody home is retried rather
+// than consuming the entire allowance.
+func (c *cdpClient) waitForBrowserReady(budget time.Duration) error {
+	const probeTimeout = 2 * time.Second
+
+	stop := time.Now().Add(budget)
+	var lastErr error
+	for {
+		// Belt and braces. In practice this cannot fire mid-launch: the only
+		// paths that set closed (readLoop's fail(), closeActiveCDP) take
+		// activeCDP.mu first, and getCDP holds it for the whole launch. A dead
+		// browser reaches us as the write error handled just below.
+		if c.closed.Load() {
+			return errors.New("browser connection closed before it became ready")
+		}
+
+		_, err := c.sendOnTimeout("", "Browser.getVersion", nil, probeTimeout)
+		if err == nil {
+			return nil
+		}
+		// Only a timeout means "not up yet". Anything else is a transport
+		// failure -- the browser died at startup and the pipe is broken -- and
+		// retrying it would trade an instant, accurate error for a 30s stall.
+		if !errors.Is(err, errCDPTimeout) {
+			return fmt.Errorf("browser died during startup: %w", err)
+		}
+		lastErr = err
+
+		if time.Now().After(stop) {
+			return fmt.Errorf("browser did not answer CDP within %s: %w", budget, lastErr)
+		}
+		time.Sleep(100 * time.Millisecond)
 	}
 }
 

--- a/sidecar/browser_ready_test.go
+++ b/sidecar/browser_ready_test.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"errors"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// errWriter fails every write, standing in for a pipe whose read end went away
+// because the browser died at startup.
+type errWriter struct{ err error }
+
+func (w errWriter) Write(p []byte) (int, error) { return 0, w.err }
+func (w errWriter) Close() error                { return nil }
+
+// blackholeWriter accepts writes and never answers, standing in for a browser
+// that has been spawned but is not reading the CDP pipe yet.
+type blackholeWriter struct{ mu sync.Mutex }
+
+func (w *blackholeWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return len(p), nil
+}
+func (w *blackholeWriter) Close() error { return nil }
+
+func newTestClient(w io.WriteCloser) *cdpClient {
+	return &cdpClient{
+		proc:    &browserProc{write: w, read: io.NopCloser(strings.NewReader("")), kill: func() {}},
+		pending: make(map[int64]chan cdpReply),
+	}
+}
+
+// A browser that dies at startup must be reported immediately, not retried for
+// the whole budget: every probe fails instantly with a transport error, so
+// retrying would turn an accurate error into a long stall.
+func TestWaitForBrowserReadyFailsFastOnTransportError(t *testing.T) {
+	c := newTestClient(errWriter{err: errors.New("broken pipe")})
+
+	start := time.Now()
+	err := c.waitForBrowserReady(30 * time.Second)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected an error when the pipe is broken")
+	}
+	if !strings.Contains(err.Error(), "broken pipe") {
+		t.Errorf("error should surface the transport cause, got: %v", err)
+	}
+	if errors.Is(err, errCDPTimeout) {
+		t.Errorf("a transport failure must not be reported as a CDP timeout: %v", err)
+	}
+	if elapsed > 2*time.Second {
+		t.Errorf("should fail fast, took %s", elapsed)
+	}
+}
+
+// A browser that is up but silent must be retried until the budget runs out,
+// and the final error must name the timeout.
+func TestWaitForBrowserReadyTimesOutWhenBrowserNeverAnswers(t *testing.T) {
+	c := newTestClient(&blackholeWriter{})
+
+	start := time.Now()
+	err := c.waitForBrowserReady(500 * time.Millisecond)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected a timeout error")
+	}
+	if !errors.Is(err, errCDPTimeout) {
+		t.Errorf("expected the wrapped CDP timeout sentinel, got: %v", err)
+	}
+	if elapsed < 500*time.Millisecond {
+		t.Errorf("returned before the budget elapsed: %s", elapsed)
+	}
+
+	// Every abandoned probe must be removed from the pending map, or a long
+	// wait would leak one entry per attempt.
+	c.pendMu.Lock()
+	leaked := len(c.pending)
+	c.pendMu.Unlock()
+	if leaked != 0 {
+		t.Errorf("timed-out probes leaked %d pending entries", leaked)
+	}
+}
+
+// A browser that answers must be detected, and quickly.
+func TestWaitForBrowserReadySucceedsWhenBrowserAnswers(t *testing.T) {
+	c := newTestClient(&blackholeWriter{})
+
+	// Stand in for readLoop: resolve whatever probe is in flight.
+	go func() {
+		deadline := time.Now().Add(5 * time.Second)
+		for time.Now().Before(deadline) {
+			c.pendMu.Lock()
+			for id, ch := range c.pending {
+				delete(c.pending, id)
+				ch <- cdpReply{result: []byte(`{"product":"Chrome/1.2.3"}`)}
+			}
+			c.pendMu.Unlock()
+			time.Sleep(5 * time.Millisecond)
+		}
+	}()
+
+	if err := c.waitForBrowserReady(5 * time.Second); err != nil {
+		t.Fatalf("expected readiness, got: %v", err)
+	}
+}
+
+// The closed flag short-circuits the wait rather than probing a dead client.
+func TestWaitForBrowserReadyStopsWhenClientClosed(t *testing.T) {
+	c := newTestClient(&blackholeWriter{})
+	c.closed.Store(true)
+
+	err := c.waitForBrowserReady(30 * time.Second)
+	if err == nil || !strings.Contains(err.Error(), "closed") {
+		t.Fatalf("expected a closed-connection error, got: %v", err)
+	}
+}


### PR DESCRIPTION
Root-cause follow-up to #370, which added retries as a safety net. Both fixes target flakes found in the Actions history.

**`rotate-encryption-key.test.ts` — hook timed out at 7349ms.** The `beforeEach` builds a real schema'd SQLite DB and writes two encrypted rows; that is ~140ms locally for the whole file, so the 5s default only blew because the runner was throttled roughly 35x. Every test also shells out to `bun run scripts/rotate-encryption-key.ts`, on the same 5s default. Explicit 30s budgets on the hooks and the tests — the work is fast, it just needs headroom.

**`launchCDP` — `attach to page: CDP timeout for Target.getTargets`.** `launchCDP` spawned Chromium and immediately fired its first real command at it, and `sendOn` had a hardcoded 30s reply budget. On a cold, loaded runner Chromium is not reading the CDP pipe yet, so that one call burned the entire 30s and failed the launch. Now `waitForBrowserReady` polls `Browser.getVersion` on a 2s per-probe budget until a 30s ceiling, so a slow start reads as "still booting" instead of one timed-out command.

`sendOn` is split into `sendOnTimeout` with the old 30s preserved as `cdpDefaultTimeout`, so every existing caller is unchanged and the `CDP timeout for <method>` message is byte-identical.

The ready-wait retries only timeouts. A transport error means the browser died at startup and the pipe is broken, so it returns immediately — retrying would turn an accurate error into a 30s stall. `browser_ready_test.go` covers that (it fails with a 30s hang if the classification is removed), plus budget expiry, the success path, and that abandoned probes leave no entries in the pending map.

Verified locally: `go vet`, `go build`, full sidecar suite green with `TestBrowserHandlerParityIntegration` exercising the new path, and the bun suite at 2433 pass / 0 fail.