### PR TITLE
fix(onboarding): bring the first-run slideshow back in line with the product

### DIFF
--- a/ui/src/ambient/Pebble.tsx
+++ b/ui/src/ambient/Pebble.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from "react";
+import { CTRL_LABEL } from "../v2/ui/platform";
 
 export type PebbleState =
   | "idle"
@@ -223,7 +224,9 @@ export function Pebble() {
             </button>
           </div>
           <div className="thread-hint">
-            <kbd>⌃</kbd>+click anywhere to summon · <kbd>esc</kbd> to dismiss
+            {/* ⌃ is a Mac keycap marking; a PC keyboard just says Ctrl. The
+                binding takes either modifier (see the mousedown handler). */}
+            <kbd>{CTRL_LABEL}</kbd>+click anywhere to summon · <kbd>esc</kbd> to dismiss
           </div>
         </div>
       )}

--- a/ui/src/components/sites/SiteEditor.tsx
+++ b/ui/src/components/sites/SiteEditor.tsx
@@ -86,7 +86,8 @@ export function SiteEditor({ projectId, filePath }: Props) {
     }
   }, []);
 
-  // Keyboard shortcut: Ctrl+S
+  // Keyboard shortcut: Ctrl+S, and ⌘S on a Mac — the handler takes either
+  // modifier and preventDefaults, so the browser's own save dialog never opens.
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       if ((e.ctrlKey || e.metaKey) && e.key === "s") {

--- a/ui/src/components/sites/SiteEditor.tsx
+++ b/ui/src/components/sites/SiteEditor.tsx
@@ -90,7 +90,7 @@ export function SiteEditor({ projectId, filePath }: Props) {
   // modifier and preventDefaults, so the browser's own save dialog never opens.
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
-      if ((e.ctrlKey || e.metaKey) && e.key === "s") {
+      if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "s") {
         e.preventDefault();
         handleSave();
       }

--- a/ui/src/v2/onboarding/OnboardingWizard.css
+++ b/ui/src/v2/onboarding/OnboardingWizard.css
@@ -148,6 +148,10 @@ select.obw-inp { cursor: pointer; -webkit-appearance: none; appearance: none; }
 .obw-rows { display: flex; flex-direction: column; gap: 8px; margin-top: 4px; }
 .obw-prow { display: flex; align-items: center; gap: 13px; padding: 13px 14px; border: 1px solid var(--rule); border-radius: 11px 2px 11px 11px; background: var(--raise); }
 .obw-prow .pg { width: 36px; height: 36px; flex-shrink: 0; border-radius: 9px 2px 9px 9px; background: var(--panel); display: grid; place-items: center; color: var(--ink2); }
+/* Every row glyph reads the same size. The set is not uniform at source —
+   `check` is drawn at 15px and the rest at 18px — which only showed once two
+   rows sat side by side using different ones. */
+.obw-prow .pg svg { width: 18px; height: 18px; }
 .obw-prow .pt { flex: 1; min-width: 0; }
 .obw-prow .pt .pn { font-size: 13px; font-weight: 600; color: var(--ink); }
 .obw-prow .pt .pn .req { font-family: var(--mono); font-size: 8px; letter-spacing: 0.08em; text-transform: uppercase; color: var(--listen); margin-left: 7px; }

--- a/ui/src/v2/onboarding/OnboardingWizard.css
+++ b/ui/src/v2/onboarding/OnboardingWizard.css
@@ -116,7 +116,6 @@ select.obw-inp { cursor: pointer; -webkit-appearance: none; appearance: none; }
 .obw-choice.on .rad { border-color: var(--ink); }
 .obw-choice.on .rad::after { content: ""; position: absolute; inset: 3px; border-radius: 50%; background: var(--ink); }
 .obw-subctl { margin: 9px 0 2px; padding-left: 46px; display: flex; align-items: center; gap: 10px; }
-.obw-pill { display: inline-flex; align-items: center; gap: 5px; font-family: var(--mono); font-size: 8.5px; letter-spacing: 0.06em; text-transform: uppercase; color: var(--ink3); background: var(--panel); border: 1px solid var(--rule); border-radius: 5px; padding: 2px 6px; }
 
 /* provider grid (LLM) */
 .obw-provgrid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 8px; margin-top: 4px; }

--- a/ui/src/v2/onboarding/OnboardingWizard.css
+++ b/ui/src/v2/onboarding/OnboardingWizard.css
@@ -294,14 +294,22 @@ select.obw-inp { cursor: pointer; -webkit-appearance: none; appearance: none; }
    on the last slide with no way forward. Pinned to the bottom edge it is always
    whole and its buttons always reachable; the callout stops pointing at a
    specific row, which is the right thing to lose when the alternative is a
-   dead end. `!important` because each slide's position is an inline style. */
-@media (max-height: 560px) {
+   dead end. `!important` because each slide's position is an inline style, and
+   an important declaration in a stylesheet is the one thing that outranks one.
+   The breakpoint is derived, not guessed: the tour step renders no progress bar,
+   so the frame is about `viewport - 98px`, and slide 5's card runs to ~325px —
+   clipping starts near a 425px viewport. Pinning earlier than that only costs
+   the pointing, so there is a little headroom and no more. */
+@media (max-height: 470px) {
   .obw-spot {
     top: auto !important;
     bottom: 12px !important;
     left: 12px !important;
     right: 12px !important;
+    /* Bounded, or a wide-short window stretches the callout into a 1300px
+       ribbon of 13px text with its buttons stranded at the far end. */
     width: auto !important;
+    max-width: 420px !important;
   }
 }
 @media (prefers-reduced-motion: reduce) {

--- a/ui/src/v2/onboarding/OnboardingWizard.css
+++ b/ui/src/v2/onboarding/OnboardingWizard.css
@@ -222,8 +222,13 @@ select.obw-inp { cursor: pointer; -webkit-appearance: none; appearance: none; }
      drift apart. Grows with the frame, within bounds that keep it looking like
      a sidebar rather than a stripe or a second pane. */
   --mrail-w: clamp(118px, 15%, 200px);
-  width: 100%;
-  height: 100%;
+  /* Fills an ordinary window, and stops before a very large one. The mock's
+     type and rail rows are fixed-size, so past roughly here it grows without
+     scaling: a 200px rail of 10px type beside a 2000px pane reads as a mostly
+     empty panel — a different wrong answer from the small floating rectangle
+     this replaced, but still a wrong one. */
+  width: min(1400px, 100%);
+  height: min(860px, 100%);
   border: 1px solid var(--rule);
   border-radius: 14px 3px 14px 14px;
   overflow: hidden;
@@ -242,7 +247,14 @@ select.obw-inp { cursor: pointer; -webkit-appearance: none; appearance: none; }
 .obw-miniapp .mtop { height: 30px; border: 1px solid var(--rule); border-radius: 8px; background: var(--bg); display: flex; align-items: center; padding: 0 11px; gap: 8px; font-family: var(--mono); font-size: 9px; color: var(--ink3); }
 /* auto-fit, so a wide frame lays the four cards out across the space instead of
    stretching two of them into slabs. */
-.obw-miniapp .mgrid { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); grid-auto-rows: minmax(60px, 1fr); gap: 9px; margin-top: 11px; align-content: start; }
+/* min() on the floor so a narrow frame SHRINKS the cards instead of overflowing
+   a track it cannot fit — the bare 180px minimum sheared a card against the
+   frame's overflow:hidden once the main pane fell below it.
+   Rows are capped rather than 1fr: letting them stretch made each card a
+   floor-to-ceiling rectangle on a large window, which is bigger without being
+   more convincing, and left `align-content: start` with nothing to do. A
+   dashboard has cards near the top and room beneath them. */
+.obw-miniapp .mgrid { display: grid; grid-template-columns: repeat(auto-fit, minmax(min(180px, 100%), 1fr)); grid-auto-rows: minmax(60px, 132px); gap: 9px; margin-top: 11px; align-content: start; }
 .obw-miniapp .mcard { min-height: 60px; border: 1px solid var(--rule); border-radius: 9px; background: var(--bg); }
 .obw-miniapp .mpeb { position: absolute; right: 16px; bottom: 14px; }
 .obw-tourdim { position: absolute; inset: 0; background: rgba(8, 10, 14, 0.52); z-index: 40; }
@@ -266,7 +278,14 @@ select.obw-inp { cursor: pointer; -webkit-appearance: none; appearance: none; }
 .obw-themeseg button.on { background: var(--ink); color: var(--bg); }
 .obw-themelab { font-size: 11px; color: var(--ink3); margin-bottom: 7px; }
 
-@media (max-width: 760px) { .obw-provgrid { grid-template-columns: 1fr; } .obw-miniapp { grid-template-columns: 84px 1fr; } }
+/* The narrow rail is set through the VARIABLE, not by overriding the column.
+   Overriding the column moved the rail and left the three spotlights that
+   follow --mrail-w sitting where a 118px rail used to end — 46px adrift, in the
+   main area, pointing at nothing. One knob, both consumers. */
+@media (max-width: 760px) {
+  .obw-provgrid { grid-template-columns: 1fr; }
+  .obw-tourframe { --mrail-w: 84px; }
+}
 @media (prefers-reduced-motion: reduce) {
   .obw-drop .in, .obw-drop .ring, .obw-spot .sh .sd .in, .obw-micbars b, .obw-wave b, .obw-voicepill .ld { animation: none !important; }
   .obw-drop .in { opacity: 1 !important; }

--- a/ui/src/v2/onboarding/OnboardingWizard.css
+++ b/ui/src/v2/onboarding/OnboardingWizard.css
@@ -286,6 +286,24 @@ select.obw-inp { cursor: pointer; -webkit-appearance: none; appearance: none; }
   .obw-provgrid { grid-template-columns: 1fr; }
   .obw-tourframe { --mrail-w: 84px; }
 }
+/* Short windows: pin the spotlight to the bottom of the frame instead of the
+   place its slide asked for.
+   The frame clips (overflow:hidden, for the mock), and slide 5's card starts
+   150px down and runs ~175px — so once the frame drops under roughly 330px it
+   was cut off, taking "Skip tour" and "Finish" with it and stranding the user
+   on the last slide with no way forward. Pinned to the bottom edge it is always
+   whole and its buttons always reachable; the callout stops pointing at a
+   specific row, which is the right thing to lose when the alternative is a
+   dead end. `!important` because each slide's position is an inline style. */
+@media (max-height: 560px) {
+  .obw-spot {
+    top: auto !important;
+    bottom: 12px !important;
+    left: 12px !important;
+    right: 12px !important;
+    width: auto !important;
+  }
+}
 @media (prefers-reduced-motion: reduce) {
   .obw-drop .in, .obw-drop .ring, .obw-spot .sh .sd .in, .obw-micbars b, .obw-wave b, .obw-voicepill .ld { animation: none !important; }
   .obw-drop .in { opacity: 1 !important; }

--- a/ui/src/v2/onboarding/OnboardingWizard.css
+++ b/ui/src/v2/onboarding/OnboardingWizard.css
@@ -202,29 +202,44 @@ select.obw-inp { cursor: pointer; -webkit-appearance: none; appearance: none; }
     radial-gradient(65% 60% at 50% 42%, color-mix(in srgb, var(--ink) 5%, transparent), transparent),
     var(--panel2);
 }
-/* The mini-app is a contained *preview*, not the whole window — a fixed
-   frame centred in the stage so the spotlights land on their targets and
-   it never balloons into a broken-looking empty dashboard. */
+/* The mini-app previews the dashboard the user is about to meet, so it fills
+   the stage rather than sitting in the middle of it. It used to be pinned at
+   880x520 and centred, which on any ordinary window left it a small rectangle
+   adrift in empty space — it read as a screenshot of something else, not as
+   "this is your dashboard".
+   The old cap was there so the spotlights, which are positioned in pixels,
+   kept landing on their targets. That still holds: the two on the right are
+   anchored to the frame's own edges, and the three that point at the rail now
+   follow --mrail-w rather than a hardcoded 130px, so they track the rail at
+   any width. */
 .obw-tourframe {
   position: relative;
-  width: min(880px, 100%);
-  height: min(520px, 100%);
+  /* Consumed by the rail column AND by the rail spotlights, so the two cannot
+     drift apart. Grows with the frame, within bounds that keep it looking like
+     a sidebar rather than a stripe or a second pane. */
+  --mrail-w: clamp(118px, 15%, 200px);
+  width: 100%;
+  height: 100%;
   border: 1px solid var(--rule);
   border-radius: 14px 3px 14px 14px;
   overflow: hidden;
   background: var(--bg);
   box-shadow: 0 30px 70px -34px rgba(0, 0, 0, 0.65);
 }
-.obw-miniapp { position: absolute; inset: 0; display: grid; grid-template-columns: 118px 1fr; }
+.obw-miniapp { position: absolute; inset: 0; display: grid; grid-template-columns: var(--mrail-w) 1fr; }
 .obw-miniapp .mrail { border-right: 1px solid var(--rule); background: var(--bg); padding: 12px 10px; display: flex; flex-direction: column; gap: 5px; }
 .obw-miniapp .mrail .mh { font-family: var(--mono); font-size: 8px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--faint); margin: 7px 0 2px; }
 .obw-miniapp .mrail .mr { font-size: 10.5px; color: var(--ink2); padding: 3px 6px; border-radius: 5px; display: flex; align-items: center; gap: 6px; }
 .obw-miniapp .mrail .mr.on { background: var(--panel); color: var(--ink); font-weight: 600; }
 .obw-miniapp .mrail .mr .bd { margin-left: auto; font-family: var(--mono); font-size: 8px; color: var(--hold); }
-.obw-miniapp .mmain { padding: 14px; position: relative; }
+/* A grid so the cards take the height the top bar does not, instead of a fixed
+   block of them stranded under a tall frame. */
+.obw-miniapp .mmain { padding: 14px; position: relative; display: grid; grid-template-rows: auto 1fr; }
 .obw-miniapp .mtop { height: 30px; border: 1px solid var(--rule); border-radius: 8px; background: var(--bg); display: flex; align-items: center; padding: 0 11px; gap: 8px; font-family: var(--mono); font-size: 9px; color: var(--ink3); }
-.obw-miniapp .mgrid { display: grid; grid-template-columns: 1fr 1fr; gap: 9px; margin-top: 11px; }
-.obw-miniapp .mcard { height: 60px; border: 1px solid var(--rule); border-radius: 9px; background: var(--bg); }
+/* auto-fit, so a wide frame lays the four cards out across the space instead of
+   stretching two of them into slabs. */
+.obw-miniapp .mgrid { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); grid-auto-rows: minmax(60px, 1fr); gap: 9px; margin-top: 11px; align-content: start; }
+.obw-miniapp .mcard { min-height: 60px; border: 1px solid var(--rule); border-radius: 9px; background: var(--bg); }
 .obw-miniapp .mpeb { position: absolute; right: 16px; bottom: 14px; }
 .obw-tourdim { position: absolute; inset: 0; background: rgba(8, 10, 14, 0.52); z-index: 40; }
 :root[data-theme="dark"] .obw-tourdim { background: rgba(0, 0, 0, 0.62); }

