### PR TITLE
feat(usage): hosted LLM usage meter and threshold warnings

### DIFF
--- a/sidecar/notification.go
+++ b/sidecar/notification.go
@@ -3,9 +3,10 @@ package main
 import "sync/atomic"
 
 // Outbound OS notifications (design: usejarvis-tray.html §01). The brain
-// decides WHEN to interrupt — the four reasons Jarvis is allowed to: it needs
+// decides WHEN to interrupt — the five reasons Jarvis is allowed to: it needs
 // your OK (approval), it finished something (done), a machine dropped (sidecar),
-// or an update is ready (update) — and pushes a `notify.show` RPC. The sidecar
+// an update is ready (update), or a hosted plan's included AI usage is running
+// low or spent (usage) — and pushes a `notify.show` RPC. The sidecar
 // raises the native notification; a click (or an action button, where the
 // platform supports them) emits `notify.action` back so the brain can act.
 //
@@ -23,7 +24,7 @@ type NotifyAction struct {
 
 type Notification struct {
 	ID          string // approval id, or a synthetic id for done/sidecar/update
-	Kind        string // approval | done | sidecar | update
+	Kind        string // approval | done | sidecar | update | usage
 	Title       string
 	Body        string
 	Meta        string // e.g. "external · send_email" (shown inline on Windows)

--- a/sidecar/notify_darwin.go
+++ b/sidecar/notify_darwin.go
@@ -92,7 +92,15 @@ static void jarvisNotifySetup(void) {
         UNNotificationAction* later     = [UNNotificationAction actionWithIdentifier:@"later"  title:@"Later"       options:UNNotificationActionOptionNone];
         UNNotificationCategory* update  = [UNNotificationCategory categoryWithIdentifier:@"update" actions:@[openU, later] intentIdentifiers:@[] options:UNNotificationCategoryOptionNone];
 
-        [center setNotificationCategories:[NSSet setWithObjects:approval, done, sidecar, update, nil]];
+        // usage: a hosted plan's included AI usage running low or spent. Same
+        // shape as `done` — nothing to decide, just somewhere to look — but its
+        // own category because macOS keys the action buttons off the identifier
+        // and an unregistered one renders the alert with no buttons at all.
+        UNNotificationAction* viewU     = [UNNotificationAction actionWithIdentifier:@"review"  title:@"Open Jarvis" options:UNNotificationActionOptionForeground];
+        UNNotificationAction* dismissU  = [UNNotificationAction actionWithIdentifier:@"dismiss" title:@"Dismiss"     options:UNNotificationActionOptionNone];
+        UNNotificationCategory* usage   = [UNNotificationCategory categoryWithIdentifier:@"usage" actions:@[viewU, dismissU] intentIdentifiers:@[] options:UNNotificationCategoryOptionNone];
+
+        [center setNotificationCategories:[NSSet setWithObjects:approval, done, sidecar, update, usage, nil]];
 
         [center requestAuthorizationWithOptions:(UNAuthorizationOptionAlert | UNAuthorizationOptionSound)
                               completionHandler:^(BOOL granted, NSError* _Nullable error) {
@@ -113,7 +121,7 @@ static void jarvisNotifyShow(const char* cid, const char* ckind, const char* cti
             content.title = title;
             content.body  = body;
             content.sound = [UNNotificationSound defaultSound];
-            content.categoryIdentifier = kind; // approval / done / sidecar
+            content.categoryIdentifier = kind; // approval / done / sidecar / update / usage
             content.userInfo = @{@"id": nid, @"kind": kind};
             UNNotificationRequest* req = [UNNotificationRequest requestWithIdentifier:[[NSUUID UUID] UUIDString]
                                                                               content:content

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -456,6 +456,21 @@ export type JarvisConfig = {
     base_url?: string;
     api_key?: string;
     /**
+     * Where this instance reads its OWN usage meter, and how it proves it is
+     * itself (control plane: POST /api/llm/instance-usage).
+     *
+     * In THIS block rather than under `google` — where `instance_id` also
+     * appears — because the meter is hosted-only and this block is exactly the
+     * hosted marker, while the google fields exist only when Google is
+     * configured. A hosted tenant who never connects Google still has a meter.
+     *
+     * All three or none: a partial set cannot authenticate, and treating it as
+     * present would poll a control plane that answers 401 on a timer.
+     */
+    usage_url?: string;
+    instance_id?: string;
+    usage_secret?: string;
+    /**
      * OPT-IN for Anthropic prompt-cache breakpoints on hosted LLM calls
      * (margin-critical when on: cached reads bill at ~0.1x fresh input).
      * Absent/false means OFF.

--- a/src/daemon/api-llm-budget.test.ts
+++ b/src/daemon/api-llm-budget.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'bun:test';
+import { createApiRoutes, type ApiContext } from './api-routes.ts';
+import type { JarvisConfig } from '../config/types.ts';
+
+/**
+ * Tests for GET /api/llm/budget.
+ *
+ * Two things matter here and they are the same two the sibling catalog route
+ * guards: (1) availability — a self-hosted install has no key, no plan and no
+ * windows, so 503 is the honest answer rather than a meter of zeros; and (2)
+ * secrecy — no path may echo the control-plane host or the usage secret back to
+ * the client, which is a browser-reachable surface.
+ */
+
+type Handler = (req: Request) => Response | Promise<Response>;
+
+function handlerFor(config: Partial<JarvisConfig>): Handler {
+  const routes = createApiRoutes({
+    daemonStartedAt: Date.now(),
+    healthMonitor: {} as ApiContext['healthMonitor'],
+    config: { llm: { providers: {} }, ...config } as JarvisConfig,
+  } as ApiContext);
+  const route = routes['/api/llm/budget'] as { GET?: Handler } | undefined;
+  if (!route?.GET) throw new Error('Route /api/llm/budget GET not registered');
+  return route.GET;
+}
+
+const SECRET = 'c'.repeat(64);
+
+describe('GET /api/llm/budget', () => {
+  it('is 503 on a self-hosted install', async () => {
+    // No hosted block at all: there is no window to report on, and answering
+    // with zeros would invent a budget this install does not have.
+    const res = await handlerFor({})(new Request('http://localhost/api/llm/budget'));
+    expect(res.status).toBe(503);
+  });
+
+  it('is 503 when the hosted block is incomplete', async () => {
+    // hasUsejarvisAi requires BOTH base_url and api_key; half a block is not a
+    // hosted install.
+    const res = await handlerFor({
+      usejarvis_ai: { base_url: 'https://llm.example/v1' },
+    } as Partial<JarvisConfig>)(new Request('http://localhost/api/llm/budget'));
+    expect(res.status).toBe(503);
+  });
+
+  it('reports UNAVAILABLE — not an error, and not a fake meter — when the usage fields are absent', async () => {
+    // A hosted install whose control plane has no reachable origin renders the
+    // block without the usage triple. That is a normal state: the meter simply
+    // cannot be read, and the surface says so.
+    const res = await handlerFor({
+      usejarvis_ai: { base_url: 'https://llm.example/v1', api_key: 'sk-uj-x' },
+    } as Partial<JarvisConfig>)(new Request('http://localhost/api/llm/budget'));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: false, error: 'Usage is unavailable right now' });
+  });
+
+  it('never echoes the control-plane host or the usage secret when the read fails', async () => {
+    // This body reaches a browser. The catalog route next door exists partly
+    // because an upstream error page leaked a hostname the settings surface
+    // deliberately hides; the same rule applies here.
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (async () => {
+      throw new Error('connect ECONNREFUSED https://control-plane.internal');
+    }) as unknown as typeof fetch;
+    try {
+      const res = await handlerFor({
+        usejarvis_ai: {
+          base_url: 'https://llm.example/v1',
+          api_key: 'sk-uj-x',
+          usage_url: 'https://control-plane.internal/api/llm/instance-usage',
+          instance_id: 'inst-1',
+          usage_secret: SECRET,
+        },
+      } as Partial<JarvisConfig>)(new Request('http://localhost/api/llm/budget'));
+      const text = await res.text();
+      expect(text).not.toContain('control-plane.internal');
+      expect(text).not.toContain(SECRET);
+      expect(text).not.toContain('inst-1');
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
+});

--- a/src/daemon/api-routes.ts
+++ b/src/daemon/api-routes.ts
@@ -1671,6 +1671,31 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
     // call (the proxy filters per key, so there is no hardcoded list). The
     // provider is built from the system-owned config.yaml block — the route
     // takes no credentials and never echoes the base_url or key back.
+    /**
+     * This instance's hosted usage meter — % of each window used and when they
+     * reset (docs/LLM.md on the control plane, "Windows + meters").
+     *
+     * Hosted-only, like its neighbour below: a self-hosted install has no key,
+     * no plan and no windows, so 503 is the honest answer rather than zeros.
+     *
+     * Degrades to `{ ok: false }` rather than throwing, and never carries the
+     * upstream body — the control-plane host is withheld here for the same
+     * reason the catalog route withholds the proxy's.
+     */
+    '/api/llm/budget': {
+      GET: async () => {
+        const { hasUsejarvisAi } = await import('./usejarvis-ai.ts');
+        if (!hasUsejarvisAi(ctx.config)) {
+          return error('The usage meter is only available on hosted installs.', 503);
+        }
+        const { readHostedUsage } = await import('./hosted-usage.ts');
+        const meter = await readHostedUsage(ctx.config);
+        return meter
+          ? json({ ok: true, meter })
+          : json({ ok: false, error: 'Usage is unavailable right now' });
+      },
+    },
+
     '/api/config/llm/usejarvis/models': {
       GET: async () => {
         const { hasUsejarvisAi } = await import('./usejarvis-ai.ts');

--- a/src/daemon/hosted-usage.test.ts
+++ b/src/daemon/hosted-usage.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, test } from 'bun:test';
+import { createHmac } from 'node:crypto';
+import type { JarvisConfig } from '../config/types.ts';
+import {
+  makeHostedUsageReader,
+  readHostedUsageConfig,
+  USAGE_CACHE_MS,
+  type HostedUsageMeter,
+} from './hosted-usage.ts';
+
+const METER: HostedUsageMeter = {
+  entitled: true,
+  blocked: false,
+  sessionPct: 40,
+  weekPct: 12,
+  sessionResetsAt: '2026-08-26T12:00:00.000Z',
+  weekResetsAt: '2026-08-31T00:00:00.000Z',
+};
+
+const SECRET = 'a'.repeat(64);
+const configWith = (over: Record<string, unknown> = {}): JarvisConfig =>
+  ({
+    usejarvis_ai: {
+      base_url: 'https://llm.example/v1',
+      api_key: 'sk-uj-x',
+      usage_url: 'https://cp.example/api/llm/instance-usage',
+      instance_id: 'inst-1',
+      usage_secret: SECRET,
+      ...over,
+    },
+  }) as unknown as JarvisConfig;
+
+/** A fetch that records what it was given and answers with `reply`. */
+function stubFetch(reply: () => Response) {
+  const calls: Array<{ url: string; body: string; signature: string | null }> = [];
+  const fn = (async (input: Parameters<typeof fetch>[0], init?: RequestInit) => {
+    calls.push({
+      url: String(input),
+      body: String(init?.body ?? ''),
+      signature: new Headers(init?.headers).get('x-jarvis-signature'),
+    });
+    return reply();
+  }) as unknown as typeof fetch;
+  return { fn, calls };
+}
+
+const ok = () => new Response(JSON.stringify(METER), { status: 200 });
+
+describe('hosted usage reader', () => {
+  test('all three fields or the meter is OFF', () => {
+    // A partial set cannot authenticate, so treating it as present would poll a
+    // control plane that answers 401 every minute.
+    expect(readHostedUsageConfig(configWith())).toEqual({
+      url: 'https://cp.example/api/llm/instance-usage',
+      instanceId: 'inst-1',
+      secret: SECRET,
+    });
+    expect(readHostedUsageConfig(configWith({ usage_secret: '' }))).toBeNull();
+    expect(readHostedUsageConfig(configWith({ instance_id: undefined }))).toBeNull();
+    expect(readHostedUsageConfig(configWith({ usage_url: '   ' }))).toBeNull();
+    expect(readHostedUsageConfig({} as JarvisConfig)).toBeNull();
+  });
+
+  test('signs the EXACT bytes it sends, with the usage secret', async () => {
+    const { fn, calls } = stubFetch(ok);
+    const read = makeHostedUsageReader({ fetchImpl: fn, now: () => 1_000 });
+    expect(await read(configWith())).toEqual(METER);
+
+    const call = calls[0]!;
+    expect(call.url).toBe('https://cp.example/api/llm/instance-usage');
+    // The signature must cover the body verbatim — signing a re-serialised
+    // copy is how a working client starts failing on a key order change.
+    expect(call.signature).toBe(
+      createHmac('sha256', SECRET).update(call.body).digest('hex'),
+    );
+    // The timestamp rides INSIDE the signed bytes, which is what bounds replay.
+    expect(JSON.parse(call.body)).toEqual({
+      instanceId: 'inst-1',
+      at: new Date(1_000).toISOString(),
+    });
+  });
+
+  test('one request per cache window, shared by every caller', async () => {
+    // The room's poll and the threshold check must share a request, not take
+    // one each.
+    let clock = 0;
+    const { fn, calls } = stubFetch(ok);
+    const read = makeHostedUsageReader({ fetchImpl: fn, now: () => clock });
+    await read(configWith());
+    await read(configWith());
+    clock = USAGE_CACHE_MS - 1;
+    await read(configWith());
+    expect(calls).toHaveLength(1);
+    clock = USAGE_CACHE_MS + 1;
+    await read(configWith());
+    expect(calls).toHaveLength(2);
+  });
+
+  test('a ROTATED secret invalidates the cache instead of signing with the old one', async () => {
+    // config.yaml's system block is re-read on SIGHUP precisely so a key can be
+    // rotated without a restart; serving a cached minute would answer with a
+    // reading obtained under a key we no longer hold.
+    const { fn, calls } = stubFetch(ok);
+    const read = makeHostedUsageReader({ fetchImpl: fn, now: () => 0 });
+    await read(configWith());
+    await read(configWith({ usage_secret: 'b'.repeat(64) }));
+    expect(calls).toHaveLength(2);
+    expect(calls[1]!.signature).toBe(
+      createHmac('sha256', 'b'.repeat(64)).update(calls[1]!.body).digest('hex'),
+    );
+  });
+
+  test('a FAILURE is cached too, so an outage is not one request per render', async () => {
+    let clock = 0;
+    const { fn, calls } = stubFetch(() => new Response('nope', { status: 502 }));
+    const read = makeHostedUsageReader({ fetchImpl: fn, now: () => clock });
+    expect(await read(configWith())).toBeNull();
+    clock = USAGE_CACHE_MS - 1;
+    expect(await read(configWith())).toBeNull();
+    expect(calls).toHaveLength(1);
+  });
+
+  test('an unrecognised shape reads as UNAVAILABLE, never a meter of undefineds', async () => {
+    const { fn } = stubFetch(() => new Response(JSON.stringify({ hello: 'world' }), { status: 200 }));
+    const read = makeHostedUsageReader({ fetchImpl: fn, now: () => 0 });
+    expect(await read(configWith())).toBeNull();
+  });
+
+  test('a missing sessionPct stays NULL rather than becoming zero', async () => {
+    // The control plane sends null when it could not read the proxy. Rendering
+    // that as 0% would tell a user their window is empty when it may be full.
+    const { fn } = stubFetch(
+      () => new Response(JSON.stringify({ ...METER, sessionPct: null }), { status: 200 }),
+    );
+    const read = makeHostedUsageReader({ fetchImpl: fn, now: () => 0 });
+    const meter = await read(configWith());
+    expect(meter?.sessionPct).toBeNull();
+    expect(meter?.weekPct).toBe(12);
+  });
+
+  test('an unreachable control plane is null, and never throws at the caller', async () => {
+    const fn = (async () => {
+      throw new Error('connect ECONNREFUSED https://cp.example');
+    }) as unknown as typeof fetch;
+    const read = makeHostedUsageReader({ fetchImpl: fn, now: () => 0 });
+    expect(await read(configWith())).toBeNull();
+  });
+});

--- a/src/daemon/hosted-usage.ts
+++ b/src/daemon/hosted-usage.ts
@@ -1,0 +1,186 @@
+import type { JarvisConfig } from '../config/types.ts';
+import { INSTANCE_SIGNATURE_HEADER, signWithSecret } from '../integrations/google-signature.ts';
+import { redactSecrets } from '../util/redact.ts';
+
+/**
+ * This instance's hosted usage meter, read from the control plane.
+ *
+ * ## Why not straight from the proxy
+ *
+ * The 6-hour window IS readable here — `/key/info` carries spend, max_budget
+ * and the reset, and the provider already reads it for budget copy. The WEEK is
+ * not: its allowance comes from plan grants this instance does not hold, and
+ * weekly spend lives in the control plane's rollups. Reading one window from
+ * the proxy and the other from the control plane would mean two conversion
+ * sites, and the dashboard and this app could then quote a user different
+ * numbers for the same window. One endpoint answers both.
+ *
+ * ## What never leaves this module
+ *
+ * The same split the hosted provider keeps (util/hosted-error.ts): the
+ * upstream body and the control-plane hostname never reach USER-FACING copy,
+ * while the operator gets the detail through `console.warn`. Failures return
+ * `null` and the surface above renders "unavailable" — which is honest, and
+ * carries none of the hostname the settings and catalog routes deliberately
+ * withhold. Log lines are the operator's channel and do name the host; that is
+ * the point of them, not a leak.
+ */
+
+export interface HostedUsageMeter {
+  entitled: boolean;
+  blocked: boolean;
+  /** % of the 6h window used, or null when the control plane could not read
+   * the proxy. Never render this as 0 — "unknown" and "empty" differ. */
+  sessionPct: number | null;
+  /** % of the weekly window used. */
+  weekPct: number;
+  /** ISO-8601. */
+  sessionResetsAt: string;
+  weekResetsAt: string;
+}
+
+/**
+ * The three fields that must travel together, or the meter is off.
+ *
+ * A partial set cannot authenticate, so treating it as present would poll a
+ * control plane that answers 401 every minute. Absent is the honest state: the
+ * meter does not render.
+ */
+export interface HostedUsageConfig {
+  url: string;
+  instanceId: string;
+  secret: string;
+}
+
+export function readHostedUsageConfig(config: JarvisConfig): HostedUsageConfig | null {
+  const block = config.usejarvis_ai;
+  if (!block) return null;
+  const url = typeof block.usage_url === 'string' ? block.usage_url.trim() : '';
+  const instanceId = typeof block.instance_id === 'string' ? block.instance_id.trim() : '';
+  const secret = typeof block.usage_secret === 'string' ? block.usage_secret.trim() : '';
+  if (!url || !instanceId || !secret) return null;
+  return { url, instanceId, secret };
+}
+
+/** How long to wait on the control plane. Nothing is blocked on this — a meter
+ * that takes ten seconds is a meter nobody sees, so fail fast and retry later. */
+const TIMEOUT_MS = 5_000;
+
+/**
+ * How long a reading is reused.
+ *
+ * Matches the control plane's own per-user cache, so polling faster buys
+ * nothing but load. Both the room's poll and the threshold check read through
+ * this, so a 15-minute check and an open Usage room share one request.
+ *
+ * A FAILURE is cached too, and for the same reason the provider caches its
+ * `/key/info` miss: an unreachable control plane must not turn into a request
+ * per render.
+ */
+export const USAGE_CACHE_MS = 60_000;
+
+interface CacheEntry {
+  at: number;
+  value: HostedUsageMeter | null;
+}
+
+export interface HostedUsageReaderDeps {
+  fetchImpl?: typeof fetch;
+  now?: () => number;
+}
+
+/**
+ * The config is passed PER CALL, not captured.
+ *
+ * `config.yaml`'s system block is re-read on SIGHUP so a key can be rotated
+ * without a restart; a reader holding the object it was built with would keep
+ * signing with the old secret and answer 401 until the daemon bounced.
+ */
+export function makeHostedUsageReader(
+  deps: HostedUsageReaderDeps = {},
+): (config: JarvisConfig) => Promise<HostedUsageMeter | null> {
+  // Resolved at CALL time, not captured here: the daemon builds its shared
+  // reader at module load, so binding the global then made the route
+  // untestable (a stub installed later never applied) and would ignore any
+  // legitimate later swap.
+  const callFetch = (
+    ...args: Parameters<typeof fetch>
+  ): ReturnType<typeof fetch> => (deps.fetchImpl ?? fetch)(...args);
+  const now = deps.now ?? (() => Date.now());
+  let cache: (CacheEntry & { key: string }) | null = null;
+
+  return async (config: JarvisConfig) => {
+    const cfg = readHostedUsageConfig(config);
+    if (!cfg) return null;
+    // Keyed by the credentials themselves, so a converge that rotates the
+    // secret or moves the endpoint invalidates the reading rather than serving
+    // a minute of answers obtained with a key we no longer hold.
+    const key = `${cfg.url}|${cfg.instanceId}|${cfg.secret}`;
+    if (cache && cache.key === key && now() - cache.at < USAGE_CACHE_MS) return cache.value;
+
+    const body = JSON.stringify({ instanceId: cfg.instanceId, at: new Date(now()).toISOString() });
+    let value: HostedUsageMeter | null = null;
+    try {
+      const res = await callFetch(cfg.url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          [INSTANCE_SIGNATURE_HEADER]: signWithSecret(cfg.secret, body),
+        },
+        body,
+        signal: AbortSignal.timeout(TIMEOUT_MS),
+      });
+      if (res.ok) {
+        const parsed = (await res.json()) as Partial<HostedUsageMeter> | null;
+        // Validated, not trusted: a shape we do not recognise must read as
+        // "unavailable" rather than render a meter of undefineds.
+        if (
+          parsed
+          && typeof parsed.weekPct === 'number'
+          && typeof parsed.sessionResetsAt === 'string'
+          && typeof parsed.weekResetsAt === 'string'
+        ) {
+          value = {
+            entitled: parsed.entitled === true,
+            blocked: parsed.blocked === true,
+            sessionPct: typeof parsed.sessionPct === 'number' ? parsed.sessionPct : null,
+            weekPct: parsed.weekPct,
+            sessionResetsAt: parsed.sessionResetsAt,
+            weekResetsAt: parsed.weekResetsAt,
+          };
+        } else {
+          console.warn('[usage] control plane returned an unrecognised meter shape; meter unavailable');
+        }
+      } else {
+        // STATUS only. The body can name the control-plane host, and a 401 body
+        // could echo what we presented.
+        console.warn(`[usage] control plane answered ${res.status}; meter unavailable`);
+      }
+    } catch (err) {
+      console.warn(
+        '[usage] could not reach the control plane; meter unavailable:',
+        redactSecrets(err instanceof Error ? err.message : String(err)),
+      );
+    }
+    cache = { key, at: now(), value };
+    return value;
+  };
+}
+
+/**
+ * The daemon's one reader.
+ *
+ * A module-level singleton because the CACHE is the point: the Usage room's
+ * poll and the threshold check must share one request rather than take one
+ * each. It holds no config — that arrives per call — so a SIGHUP rotation is
+ * picked up immediately, and the cache key includes the credentials so a
+ * rotated secret invalidates the reading rather than serving a stale minute.
+ *
+ * The factory stays exported so tests drive it with their own clock and fetch
+ * instead of reaching through this.
+ */
+const shared = makeHostedUsageReader();
+
+export function readHostedUsage(config: JarvisConfig): Promise<HostedUsageMeter | null> {
+  return shared(config);
+}

--- a/src/daemon/hosted-usage.ts
+++ b/src/daemon/hosted-usage.ts
@@ -148,9 +148,25 @@ export function makeHostedUsageReader(
             sessionResetsAt: parsed.sessionResetsAt,
             weekResetsAt: parsed.weekResetsAt,
           };
+          if (typeof parsed.entitled !== 'boolean') {
+            // Not fatal — the three checked fields are all present — but it is
+            // the one field whose absence degrades SILENTLY: `=== true` makes
+            // it false, the strip disappears and every warning stops, fleet
+            // wide, reading exactly like "this customer has no plan".
+            console.warn('[usage] meter has no `entitled` field; treating as not entitled');
+          }
         } else {
           console.warn('[usage] control plane returned an unrecognised meter shape; meter unavailable');
         }
+      } else if (res.status === 400) {
+        // 400 is the one status whose body is worth keeping. The control plane
+        // puts a deliberate diagnosis there — "check the instance clock" — and
+        // a >5min drift makes EVERY read fail, so the meter and every usage
+        // warning vanish with no other symptom. Redacted, and to the operator's
+        // console, which is the channel this module's header reserves for
+        // exactly this. Bounded so a long body cannot flood the log.
+        const detail = redactSecrets(await res.text().catch(() => '')).slice(0, 300);
+        console.warn(`[usage] control plane rejected the request: ${detail || '(no detail)'}`);
       } else {
         // STATUS only. The body can name the control-plane host, and a 401 body
         // could echo what we presented.

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -4177,6 +4177,15 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
       canNotify: () => sidecarManager.getConnectedSidecars().length > 0,
     });
     usageAlerts.start();
+    // A pass with no sidecar connected leaves its flags unset on purpose, so
+    // the warning survives — but it would then wait up to fifteen minutes for
+    // the next tick. Re-check as soon as a machine appears, which is exactly
+    // when someone is there to read it. The 60s reader cache makes a reconnect
+    // storm cost one upstream request, and the flags make a duplicate pass a
+    // no-op.
+    sidecarManager.onSidecarConnected(() => {
+      void usageAlerts?.check().catch(() => {});
+    });
 
     // Bootstrap the workflow engine: build/locate the bundle, compile pieces,
     // start the loopback SandboxApi, construct the EngineRuntime, extract the

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -100,6 +100,7 @@ let workflowWorker: WorkflowWorker | null = null;
 let triggerManager: TriggerManager | null = null;
 let workflowEngineShutdown: (() => Promise<void>) | null = null;
 let systemCron: import('./system-cron.ts').SystemCronService | null = null;
+let usageAlerts: import('./usage-alerts-service.ts').UsageAlertsService | null = null;
 let timerScheduler: TimerWaitpointScheduler | null = null;
 let settingsReload: import('./settings-reload.ts').SettingsReloadCoordinator | null = null;
 /** Set once the sidecar manager is up; re-pushes the pebble realtime
@@ -220,6 +221,12 @@ async function handleShutdown(signal: string): Promise<void> {
     if (systemCron) {
       systemCron.stop();
       systemCron = null;
+    }
+
+    // Stop the hosted usage threshold check
+    if (usageAlerts) {
+      usageAlerts.stop();
+      usageAlerts = null;
     }
 
     // Stop commitment executor
@@ -4157,6 +4164,19 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
     const { SystemCronService } = await import('./system-cron.ts');
     systemCron = new SystemCronService(sharedEventBus, jarvisConfig.cron);
     systemCron.start();
+
+    // Hosted usage warnings: three-quarters used, and used up, for each of the
+    // two windows the proxy enforces. Registered even on a self-hosted install
+    // — the reader answers null there, so the pass is a no-op and costs one
+    // config read every 15 minutes, which is cheaper than deciding whether to
+    // register it from a config that can change under SIGHUP.
+    const { UsageAlertsService } = await import('./usage-alerts-service.ts');
+    usageAlerts = new UsageAlertsService({
+      getConfig: () => jarvisConfig,
+      notify: notifyAll,
+      canNotify: () => sidecarManager.getConnectedSidecars().length > 0,
+    });
+    usageAlerts.start();
 
     // Bootstrap the workflow engine: build/locate the bundle, compile pieces,
     // start the loopback SandboxApi, construct the EngineRuntime, extract the

--- a/src/daemon/usage-alerts-service.test.ts
+++ b/src/daemon/usage-alerts-service.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, test } from 'bun:test';
+import type { JarvisConfig } from '../config/types.ts';
+import type { HostedUsageMeter } from './hosted-usage.ts';
+import { UsageAlertsService, USAGE_NOTIFY_KIND } from './usage-alerts-service.ts';
+import { alertKey, FLAG_PREFIX } from './usage-alerts.ts';
+
+const SESSION_RESET = '2026-08-26T12:00:00.000Z';
+
+const meter = (over: Partial<HostedUsageMeter> = {}): HostedUsageMeter => ({
+  entitled: true,
+  blocked: false,
+  sessionPct: 10,
+  weekPct: 10,
+  sessionResetsAt: SESSION_RESET,
+  weekResetsAt: '2026-08-31T00:00:00.000Z',
+  ...over,
+});
+
+function harness(
+  reading: HostedUsageMeter | null,
+  opts: { canNotify?: boolean; seeded?: Record<string, string> } = {},
+) {
+  const rows = new Map<string, string>(Object.entries(opts.seeded ?? {}));
+  const sent: Record<string, unknown>[] = [];
+  let reads = 0;
+  const svc = new UsageAlertsService({
+    getConfig: () => ({}) as JarvisConfig,
+    notify: (p) => sent.push(p),
+    canNotify: () => opts.canNotify !== false,
+    readMeter: async () => {
+      reads += 1;
+      return reading;
+    },
+    store: {
+      get: (k) => rows.get(k) ?? null,
+      set: (k, v) => void rows.set(k, v),
+      keys: () => [...rows.keys()],
+      delete: (k) => void rows.delete(k),
+    },
+    now: () => 1_000,
+  });
+  return { svc, sent, rows, reads: () => reads };
+}
+
+describe('the threshold check', () => {
+  test('notifies once and does not repeat on the next pass', async () => {
+    const h = harness(meter({ sessionPct: 80 }));
+    expect(await h.svc.check()).toHaveLength(1);
+    expect(h.sent).toHaveLength(1);
+    expect(await h.svc.check()).toEqual([]);
+    expect(h.sent).toHaveLength(1);
+  });
+
+  test('sends the fifth notification kind, with somewhere to look and nothing to decide', async () => {
+    const h = harness(meter({ weekPct: 100 }));
+    await h.svc.check();
+    const [payload] = h.sent as Array<{ kind: string; destructive: boolean; actions: { id: string }[]; body: string }>;
+    expect(payload!.kind).toBe(USAGE_NOTIFY_KIND);
+    expect(payload!.destructive).toBe(false);
+    // No Approve/Deny: there is no decision here, only a place to look.
+    expect(payload!.actions.map((a) => a.id)).toEqual(['review', 'dismiss']);
+    expect(payload!.body).toContain('this week');
+  });
+
+  test('the flag is written BEFORE the notify, so a throwing sidecar cannot loop', async () => {
+    // A notify that throws with the flag unset would re-send the same toast
+    // every 15 minutes for the life of the window.
+    const rows = new Map<string, string>();
+    const svc = new UsageAlertsService({
+      getConfig: () => ({}) as JarvisConfig,
+      notify: () => { throw new Error('sidecar went away mid-dispatch'); },
+      canNotify: () => true,
+      readMeter: async () => meter({ sessionPct: 80 }),
+      store: {
+        get: (k) => rows.get(k) ?? null,
+        set: (k, v) => void rows.set(k, v),
+        keys: () => [...rows.keys()],
+        delete: (k) => void rows.delete(k),
+      },
+    });
+    await expect(svc.check()).rejects.toThrow('sidecar went away');
+    expect(rows.has(alertKey('session', 75, SESSION_RESET))).toBe(true);
+  });
+
+  test('with NO sidecar connected the flag is left unset, so the warning still lands later', async () => {
+    // Consuming the once-per-window flag against a closed door would mean a
+    // user who opens their laptop at 90% is never told.
+    const h = harness(meter({ sessionPct: 80 }), { canNotify: false });
+    expect(await h.svc.check()).toEqual([]);
+    expect(h.rows.size).toBe(0);
+    expect(h.sent).toEqual([]);
+  });
+
+  test('a self-hosted install reads null and does nothing at all', async () => {
+    const h = harness(null);
+    expect(await h.svc.check()).toEqual([]);
+    expect(h.rows.size).toBe(0);
+  });
+
+  test('overlapping passes cannot double-notify', async () => {
+    // The read is a network round trip; two passes deciding before either
+    // records would send the same toast twice.
+    const h = harness(meter({ sessionPct: 80 }));
+    const [a, b] = await Promise.all([h.svc.check(), h.svc.check()]);
+    expect([a.length, b.length].sort()).toEqual([0, 1]);
+    expect(h.sent).toHaveLength(1);
+  });
+
+  test('prunes flags from windows that have rolled, and leaves other settings alone', async () => {
+    const h = harness(meter({ sessionPct: 80 }), {
+      seeded: {
+        [alertKey('session', 75, '2026-08-26T06:00:00.000Z')]: '1',
+        [`${FLAG_PREFIX}blocked.2026-01-01T00:00:00.000Z`]: '1',
+      },
+    });
+    await h.svc.check();
+    expect([...h.rows.keys()]).toEqual([alertKey('session', 75, SESSION_RESET)]);
+  });
+});

--- a/src/daemon/usage-alerts-service.ts
+++ b/src/daemon/usage-alerts-service.ts
@@ -1,0 +1,121 @@
+import { CronScheduler } from '../lib/cron-scheduler.ts';
+import type { JarvisConfig } from '../config/types.ts';
+import { readHostedUsage, type HostedUsageMeter } from './hosted-usage.ts';
+import { decideUsageAlerts, staleFlagKeys, type UsageAlert } from './usage-alerts.ts';
+import { deleteSetting, getSetting, getSettingsByPrefix, setSetting } from '../vault/settings.ts';
+
+/**
+ * The job that turns a usage reading into an OS notification.
+ *
+ * ## Why 15 minutes, and why a NAMED job
+ *
+ * `cron.hourly` is too coarse: a six-hour window can go from three-quarters to
+ * full inside one hour, so the warning that was supposed to arrive first would
+ * land after the wall. This is a registered CronScheduler job rather than a
+ * revival of the deleted 15-minute heartbeat — it appears in the scheduler's
+ * job list, it stops with the daemon, and it does one thing.
+ *
+ * The check costs nothing upstream when a room is already open: both this and
+ * the Usage room read through the same 60s-cached reader.
+ */
+
+/** The fifth reason Jarvis interrupts (sidecar/notification.go's closed set). */
+export const USAGE_NOTIFY_KIND = 'usage';
+export const USAGE_CHECK_EXPRESSION = '@every 15m';
+
+export interface UsageAlertsDeps {
+  getConfig: () => JarvisConfig;
+  /** Sends a `notify.show` payload to every connected sidecar. */
+  notify: (payload: Record<string, unknown>) => void;
+  /** True when at least one sidecar is connected — a notification with nowhere
+   *  to go must not burn the once-per-window flag. */
+  canNotify: () => boolean;
+  /** Seams for tests; default to the settings table and the shared reader. */
+  readMeter?: (config: JarvisConfig) => Promise<HostedUsageMeter | null>;
+  store?: {
+    get(key: string): string | null;
+    set(key: string, value: string): void;
+    keys(): string[];
+    delete(key: string): void;
+  };
+  now?: () => number;
+}
+
+const settingsStore = {
+  get: (key: string) => getSetting(key),
+  set: (key: string, value: string) => setSetting(key, value),
+  keys: () => Object.keys(getSettingsByPrefix('usage.notified.')),
+  delete: (key: string) => deleteSetting(key),
+};
+
+export class UsageAlertsService {
+  private readonly scheduler = new CronScheduler();
+  private started = false;
+  private running = false;
+
+  constructor(private readonly deps: UsageAlertsDeps) {}
+
+  start(): void {
+    if (this.started) return;
+    try {
+      this.scheduler.schedule('usage.thresholds', USAGE_CHECK_EXPRESSION, () => {
+        void this.check().catch((err) => console.warn('[usage] threshold check failed:', err));
+      });
+      this.started = true;
+    } catch (err) {
+      console.error('[usage] failed to schedule the threshold check:', err);
+    }
+  }
+
+  stop(): void {
+    if (!this.started) return;
+    this.scheduler.cancelAll();
+    this.started = false;
+  }
+
+  /** One pass. Exposed so tests drive it without waiting on a timer. */
+  async check(): Promise<UsageAlert[]> {
+    // A slow control plane must not let two passes overlap and double-notify
+    // through the gap between deciding and recording.
+    if (this.running) return [];
+    this.running = true;
+    try {
+      const store = this.deps.store ?? settingsStore;
+      const read = this.deps.readMeter ?? readHostedUsage;
+      const meter = await read(this.deps.getConfig());
+      if (!meter) return [];
+
+      const due = decideUsageAlerts(meter, (key) => store.get(key) !== null);
+      // Nowhere to deliver: leave the flags unset so the warning still lands
+      // once a sidecar connects, rather than being silently consumed here.
+      if (due.length > 0 && !this.deps.canNotify()) return [];
+
+      const at = String(this.deps.now?.() ?? Date.now());
+      for (const alert of due) {
+        // Recorded BEFORE sending. A notify that throws would otherwise leave
+        // the flag unset and re-fire the same toast every 15 minutes.
+        store.set(alert.key, at);
+        this.deps.notify({
+          id: alert.key,
+          kind: USAGE_NOTIFY_KIND,
+          title: alert.title,
+          body: alert.body,
+          meta: 'usage',
+          destructive: false,
+          actions: [
+            { id: 'review', label: 'Open Jarvis', primary: true },
+            { id: 'dismiss', label: 'Dismiss' },
+          ],
+        });
+      }
+      for (const stale of staleFlagKeys(store.keys(), meter)) store.delete(stale);
+      return due;
+    } finally {
+      this.running = false;
+    }
+  }
+
+  getJobs() {
+    return this.scheduler.getJobs();
+  }
+}

--- a/src/daemon/usage-alerts-service.ts
+++ b/src/daemon/usage-alerts-service.ts
@@ -1,7 +1,7 @@
 import { CronScheduler } from '../lib/cron-scheduler.ts';
 import type { JarvisConfig } from '../config/types.ts';
 import { readHostedUsage, type HostedUsageMeter } from './hosted-usage.ts';
-import { decideUsageAlerts, staleFlagKeys, type UsageAlert } from './usage-alerts.ts';
+import { decideUsageAlerts, FLAG_PREFIX, staleFlagKeys, type UsageAlert } from './usage-alerts.ts';
 import { deleteSetting, getSetting, getSettingsByPrefix, setSetting } from '../vault/settings.ts';
 
 /**
@@ -44,7 +44,7 @@ export interface UsageAlertsDeps {
 const settingsStore = {
   get: (key: string) => getSetting(key),
   set: (key: string, value: string) => setSetting(key, value),
-  keys: () => Object.keys(getSettingsByPrefix('usage.notified.')),
+  keys: () => Object.keys(getSettingsByPrefix(FLAG_PREFIX)),
   delete: (key: string) => deleteSetting(key),
 };
 
@@ -88,6 +88,11 @@ export class UsageAlertsService {
       const due = decideUsageAlerts(meter, (key) => store.get(key) !== null);
       // Nowhere to deliver: leave the flags unset so the warning still lands
       // once a sidecar connects, rather than being silently consumed here.
+      //
+      // Sampled HERE, after the meter read, rather than before it: the read is
+      // a network round trip, and a sidecar that disconnects across it would
+      // otherwise have its warning recorded as delivered against a closed door.
+      // A `week.100` lost that way is lost for the rest of the week.
       if (due.length > 0 && !this.deps.canNotify()) return [];
 
       const at = String(this.deps.now?.() ?? Date.now());

--- a/src/daemon/usage-alerts.test.ts
+++ b/src/daemon/usage-alerts.test.ts
@@ -112,20 +112,33 @@ describe('states that must NOT produce a warning', () => {
   });
 });
 
-describe('the proxy refusing while both bars look fine', () => {
-  test('still warns, because silence is the worst outcome there', () => {
-    // The proxy enforces a rolling 7d from key creation; we report a
-    // Monday-aligned week. A user can be refused at 3%.
+describe('a key that is switched off', () => {
+  test('warns, and does NOT call it "used up"', () => {
+    // The control plane sets `blocked` for a user with no plan or a converge
+    // that failed part-way — never for spending too much. Since !entitled has
+    // already returned, this is a paying user whose assistant does not work.
+    // Blaming their usage would send them to a meter reading 3%.
     const out = decideUsageAlerts(meter({ blocked: true, sessionPct: 3, weekPct: 3 }), fakeStore().delivered);
     expect(out).toHaveLength(1);
-    expect(out[0]!.body).toContain('used up');
+    expect(out[0]!.body).not.toContain('used up');
+    expect(out[0]!.title).toBe('AI is temporarily unavailable');
     expect(out[0]!.key).toBe(`${FLAG_PREFIX}blocked.${SESSION_RESET}`);
   });
 
-  test('does not double up when a window already explains it', () => {
+  test('stays quiet when a FULL window already explains the refusal', () => {
     const out = decideUsageAlerts(meter({ blocked: true, sessionPct: 100 }), fakeStore().delivered);
     expect(out).toHaveLength(1);
     expect(out[0]!.key).toBe(alertKey('session', 100, SESSION_RESET));
+  });
+
+  test('a 75% alert in the same pass does NOT suppress it', () => {
+    // "Running low" while nothing works at all is worse than saying nothing:
+    // the user reads it as a warning they still have room. Only a window that
+    // is actually full explains a refusal.
+    const out = decideUsageAlerts(meter({ blocked: true, sessionPct: 80 }), fakeStore().delivered);
+    expect(out.map((a) => a.key).sort()).toEqual(
+      [`${FLAG_PREFIX}blocked.${SESSION_RESET}`, alertKey('session', 75, SESSION_RESET)].sort(),
+    );
   });
 
   test('repeats at most once per session window while it lasts', () => {

--- a/src/daemon/usage-alerts.test.ts
+++ b/src/daemon/usage-alerts.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, test } from 'bun:test';
+import type { HostedUsageMeter } from './hosted-usage.ts';
+import {
+  alertKey,
+  decideUsageAlerts,
+  FLAG_PREFIX,
+  staleFlagKeys,
+  WARN_PCT,
+  type UsageAlert,
+} from './usage-alerts.ts';
+
+const SESSION_RESET = '2026-08-26T12:00:00.000Z';
+const WEEK_RESET = '2026-08-31T00:00:00.000Z';
+
+const meter = (over: Partial<HostedUsageMeter> = {}): HostedUsageMeter => ({
+  entitled: true,
+  blocked: false,
+  sessionPct: 10,
+  weekPct: 10,
+  sessionResetsAt: SESSION_RESET,
+  weekResetsAt: WEEK_RESET,
+  ...over,
+});
+
+/** A store that behaves like the settings table, without SQLite. */
+function fakeStore(initial: string[] = []) {
+  const seen = new Set(initial);
+  return {
+    seen,
+    delivered: (k: string) => seen.has(k),
+    record: (alerts: UsageAlert[]) => alerts.forEach((a) => seen.add(a.key)),
+  };
+}
+
+describe('deciding which warnings are due', () => {
+  test('silent below the threshold', () => {
+    const s = fakeStore();
+    expect(decideUsageAlerts(meter(), s.delivered)).toEqual([]);
+  });
+
+  test('fires at the threshold, once, and NOT again on the next check', () => {
+    const s = fakeStore();
+    const first = decideUsageAlerts(meter({ sessionPct: WARN_PCT }), s.delivered);
+    expect(first).toHaveLength(1);
+    expect(first[0]!.window).toBe('session');
+    expect(first[0]!.level).toBe(75);
+    s.record(first);
+    // Same window, higher but still under 100 — already warned.
+    expect(decideUsageAlerts(meter({ sessionPct: 92 }), s.delivered)).toEqual([]);
+  });
+
+  test('a RESTART inside the window does not re-fire', () => {
+    // The whole reason the flag is persisted rather than held in a Set: the
+    // daemon bounces (upgrade, crash, laptop lid) inside a six-hour window.
+    const s = fakeStore([alertKey('session', 75, SESSION_RESET)]);
+    expect(decideUsageAlerts(meter({ sessionPct: 80 }), s.delivered)).toEqual([]);
+  });
+
+  test('a NEW window fires again, with no cleanup needed', () => {
+    // The stamp is part of the key, so the old flag simply cannot match.
+    const s = fakeStore([alertKey('session', 75, SESSION_RESET)]);
+    const next = decideUsageAlerts(
+      meter({ sessionPct: 80, sessionResetsAt: '2026-08-26T18:00:00.000Z' }),
+      s.delivered,
+    );
+    expect(next).toHaveLength(1);
+  });
+
+  test('crossing BOTH thresholds between checks sends one notification, not two', () => {
+    // 40% → full in a single 15-minute gap is ordinary on a small plan; a
+    // "running low" toast immediately followed by "used up" is noise.
+    const out = decideUsageAlerts(meter({ sessionPct: 100 }), fakeStore().delivered);
+    expect(out).toHaveLength(1);
+    expect(out[0]!.level).toBe(100);
+  });
+
+  test('having warned at 75 does not suppress the later "used up"', () => {
+    const s = fakeStore([alertKey('session', 75, SESSION_RESET)]);
+    const out = decideUsageAlerts(meter({ sessionPct: 100 }), s.delivered);
+    expect(out).toHaveLength(1);
+    expect(out[0]!.level).toBe(100);
+  });
+
+  test('the two windows are independent', () => {
+    const both = decideUsageAlerts(meter({ sessionPct: 80, weekPct: 100 }), fakeStore().delivered);
+    expect(both.map((a) => `${a.window}:${a.level}`).sort()).toEqual(['session:75', 'week:100']);
+  });
+
+  test('names the window in copy the user can act on', () => {
+    const [a] = decideUsageAlerts(meter({ weekPct: 100 }), fakeStore().delivered);
+    expect(a!.body).toContain('this week');
+    expect(a!.title).toBe('Included AI usage used up');
+  });
+});
+
+describe('states that must NOT produce a warning', () => {
+  test('no reading at all', () => {
+    // An unreachable control plane is not 0% (silent) and not 100% (a false
+    // alarm at 3am). It produces nothing and the next check retries.
+    expect(decideUsageAlerts(null, fakeStore().delivered)).toEqual([]);
+  });
+
+  test('a hosted user with no plan', () => {
+    expect(decideUsageAlerts(meter({ entitled: false, blocked: true }), fakeStore().delivered)).toEqual([]);
+  });
+
+  test('an unreadable session window is not a signal either way', () => {
+    // sessionPct is null when the control plane could not reach the proxy.
+    expect(decideUsageAlerts(meter({ sessionPct: null }), fakeStore().delivered)).toEqual([]);
+    // The week is still readable and still warns.
+    expect(decideUsageAlerts(meter({ sessionPct: null, weekPct: 99 }), fakeStore().delivered)).toHaveLength(1);
+  });
+});
+
+describe('the proxy refusing while both bars look fine', () => {
+  test('still warns, because silence is the worst outcome there', () => {
+    // The proxy enforces a rolling 7d from key creation; we report a
+    // Monday-aligned week. A user can be refused at 3%.
+    const out = decideUsageAlerts(meter({ blocked: true, sessionPct: 3, weekPct: 3 }), fakeStore().delivered);
+    expect(out).toHaveLength(1);
+    expect(out[0]!.body).toContain('used up');
+    expect(out[0]!.key).toBe(`${FLAG_PREFIX}blocked.${SESSION_RESET}`);
+  });
+
+  test('does not double up when a window already explains it', () => {
+    const out = decideUsageAlerts(meter({ blocked: true, sessionPct: 100 }), fakeStore().delivered);
+    expect(out).toHaveLength(1);
+    expect(out[0]!.key).toBe(alertKey('session', 100, SESSION_RESET));
+  });
+
+  test('repeats at most once per session window while it lasts', () => {
+    const s = fakeStore([`${FLAG_PREFIX}blocked.${SESSION_RESET}`]);
+    expect(decideUsageAlerts(meter({ blocked: true, sessionPct: 3 }), s.delivered)).toEqual([]);
+  });
+});
+
+describe('pruning', () => {
+  test('keeps the live windows and drops the rest', () => {
+    // Keys are only ever added, so without this a long-lived install grows a
+    // settings row per window forever.
+    const all = [
+      alertKey('session', 75, SESSION_RESET),
+      alertKey('week', 100, WEEK_RESET),
+      alertKey('session', 75, '2026-08-26T06:00:00.000Z'),
+      `${FLAG_PREFIX}blocked.2026-01-01T00:00:00.000Z`,
+      'llm.provider.default',
+    ];
+    expect(staleFlagKeys(all, meter())).toEqual([
+      alertKey('session', 75, '2026-08-26T06:00:00.000Z'),
+      `${FLAG_PREFIX}blocked.2026-01-01T00:00:00.000Z`,
+    ]);
+  });
+
+  test('never touches a setting that is not one of ours', () => {
+    expect(staleFlagKeys(['llm.provider.default', 'voice.realtime.month'], meter())).toEqual([]);
+  });
+});

--- a/src/daemon/usage-alerts.ts
+++ b/src/daemon/usage-alerts.ts
@@ -26,7 +26,7 @@ import type { HostedUsageMeter } from './hosted-usage.ts';
  */
 
 export type UsageWindow = 'session' | 'week';
-export type UsageLevel = 75 | 100;
+export type UsageLevel = typeof WARN_PCT | 100;
 
 export interface UsageAlert {
   window: UsageWindow;
@@ -39,7 +39,7 @@ export interface UsageAlert {
 
 /** Must match the room's WARN_PCT (ui/.../hosted-budget.ts) — if these drift, a
  *  user gets a notification while the meter still shows a calm bar. */
-export const WARN_PCT = 75;
+export const WARN_PCT = 75 as const;
 
 export const FLAG_PREFIX = 'usage.notified.';
 
@@ -83,17 +83,22 @@ export function decideUsageAlerts(
   if (!meter || !meter.entitled) return [];
 
   const out: UsageAlert[] = [];
+  // Tracks whether a window is FULL, not whether anything was queued: a 75%
+  // alert firing in the same pass must not suppress the block notice, or the
+  // user is told "running low" while nothing works at all.
+  let exhausted = false;
   const consider = (window: UsageWindow, pct: number | null, resetsAt: string) => {
     if (pct === null) return; // unreadable window: no signal either way
     // 100 FIRST, and it suppresses the 75 for the same window: a user who goes
     // from 40% to full between two checks gets one notification, not two.
     if (pct >= 100) {
+      exhausted = true;
       const full = alertFor(window, 100, resetsAt);
       if (!delivered(full.key)) out.push(full);
       return;
     }
     if (pct >= WARN_PCT) {
-      const warn = alertFor(window, WARN_PCT as UsageLevel, resetsAt);
+      const warn = alertFor(window, WARN_PCT, resetsAt);
       if (!delivered(warn.key)) out.push(warn);
     }
   };
@@ -101,18 +106,31 @@ export function decideUsageAlerts(
   consider('session', meter.sessionPct, meter.sessionResetsAt);
   consider('week', meter.weekPct, meter.weekResetsAt);
 
-  // The proxy enforces a rolling 7 days from key creation while we report a
-  // Monday-aligned week (docs/LLM.md), so it can be REFUSING at a percentage
-  // both bars call fine. Staying silent there is the worst outcome: the user is
-  // blocked and nothing has told them why. Keyed on the session stamp so it
-  // repeats at most once every 6 hours while the disagreement lasts.
-  if (meter.blocked && out.length === 0) {
+  // `blocked` does NOT mean "the proxy refused you for spending too much".
+  //
+  // It is LiteLLM's explicit key-block flag, and the control plane writes it in
+  // exactly two situations (hosting-llm packages/db/src/llm-sweeps.ts:380,488):
+  // the user has no plan, and a converge that failed part-way left the key
+  // blocked fail-closed. The first is already gone — !entitled returned above —
+  // so reaching here means a user WITH a plan whose key is switched off. Their
+  // assistant does not work and it is not their doing, which is worth an
+  // interruption; calling it "used up" would be a lie that sends them to a
+  // meter reading 4%.
+  //
+  // Budget exhaustion is caught by the percentages instead: sessionPct is
+  // spend÷max_budget on the very key the proxy enforces, so >=100 IS the
+  // refusal condition for the 6-hour window. The WEEK has no such guarantee —
+  // the proxy enforces a rolling 7 days from key creation while we report a
+  // Monday-aligned week, and nothing reads the proxy's own weekly counter, so a
+  // refusal on it is invisible here. That gap is docs/LLM.md POC item 1 and
+  // needs a live probe to close, not a guess from this side.
+  if (meter.blocked && !exhausted) {
     const blocked: UsageAlert = {
       window: 'session',
       level: 100,
       key: `${FLAG_PREFIX}blocked.${meter.sessionResetsAt}`,
-      title: 'Included AI usage used up',
-      body: 'Your included AI usage is temporarily used up. It resumes when your usage window resets.',
+      title: 'AI is temporarily unavailable',
+      body: 'Your assistant cannot reach its AI models right now. This is being fixed on our side — nothing you need to do.',
     };
     if (!delivered(blocked.key)) out.push(blocked);
   }

--- a/src/daemon/usage-alerts.ts
+++ b/src/daemon/usage-alerts.ts
@@ -1,0 +1,140 @@
+import type { HostedUsageMeter } from './hosted-usage.ts';
+
+/**
+ * Warn a hosted tenant BEFORE the proxy starts refusing them.
+ *
+ * Today the only signal that a window is full is the assistant declining to
+ * answer (src/util/hosted-error.ts turns the proxy's 429 into copy that points
+ * at a meter). This fires two warnings per window — three-quarters used, and
+ * used up — for the 6-hour session window and the week.
+ *
+ * ## Why the de-duplication is PERSISTENT
+ *
+ * The windows are hours long and the daemon restarts (upgrades, crashes, a
+ * laptop closing). The in-memory `notifiedApprovalIds` set next door is right
+ * for approvals, which live minutes; here it would re-notify on every restart,
+ * which for a user who leaves a machine on is a notification every time the
+ * daemon bounces for six hours.
+ *
+ * ## Why the flag key contains the window's own reset stamp
+ *
+ * It self-expires. `usage.notified.session.75.<sessionResetsAt>` cannot match
+ * once the window rolls, so a new window notifies again with no clock
+ * arithmetic and no cleanup on the critical path — the same bucket-key mechanic
+ * `realtime-budget.ts` uses for its month. Old keys are pruned on a hit rather
+ * than expired by a timer.
+ */
+
+export type UsageWindow = 'session' | 'week';
+export type UsageLevel = 75 | 100;
+
+export interface UsageAlert {
+  window: UsageWindow;
+  level: UsageLevel;
+  /** The settings key that records this alert as delivered. */
+  key: string;
+  title: string;
+  body: string;
+}
+
+/** Must match the room's WARN_PCT (ui/.../hosted-budget.ts) — if these drift, a
+ *  user gets a notification while the meter still shows a calm bar. */
+export const WARN_PCT = 75;
+
+export const FLAG_PREFIX = 'usage.notified.';
+
+export function alertKey(window: UsageWindow, level: UsageLevel, resetsAt: string): string {
+  return `${FLAG_PREFIX}${window}.${level}.${resetsAt}`;
+}
+
+const WINDOW_LABEL: Record<UsageWindow, string> = {
+  session: 'this 6-hour window',
+  week: 'this week',
+};
+
+function alertFor(window: UsageWindow, level: UsageLevel, resetsAt: string): UsageAlert {
+  const label = WINDOW_LABEL[window];
+  return {
+    window,
+    level,
+    key: alertKey(window, level, resetsAt),
+    title: level === 100 ? 'Included AI usage used up' : 'Included AI usage running low',
+    body:
+      level === 100
+        ? `You have used all of your included AI usage for ${label}. It resumes when the window resets.`
+        : `You have used over ${WARN_PCT}% of your included AI usage for ${label}.`,
+  };
+}
+
+/**
+ * Which alerts are due, given a reading and what has already been delivered.
+ *
+ * Pure, so the awkward cases are testable: crossing both thresholds between two
+ * checks, a restart inside a window, a window that has rolled over, and the
+ * proxy refusing at a percentage that still looks fine.
+ */
+export function decideUsageAlerts(
+  meter: HostedUsageMeter | null,
+  delivered: (key: string) => boolean,
+): UsageAlert[] {
+  // No reading and no plan both mean there is no window to warn about. A failed
+  // read must never be treated as 0% (silent) OR as exhausted (a false alarm) —
+  // it produces nothing, and the next check tries again.
+  if (!meter || !meter.entitled) return [];
+
+  const out: UsageAlert[] = [];
+  const consider = (window: UsageWindow, pct: number | null, resetsAt: string) => {
+    if (pct === null) return; // unreadable window: no signal either way
+    // 100 FIRST, and it suppresses the 75 for the same window: a user who goes
+    // from 40% to full between two checks gets one notification, not two.
+    if (pct >= 100) {
+      const full = alertFor(window, 100, resetsAt);
+      if (!delivered(full.key)) out.push(full);
+      return;
+    }
+    if (pct >= WARN_PCT) {
+      const warn = alertFor(window, WARN_PCT as UsageLevel, resetsAt);
+      if (!delivered(warn.key)) out.push(warn);
+    }
+  };
+
+  consider('session', meter.sessionPct, meter.sessionResetsAt);
+  consider('week', meter.weekPct, meter.weekResetsAt);
+
+  // The proxy enforces a rolling 7 days from key creation while we report a
+  // Monday-aligned week (docs/LLM.md), so it can be REFUSING at a percentage
+  // both bars call fine. Staying silent there is the worst outcome: the user is
+  // blocked and nothing has told them why. Keyed on the session stamp so it
+  // repeats at most once every 6 hours while the disagreement lasts.
+  if (meter.blocked && out.length === 0) {
+    const blocked: UsageAlert = {
+      window: 'session',
+      level: 100,
+      key: `${FLAG_PREFIX}blocked.${meter.sessionResetsAt}`,
+      title: 'Included AI usage used up',
+      body: 'Your included AI usage is temporarily used up. It resumes when your usage window resets.',
+    };
+    if (!delivered(blocked.key)) out.push(blocked);
+  }
+  return out;
+}
+
+/** Pluggable persistence so the decision is unit-testable without SQLite. */
+export interface UsageAlertStore {
+  get(key: string): string | null;
+  set(key: string, value: string): void;
+  /** Every delivered-flag key currently stored, for pruning. */
+  keys(): string[];
+  delete(key: string): void;
+}
+
+/**
+ * Keys are only ever added, so without this a long-lived install accumulates
+ * one row per window forever. A key is stale once neither live reset stamp
+ * appears in it — that is the same self-expiry the key format already encodes,
+ * just collected.
+ */
+export function staleFlagKeys(all: string[], meter: HostedUsageMeter): string[] {
+  const live = [meter.sessionResetsAt, meter.weekResetsAt];
+  return all.filter((k) => k.startsWith(FLAG_PREFIX) && !live.some((stamp) => k.endsWith(stamp)));
+}

--- a/src/daemon/usage-contract.test.ts
+++ b/src/daemon/usage-contract.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from 'bun:test';
+import { WARN_PCT as DAEMON_WARN_PCT } from './usage-alerts.ts';
+import type { HostedUsageMeter } from './hosted-usage.ts';
+import { WARN_PCT as UI_WARN_PCT, type HostedMeter } from '../../ui/src/v2/rooms/usage/hosted-budget.ts';
+
+/**
+ * The daemon and the room each declare the meter's shape and its warning
+ * threshold, and neither imports the other — the room is bundled for the
+ * browser and must not pull daemon code in. Comments in both files say "keep
+ * these in step"; this is the thing that actually makes them.
+ *
+ * A review found the previous attempt tautological: the room's own test
+ * asserted the room's own constant, which passes at any value.
+ */
+
+describe('the daemon and the Usage room agree', () => {
+  test('on the warning threshold', () => {
+    // Drift here means a user gets an OS notification while the room still
+    // shows a calm bar, or a bar turns amber with no notification behind it.
+    expect(UI_WARN_PCT).toBe(DAEMON_WARN_PCT);
+  });
+
+  test('on the meter shape, in both directions', () => {
+    // Assigning each to the other is the check: a field added, removed or
+    // retyped on one side fails to compile here rather than silently rendering
+    // `undefined` in the room. `satisfies` keeps this a type assertion that
+    // survives the value being unused.
+    const fromDaemon: HostedUsageMeter = {
+      entitled: true,
+      blocked: false,
+      sessionPct: 10,
+      weekPct: 20,
+      sessionResetsAt: '2026-08-26T12:00:00.000Z',
+      weekResetsAt: '2026-08-31T00:00:00.000Z',
+    };
+    const asRoom: HostedMeter = fromDaemon;
+    const backAgain: HostedUsageMeter = asRoom;
+    expect(Object.keys(backAgain).sort()).toEqual([
+      'blocked',
+      'entitled',
+      'sessionPct',
+      'sessionResetsAt',
+      'weekPct',
+      'weekResetsAt',
+    ]);
+  });
+});

--- a/ui/src/v2/rooms/usage/UsageRoom.css
+++ b/ui/src/v2/rooms/usage/UsageRoom.css
@@ -33,3 +33,10 @@
 
 .rk-usage__err { color: var(--hold-tx); }
 .rk-usage__raw-mono { font-family: var(--mono); font-size: 10.5px; color: var(--ink2); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+
+/* ── hosted budget strip: the two windows the proxy enforces ── */
+.rk-usage__budget { border-bottom: 1px solid var(--rule); background: var(--panel2); flex-shrink: 0; }
+.rk-usage__meters { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 14px 28px; padding: 11px 16px; }
+.rk-usage__banner { padding: 9px 16px; font-size: 11.5px; line-height: 1.45; border-bottom: 1px solid var(--rule2); }
+.rk-usage__banner--hold { color: var(--hold-tx); background: color-mix(in srgb, var(--hold) 10%, transparent); }
+.rk-usage__banner--fail { color: var(--listen-tx); background: color-mix(in srgb, var(--listen) 10%, transparent); }

--- a/ui/src/v2/rooms/usage/UsageRoom.tsx
+++ b/ui/src/v2/rooms/usage/UsageRoom.tsx
@@ -120,8 +120,11 @@ function FilterBar({ data }: { data: ReturnType<typeof useUsageData> }) {
  * one strip would invite exactly that comparison.
  */
 function HostedBudgetStrip() {
-  const { state, meter } = useHostedBudget();
-  // Re-rendered on the poll, so the countdowns advance without their own timer.
+  const { state, meter, readAt } = useHostedBudget();
+  // Re-rendered on every completed read — including a failed one, which is the
+  // case that matters: a control-plane outage keeps the last good meter on
+  // screen, and without a re-render its countdowns would freeze with it.
+  void readAt;
   const now = Date.now();
   // Renders NOTHING while unknown and on a self-hosted install. An entitled
   // flag that is false means a hosted user with no active plan; there is no
@@ -135,13 +138,13 @@ function HostedBudgetStrip() {
         <Meter
           label="6-hour window"
           value={meter.sessionPct}
-          tone={meterTone(meter.sessionPct, meter.blocked)}
+          tone={meterTone(meter.sessionPct)}
           note={formatResetIn(meter.sessionResetsAt, now)}
         />
         <Meter
           label="this week"
           value={meter.weekPct}
-          tone={meterTone(meter.weekPct, meter.blocked)}
+          tone={meterTone(meter.weekPct)}
           note={formatResetIn(meter.weekResetsAt, now)}
         />
       </div>

--- a/ui/src/v2/rooms/usage/UsageRoom.tsx
+++ b/ui/src/v2/rooms/usage/UsageRoom.tsx
@@ -1,10 +1,12 @@
 import React, { useMemo } from "react";
 import { BarChart3, Calendar, RefreshCw, type LucideIcon } from "lucide-react";
 import { Icon } from "../../ui";
-import { Select, FilterChip, Check, Table, Row, Cell, HCell } from "../../ui/roomkit";
+import { Select, FilterChip, Check, Table, Row, Cell, HCell, Meter } from "../../ui/roomkit";
 import { RoomShell } from "../RoomShell";
 import { MultiSelectDropdown } from "./MultiSelectDropdown";
 import { useUsageData, type UsageGroupBy, type UsagePeriod, type UsageRawRow } from "./useUsageData";
+import { useHostedBudget } from "./useHostedBudget";
+import { bannerFor, formatResetIn, meterTone } from "./hosted-budget";
 import "./UsageRoom.css";
 
 const PERIOD_LABELS: Record<UsagePeriod, string> = {
@@ -36,6 +38,7 @@ export function UsageRoomBody({ mode = "expanded" }: { mode?: RoomBodyMode } = {
   return (
     <div className="rk-usage">
       <FilterBar data={data} />
+      <HostedBudgetStrip />
       <TotalsStrip totals={total} />
       <div className="rk-usage__main">
         {data.error && <div className="rk-usage__empty">{data.error}</div>}
@@ -101,6 +104,46 @@ function FilterBar({ data }: { data: ReturnType<typeof useUsageData> }) {
         <MultiSelectDropdown label="Provider" options={options?.providers ?? []} selected={filters.providers} onToggle={(v) => toggleListFilter("providers", v)} onClear={() => setFilter("providers", [])} />
         <Check on={filters.errorsOnly} onClick={() => setFilter("errorsOnly", !filters.errorsOnly)}>errors only</Check>
         {anyFilter && <FilterChip onClick={clearFilters}>✕ clear filters</FilterChip>}
+      </div>
+    </div>
+  );
+}
+
+// ─── Hosted budget strip ──────────────────────────────────────────────────
+/**
+ * The two enforced windows, on a hosted install only.
+ *
+ * Separate from TotalsStrip below on purpose: that one counts what THIS
+ * instance recorded locally, while these are the control plane's own numbers
+ * for the budgets the proxy actually enforces. They will not tie out — local
+ * telemetry misses nothing but prices nothing either — and presenting them as
+ * one strip would invite exactly that comparison.
+ */
+function HostedBudgetStrip() {
+  const { state, meter } = useHostedBudget();
+  // Re-rendered on the poll, so the countdowns advance without their own timer.
+  const now = Date.now();
+  // Renders NOTHING while unknown and on a self-hosted install. An entitled
+  // flag that is false means a hosted user with no active plan; there is no
+  // window to meter, and a pair of empty bars would read as "all used up".
+  if (state !== "hosted" || !meter || !meter.entitled) return null;
+  const banner = bannerFor(meter);
+  return (
+    <div className="rk-usage__budget">
+      {banner && <div className={`rk-usage__banner rk-usage__banner--${banner.tone}`}>{banner.text}</div>}
+      <div className="rk-usage__meters">
+        <Meter
+          label="6-hour window"
+          value={meter.sessionPct}
+          tone={meterTone(meter.sessionPct, meter.blocked)}
+          note={formatResetIn(meter.sessionResetsAt, now)}
+        />
+        <Meter
+          label="this week"
+          value={meter.weekPct}
+          tone={meterTone(meter.weekPct, meter.blocked)}
+          note={formatResetIn(meter.weekResetsAt, now)}
+        />
       </div>
     </div>
   );

--- a/ui/src/v2/rooms/usage/hosted-budget.test.ts
+++ b/ui/src/v2/rooms/usage/hosted-budget.test.ts
@@ -1,11 +1,14 @@
 import { describe, expect, test } from 'bun:test';
 import {
+  applyBudgetProbe,
   bannerFor,
+  classifyBudgetResponse,
   barWidthPct,
   formatPct,
   formatResetIn,
   meterTone,
   WARN_PCT,
+  type BudgetView,
   type HostedMeter,
 } from './hosted-budget.ts';
 
@@ -30,11 +33,12 @@ describe('meter tone', () => {
     expect(meterTone(100)).toBe('fail');
   });
 
-  test('BLOCKED is fail regardless of the percentage', () => {
-    // The proxy enforces a rolling 7d while we display a Monday-aligned week,
-    // so it can refuse at a percentage that looks fine.
-    expect(meterTone(4, true)).toBe('fail');
-    expect(meterTone(null, true)).toBe('fail');
+  test('a BLOCKED key does not repaint a window that is nearly empty', () => {
+    // `blocked` means the key is switched off (no plan, or a converge gap) —
+    // not that this window is full. Painting a 4% bar red would contradict the
+    // number printed beside it; the block state is the banner's job.
+    expect(meterTone(4)).toBe('mut');
+    expect(meterTone(null)).toBe('mut');
   });
 
   test('an UNKNOWN reading is not a warning', () => {
@@ -98,18 +102,74 @@ describe('banner', () => {
     expect(both.tone).toBe('hold');
   });
 
-  test('BLOCKED wins over the percentages', () => {
-    // The whole reason the banner keys off `blocked`: the proxy can be
-    // refusing while our Monday-aligned week still shows headroom, and the
-    // room must not tell a user they have room they do not have.
+  test('a blocked key reads as OUR fault, not as the user being out of usage', () => {
+    // The control plane sets `blocked` for a user with no plan (filtered out
+    // above) or a converge that failed part-way — never for spending too much.
+    // "Used up" would send someone to a meter reading 3% and blame them for it.
     const b = bannerFor(meter({ blocked: true, sessionPct: 3, weekPct: 3 }))!;
     expect(b.tone).toBe('fail');
-    expect(b.text).toContain('used up');
+    expect(b.text).not.toContain('used up');
+    expect(b.text).toContain('being fixed on our side');
   });
 
   test('an unreadable session window alone does not raise a banner', () => {
     expect(bannerFor(meter({ sessionPct: null }))).toBeNull();
     // …but a hot week still does.
     expect(bannerFor(meter({ sessionPct: null, weekPct: 88 }))?.text).toContain('this week');
+  });
+});
+
+
+describe('the hosted gate', () => {
+  const hosted: BudgetView = { state: 'hosted', meter: meter() };
+  const unknown: BudgetView = { state: 'unknown', meter: null };
+
+  test('ONLY a 503 means self-hosted', () => {
+    // It is the route's own hasUsejarvisAi guard. Nothing else is evidence
+    // about which kind of install this is.
+    expect(classifyBudgetResponse(503, null).kind).toBe('self');
+    expect(classifyBudgetResponse(500, null).kind).toBe('failed');
+    expect(classifyBudgetResponse(404, null).kind).toBe('failed');
+    expect(classifyBudgetResponse(401, null).kind).toBe('failed');
+  });
+
+  test('a failure never demotes a hosted user to self-hosted', () => {
+    // OnboardingWizard.tsx records the bug this exists to prevent: a probe that
+    // read as self-hosted while it was merely slow. Here the cost is a hosted
+    // user's meter disappearing for good — the poll stops on 'self'.
+    expect(applyBudgetProbe(hosted, { kind: 'failed' })).toEqual(hosted);
+    expect(applyBudgetProbe(unknown, { kind: 'failed' })).toEqual(unknown);
+  });
+
+  test('a 404 from a daemon older than the route does not read as self-hosted', () => {
+    // Version skew during an upgrade: the UI ships before the daemon restarts.
+    const after = applyBudgetProbe(hosted, classifyBudgetResponse(404, null));
+    expect(after.state).toBe('hosted');
+    expect(after.meter).toEqual(hosted.meter!);
+  });
+
+  test('hosted-but-unreadable KEEPS the last good meter', () => {
+    // A minute-old reading beats a strip that flickers empty every time the
+    // control plane hiccups.
+    const probe = classifyBudgetResponse(200, { ok: false });
+    expect(probe.kind).toBe('unreadable');
+    expect(applyBudgetProbe(hosted, probe)).toEqual(hosted);
+  });
+
+  test('a reading promotes an unknown install and replaces the meter', () => {
+    const fresh = meter({ weekPct: 77 });
+    const after = applyBudgetProbe(unknown, classifyBudgetResponse(200, { ok: true, meter: fresh }));
+    expect(after).toEqual({ state: 'hosted', meter: fresh });
+  });
+
+  test('a 200 with a missing meter is unreadable, not a reading', () => {
+    // ok:true with no meter would otherwise set `meter: undefined` and render
+    // a strip of blanks.
+    expect(classifyBudgetResponse(200, { ok: true }).kind).toBe('unreadable');
+    expect(classifyBudgetResponse(200, null).kind).toBe('unreadable');
+  });
+
+  test('self-hosted clears any meter it was holding', () => {
+    expect(applyBudgetProbe(hosted, { kind: 'self' })).toEqual({ state: 'self', meter: null });
   });
 });

--- a/ui/src/v2/rooms/usage/hosted-budget.test.ts
+++ b/ui/src/v2/rooms/usage/hosted-budget.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  bannerFor,
+  barWidthPct,
+  formatPct,
+  formatResetIn,
+  meterTone,
+  WARN_PCT,
+  type HostedMeter,
+} from './hosted-budget.ts';
+
+const meter = (over: Partial<HostedMeter> = {}): HostedMeter => ({
+  entitled: true,
+  blocked: false,
+  sessionPct: 10,
+  weekPct: 10,
+  sessionResetsAt: '2026-08-26T12:00:00.000Z',
+  weekResetsAt: '2026-08-31T00:00:00.000Z',
+  ...over,
+});
+
+const NOW = Date.parse('2026-08-26T09:30:00.000Z');
+
+describe('meter tone', () => {
+  test('turns at the SAME threshold the daemon notifies on', () => {
+    // If these drift, a user gets an OS notification while the room still
+    // shows a calm bar, or the reverse.
+    expect(meterTone(WARN_PCT - 0.1)).toBe('mut');
+    expect(meterTone(WARN_PCT)).toBe('hold');
+    expect(meterTone(100)).toBe('fail');
+  });
+
+  test('BLOCKED is fail regardless of the percentage', () => {
+    // The proxy enforces a rolling 7d while we display a Monday-aligned week,
+    // so it can refuse at a percentage that looks fine.
+    expect(meterTone(4, true)).toBe('fail');
+    expect(meterTone(null, true)).toBe('fail');
+  });
+
+  test('an UNKNOWN reading is not a warning', () => {
+    expect(meterTone(null)).toBe('mut');
+  });
+});
+
+describe('rendering a reading', () => {
+  test('null reads as unavailable and draws an EMPTY bar, never a full-looking zero', () => {
+    expect(formatPct(null)).toBe('unavailable');
+    expect(barWidthPct(null)).toBe(0);
+  });
+
+  test('an overshoot keeps its true number in the label but clamps the bar', () => {
+    // max_budget can be exceeded by the request that crosses it, so >100 is a
+    // real state; a silently capped "100%" would hide it.
+    expect(formatPct(104.4)).toBe('104%');
+    expect(barWidthPct(104.4)).toBe(100);
+  });
+});
+
+describe('reset countdown', () => {
+  test('reads in the units the window actually has', () => {
+    expect(formatResetIn('2026-08-26T12:00:00.000Z', NOW)).toBe('resets in 2h 30m');
+    expect(formatResetIn('2026-08-31T00:00:00.000Z', NOW)).toBe('resets in 4d 14h');
+    expect(formatResetIn('2026-08-26T09:44:00.000Z', NOW)).toBe('resets in 14m');
+  });
+
+  test('a reset already PAST is "resetting…", never a negative countdown', () => {
+    // Both sides cache the meter for up to a minute, so the boundary routinely
+    // passes while a reading is still being served. That is not an error.
+    expect(formatResetIn('2026-08-26T09:29:00.000Z', NOW)).toBe('resetting…');
+    expect(formatResetIn('2026-08-26T09:30:00.000Z', NOW)).toBe('resetting…');
+  });
+
+  test('never rounds down to a stuck-looking "0m"', () => {
+    expect(formatResetIn('2026-08-26T09:30:20.000Z', NOW)).toBe('resets in 1m');
+  });
+
+  test('an unparseable stamp renders nothing rather than "NaN"', () => {
+    expect(formatResetIn('not a date', NOW)).toBe('');
+  });
+});
+
+describe('banner', () => {
+  test('silent below the threshold', () => {
+    expect(bannerFor(meter())).toBeNull();
+    expect(bannerFor(null)).toBeNull();
+  });
+
+  test('a user with no plan gets no banner and no meter', () => {
+    // Not entitled is not "used up" — there is no window at all.
+    expect(bannerFor(meter({ entitled: false, blocked: true }))).toBeNull();
+  });
+
+  test('names WHICH window is hot, and both when both are', () => {
+    expect(bannerFor(meter({ sessionPct: 80 }))?.text).toContain('this 6-hour window');
+    expect(bannerFor(meter({ weekPct: 91 }))?.text).toContain('this week');
+    const both = bannerFor(meter({ sessionPct: 80, weekPct: 91 }))!;
+    expect(both.text).toContain('this 6-hour window and this week');
+    expect(both.tone).toBe('hold');
+  });
+
+  test('BLOCKED wins over the percentages', () => {
+    // The whole reason the banner keys off `blocked`: the proxy can be
+    // refusing while our Monday-aligned week still shows headroom, and the
+    // room must not tell a user they have room they do not have.
+    const b = bannerFor(meter({ blocked: true, sessionPct: 3, weekPct: 3 }))!;
+    expect(b.tone).toBe('fail');
+    expect(b.text).toContain('used up');
+  });
+
+  test('an unreadable session window alone does not raise a banner', () => {
+    expect(bannerFor(meter({ sessionPct: null }))).toBeNull();
+    // …but a hot week still does.
+    expect(bannerFor(meter({ sessionPct: null, weekPct: 88 }))?.text).toContain('this week');
+  });
+});

--- a/ui/src/v2/rooms/usage/hosted-budget.ts
+++ b/ui/src/v2/rooms/usage/hosted-budget.ts
@@ -1,0 +1,90 @@
+/**
+ * The hosted usage meter, as the Usage room renders it.
+ *
+ * Pure on purpose — every rule below is a decision that has to hold at a
+ * boundary (a null reading, a reset that has already passed, a window at
+ * exactly 75%), and the room's own tests cannot reach those through JSX.
+ */
+
+export type MeterTone = "mut" | "hold" | "fail";
+
+/** Mirrors the daemon's `HostedUsageMeter` (src/daemon/hosted-usage.ts). */
+export interface HostedMeter {
+  entitled: boolean;
+  blocked: boolean;
+  /** null when the control plane could not read the proxy. NEVER render as 0. */
+  sessionPct: number | null;
+  weekPct: number;
+  sessionResetsAt: string;
+  weekResetsAt: string;
+}
+
+/** Where a window turns from information into a warning. Matches the daemon's
+ *  notification threshold, so the banner and the OS notification agree. */
+export const WARN_PCT = 75;
+
+export function meterTone(pct: number | null, blocked = false): MeterTone {
+  if (blocked || (pct !== null && pct >= 100)) return "fail";
+  if (pct !== null && pct >= WARN_PCT) return "hold";
+  return "mut";
+}
+
+/** Clamped for the BAR only. The label keeps the true number: a proxy that has
+ *  overshot its budget should read "104%", not a quietly capped "100%". */
+export function barWidthPct(pct: number | null): number {
+  if (pct === null) return 0;
+  return Math.max(0, Math.min(100, pct));
+}
+
+export function formatPct(pct: number | null): string {
+  return pct === null ? "unavailable" : `${Math.round(pct)}%`;
+}
+
+/**
+ * "resets in 2h 14m".
+ *
+ * A reset in the PAST is normal here rather than a bug: both sides cache the
+ * meter for up to a minute, so the boundary can pass while a reading is still
+ * being served. It reads as "resetting…" — never as a negative countdown, and
+ * never as "resets in 0m", which would look stuck.
+ */
+export function formatResetIn(resetsAt: string, nowMs: number): string {
+  const at = Date.parse(resetsAt);
+  if (!Number.isFinite(at)) return "";
+  const ms = at - nowMs;
+  if (ms <= 0) return "resetting…";
+  const mins = Math.floor(ms / 60_000);
+  const days = Math.floor(mins / 1_440);
+  const hours = Math.floor((mins % 1_440) / 60);
+  if (days > 0) return `resets in ${days}d ${hours}h`;
+  if (hours > 0) return `resets in ${hours}h ${mins % 60}m`;
+  return `resets in ${Math.max(1, mins)}m`;
+}
+
+export interface MeterBanner {
+  tone: "hold" | "fail";
+  text: string;
+}
+
+/**
+ * The banner above the meter, or null when there is nothing to say.
+ *
+ * Keyed off `blocked` FIRST, and independently of the percentages. The proxy
+ * enforces a rolling 7 days from key creation while we display a Monday-aligned
+ * week (docs/LLM.md), so the two can disagree — and when they do, the surface
+ * must not claim headroom the proxy is already refusing.
+ */
+export function bannerFor(meter: HostedMeter | null): MeterBanner | null {
+  if (!meter || !meter.entitled) return null;
+  if (meter.blocked) {
+    return {
+      tone: "fail",
+      text: "Included AI usage is used up for this window. It resumes when the window resets — the meter below shows when.",
+    };
+  }
+  const hot: string[] = [];
+  if (meter.sessionPct !== null && meter.sessionPct >= WARN_PCT) hot.push("this 6-hour window");
+  if (meter.weekPct >= WARN_PCT) hot.push("this week");
+  if (hot.length === 0) return null;
+  return { tone: "hold", text: `You have used over ${WARN_PCT}% of your included AI usage for ${hot.join(" and ")}.` };
+}

--- a/ui/src/v2/rooms/usage/hosted-budget.ts
+++ b/ui/src/v2/rooms/usage/hosted-budget.ts
@@ -23,14 +23,23 @@ export interface HostedMeter {
  *  notification threshold, so the banner and the OS notification agree. */
 export const WARN_PCT = 75;
 
-export function meterTone(pct: number | null, blocked = false): MeterTone {
-  if (blocked || (pct !== null && pct >= 100)) return "fail";
+/**
+ * Tone for ONE window's bar, from that window's own number.
+ *
+ * Deliberately not a function of `blocked`: that flag means the key is switched
+ * off (no plan, or a converge that failed part-way), not that this window is
+ * full, and painting a 4% bar red because of it tells the user the opposite of
+ * what the number says. The block state is the banner's job.
+ */
+export function meterTone(pct: number | null): MeterTone {
+  if (pct !== null && pct >= 100) return "fail";
   if (pct !== null && pct >= WARN_PCT) return "hold";
   return "mut";
 }
 
-/** Clamped for the BAR only. The label keeps the true number: a proxy that has
- *  overshot its budget should read "104%", not a quietly capped "100%". */
+/** Defensive clamp. The control plane already caps both percentages at 100
+ *  (llm-sweeps.ts `Math.min(100, Math.ceil(…))`), so >100 should not arrive;
+ *  this keeps a bar inside its track if that ever changes. */
 export function barWidthPct(pct: number | null): number {
   if (pct === null) return 0;
   return Math.max(0, Math.min(100, pct));
@@ -69,17 +78,22 @@ export interface MeterBanner {
 /**
  * The banner above the meter, or null when there is nothing to say.
  *
- * Keyed off `blocked` FIRST, and independently of the percentages. The proxy
- * enforces a rolling 7 days from key creation while we display a Monday-aligned
- * week (docs/LLM.md), so the two can disagree — and when they do, the surface
- * must not claim headroom the proxy is already refusing.
+ * Note what this CANNOT tell the user: the proxy enforces a rolling 7 days from
+ * key creation while we display a Monday-aligned week (docs/LLM.md POC item 1),
+ * and nothing reads the proxy's own weekly counter — so a refusal on it shows
+ * up here as neither a full bar nor a banner. The chat surface still explains
+ * it (src/util/hosted-error.ts); this one stays silent, which is a known gap
+ * rather than a claim of headroom.
  */
 export function bannerFor(meter: HostedMeter | null): MeterBanner | null {
   if (!meter || !meter.entitled) return null;
+  // Blocked is NOT "used up" — see the note in src/daemon/usage-alerts.ts. The
+  // control plane sets it for a user with no plan (filtered out above) or a
+  // converge gap, so reaching here means a plan whose key is switched off.
   if (meter.blocked) {
     return {
       tone: "fail",
-      text: "Included AI usage is used up for this window. It resumes when the window resets — the meter below shows when.",
+      text: "Your assistant cannot reach its AI models right now. This is being fixed on our side — nothing you need to do.",
     };
   }
   const hot: string[] = [];
@@ -87,4 +101,58 @@ export function bannerFor(meter: HostedMeter | null): MeterBanner | null {
   if (meter.weekPct >= WARN_PCT) hot.push("this week");
   if (hot.length === 0) return null;
   return { tone: "hold", text: `You have used over ${WARN_PCT}% of your included AI usage for ${hot.join(" and ")}.` };
+}
+
+// ─── The hosted gate, as a pure decision ─────────────────────────────────
+/**
+ * What one answer from `/api/llm/budget` means, and what it does to the strip.
+ *
+ * Split out of `useHostedBudget` because this is the part that re-litigates a
+ * recorded bug — OnboardingWizard.tsx documents a hosted probe that read as
+ * self-hosted while it was merely slow, and walked a hosted user through three
+ * screens of setup that the server then discarded. There is no DOM in this test
+ * suite, so a decision left inside the hook is a decision nothing checks.
+ */
+
+export type BudgetProbe =
+  | { kind: "self" }
+  | { kind: "meter"; meter: HostedMeter }
+  | { kind: "unreadable" }
+  | { kind: "failed" };
+
+export interface BudgetView {
+  state: "unknown" | "hosted" | "self";
+  meter: HostedMeter | null;
+}
+
+/** 503 is the ONLY answer that means "not a hosted install" — it is the route's
+ *  own `hasUsejarvisAi` guard. Everything else is either a reading or a
+ *  failure, and a failure is not evidence about which kind of install this is. */
+export function classifyBudgetResponse(
+  status: number,
+  body: { ok?: boolean; meter?: HostedMeter } | null,
+): BudgetProbe {
+  if (status === 503) return { kind: "self" };
+  if (status < 200 || status >= 300) return { kind: "failed" };
+  if (body?.ok && body.meter) return { kind: "meter", meter: body.meter };
+  return { kind: "unreadable" };
+}
+
+export function applyBudgetProbe(prev: BudgetView, probe: BudgetProbe): BudgetView {
+  switch (probe.kind) {
+    case "self":
+      return { state: "self", meter: null };
+    case "meter":
+      return { state: "hosted", meter: probe.meter };
+    case "unreadable":
+      // Hosted, but the control plane could not be read. KEEP the last good
+      // meter: a minute-old reading beats a strip that flickers empty every
+      // time the control plane hiccups.
+      return { state: "hosted", meter: prev.meter };
+    case "failed":
+      // Changes NOTHING — least of all to "self". An unreachable daemon is the
+      // slow-probe case from the wizard, and answering it with "self-hosted"
+      // hides a hosted user's meter exactly when they need it.
+      return prev;
+  }
 }

--- a/ui/src/v2/rooms/usage/useHostedBudget.ts
+++ b/ui/src/v2/rooms/usage/useHostedBudget.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import type { HostedMeter } from "./hosted-budget";
+import { applyBudgetProbe, classifyBudgetResponse, type HostedMeter } from "./hosted-budget";
 
 /**
  * Polls the daemon's `/api/llm/budget`.
@@ -19,7 +19,11 @@ import type { HostedMeter } from "./hosted-budget";
 
 /** Matches the 60s caches on both sides — polling faster buys nothing. */
 export const BUDGET_POLL_MS = 60_000;
+/** First retry after a failed probe. Doubles up to RETRY_MAX_MS: a daemon that
+ *  is down stays down, and a fixed 5s retry on top of the poll is a request
+ *  every five seconds for as long as the room is open. */
 const RETRY_MS = 5_000;
+const RETRY_MAX_MS = BUDGET_POLL_MS;
 
 export type HostedState = "unknown" | "hosted" | "self";
 
@@ -28,6 +32,10 @@ export interface HostedBudget {
   /** null while unknown, on a self-hosted install, or when the control plane
    *  could not be reached — the strip renders "unavailable", not zeros. */
   meter: HostedMeter | null;
+  /** When the last read COMPLETED, successful or not. The strip derives its
+   *  countdowns at render, so this is what makes them tick during an outage
+   *  instead of freezing on the last good reading. */
+  readAt: number;
   refresh: () => void;
 }
 
@@ -39,7 +47,15 @@ interface BudgetResponse {
 export function useHostedBudget(): HostedBudget {
   const [state, setState] = useState<HostedState>("unknown");
   const [meter, setMeter] = useState<HostedMeter | null>(null);
+  // Bumped on every completed read, including a failed one, so the strip
+  // re-renders and its countdowns advance. Without it a room left open across
+  // a control-plane outage keeps a last-good meter on screen and goes on
+  // printing "resets in 2h 30m" an hour later.
+  const [readAt, setReadAt] = useState(0);
   const inFlightRef = useRef(false);
+  const retryRef = useRef<number | null>(null);
+  const backoffRef = useRef(RETRY_MS);
+  const aliveRef = useRef(true);
   const [attempt, setAttempt] = useState(0);
 
   const load = useCallback(async () => {
@@ -47,27 +63,43 @@ export function useHostedBudget(): HostedBudget {
     inFlightRef.current = true;
     try {
       const res = await fetch("/api/llm/budget");
-      if (res.status === 503) {
-        // The only answer that means "not a hosted install".
-        setState("self");
-        setMeter(null);
-        return;
-      }
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const body = (await res.json()) as BudgetResponse | null;
-      setState("hosted");
-      // ok:false is hosted-but-unreadable. Keep the LAST GOOD meter rather
-      // than blanking the strip on one failed poll — a minute-old reading is
-      // far better than a room that flickers empty every time the control
-      // plane hiccups.
-      if (body?.ok && body.meter) setMeter(body.meter);
+      // A non-2xx that is not 503 has no body worth parsing, and a body that
+      // is not JSON must not read as a failed FETCH — both are "failed".
+      const body =
+        res.ok ? ((await res.json().catch(() => null)) as BudgetResponse | null) : null;
+      if (!aliveRef.current) return;
+      const probe = classifyBudgetResponse(res.status, body);
+      if (probe.kind === "failed") throw new Error(`HTTP ${res.status}`);
+      backoffRef.current = RETRY_MS;
+      setState((prevState) => applyBudgetProbe({ state: prevState, meter: null }, probe).state);
+      setMeter((prevMeter) => applyBudgetProbe({ state: "hosted", meter: prevMeter }, probe).meter);
+      setReadAt(Date.now());
     } catch {
       // Unreachable daemon stays UNKNOWN, never "self": the strip must not
       // vanish for a hosted user because one request failed.
-      setTimeout(() => setAttempt((n) => n + 1), RETRY_MS);
+      if (!aliveRef.current) return;
+      setReadAt(Date.now());
+      // Backed off and CLEARED on unmount. A UI newer than its daemon gets a
+      // 404 here on every attempt; at a fixed interval that is a request every
+      // five seconds forever, and the timer outlived the component besides.
+      const wait = backoffRef.current;
+      backoffRef.current = Math.min(wait * 2, RETRY_MAX_MS);
+      retryRef.current = window.setTimeout(() => {
+        retryRef.current = null;
+        if (typeof document !== "undefined" && document.hidden) return;
+        setAttempt((n) => n + 1);
+      }, wait);
     } finally {
       inFlightRef.current = false;
     }
+  }, []);
+
+  useEffect(() => {
+    aliveRef.current = true;
+    return () => {
+      aliveRef.current = false;
+      if (retryRef.current !== null) window.clearTimeout(retryRef.current);
+    };
   }, []);
 
   useEffect(() => {
@@ -83,5 +115,5 @@ export function useHostedBudget(): HostedBudget {
     return () => window.clearInterval(id);
   }, [load, state]);
 
-  return { state, meter, refresh: () => void load() };
+  return { state, meter, readAt, refresh: () => void load() };
 }

--- a/ui/src/v2/rooms/usage/useHostedBudget.ts
+++ b/ui/src/v2/rooms/usage/useHostedBudget.ts
@@ -1,0 +1,87 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { HostedMeter } from "./hosted-budget";
+
+/**
+ * Polls the daemon's `/api/llm/budget`.
+ *
+ * ## Why there is no separate hosted probe
+ *
+ * The route ITSELF is the gate: it answers 503 on a self-hosted install, where
+ * there is no key, no plan and no window to report. Probing `/api/config/llm`
+ * separately (as the onboarding wizard must, since it renders before any of
+ * this exists) would add a second request that can disagree with the first.
+ *
+ * TRI-state, for the reason recorded in OnboardingWizard.tsx: a slow or
+ * erroring probe that defaults to "self-hosted" hides a hosted user's meter
+ * exactly when they most need it. Unknown renders NOTHING and retries; only a
+ * real 503 means self-hosted.
+ */
+
+/** Matches the 60s caches on both sides — polling faster buys nothing. */
+export const BUDGET_POLL_MS = 60_000;
+const RETRY_MS = 5_000;
+
+export type HostedState = "unknown" | "hosted" | "self";
+
+export interface HostedBudget {
+  state: HostedState;
+  /** null while unknown, on a self-hosted install, or when the control plane
+   *  could not be reached — the strip renders "unavailable", not zeros. */
+  meter: HostedMeter | null;
+  refresh: () => void;
+}
+
+interface BudgetResponse {
+  ok?: boolean;
+  meter?: HostedMeter;
+}
+
+export function useHostedBudget(): HostedBudget {
+  const [state, setState] = useState<HostedState>("unknown");
+  const [meter, setMeter] = useState<HostedMeter | null>(null);
+  const inFlightRef = useRef(false);
+  const [attempt, setAttempt] = useState(0);
+
+  const load = useCallback(async () => {
+    if (inFlightRef.current) return;
+    inFlightRef.current = true;
+    try {
+      const res = await fetch("/api/llm/budget");
+      if (res.status === 503) {
+        // The only answer that means "not a hosted install".
+        setState("self");
+        setMeter(null);
+        return;
+      }
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const body = (await res.json()) as BudgetResponse | null;
+      setState("hosted");
+      // ok:false is hosted-but-unreadable. Keep the LAST GOOD meter rather
+      // than blanking the strip on one failed poll — a minute-old reading is
+      // far better than a room that flickers empty every time the control
+      // plane hiccups.
+      if (body?.ok && body.meter) setMeter(body.meter);
+    } catch {
+      // Unreachable daemon stays UNKNOWN, never "self": the strip must not
+      // vanish for a hosted user because one request failed.
+      setTimeout(() => setAttempt((n) => n + 1), RETRY_MS);
+    } finally {
+      inFlightRef.current = false;
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load, attempt]);
+
+  useEffect(() => {
+    if (state === "self") return;
+    const id = window.setInterval(() => {
+      if (typeof document !== "undefined" && document.hidden) return;
+      void load();
+    }, BUDGET_POLL_MS);
+    return () => window.clearInterval(id);
+  }, [load, state]);
+
+  return { state, meter, refresh: () => void load() };
+}

--- a/ui/src/v2/ui/roomkit.css
+++ b/ui/src/v2/ui/roomkit.css
@@ -160,3 +160,17 @@
 .rk-check__bx { width: 13px; height: 13px; border-radius: 4px 1px 4px 4px; border: 1.5px solid var(--ink2); flex-shrink: 0; display: flex; align-items: center; justify-content: center; }
 .rk-check--on .rk-check__bx { background: var(--ink); border-color: var(--ink); }
 .rk-check--on .rk-check__bx::after { content: ""; width: 6px; height: 6px; border-radius: 2px; background: var(--bg); }
+
+/* ── meter: a labelled window gauge (usage §03) ── */
+.rk-meter { display: flex; flex-direction: column; gap: 5px; min-width: 0; }
+.rk-meter__top { display: flex; align-items: baseline; gap: 8px; }
+.rk-meter__label { font-family: var(--mono); font-size: 8px; letter-spacing: .1em; text-transform: uppercase; color: var(--ink3); }
+.rk-meter__val { margin-left: auto; font-family: var(--mono); font-size: 12px; font-variant-numeric: tabular-nums; color: var(--ink); }
+.rk-meter__val--hold { color: var(--hold-tx); }
+.rk-meter__val--fail { color: var(--listen-tx); }
+.rk-meter__track { height: 5px; border-radius: 3px; background: color-mix(in srgb, var(--ink) 10%, transparent); overflow: hidden; }
+.rk-meter__fill { display: block; height: 100%; border-radius: 3px; background: color-mix(in srgb, var(--ink) 45%, transparent); transition: width .4s ease; }
+.rk-meter__fill--hold { background: var(--hold); }
+.rk-meter__fill--fail { background: var(--listen); }
+.rk-meter__note { font-family: var(--mono); font-size: 9px; color: var(--ink3); font-variant-numeric: tabular-nums; }
+@media (prefers-reduced-motion: reduce) { .rk-meter__fill { transition: none; } }

--- a/ui/src/v2/ui/roomkit.tsx
+++ b/ui/src/v2/ui/roomkit.tsx
@@ -33,6 +33,42 @@ export function StatsStrip({ items }: { items: { k: string; n: React.ReactNode; 
   );
 }
 
+/* ── Meter ── */
+/* A labelled progress bar. Announced as a real progressbar so the value is not
+   carried by colour alone — the amber/red tones are a second signal, never the
+   only one. `value` may be null ("unavailable"), which renders an empty track
+   rather than a full-looking zero. */
+export function Meter({ label, value, note, tone = "mut" }: {
+  label: React.ReactNode;
+  value: number | null;
+  note?: React.ReactNode;
+  tone?: "mut" | "hold" | "fail";
+}) {
+  const width = value === null ? 0 : Math.max(0, Math.min(100, value));
+  return (
+    <div className="rk-meter">
+      <div className="rk-meter__top">
+        <span className="rk-meter__label">{label}</span>
+        <span className={`rk-meter__val rk-meter__val--${tone}`}>
+          {value === null ? "unavailable" : `${Math.round(value)}%`}
+        </span>
+      </div>
+      <div
+        className="rk-meter__track"
+        role="progressbar"
+        aria-label={typeof label === "string" ? label : undefined}
+        aria-valuenow={value === null ? undefined : Math.round(value)}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuetext={value === null ? "unavailable" : undefined}
+      >
+        <span className={`rk-meter__fill rk-meter__fill--${tone}`} style={{ width: `${width}%` }} />
+      </div>
+      {note && <div className="rk-meter__note">{note}</div>}
+    </div>
+  );
+}
+
 /* ── Tabs ── */
 export function Tabs({ tabs, active, onChange }: { tabs: { key: string; label: string }[]; active: string; onChange: (k: string) => void }) {
   return (


### PR DESCRIPTION
Hosted tenants get two enforced LLM budgets — a 6-hour session window and a week — and until now the only signal either was full was the assistant refusing to answer. This adds a meter and warnings ahead of the wall.

Requires the control-plane half (usejarvis/hosting `0409652`), which serves `POST /api/llm/instance-usage` and renders `usage_url` / `instance_id` / `usage_secret` into the instance's `usejarvis_ai` block. Self-hosted installs are unaffected: the route answers 503 and every surface stays dark.

## What's here

**Reader + route** — `src/daemon/hosted-usage.ts` reads the meter over a signed POST; `GET /api/llm/budget` exposes it. Both windows come from that one endpoint: the 6h window is readable from `/key/info`, but the week's allowance comes from plan grants the instance doesn't hold, and splitting the two would put a second conversion site between the assistant and the dashboard.

The reader is a module singleton for its cache but holds **no config** — config arrives per call, so a SIGHUP secret rotation is picked up without a restart. The cache key is the credentials themselves, so a converge invalidates the reading rather than serving a minute obtained under a key we no longer hold.

**Meter** — a strip at the top of the Usage room, above the local telemetry (they don't tie out and shouldn't be read as if they do). The route's own 503 is the hosted gate, so there's no second probe that can disagree with it. Tri-state: an unreachable daemon stays `unknown`, never "self" — `OnboardingWizard.tsx` records what that bug cost last time. A null session reading renders "unavailable", never 0%.

**Warnings** — 75% and exhausted, per window, as OS notifications plus the room banner. `usage` is a new value in the sidecar's closed `Kind` enum, with a macOS category (an unregistered identifier renders the alert with no buttons).

Dedup is **persisted** and keyed by the window's own reset stamp. The in-memory set the approval poll uses is right for approvals, which live minutes; across a six-hour window it would re-notify on every daemon restart. The stamp makes the flag self-expire with no clock arithmetic. Crossing both thresholds between checks sends one notification, not two. A pass with no sidecar connected leaves the flag unset, so the warning still lands when a machine reconnects — and a reconnect triggers an immediate check rather than waiting out the quarter-hour.

## One thing to know before merging

`blocked` does **not** mean "the proxy is refusing you". It's LiteLLM's explicit key-block flag, and the control plane only ever sets it for a user with no plan or a converge that failed part-way — never on budget exhaustion. The first pass here was built on the opposite assumption and would have told a paying user their usage was "used up" while the meter read 3%. The last commit corrects that.

What this leaves open: the 6-hour window is sound, because `sessionPct` is spend ÷ the very `max_budget` the proxy enforces, so 100% there *is* the refusal condition. The **week** is not — the proxy enforces a rolling 7d from key creation while we display Monday-aligned, and nothing reads the proxy's own weekly counter. Those disagree for nearly every user (a key minted Thursday runs Thu→Thu). A refusal on the proxy's week is invisible to this meter; the chat error copy in `src/util/hosted-error.ts` remains the only signal. Closing it needs a `/user/info` read whose response shape has to be probed live first — that's the live half of POC item 1, written up in `docs/LLM.md` on the control-plane side rather than papered over here.

## Testing

`bunx tsc --noEmit`, `bun test` (2512 pass, 0 fail), `bun run build:ui`, `go build ./...` in `sidecar/`.

New tests cover the decision logic rather than restating the implementation: threshold crossing, restart inside a window, window rollover, pruning, overlapping passes, flag-written-before-send, no-sidecar-leaves-flag-unset, and the tri-state gate (extracted to a pure function — there's no DOM in this suite, so a decision left inside the hook is a decision nothing checks). A cross-module test pins the daemon and the room to the same threshold and meter shape, since neither imports the other.
