### PR TITLE
Hand the pieces catalog to the host on a managed install

### DIFF
--- a/src/actions/tools/manage-workflow.test.ts
+++ b/src/actions/tools/manage-workflow.test.ts
@@ -267,3 +267,36 @@ describe("manage_workflow: compose", () => {
     expect(out.rawResponse).toContain("truncated");
   });
 });
+
+describe("manage_workflow: the suggest-install wording follows the library index", () => {
+  const LIBRARY = [
+    {
+      id: "discord",
+      npmPackage: "@activepieces/piece-discord",
+      displayName: "Discord",
+      description: "Post messages to Discord.",
+    },
+  ];
+
+  test("with a library, the description tells the agent to relay suggestedInstalls", () => {
+    const t = createManageWorkflowTool({ library: LIBRARY });
+    expect(t.description).toContain("suggestedInstalls");
+    expect(t.description).toContain("Library page");
+  });
+
+  test("with NO library, that advice is gone entirely", () => {
+    // The host-managed case. The composer has no search_library tool there,
+    // so it can never return suggestedInstalls -- and the advice it replaced
+    // ("ask the user to install it from the dashboard's Library page") is a
+    // dead end on an install whose Library has no button and whose install
+    // API answers 403. Leaving the sentence in the prompt is how the agent
+    // ends up giving a hosted user an instruction they cannot follow.
+    for (const t of [createManageWorkflowTool(), createManageWorkflowTool({ library: [] })]) {
+      expect(t.description).not.toContain("suggestedInstalls");
+      expect(t.description).not.toContain("Library page");
+      // The rest of the compose contract must survive the excision.
+      expect(t.description).toContain("compose { name, description }");
+      expect(t.description).toContain("Composed flows are DISABLED");
+    }
+  });
+});

--- a/src/actions/tools/manage-workflow.ts
+++ b/src/actions/tools/manage-workflow.ts
@@ -97,11 +97,25 @@ export interface ManageWorkflowDeps {
    * the composer's tool loop can search it and suggest installs (surfaced as
    * `suggestedInstalls` on a failed compose) instead of forcing a request
    * through the wrong piece when the right one just isn't installed yet.
