### PR TITLE
feat(sidecar): open the dashboard on a brain's first run and add an open-at-startup preference

### DIFF
--- a/sidecar/client.go
+++ b/sidecar/client.go
@@ -51,14 +51,17 @@ type SidecarClient struct {
 	// and written by connectAndServe; Stop() clears it from the signal-handler
 	// goroutine. atomic.Pointer makes those cross-goroutine accesses race-free
 	// (c.mu intentionally does not cover conn).
-	conn            atomic.Pointer[websocket.Conn]
-	reconnectDelay  time.Duration
-	stopped         bool
-	incompatible    bool         // brain hard-blocked us (version < MIN); do not reconnect
-	connState       atomic.Int32 // connConnecting/connConnected/connError (tray icon + status)
-	alertOnce       sync.Once    // show the invalid-token pop-up at most once
-	availableCaps   []SidecarCapability
-	unavailableCaps []UnavailableCapability
+	conn           atomic.Pointer[websocket.Conn]
+	reconnectDelay time.Duration
+	stopped        bool
+	incompatible   bool         // brain hard-blocked us (version < MIN); do not reconnect
+	connState      atomic.Int32 // connConnecting/connConnected/connError (tray icon + status)
+	alertOnce      sync.Once    // show the invalid-token pop-up at most once
+	// openDashboardOnce gates the "Open dashboard at startup" preference to a
+	// single firing per process — see shouldOpenDashboardAtStartup.
+	openDashboardOnce sync.Once
+	availableCaps     []SidecarCapability
+	unavailableCaps   []UnavailableCapability
 
 	shutdown  func()             // full process-shutdown (client stop + ctx cancel); set by runWithTray
 	obsCancel context.CancelFunc // cancel function for running observers
@@ -369,6 +372,25 @@ func (c *SidecarClient) applyPebblePrefs() {
 	}
 }
 
+// shouldOpenDashboardAtStartup reports whether this connection should open the
+// dashboard window because of the "Open dashboard at startup" preference.
+//
+// True at most once per process, and only on the FIRST successful registration:
+// the panel needs a minted access token and the brain origin, so it cannot run
+// before we are connected, and a reconnect must never re-open a window the user
+// deliberately closed. The once-guard is consumed on the first call regardless
+// of the preference, so toggling the setting on mid-session does not retro-fire
+// on the next reconnect — it is a *startup* setting and takes effect on the
+// next launch.
+func (c *SidecarClient) shouldOpenDashboardAtStartup() bool {
+	first := false
+	c.openDashboardOnce.Do(func() { first = true })
+	if !first {
+		return false
+	}
+	return c.Preferences().OpenDashboardAtStartup
+}
+
 func (c *SidecarClient) reloadConfig() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -512,6 +534,19 @@ func (c *SidecarClient) connectAndServe(ctx context.Context) error {
 	c.mu.Unlock()
 
 	StartObservers(obsCtx, c.config, c.availableCaps, sendFn)
+
+	// "Open dashboard at startup" — the user asked to see the full window and
+	// not just the pebble. Placed after the c.mu block above so obsCtx is
+	// already published when OpenChat snapshots it, and on its own goroutine
+	// because minting the panel's access token is a network round-trip that
+	// must not stall this loop.
+	// OpenChat already handles every failure itself (no 'windows' capability,
+	// unknown brain origin, mint failure) and focuses the window instead of
+	// spawning a second one if it is somehow already open.
+	if c.shouldOpenDashboardAtStartup() {
+		log.Println("[sidecar] opening the dashboard (open-at-startup preference)")
+		go c.OpenChat()
+	}
 
 	// Wire the pebble's summon hotkey to the brain via a SidecarEvent.
 	// The daemon listens for "pebble.summon" and drives state transitions

--- a/sidecar/client_test.go
+++ b/sidecar/client_test.go
@@ -47,3 +47,64 @@ func TestNormalizeBrainOverrideAcceptsHTTPOrigin(t *testing.T) {
 		t.Fatalf("expected %q, got %q", want, got)
 	}
 }
