### PR TITLE
fix(codesign): make the macOS plists well-formed XML so codesign can parse the entitlements

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -295,6 +295,33 @@ jobs:
   # bugs (dictionary terms shadowing variables) only surface on a real macOS
   # interpreter at runtime — osacompile alone won't catch them, hence the
   # event-free `probe` command.
+  # Every .plist must be well-formed XML. This is not pedantry: codesign parses
+  # entitlements with AMFIUnserializeXML, which is far stricter than the
+  # CFPropertyList used for bundle Info.plists, and it rejects the file outright.
+  # XML forbids "--" inside a comment, so writing a flag name like --options in
+  # explanatory prose silently breaks signing — and only at release time, on a
+  # macOS runner, after the build has already burned several minutes.
+  plist-lint:
+    needs: changes
+    if: needs.changes.outputs.sidecar == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Parse every plist
+        run: |
+          set -euo pipefail
+          fail=0
+          while IFS= read -r f; do
+            if python3 -c "import plistlib,sys; plistlib.load(open(sys.argv[1],'rb'))" "$f" 2>/tmp/err; then
+              echo "ok   $f"
+            else
+              echo "FAIL $f — $(cat /tmp/err | tail -1)"
+              grep -n -- '--' "$f" | grep -v DOCTYPE | sed 's/^/       double-hyphen: /' || true
+              fail=1
+            fi
+          done < <(find . -name '*.plist' -not -path './.git/*' | sort)
+          exit $fail
+
   applescript-check:
     runs-on: macos-latest
     steps:

--- a/sidecar/packaging/macos/Installer-Info.plist
+++ b/sidecar/packaging/macos/Installer-Info.plist
@@ -27,6 +27,6 @@
 	<key>NSHighResolutionCapable</key>
 	<true/>
 	<!-- No TCC usage strings on purpose: the installer never requests
-	     permissions — the installed Jarvis.app does, in its --setup wizard. -->
+	     permissions — the installed Jarvis.app does, in its setup wizard. -->
 </dict>
 </plist>

--- a/sidecar/packaging/macos/entitlements.plist
+++ b/sidecar/packaging/macos/entitlements.plist
@@ -3,8 +3,8 @@
 <plist version="1.0">
 <dict>
 	<!-- Hardened-runtime entitlements for the notarized bundle. Notarization
-	     requires --options runtime, and the hardened runtime denies these
-	     capabilities unless they are declared here (the TCC usage strings in
+	     requires the hardened runtime (codesign option `runtime`), which
+	     denies these capabilities unless they are declared here (the TCC usage strings in
 	     Info.plist are still required on top). Keep this list minimal: every
 	     entitlement is attack surface and shows up in security review. -->
 


### PR DESCRIPTION
The v0.12.0 release failed at sidecar macOS signing:

```
Signing as: Developer ID Application: Usejarvis Inc. (D99CATW2CS)
Failed to parse entitlements: AMFIUnserializeXML: syntax error near line 6
```

The credentials were fine — the identity imported and was found. The
entitlements file simply is not well-formed XML.

### Cause

**XML forbids `--` inside a comment.** Both plists document a command-line flag
in prose:

- `entitlements.plist:6` — "requires `--options` runtime"
- `Installer-Info.plist:30` — "in its `--setup` wizard"

Fixed by rewording; no key, value, or entitlement changes. The parsed
entitlements are identical:

```
{'com.apple.security.device.audio-input': True,
 'com.apple.security.automation.apple-events': True}
```

### Why it went unnoticed

Two reasons this survived since #312:

1. macOS signing had never run — there were no Apple credentials until today,
   so the step was always skipped.
2. `Installer-Info.plist` is *still* malformed in the same way, yet the
   installer signed, notarized and stapled successfully an hour ago. Bundle
   plists go through `CFPropertyList`, which tolerates this; entitlements go
   through `AMFIUnserializeXML`, which does not. Fixed anyway — it was working
   by luck, not by design.

### Guard

New `plist-lint` job parses every `.plist` in the repo. Verified by mutation:
green on this branch, and red with the original text restored, reporting the
same line and an `ExpatError`.

This class of bug is expensive without a guard — it is invisible locally,
surfaces only on a macOS runner at release time, and only after the build has
already spent minutes.