+   *
+   * OMIT on a host-managed install: the whole catalog is already present, so
+   * the only pieces this index could ever surface as "not installed" are the
+   * ones whose metadata extraction failed on the HOST -- which the user
+   * cannot install and cannot fix. Omitting it also drops the suggest-install
+   * wording from this tool's description and from the composer's prompt.
    */
   library?: ComposerLibraryEntry[];
 }
 
 export function createManageWorkflowTool(deps: ManageWorkflowDeps = {}): ToolDefinition {
+  // No library index => the composer has no search_library tool and can never
+  // return suggestedInstalls, so the paragraph describing them is dropped
+  // rather than left as advice the agent cannot act on. A host-managed
+  // install is the case that matters: the daemon withholds the library there
+  // because the whole catalog is already present and the install API is gone,
+  // and "ask the user to install it from the Library page" would be a
+  // dead-end instruction.
+  const hasLibrary = (deps.library?.length ?? 0) > 0;
   return {
     name: "manage_workflow",
     description: [
@@ -123,10 +137,14 @@ export function createManageWorkflowTool(deps: ManageWorkflowDeps = {}): ToolDef
       "                                      On success returns { ok: true, flow, versionId }.",
       "                                      On failure returns { ok: false, errors, rawResponse }: read the errors,",
       "                                      refine the description with concrete piece/tool names, and call again.",
-      "                                      A failure may also carry suggestedInstalls: [{ id, displayName, reason }] --",
-      "                                      community-library pieces that would make the request possible. Relay them",
-      "                                      to the user (pieces are installed from the dashboard's Library page) and",
-      "                                      offer to compose again after installing; do NOT retry compose unchanged.",
+      ...(hasLibrary
+        ? [
+            "                                      A failure may also carry suggestedInstalls: [{ id, displayName, reason }] --",
+            "                                      community-library pieces that would make the request possible. Relay them",
+            "                                      to the user (pieces are installed from the dashboard's Library page) and",
+            "                                      offer to compose again after installing; do NOT retry compose unchanged.",
+          ]
+        : []),
       "                                      Composed flows are DISABLED; follow up with `publish` once the user",
       "                                      confirms, then optionally `run` to test.",
       "  create { name, empty: true }        Create an EMPTY workflow with a manual trigger (no steps). The `empty: true`",

--- a/src/daemon/agent-service.ts
+++ b/src/daemon/agent-service.ts
@@ -44,6 +44,8 @@ import { documentTool } from '../actions/tools/documents.ts';
 import { AgentTaskManager } from '../agents/task-manager.ts';
 import { discoverSpecialists, formatSpecialistList } from '../agents/role-discovery.ts';
 import { buildSystemPromptParts, type PromptContext, type SystemPromptParts } from '../roles/prompt-builder.ts';
+import { piecesManagedByHost } from '../workflows/pieces-library/shared.ts';
+import { resolveSharedRuntimePaths } from '../workflows/runtime/shared-runtime-paths.ts';
 import type { ProgressCallback } from '../agents/sub-agent-runner.ts';
 import {
   getPersonality,
@@ -834,6 +836,20 @@ export class AgentService implements Service, IAgentService {
     };
   }
 
+  /**
+   * Whether a host owns the pieces catalog. Resolved from config the daemon
+   * read at boot and memoized: the tool guide it feeds lands in the
+   * prompt-cached static section, so a value that moved between turns would
+   * silently break that cache for no reason.
+   */
+  private piecesManagedCache: boolean | null = null;
+  private piecesManaged(): boolean {
+    this.piecesManagedCache ??= piecesManagedByHost(
+      resolveSharedRuntimePaths(this.config).piecesDir,
+    );
+    return this.piecesManagedCache;
+  }
+
   private buildPromptContext(userMessage?: string, opts?: { slim?: boolean }): PromptContext {
     // Slim mode: voice channels skip the heavyweight context blocks
     // (observations, content pipeline, commitments) so the LLM has
@@ -851,6 +867,9 @@ export class AgentService implements Service, IAgentService {
       currentTime: new Date().toISOString(),
       availableSpecialists: this.specialistListText || undefined,
       hasSidecars,
+      // Derived from config, so it is stable turn over turn and safe to sit
+      // in the prompt-CACHED static section alongside hasSidecars.
+      piecesManaged: this.piecesManaged(),
     };
 
     try {

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -71,7 +71,6 @@ import {
 } from "../workflows/runtime/engine-bootstrap.ts";
 import { CredentialResolver } from "../workflows/credentials/adapter.ts";
 import { metadataToCatalogEntry } from "../workflows/runtime/piece-catalog.ts";
-import { sharedPieceVersions } from "../workflows/pieces-library/shared.ts";
 import { resolveSharedRuntimePaths } from "../workflows/runtime/shared-runtime-paths.ts";
 import { DEFAULT_IDS } from "../workflows/db/schema.ts";
 import { apId } from "../workflows/db/ids.ts";
@@ -4301,22 +4300,15 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
             kind: "installed" | "uninstalled";
             piece: { npmPackage: string; resolvedVersion: string };
           }) => {
-            // Uninstalling a piece the SHARED catalog also provides reverts
-            // to the shared copy (that's what the next restart would produce
-            // via discoverPieces, and what the Library reports as Included) —
-            // so re-extract at the shared version instead of dropping the
-            // entry and leaving the live catalog disagreeing with the
-            // Library until restart.
-            const sharedVersion =
-              event.kind === "uninstalled"
-                ? sharedPieceVersions(sharedRuntime.piecesDir).get(event.piece.npmPackage)
-                : undefined;
-            if (event.kind === "uninstalled" && sharedVersion === undefined) {
+            // Only ever reached on a SELF-MANAGED install: the Library
+            // mutations that fire this are refused when a host owns the
+            // catalog, and a host owning the catalog is exactly what having a
+            // shared tree means. So an uninstall here has no shared copy to
+            // fall back to — the piece is simply gone.
+            if (event.kind === "uninstalled") {
               workflowPieceCatalog.remove(event.piece.npmPackage);
               return;
             }
-            const extractVersion =
-              event.kind === "uninstalled" ? sharedVersion! : event.piece.resolvedVersion;
             // Unique runId per acquire so any future parallel installs
             // (today serialized by the API's library mutex) don't collide on
             // the engine's runId-keyed state.
@@ -4327,7 +4319,7 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
             try {
               const meta = await handle.extractPieceMetadata({
                 pieceName: event.piece.npmPackage,
-                pieceVersion: extractVersion,
+                pieceVersion: event.piece.resolvedVersion,
               });
               workflowPieceCatalog.upsert(metadataToCatalogEntry(meta));
             } finally {
@@ -4483,13 +4475,26 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
       // Compact community-library index for the composer's search_library
       // tool: lets it suggest "install piece X first" when the user asks for
       // a service that isn't installed, instead of forcing a wrong fit.
+      //
+      // Withheld on a HOST-MANAGED install, where that suggestion is a
+      // dead end. The host installed the whole catalog, so every piece the
+      // engine could actually run is already in the registry list_pieces
+      // reads; the only ids this index could still flag "not installed" are
+      // ones whose metadata extraction failed on the host — which the tenant
+      // can neither install (the API answers 403) nor repair. Passing no
+      // library also strips search_library from the composer's tool loop and
+      // the suggest-install wording from both prompts, so the agent stops
+      // telling hosted users to visit a Library page that has no button.
       const { CATALOG: piecesLibraryCatalog } = await import('../workflows/pieces-library/catalog.ts');
-      const composerLibrary = piecesLibraryCatalog.map((e) => ({
-        id: e.id,
-        npmPackage: e.npmPackage,
-        displayName: e.displayName,
-        description: e.description,
-      }));
+      const { piecesManagedByHost } = await import('../workflows/pieces-library/shared.ts');
+      const composerLibrary = piecesManagedByHost(sharedRuntime.piecesDir)
+        ? []
+        : piecesLibraryCatalog.map((e) => ({
+            id: e.id,
+            npmPackage: e.npmPackage,
+            displayName: e.displayName,
+            description: e.description,
+          }));
       const composerToolRegistry = toolRegistry
         ? {
             listNames: (cat?: string) => toolRegistry.list(cat).map((t) => t.name),

--- a/src/roles/prompt-builder.test.ts
+++ b/src/roles/prompt-builder.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'bun:test';
 import { buildSystemPrompt, buildSystemPromptParts, type PromptContext } from './prompt-builder.ts';
+import { buildToolGuide } from './tool-guide.ts';
 import type { RoleDefinition } from './types.ts';
 
 const role: RoleDefinition = {
@@ -63,5 +64,36 @@ describe('buildSystemPromptParts', () => {
     const parts = buildSystemPromptParts(role, undefined);
     expect(parts.dynamic).toBe('');
     expect(buildSystemPrompt(role, undefined)).toBe(parts.static);
+  });
+});
+
+describe("tool guide: install advice follows who owns the pieces catalog", () => {
+  it("self-managed keeps the install remedy", () => {
+    const g = buildToolGuide({ hasSidecars: false, piecesManaged: false });
+    expect(g).toContain("suggestedInstalls");
+    expect(g).toContain("Library page");
+  });
+
+  it("host-managed drops it, keeping the rest of the workflow guide", () => {
+    // The THIRD surface carrying this advice, after the manage_workflow tool
+    // description and the composer's prompts. It is the easiest to miss --
+    // nothing about workflows imports it, it just gets concatenated into
+    // every primary-agent system prompt -- and it is the most damaging to
+    // get wrong, because it teaches the model the remedy up front rather
+    // than only on a compose failure.
+    const g = buildToolGuide({ hasSidecars: false, piecesManaged: true });
+    expect(g).not.toContain("suggestedInstalls");
+    expect(g).not.toContain("Library page");
+    expect(g).toContain("### manage_workflow");
+    expect(g).toContain("compose { name, description }");
+  });
+
+  it("the pieces flag does not disturb the sidecar sections", () => {
+    for (const piecesManaged of [false, true]) {
+      expect(buildToolGuide({ hasSidecars: true, piecesManaged })).toContain("Sidecar name or ID");
+      expect(buildToolGuide({ hasSidecars: false, piecesManaged })).not.toContain(
+        "Sidecar name or ID",
+      );
+    }
   });
 });

--- a/src/roles/prompt-builder.ts
+++ b/src/roles/prompt-builder.ts
@@ -14,6 +14,17 @@ export type PromptContext = {
   authorityRules?: string;
   activeGoals?: string;
   hasSidecars?: boolean;
+  /**
+   * A host owns the pieces catalog (see `piecesManagedByHost`). Drops the
+   * "have the user install it from the Library page" advice from the tool
+   * guide, which is a dead end on such an install.
+   *
+   * Defaults to false, i.e. the self-managed guide. That is the safe
+   * direction for a MISSING value: the worst case is advice that does not
+   * apply, whereas defaulting the other way would withhold a real, working
+   * remedy from a self-hosted user.
+   */
+  piecesManaged?: boolean;
   effectiveAuthorityLevel?: number;
 };
 
@@ -178,12 +189,17 @@ export function buildSystemPromptParts(role: RoleDefinition, context?: PromptCon
   sections.push('');
 
   // Tool Guide (static reference, sidecar section conditional)
-  sections.push(buildToolGuide(context?.hasSidecars ?? false));
+  sections.push(
+    buildToolGuide({
+      hasSidecars: context?.hasSidecars ?? false,
+      piecesManaged: context?.piecesManaged ?? false,
+    }),
+  );
   sections.push('');
 
   // ── Static/dynamic boundary ─────────────────────────────────────────────
   // Everything above depends only on the role (+ process-stable context like
-  // authorityRules / effectiveAuthorityLevel / hasSidecars). Everything below
+  // authorityRules / effectiveAuthorityLevel / hasSidecars / piecesManaged). Everything below
   // changes per turn and must not sit inside the cacheable prefix.
   const staticPrompt = sections.join('\n');
   const dynamicSections: string[] = [];

--- a/src/roles/tool-guide.ts
+++ b/src/roles/tool-guide.ts
@@ -7,9 +7,22 @@
  * When `hasSidecars` is false, sidecar-related content (target params,
  * list_sidecars, sidecar section) is omitted entirely so the AI
  * doesn't waste tokens thinking about remote execution.
+ *
+ * When `piecesManaged` is true, the workflow section drops the advice to have
+ * the user install a piece: a host owns the catalog there, the Library page
+ * has no install button, and the API answers 403. This is the THIRD place
+ * that advice appears (with the manage_workflow tool description and the
+ * composer's prompts) — all three have to agree, or the agent reads one of
+ * them and sends a hosted user somewhere they cannot act.
  */
 
-export function buildToolGuide(hasSidecars: boolean): string {
+export type ToolGuideOptions = {
+  hasSidecars: boolean;
+  /** A host owns the pieces catalog: nothing here is installable by the user. */
+  piecesManaged: boolean;
+};
+
+export function buildToolGuide({ hasSidecars, piecesManaged }: ToolGuideOptions): string {
   const lines: string[] = [];
 
   lines.push('# Tool Guide');
@@ -177,9 +190,11 @@ export function buildToolGuide(hasSidecars: boolean): string {
   lines.push('The action calls the LLM under the hood, validates against the piece catalog, and either persists a');
   lines.push('DISABLED draft or returns `{ ok: false, errors, rawResponse }`. Treat failures as iterative: read the errors,');
   lines.push('refine the description with concrete piece/tool names from the messages, and call `compose` again.');
-  lines.push('A failure can also carry `suggestedInstalls: [{ id, displayName, reason }]` -- community-library pieces that');
-  lines.push('would make the request possible. Relay those to the user (installs happen from the dashboard\'s Library page)');
-  lines.push('and offer to compose again after installing; do not retry compose unchanged.');
+  if (!piecesManaged) {
+    lines.push('A failure can also carry `suggestedInstalls: [{ id, displayName, reason }]` -- community-library pieces that');
+    lines.push('would make the request possible. Relay those to the user (installs happen from the dashboard\'s Library page)');
+    lines.push('and offer to compose again after installing; do not retry compose unchanged.');
+  }
   lines.push('Do not surface raw error JSON to the user, translate it. After a successful compose, summarize what was');
   lines.push('built and confirm with the user before calling `publish` (which locks the draft and enables it).');
   lines.push('');

--- a/src/workflows/api/routes.test.ts
+++ b/src/workflows/api/routes.test.ts
@@ -883,6 +883,147 @@ describe("workflow API: sample data", () => {
   });
 });
 
+describe("workflow API: pieces library on a MANAGED install", () => {
+  /**
+   * Managed = a host installed the whole catalog into a read-only shared
+   * tree. What these pin: the catalog is offered whole with no install state
+   * and no per-piece detail, and the two mutations are refused BEFORE they
+   * touch the tenant's own writable `~/.jarvis/pieces` -- which is the only
+   * thing stopping a hand-rolled POST, since that directory stays writable.
+   */
+  const MANAGED_DIR = "/opt/jarvis-pieces/1.2.3";
+
+  /** A temp JARVIS_PIECES_DIR, so a developer's own installs can't leak in. */
+  async function withTempPiecesDir<T>(fn: (dir: string) => Promise<T>): Promise<T> {
+    const { mkdtempSync, rmSync } = await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+    const dir = mkdtempSync(join(tmpdir(), "jarvis-lib-managed-"));
+    const prev = process.env.JARVIS_PIECES_DIR;
+    process.env.JARVIS_PIECES_DIR = dir;
+    try {
+      return await fn(dir);
+    } finally {
+      if (prev === undefined) delete process.env.JARVIS_PIECES_DIR;
+      else process.env.JARVIS_PIECES_DIR = prev;
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+
+  test("GET offers the WHOLE catalog, with no install state and no detail", async () => {
+    const { CATALOG } = await import("../pieces-library/catalog");
+    await withTempPiecesDir(async () => {
+      const r = createWorkflowRoutes({ sharedPiecesDir: MANAGED_DIR });
+      const get = r["/api/workflows/pieces/library"]?.GET;
+      const { status, body } = await callJson(
+        get,
+        plainReq("GET", "http://x/api/workflows/pieces/library"),
+      );
+      expect(status).toBe(200);
+      expect(body.managed).toBe(true);
+      // The whole catalog is available -- not the subset a user installed.
+      expect(body.entries.length).toBe(CATALOG.length);
+      for (const entry of body.entries) {
+        // What the UI still binds to.
+        expect(typeof entry.id).toBe("string");
+        expect(typeof entry.npmPackage).toBe("string");
+        expect(typeof entry.displayName).toBe("string");
+        expect(entry.tier === "verified" || entry.tier === "community").toBe(true);
+        // ...and what must not reach it. Absent on the WIRE, not merely
+        // unrendered: hiding these client-side would leave a stale cached
+        // bundle free to show them again.
+        for (const gone of [
+          "installed",
+          "versionRange",
+          "vettedVersion",
+          "vettedAt",
+          "estimatedSizeMb",
+          "licenseSpdx",
+          "sourceUrl",
+        ]) {
+          expect(Object.hasOwn(entry, gone)).toBe(false);
+        }
+      }
+    });
+  });
+
+  test("POST install is refused, and writes nothing to the tenant's pieces dir", async () => {
+    await withTempPiecesDir(async (dir) => {
+      const { readdirSync } = await import("node:fs");
+      const r = createWorkflowRoutes({ sharedPiecesDir: MANAGED_DIR });
+      const post = r["/api/workflows/pieces/library/:id/install"]?.POST;
+      const { status, body } = await callJson(
+        post,
+        // A REAL catalog id: a 403 that only ever fired for unknown ids
+        // would be the pre-existing 404 wearing a different number.
+        reqWithParams("POST", "http://x/api/workflows/pieces/library/gmail/install", {
+          id: "gmail",
+        }),
+      );
+      expect(status).toBe(403);
+      expect(body.error).toMatch(/managed by this install's host/);
+      // The guard has to come before the manifest write, not just before the
+      // bun install -- a written manifest would be reconciled onto disk at
+      // the next daemon start.
+      expect(readdirSync(dir)).toEqual([]);
+    });
+  });
+
+  test("DELETE is refused even for a piece the manifest really holds", async () => {
+    await withTempPiecesDir(async (dir) => {
+      // A leftover user install -- e.g. made before this instance became
+      // managed. Uninstall is still not the tenant's call, and the refusal
+      // must not depend on the manifest being empty.
+      const { writeManifest, readManifest } = await import("../pieces-library/installer");
+      const piece = {
+        id: "gmail",
+        npmPackage: "@activepieces/piece-gmail",
+        versionRange: "^0.12.2",
+        resolvedVersion: "0.12.3",
+        installedAt: 1,
+      };
+      await writeManifest({ version: 1, pieces: [piece] }, dir);
+
+      const r = createWorkflowRoutes({ sharedPiecesDir: MANAGED_DIR });
+      const del = r["/api/workflows/pieces/library/:id"]?.DELETE;
+      const { status, body } = await callJson(
+        del,
+        reqWithParams("DELETE", "http://x/api/workflows/pieces/library/gmail", { id: "gmail" }),
+      );
+      expect(status).toBe(403);
+      expect(body.error).toMatch(/managed by this install's host/);
+      expect((await readManifest(dir)).pieces).toEqual([piece]);
+    });
+  });
+
+  test("an EMPTY sharedPiecesDir is not managed -- install stays the user's", async () => {
+    // `null` means "definitively no shared tree"; the self-managed Library
+    // must survive it, or a self-hosted install would lose its only way to
+    // get a piece.
+    await withTempPiecesDir(async () => {
+      const r = createWorkflowRoutes({ sharedPiecesDir: null });
+      const { status, body } = await callJson(
+        r["/api/workflows/pieces/library"]?.GET,
+        plainReq("GET", "http://x/api/workflows/pieces/library"),
+      );
+      expect(status).toBe(200);
+      expect(body.managed).toBe(false);
+      expect(typeof body.entries[0].versionRange).toBe("string");
+      expect(body.entries[0].installed).toBeNull();
+    });
+  });
+});
+
+/**
+ * The self-managed Library. Every case here assumes the user owns the
+ * catalog, so the mode is pinned rather than inherited: without
+ * `sharedPiecesDir`, `piecesManagedByHost` consults JARVIS_SHARED_PIECES_DIR,
+ * and a developer or CI runner that happens to export it would flip this
+ * whole suite into managed mode and fail it with 403s that look like real
+ * regressions. The managed suite above pins its own side the same way.
+ */
+const SELF_MANAGED = { sharedPiecesDir: null } as const;
+
 describe("workflow API: pieces library", () => {
   test("GET /api/workflows/pieces/library returns the catalog with per-entry installed status", async () => {
     // Isolate from any pieces installed on the developer's machine.
@@ -893,7 +1034,7 @@ describe("workflow API: pieces library", () => {
     const prev = process.env.JARVIS_PIECES_DIR;
     process.env.JARVIS_PIECES_DIR = tempDir;
     try {
-      const r = createWorkflowRoutes();
+      const r = createWorkflowRoutes(SELF_MANAGED);
       const get = r["/api/workflows/pieces/library"]?.GET;
       const { status, body } = await callJson(get, plainReq("GET", "http://x/api/workflows/pieces/library"));
       expect(status).toBe(200);
@@ -915,7 +1056,7 @@ describe("workflow API: pieces library", () => {
   });
 
   test("POST /api/workflows/pieces/library/:id/install rejects an unknown piece id", async () => {
-    const r = createWorkflowRoutes();
+    const r = createWorkflowRoutes(SELF_MANAGED);
     const post = r["/api/workflows/pieces/library/:id/install"]?.POST;
     const { status, body } = await callJson(
       post,
@@ -930,7 +1071,7 @@ describe("workflow API: pieces library", () => {
   });
 
   test("DELETE on a never-installed piece returns 200 with alreadyAbsent (idempotent uninstall)", async () => {
-    const r = createWorkflowRoutes();
+    const r = createWorkflowRoutes(SELF_MANAGED);
     const del = r["/api/workflows/pieces/library/:id"]?.DELETE;
     const { status, body } = await callJson(
       del,
@@ -973,7 +1114,7 @@ describe("workflow API: pieces library", () => {
         tempDir,
       );
 
-      const r = createWorkflowRoutes();
+      const r = createWorkflowRoutes(SELF_MANAGED);
       const del = r["/api/workflows/pieces/library/:id"]?.DELETE;
       const { status, body } = await callJson(
         del,
@@ -1002,7 +1143,7 @@ describe("workflow API: pieces library", () => {
     const prev = process.env.JARVIS_PIECES_DIR;
     process.env.JARVIS_PIECES_DIR = tempDir;
     try {
-      const r = createWorkflowRoutes();
+      const r = createWorkflowRoutes(SELF_MANAGED);
       const del = r["/api/workflows/pieces/library/:id"]?.DELETE;
       const { status, body } = await callJson(
         del,

--- a/src/workflows/api/routes.ts
+++ b/src/workflows/api/routes.ts
@@ -71,7 +71,7 @@ import type { CredentialResolver } from "../credentials/adapter";
 import type { TriggerManager } from "../runner/triggers/manager";
 import type { PieceLookup } from "../runtime/piece-catalog";
 import { CATALOG, findCatalogEntry } from "../pieces-library/catalog";
-import { sharedPieceVersions } from "../pieces-library/shared";
+import { piecesManagedByHost } from "../pieces-library/shared";
 import {
   installPiece,
   readManifest,
@@ -143,8 +143,10 @@ export interface CreateWorkflowRoutesOptions {
   pieceRegistry?: PieceLookup;
   /**
    * Config-resolved ready-made pieces dir (workflows.pieces_dir, ${version}
-   * expanded). `undefined` falls back to the env var inside
-   * sharedPieceVersions; `null` = definitively none.
+   * expanded). `undefined` falls back to the env var; `null` = definitively
+   * none. Same convention as `piecesManagedByHost`, which is the only thing
+   * these routes do with it: SET means this install's pieces are host-managed
+   * and the Library serves its managed shape.
    */
   sharedPiecesDir?: string | null;
   /**
@@ -198,8 +200,23 @@ function withLibraryLock<T>(fn: () => Promise<T>): Promise<T> {
   return release;
 }
 
+/**
+ * What the Library routes answer on a managed install. Says WHOSE decision it
+ * is and that nothing is missing, because the only two ways a client reaches
+ * a 403 here are a stale cached bundle and a hand-rolled request -- both of
+ * which are read by a person trying to work out what broke.
+ */
+const MANAGED_MESSAGE =
+  "pieces are managed by this install's host: the full catalog is already available, " +
+  "and it cannot be installed to or uninstalled from here";
+
 /** Build the workflow route map. Side-effect-free; spread into the daemon's main route table. */
 export function createWorkflowRoutes(opts: CreateWorkflowRoutesOptions = {}): WorkflowRouteMap {
+  // Resolved ONCE per route map rather than per request: the shared dir comes
+  // from config the daemon read at boot and cannot change under a running
+  // process, and one value means the GET's shape and the mutations' guard can
+  // never disagree about which mode this install is in.
+  const managed = piecesManagedByHost(opts.sharedPiecesDir);
   const refreshTrigger = (flowId: string): void => {
     if (!opts.triggerManager) return;
     // Fire-and-forget: API responses must not block on engine round-trips
@@ -262,33 +279,66 @@ export function createWorkflowRoutes(opts: CreateWorkflowRoutesOptions = {}): Wo
     },
 
     // ------------------------------------------------------------- pieces library
-    // The Library tab in the dashboard renders this list. Each entry is a
-    // *curated* (Jarvis-vetted) community piece the user can opt into
-    // installing. Installed pieces are merged in with their resolved
-    // version + install timestamp so the UI can show "Installed" /
-    // "Update available" badges.
+    // The Library tab in the dashboard renders this list. It has two modes,
+    // and `managed` (a host-owned shared catalog) picks between them.
     //
-    // Install / uninstall mutate `~/.jarvis/pieces/` (manifest + bun
-    // install). They block until bun finishes -- typical first install of a
-    // single piece is 3-8s end to end. The UI shows a spinner during the
-    // wait. A `withLibraryLock` mutex serializes concurrent requests so a
-    // second install doesn't race the first one's bun-install.
+    // SELF-MANAGED -- each entry is a *curated* community piece the user can
+    // opt into installing. Installed pieces are merged in with their resolved
+    // version + install timestamp so the UI can show "Installed" / "Update
+    // available" badges. Install / uninstall mutate `~/.jarvis/pieces/`
+    // (manifest + bun install) and block until bun finishes -- a first
+    // install of a single piece is typically 3-8s end to end, and the UI
+    // shows a spinner for the wait. A `withLibraryLock` mutex serializes
+    // concurrent requests so a second install can't race the first one's
+    // bun-install.
+    //
+    // MANAGED -- the host installed the whole catalog once per version into a
+    // read-only tree every tenant shares, so every entry is already usable
+    // and install/uninstall are not the tenant's to make: both mutations are
+    // refused, and the list carries no install state and no per-piece detail.
+    // The refusal is the guarantee, not the hidden button: the tenant's own
+    // `~/.jarvis/pieces` is still writable, so nothing but this guard stops a
+    // hand-rolled POST from shadowing a shared piece with an unreviewed copy
+    // and spending the tenant's disk quota doing it.
     "/api/workflows/pieces/library": {
       GET: () =>
         trapErrors(async () => {
+          // MANAGED (a host owns the catalog): the whole catalog is already
+          // installed in the shared tree, so there is no install state to
+          // report and nothing the user could act on. Every entry is simply
+          // available, and the per-piece specifics an install decision needed
+          // -- resolved/vetted version, disk footprint, audit date, license,
+          // upstream link -- are dropped from the PAYLOAD rather than merely
+          // hidden by the client, so that no client can render them: not a
+          // stale cached bundle, not a future one that forgets to check
+          // `managed`, not curl.
+          if (managed) {
+            return ok({
+              managed: true,
+              entries: CATALOG.map((entry) => ({
+                id: entry.id,
+                // Kept because the Library's search matches on it -- users
+                // type "activepieces" or a package name as readily as a
+                // display name. It is not RENDERED on a managed row.
+                npmPackage: entry.npmPackage,
+                displayName: entry.displayName,
+                description: entry.description,
+                iconUrl: entry.iconUrl ?? null,
+                tier: entry.tier,
+              })),
+            });
+          }
+          // Reaching here means NO shared tree is configured -- that is the
+          // whole of what `managed` tests -- so every piece that exists on
+          // this install got there through the manifest. There is no shared
+          // baseline to merge in and no `source: "shared"` case: a
+          // deployment either owns the catalog (above) or the user does.
           const manifest = await readManifest();
           const installedById = new Map(
             manifest.pieces.map((p) => [p.id, p]),
           );
-          // Shared read-only catalog (multi-tenant hosting): pieces present
-          // there work with NO installation, so the Library reports them as
-          // included (`source: "shared"`). A user install shadows the shared
-          // copy (engine-bootstrap orders roots user-first), so the user's
-          // manifest wins when both exist.
-          const shared = sharedPieceVersions(opts.sharedPiecesDir);
           const entries = CATALOG.map((entry) => {
             const installed = installedById.get(entry.id) ?? null;
-            const sharedVersion = shared.get(entry.npmPackage) ?? null;
             return {
               id: entry.id,
               npmPackage: entry.npmPackage,
@@ -308,22 +358,17 @@ export function createWorkflowRoutes(opts: CreateWorkflowRoutesOptions = {}): Wo
                     installedAt: installed.installedAt,
                     source: "user" as const,
                   }
-                : sharedVersion
-                  ? {
-                      resolvedVersion: sharedVersion,
-                      installedAt: 0,
-                      source: "shared" as const,
-                    }
-                  : null,
+                : null,
             };
           });
-          return ok({ entries });
+          return ok({ managed: false, entries });
         }),
     },
 
     "/api/workflows/pieces/library/:id/install": {
       POST: (req) =>
         trapErrors(async () => {
+          if (managed) return err(MANAGED_MESSAGE, 403);
           const { id } = (req as RequestWithParams<{ id: string }>).params;
           const entry = findCatalogEntry(id);
           if (!entry) return err(`unknown piece id "${id}"`, 404);
@@ -357,6 +402,7 @@ export function createWorkflowRoutes(opts: CreateWorkflowRoutesOptions = {}): Wo
     "/api/workflows/pieces/library/:id": {
       DELETE: (req) =>
         trapErrors(async () => {
+          if (managed) return err(MANAGED_MESSAGE, 403);
           const { id } = (req as RequestWithParams<{ id: string }>).params;
           // Check the manifest BEFORE the catalog. A piece can legitimately
           // be installed but not in the catalog -- we yank entries from the

--- a/src/workflows/pieces-library/README.md
+++ b/src/workflows/pieces-library/README.md
@@ -78,6 +78,60 @@ Docker: `~/.jarvis` should be mounted as a persistent volume. The manifest
 re-runs `bun install` on startup if any catalog-installed piece is missing
 from `node_modules`.
 
+## Managed installs: the host owns the catalog
+
+Everything above describes a **self-managed** install, where the user picks
+pieces one at a time. A multi-tenant host inverts that: it builds the WHOLE
+catalog once per brain version into a root-owned read-only tree and points
+every tenant at it with `workflows.pieces_dir` (or
+`JARVIS_SHARED_PIECES_DIR`). `piecesManagedByHost()` in `shared.ts` is the
+switch, and a configured shared dir is the whole condition — the question the
+Library asks is "does something other than this user decide which pieces
+exist here?", and that setting IS the deployment's answer.
+
+When it is set:
+
+- `GET /api/workflows/pieces/library` returns `managed: true` and the whole
+  catalog as plain entries — id, package, name, description, tier. No install
+  state (everything is installed, so the badge would be noise on every row)
+  and none of the install-decision detail: version, vetted date, size,
+  license, source. Those are dropped from the PAYLOAD, not hidden by the
+  client, so a stale cached bundle can't put them back.
+- `POST .../:id/install` and `DELETE .../:id` answer **403**, before touching
+  disk.
+
+The 403 is the guarantee, not the hidden button. The tenant's own
+`~/.jarvis/pieces` is still writable and still shadows the shared tree
+(engine-bootstrap orders the roots user-first), so without the guard a
+hand-rolled POST would happily shadow a reviewed shared piece with an
+unreviewed npm copy and spend the tenant's disk quota doing it.
+
+The agent side follows the same switch. A managed daemon passes the composer
+no library index, which drops its `search_library` tool and the
+"suggest installs" wording from both prompts — otherwise the assistant would
+answer "install Discord from the Library page first" on an install whose
+Library has no button and whose install API answers 403.
+
+Two known rough edges:
+
+- A piece installed into `~/.jarvis/pieces` BEFORE the instance became managed
+  keeps shadowing the shared copy and can no longer be uninstalled through the
+  product. Clearing one is an SSH-level chore. This wants no migration and no
+  startup pruning: the managed Library shipped before the hosted product had
+  users, so the only installs that can predate it are a developer's own. Do
+  not add a reconciler pass that deletes from a manifest the user did not ask
+  you to touch.
+- Managedness rides on the RESOLVED dir, so it fails OPEN if the path cannot
+  be resolved. A host writes `pieces_dir: /opt/jarvis-pieces/${version}`, and
+  `resolveSharedRuntimePaths` refuses to expand `${version}` unless
+  `JARVIS_VERSION` names a concrete version — which it does not if the
+  per-instance env file is missing and systemd falls back to its
+  `JARVIS_VERSION=current` default. That instance reads as self-managed: full
+  detail, working install API, bun installing into the tenant's own quota. It
+  degrades to the pre-feature status quo rather than breaking, and such a host
+  is already badly broken (it is also running the wrong brain), but the only
+  announcement is a `[shared-runtime] WARNING` in the daemon log.
+
 ## Catalog entry schema
 
 ```ts

--- a/src/workflows/pieces-library/shared.test.ts
+++ b/src/workflows/pieces-library/shared.test.ts
@@ -1,0 +1,51 @@
+/**
+ * `piecesManagedByHost` — the switch that decides whether this install's
+ * pieces are the user's to install and remove, or the host's. Both Library
+ * mutations are gated on it, so its edge cases are worth pinning directly
+ * rather than only through the routes.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { piecesManagedByHost } from "./shared";
+
+const ENV = "JARVIS_SHARED_PIECES_DIR";
+let prev: string | undefined;
+
+beforeEach(() => {
+  prev = process.env[ENV];
+  delete process.env[ENV];
+});
+
+afterEach(() => {
+  if (prev === undefined) delete process.env[ENV];
+  else process.env[ENV] = prev;
+});
+
+describe("piecesManagedByHost", () => {
+  test("an explicit dir is managed; null is not", () => {
+    expect(piecesManagedByHost("/opt/jarvis-pieces/1.2.3")).toBe(true);
+    expect(piecesManagedByHost(null)).toBe(false);
+  });
+
+  test("a blank configured dir is NOT managed", () => {
+    // `resolve("")` is the process cwd, so treating whitespace as a real dir
+    // would declare a self-hosted install managed and take its Library away
+    // over a stray space in config.yaml.
+    expect(piecesManagedByHost("")).toBe(false);
+    expect(piecesManagedByHost("   ")).toBe(false);
+  });
+
+  test("undefined consults the env var", () => {
+    expect(piecesManagedByHost(undefined)).toBe(false);
+    process.env[ENV] = "/opt/jarvis-pieces/1.2.3";
+    expect(piecesManagedByHost(undefined)).toBe(true);
+  });
+
+  test("an explicit null OUTRANKS the env var", () => {
+    // `null` is the daemon saying "config resolved to no shared tree". A
+    // leftover env var must not override that and silently re-manage the
+    // install; config wins, exactly as it does in resolveSharedRuntimePaths.
+    process.env[ENV] = "/opt/jarvis-pieces/1.2.3";
+    expect(piecesManagedByHost(null)).toBe(false);
+  });
+});

--- a/src/workflows/pieces-library/shared.ts
+++ b/src/workflows/pieces-library/shared.ts
@@ -1,61 +1,55 @@
 /**
  * Read-only SHARED pieces catalog (multi-tenant hosting): a root-owned tree
  * the host builds once per installed version and exposes via
- * `JARVIS_SHARED_PIECES_DIR`. Pieces present there are usable by every
- * instance without installation — the Library shows them as included, and a
- * user install of the same piece shadows the shared copy (engine-bootstrap
- * orders the roots user-first).
+ * `workflows.pieces_dir` / `JARVIS_SHARED_PIECES_DIR`. It holds the WHOLE
+ * catalog, and every instance pointed at it can use all of it with no
+ * installation.
+ *
+ * Configuring it hands the catalog to the HOST: `piecesManagedByHost` is the
+ * switch, and the Library then offers every piece as simply available — no
+ * install state, no per-piece detail — while install and uninstall answer
+ * 403. There is no in-between where a shared baseline is topped up with user
+ * installs; a deployment either owns the catalog or the user does. (This
+ * module used to also enumerate the tree's npmPackage -> version map, for a
+ * Library that merged shared pieces and user installs into one list. That
+ * hybrid is gone, and so is the enumeration — nothing needs to read the tree
+ * to decide what is available any more, because the answer is "all of it".)
+ *
+ * What the shared tree does NOT do is take the tenant's own directory away.
+ * `~/.jarvis/pieces` stays writable and still SHADOWS the shared copy
+ * (engine-bootstrap orders the roots user-first), which is precisely why the
+ * refusal has to live in the API rather than in the UI.
  */
 
-import { existsSync, readdirSync, readFileSync } from "node:fs";
-import { join, resolve } from "node:path";
+import { resolve } from "node:path";
 
 export function sharedPiecesDir(): string | null {
   const dir = process.env.JARVIS_SHARED_PIECES_DIR?.trim();
   return dir ? resolve(dir) : null;
 }
 
-const memo = new Map<string, Map<string, string>>();
-
 /**
- * npmPackage -> version for every piece in the shared tree. `dirArg`
- * overrides discovery (the daemon passes the config-resolved dir; `null` =
- * definitely none; `undefined` = fall back to the env var). Memoized per dir
- * for the process lifetime: the tree is immutable per installed version, and
- * version changes restart the daemon.
+ * True when a HOST manages this install's pieces: a shared catalog dir is
+ * configured, so the whole catalog is already installed and read-only.
+ *
+ * This is the gate for the managed Library — no install, no uninstall, no
+ * per-piece version/size detail — and it keys off the shared dir rather than
+ * a generic "am I hosted" flag on purpose. The question the Library asks is
+ * "does something other than this user decide which pieces exist here?", and
+ * a configured `workflows.pieces_dir` IS that declaration, whoever wrote it.
+ * Keying off hostedness signals like the `usejarvis_ai` block would be both
+ * too narrow (a managed instance provisioned without the hosted LLM has no
+ * such block) and too broad (it says nothing about pieces).
+ *
+ * Configured-but-missing still counts as managed: an empty or absent shared
+ * tree is a broken host to repair, not an invitation for every tenant to
+ * install the catalog into their own quota.
+ *
+ * Argument convention: `undefined` = consult the env var, `null` = definitely
+ * none. Callers that resolved config already pass `string | null`, so the env
+ * branch serves callers that have no config to hand.
  */
-export function sharedPieceVersions(dirArg?: string | null): Map<string, string> {
-  const dir = dirArg !== undefined ? (dirArg ? resolve(dirArg) : null) : sharedPiecesDir();
-  const key = dir ?? "";
-  const hit = memo.get(key);
-  if (hit) return hit;
-  const out = new Map<string, string>();
-  if (dir) {
-    const scoped = join(dir, "node_modules", "@activepieces");
-    if (existsSync(scoped)) {
-      for (const ent of readdirSync(scoped, { withFileTypes: true })) {
-        if (!ent.isDirectory() && !ent.isSymbolicLink()) continue;
-        const pkgPath = join(scoped, ent.name, "package.json");
-        try {
-          const pkg = JSON.parse(readFileSync(pkgPath, "utf8")) as {
-            name?: unknown;
-            version?: unknown;
-          };
-          if (typeof pkg.name !== "string" || typeof pkg.version !== "string") continue;
-          // Same convention as discoverPieces: real pieces only.
-          if (!/(^|\/)piece-[a-z0-9][a-z0-9-]*$/.test(pkg.name)) continue;
-          out.set(pkg.name, pkg.version);
-        } catch {
-          // Missing/unreadable package.json: not a piece.
-        }
-      }
-    }
-  }
-  memo.set(key, out);
-  return out;
-}
-
-/** Test seam: drop the memo (the env/dir changed under the test). */
-export function resetSharedPiecesCache(): void {
-  memo.clear();
+export function piecesManagedByHost(dirArg?: string | null): boolean {
+  if (dirArg !== undefined) return dirArg !== null && dirArg.trim() !== "";
+  return sharedPiecesDir() !== null;
 }

--- a/ui/src/v2/rooms/workflows/LibraryPanel.tsx
+++ b/ui/src/v2/rooms/workflows/LibraryPanel.tsx
@@ -1,19 +1,28 @@
 /**
- * Library panel: tiered list of activepieces community pieces a Jarvis user
- * can opt into installing. Rendered as two sections:
+ * Library panel: tiered list of activepieces community pieces. Two sections
+ * either way, and `lib.managed` decides what a row is FOR.
  *
  *   - Verified  -- hand-reviewed by a maintainer, no preamble needed.
  *   - Community -- pulled from npm; runs in the engine sandbox but has not
- *                  been individually reviewed. Collapsed by default behind
- *                  a one-line "third-party code" notice so users opt in
- *                  with their eyes open.
+ *                  been individually reviewed. Collapsed by default (it is
+ *                  the overwhelming majority of the catalog), and search
+ *                  auto-expands it.
  *
- * Each row shows piece metadata, vetted version, license, source link, and
- * an Install / Uninstall button. Search filters across both tiers.
+ * SELF-MANAGED -- a row is a decision. It shows the metadata that decision
+ * needs (resolved + vetted version, license, disk footprint, source link)
+ * and an Install / Uninstall button, and the Community section carries a
+ * "third-party code" notice so users opt in with their eyes open. Pieces
+ * install via npm at runtime into `~/.jarvis/pieces/`; this panel only
+ * triggers the install + reflects state, it doesn't bundle any piece code.
  *
- * Pieces install via npm at runtime into `~/.jarvis/pieces/`; this panel
- * only triggers the install/uninstall + reflects state, it doesn't bundle
- * any piece code itself.
+ * MANAGED -- a host installed the whole catalog once into a read-only tree
+ * every tenant shares, so a row is not a decision, it is a fact: this piece
+ * is here and it works. Name and description, nothing else. No install state
+ * (everything is installed, so the badge would be noise on every row), no
+ * versions or size (the user neither picks them nor pays for them), and no
+ * opt-in notice (there is nothing left to opt into -- the tier heading still
+ * says which pieces a maintainer reviewed, which is the part that stayed
+ * true).
  */
 
 import React, { useMemo, useState } from "react";
@@ -33,7 +42,9 @@ export function LibraryPanel(): React.ReactElement {
     window.setTimeout(() => setToast(null), 4000);
   };
 
-  const installedCount = lib.entries.filter((e) => e.installed !== null).length;
+  // Self-managed only: on a managed install every entry is installed, so the
+  // count would say the same thing as the total on every single render.
+  const installedCount = lib.entries.filter((e) => e.installed != null).length;
 
   // Filtered + tier-split view. Search is case-insensitive against
   // displayName + npmPackage + description so users typing "gmail" find
@@ -68,7 +79,9 @@ export function LibraryPanel(): React.ReactElement {
           <p className="wf-lib__subtitle">
             {lib.loading
               ? "loading..."
-              : `${installedCount} installed of ${lib.entries.length} available`}
+              : lib.managed
+                ? `${lib.entries.length} pieces available`
+                : `${installedCount} installed of ${lib.entries.length} available`}
             {lib.error ? ` - ${lib.error}` : null}
           </p>
         </div>
@@ -109,15 +122,19 @@ export function LibraryPanel(): React.ReactElement {
               </div>
             ) : (
               <ul className="wf-lib__list">
-                {verified.map((entry) => (
-                  <LibraryRowWired
-                    key={entry.id}
-                    entry={entry}
-                    actionState={lib.actionState[entry.id] ?? "idle"}
-                    lib={lib}
-                    flash={flash}
-                  />
-                ))}
+                {verified.map((entry) =>
+                  lib.managed ? (
+                    <ManagedLibraryRow key={entry.id} entry={entry} />
+                  ) : (
+                    <LibraryRowWired
+                      key={entry.id}
+                      entry={entry}
+                      actionState={lib.actionState[entry.id] ?? "idle"}
+                      lib={lib}
+                      flash={flash}
+                    />
+                  ),
+                )}
               </ul>
             )}
           </section>
@@ -143,26 +160,37 @@ export function LibraryPanel(): React.ReactElement {
             </button>
             {showCommunity ? (
               <>
-                <p className="wf-lib__section-hint wf-lib__section-hint--warn">
-                  Community pieces are installed from npm and run inside the engine
-                  sandbox. They haven't been individually reviewed by Jarvis -- check
-                  each piece's source link before opting in.
-                </p>
+                {/* The opt-in notice is addressed to someone about to
+                    install. On a managed install that decision was already
+                    made by the host, and there is no source link on the row
+                    to send them to, so the warning would ask for a judgement
+                    the user cannot act on. */}
+                {lib.managed ? null : (
+                  <p className="wf-lib__section-hint wf-lib__section-hint--warn">
+                    Community pieces are installed from npm and run inside the engine
+                    sandbox. They haven't been individually reviewed by Jarvis -- check
+                    each piece's source link before opting in.
+                  </p>
+                )}
                 {community.length === 0 ? (
                   <div className="wf-lib__empty-section">
                     {query ? "No community pieces match the search." : "No community pieces."}
                   </div>
                 ) : (
                   <ul className="wf-lib__list">
-                    {community.map((entry) => (
-                      <LibraryRowWired
-                        key={entry.id}
-                        entry={entry}
-                        actionState={lib.actionState[entry.id] ?? "idle"}
-                        lib={lib}
-                        flash={flash}
-                      />
-                    ))}
+                    {community.map((entry) =>
+                      lib.managed ? (
+                        <ManagedLibraryRow key={entry.id} entry={entry} />
+                      ) : (
+                        <LibraryRowWired
+                          key={entry.id}
+                          entry={entry}
+                          actionState={lib.actionState[entry.id] ?? "idle"}
+                          lib={lib}
+                          flash={flash}
+                        />
+                      ),
+                    )}
                   </ul>
                 )}
               </>
@@ -171,6 +199,28 @@ export function LibraryPanel(): React.ReactElement {
         </>
       )}
     </div>
+  );
+}
+
+/**
+ * A row on a MANAGED install: name + description, no chips, no meta line, no
+ * buttons. Deliberately a separate component rather than a pile of
+ * conditionals inside LibraryRow -- what the two rows have in common is a
+ * name and a sentence; everything else in LibraryRow exists to serve an
+ * install decision this row does not offer.
+ */
+function ManagedLibraryRow({ entry }: { entry: LibraryEntry }): React.ReactElement {
+  return (
+    <li className="wf-lib__row wf-lib__row--managed">
+      <div className="wf-lib__row-main">
+        <div className="wf-lib__row-title">
+          <span className="wf-lib__row-name">{entry.displayName}</span>
+        </div>
+        {entry.description ? (
+          <p className="wf-lib__row-desc">{entry.description}</p>
+        ) : null}
+      </div>
+    </li>
   );
 }
 
@@ -194,7 +244,7 @@ function LibraryRowWired({
       entry={entry}
       actionState={actionState}
       onInstall={async () => {
-        if (entry.estimatedSizeMb !== null && entry.estimatedSizeMb >= 100) {
+        if (entry.estimatedSizeMb != null && entry.estimatedSizeMb >= 100) {
           if (
             !await confirmDialog(
               `Installing ${entry.displayName} will use about ${entry.estimatedSizeMb}MB of disk. Continue?`,
@@ -237,18 +287,21 @@ function LibraryRow({
   onInstall: () => void;
   onUninstall: () => void;
 }): React.ReactElement {
-  const isInstalled = entry.installed !== null;
-  // Shared-catalog pieces are managed by the host, not the user: no install
-  // (it already works), no uninstall (the tree is read-only), no update chip
-  // (updates arrive with the host's version upgrades).
-  const isShared = entry.installed?.source === "shared";
+  // This row renders only on a SELF-MANAGED install, where the server sends
+  // every optional detail field. They are typed optional because ONE endpoint
+  // serves both shapes (see useLibrary) -- the fallbacks below are for the
+  // type, not for a case that happens: an entry reaching here without a
+  // version came from a managed payload routed to the wrong row, and an empty
+  // string renders as a blank chip instead of "undefined".
+  const vettedVersion = entry.vettedVersion ?? "";
+  const isInstalled = entry.installed != null;
   const busy = actionState !== "idle";
   // Compare resolved vs vetted to surface the right hint:
   //   resolved < vetted -> "Update available" (we vetted a newer version)
   //   resolved > vetted -> "Newer than vetted" (user upgraded past our audit)
   //   resolved == vetted -> no chip
-  const versionRel = isInstalled && !isShared
-    ? compareSemver(entry.installed!.resolvedVersion, entry.vettedVersion)
+  const versionRel = isInstalled
+    ? compareSemver(entry.installed!.resolvedVersion, vettedVersion)
     : 0;
   const updateAvailable = versionRel < 0;
   const newerThanVetted = versionRel > 0;
@@ -258,11 +311,7 @@ function LibraryRow({
       <div className="wf-lib__row-main">
         <div className="wf-lib__row-title">
           <span className="wf-lib__row-name">{entry.displayName}</span>
-          {isShared ? (
-            <Chip tone="ok" title="Included with this Jarvis install — ready to use, nothing to manage">
-              Included {entry.installed!.resolvedVersion}
-            </Chip>
-          ) : isInstalled ? (
+          {isInstalled ? (
             <Chip tone="ok">Installed {entry.installed!.resolvedVersion}</Chip>
           ) : (
             <Chip tone="neutral">{entry.versionRange}</Chip>
@@ -270,18 +319,18 @@ function LibraryRow({
           {updateAvailable ? (
             <Chip
               tone="warn"
-              title={`Installed ${entry.installed!.resolvedVersion} -- catalog vetted ${entry.vettedVersion}. Click Install again to upgrade.`}
+              title={`Installed ${entry.installed!.resolvedVersion} -- catalog vetted ${vettedVersion}. Click Install again to upgrade.`}
             >
-              {`Update -> ${entry.vettedVersion}`}
+              {`Update -> ${vettedVersion}`}
             </Chip>
           ) : null}
           {newerThanVetted ? (
-            <Chip tone="warn" title={`Tested with ${entry.vettedVersion}; you have a newer version`}>
-              ahead of vetted {entry.vettedVersion}
+            <Chip tone="warn" title={`Tested with ${vettedVersion}; you have a newer version`}>
+              ahead of vetted {vettedVersion}
             </Chip>
           ) : null}
           {entry.licenseSpdx ? <Chip tone="neutral">{entry.licenseSpdx}</Chip> : null}
-          {entry.estimatedSizeMb !== null ? (
+          {entry.estimatedSizeMb != null ? (
             <Chip tone="neutral" title="Approximate disk footprint after install">
               ~{entry.estimatedSizeMb}MB
             </Chip>
@@ -304,7 +353,7 @@ function LibraryRow({
         </div>
       </div>
       <div className="wf-lib__row-actions">
-        {isShared ? null : isInstalled ? (
+        {isInstalled ? (
           <>
             {updateAvailable ? (
               <Button variant="primary" size="sm" onClick={onInstall} disabled={busy}>

--- a/ui/src/v2/rooms/workflows/WorkflowEditor.tsx
+++ b/ui/src/v2/rooms/workflows/WorkflowEditor.tsx
@@ -900,6 +900,7 @@ export function WorkflowEditor({ flowId, onClose }: WorkflowEditorProps): React.
           anchor={libraryPicker.screen}
           catalog={editor.catalog}
           library={library.entries}
+          managed={library.managed}
           installingId={pendingInstall?.id ?? null}
           onPick={onPickFromLibrary}
           onClose={closeLibraryPicker}
@@ -2349,6 +2350,7 @@ function PieceLibraryPopover({
   anchor,
   catalog,
   library,
+  managed,
   installingId,
   onPick,
   onClose,
@@ -2363,6 +2365,15 @@ function PieceLibraryPopover({
    * safe fallback when the library endpoint is still loading.
    */
   library: InstallableLibraryEntry[];
+  /**
+   * True when a host owns the catalog. Suppresses the "installable" layer
+   * entirely: the whole catalog is already in the shared tree, so every piece
+   * that has usable metadata is already in `catalog` above WITH its actions,
+   * which is strictly more useful than a piece-level Install row. A leftover
+   * row here could only be a piece whose extraction failed on the host, and
+   * picking it would POST to an install route that answers 403.
+   */
+  managed: boolean;
   /**
    * Id of the piece currently being installed via this popover, or null
    * when no install is in flight. The row matching this id renders as a
@@ -2383,6 +2394,7 @@ function PieceLibraryPopover({
   //   1. Control-flow built-ins (top -- always-available, always visible)
   //   2. Installed pieces' actions (one row per action)
   //   3. Uninstalled curated pieces (one row per piece, "Install" chip)
+  //      -- self-managed only; see the `managed` prop.
   //
   // Installed pieces are matched against the library catalog by piece name
   // (`@activepieces/piece-<id>` vs the engine's piece.name). Any installed
@@ -2397,15 +2409,17 @@ function PieceLibraryPopover({
       }
     }
     const uninstalledEntries: LibraryEntry[] = [];
-    for (const lib of library) {
-      // Library ids are bare ("gmail"); the engine's piece.name is the
-      // full npm spec ("@activepieces/piece-gmail"). Match on the latter.
-      if (installedNames.has(lib.npmPackage)) continue;
-      if (lib.installed) continue; // belt + suspenders -- the library hook also tracks this
-      uninstalledEntries.push({ kind: "piece-uninstalled", catalogEntry: lib });
+    if (!managed) {
+      for (const lib of library) {
+        // Library ids are bare ("gmail"); the engine's piece.name is the
+        // full npm spec ("@activepieces/piece-gmail"). Match on the latter.
+        if (installedNames.has(lib.npmPackage)) continue;
+        if (lib.installed) continue; // belt + suspenders -- the library hook also tracks this
+        uninstalledEntries.push({ kind: "piece-uninstalled", catalogEntry: lib });
+      }
     }
     return [...CONTROL_FLOW_ENTRIES, ...pieceEntries, ...uninstalledEntries];
-  }, [catalog, library]);
+  }, [catalog, library, managed]);
 
   // Apply the category filter and search query. Same lowercased q is
   // reused across every entry so we don't pay for the per-iteration call.

--- a/ui/src/v2/rooms/workflows/WorkflowsRoom.css
+++ b/ui/src/v2/rooms/workflows/WorkflowsRoom.css
@@ -585,6 +585,10 @@
   border-radius: var(--radius-2, 6px);
   background: var(--surface-1);
 }
+/* Managed install: a row is a name and a sentence -- no chips, no meta line,
+   no action column. The full row padding was sized around a two-line control;
+   across the whole catalog it reads as a stack of cards rather than a list. */
+.wf-lib__row--managed { padding: var(--s-2) var(--s-3); }
 .wf-lib__row-main { display: flex; flex-direction: column; gap: 4px; flex: 1 1 auto; min-width: 0; }
 .wf-lib__row-title { display: flex; align-items: center; gap: var(--s-1); flex-wrap: wrap; }
 .wf-lib__row-name { font-weight: 600; color: var(--ink-1); }

--- a/ui/src/v2/rooms/workflows/useLibrary.ts
+++ b/ui/src/v2/rooms/workflows/useLibrary.ts
@@ -3,6 +3,16 @@
  * Jarvis users can install), tracks per-piece "installing" / "uninstalling"
  * state, exposes install + uninstall mutations.
  *
+ * On a MANAGED install (`managed: true` -- a host installed the whole catalog
+ * into a shared read-only tree) the server sends a reduced entry: no install
+ * state and none of the per-piece detail an install decision needed. The
+ * detail fields are therefore OPTIONAL on this type, and consumers must gate
+ * on `managed` rather than on a field happening to be present -- the two
+ * shapes come from one endpoint and only `managed` says which one arrived.
+ *
+ * `install` / `uninstall` stay callable in both modes but the managed server
+ * refuses them with a 403; no caller should reach them there.
+ *
  * Secrets stay server-side; this layer only models metadata + transitions.
  */
 
@@ -13,17 +23,9 @@ export type PieceTier = "verified" | "community";
 export interface LibraryEntry {
   id: string;
   npmPackage: string;
-  versionRange: string;
   displayName: string;
   description: string;
   iconUrl: string | null;
-  vettedVersion: string;
-  /** ISO date when a human last vetted this piece. Null on community pieces. */
-  vettedAt: string | null;
-  sourceUrl: string;
-  licenseSpdx: string;
-  /** Disk footprint after install, in MB. Null when not measured. */
-  estimatedSizeMb: number | null;
   /**
    * Trust tier:
    *   "verified"  -- hand-reviewed + smoke-tested by a Jarvis maintainer.
@@ -32,15 +34,29 @@ export interface LibraryEntry {
    *                  sandbox; user opts in with explicit eyes.
    */
   tier: PieceTier;
-  installed: {
+
+  // ---- Self-managed only. Absent on a managed install, where the host
+  // decides what is installed and none of this is the user's to act on.
+
+  versionRange?: string;
+  vettedVersion?: string;
+  /** ISO date when a human last vetted this piece. Null on community pieces. */
+  vettedAt?: string | null;
+  sourceUrl?: string;
+  licenseSpdx?: string;
+  /** Disk footprint after install, in MB. Null when not measured. */
+  estimatedSizeMb?: number | null;
+  installed?: {
     resolvedVersion: string;
     installedAt: number;
     /**
-     * "user"   -- installed into ~/.jarvis/pieces by this user.
-     * "shared" -- included in the host's read-only shared catalog: usable
-     *             with no install, not uninstallable (installedAt is 0).
+     * Always "user" -- installed into ~/.jarvis/pieces by this user, which
+     * is the only way a piece gets installed on an install that reports
+     * install state at all. The server once also emitted "shared" for the
+     * host's read-only catalog; that mode is now `managed`, which reports no
+     * install state whatsoever.
      */
-    source: "user" | "shared";
+    source: "user";
   } | null;
 }
 
@@ -49,6 +65,19 @@ export type LibraryActionState = "idle" | "installing" | "uninstalling";
 export interface LibraryState {
   loading: boolean;
   error: string | null;
+  /**
+   * True when a host owns this install's catalog: every entry is already
+   * usable, entries carry no install state or detail, and the install /
+   * uninstall mutations are refused server-side.
+   *
+   * Starts false and only a successful fetch can raise it, so a failed or
+   * in-flight probe renders the self-managed view. That is the safe default
+   * in exactly one direction: the managed view's extra claim is "everything
+   * here already works", and showing it while the truth is unknown would
+   * leave a self-hosted user staring at a list of pieces they do not have
+   * and no way to install them.
+   */
+  managed: boolean;
   entries: LibraryEntry[];
   /** Per-entry transition state, keyed by piece id. */
   actionState: Record<string, LibraryActionState>;
@@ -60,6 +89,7 @@ export interface LibraryState {
 export function useLibrary(): LibraryState {
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
+  const [managed, setManaged] = useState<boolean>(false);
   const [entries, setEntries] = useState<LibraryEntry[]>([]);
   const [actionState, setActionState] = useState<Record<string, LibraryActionState>>({});
 
@@ -76,7 +106,11 @@ export function useLibrary(): LibraryState {
         setError(`fetch failed: ${r.status}`);
         return;
       }
-      const body = (await r.json()) as { entries: LibraryEntry[] };
+      const body = (await r.json()) as { managed?: boolean; entries: LibraryEntry[] };
+      // `managed` and `entries` are set together: they describe one snapshot,
+      // and a render that paired the managed flag with self-managed rows (or
+      // the reverse) would read every optional field wrong.
+      setManaged(body.managed === true);
       setEntries(body.entries);
     } catch (e) {
       setError((e as Error).message);
@@ -145,5 +179,5 @@ export function useLibrary(): LibraryState {
     [refresh, setOne],
   );
 
-  return { loading, error, entries, actionState, refresh, install, uninstall };
+  return { loading, error, managed, entries, actionState, refresh, install, uninstall };
 }


### PR DESCRIPTION
On a multi-tenant host the whole pieces catalog is already installed, once per
brain version, into a root-owned read-only tree every tenant shares. The
Library was still presenting that as if the user had to choose: install
buttons, install state per row, versions, vetted dates, disk sizes — and a
working install/uninstall API behind them.

When a shared catalog dir is configured, the catalog is now offered whole:
every piece simply available, name and description only, tier split kept.
Install and uninstall answer 403.

## The switch

`piecesManagedByHost()` — a configured `workflows.pieces_dir` (env fallback
`JARVIS_SHARED_PIECES_DIR`). That setting *is* the deployment declaring
"something other than this user decides which pieces exist here", so it needs
no new config key and it reaches instances already provisioned. Hostedness
signals like the `usejarvis_ai` block were rejected as both too narrow (a
managed instance without the hosted LLM has no such block) and too broad
(they say nothing about pieces).

## What changed

- **API.** Managed GET returns the whole catalog with `managed: true`; the
  detail fields are dropped from the *payload*, not hidden client-side, so no
  client can render them. Install/uninstall 403 before touching disk — the
  tenant's `~/.jarvis/pieces` stays writable and still shadows the shared
  tree, so the refusal is the guarantee, not the hidden button.
- **UI.** `ManagedLibraryRow` (name + description); the editor's piece picker
  stops generating "Install" rows, since every extractable piece is already in
  the engine catalog with its actions.
- **Agent.** Three separate prompts told users to install from the Library
  page: the `manage_workflow` tool description, the composer's prompts, and
  the primary agent's tool guide. A managed daemon now passes no library
  index, which drops `search_library` and that advice from all three.
- **Retired the hybrid mode.** A shared baseline topped up with user installs
  no longer exists, so its unreachable paths are gone: the `source: "shared"`
  merge, the "Included" chip, the revert-to-shared on uninstall, and
  `sharedPieceVersions` itself.

## Known, deliberate

- Managedness rides on the *resolved* dir, so it fails **open** if
  `${version}` cannot expand (a lost per-instance env file leaves systemd's
  `JARVIS_VERSION=current`). Gating on the raw config key instead would fail
  *closed into a lie* — the managed Library over a tree that isn't mounted —
  so this degrades to self-managed and is documented rather than restructured.
- A piece installed before an instance became managed keeps shadowing and can
  only be cleared over SSH. No migration: this lands before the hosted product
  has users, so only a dev instance can hold such a leftover.

## Verification

`tsc` clean, 2446 tests pass, UI bundle builds. Every guard mutation-checked —
the install 403, the uninstall 403, the managed GET branch, and the tool-guide
gate each have a test that fails when the guard is forced off.