+
+// newTestClientWithPref builds a client whose only interesting property is the
+// "Open dashboard at startup" preference. testConfig() restricts capabilities to
+// pure-Go ones, so no GTK overlay or browser is constructed.
+func newTestClientWithPref(t *testing.T, openAtStartup bool) *SidecarClient {
+	t.Helper()
+	cfg := testConfig()
+	cfg.Token = fakeToken(t, SidecarTokenClaims{
+		Sub:   "sidecar:test",
+		Sid:   "sid",
+		Name:  "test",
+		Brain: "ws://127.0.0.1:3142/sidecar/connect",
+		Iat:   1,
+	})
+	cfg.Preferences.OpenDashboardAtStartup = openAtStartup
+	client, err := NewSidecarClient(cfg)
+	if err != nil {
+		t.Fatalf("NewSidecarClient returned error: %v", err)
+	}
+	return client
+}
+
+// TestShouldOpenDashboardAtStartup covers the three cases that matter: the
+// preference is off (never), on (exactly once), and the reconnect case — a
+// second registration on the same process must NOT re-open a window the user
+// deliberately closed.
+func TestShouldOpenDashboardAtStartup(t *testing.T) {
+	t.Run("off: never opens", func(t *testing.T) {
+		c := newTestClientWithPref(t, false)
+		if c.shouldOpenDashboardAtStartup() {
+			t.Fatal("preference is off — should not open the dashboard")
+		}
+		if c.shouldOpenDashboardAtStartup() {
+			t.Fatal("preference is off — should not open on reconnect either")
+		}
+	})
+
+	t.Run("on: opens exactly once", func(t *testing.T) {
+		c := newTestClientWithPref(t, true)
+		if !c.shouldOpenDashboardAtStartup() {
+			t.Fatal("preference is on — the first registration should open the dashboard")
+		}
+		if c.shouldOpenDashboardAtStartup() {
+			t.Fatal("a reconnect must not re-open the dashboard")
+		}
+	})
+
+	t.Run("toggled on mid-session does not retro-fire", func(t *testing.T) {
+		c := newTestClientWithPref(t, false)
+		if c.shouldOpenDashboardAtStartup() {
+			t.Fatal("preference is off — should not open the dashboard")
+		}
+		// The settings window can flip this while the sidecar is running; it is
+		// a *startup* setting, so it must take effect on the next launch, not on
+		// the next reconnect.
+		c.config.Preferences.OpenDashboardAtStartup = true
+		if c.shouldOpenDashboardAtStartup() {
+			t.Fatal("a mid-session toggle must not open the dashboard on reconnect")
+		}
+	})
+}

--- a/sidecar/config_test.go
+++ b/sidecar/config_test.go
@@ -120,3 +120,64 @@ func TestSaveConfigRefusesSymlink(t *testing.T) {
 		t.Fatalf("decoy was overwritten: got %q, want %q", data, "innocent")
 	}
 }