--- a/ui/src/v2/onboarding/OnboardingWizard.tsx
+++ b/ui/src/v2/onboarding/OnboardingWizard.tsx
@@ -3,7 +3,7 @@ import { useInterviewSession } from "./useInterviewSession";
 import type { OnboardingStatus } from "./useOnboardingStatus";
 import "./OnboardingWizard.css";
 import { modelForOnboardingTest, onboardingDefaultModelRef } from "./llm-setup";
-import { IS_MAC, modKey } from "../ui/platform";
+import { DESKTOP, modKey } from "../ui/platform";
 
 /* ═══════════════════ Onboarding · the nine-screen first-run flow ═══════════
    Faithful to the design (usejarvis-onboarding.html): Welcome · Permissions
@@ -119,8 +119,6 @@ const ELEVEN_PREMADE = [
 ];
 
 
-// Deep links to the OS privacy pane per permission. The app can't self-grant
-// (the OS forbids it), but it can open the exact place you grant it.
 /**
  * macOS panes only. The Windows column that used to live here pointed at
  * `ms-settings:` pages that cannot grant any of this — `easeofaccess` is the
@@ -829,7 +827,8 @@ export function OnboardingWizard({
       );
 
       case "perms": {
-        const rows: Array<[string, string, string, boolean]> = [
+        // macOS only — four strings that no other platform renders.
+        const macRows: Array<[string, string, string, boolean]> = [
           ["access", "Accessibility", "Click, type, and read on-screen controls so Jarvis can operate your apps.", true],
           ["screen", "Screen Recording", "See your screen for Awareness: OCR, and noticing when you’re stuck.", false],
           ["auto", "Automation", "Drive other apps directly: your calendar, browser, and mail.", false],
@@ -845,12 +844,12 @@ export function OnboardingWizard({
                 ms-settings: would be sending them somewhere that cannot help.
                 Same step either way, so the flow and the hosted setup POST
                 below are untouched; only what the screen says changes. */}
-            {IS_MAC ? (
+            {DESKTOP === "mac" ? (
               <>
                 <h2>Let Jarvis reach your machine.</h2>
                 <div className="obw-sub">It acts on your computer through these. Jarvis can’t grant them itself (the OS won’t let it), so each one opens the exact settings pane. Grant what you’re comfortable with, or approve later when your Mac asks.</div>
                 <div className="obw-rows" style={{ marginTop: 16 }}>
-                  {rows.map(([id, name, body, req]) => (
+                  {macRows.map(([id, name, body, req]) => (
                     <button key={id} type="button" className="obw-prow" style={{ cursor: "pointer", textAlign: "left", width: "100%", background: "var(--raise)" }}
                       onClick={() => { try { window.open(PERM_PANE[id] || "", "_blank"); } catch { /* webview may block the scheme */ } }}>
                       <span className="pg"><Glyph k={id} /></span>
@@ -864,22 +863,36 @@ export function OnboardingWizard({
             ) : (
               <>
                 <h2>Nothing to set up here.</h2>
-                <div className="obw-sub">Jarvis already has the access it needs on Windows — there is no permissions pane to visit and nothing for you to switch on.</div>
+                <div className="obw-sub">Jarvis already has the access it needs{DESKTOP === "windows" ? " on Windows" : ""} — none of it is gated behind a permission you have to grant first.</div>
                 <div className="obw-rows" style={{ marginTop: 16 }}>
                   <div className="obw-prow">
                     <span className="pg"><Glyph k="check" /></span>
                     <div className="pt">
                       <div className="pn">All set</div>
-                      <div className="pb">Windows granted Jarvis what it needs when you installed it.</div>
+                      <div className="pb">Nothing to switch on for Jarvis to act on your machine.</div>
                     </div>
                   </div>
-                  <div className="obw-prow">
-                    <span className="pg"><Glyph k="mic" /></span>
-                    <div className="pt">
-                      <div className="pn">Microphone</div>
-                      <div className="pb">Windows asks the first time you talk to Jarvis. It can only be granted then — there is no setting to turn it on in advance.</div>
-                    </div>
-                  </div>
+                  {DESKTOP === "windows" && (
+                    // The ONE pane that is real here. Windows has no per-app
+                    // permission model for a desktop app, so the microphone is
+                    // governed by a single global toggle — and with it off there
+                    // is no in-the-moment prompt to rescue you, the capture just
+                    // fails. The sidecar's own native wizard deep-links exactly
+                    // this page for exactly this reason.
+                    <button
+                      type="button"
+                      className="obw-prow"
+                      style={{ cursor: "pointer", textAlign: "left", width: "100%", background: "var(--raise)" }}
+                      onClick={() => { try { window.open("ms-settings:privacy-microphone", "_blank"); } catch { /* webview may block the scheme */ } }}
+                    >
+                      <span className="pg"><Glyph k="mic" /></span>
+                      <div className="pt">
+                        <div className="pn">Microphone</div>
+                        <div className="pb">Only needed if you want to talk to Jarvis. Windows keeps one switch for all desktop apps — check it is on if the mic stays silent.</div>
+                      </div>
+                      <span className="obw-grant" style={{ pointerEvents: "none" }}>Open settings ↗</span>
+                    </button>
+                  )}
                 </div>
               </>
             )}

--- a/ui/src/v2/onboarding/OnboardingWizard.tsx
+++ b/ui/src/v2/onboarding/OnboardingWizard.tsx
@@ -70,9 +70,7 @@ const SVG: Record<string, string> = {
   vol: '<svg width="18" height="18" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round"><path d="M4 8h3l4-3v10l-4-3H4z"/><path d="M14 7a4 4 0 0 1 0 6"/></svg>',
   voloff: '<svg width="18" height="18" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M4 8h3l4-3v10l-4-3H4z"/><path d="M13.5 8l4 4M17.5 8l-4 4"/></svg>',
   calendar: '<svg width="18" height="18" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="3" y="4.5" width="14" height="12.5" rx="2"/><path d="M3 8.5h14M7 3v3M13 3v3"/></svg>',
-  mail: '<svg width="18" height="18" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round"><rect x="3" y="5" width="14" height="10" rx="2"/><path d="M3.5 6l6.5 4.5L16.5 6"/></svg>',
   send: '<svg width="18" height="18" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round"><path d="M17 3L8.5 11.5M17 3l-5.5 14-3-6-6-3z"/></svg>',
-  chat: '<svg width="18" height="18" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round"><path d="M4 5h12a1 1 0 0 1 1 1v6.5a1 1 0 0 1-1 1H8l-4 3V6a1 1 0 0 1 1-1z"/></svg>',
   check: '<svg viewBox="0 0 16 16" width="15" height="15" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M13 4.5 6.5 11.5 3 8"/></svg>',
 };
 const Glyph = ({ k }: { k: string }) => <span dangerouslySetInnerHTML={{ __html: SVG[k] ?? "" }} />;
@@ -631,7 +629,7 @@ export function OnboardingWizard({
             if (d.is_authenticated || d.status === "connected") {
               stopGooglePoll();
               setGoogleState("connected");
-              setConnected((c) => new Set(c).add("google").add("gmail"));
+              setConnected((c) => new Set(c).add("google"));
             }
           } catch { /* ignore */ }
         }, 2000);
@@ -671,7 +669,7 @@ export function OnboardingWizard({
         if (d.is_authenticated || d.status === "connected") {
           stopGooglePoll();
           setGoogleState("connected");
-          setConnected((c) => new Set(c).add("google").add("gmail"));
+          setConnected((c) => new Set(c).add("google"));
         }
       } catch { /* ignore */ }
       if (tries > 150) { stopGooglePoll(); setGoogleState((g) => (g === "pending" ? "idle" : g)); } // ~5 min cap
@@ -987,34 +985,39 @@ export function OnboardingWizard({
       }
 
       case "connect": {
-        const rows: Array<[string, string, string, string, boolean]> = [
-          ["google", "calendar", "Google Calendar", "Read your schedule and add holds.", false],
-          ["gmail", "mail", "Gmail", "Triage and draft, with your approval.", false],
-          ["telegram", "send", "Telegram", "Talk to Jarvis from your phone.", false],
-          ["discord", "chat", "Discord", "In the code as a stub today.", true],
-          ["whatsapp", "chat", "WhatsApp", "In the code as a stub today.", true],
+        // ONE Google row, because there is one Google grant. Calendar and Gmail
+        // were listed separately while both buttons ran the same consent and
+        // both were satisfied by it — so connecting either flipped both to
+        // "Connected", which reads like a bug even though it was correct.
+        // Discord and WhatsApp are gone: they were stubs advertised as "Soon".
+        const rows: Array<[string, string, string, string]> = [
+          // READ-ONLY, and the copy says only what the grant allows. The scopes
+          // are gmail.readonly and calendar.readonly, so "add holds" and "draft
+          // mail" — inherited from the two rows this replaces — described things
+          // no token from this consent can do. A first-run screen that promises
+          // more than the consent grants is a promise broken later, quietly.
+          ["google", "calendar", "Google", "Read-only access to your calendar and Gmail, so Jarvis can plan around your day and flag what needs you."],
+          ["telegram", "send", "Telegram", "Talk to Jarvis from your phone."],
         ];
         return (
           <div className="obw-body"><div className="obw-wrap wide">
             <h2>Connect your world.</h2>
             <div className="obw-sub">Hook up the apps Jarvis should know about. All optional, all revocable from Settings.</div>
             <div className="obw-rows" style={{ marginTop: 14 }}>
-              {rows.map(([id, ic, nm, bd, soon]) => {
-                const isGoogle = id === "google" || id === "gmail";
+              {rows.map(([id, ic, nm, bd]) => {
                 const isConnected = connected.has(id);
                 return (
                   <div key={id} className="obw-prow" style={{ flexWrap: "wrap" }}>
                     <span className="pg"><Glyph k={ic} /></span>
                     <div className="pt"><div className="pn">{nm}</div><div className="pb">{bd}</div></div>
-                    {soon ? <span className="obw-pill">Soon</span>
-                      : isConnected ? <span className="obw-granted"><Glyph k="check" />Connected</span>
-                      : isGoogle ? (
+                    {isConnected ? <span className="obw-granted"><Glyph k="check" />Connected</span>
+                      : id === "google" ? (
                         googleState === "pending"
                           ? <button className="obw-grant" onClick={cancelGoogle} title="Stop waiting for the sign-in">Connecting… ✕</button>
                           : <button className="obw-grant" onClick={connectGoogle}>Connect</button>
                       )
                       : id === "telegram" ? <button className="obw-grant" onClick={() => setTgOpen((o) => !o)}>Connect</button>
-                      : <span className="obw-pill">Soon</span>}
+                      : null}
                     {id === "telegram" && tgOpen && !isConnected && (
                       <div style={{ flexBasis: "100%", display: "flex", gap: 8, marginTop: 10 }}>
                         <input className="obw-inp" style={{ flex: 1 }} placeholder="Bot token from @BotFather" value={tgToken} onChange={(e) => setTgToken(e.target.value)} />

--- a/ui/src/v2/onboarding/OnboardingWizard.tsx
+++ b/ui/src/v2/onboarding/OnboardingWizard.tsx
@@ -3,6 +3,7 @@ import { useInterviewSession } from "./useInterviewSession";
 import type { OnboardingStatus } from "./useOnboardingStatus";
 import "./OnboardingWizard.css";
 import { modelForOnboardingTest, onboardingDefaultModelRef } from "./llm-setup";
+import { IS_MAC, modKey } from "../ui/platform";
 
 /* ═══════════════════ Onboarding · the nine-screen first-run flow ═══════════
    Faithful to the design (usejarvis-onboarding.html): Welcome · Permissions
@@ -117,7 +118,7 @@ const ELEVEN_PREMADE = [
   { voice_id: "TxGEqnHWrfWFTfGW9XjX", name: "Josh · deep" },
 ];
 
-const IS_MAC = typeof navigator !== "undefined" && /mac|iphone|ipad/i.test(navigator.userAgent || (navigator as { platform?: string }).platform || "");
+
 // Deep links to the OS privacy pane per permission. The app can't self-grant
 // (the OS forbids it), but it can open the exact place you grant it.
 /**
@@ -145,7 +146,10 @@ async function playPreviewAudio(res: Response): Promise<void> {
 
 const TOUR = [
   { sm: "This is the Pebble, your companion. It lives at your cursor. Click it any time to talk to me.", t: "→ Click the Pebble to try", pos: { right: 18, bottom: 50 } },
-  { sm: "Press ⌘J to summon Talk, the conversation panel. Everything we say lives there, across sessions.", t: "→ Press ⌘J", pos: { right: 18, top: 60 } },
+  // The shortcut takes either modifier (AppShell: metaKey || ctrlKey), so this
+  // is the LABEL being wrong, not the binding — which is why a hardcoded ⌘
+  // survived: it kept working for any Windows user who guessed Ctrl.
+  { sm: `Press ${modKey("J")} to summon Talk, the conversation panel. Everything we say lives there, across sessions.`, t: `→ Press ${modKey("J")}`, pos: { right: 18, top: 60 } },
   { sm: "The Index, on the left, is every room. Names spelled out, badges flag what needs you. Recognition over recall.", t: "", pos: { left: 130, top: 58 } },
   { sm: "Now is your monitoring surface: what I’m doing and what’s waiting on you, at a glance.", t: "", pos: { left: 130, top: 104 } },
   { sm: "Authority is your control panel, with a kill-switch. Nothing with real-world impact happens without your yes.", t: "", pos: { left: 130, top: 150 } },

--- a/ui/src/v2/onboarding/OnboardingWizard.tsx
+++ b/ui/src/v2/onboarding/OnboardingWizard.tsx
@@ -150,9 +150,9 @@ const TOUR = [
   // is the LABEL being wrong, not the binding — which is why a hardcoded ⌘
   // survived: it kept working for any Windows user who guessed Ctrl.
   { sm: `Press ${modKey("J")} to summon Talk, the conversation panel. Everything we say lives there, across sessions.`, t: `→ Press ${modKey("J")}`, pos: { right: 18, top: 60 } },
-  { sm: "The Index, on the left, is every room. Names spelled out, badges flag what needs you. Recognition over recall.", t: "", pos: { left: 130, top: 58 } },
-  { sm: "Now is your monitoring surface: what I’m doing and what’s waiting on you, at a glance.", t: "", pos: { left: 130, top: 104 } },
-  { sm: "Authority is your control panel, with a kill-switch. Nothing with real-world impact happens without your yes.", t: "", pos: { left: 130, top: 150 } },
+  { sm: "The Index, on the left, is every room. Names spelled out, badges flag what needs you. Recognition over recall.", t: "", pos: { left: "calc(var(--mrail-w) + 12px)", top: 58 } },
+  { sm: "Now is your monitoring surface: what I’m doing and what’s waiting on you, at a glance.", t: "", pos: { left: "calc(var(--mrail-w) + 12px)", top: 104 } },
+  { sm: "Authority is your control panel, with a kill-switch. Nothing with real-world impact happens without your yes.", t: "", pos: { left: "calc(var(--mrail-w) + 12px)", top: 150 } },
 ];
 
 type TestState = { status: "idle" | "testing" | "ok" | "err"; msg?: string; validatedModel?: string };

--- a/ui/src/v2/onboarding/OnboardingWizard.tsx
+++ b/ui/src/v2/onboarding/OnboardingWizard.tsx
@@ -120,11 +120,18 @@ const ELEVEN_PREMADE = [
 const IS_MAC = typeof navigator !== "undefined" && /mac|iphone|ipad/i.test(navigator.userAgent || (navigator as { platform?: string }).platform || "");
 // Deep links to the OS privacy pane per permission. The app can't self-grant
 // (the OS forbids it), but it can open the exact place you grant it.
-const PERM_PANE: Record<string, { mac: string; win: string }> = {
-  access: { mac: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility", win: "ms-settings:easeofaccess" },
-  screen: { mac: "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture", win: "ms-settings:privacy-general" },
-  auto: { mac: "x-apple.systempreferences:com.apple.preference.security?Privacy_Automation", win: "ms-settings:privacy-general" },
-  files: { mac: "x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles", win: "ms-settings:privacy-broadfilesystemaccess" },
+/**
+ * macOS panes only. The Windows column that used to live here pointed at
+ * `ms-settings:` pages that cannot grant any of this — `easeofaccess` is the
+ * accessibility *features* page, and `privacy-general` has no toggle for
+ * screen capture or automation — so it sent people somewhere that could not
+ * help them. Windows shows a different screen entirely now.
+ */
+const PERM_PANE: Record<string, string> = {
+  access: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility",
+  screen: "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture",
+  auto: "x-apple.systempreferences:com.apple.preference.security?Privacy_Automation",
+  files: "x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles",
 };
 
 // Play MP3 bytes returned by /api/tts/preview in the dashboard itself.
@@ -826,19 +833,52 @@ export function OnboardingWizard({
         ];
         return (
           <div className="obw-body"><div className="obw-wrap wide">
-            <h2>Let Jarvis reach your machine.</h2>
-            <div className="obw-sub">It acts on your computer through these. Jarvis can’t grant them itself (the OS won’t let it), so each one opens the exact settings pane. Grant what you’re comfortable with, or approve later when your {IS_MAC ? "Mac" : "PC"} asks.</div>
-            <div className="obw-rows" style={{ marginTop: 16 }}>
-              {rows.map(([id, name, body, req]) => (
-                <button key={id} type="button" className="obw-prow" style={{ cursor: "pointer", textAlign: "left", width: "100%", background: "var(--raise)" }}
-                  onClick={() => { try { window.open((IS_MAC ? PERM_PANE[id]?.mac : PERM_PANE[id]?.win) || "", "_blank"); } catch { /* webview may block the scheme */ } }}>
-                  <span className="pg"><Glyph k={id} /></span>
-                  <div className="pt"><div className="pn">{name}{req && <span className="req">required</span>}</div><div className="pb">{body}</div></div>
-                  <span className="obw-grant" style={{ pointerEvents: "none" }}>Open settings ↗</span>
-                </button>
-              ))}
-            </div>
-            <div className="obw-hint" style={{ marginTop: 12 }}>Review or revoke any of these anytime in {IS_MAC ? "System Settings → Privacy & Security" : "Windows Settings → Privacy & security"}, or from Settings → Permissions.</div>
+            {/* macOS gates each of these behind a pane the user must visit, and
+                Jarvis cannot grant them itself. Windows does not work that way:
+                the app already has what it needs, and the one thing it might
+                ask for later — the microphone, for the embedded browser window
+                — has no Settings toggle to pre-grant, so sending someone to
+                ms-settings: would be sending them somewhere that cannot help.
+                Same step either way, so the flow and the hosted setup POST
+                below are untouched; only what the screen says changes. */}
+            {IS_MAC ? (
+              <>
+                <h2>Let Jarvis reach your machine.</h2>
+                <div className="obw-sub">It acts on your computer through these. Jarvis can’t grant them itself (the OS won’t let it), so each one opens the exact settings pane. Grant what you’re comfortable with, or approve later when your Mac asks.</div>
+                <div className="obw-rows" style={{ marginTop: 16 }}>
+                  {rows.map(([id, name, body, req]) => (
+                    <button key={id} type="button" className="obw-prow" style={{ cursor: "pointer", textAlign: "left", width: "100%", background: "var(--raise)" }}
+                      onClick={() => { try { window.open(PERM_PANE[id] || "", "_blank"); } catch { /* webview may block the scheme */ } }}>
+                      <span className="pg"><Glyph k={id} /></span>
+                      <div className="pt"><div className="pn">{name}{req && <span className="req">required</span>}</div><div className="pb">{body}</div></div>
+                      <span className="obw-grant" style={{ pointerEvents: "none" }}>Open settings ↗</span>
+                    </button>
+                  ))}
+                </div>
+                <div className="obw-hint" style={{ marginTop: 12 }}>Review or revoke any of these anytime in System Settings → Privacy &amp; Security.</div>
+              </>
+            ) : (
+              <>
+                <h2>Nothing to set up here.</h2>
+                <div className="obw-sub">Jarvis already has the access it needs on Windows — there is no permissions pane to visit and nothing for you to switch on.</div>
+                <div className="obw-rows" style={{ marginTop: 16 }}>
+                  <div className="obw-prow">
+                    <span className="pg"><Glyph k="check" /></span>
+                    <div className="pt">
+                      <div className="pn">All set</div>
+                      <div className="pb">Windows granted Jarvis what it needs when you installed it.</div>
+                    </div>
+                  </div>
+                  <div className="obw-prow">
+                    <span className="pg"><Glyph k="mic" /></span>
+                    <div className="pt">
+                      <div className="pn">Microphone</div>
+                      <div className="pb">Windows asks the first time you talk to Jarvis. It can only be granted then — there is no setting to turn it on in advance.</div>
+                    </div>
+                  </div>
+                </div>
+              </>
+            )}
             <div className="obw-btnrow">
               <button className="obw-btn obw-btn-ghost" onClick={back}>Back</button>
               <span className="grow" />

--- a/ui/src/v2/rooms/workflows/WorkflowEditor.tsx
+++ b/ui/src/v2/rooms/workflows/WorkflowEditor.tsx
@@ -53,6 +53,7 @@ import type { ConnectionMeta } from "./useConnections";
 import { useFlowRuns } from "./useFlowRuns";
 import type { FlowRun, FlowRunStatus } from "./useWorkflowsData";
 import "./WorkflowEditor.css";
+import { modKey } from "../../ui/platform";
 
 // Horizontal flow layout. Each step in the flattened chain advances the
 // cursor rightward by NODE_X_STEP; nested branches (loop body / router
@@ -677,7 +678,7 @@ export function WorkflowEditor({ flowId, onClose }: WorkflowEditorProps): React.
             disabled={!editor.canUndo}
             title={
               editor.canUndo
-                ? `Undo: ${editor.undoLabel ?? "last destructive change"} (Ctrl+Z)`
+                ? `Undo: ${editor.undoLabel ?? "last destructive change"} (${modKey("Z")})`
                 : "Nothing to undo"
             }
           >

--- a/ui/src/v2/shell/AppShell.tsx
+++ b/ui/src/v2/shell/AppShell.tsx
@@ -31,6 +31,7 @@ import { TopBar } from "./TopBar";
 import { NowRoom } from "./NowRoom";
 import "./AppShell.css";
 import "./roomShell.css";
+import { modKey } from "../ui/platform";
 
 const PALETTE_TYPE_TO_OBJECT_TYPE: Record<PaletteResultType, ObjectType> = {
   workflow: "workflow",
@@ -979,7 +980,7 @@ function ShellLayout({
                 {voiceState === "idle" ? "tap the pebble to talk" : TALK_HINT[voiceState]}
               </span>
             </div>
-            <button className="esc" onClick={() => setTalkOpen(false)} aria-label="Close Talk">⌘J · esc</button>
+            <button className="esc" onClick={() => setTalkOpen(false)} aria-label="Close Talk">{modKey("J")} · esc</button>
           </div>
 
           <div className="rs-talk-thread">

--- a/ui/src/v2/shell/Header.tsx
+++ b/ui/src/v2/shell/Header.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Bell, Search } from "lucide-react";
 import { Button, Icon, KBD } from "../ui";
 import "./Header.css";
+import { modKey } from "../ui/platform";
 
 export type ConnectionState = "live" | "degraded" | "offline";
 /**
@@ -74,7 +75,7 @@ export function Header({
             <Icon icon={Search} size="sm" />
           </span>
           <span className="v2-header__palette-label">Quick open</span>
-          <KBD>⌘K</KBD>
+          <KBD>{modKey("K")}</KBD>
         </button>
 
         <span className="v2-header__notif-anchor">

--- a/ui/src/v2/shell/IndexSidebar.tsx
+++ b/ui/src/v2/shell/IndexSidebar.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { closeRoom, openRoom, useV2Route, type RoomKey } from "../router";
 import { useLiveData } from "./LiveDataContext";
+import { modKey } from "../ui/platform";
 
 /**
  * The Index — Brand Book III room-centric sidebar. Three states:
@@ -18,16 +19,16 @@ type Row =
   | { kind: "now"; label: string; kbd: string };
 
 const ROWS: Row[] = [
-  { kind: "now", label: "Now", kbd: "⌘1" },
+  { kind: "now", label: "Now", kbd: modKey("1") },
   { kind: "heading", label: "run" },
-  { kind: "room", key: "workflows", label: "Workflows", kbd: "⌘2" },
-  { kind: "room", key: "agents", label: "Agents", kbd: "⌘3" },
-  { kind: "room", key: "tasks", label: "Tasks", kbd: "⌘4" },
+  { kind: "room", key: "workflows", label: "Workflows", kbd: modKey("2") },
+  { kind: "room", key: "agents", label: "Agents", kbd: modKey("3") },
+  { kind: "room", key: "tasks", label: "Tasks", kbd: modKey("4") },
   { kind: "heading", label: "know" },
-  { kind: "room", key: "memory", label: "Memory", kbd: "⌘5" },
-  { kind: "room", key: "goals", label: "Goals", kbd: "⌘6" },
-  { kind: "room", key: "calendar", label: "Calendar", kbd: "⌘7" },
-  { kind: "room", key: "content", label: "Content", kbd: "⌘8" },
+  { kind: "room", key: "memory", label: "Memory", kbd: modKey("5") },
+  { kind: "room", key: "goals", label: "Goals", kbd: modKey("6") },
+  { kind: "room", key: "calendar", label: "Calendar", kbd: modKey("7") },
+  { kind: "room", key: "content", label: "Content", kbd: modKey("8") },
   { kind: "heading", label: "guard" },
   { kind: "room", key: "authority", label: "Authority" },
   { kind: "room", key: "logs", label: "Logs" },
@@ -35,7 +36,7 @@ const ROWS: Row[] = [
   { kind: "heading", label: "build" },
   { kind: "room", key: "workspaces", label: "Workspaces" },
   { kind: "room", key: "tools", label: "Tools" },
-  { kind: "room", key: "settings", label: "Settings", kbd: "⌘9", spaced: true },
+  { kind: "room", key: "settings", label: "Settings", kbd: modKey("9"), spaced: true },
 ];
 
 /** Cluster → its rooms, for collapsed tiles + hover-peek. */

--- a/ui/src/v2/shell/TopBar.tsx
+++ b/ui/src/v2/shell/TopBar.tsx
@@ -4,7 +4,7 @@ import { ROOM_NAV_ENTRIES } from "../palette/types";
 import type { ConnectionState } from "./Header";
 import type { VoiceState } from "./VoiceRail";
 import { useTheme } from "./useTheme";
-import { modKey } from "../ui/platform";
+import { altKey, modKey } from "../ui/platform";
 
 /**
  * Top bar — 44px, never two rows. Left: room name + contextual actions
@@ -106,7 +106,7 @@ export function TopBar({
             aria-label={`Notifications${count > 0 ? `, ${count} unread` : ""}`}
             aria-expanded={notificationsOpen}
           >
-            <span className="bb">⌥N</span>
+            <span className="bb">{altKey("N")}</span>
             {count > 0 && <span className="bn">{count > 9 ? "9+" : count}</span>}
           </button>
         )}

--- a/ui/src/v2/shell/TopBar.tsx
+++ b/ui/src/v2/shell/TopBar.tsx
@@ -4,6 +4,7 @@ import { ROOM_NAV_ENTRIES } from "../palette/types";
 import type { ConnectionState } from "./Header";
 import type { VoiceState } from "./VoiceRail";
 import { useTheme } from "./useTheme";
+import { modKey } from "../ui/platform";
 
 /**
  * Top bar — 44px, never two rows. Left: room name + contextual actions
@@ -96,7 +97,7 @@ export function TopBar({
           {theme === "dark" ? "● dark" : "○ light"}
         </button>
 
-        <button className="rs-chip" onClick={onOpenPalette} aria-label="Quick open">⌘K</button>
+        <button className="rs-chip" onClick={onOpenPalette} aria-label="Quick open">{modKey("K")}</button>
 
         {onToggleNotifications && (
           <button

--- a/ui/src/v2/ui/index.ts
+++ b/ui/src/v2/ui/index.ts
@@ -15,3 +15,4 @@ export type { MetaProps } from "./Meta";
 
 export { Icon } from "./Icon";
 export type { IconProps, IconSize } from "./Icon";
+export { IS_MAC, modKey } from "./platform";

--- a/ui/src/v2/ui/platform.test.ts
+++ b/ui/src/v2/ui/platform.test.ts
@@ -1,20 +1,45 @@
 import { describe, expect, test } from "bun:test";
-import { IS_MAC, modKey } from "./platform";
+import { detectMac, modKeyFor } from "./platform";
 
 /**
  * The onboarding tour told every Windows user to press a key their keyboard
  * does not have. It survived because the BINDING accepts either modifier
  * (AppShell: `metaKey || ctrlKey`), so the wrong label still worked for anyone
  * who guessed Ctrl — nothing failed loudly enough to notice.
+ *
+ * Asserted against real user-agent strings rather than the module's own
+ * `IS_MAC`. Under `bun test` navigator.userAgent is "Bun/1.3.14", so `IS_MAC`
+ * is false on every host including a Mac: a test written against it agrees with
+ * whatever the implementation decided and never executes the ⌘ branch at all.
  */
-describe("modKey", () => {
-  test("writes the modifier the way this platform writes it", () => {
-    expect(modKey("J")).toBe(IS_MAC ? "\u2318J" : "Ctrl+J");
+const MAC_WEBVIEW =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15";
+const WINDOWS_WEBVIEW2 =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 Edg/120.0.0.0";
+const LINUX =
+  "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+
+describe("detectMac", () => {
+  test("recognises the hosts this app actually runs in", () => {
+    expect(detectMac(MAC_WEBVIEW)).toBe(true);
+    expect(detectMac(WINDOWS_WEBVIEW2)).toBe(false);
+    expect(detectMac(LINUX)).toBe(false);
   });
 
-  test("never shows the Mac glyph off a Mac", () => {
-    if (IS_MAC) return;
-    expect(modKey("K")).not.toContain("\u2318");
-    expect(modKey("K")).toBe("Ctrl+K");
+  test("an empty or unknown agent is NOT a Mac", () => {
+    // The regression this exists for: a stray alternation (/mac|ipad|/i) makes
+    // the pattern match everything, IS_MAC becomes true on every platform, and
+    // Windows silently gets ⌘ back. A test keyed on IS_MAC cannot see that;
+    // this one fails immediately.
+    expect(detectMac("")).toBe(false);
+    expect(detectMac("Bun/1.3.14")).toBe(false);
+  });
+});
+
+describe("modKeyFor", () => {
+  test("both branches, neither inferred from the running platform", () => {
+    expect(modKeyFor("J", true)).toBe("⌘J");
+    expect(modKeyFor("J", false)).toBe("Ctrl+J");
+    expect(modKeyFor("K", false)).not.toContain("⌘");
   });
 });

--- a/ui/src/v2/ui/platform.test.ts
+++ b/ui/src/v2/ui/platform.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test";
+import { IS_MAC, modKey } from "./platform";
+
+/**
+ * The onboarding tour told every Windows user to press a key their keyboard
+ * does not have. It survived because the BINDING accepts either modifier
+ * (AppShell: `metaKey || ctrlKey`), so the wrong label still worked for anyone
+ * who guessed Ctrl — nothing failed loudly enough to notice.
+ */
+describe("modKey", () => {
+  test("writes the modifier the way this platform writes it", () => {
+    expect(modKey("J")).toBe(IS_MAC ? "\u2318J" : "Ctrl+J");
+  });
+
+  test("never shows the Mac glyph off a Mac", () => {
+    if (IS_MAC) return;
+    expect(modKey("K")).not.toContain("\u2318");
+    expect(modKey("K")).toBe("Ctrl+K");
+  });
+});

--- a/ui/src/v2/ui/platform.test.ts
+++ b/ui/src/v2/ui/platform.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { detectMac, modKeyFor } from "./platform";
+import { detectDesktop, detectMac, modKeyFor } from "./platform";
 
 /**
  * The onboarding tour told every Windows user to press a key their keyboard
@@ -33,6 +33,25 @@ describe("detectMac", () => {
     // this one fails immediately.
     expect(detectMac("")).toBe(false);
     expect(detectMac("Bun/1.3.14")).toBe(false);
+  });
+});
+
+describe("detectDesktop", () => {
+  test("names an OS only when it can positively identify one", () => {
+    expect(detectDesktop(MAC_WEBVIEW)).toBe("mac");
+    expect(detectDesktop(WINDOWS_WEBVIEW2)).toBe("windows");
+    expect(detectDesktop(LINUX)).toBe("other");
+    // Unknown is "other", never Windows by elimination — the screen that names
+    // an OS has to be sure, or it tells a Linux user about Windows settings.
+    expect(detectDesktop("")).toBe("other");
+    expect(detectDesktop("Bun/1.3.14")).toBe("other");
+  });
+
+  test("a Linux marker beats a mac-shaped agent string", () => {
+    // Some WebKit builds on Linux carry a macOS-looking UA. Falling through to
+    // OS-neutral copy is recoverable; handing a Linux user a button that opens
+    // an Apple settings pane is the exact failure this file exists to stop.
+    expect(detectDesktop("Mozilla/5.0 (X11; Linux x86_64) ... Macintosh; Intel Mac OS X 10_15")).toBe("other");
   });
 });
 

--- a/ui/src/v2/ui/platform.test.ts
+++ b/ui/src/v2/ui/platform.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { detectDesktop, detectMac, modKeyFor } from "./platform";
+import { altKeyFor, ctrlLabelFor, detectDesktop, detectMac, modKeyFor } from "./platform";
 
 /**
  * The onboarding tour told every Windows user to press a key their keyboard
@@ -60,5 +60,19 @@ describe("modKeyFor", () => {
     expect(modKeyFor("J", true)).toBe("⌘J");
     expect(modKeyFor("J", false)).toBe("Ctrl+J");
     expect(modKeyFor("K", false)).not.toContain("⌘");
+  });
+});
+
+describe("the other two modifiers", () => {
+  test("Option/Alt is its own key, not Command/Control", () => {
+    // The notifications bell binds `altKey`; labelling it with modKey would
+    // have written ⌘/Ctrl over a key that is neither.
+    expect(altKeyFor("N", true)).toBe("⌥N");
+    expect(altKeyFor("N", false)).toBe("Alt+N");
+  });
+
+  test("the bare Control glyph is a Mac keycap marking", () => {
+    expect(ctrlLabelFor(true)).toBe("⌃");
+    expect(ctrlLabelFor(false)).toBe("Ctrl");
   });
 });

--- a/ui/src/v2/ui/platform.ts
+++ b/ui/src/v2/ui/platform.ts
@@ -7,15 +7,31 @@
  * hardcoded ⌘ still worked on Windows for whoever guessed Ctrl, so nothing
  * broke loudly enough to notice, and the onboarding tour taught new Windows
  * users a key their keyboard does not have.
+ *
+ * Split into PURE functions with the globals read once at the bottom. The
+ * obvious shape — a lone `IS_MAC` const and a `modKey` that branches on it —
+ * cannot be tested: under `bun test` there is a `navigator`, and its userAgent
+ * is "Bun/1.3.14", so `IS_MAC` is frozen false on every host. Any test then
+ * derives its expectation from the same constant the code branches on, agrees
+ * with itself, and would sail past the one regression that matters — a
+ * detection bug that reports Mac everywhere.
  */
+
+/** Does this user-agent (or legacy platform string) describe a Mac? */
+export function detectMac(uaOrPlatform: string): boolean {
+  return /mac|iphone|ipad/i.test(uaOrPlatform);
+}
+
+/** Write a modifier shortcut the way the given platform writes it. */
+export function modKeyFor(key: string, isMac: boolean): string {
+  return isMac ? `⌘${key}` : `Ctrl+${key}`;
+}
+
 export const IS_MAC =
   typeof navigator !== "undefined" &&
-  /mac|iphone|ipad/i.test(navigator.userAgent || (navigator as { platform?: string }).platform || "");
+  detectMac(navigator.userAgent || (navigator as { platform?: string }).platform || "");
 
-/**
- * Render a modifier shortcut the way this platform writes it: `⌘J` on a Mac,
- * `Ctrl+J` everywhere else.
- */
+/** `⌘J` on a Mac, `Ctrl+J` everywhere else. */
 export function modKey(key: string): string {
-  return IS_MAC ? `⌘${key}` : `Ctrl+${key}`;
+  return modKeyFor(key, IS_MAC);
 }

--- a/ui/src/v2/ui/platform.ts
+++ b/ui/src/v2/ui/platform.ts
@@ -59,6 +59,31 @@ const HOST_UA =
 export const DESKTOP: Desktop = detectDesktop(HOST_UA);
 export const IS_MAC = DESKTOP === "mac";
 
+/**
+ * The Option/Alt modifier, which is a DIFFERENT key from the one above — worth
+ * its own function rather than a parameter, because the bell's shortcut is
+ * `altKey` and reaching for `modKey` there would have written ⌘/Ctrl over a key
+ * that is neither.
+ */
+export function altKeyFor(key: string, isMac: boolean): string {
+  return isMac ? `⌥${key}` : `Alt+${key}`;
+}
+
+/** `⌥N` on a Mac, `Alt+N` everywhere else. */
+export function altKey(key: string): string {
+  return altKeyFor(key, IS_MAC);
+}
+
+/**
+ * The bare Control glyph, for shortcuts written as "<key>+click" rather than as
+ * a combination. `⌃` is a Mac keyboard's marking and means nothing on a PC
+ * keycap, which just reads "Ctrl".
+ */
+export function ctrlLabelFor(isMac: boolean): string {
+  return isMac ? "⌃" : "Ctrl";
+}
+export const CTRL_LABEL = ctrlLabelFor(IS_MAC);
+
 /** `⌘J` on a Mac, `Ctrl+J` everywhere else. */
 export function modKey(key: string): string {
   return modKeyFor(key, IS_MAC);

--- a/ui/src/v2/ui/platform.ts
+++ b/ui/src/v2/ui/platform.ts
@@ -17,9 +17,32 @@
  * detection bug that reports Mac everywhere.
  */
 
+export type Desktop = "mac" | "windows" | "other";
+
+/**
+ * Classify the host from its user-agent, POSITIVELY — never "not a Mac,
+ * therefore Windows".
+ *
+ * That inference is what this replaces, and it was wrong twice over. The app
+ * ships on Linux too, so "not a Mac" named the wrong OS to those users; and a
+ * WebKit build on Linux can carry a mac-shaped agent string, so the Linux
+ * marker is checked FIRST and wins — better to fall through to copy that names
+ * no OS than to hand a Linux user a button that opens an Apple settings pane.
+ *
+ * A UA is still a guess. The host knows for certain (the sidecar is Go, and
+ * `runtime.GOOS` is right there); if this ever needs to be reliable rather than
+ * merely careful, that is where the answer should come from.
+ */
+export function detectDesktop(uaOrPlatform: string): Desktop {
+  if (/x11|linux|android|cros/i.test(uaOrPlatform)) return "other";
+  if (/mac|iphone|ipad/i.test(uaOrPlatform)) return "mac";
+  if (/windows|win32|win64/i.test(uaOrPlatform)) return "windows";
+  return "other";
+}
+
 /** Does this user-agent (or legacy platform string) describe a Mac? */
 export function detectMac(uaOrPlatform: string): boolean {
-  return /mac|iphone|ipad/i.test(uaOrPlatform);
+  return detectDesktop(uaOrPlatform) === "mac";
 }
 
 /** Write a modifier shortcut the way the given platform writes it. */
@@ -27,9 +50,14 @@ export function modKeyFor(key: string, isMac: boolean): string {
   return isMac ? `⌘${key}` : `Ctrl+${key}`;
 }
 
-export const IS_MAC =
-  typeof navigator !== "undefined" &&
-  detectMac(navigator.userAgent || (navigator as { platform?: string }).platform || "");
+const HOST_UA =
+  typeof navigator !== "undefined"
+    ? navigator.userAgent || (navigator as { platform?: string }).platform || ""
+    : "";
+
+/** What this app is running on, as best a user-agent can say. */
+export const DESKTOP: Desktop = detectDesktop(HOST_UA);
+export const IS_MAC = DESKTOP === "mac";
 
 /** `⌘J` on a Mac, `Ctrl+J` everywhere else. */
 export function modKey(key: string): string {

--- a/ui/src/v2/ui/platform.ts
+++ b/ui/src/v2/ui/platform.ts
@@ -1,0 +1,21 @@
+/**
+ * What to call the Command/Control key in text the user reads.
+ *
+ * The shortcuts themselves accept EITHER modifier — AppShell's Talk hotkey is
+ * `(e.metaKey || e.ctrlKey) && j`, and the palette's is the same shape — so
+ * this is only ever about the label. Which is exactly why it went wrong: a
+ * hardcoded ⌘ still worked on Windows for whoever guessed Ctrl, so nothing
+ * broke loudly enough to notice, and the onboarding tour taught new Windows
+ * users a key their keyboard does not have.
+ */
+export const IS_MAC =
+  typeof navigator !== "undefined" &&
+  /mac|iphone|ipad/i.test(navigator.userAgent || (navigator as { platform?: string }).platform || "");
+
+/**
+ * Render a modifier shortcut the way this platform writes it: `⌘J` on a Mac,
+ * `Ctrl+J` everywhere else.
+ */
+export function modKey(key: string): string {
+  return IS_MAC ? `⌘${key}` : `Ctrl+${key}`;
+}


### PR DESCRIPTION
Fixes the first-run setup slideshow, which had drifted from the product it introduces — and then the places elsewhere in the UI that it contradicted.

## Connections screen

**One Google row.** Calendar and Gmail were listed as separate connections while both buttons ran the same consent and both were satisfied by it, so connecting either flipped both to "Connected". There is one Google grant, so there is one row.

**Its copy no longer overclaims.** The scopes are `gmail.readonly` and `calendar.readonly`; the wording inherited from the old rows promised to "add holds" and "draft mail", which no token from that consent can do.

**Discord and WhatsApp removed.** WhatsApp is a genuine stub — its adapter throws "not yet implemented". Discord is not, but in onboarding it was a disabled "Soon" pill either way and stays connectable from Settings. A first-run screen that lists things you cannot connect spends attention on nothing.

## Permissions screen

macOS gates each permission behind a pane the user must visit and Jarvis cannot grant itself. Windows does not work that way: the app already has what it needs, and the `ms-settings:` pages this screen opened could grant none of it (`easeofaccess` is the accessibility *features* page; `privacy-general` has no toggle for screen capture or automation). Every button sent someone somewhere that could not help them. Windows now gets a "nothing to set up here" screen.

The one real pane is the microphone. Windows has no per-app permission model for a desktop app, so a single global toggle governs it — and with it off there is no in-the-moment prompt to rescue you; capture just fails. The sidecar's own native wizard deep-links `ms-settings:privacy-microphone` for exactly this reason, so that row is the pane rather than a claim that no setting exists.

Platform is identified **positively** rather than as "not a Mac, therefore Windows". The app ships on Linux, so that inference named the wrong OS there — and a WebKit build on Linux can carry a mac-shaped user agent, which would have handed Linux users buttons opening Apple settings panes. The Linux marker wins over a mac one, and anything unidentified falls through to copy that names no OS.

## Keyboard labels

The tour told every user to press `⌘J`; the shell showed `⌘K`, `⌘J · esc` and `⌘1–9`; the bell showed `⌥N`; the pebble's summon hint showed `⌃`; the workflow editor's undo tooltip said `Ctrl+Z` to Mac users. Every one of those bindings already accepted the right keys — this was only ever the label, which is why it survived: a wrong label still works for anyone who guesses.

All of them now go through one helper. Command/Control, Option/Alt and the bare Control glyph are separate functions rather than one with a parameter, because they are different keys and a parameter invites writing ⌘ over a shortcut that is actually Alt.

The helper is split into pure functions on purpose. Under `bun test` there is a `navigator` and its `userAgent` is `Bun/1.3.14`, so a module-level `IS_MAC` is false on every host — a test written against it agrees with whatever the implementation decided and never exercises the ⌘ branch. The tests assert against real WKWebView, WebView2 and Linux agent strings, and were checked by mutation: a stray alternation in the pattern fails them.

## Tour preview

The mock dashboard was pinned at 880×520 and centred, so on an ordinary window it sat as a small rectangle in empty space and read as a screenshot of some other app. It now scales with the window, capped at 1400×860 — past roughly that it would grow without scaling, since the mock's type and rail rows are fixed-size.

The cap existed so the pixel-positioned spotlights kept landing on their targets. That still holds: the two on the right are anchored to the frame's edges, and the three pointing at the rail follow a `--mrail-w` custom property shared with the rail's own column, including at the narrow-window breakpoint, so the two cannot drift apart.

On short windows the spotlight is pinned to the bottom of the frame. The frame clips for the mock, and the last slide's card starts 150px down and runs ~175px, so under roughly a 425px viewport it was cut off — taking "Skip tour" and "Finish" with it and leaving the user on the final slide with no way forward.

## Notes

- Each change was reviewed and its findings folded back in: the positive platform detection, the microphone pane, the narrow-window rail, the corrected breakpoint, and the two modifier labels that the first sweep missed all came from that pass.
- `bun test ui/src/v2` (125 tests), typecheck and `build:ui` are green.
- One `⌃` remains, in `pebble.css`, inside a `browser dev mode` backdrop — developer-only, and CSS `content:` cannot reach the helper.