+
+// TestOpenDashboardAtStartupDefaultsOff locks in the off-by-default contract
+// for the "Open dashboard at startup" preference: a config file written before
+// the key existed must load as false, not pop a window on the user's next
+// launch. Mirrors TestAwarenessOCRDefault, but the polarity is the point here —
+// the zero value IS the default, so unlike telemetry this needs no pointer.
+func TestOpenDashboardAtStartupDefaultsOff(t *testing.T) {
+	cases := []struct {
+		name string
+		yaml string
+		want bool
+	}{
+		{"no preferences block", "token: abc\n", false},
+		{"preferences without the key", "preferences:\n  start_at_startup: true\n", false},
+		{"explicit false", "preferences:\n  open_dashboard_at_startup: false\n", false},
+		{"explicit true", "preferences:\n  open_dashboard_at_startup: true\n", true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := defaultConfig()
+			if cfg.Preferences.OpenDashboardAtStartup {
+				t.Fatal("defaultConfig must leave open_dashboard_at_startup off")
+			}
+			if err := yaml.Unmarshal([]byte(tc.yaml), &cfg); err != nil {
+				t.Fatalf("yaml: %v", err)
+			}
+			if cfg.Preferences.OpenDashboardAtStartup != tc.want {
+				t.Fatalf("OpenDashboardAtStartup = %v, want %v", cfg.Preferences.OpenDashboardAtStartup, tc.want)
+			}
+		})
+	}
+}
+
+// TestOpenDashboardAtStartupRoundTrips proves the toggle survives the on-disk
+// write/read cycle (SaveConfig -> LoadConfig).
+func TestOpenDashboardAtStartupRoundTrips(t *testing.T) {
+	originalConfigDir := configDir
+	originalConfigFile := configFile
+	t.Cleanup(func() {
+		configDir = originalConfigDir
+		configFile = originalConfigFile
+	})
+
+	configDir = filepath.Join(t.TempDir(), ".jarvis")
+	configFile = filepath.Join(configDir, "sidecar.yaml")
+
+	cfg := defaultConfig()
+	cfg.Preferences.OpenDashboardAtStartup = true
+	if err := SaveConfig(&cfg); err != nil {
+		t.Fatalf("SaveConfig: %v", err)
+	}
+
+	loaded, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if !loaded.Preferences.OpenDashboardAtStartup {
+		t.Fatal("OpenDashboardAtStartup did not survive the save/load round trip")
+	}
+}

--- a/sidecar/settings_window.go
+++ b/sidecar/settings_window.go
@@ -29,10 +29,11 @@ func (c *SidecarClient) OpenSettings() {
 type settingsState struct {
 	Status string `json:"status"` // "connected" | "connecting" | "error"
 	Prefs  struct {
-		StartAtStartup      bool `json:"start_at_startup"`
-		EtherealPebble      bool `json:"ethereal_pebble"`
-		EtherealIdleSeconds int  `json:"ethereal_idle_seconds"`
-		TelemetryEnabled    bool `json:"telemetry_enabled"`
+		StartAtStartup         bool `json:"start_at_startup"`
+		OpenDashboardAtStartup bool `json:"open_dashboard_at_startup"`
+		EtherealPebble         bool `json:"ethereal_pebble"`
+		EtherealIdleSeconds    int  `json:"ethereal_idle_seconds"`
+		TelemetryEnabled       bool `json:"telemetry_enabled"`
 	} `json:"prefs"`
 }
 
@@ -66,6 +67,7 @@ func (c *SidecarClient) runSettingsWindow() {
 			var st settingsState
 			st.Status = connStateString(c.ConnState())
 			st.Prefs.StartAtStartup = prefs.StartAtStartup
+			st.Prefs.OpenDashboardAtStartup = prefs.OpenDashboardAtStartup
 			st.Prefs.EtherealPebble = prefs.EtherealPebble
 			st.Prefs.EtherealIdleSeconds = prefs.EtherealIdleSeconds
 			if st.Prefs.EtherealIdleSeconds <= 0 {
@@ -142,6 +144,10 @@ func (c *SidecarClient) runSettingsWindow() {
 					return fmt.Errorf("Could not %s start-at-startup: %v", verb, err)
 				}
 				return c.editConfig(func(cfg *SidecarConfig) { cfg.Preferences.StartAtStartup = enabled })
+			case "open_dashboard_at_startup":
+				// Read once per launch (shouldOpenDashboardAtStartup), so there
+				// is no live state to apply here — just persist the choice.
+				return c.editConfig(func(cfg *SidecarConfig) { cfg.Preferences.OpenDashboardAtStartup = enabled })
 			case "ethereal_pebble":
 				if err := c.editConfig(func(cfg *SidecarConfig) { cfg.Preferences.EtherealPebble = enabled }); err != nil {
 					return err
@@ -283,6 +289,10 @@ const settingsWindowHTML = `<!doctype html>
       <div class="sl7"><div class="a">Start at system startup</div><div class="b">Launch the sidecar automatically when you log in.</div></div>
       <div class="sv7"><label class="sw"><input type="checkbox" id="start_at_startup" onchange="togglePref(this)"><span class="track"></span></label></div>
     </div>
+    <div class="srow">
+      <div class="sl7"><div class="a">Open dashboard at startup</div><div class="b">Show the full Jarvis window every time the sidecar starts, not just the pebble.</div></div>
+      <div class="sv7"><label class="sw"><input type="checkbox" id="open_dashboard_at_startup" onchange="togglePref(this)"><span class="track"></span></label></div>
+    </div>
   </div>
 
   <div class="sec">Style</div>
@@ -341,6 +351,7 @@ const settingsWindowHTML = `<!doctype html>
     var st = await window.getState();
     paintStatus(st.status);
     document.getElementById('start_at_startup').checked = !!st.prefs.start_at_startup;
+    document.getElementById('open_dashboard_at_startup').checked = !!st.prefs.open_dashboard_at_startup;
     document.getElementById('ethereal_pebble').checked = !!st.prefs.ethereal_pebble;
     document.getElementById('ethereal_idle_seconds').value = st.prefs.ethereal_idle_seconds || 5;
     document.getElementById('telemetry_enabled').checked = !!st.prefs.telemetry_enabled;

--- a/sidecar/tray_actions.go
+++ b/sidecar/tray_actions.go
@@ -42,7 +42,12 @@ func (c *SidecarClient) openRoom(id PanelID, route, title string, w, h int) {
 	// never the long-lived enrollment JWT (c.config.Token) — so injecting the
 	// enrollment JWT here returns a 401. Mirrors the brain-driven panel.spawn
 	// path, which mints via this same provider (NewHandlerRegistry(..., c.tokenProvider.Token)).
+	// Snapshot obsCtx under the lock: connectAndServe re-writes it under c.mu on
+	// every reconnect, and openRoom runs on a tray / startup goroutine — an
+	// unlocked read of the interface value races a reconnect that lands mid-open.
+	c.mu.Lock()
 	ctx := c.obsCtx
+	c.mu.Unlock()
 	if ctx == nil {
 		ctx = context.Background()
 	}

--- a/sidecar/types.go
+++ b/sidecar/types.go
@@ -150,6 +150,12 @@ type TelemetryConfig struct {
 type PreferencesConfig struct {
 	// General
 	StartAtStartup bool `yaml:"start_at_startup"` // register the sidecar to launch on login
+	// OpenDashboardAtStartup opens the dashboard window on every sidecar
+	// startup (once the brain connection is up, since the panel needs a
+	// minted access token). Off by default: normally only the pebble appears.
+	// A plain bool is right here — false IS the default, so a config file
+	// written before this key existed reads correctly as off.
+	OpenDashboardAtStartup bool `yaml:"open_dashboard_at_startup"`
 	// Style
 	EtherealPebble      bool `yaml:"ethereal_pebble"`       // fade the pebble out while idle, pop it back on activity
 	EtherealIdleSeconds int  `yaml:"ethereal_idle_seconds"` // idle time before the pebble fades out (default 5)

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -49,6 +49,8 @@ import { DeferredExecutor } from "../authority/deferred-executor.ts";
 import { applyApprovalDecision } from "./approval-decision.ts";
 import { sendDesktopNotification } from "../comms/desktop-notify.ts";
 import { SidecarManager, buildEnrollmentUrls } from "../sidecar/manager.ts";
+import { claimDashboardIntro } from "../sidecar/first-run.ts";
+import type { ConnectedSidecar } from "../sidecar/types.ts";
 import { resolveExternalOrigin } from "../util/external-origin.ts";
 import { ensureWorkflowSchema } from "../workflows/db/index.ts";
 import { Worker as WorkflowWorker } from "../workflows/queue/worker.ts";
@@ -1093,6 +1095,53 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
         return Buffer.concat([header, pcm]);
       };
 
+      // The very first sidecar ever to connect to THIS brain gets the dashboard
+      // opened alongside the pebble: a lone pebble on a fresh install reads as
+      // "nothing happened", and on Linux there is no tray to find the dashboard
+      // from. Scoped to the brain (claimDashboardIntro persists the flag in the
+      // vault), so a re-issued enrollment token or a second machine is NOT a
+      // first run. Distinct from the sidecar-local "Open dashboard at startup"
+      // preference, which the sidecar honours itself on every launch.
+      //
+      // Never throws: this is a nicety, and the caller's catch block owns the
+      // pebble's spawn bookkeeping — a failure here must not un-guard that.
+      const openFirstRunDashboard = async (sidecar: ConnectedSidecar): Promise<void> => {
+        // Everything lives inside the try — claimDashboardIntro() does
+        // synchronous SQLite I/O and can throw on a sick vault, and the caller's
+        // catch owns the pebble's spawn bookkeeping.
+        try {
+          // Without the 'windows' capability the sidecar has no panel service at
+          // all, so the spawn could only fail — leave the intro unclaimed for a
+          // capable sidecar instead of burning it here.
+          if (!sidecar.capabilities.includes('windows')) return;
+          if (!claimDashboardIntro()) return;
+          // The full dashboard SPA at '#/' — the same window (and the same
+          // panel id) the tray's "Open dashboard" opens, so this can never
+          // produce a duplicate. NOT dashboardURL(), which renders a single
+          // chrome-less room body.
+          await sidecarManager.dispatchRPC(sidecar.id, 'panel.spawn', {
+            id: 'tray:chat',
+            url: `${pebblePanelOrigin}/#/`,
+            title: 'JARVIS',
+            bounds: { x: -1, y: -1, w: 1100, h: 760 },
+            resizable: true,
+            multi_instance: false,
+          });
+          console.log(`[ambient-ui] first-run dashboard opened on ${sidecar.id}`);
+        } catch (err) {
+          // Losing the race for the 'tray:chat' id (the user clicked the tray, or
+          // the sidecar's own open-at-startup preference got there first) means
+          // the dashboard IS up — the intro's whole purpose is served. Not a
+          // failure; say so rather than crying wolf in the log.
+          const msg = err instanceof Error ? err.message : String(err);
+          if (msg.includes('panel already exists')) {
+            console.log(`[ambient-ui] first-run dashboard already open on ${sidecar.id}`);
+            return;
+          }
+          console.warn(`[ambient-ui] first-run dashboard open failed on ${sidecar.id}:`, err);
+        }
+      };
+
       sidecarManager.onSidecarConnected(async (sidecar) => {
         if (!sidecar.capabilities.includes('pebble')) {
           console.log(`[ambient-ui] Sidecar ${sidecar.id} lacks 'pebble' capability — skipping native pebble spawn`);
@@ -1113,6 +1162,13 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
           const awarenessEnabled = (jarvisConfig.awareness as { enabled?: boolean })?.enabled ?? true;
           sidecarManager.dispatchRPC(sidecar.id, 'pebble.set_blinded', { blinded: !awarenessEnabled })
             .catch(() => { /* sidecar might not have the cap yet */ });
+          // Deliberately last: the pebble comes up first, then the dashboard
+          // lands behind it. Note this ties the intro to the 'pebble'
+          // capability — unreachable today (both 'pebble' and 'windows' are
+          // defaults, and LoadConfig re-adds any default a config file drops),
+          // but if pebble ever becomes disableable, hoist this call out of the
+          // pebble gate or a windows-only sidecar will see nothing at all.
+          await openFirstRunDashboard(sidecar);
         } catch (err) {
           spawnedOn.delete(sidecar.id);
           console.warn(`[ambient-ui] Failed to spawn native pebble on ${sidecar.id}:`, err);

--- a/src/sidecar/enrollment.test.ts
+++ b/src/sidecar/enrollment.test.ts
@@ -130,3 +130,43 @@ test('rotate: fresh sid, old tokens die with the old row', async () => {
     await rm(dir, { recursive: true, force: true });
   }
 });
+
+test('rotate: carries the old row\'s connection history onto the new sid', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'jarvis-rotate-seen-'));
+  initDatabase(':memory:');
+  try {
+    const first = await enrollDevice(dir, 'u1.vps1.usejarvis.host', 'desktop-A', { onExisting: 'upsert' });
+    // Simulate the device having actually connected once.
+    getDb().run('UPDATE sidecars SET last_seen_at = ? WHERE id = ?', ['2026-01-01 00:00:00', first.sidecar.id]);
+
+    const rotated = await enrollDevice(dir, 'u1.vps1.usejarvis.host', 'desktop-A', {
+      onExisting: 'upsert',
+      rotate: true,
+    });
+
+    // Rotation replaces the credential, not the device. Losing last_seen_at here
+    // would make a veteran brain look brand-new to the first-run dashboard
+    // backfill in src/vault/schema.ts and re-show an intro already seen.
+    expect(rotated.sidecar.last_seen_at).toBe('2026-01-01 00:00:00');
+  } finally {
+    closeDb();
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('rotate: a device that never connected stays never-connected', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'jarvis-rotate-unseen-'));
+  initDatabase(':memory:');
+  try {
+    await enrollDevice(dir, 'u1.vps1.usejarvis.host', 'desktop-A', { onExisting: 'upsert' });
+    const rotated = await enrollDevice(dir, 'u1.vps1.usejarvis.host', 'desktop-A', {
+      onExisting: 'upsert',
+      rotate: true,
+    });
+
+    expect(rotated.sidecar.last_seen_at).toBeNull();
+  } finally {
+    closeDb();
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/src/sidecar/enrollment.ts
+++ b/src/sidecar/enrollment.ts
@@ -194,14 +194,23 @@ export async function enrollDevice(
 
   const db = getDb();
   let existing = db
-    .query('SELECT id FROM sidecars WHERE name = ? AND status = ?')
-    .get(trimmed, 'enrolled') as { id: string } | null;
+    .query('SELECT id, last_seen_at FROM sidecars WHERE name = ? AND status = ?')
+    .get(trimmed, 'enrolled') as { id: string; last_seen_at: string | null } | null;
 
   if (existing && options.onExisting === 'reject') {
     throw new Error(`Sidecar "${trimmed}" is already enrolled`);
   }
 
+  // Rotation replaces the CREDENTIAL, not the device: carry the old row's
+  // connection history onto the replacement so "has this brain ever had a
+  // sidecar connect?" stays answerable across a rotate. The first-run dashboard
+  // backfill (src/vault/schema.ts) reads exactly that, and without this a
+  // rotated device looks brand-new and re-triggers a first-run intro the user
+  // has already seen.
+  let rotatedLastSeenAt: string | null = null;
+
   if (existing && options.rotate) {
+    rotatedLastSeenAt = existing.last_seen_at;
     db.run('DELETE FROM sidecars WHERE id = ?', [existing.id]);
     existing = null; // fall through to a brand-new sid
   }
@@ -231,7 +240,13 @@ export async function enrollDevice(
     // strand a device that already received the earlier token.
     db.run('UPDATE sidecars SET token_id = ? WHERE id = ?', [tokenId, id]);
   } else {
-    db.run('INSERT INTO sidecars (id, name, token_id) VALUES (?, ?, ?)', [id, trimmed, tokenId]);
+    // last_seen_at is NULL for a genuinely new device and inherited on a rotate.
+    db.run('INSERT INTO sidecars (id, name, token_id, last_seen_at) VALUES (?, ?, ?, ?)', [
+      id,
+      trimmed,
+      tokenId,
+      rotatedLastSeenAt,
+    ]);
   }
 
   const sidecar = db.query('SELECT * FROM sidecars WHERE id = ?').get(id) as SidecarRecord;

--- a/src/sidecar/first-run.test.ts
+++ b/src/sidecar/first-run.test.ts
@@ -1,0 +1,102 @@
+import { test, expect, describe, beforeEach, afterEach } from 'bun:test';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { initDatabase, closeDb, getDb } from '../vault/schema.ts';
+import { getSetting, setSetting } from '../vault/settings.ts';
+import { claimDashboardIntro, DASHBOARD_INTRO_KEY } from './first-run.ts';
+
+// Inserts a sidecar row; `seen` controls last_seen_at, which is what the
+// schema backfill keys off ("has a sidecar ever actually connected?").
+function insertSidecar(id: string, seen: boolean): void {
+  getDb().run(
+    `INSERT INTO sidecars (id, name, token_id, last_seen_at)
+     VALUES (?, ?, ?, ?)`,
+    [id, `name-${id}`, `tok-${id}`, seen ? '2026-01-01 00:00:00' : null],
+  );
+}
+
+describe('claimDashboardIntro', () => {
+  beforeEach(() => {
+    initDatabase(':memory:');
+  });
+
+  afterEach(() => {
+    closeDb();
+  });
+
+  test('claims exactly once, then never again', () => {
+    expect(claimDashboardIntro()).toBe(true);
+    expect(claimDashboardIntro()).toBe(false);
+    expect(claimDashboardIntro()).toBe(false);
+  });
+
+  test('persists the claim so a daemon restart cannot re-claim', () => {
+    claimDashboardIntro();
+    expect(getSetting(DASHBOARD_INTRO_KEY)).toBe('1');
+  });
+
+  test('never claims when the flag is already set', () => {
+    setSetting(DASHBOARD_INTRO_KEY, '1');
+    expect(claimDashboardIntro()).toBe(false);
+  });
+});
+
+describe('first-run backfill migration', () => {
+  let dataDir: string;
+  let dbPath: string;
+
+  beforeEach(async () => {
+    dataDir = await mkdtemp(join(tmpdir(), 'jarvis-firstrun-'));
+    dbPath = join(dataDir, 'vault.db');
+  });
+
+  afterEach(async () => {
+    closeDb();
+    await rm(dataDir, { recursive: true, force: true });
+  });
+
+  // A file-backed DB is required here: the backfill runs inside initDatabase,
+  // so to prove it we must close and REOPEN the same database — which :memory:
+  // cannot do.
+  test('a brain whose sidecar has already connected is not a first run', () => {
+    initDatabase(dbPath);
+    insertSidecar('sc-1', true);
+    closeDb();
+
+    initDatabase(dbPath);
+    expect(getSetting(DASHBOARD_INTRO_KEY)).toBe('1');
+    expect(claimDashboardIntro()).toBe(false);
+  });
+
+  test('an enrolled-but-never-connected sidecar still leaves the intro available', () => {
+    initDatabase(dbPath);
+    insertSidecar('sc-1', false);
+    closeDb();
+
+    initDatabase(dbPath);
+    expect(getSetting(DASHBOARD_INTRO_KEY)).toBeNull();
+    expect(claimDashboardIntro()).toBe(true);
+  });
+
+  test('a fresh brain with no sidecars can still claim the intro', () => {
+    initDatabase(dbPath);
+    closeDb();
+
+    initDatabase(dbPath);
+    expect(getSetting(DASHBOARD_INTRO_KEY)).toBeNull();
+    expect(claimDashboardIntro()).toBe(true);
+  });
+
+  test('the backfill does not overwrite an existing flag on reopen', () => {
+    initDatabase(dbPath);
+    insertSidecar('sc-1', true);
+    // A value the backfill would clobber if it were an upsert rather than
+    // INSERT OR IGNORE.
+    setSetting(DASHBOARD_INTRO_KEY, 'claimed-by-connect');
+    closeDb();
+
+    initDatabase(dbPath);
+    expect(getSetting(DASHBOARD_INTRO_KEY)).toBe('claimed-by-connect');
+  });
+});

--- a/src/sidecar/first-run.ts
+++ b/src/sidecar/first-run.ts
@@ -1,0 +1,37 @@
+/**
+ * First-run state for the sidecar's ambient UI.
+ *
+ * The very first time a sidecar ever connects to a brain, the only thing the
+ * user sees is the pebble — which reads as "nothing happened". The brain opens
+ * the dashboard once alongside it so the product introduces itself.
+ *
+ * "First time ever" is scoped to the BRAIN, not the machine: the flag lives in
+ * the brain's settings table, so re-issuing an enrollment token or installing
+ * the sidecar on a second PC is not a first run. That is deliberately different
+ * from the sidecar-local "Open dashboard at startup" preference, which fires on
+ * every launch of one machine's sidecar.
+ */
+
+import { getSetting, setSetting } from '../vault/settings.ts';
+
+/** Settings key holding "the first-run dashboard has been shown on this brain". */
+export const DASHBOARD_INTRO_KEY = 'sidecar.dashboard_intro_shown';
+
+/**
+ * One-shot claim of the "first sidecar ever connected to this brain" moment.
+ * Returns true exactly once per brain, and false forever after.
+ *
+ * The flag is claimed BEFORE the caller dispatches anything: if the spawn then
+ * fails, we do not want an unclaimed flag re-firing the attempt on every single
+ * subsequent connect. A one-time intro that occasionally misses is far better
+ * than one that retries forever.
+ *
+ * The read and the write are synchronous with no `await` between them, so two
+ * sidecars connecting in the same tick cannot both win the claim on Bun's
+ * single-threaded event loop.
+ */
+export function claimDashboardIntro(): boolean {
+  if (getSetting(DASHBOARD_INTRO_KEY) !== null) return false;
+  setSetting(DASHBOARD_INTRO_KEY, '1');
+  return true;
+}

--- a/src/vault/schema.ts
+++ b/src/vault/schema.ts
@@ -689,6 +689,20 @@ function createTables(db: Database): void {
     )
   `);
 
+  // Backfill for the first-run dashboard intro (src/sidecar/first-run.ts): a
+  // brain that has ALREADY had a sidecar connect is not a first run, so pre-set
+  // the flag rather than popping an unannounced window on an established
+  // install's next connect. A fresh brain has an empty sidecars table, inserts
+  // nothing, and lets the first real connection claim the intro. Runs at DB
+  // open — before any connection can be served — and INSERT OR IGNORE keeps it
+  // idempotent across daemon restarts. Must stay after the sidecars table above
+  // so the subquery resolves.
+  db.run(`
+    INSERT OR IGNORE INTO settings (key, value)
+    SELECT 'sidecar.dashboard_intro_shown', '1'
+    WHERE EXISTS (SELECT 1 FROM sidecars WHERE last_seen_at IS NOT NULL)
+  `);
+
   // Documents table: vault-stored documents created by JARVIS
   db.run(`
     CREATE TABLE IF NOT EXISTS documents (


### PR DESCRIPTION
## Problem

When the sidecar starts, the only thing that appears is the pebble. New users think nothing happened. On Linux it's worse — there's no tray, so the "Open dashboard" entry that's normally the way in doesn't exist at all.

## Changes

**1. First-run intro (brain-driven).** The first time a sidecar ever connects to a brain, the brain opens the dashboard alongside the pebble.

"First time ever" is scoped to the **brain**, not the machine: a one-shot claim (`claimDashboardIntro`) against the vault's `settings` table. Re-issuing an enrollment token or installing on a second PC does not re-trigger it.

`initDatabase` backfills the flag on any brain where a sidecar has already connected, so this doesn't pop an unannounced window on existing installs.

**2. New sidecar preference — "Open dashboard at startup"** (default off). When on, the sidecar opens the dashboard itself, once per process, after its first successful registration. A reconnect never re-opens a window you closed.

Both paths open the same panel the tray already opens (`tray:chat`, `#/`), and `panelService.Spawn` dedupes on ID, so they can't produce duplicate windows.

**3. Token rotation now preserves `last_seen_at`.** `enroll --rotate` deleted and re-inserted the sidecar row, dropping its connection history — which made a rotated device look brand-new to the backfill and would have re-shown the intro. Rotation replaces the credential, not the device.

## Notes

- The panel URL is still host-pinned and the access token minted sidecar-side; the brain sends a bare URL and no credential.
- The claim is taken *before* dispatch: a failed spawn is a one-time miss rather than a retry on every connect.
- Known accepted gap: on a brand-new brain, if the first sidecar lacks the `windows` capability and the daemon then restarts, the backfill suppresses the intro permanently. One-time miss, never a repeat-fire.

## Testing

16 new tests. Full brain suite 2509 pass / 0 fail; `tsc --noEmit` clean; `check:migrations` OK; sidecar `go vet` clean and `go test -race` green.
