### PR TITLE
fix(realtime): serve realtime voice to hosted tenants whose plan includes it

### DIFF
--- a/src/config/realtime.test.ts
+++ b/src/config/realtime.test.ts
@@ -217,9 +217,28 @@ describe('resolveRealtimeVoice', () => {
     }
   });
 
-  test("a user's own OpenAI key still wins over the hosted path", () => {
+  test('on a HOSTED install the plan serves realtime, not the user\'s own key', () => {
+    // This precedence was deliberately inverted. It used to be "the user's own
+    // key wins", which was safe only while realtime needed an opt-in almost
+    // nobody had. Now that hosted tenants get it by default, that rule billed
+    // a personal OpenAI account at ~$0.30/min — ungated, since a BYO session
+    // carries no modelsUrl and the plan gate skips it, and unbudgeted — for
+    // someone who had merely toggled the feature on.
     const config = withOpenAIProvider(makeConfig(), 'sk-user-own');
     config.usejarvis_ai = { base_url: 'https://llm.usejarvis.host', api_key: 'sk-uj-abc' };
+    config.voice!.realtime = { enabled: true };
+    const res = resolveRealtimeVoice(config);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.resolved.provider).toBe('usejarvis_ai');
+      expect(res.resolved.apiKey).not.toBe('sk-user-own');
+      expect(res.resolved.modelsUrl).toBeTruthy(); // so the plan gate applies
+    }
+  });
+
+  test("a SELF-HOSTED install still uses the user's own OpenAI key", () => {
+    // Nothing else can serve it there, and it is their explicit choice.
+    const config = withOpenAIProvider(makeConfig(), 'sk-user-own');
     config.voice!.realtime = { enabled: true };
     const res = resolveRealtimeVoice(config);
     expect(res.ok).toBe(true);

--- a/src/config/realtime.ts
+++ b/src/config/realtime.ts
@@ -88,13 +88,10 @@ export function resolveRealtimeVoice(
    * Whether realtime is switched on, and on WHOSE authority
    * (daemon/usejarvis-ai.ts realtimeEnablement).
    *
-   * The distinction is load-bearing, not bookkeeping. `hosted-default` means
-   * nobody asked for realtime — it is on only because the plan may include it —
-   * so such a session must resolve to the hosted alias and NEVER to a BYO
-   * OpenAI key. Without that, a hosted tenant who added a personal OpenAI
-   * provider for chat would have every voice turn billed to their own account
-   * at ~$0.30/min, ungated (the plan gate skips BYO sessions) and unbudgeted
-   * (they never set a monthly cap), having opted into none of it.
+   * Only `off` is read here now — a hosted install resolves to the plan's alias
+   * whether the tenant asked or not (see the key selection below), because
+   * scoping that rule to `hosted-default` left the same billing harm reachable
+   * by toggling realtime off and on again.
    *
    * Passed IN rather than read here so this stays a pure function of config —
    * the binding view needs the vault DB to tell an explicit "off" from the
@@ -114,9 +111,25 @@ export function resolveRealtimeVoice(
     return { ok: false, reason: 'Realtime voice disabled (voice.realtime.enabled is false)' };
   }
 
-  // A default-on session spends OUR money at the proxy or it does not happen.
-  // Reading the user's own key here is what would silently bill them.
-  const apiKey = enablement === 'hosted-default' ? '' : findOpenAIProviderKey(config).trim();
+  // On a HOSTED install the plan serves realtime, whoever asked for it.
+  //
+  // Gating this on `hosted-default` alone was not enough: a hosted tenant with
+  // a personal OpenAI key (allowed — hosted installs permit BYO providers for
+  // chat) who merely toggled realtime off and on again became `user-on`, at
+  // which point their own key won and every turn was billed to them at
+  // ~$0.30/min, ungated and unbudgeted — the same harm, one innocent click
+  // away, while the settings tab told them it was included in their plan.
+  //
+  // So BYO is read only where there is no hosted block to serve the session.
+  // The cost is a niche capability: a hosted tenant whose plan EXCLUDES
+  // realtime can no longer spend their own key on it. That is the right trade
+  // — losing a rare feature beats silently charging someone's personal card —
+  // and it makes one rule true everywhere: on a hosted install, realtime is
+  // either included in your plan or it does not run.
+  const hostedForRealtime = Boolean(
+    config.usejarvis_ai?.base_url?.trim() && config.usejarvis_ai?.api_key?.trim(),
+  );
+  const apiKey = hostedForRealtime ? '' : findOpenAIProviderKey(config).trim();
 
   // Hosted fallback: no BYO OpenAI key, but the platform block is live — the
   // proxy serves realtime under the plan-gated uj-realtime alias. A user's

--- a/src/config/realtime.ts
+++ b/src/config/realtime.ts
@@ -52,6 +52,12 @@ const VALID_EFFORTS: RealtimeReasoningEffort[] = ['minimal', 'low', 'medium', 'h
 /**
  * Would a realtime session run on the PLAN rather than on a user's own key?
  *
+ * The twin of `readUsejarvisAiBlock` (daemon/usejarvis-ai.ts) and required to
+ * agree with it on every input — `realtime-enablement.test.ts` pins that over a
+ * table of block shapes. They are separate functions rather than one because
+ * this module must not take a runtime dependency on the daemon layer; the test
+ * is what keeps the duplication honest.
+ *
  * The single predicate behind the money rule, exported so the settings route
  * cannot drift from it. Deliberately a function of the hosted block ALONE —
  * not of whether realtime is currently switched on, and not of whether the
@@ -171,12 +177,16 @@ export function resolveRealtimeVoice(
   // — losing a rare feature beats silently charging someone's personal card —
   // and it makes one rule true everywhere: on a hosted install, realtime is
   // either included in your plan or it does not run.
-  const apiKey = realtimeServedByPlan(config) ? '' : findOpenAIProviderKey(config).trim();
+  const servedByPlan = realtimeServedByPlan(config);
+  // Read only where the plan cannot serve it. On a hosted install this stays
+  // '' and is never consulted — the branch below returns first — which is the
+  // whole money rule in one line.
+  const apiKey = servedByPlan ? '' : findOpenAIProviderKey(config).trim();
 
   // The platform block is live, so the proxy serves realtime under the
   // plan-gated uj-realtime alias and the user's own key is never read.
   const hosted = config.usejarvis_ai;
-  if (realtimeServedByPlan(config)) {
+  if (servedByPlan) {
     // Normalize through URL parsing rather than string surgery: the block is
     // provisioner-written, and each of these typo classes previously derailed
     // the ws(s) derivation into an undialable URL — an uppercase scheme

--- a/src/config/realtime.ts
+++ b/src/config/realtime.ts
@@ -183,10 +183,12 @@ export function resolveRealtimeVoice(
   // whole money rule in one line.
   const apiKey = servedByPlan ? '' : findOpenAIProviderKey(config).trim();
 
-  // The platform block is live, so the proxy serves realtime under the
-  // plan-gated uj-realtime alias and the user's own key is never read.
-  const hosted = config.usejarvis_ai;
   if (servedByPlan) {
+    // The platform block is live (realtimeServedByPlan checked both fields are
+    // non-empty strings, which is what the assertions below rest on), so the
+    // proxy serves realtime under the plan-gated uj-realtime alias and the
+    // user's own key is never read.
+    const hosted = config.usejarvis_ai;
     // Normalize through URL parsing rather than string surgery: the block is
     // provisioner-written, and each of these typo classes previously derailed
     // the ws(s) derivation into an undialable URL — an uppercase scheme

--- a/src/config/realtime.ts
+++ b/src/config/realtime.ts
@@ -69,8 +69,22 @@ const VALID_EFFORTS: RealtimeReasoningEffort[] = ['minimal', 'low', 'medium', 'h
  *    they simply do not get it.
  */
 export function realtimeServedByPlan(config: JarvisConfig): boolean {
-  const hosted = config.usejarvis_ai;
-  return Boolean(hosted?.base_url?.trim() && hosted?.api_key?.trim());
+  const block = config.usejarvis_ai;
+  if (!block || typeof block !== 'object') return false;
+  const { base_url, api_key } = block as Record<string, unknown>;
+  // Typed, not just present. The block is YAML the provisioner wrote, so a
+  // value can be any shape at runtime whatever the TS type says — an unquoted
+  // scalar parses as a number or a boolean, which is the exact case
+  // readUsejarvisAiBlock guards against and warns about. Reaching straight for
+  // `.trim()` threw a TypeError there, and this predicate is called from the
+  // settings route OUTSIDE its try/catch, so one mistyped line in config.yaml
+  // took the whole Voice tab down with a 500.
+  if (typeof base_url !== 'string' || typeof api_key !== 'string') return false;
+  // Trailing slashes stripped before the emptiness test, matching
+  // normalizeBlockUrl — otherwise a base_url of "///" reads as present here
+  // and as absent to hasUsejarvisAi, and the two must never disagree about
+  // whether this install is hosted.
+  return base_url.trim().replace(/\/+$/, '') !== '' && api_key.trim() !== '';
 }
 
 /**

--- a/src/config/realtime.ts
+++ b/src/config/realtime.ts
@@ -1,4 +1,4 @@
-import type { JarvisConfig, RealtimeReasoningEffort } from './types.ts';
+import type { JarvisConfig, RealtimeReasoningEffort, RealtimeVoiceConfig } from './types.ts';
 import { IMPACT_MAP, type ActionCategory } from '../roles/authority.ts';
 
 /**
@@ -83,10 +83,28 @@ function findOpenAIProviderKey(config: JarvisConfig): string {
  */
 export function resolveRealtimeVoice(
   config: JarvisConfig,
+  /**
+   * Whether realtime is switched on, as the BINDING view sees it
+   * (daemon/usejarvis-ai.ts effectiveRealtimeEnabled): a hosted tenant who
+   * never chose gets it on and the plan gate decides per session, while a
+   * BYO-key user keeps the explicit opt-in because realtime spends their own
+   * OpenAI money.
+   *
+   * Passed IN rather than read here so this stays a pure function of config —
+   * the binding view needs the vault DB to tell an explicit "off" from the
+   * default false, and this module is imported by paths that have no DB.
+   * Defaults to the raw config value, which is what a caller without the DB
+   * (and every existing test) should see.
+   */
+  enabled: boolean = config.voice?.realtime?.enabled === true,
 ): RealtimeVoiceResolution {
-  const rt = config.voice?.realtime;
+  // Every read below is defaulted, because the block can be legitimately
+  // ABSENT now: a hosted tenant who never opened the Voice tab has no stored
+  // `voice` section at all, and that is precisely the tenant this path exists
+  // to serve. Previously `!rt?.enabled` returned first and narrowed it away.
+  const rt: Partial<RealtimeVoiceConfig> = config.voice?.realtime ?? {};
 
-  if (!rt?.enabled) {
+  if (!enabled) {
     return { ok: false, reason: 'Realtime voice disabled (voice.realtime.enabled is false)' };
   }
 

--- a/src/config/realtime.ts
+++ b/src/config/realtime.ts
@@ -1,4 +1,5 @@
 import type { JarvisConfig, RealtimeReasoningEffort, RealtimeVoiceConfig } from './types.ts';
+import type { RealtimeEnablement } from '../daemon/usejarvis-ai.ts';
 import { IMPACT_MAP, type ActionCategory } from '../roles/authority.ts';
 
 /**
@@ -84,11 +85,16 @@ function findOpenAIProviderKey(config: JarvisConfig): string {
 export function resolveRealtimeVoice(
   config: JarvisConfig,
   /**
-   * Whether realtime is switched on, as the BINDING view sees it
-   * (daemon/usejarvis-ai.ts effectiveRealtimeEnabled): a hosted tenant who
-   * never chose gets it on and the plan gate decides per session, while a
-   * BYO-key user keeps the explicit opt-in because realtime spends their own
-   * OpenAI money.
+   * Whether realtime is switched on, and on WHOSE authority
+   * (daemon/usejarvis-ai.ts realtimeEnablement).
+   *
+   * The distinction is load-bearing, not bookkeeping. `hosted-default` means
+   * nobody asked for realtime — it is on only because the plan may include it —
+   * so such a session must resolve to the hosted alias and NEVER to a BYO
+   * OpenAI key. Without that, a hosted tenant who added a personal OpenAI
+   * provider for chat would have every voice turn billed to their own account
+   * at ~$0.30/min, ungated (the plan gate skips BYO sessions) and unbudgeted
+   * (they never set a monthly cap), having opted into none of it.
    *
    * Passed IN rather than read here so this stays a pure function of config —
    * the binding view needs the vault DB to tell an explicit "off" from the
@@ -96,7 +102,7 @@ export function resolveRealtimeVoice(
    * Defaults to the raw config value, which is what a caller without the DB
    * (and every existing test) should see.
    */
-  enabled: boolean = config.voice?.realtime?.enabled === true,
+  enablement: RealtimeEnablement = config.voice?.realtime?.enabled === true ? 'user-on' : 'off',
 ): RealtimeVoiceResolution {
   // Every read below is defaulted, because the block can be legitimately
   // ABSENT now: a hosted tenant who never opened the Voice tab has no stored
@@ -104,11 +110,13 @@ export function resolveRealtimeVoice(
   // to serve. Previously `!rt?.enabled` returned first and narrowed it away.
   const rt: Partial<RealtimeVoiceConfig> = config.voice?.realtime ?? {};
 
-  if (!enabled) {
+  if (enablement === 'off') {
     return { ok: false, reason: 'Realtime voice disabled (voice.realtime.enabled is false)' };
   }
 
-  const apiKey = findOpenAIProviderKey(config).trim();
+  // A default-on session spends OUR money at the proxy or it does not happen.
+  // Reading the user's own key here is what would silently bill them.
+  const apiKey = enablement === 'hosted-default' ? '' : findOpenAIProviderKey(config).trim();
 
   // Hosted fallback: no BYO OpenAI key, but the platform block is live — the
   // proxy serves realtime under the plan-gated uj-realtime alias. A user's

--- a/src/config/realtime.ts
+++ b/src/config/realtime.ts
@@ -50,6 +50,30 @@ const DEFAULT_MAX_SESSION_MINUTES = 10;
 const VALID_EFFORTS: RealtimeReasoningEffort[] = ['minimal', 'low', 'medium', 'high', 'xhigh'];
 
 /**
+ * Would a realtime session run on the PLAN rather than on a user's own key?
+ *
+ * The single predicate behind the money rule, exported so the settings route
+ * cannot drift from it. Deliberately a function of the hosted block ALONE —
+ * not of whether realtime is currently switched on, and not of whether the
+ * plan actually includes the alias:
+ *
+ *  - Independent of enablement, because the settings tab's billing copy renders
+ *    next to the toggle, i.e. to someone deciding whether to switch it ON.
+ *    Deriving it from the current resolution made it false for a hosted tenant
+ *    who had realtime off, so they were told they would be "billed by OpenAI,
+ *    ~$0.30/min" for something their plan would serve for nothing — the same
+ *    false-billing statement this rule exists to prevent, pointed the other way.
+ *  - Independent of the plan's contents, because "who would serve it" and "may
+ *    you have it" are different questions. The catalog gate answers the second,
+ *    and a tenant whose plan excludes realtime still is not billed personally —
+ *    they simply do not get it.
+ */
+export function realtimeServedByPlan(config: JarvisConfig): boolean {
+  const hosted = config.usejarvis_ai;
+  return Boolean(hosted?.base_url?.trim() && hosted?.api_key?.trim());
+}
+
+/**
  * Find the first OpenAI provider key in `llm.providers`. A provider entry's
  * effective kind is `entry.kind ?? name` (matches `instantiateProvider`), so a
  * user-named instance like `"openai-personal"` with `kind: 'openai'` is
@@ -71,16 +95,23 @@ function findOpenAIProviderKey(config: JarvisConfig): string {
 /**
  * Gate + resolve the premium realtime voice mode.
  *
- * Decision (see docs/GPT_REALTIME_2_INTEGRATION.md): entitlement is simply
- * "user has an OpenAI provider configured under llm.providers". The realtime
- * session reuses that key - there is no separate realtime credential. This
- * NEVER throws - when realtime is unavailable it returns `{ ok: false, reason }`
+ * Entitlement is no longer "the user has an OpenAI provider configured", which
+ * is what docs/GPT_REALTIME_2_INTEGRATION.md still describes. There are two
+ * answers now, and which applies is decided by the install:
+ *
+ *  - HOSTED (a complete `usejarvis_ai` block): the plan serves it through the
+ *    proxy's `uj-realtime` alias, and the user's own OpenAI key is never read —
+ *    see realtimeServedByPlan above for why that holds whoever asked for the
+ *    session. Whether the plan actually includes the alias is a separate
+ *    question, answered per session by daemon/realtime-gate.ts.
+ *  - SELF-HOSTED: unchanged. Scan `llm.providers` for a `kind: 'openai'` entry
+ *    and reuse its key (injected from the keychain at startup); LLM credentials
+ *    live only in the DB + keychain, with no config.yaml or env fallback. There
+ *    is no separate realtime credential.
+ *
+ * NEVER throws — when realtime is unavailable it returns `{ ok: false, reason }`
  * so the caller can log a warning and fall back to the standard STT -> LLM ->
  * TTS pipeline.
- *
- * Key resolution: scan `llm.providers` for a `kind: 'openai'` entry and reuse
- * its key (injected from the keychain at startup). LLM credentials live only
- * in the DB + keychain - there is no config.yaml or env fallback.
  */
 export function resolveRealtimeVoice(
   config: JarvisConfig,
@@ -126,17 +157,12 @@ export function resolveRealtimeVoice(
   // — losing a rare feature beats silently charging someone's personal card —
   // and it makes one rule true everywhere: on a hosted install, realtime is
   // either included in your plan or it does not run.
-  const hostedForRealtime = Boolean(
-    config.usejarvis_ai?.base_url?.trim() && config.usejarvis_ai?.api_key?.trim(),
-  );
-  const apiKey = hostedForRealtime ? '' : findOpenAIProviderKey(config).trim();
+  const apiKey = realtimeServedByPlan(config) ? '' : findOpenAIProviderKey(config).trim();
 
-  // Hosted fallback: no BYO OpenAI key, but the platform block is live — the
-  // proxy serves realtime under the plan-gated uj-realtime alias. A user's
-  // own OpenAI provider still wins (their explicit choice, their own spend).
+  // The platform block is live, so the proxy serves realtime under the
+  // plan-gated uj-realtime alias and the user's own key is never read.
   const hosted = config.usejarvis_ai;
-  const hostedReady = Boolean(hosted?.base_url?.trim() && hosted?.api_key?.trim());
-  if (!apiKey && hostedReady) {
+  if (realtimeServedByPlan(config)) {
     // Normalize through URL parsing rather than string surgery: the block is
     // provisioner-written, and each of these typo classes previously derailed
     // the ws(s) derivation into an undialable URL — an uppercase scheme

--- a/src/daemon/api-routes.ts
+++ b/src/daemon/api-routes.ts
@@ -2761,20 +2761,23 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
       GET: () => {
         const voice = ctx.config.voice;
         const rt = voice?.realtime;
-        // Surface whether realtime would actually resolve (BYO key cascade),
-        // so the UI can show "active / no key" without exposing secrets.
-        // The plan gate is part of "available": this flag is what puts the
-        // browser into raw-PCM capture mode, so reporting true for a plan
-        // that excludes uj-realtime makes client and server disagree about
-        // the wire format for a whole utterance. Read the gate's CACHE only —
-        // the dashboard polls this route, and a fetching gate here would turn
-        // that poll into sustained catalog traffic. An unknown verdict stays
-        // available, matching the gate's own advisory-allow stance.
         // The BINDING view, not the raw field: on a hosted install a tenant who
         // never chose gets realtime on, and reporting the stored false here
         // would show an off toggle for a feature that is actually running.
         const enablement = realtimeEnablement(ctx.config);
         const enabledNow = enablement !== 'off';
+        // Whether realtime would actually resolve, so the UI can show its state
+        // without exposing secrets. The plan gate is part of "available": this
+        // flag is what puts the browser into raw-PCM capture mode, so reporting
+        // true for a plan that excludes uj-realtime makes client and server
+        // disagree about the wire format for a whole utterance.
+        //
+        // Read through the CACHE-ONLY gate, which never stalls this poll. It
+        // does now start a background fetch on a miss or a stale entry — that
+        // changed when the boot warm turned out not to cover a cache cleared by
+        // SIGHUP — but the entry it writes ends the misses, so the ceiling is
+        // one request per cache-empty poll rather than one per poll. An unknown
+        // verdict still reads as available, matching the gate's advisory stance.
         let available = false;
         try {
           const res = resolveRealtimeVoice(ctx.config, enablement);

--- a/src/daemon/api-routes.ts
+++ b/src/daemon/api-routes.ts
@@ -12,6 +12,7 @@ import { SecretStorageError } from './section-secrets.ts';
 import type { AgentService } from './agent-service.ts';
 import type { JarvisConfig } from '../config/types.ts';
 import { resolveRealtimeVoice, DEFAULT_BLOCKED_CATEGORIES } from '../config/realtime.ts';
+import { effectiveRealtimeEnabled } from './usejarvis-ai.ts';
 import { hasUsejarvisAi, effectiveSttForBinding, effectiveTtsForBinding, usejarvisVoiceCredentials } from './usejarvis-ai.ts';
 import { cachedRealtimeVerdict } from './realtime-gate.ts';
 import type { EntityType } from '../vault/entities.ts';
@@ -2770,15 +2771,19 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
         // the dashboard polls this route, and a fetching gate here would turn
         // that poll into sustained catalog traffic. An unknown verdict stays
         // available, matching the gate's own advisory-allow stance.
+        // The BINDING view, not the raw field: on a hosted install a tenant who
+        // never chose gets realtime on, and reporting the stored false here
+        // would show an off toggle for a feature that is actually running.
+        const enabledNow = effectiveRealtimeEnabled(ctx.config);
         let available = false;
         try {
-          const res = resolveRealtimeVoice(ctx.config);
+          const res = resolveRealtimeVoice(ctx.config, enabledNow);
           available = res.ok && cachedRealtimeVerdict(res.resolved) !== false;
         } catch { available = false; }
         return json({
           wake_engine: voice?.wake_engine ?? 'openwakeword',
           realtime: {
-            enabled: rt?.enabled ?? false,
+            enabled: enabledNow,
             model: rt?.model ?? 'gpt-realtime-2',
             voice: rt?.voice ?? null,
             reasoning_effort: rt?.reasoning_effort ?? 'low',

--- a/src/daemon/api-routes.ts
+++ b/src/daemon/api-routes.ts
@@ -2776,9 +2776,11 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
         const enablement = realtimeEnablement(ctx.config);
         const enabledNow = enablement !== 'off';
         let available = false;
+        let hostedRealtime = false;
         try {
           const res = resolveRealtimeVoice(ctx.config, enablement);
           available = res.ok && cachedRealtimeVerdict(res.resolved) !== false;
+          hostedRealtime = res.ok && res.resolved.provider === 'usejarvis_ai';
         } catch { available = false; }
         return json({
           wake_engine: voice?.wake_engine ?? 'openwakeword',
@@ -2804,6 +2806,11 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
             // Same shape as blocked_categories_default above: the effective
             // value plus a flag saying whose answer it is.
             enabled_default: enablement === 'hosted-default',
+            // Who would actually SERVE a session, not merely whether this
+            // install is hosted. The tab's billing copy keys off this: saying
+            // "included in your plan" while a BYO key was about to be charged
+            // is the assurance that made the billing bug worse than silent.
+            served_by_plan: hostedRealtime,
             hosted: hasUsejarvisAi(ctx.config),
             // true when enabled AND an OpenAI provider key resolves (via
             // llm.providers or env) - reflects whether realtime would actually

--- a/src/daemon/api-routes.ts
+++ b/src/daemon/api-routes.ts
@@ -12,8 +12,7 @@ import { SecretStorageError } from './section-secrets.ts';
 import type { AgentService } from './agent-service.ts';
 import type { JarvisConfig } from '../config/types.ts';
 import { resolveRealtimeVoice, DEFAULT_BLOCKED_CATEGORIES } from '../config/realtime.ts';
-import { effectiveRealtimeEnabled } from './usejarvis-ai.ts';
-import { hasUsejarvisAi, effectiveSttForBinding, effectiveTtsForBinding, usejarvisVoiceCredentials } from './usejarvis-ai.ts';
+import { hasUsejarvisAi, effectiveSttForBinding, effectiveTtsForBinding, realtimeEnablement, usejarvisVoiceCredentials } from './usejarvis-ai.ts';
 import { cachedRealtimeVerdict } from './realtime-gate.ts';
 import type { EntityType } from '../vault/entities.ts';
 import type { CommitmentPriority, CommitmentStatus } from '../vault/commitments.ts';
@@ -2774,10 +2773,11 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
         // The BINDING view, not the raw field: on a hosted install a tenant who
         // never chose gets realtime on, and reporting the stored false here
         // would show an off toggle for a feature that is actually running.
-        const enabledNow = effectiveRealtimeEnabled(ctx.config);
+        const enablement = realtimeEnablement(ctx.config);
+        const enabledNow = enablement !== 'off';
         let available = false;
         try {
-          const res = resolveRealtimeVoice(ctx.config, enabledNow);
+          const res = resolveRealtimeVoice(ctx.config, enablement);
           available = res.ok && cachedRealtimeVerdict(res.resolved) !== false;
         } catch { available = false; }
         return json({
@@ -2797,6 +2797,14 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
             // it is so a client can tell "using the default" from an explicit set.
             blocked_categories: rt?.blocked_categories ?? DEFAULT_BLOCKED_CATEGORIES,
             blocked_categories_default: rt?.blocked_categories === undefined,
+            // WHY it is on, so the tab can stop telling a hosted tenant they
+            // are billed by OpenAI at $0.30/min for something their plan
+            // includes, and can name the real reason it is unavailable ("not
+            // in your plan") instead of "no OpenAI provider is configured".
+            // Same shape as blocked_categories_default above: the effective
+            // value plus a flag saying whose answer it is.
+            enabled_default: enablement === 'hosted-default',
+            hosted: hasUsejarvisAi(ctx.config),
             // true when enabled AND an OpenAI provider key resolves (via
             // llm.providers or env) - reflects whether realtime would actually
             // start if voice_start arrived right now.
@@ -2807,15 +2815,20 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
       POST: async (req: Request) => {
         try {
           const body = await req.json() as Record<string, unknown>;
-          const { saveUserSection } = await import('./user-settings.ts');
+          const { persistUserPatch } = await import('./user-settings.ts');
           const { mergeVoiceConfig, validateVoicePatch } = await import('./config-merge.ts');
 
           const validation = validateVoicePatch(body);
           if (!validation.ok) return error(validation.error, 400);
 
+          // Persist the PATCH over the stored row, never the merged in-memory
+          // section: the latter always carries DEFAULT_CONFIG's
+          // `realtime.enabled: false`, and writing that back reads as the user
+          // explicitly declining realtime. The in-memory config is still
+          // updated below for the next voice_start — the two differ on purpose.
+          persistUserPatch('voice', validation.patch as Record<string, unknown>);
           const freshConfig = ctx.config;
           freshConfig.voice = mergeVoiceConfig(freshConfig.voice, validation.patch);
-          saveUserSection('voice', freshConfig.voice);
           // Update in-memory config so the next voice_start resolves with the
           // new settings — resolveRealtimeVoice reads ctx.config live, so no
           // provider hot-reload is needed (unlike TTS/LLM).

--- a/src/daemon/api-routes.ts
+++ b/src/daemon/api-routes.ts
@@ -11,7 +11,7 @@ import { applyApprovalDecision } from './approval-decision.ts';
 import { SecretStorageError } from './section-secrets.ts';
 import type { AgentService } from './agent-service.ts';
 import type { JarvisConfig } from '../config/types.ts';
-import { resolveRealtimeVoice, DEFAULT_BLOCKED_CATEGORIES } from '../config/realtime.ts';
+import { realtimeServedByPlan, resolveRealtimeVoice, DEFAULT_BLOCKED_CATEGORIES } from '../config/realtime.ts';
 import { hasUsejarvisAi, effectiveSttForBinding, effectiveTtsForBinding, realtimeEnablement, usejarvisVoiceCredentials } from './usejarvis-ai.ts';
 import { cachedRealtimeVerdict } from './realtime-gate.ts';
 import type { EntityType } from '../vault/entities.ts';
@@ -2776,12 +2776,16 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
         const enablement = realtimeEnablement(ctx.config);
         const enabledNow = enablement !== 'off';
         let available = false;
-        let hostedRealtime = false;
         try {
           const res = resolveRealtimeVoice(ctx.config, enablement);
           available = res.ok && cachedRealtimeVerdict(res.resolved) !== false;
-          hostedRealtime = res.ok && res.resolved.provider === 'usejarvis_ai';
         } catch { available = false; }
+        // NOT derived from the resolution above: that is computed under the
+        // CURRENT enablement, so a tenant with realtime off resolves ok:false
+        // and would be told they are billed by OpenAI — next to the toggle
+        // they are deciding whether to flip. Who would serve a session is a
+        // property of the install, not of whether one is switched on.
+        const hostedRealtime = realtimeServedByPlan(ctx.config);
         return json({
           wake_engine: voice?.wake_engine ?? 'openwakeword',
           realtime: {

--- a/src/daemon/api-voice-config.test.ts
+++ b/src/daemon/api-voice-config.test.ts
@@ -378,3 +378,67 @@ describe('a corrupt voice row is not an answer', () => {
     expect(realtimeEnablement(hostedConfig())).toBe('hosted-default');
   });
 });
+
+describe('GET /api/config/voice tells the truth about who pays', () => {
+  let secretsDir: string;
+  let prevSecretsDir: string | undefined;
+  let prevEnv: string | undefined;
+
+  beforeEach(() => {
+    prevSecretsDir = process.env.JARVIS_SECRETS_DIR;
+    prevEnv = process.env.JARVIS_REALTIME_VOICE;
+    delete process.env.JARVIS_REALTIME_VOICE;
+    secretsDir = mkdtempSync(join(tmpdir(), 'jarvis-rt-served-'));
+    process.env.JARVIS_SECRETS_DIR = secretsDir;
+    closeDb();
+    initDatabase(':memory:');
+  });
+  afterEach(() => {
+    closeDb();
+    if (prevSecretsDir === undefined) delete process.env.JARVIS_SECRETS_DIR;
+    else process.env.JARVIS_SECRETS_DIR = prevSecretsDir;
+    if (prevEnv === undefined) delete process.env.JARVIS_REALTIME_VOICE;
+    else process.env.JARVIS_REALTIME_VOICE = prevEnv;
+    rmSync(secretsDir, { recursive: true, force: true });
+  });
+
+  const read = async (config: JarvisConfig) => {
+    const routes = createApiRoutes(makeCtx(config));
+    const res = await getHandler(routes, '/api/config/voice', 'GET')(
+      new Request('http://x/api/config/voice'),
+    );
+    return (await res.json()) as { realtime: { served_by_plan?: boolean; enabled: boolean } };
+  };
+
+  test('a hosted tenant who DECLINED is still told the plan would serve it', async () => {
+    // The regression: served_by_plan was derived from a resolution computed
+    // under the current enablement, so an off toggle made it false — and the
+    // tab then told them they would be "billed by OpenAI, ~$0.30/min", right
+    // next to the switch they were deciding whether to flip. Who would serve a
+    // session is a property of the install, not of whether one is running.
+    setSetting('cfg.voice', JSON.stringify({ realtime: { enabled: false } }));
+    const body = await read(hostedConfig());
+    expect(body.realtime.enabled).toBe(false);
+    expect(body.realtime.served_by_plan).toBe(true);
+  });
+
+  test('a hosted tenant with realtime on is told the same thing', async () => {
+    const body = await read(hostedConfig());
+    expect(body.realtime.enabled).toBe(true);
+    expect(body.realtime.served_by_plan).toBe(true);
+  });
+
+  test('a hosted tenant with a BYO OpenAI key is NOT told they pay for it', async () => {
+    // The whole point of the precedence inversion: their own key is not read
+    // on a hosted install, so the billing copy must not claim otherwise.
+    const config = hostedConfig();
+    config.llm = { providers: { openai: { api_key: 'sk-their-own' } } } as JarvisConfig['llm'];
+    expect((await read(config)).realtime.served_by_plan).toBe(true);
+  });
+
+  test('a self-hosted install says the opposite, because it IS their key', async () => {
+    const config = structuredClone(DEFAULT_CONFIG);
+    config.llm = { providers: { openai: { api_key: 'sk-their-own' } } } as JarvisConfig['llm'];
+    expect((await read(config)).realtime.served_by_plan).toBe(false);
+  });
+});

--- a/src/daemon/api-voice-config.test.ts
+++ b/src/daemon/api-voice-config.test.ts
@@ -6,8 +6,9 @@ import { createApiRoutes, type ApiContext } from './api-routes.ts';
 import { initDatabase, closeDb } from '../vault/schema.ts';
 import { DEFAULT_CONFIG, type JarvisConfig } from '../config/types.ts';
 import { loadUserSection } from './user-settings.ts';
+import { setSetting } from '../vault/settings.ts';
 import { getSecret } from '../vault/keychain.ts';
-import { effectiveSttForBinding, effectiveTtsForBinding, realtimeEnablement } from './usejarvis-ai.ts';
+import { effectiveSttForBinding, effectiveTtsForBinding, realtimeEnablement, resetRealtimeVaultWarningForTest } from './usejarvis-ai.ts';
 
 /**
  * Route-level regressions for the voice-config persistence discipline.
@@ -333,5 +334,47 @@ describe('voice config routes: a save must not silently decline realtime', () =>
     const stored = loadUserSection('voice') as { realtime?: { enabled?: unknown } };
     expect(stored.realtime?.enabled).toBe(false);
     expect(realtimeEnablement(config)).toBe('off');
+  });
+});
+
+describe('a corrupt voice row is not an answer', () => {
+  let secretsDir: string;
+  let prevSecretsDir: string | undefined;
+  let prevEnv: string | undefined;
+
+  beforeEach(() => {
+    prevSecretsDir = process.env.JARVIS_SECRETS_DIR;
+    prevEnv = process.env.JARVIS_REALTIME_VOICE;
+    delete process.env.JARVIS_REALTIME_VOICE;
+    secretsDir = mkdtempSync(join(tmpdir(), 'jarvis-rt-corrupt-'));
+    process.env.JARVIS_SECRETS_DIR = secretsDir;
+    closeDb();
+    initDatabase(':memory:');
+    resetRealtimeVaultWarningForTest();
+  });
+  afterEach(() => {
+    closeDb();
+    if (prevSecretsDir === undefined) delete process.env.JARVIS_SECRETS_DIR;
+    else process.env.JARVIS_SECRETS_DIR = prevSecretsDir;
+    if (prevEnv === undefined) delete process.env.JARVIS_REALTIME_VOICE;
+    else process.env.JARVIS_REALTIME_VOICE = prevEnv;
+    rmSync(secretsDir, { recursive: true, force: true });
+  });
+
+  test('unparseable JSON fails CLOSED rather than reading as "never asked"', () => {
+    // Exercised against the real vault seam, not an injected fake: the default
+    // loader is where the distinction lives. loadUserSection swallows a parse
+    // error and returns undefined — which means "absent", which means "default
+    // it on". A tenant who declined, whose row later corrupts, would have had
+    // realtime switched back on.
+    setSetting('cfg.voice', '{ this is not json');
+    expect(realtimeEnablement(hostedConfig())).toBe('off');
+  });
+
+  test('a well-formed row still answers normally through the same seam', () => {
+    setSetting('cfg.voice', JSON.stringify({ realtime: { enabled: true } }));
+    expect(realtimeEnablement(hostedConfig())).toBe('user-on');
+    setSetting('cfg.voice', JSON.stringify({ wake_engine: 'openwakeword' }));
+    expect(realtimeEnablement(hostedConfig())).toBe('hosted-default');
   });
 });

--- a/src/daemon/api-voice-config.test.ts
+++ b/src/daemon/api-voice-config.test.ts
@@ -6,7 +6,9 @@ import { createApiRoutes, type ApiContext } from './api-routes.ts';
 import { initDatabase, closeDb } from '../vault/schema.ts';
 import { DEFAULT_CONFIG, type JarvisConfig } from '../config/types.ts';
 import { loadUserSection } from './user-settings.ts';
-import { setSetting } from '../vault/settings.ts';
+import { getSetting, setSetting } from '../vault/settings.ts';
+import { persistUserPatch } from './user-settings.ts';
+import { clearRealtimeGateCache } from './realtime-gate.ts';
 import { getSecret } from '../vault/keychain.ts';
 import { effectiveSttForBinding, effectiveTtsForBinding, realtimeEnablement, resetRealtimeVaultWarningForTest } from './usejarvis-ai.ts';
 
@@ -33,9 +35,18 @@ function getHandler(routes: Record<string, unknown>, path: string, method: 'GET'
   return handler;
 }
 
+/**
+ * A hosted install pointed at a host that cannot resolve.
+ *
+ * Deliberately NOT the real `llm.usejarvis.host`: reading the realtime block
+ * misses the plan-gate cache and kicks a background catalog fetch, so a
+ * production hostname here means every unit-test run sends a bearer token at
+ * prod infra — and a 401 back would cache a DEFINITIVE "excluded" in the
+ * module-level gate cache, flaking any later test that asserts availability.
+ */
 function hostedConfig(): JarvisConfig {
   const config = structuredClone(DEFAULT_CONFIG);
-  config.usejarvis_ai = { base_url: 'https://llm.usejarvis.host', api_key: 'sk-uj-abc123' };
+  config.usejarvis_ai = { base_url: 'https://llm.invalid/v1', api_key: 'sk-uj-abc123' };
   return config;
 }
 
@@ -68,6 +79,7 @@ describe('voice config routes: persistence stays silence-preserving', () => {
     process.env.JARVIS_SECRETS_DIR = secretsDir;
     closeDb();
     initDatabase(':memory:');
+    clearRealtimeGateCache();
   });
   afterEach(() => {
     closeDb();
@@ -276,6 +288,7 @@ describe('voice config routes: a save must not silently decline realtime', () =>
     process.env.JARVIS_SECRETS_DIR = secretsDir;
     closeDb();
     initDatabase(':memory:');
+    clearRealtimeGateCache();
   });
   afterEach(() => {
     closeDb();
@@ -392,6 +405,7 @@ describe('GET /api/config/voice tells the truth about who pays', () => {
     process.env.JARVIS_SECRETS_DIR = secretsDir;
     closeDb();
     initDatabase(':memory:');
+    clearRealtimeGateCache();
   });
   afterEach(() => {
     closeDb();
@@ -440,5 +454,68 @@ describe('GET /api/config/voice tells the truth about who pays', () => {
     const config = structuredClone(DEFAULT_CONFIG);
     config.llm = { providers: { openai: { api_key: 'sk-their-own' } } } as JarvisConfig['llm'];
     expect((await read(config)).realtime.served_by_plan).toBe(false);
+  });
+});
+
+describe('replacing an unreadable settings row says so', () => {
+  let secretsDir: string;
+  let prevSecretsDir: string | undefined;
+  let warnings: string[];
+  let realWarn: typeof console.warn;
+
+  beforeEach(() => {
+    prevSecretsDir = process.env.JARVIS_SECRETS_DIR;
+    secretsDir = mkdtempSync(join(tmpdir(), 'jarvis-rt-warn-'));
+    process.env.JARVIS_SECRETS_DIR = secretsDir;
+    closeDb();
+    initDatabase(':memory:');
+    warnings = [];
+    realWarn = console.warn;
+    console.warn = (...args: unknown[]) => { warnings.push(args.join(' ')); };
+  });
+  afterEach(() => {
+    console.warn = realWarn;
+    closeDb();
+    if (prevSecretsDir === undefined) delete process.env.JARVIS_SECRETS_DIR;
+    else process.env.JARVIS_SECRETS_DIR = prevSecretsDir;
+    rmSync(secretsDir, { recursive: true, force: true });
+  });
+
+  const replaced = () => warnings.filter((w) => w.includes('is being REPLACED'));
+
+  test('warns when the row will not parse', () => {
+    // The read path fails closed on corruption; the write path cannot refuse
+    // without locking someone out of their own settings, so it is loud instead
+    // — an explicit realtime decline is about to be lost.
+    setSetting('cfg.voice', '{ not json');
+    persistUserPatch('voice', { wake_engine: 'webspeech' });
+    expect(replaced()).toHaveLength(1);
+  });
+
+  test('warns when the row parses to the WRONG SHAPE', () => {
+    // The earlier condition keyed on loadUserSection returning undefined, which
+    // this case does not: valid JSON of the wrong type parses fine and was
+    // replaced in silence.
+    setSetting('cfg.voice', '[1,2]');
+    persistUserPatch('voice', { wake_engine: 'webspeech' });
+    expect(replaced()).toHaveLength(1);
+  });
+
+  test('stays QUIET for an absent row and for a canonical null row', () => {
+    // saveUserSection writes 'null' for an absent section, so warning on it
+    // would fire on ordinary saves for anyone who has never set voice options.
+    persistUserPatch('voice', { wake_engine: 'webspeech' });
+    expect(replaced()).toHaveLength(0);
+    setSetting('cfg.voice', 'null');
+    persistUserPatch('voice', { wake_engine: 'openwakeword' });
+    expect(replaced()).toHaveLength(0);
+  });
+
+  test('stays quiet for a healthy row, and preserves it', () => {
+    setSetting('cfg.voice', JSON.stringify({ realtime: { enabled: false } }));
+    persistUserPatch('voice', { wake_engine: 'webspeech' });
+    expect(replaced()).toHaveLength(0);
+    const stored = JSON.parse(getSetting('cfg.voice')!) as { realtime?: { enabled?: boolean } };
+    expect(stored.realtime?.enabled).toBe(false); // the decline survived
   });
 });

--- a/src/daemon/api-voice-config.test.ts
+++ b/src/daemon/api-voice-config.test.ts
@@ -4,10 +4,10 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { createApiRoutes, type ApiContext } from './api-routes.ts';
 import { initDatabase, closeDb } from '../vault/schema.ts';
-import { DEFAULT_CONFIG, type JarvisConfig } from '../config/types.ts';
+import { DEFAULT_CONFIG, type JarvisConfig, type VoiceConfig } from '../config/types.ts';
 import { loadUserSection } from './user-settings.ts';
 import { getSetting, setSetting } from '../vault/settings.ts';
-import { persistUserPatch } from './user-settings.ts';
+import { persistUserPatch, saveUserSection } from './user-settings.ts';
 import { clearRealtimeGateCache } from './realtime-gate.ts';
 import { getSecret } from '../vault/keychain.ts';
 import { effectiveSttForBinding, effectiveTtsForBinding, realtimeEnablement, resetRealtimeVaultWarningForTest } from './usejarvis-ai.ts';
@@ -388,6 +388,22 @@ describe('a corrupt voice row is not an answer', () => {
     setSetting('cfg.voice', JSON.stringify({ realtime: { enabled: true } }));
     expect(realtimeEnablement(hostedConfig())).toBe('user-on');
     setSetting('cfg.voice', JSON.stringify({ wake_engine: 'openwakeword' }));
+    expect(realtimeEnablement(hostedConfig())).toBe('hosted-default');
+  });
+
+  test('the reader reads what the WRITER writes — no hardcoded key', () => {
+    // Written through saveUserSection rather than setSetting so the settings
+    // key is never spelled out on the read side. It once was, in a copy of the
+    // `cfg.` prefix: had that prefix changed, the reader would have missed the
+    // row, read it as "never asked", and switched realtime ON for a tenant who
+    // had explicitly declined — silently, and into billed audio sessions.
+    saveUserSection('voice', { realtime: { enabled: false } } as unknown as VoiceConfig);
+    expect(realtimeEnablement(hostedConfig())).toBe('off');
+
+    saveUserSection('voice', { realtime: { enabled: true } } as unknown as VoiceConfig);
+    expect(realtimeEnablement(hostedConfig())).toBe('user-on');
+
+    saveUserSection('voice', { wake_engine: 'openwakeword' } as unknown as VoiceConfig);
     expect(realtimeEnablement(hostedConfig())).toBe('hosted-default');
   });
 });

--- a/src/daemon/api-voice-config.test.ts
+++ b/src/daemon/api-voice-config.test.ts
@@ -7,7 +7,7 @@ import { initDatabase, closeDb } from '../vault/schema.ts';
 import { DEFAULT_CONFIG, type JarvisConfig } from '../config/types.ts';
 import { loadUserSection } from './user-settings.ts';
 import { getSecret } from '../vault/keychain.ts';
-import { effectiveSttForBinding, effectiveTtsForBinding } from './usejarvis-ai.ts';
+import { effectiveSttForBinding, effectiveTtsForBinding, realtimeEnablement } from './usejarvis-ai.ts';
 
 /**
  * Route-level regressions for the voice-config persistence discipline.
@@ -259,5 +259,79 @@ describe('voice config routes: persistence stays silence-preserving', () => {
     expect(body.provider).toBe('usejarvis');
     expect(body.usejarvis_available).toBe(true);
     expect(JSON.stringify(body)).not.toContain('sk-uj-abc123');
+  });
+});
+
+describe('voice config routes: a save must not silently decline realtime', () => {
+  let secretsDir: string;
+  let prevSecretsDir: string | undefined;
+  let prevEnv: string | undefined;
+
+  beforeEach(() => {
+    prevSecretsDir = process.env.JARVIS_SECRETS_DIR;
+    prevEnv = process.env.JARVIS_REALTIME_VOICE;
+    delete process.env.JARVIS_REALTIME_VOICE;
+    secretsDir = mkdtempSync(join(tmpdir(), 'jarvis-api-rt-'));
+    process.env.JARVIS_SECRETS_DIR = secretsDir;
+    closeDb();
+    initDatabase(':memory:');
+  });
+  afterEach(() => {
+    closeDb();
+    if (prevSecretsDir === undefined) delete process.env.JARVIS_SECRETS_DIR;
+    else process.env.JARVIS_SECRETS_DIR = prevSecretsDir;
+    if (prevEnv === undefined) delete process.env.JARVIS_REALTIME_VOICE;
+    else process.env.JARVIS_REALTIME_VOICE = prevEnv;
+    rmSync(secretsDir, { recursive: true, force: true });
+  });
+
+  test('changing the WAKE ENGINE does not turn realtime off', async () => {
+    // The regression: the route merged the patch over the in-memory section,
+    // which always carries DEFAULT_CONFIG's `realtime.enabled: false`, and
+    // saved the whole thing. That false then reads as an explicit decline.
+    const config = hostedConfig();
+    expect(realtimeEnablement(config)).toBe('hosted-default');
+
+    const routes = createApiRoutes(makeCtx(config));
+    const res = await post(getHandler(routes, '/api/config/voice', 'POST'), '/api/config/voice', {
+      wake_engine: 'webspeech',
+    });
+    expect(res.status).toBe(200);
+
+    const stored = loadUserSection('voice') as { wake_engine?: string; realtime?: { enabled?: unknown } };
+    expect(stored.wake_engine).toBe('webspeech');
+    // The patch never mentioned realtime, so the row must not claim an answer.
+    expect(stored.realtime?.enabled).toBeUndefined();
+    expect(realtimeEnablement(config)).toBe('hosted-default');
+  });
+
+  test('picking a realtime VOICE does not turn realtime off', async () => {
+    // The cruellest version: the user is configuring realtime at the moment it
+    // switches itself off, because the partial patch merges over a base that
+    // carries the default false.
+    const config = hostedConfig();
+    const routes = createApiRoutes(makeCtx(config));
+    const res = await post(getHandler(routes, '/api/config/voice', 'POST'), '/api/config/voice', {
+      realtime: { voice: 'cedar' },
+    });
+    expect(res.status).toBe(200);
+
+    const stored = loadUserSection('voice') as { realtime?: { voice?: string; enabled?: unknown } };
+    expect(stored.realtime?.voice).toBe('cedar');
+    expect(stored.realtime?.enabled).toBeUndefined();
+    expect(realtimeEnablement(config)).toBe('hosted-default');
+  });
+
+  test('an EXPLICIT off is still recorded and still wins', async () => {
+    // The flip side: the discipline must not make the toggle unusable.
+    const config = hostedConfig();
+    const routes = createApiRoutes(makeCtx(config));
+    const res = await post(getHandler(routes, '/api/config/voice', 'POST'), '/api/config/voice', {
+      realtime: { enabled: false },
+    });
+    expect(res.status).toBe(200);
+    const stored = loadUserSection('voice') as { realtime?: { enabled?: unknown } };
+    expect(stored.realtime?.enabled).toBe(false);
+    expect(realtimeEnablement(config)).toBe('off');
   });
 });

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -22,10 +22,10 @@ import { createObservation } from "../vault/observations.ts";
 import { ObserverService, mapEventType } from "./observer-service.ts";
 import { WebSocketService } from "./ws-service.ts";
 import { PebbleRealtimeManager } from "./pebble-realtime.ts";
-import { hostedRealtimeIncluded } from './realtime-gate.ts';
+import { hostedRealtimeIncluded, warmRealtimeGateFor } from './realtime-gate.ts';
 import { resolveRealtimeVoice } from "../config/realtime.ts";
-import { effectiveRealtimeEnabled } from "./usejarvis-ai.ts";
-import { warmRealtimeGate } from "./realtime-gate.ts";
+import { realtimeEnablement } from "./usejarvis-ai.ts";
+
 import { REALTIME_NAV_TOOLS, REALTIME_NAV_TOOL_NAMES } from "./realtime-nav-tools.ts";
 import { EventReactor } from "./event-reactor.ts";
 import { EventCoalescer } from "./event-coalescer.ts";
@@ -811,7 +811,7 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
         getAudioChannel: (sidecarId) => sidecarManager.getAudioChannel(sidecarId),
         resolve: () => {
           const cfg = agentService.getConfig();
-          return resolveRealtimeVoice(cfg, effectiveRealtimeEnabled(cfg));
+          return resolveRealtimeVoice(cfg, realtimeEnablement(cfg));
         },
         // Agent tools + the nav tools (open_dashboard_room, …) so realtime voice
         // can drive the desktop UI just like the one-shot path ("open settings").
@@ -846,7 +846,7 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
       // summon hotkey knows to toggle a live session vs. the one-shot capture.
       const advertiseRealtime = async (sidecarId: string) => {
         const cfg = agentService.getConfig();
-        const res = resolveRealtimeVoice(cfg, effectiveRealtimeEnabled(cfg));
+        const res = resolveRealtimeVoice(cfg, realtimeEnablement(cfg));
         // The advertisement must agree with the starters' plan gate, or the
         // summon hotkey opens sessions the plan refuses at dial.
         const enabled = res.ok && (await hostedRealtimeIncluded(res.resolved));
@@ -4191,13 +4191,13 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
     // WITHOUT realtime that first utterance is refused and its frames dropped,
     // so the user speaks and nothing happens. One catalog request at boot
     // removes it; a failure just expires in 30s.
-    try {
+    const warmRealtime = () => warmRealtimeGateFor(() => {
       const rtCfg = agentService.getConfig();
-      const rtRes = resolveRealtimeVoice(rtCfg, effectiveRealtimeEnabled(rtCfg));
-      if (rtRes.ok) warmRealtimeGate(rtRes.resolved);
-    } catch (err) {
-      console.warn('[Daemon] could not warm the realtime plan gate:', err);
-    }
+      return resolveRealtimeVoice(rtCfg, realtimeEnablement(rtCfg));
+    });
+    warmRealtime();
+    // And again after every SIGHUP reload, which clears the verdict cache.
+    settingsReload.setWarmRealtime(warmRealtime);
     // A pass with no sidecar connected leaves its flags unset on purpose, so
     // the warning survives — but it would then wait up to fifteen minutes for
     // the next tick. Re-check as soon as a machine appears, which is exactly

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -25,7 +25,6 @@ import { PebbleRealtimeManager } from "./pebble-realtime.ts";
 import { hostedRealtimeIncluded, warmRealtimeGateFor } from './realtime-gate.ts';
 import { resolveRealtimeVoice } from "../config/realtime.ts";
 import { realtimeEnablement } from "./usejarvis-ai.ts";
-
 import { REALTIME_NAV_TOOLS, REALTIME_NAV_TOOL_NAMES } from "./realtime-nav-tools.ts";
 import { EventReactor } from "./event-reactor.ts";
 import { EventCoalescer } from "./event-coalescer.ts";
@@ -4183,21 +4182,6 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
       canNotify: () => sidecarManager.getConnectedSidecars().length > 0,
     });
     usageAlerts.start();
-
-    // Prime the realtime plan verdict before anyone speaks. Realtime is now on
-    // by default for hosted tenants, so the gate decides for every hosted
-    // install — and with a cold cache GET /api/config/voice reports
-    // "available", which puts the browser into raw-PCM capture. On a plan
-    // WITHOUT realtime that first utterance is refused and its frames dropped,
-    // so the user speaks and nothing happens. One catalog request at boot
-    // removes it; a failure just expires in 30s.
-    const warmRealtime = () => warmRealtimeGateFor(() => {
-      const rtCfg = agentService.getConfig();
-      return resolveRealtimeVoice(rtCfg, realtimeEnablement(rtCfg));
-    });
-    warmRealtime();
-    // And again after every SIGHUP reload, which clears the verdict cache.
-    settingsReload.setWarmRealtime(warmRealtime);
     // A pass with no sidecar connected leaves its flags unset on purpose, so
     // the warning survives — but it would then wait up to fifteen minutes for
     // the next tick. Re-check as soon as a machine appears, which is exactly
@@ -4207,6 +4191,25 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
     sidecarManager.onSidecarConnected(() => {
       void usageAlerts?.check().catch(() => {});
     });
+
+    // Prime the realtime plan verdict before anyone speaks. Realtime is now on
+    // by default for hosted tenants, so the gate decides for every hosted
+    // install — and with a cold cache GET /api/config/voice reports
+    // "available", which puts the browser into raw-PCM capture. On a plan
+    // WITHOUT realtime that first utterance is refused and its frames dropped,
+    // so the user speaks and nothing happens. One catalog request at boot
+    // removes it, and it is issued here — well before registry.startAll()
+    // binds any listener — so the dashboard's first poll already has a verdict.
+    const warmRealtime = () => warmRealtimeGateFor(() => {
+      const rtCfg = agentService.getConfig();
+      return resolveRealtimeVoice(rtCfg, realtimeEnablement(rtCfg));
+    });
+    warmRealtime();
+    // And again after every SIGHUP reload, which clears the verdict cache. A
+    // reload arriving BEFORE this line is registered simply has no warm; the
+    // miss-triggered fetch in cachedRealtimeVerdict covers that gap, which is
+    // why that fetch exists rather than warming being the only defence.
+    settingsReload.setWarmRealtime(warmRealtime);
 
     // Bootstrap the workflow engine: build/locate the bundle, compile pieces,
     // start the loopback SandboxApi, construct the EngineRuntime, extract the

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -25,6 +25,7 @@ import { PebbleRealtimeManager } from "./pebble-realtime.ts";
 import { hostedRealtimeIncluded } from './realtime-gate.ts';
 import { resolveRealtimeVoice } from "../config/realtime.ts";
 import { effectiveRealtimeEnabled } from "./usejarvis-ai.ts";
+import { warmRealtimeGate } from "./realtime-gate.ts";
 import { REALTIME_NAV_TOOLS, REALTIME_NAV_TOOL_NAMES } from "./realtime-nav-tools.ts";
 import { EventReactor } from "./event-reactor.ts";
 import { EventCoalescer } from "./event-coalescer.ts";
@@ -4182,6 +4183,21 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
       canNotify: () => sidecarManager.getConnectedSidecars().length > 0,
     });
     usageAlerts.start();
+
+    // Prime the realtime plan verdict before anyone speaks. Realtime is now on
+    // by default for hosted tenants, so the gate decides for every hosted
+    // install — and with a cold cache GET /api/config/voice reports
+    // "available", which puts the browser into raw-PCM capture. On a plan
+    // WITHOUT realtime that first utterance is refused and its frames dropped,
+    // so the user speaks and nothing happens. One catalog request at boot
+    // removes it; a failure just expires in 30s.
+    try {
+      const rtCfg = agentService.getConfig();
+      const rtRes = resolveRealtimeVoice(rtCfg, effectiveRealtimeEnabled(rtCfg));
+      if (rtRes.ok) warmRealtimeGate(rtRes.resolved);
+    } catch (err) {
+      console.warn('[Daemon] could not warm the realtime plan gate:', err);
+    }
     // A pass with no sidecar connected leaves its flags unset on purpose, so
     // the warning survives — but it would then wait up to fifteen minutes for
     // the next tick. Re-check as soon as a machine appears, which is exactly

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -24,6 +24,7 @@ import { WebSocketService } from "./ws-service.ts";
 import { PebbleRealtimeManager } from "./pebble-realtime.ts";
 import { hostedRealtimeIncluded } from './realtime-gate.ts';
 import { resolveRealtimeVoice } from "../config/realtime.ts";
+import { effectiveRealtimeEnabled } from "./usejarvis-ai.ts";
 import { REALTIME_NAV_TOOLS, REALTIME_NAV_TOOL_NAMES } from "./realtime-nav-tools.ts";
 import { EventReactor } from "./event-reactor.ts";
 import { EventCoalescer } from "./event-coalescer.ts";
@@ -807,7 +808,10 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
         dispatchRPC: (sidecarId, method, params) => sidecarManager.dispatchRPC(sidecarId, method, params ?? {}),
         dispatchNotify: (sidecarId, method, params) => sidecarManager.dispatchNotify(sidecarId, method, params ?? {}),
         getAudioChannel: (sidecarId) => sidecarManager.getAudioChannel(sidecarId),
-        resolve: () => resolveRealtimeVoice(agentService.getConfig()),
+        resolve: () => {
+          const cfg = agentService.getConfig();
+          return resolveRealtimeVoice(cfg, effectiveRealtimeEnabled(cfg));
+        },
         // Agent tools + the nav tools (open_dashboard_room, …) so realtime voice
         // can drive the desktop UI just like the one-shot path ("open settings").
         tools: () => [...agentService.getOrchestrator().getRealtimeTools(), ...REALTIME_NAV_TOOLS],
@@ -840,7 +844,8 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
       // Tell each pebble-capable sidecar whether realtime is available so its
       // summon hotkey knows to toggle a live session vs. the one-shot capture.
       const advertiseRealtime = async (sidecarId: string) => {
-        const res = resolveRealtimeVoice(agentService.getConfig());
+        const cfg = agentService.getConfig();
+        const res = resolveRealtimeVoice(cfg, effectiveRealtimeEnabled(cfg));
         // The advertisement must agree with the starters' plan gate, or the
         // summon hotkey opens sessions the plan refuses at dial.
         const enabled = res.ok && (await hostedRealtimeIncluded(res.resolved));

--- a/src/daemon/realtime-enablement.test.ts
+++ b/src/daemon/realtime-enablement.test.ts
@@ -116,10 +116,10 @@ describe('resolving a session from that decision', () => {
     expect(resolveRealtimeVoice(hosted({ voice: { realtime: { enabled: true } } })).ok).toBe(true);
   });
 
-  test('a BYO OpenAI key still wins over the hosted alias', () => {
-    // Their explicit choice, their own spend — unchanged by this work.
+  test('a SELF-HOSTED install still uses the BYO key', () => {
+    // Nothing else can serve it there, and it is their explicit choice.
     const res = resolveRealtimeVoice(
-      hosted({ llm: { providers: { openai: { api_key: 'sk-real' } } } }),
+      selfHosted({ llm: { providers: { openai: { api_key: 'sk-real' } } } }),
       'user-on',
     );
     expect(res.ok).toBe(true);
@@ -149,15 +149,37 @@ describe('the money boundary — a default-on session must never touch a BYO key
     expect(res.resolved.modelsUrl).toBeTruthy();
   });
 
-  test('but an EXPLICIT yes still lets their own key win', () => {
-    // Their choice, their spend — unchanged.
+  test('and an EXPLICIT yes does not re-open the door', () => {
+    // Scoping the rule to `hosted-default` alone left the harm one click away:
+    // toggling realtime off and on again makes the tenant `user-on`, and their
+    // own key would have won from then on — while the settings tab told them
+    // realtime was included in their plan. On a hosted install the plan serves
+    // it whoever asked.
     const cfg = hosted({
       voice: { realtime: { enabled: true } },
       llm: { providers: { openai: { api_key: 'sk-their-own' } } },
     });
     expect(realtimeEnablement(cfg, stored(undefined))).toBe('user-on');
     const res = resolveRealtimeVoice(cfg, 'user-on');
-    expect(res.ok && res.resolved.provider).toBe('openai');
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.resolved.provider).toBe('usejarvis_ai');
+    expect(res.resolved.apiKey).not.toBe('sk-their-own');
+    expect(res.resolved.modelsUrl).toBeTruthy(); // and the plan gate applies
+  });
+
+  test('a hosted tenant whose plan EXCLUDES realtime is refused, not billed', () => {
+    // The accepted cost of the rule above: their own key is not reached, so
+    // the gate refuses and they fall back to the standard pipeline. Losing a
+    // rare capability beats silently charging someone's personal card.
+    const cfg = hosted({
+      voice: { realtime: { enabled: true } },
+      llm: { providers: { openai: { api_key: 'sk-their-own' } } },
+    });
+    const res = resolveRealtimeVoice(cfg, 'user-on');
+    // Resolution succeeds; the CATALOG gate is what says no at session start,
+    // and it only applies because modelsUrl is present.
+    expect(res.ok && res.resolved.modelsUrl).toBeTruthy();
   });
 });
 

--- a/src/daemon/realtime-enablement.test.ts
+++ b/src/daemon/realtime-enablement.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { hasUsejarvisAi, realtimeEnablement } from './usejarvis-ai.ts';
+import { hasUsejarvisAi, realtimeEnablement, resetRealtimeVaultWarningForTest } from './usejarvis-ai.ts';
 import { realtimeServedByPlan, resolveRealtimeVoice } from '../config/realtime.ts';
 import type { JarvisConfig } from '../config/types.ts';
 
@@ -249,4 +249,27 @@ describe('the two hosted predicates must never disagree', () => {
       expect(realtimeServedByPlan(cfg)).toBe(hasUsejarvisAi(cfg));
     });
   }
+});
+
+describe('a mistyped config block does not flood the log', () => {
+  test('the malformed-block warning fires ONCE, not per read', () => {
+    // A hosted dashboard polls GET /api/config/voice every ~15s and each read
+    // runs hasUsejarvisAi, so one unquoted YAML scalar would print four times
+    // a minute for the life of the daemon.
+    resetRealtimeVaultWarningForTest();
+    const warnings: string[] = [];
+    const realWarn = console.warn;
+    console.warn = (...args: unknown[]) => { warnings.push(args.join(' ')); };
+    try {
+      const cfg = {
+        llm: { providers: {} },
+        usejarvis_ai: { base_url: 8080, api_key: 'sk-uj-x' },
+      } as unknown as JarvisConfig;
+      for (let i = 0; i < 5; i++) hasUsejarvisAi(cfg);
+      expect(warnings.filter((w) => w.includes('malformed usejarvis_ai'))).toHaveLength(1);
+    } finally {
+      console.warn = realWarn;
+      resetRealtimeVaultWarningForTest();
+    }
+  });
 });

--- a/src/daemon/realtime-enablement.test.ts
+++ b/src/daemon/realtime-enablement.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, test } from 'bun:test';
+import { effectiveRealtimeEnabled } from './usejarvis-ai.ts';
+import { resolveRealtimeVoice } from '../config/realtime.ts';
+import type { JarvisConfig } from '../config/types.ts';
+
+/**
+ * Who gets realtime, and who decides.
+ *
+ * The bug this fixes: `voice.realtime.enabled` defaults to false and only the
+ * JARVIS_REALTIME_VOICE env var flipped it, so the hosted branch of
+ * resolveRealtimeVoice — which dials the uj-realtime alias — never ran for a
+ * single hosted tenant, however much their plan included it.
+ */
+
+const hosted = (over: Record<string, unknown> = {}): JarvisConfig =>
+  ({
+    usejarvis_ai: { base_url: 'https://llm.example/v1', api_key: 'sk-uj-x' },
+    llm: { providers: {} },
+    ...over,
+  }) as unknown as JarvisConfig;
+
+const selfHosted = (over: Record<string, unknown> = {}): JarvisConfig =>
+  ({ llm: { providers: {} }, ...over }) as unknown as JarvisConfig;
+
+/** Stands in for the vault row `cfg.voice`. undefined = never saved. */
+const stored = (value: unknown) => () => value;
+
+describe('who realtime is on for', () => {
+  test('a hosted tenant who never opened the Voice tab gets it', () => {
+    // This is the whole fix. They have no stored `voice` section at all, and
+    // DEFAULT_CONFIG's false is not their answer — it is the absence of one.
+    expect(effectiveRealtimeEnabled(hosted(), stored(undefined))).toBe(true);
+  });
+
+  test('a self-hosted install is untouched — realtime spends the USER\'s money', () => {
+    // BYO realtime bills their own OpenAI account, so it must never switch
+    // itself on. Only the explicit opt-in counts.
+    expect(effectiveRealtimeEnabled(selfHosted(), stored(undefined))).toBe(false);
+    expect(
+      effectiveRealtimeEnabled(selfHosted({ voice: { realtime: { enabled: true } } }), stored(undefined)),
+    ).toBe(true);
+  });
+
+  test('an explicit user choice wins in BOTH directions', () => {
+    // Off: someone who prefers the standard pipeline keeps it, even on a plan
+    // that includes realtime.
+    expect(effectiveRealtimeEnabled(hosted(), stored({ realtime: { enabled: false } }))).toBe(false);
+    expect(effectiveRealtimeEnabled(hosted(), stored({ realtime: { enabled: true } }))).toBe(true);
+  });
+
+  test('an unreadable vault leaves realtime as configured, rather than switching it on', () => {
+    // The user's answer lives only in the vault. If it cannot be read we
+    // cannot tell "declined" from "never asked" — and turning realtime on for
+    // someone who switched it off opens a billed audio session to do it.
+    const throwing = () => { throw new Error('vault not open'); };
+    expect(effectiveRealtimeEnabled(hosted(), throwing)).toBe(false);
+    expect(
+      effectiveRealtimeEnabled(hosted({ voice: { realtime: { enabled: true } } }), throwing),
+    ).toBe(true);
+  });
+
+  test('an explicit true costs no vault read at all', () => {
+    // DEFAULT_CONFIG says false, so a true in the merged config can only have
+    // come from the user or the env — nothing left to disambiguate.
+    let reads = 0;
+    const counting = () => { reads++; return undefined; };
+    expect(
+      effectiveRealtimeEnabled(hosted({ voice: { realtime: { enabled: true } } }), counting),
+    ).toBe(true);
+    expect(reads).toBe(0);
+  });
+
+  test('only a PERSISTED boolean counts as a choice', () => {
+    // The merged config always carries a boolean (DEFAULT_CONFIG sets false),
+    // so reading it there cannot tell "turned it off" from "never touched" —
+    // the same trap effectiveTtsForBinding documents for Edge. A stored voice
+    // row that says nothing about realtime is not an answer.
+    expect(effectiveRealtimeEnabled(hosted(), stored({ wake_engine: 'openwakeword' }))).toBe(true);
+    expect(effectiveRealtimeEnabled(hosted(), stored({ realtime: {} }))).toBe(true);
+    expect(effectiveRealtimeEnabled(hosted(), stored({ realtime: { enabled: 'yes' } }))).toBe(true);
+    expect(effectiveRealtimeEnabled(hosted(), stored(null))).toBe(true);
+    expect(effectiveRealtimeEnabled(hosted(), stored([1, 2]))).toBe(true);
+  });
+});
+
+describe('resolving a session from that decision', () => {
+  test('a hosted tenant with NO voice block resolves against the uj-realtime alias', () => {
+    // The block being absent is the normal state for the tenant this fixes,
+    // and every field below has to survive it.
+    const res = resolveRealtimeVoice(hosted(), true);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.resolved.provider).toBe('usejarvis_ai');
+    expect(res.resolved.model).toBe('uj-realtime');
+    expect(res.resolved.url).toBe('wss://llm.example/v1/realtime');
+    // The plan gate reads this; without it every session is allowed blind.
+    expect(res.resolved.modelsUrl).toBe('https://llm.example/v1/models');
+    expect(res.resolved.maxSessionMinutes).toBe(10);
+    expect(res.resolved.reasoningEffort).toBe('low');
+    // The local $/min estimate must not double-block a hosted session.
+    expect(res.resolved.monthlyBudgetUsd).toBeUndefined();
+    // The destructive-action backstop still applies with no block to read it
+    // from — an open mic must not be able to auto-approve a payment.
+    expect(res.resolved.blockedCategories.length).toBeGreaterThan(0);
+  });
+
+  test('a false decision refuses, whatever the config says', () => {
+    const res = resolveRealtimeVoice(hosted({ voice: { realtime: { enabled: true } } }), false);
+    expect(res.ok).toBe(false);
+  });
+
+  test('the default argument is the raw config value', () => {
+    // Callers without the vault DB (and every pre-existing test) must see the
+    // old behaviour rather than a silent hosted-on.
+    expect(resolveRealtimeVoice(hosted()).ok).toBe(false);
+    expect(resolveRealtimeVoice(hosted({ voice: { realtime: { enabled: true } } })).ok).toBe(true);
+  });
+
+  test('a BYO OpenAI key still wins over the hosted alias', () => {
+    // Their explicit choice, their own spend — unchanged by this work.
+    const res = resolveRealtimeVoice(
+      hosted({ llm: { providers: { openai: { api_key: 'sk-real' } } } }),
+      true,
+    );
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.resolved.provider).toBe('openai');
+    expect(res.resolved.model).toBe('gpt-realtime-2');
+  });
+});

--- a/src/daemon/realtime-enablement.test.ts
+++ b/src/daemon/realtime-enablement.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { effectiveRealtimeEnabled } from './usejarvis-ai.ts';
+import { realtimeEnablement } from './usejarvis-ai.ts';
 import { resolveRealtimeVoice } from '../config/realtime.ts';
 import type { JarvisConfig } from '../config/types.ts';
 
@@ -29,23 +29,23 @@ describe('who realtime is on for', () => {
   test('a hosted tenant who never opened the Voice tab gets it', () => {
     // This is the whole fix. They have no stored `voice` section at all, and
     // DEFAULT_CONFIG's false is not their answer — it is the absence of one.
-    expect(effectiveRealtimeEnabled(hosted(), stored(undefined))).toBe(true);
+    expect(realtimeEnablement(hosted(), stored(undefined))).toBe('hosted-default');
   });
 
   test('a self-hosted install is untouched — realtime spends the USER\'s money', () => {
     // BYO realtime bills their own OpenAI account, so it must never switch
     // itself on. Only the explicit opt-in counts.
-    expect(effectiveRealtimeEnabled(selfHosted(), stored(undefined))).toBe(false);
+    expect(realtimeEnablement(selfHosted(), stored(undefined))).toBe('off');
     expect(
-      effectiveRealtimeEnabled(selfHosted({ voice: { realtime: { enabled: true } } }), stored(undefined)),
-    ).toBe(true);
+      realtimeEnablement(selfHosted({ voice: { realtime: { enabled: true } } }), stored(undefined)),
+    ).toBe('user-on');
   });
 
   test('an explicit user choice wins in BOTH directions', () => {
     // Off: someone who prefers the standard pipeline keeps it, even on a plan
     // that includes realtime.
-    expect(effectiveRealtimeEnabled(hosted(), stored({ realtime: { enabled: false } }))).toBe(false);
-    expect(effectiveRealtimeEnabled(hosted(), stored({ realtime: { enabled: true } }))).toBe(true);
+    expect(realtimeEnablement(hosted(), stored({ realtime: { enabled: false } }))).toBe('off');
+    expect(realtimeEnablement(hosted(), stored({ realtime: { enabled: true } }))).toBe('user-on');
   });
 
   test('an unreadable vault leaves realtime as configured, rather than switching it on', () => {
@@ -53,10 +53,10 @@ describe('who realtime is on for', () => {
     // cannot tell "declined" from "never asked" — and turning realtime on for
     // someone who switched it off opens a billed audio session to do it.
     const throwing = () => { throw new Error('vault not open'); };
-    expect(effectiveRealtimeEnabled(hosted(), throwing)).toBe(false);
+    expect(realtimeEnablement(hosted(), throwing)).toBe('off');
     expect(
-      effectiveRealtimeEnabled(hosted({ voice: { realtime: { enabled: true } } }), throwing),
-    ).toBe(true);
+      realtimeEnablement(hosted({ voice: { realtime: { enabled: true } } }), throwing),
+    ).toBe('user-on');
   });
 
   test('an explicit true costs no vault read at all', () => {
@@ -65,8 +65,8 @@ describe('who realtime is on for', () => {
     let reads = 0;
     const counting = () => { reads++; return undefined; };
     expect(
-      effectiveRealtimeEnabled(hosted({ voice: { realtime: { enabled: true } } }), counting),
-    ).toBe(true);
+      realtimeEnablement(hosted({ voice: { realtime: { enabled: true } } }), counting),
+    ).toBe('user-on');
     expect(reads).toBe(0);
   });
 
@@ -75,11 +75,11 @@ describe('who realtime is on for', () => {
     // so reading it there cannot tell "turned it off" from "never touched" —
     // the same trap effectiveTtsForBinding documents for Edge. A stored voice
     // row that says nothing about realtime is not an answer.
-    expect(effectiveRealtimeEnabled(hosted(), stored({ wake_engine: 'openwakeword' }))).toBe(true);
-    expect(effectiveRealtimeEnabled(hosted(), stored({ realtime: {} }))).toBe(true);
-    expect(effectiveRealtimeEnabled(hosted(), stored({ realtime: { enabled: 'yes' } }))).toBe(true);
-    expect(effectiveRealtimeEnabled(hosted(), stored(null))).toBe(true);
-    expect(effectiveRealtimeEnabled(hosted(), stored([1, 2]))).toBe(true);
+    expect(realtimeEnablement(hosted(), stored({ wake_engine: 'openwakeword' }))).toBe('hosted-default');
+    expect(realtimeEnablement(hosted(), stored({ realtime: {} }))).toBe('hosted-default');
+    expect(realtimeEnablement(hosted(), stored({ realtime: { enabled: 'yes' } }))).toBe('hosted-default');
+    expect(realtimeEnablement(hosted(), stored(null))).toBe('hosted-default');
+    expect(realtimeEnablement(hosted(), stored([1, 2]))).toBe('hosted-default');
   });
 });
 
@@ -87,7 +87,7 @@ describe('resolving a session from that decision', () => {
   test('a hosted tenant with NO voice block resolves against the uj-realtime alias', () => {
     // The block being absent is the normal state for the tenant this fixes,
     // and every field below has to survive it.
-    const res = resolveRealtimeVoice(hosted(), true);
+    const res = resolveRealtimeVoice(hosted(), 'hosted-default');
     expect(res.ok).toBe(true);
     if (!res.ok) return;
     expect(res.resolved.provider).toBe('usejarvis_ai');
@@ -105,7 +105,7 @@ describe('resolving a session from that decision', () => {
   });
 
   test('a false decision refuses, whatever the config says', () => {
-    const res = resolveRealtimeVoice(hosted({ voice: { realtime: { enabled: true } } }), false);
+    const res = resolveRealtimeVoice(hosted({ voice: { realtime: { enabled: true } } }), 'off');
     expect(res.ok).toBe(false);
   });
 
@@ -120,11 +120,78 @@ describe('resolving a session from that decision', () => {
     // Their explicit choice, their own spend — unchanged by this work.
     const res = resolveRealtimeVoice(
       hosted({ llm: { providers: { openai: { api_key: 'sk-real' } } } }),
-      true,
+      'user-on',
     );
     expect(res.ok).toBe(true);
     if (!res.ok) return;
     expect(res.resolved.provider).toBe('openai');
     expect(res.resolved.model).toBe('gpt-realtime-2');
+  });
+});
+
+describe('the money boundary — a default-on session must never touch a BYO key', () => {
+  test('a hosted tenant with a personal OpenAI key resolves to the HOSTED alias, not theirs', () => {
+    // The regression this guards: hosted installs allow BYO providers for
+    // chat. A tenant who added one and never opened the Voice tab would, under
+    // a plain boolean enablement, have every voice turn dialled against
+    // api.openai.com on THEIR key at ~$0.30/min — ungated (the plan gate skips
+    // BYO sessions, which have no modelsUrl) and unbudgeted (they never set a
+    // cap), having opted into none of it.
+    const cfg = hosted({ llm: { providers: { openai: { api_key: 'sk-their-own' } } } });
+    expect(realtimeEnablement(cfg, stored(undefined))).toBe('hosted-default');
+    const res = resolveRealtimeVoice(cfg, 'hosted-default');
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.resolved.provider).toBe('usejarvis_ai');
+    expect(res.resolved.apiKey).not.toBe('sk-their-own');
+    // modelsUrl present = the plan gate applies. Its absence is what made the
+    // BYO path ungated in the first place.
+    expect(res.resolved.modelsUrl).toBeTruthy();
+  });
+
+  test('but an EXPLICIT yes still lets their own key win', () => {
+    // Their choice, their spend — unchanged.
+    const cfg = hosted({
+      voice: { realtime: { enabled: true } },
+      llm: { providers: { openai: { api_key: 'sk-their-own' } } },
+    });
+    expect(realtimeEnablement(cfg, stored(undefined))).toBe('user-on');
+    const res = resolveRealtimeVoice(cfg, 'user-on');
+    expect(res.ok && res.resolved.provider).toBe('openai');
+  });
+});
+
+describe('the operator kill switch', () => {
+  const KEY = 'JARVIS_REALTIME_VOICE';
+  const restore = (v: string | undefined) => {
+    if (v === undefined) delete process.env[KEY];
+    else process.env[KEY] = v;
+  };
+
+  test('JARVIS_REALTIME_VOICE=0 still disables realtime on a hosted install', () => {
+    // loader.ts applies the env override LAST over every merge and documents
+    // "0"/"false" as an explicit disable. It is the lever an operator reaches
+    // for to stop opening billed audio sessions fleet-wide — which matters
+    // most on exactly the fleet where realtime just became default-on.
+    const before = process.env[KEY];
+    try {
+      process.env[KEY] = '0';
+      // The loader has already turned "0" into enabled:false in the merged
+      // config; what must not happen is the hosted default overriding it.
+      expect(realtimeEnablement(hosted(), stored(undefined))).toBe('off');
+      expect(realtimeEnablement(hosted(), stored({ realtime: { enabled: true } }))).toBe('off');
+    } finally {
+      restore(before);
+    }
+  });
+
+  test('with the var UNSET the hosted default still applies', () => {
+    const before = process.env[KEY];
+    try {
+      delete process.env[KEY];
+      expect(realtimeEnablement(hosted(), stored(undefined))).toBe('hosted-default');
+    } finally {
+      restore(before);
+    }
   });
 });

--- a/src/daemon/realtime-enablement.test.ts
+++ b/src/daemon/realtime-enablement.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
-import { realtimeEnablement } from './usejarvis-ai.ts';
-import { resolveRealtimeVoice } from '../config/realtime.ts';
+import { hasUsejarvisAi, realtimeEnablement } from './usejarvis-ai.ts';
+import { realtimeServedByPlan, resolveRealtimeVoice } from '../config/realtime.ts';
 import type { JarvisConfig } from '../config/types.ts';
 
 /**
@@ -216,4 +216,37 @@ describe('the operator kill switch', () => {
       restore(before);
     }
   });
+});
+
+describe('the two hosted predicates must never disagree', () => {
+  // realtimeEnablement keys off hasUsejarvisAi; the resolver and the settings
+  // route key off realtimeServedByPlan. If they diverge, enablement can say
+  // "hosted, default it on" while the resolver reads a BYO key — which is the
+  // billing bug this series exists to close — or the reverse, where a hosted
+  // tenant is told they pay OpenAI for something the plan serves.
+  const cases: Array<[string, unknown]> = [
+    ['absent', undefined],
+    ['complete', { base_url: 'https://llm.example/v1', api_key: 'sk-uj-x' }],
+    ['empty api_key', { base_url: 'https://llm.example/v1', api_key: '' }],
+    ['whitespace api_key', { base_url: 'https://llm.example/v1', api_key: '   ' }],
+    ['empty base_url', { base_url: '', api_key: 'sk-uj-x' }],
+    ['whitespace base_url', { base_url: '  ', api_key: 'sk-uj-x' }],
+    ['slashes-only base_url', { base_url: '///', api_key: 'sk-uj-x' }],
+    ['missing api_key', { base_url: 'https://llm.example/v1' }],
+    // The documented YAML hazard: an unquoted scalar parses as a number or a
+    // boolean. Reaching for .trim() on those threw a TypeError, and the
+    // settings route calls this predicate outside its try/catch.
+    ['numeric base_url', { base_url: 8080, api_key: 'sk-uj-x' }],
+    ['boolean api_key', { base_url: 'https://llm.example/v1', api_key: true }],
+    ['null block', null],
+    ['array block', []],
+  ];
+
+  for (const [name, block] of cases) {
+    test(`agree on: ${name}`, () => {
+      const cfg = { llm: { providers: {} }, usejarvis_ai: block } as unknown as JarvisConfig;
+      expect(() => realtimeServedByPlan(cfg)).not.toThrow();
+      expect(realtimeServedByPlan(cfg)).toBe(hasUsejarvisAi(cfg));
+    });
+  }
 });

--- a/src/daemon/realtime-gate-warm.test.ts
+++ b/src/daemon/realtime-gate-warm.test.ts
@@ -9,6 +9,9 @@ import {
 } from './realtime-gate.ts';
 import type { ResolvedRealtimeVoice } from '../config/realtime.ts';
 
+/** Mirrors ADVISORY_TTL_MS in realtime-gate.ts (not exported). */
+const ADVISORY_TTL_MS = 30_000;
+
 /**
  * Warming exists because realtime is now on by default for hosted tenants, so
  * the plan gate runs for EVERY hosted install. With a cold cache the browser
@@ -129,17 +132,25 @@ describe('the cache is cleared more often than boot', () => {
     expect(cachedRealtimeVerdict(hosted())).toBe(false);
   });
 
-  test('a failed warm still heals, because a MISS starts its own fetch', async () => {
-    // The proxy-still-booting case: the warm leaves only an advisory entry
-    // that expires back to nothing, so warming alone would contribute nothing.
+  test('a failed re-warm does not blind the poll for ever', async () => {
+    // The production shape, with NO artificial clear: SIGHUP clears the cache
+    // and re-warms; the proxy is restarting (which is what correlates with a
+    // key-rotation SIGHUP) so that warm fails and parks an advisory entry.
+    //
+    // Entries are never deleted, so that advisory does not expire back to
+    // absent — it becomes a stale HIT. While the read treated a stale hit as
+    // "unknown, don't ask", every later poll answered available and never
+    // fetched again: on an excluded plan, the lost utterance permanently.
     globalThis.fetch = (async () => { throw new Error('proxy not up yet'); }) as unknown as typeof fetch;
     warmRealtimeGate(hosted());
     await settle();
-    clearRealtimeGateCache(); // stand in for the advisory entry expiring away
+    expect(cachedRealtimeVerdict(hosted())).toBe(true); // advisory-open, briefly
 
-    catalog(['uj-chat']);
-    expect(cachedRealtimeVerdict(hosted())).toBeNull();
+    ageRealtimeGateCacheForTest(ADVISORY_TTL_MS + 1_000);
+    const calls = catalog(['uj-chat']); // proxy is back
+    expect(cachedRealtimeVerdict(hosted())).toBeNull(); // stale ⇒ ask again
     await settle();
+    expect(calls()).toBe(1);
     expect(cachedRealtimeVerdict(hosted())).toBe(false);
   });
 
@@ -153,10 +164,18 @@ describe('the cache is cleared more often than boot', () => {
     await settle();
     expect(cachedRealtimeVerdict(hosted())).toBe(false);
 
-    ageRealtimeGateCacheForTest(60_000);
-    globalThis.fetch = (async () => { throw new Error('catalog down'); }) as unknown as typeof fetch;
+    // Past CACHE_TTL_MS (10 min), not merely a minute: a definitive entry is
+    // FRESH for ten, so ageing by 60s left it fresh, no refresh was kicked and
+    // this test passed with the guard reverted.
+    ageRealtimeGateCacheForTest(11 * 60_000);
+    let attempts = 0;
+    globalThis.fetch = (async () => {
+      attempts++;
+      throw new Error('catalog down');
+    }) as unknown as typeof fetch;
     expect(cachedRealtimeVerdict(hosted())).toBe(false); // kicks the refresh
     await settle();
+    expect(attempts).toBe(1); // the refresh really ran, and really failed
     expect(cachedRealtimeVerdict(hosted())).toBe(false); // still excluded
   });
 });

--- a/src/daemon/realtime-gate-warm.test.ts
+++ b/src/daemon/realtime-gate-warm.test.ts
@@ -1,8 +1,10 @@
 import { afterEach, describe, expect, test } from 'bun:test';
 import {
+  ageRealtimeGateCacheForTest,
   cachedRealtimeVerdict,
   clearRealtimeGateCache,
   hostedRealtimeIncluded,
+  settleRealtimeGateForTest,
   warmRealtimeGate,
 } from './realtime-gate.ts';
 import type { ResolvedRealtimeVoice } from '../config/realtime.ts';
@@ -45,8 +47,11 @@ function catalog(ids: string[]) {
   return () => calls;
 }
 
-/** The warm is fire-and-forget; let its in-flight promise settle. */
-const settle = () => new Promise((r) => setTimeout(r, 0));
+/** The warm is fire-and-forget; await the actual in-flight request rather than
+ *  a bare setTimeout(0), which only works while the mocked body resolves inside
+ *  one macrotask flush — and whose failure mode is a test that passes against
+ *  an unsettled fetch. */
+const settle = () => settleRealtimeGateForTest();
 
 describe('warming the plan gate', () => {
   test('a plan WITHOUT realtime is known before anyone speaks', async () => {
@@ -105,5 +110,53 @@ describe('warming the plan gate', () => {
     warmRealtimeGate(hosted());
     await settle();
     expect(calls()).toBe(1);
+  });
+});
+
+describe('the cache is cleared more often than boot', () => {
+  test('a cleared cache re-warms to the same verdict', async () => {
+    // reloadAll clears this cache on every SIGHUP, which hosted ops do
+    // routinely — including the key rotation that carries a plan change. The
+    // daemon re-warms at the clear rather than waiting for a voice_start.
+    catalog(['uj-chat']);
+    warmRealtimeGate(hosted());
+    await settle();
+    expect(cachedRealtimeVerdict(hosted())).toBe(false);
+
+    clearRealtimeGateCache();
+    expect(cachedRealtimeVerdict(hosted())).toBeNull(); // and starts a fetch
+    await settle();
+    expect(cachedRealtimeVerdict(hosted())).toBe(false);
+  });
+
+  test('a failed warm still heals, because a MISS starts its own fetch', async () => {
+    // The proxy-still-booting case: the warm leaves only an advisory entry
+    // that expires back to nothing, so warming alone would contribute nothing.
+    globalThis.fetch = (async () => { throw new Error('proxy not up yet'); }) as unknown as typeof fetch;
+    warmRealtimeGate(hosted());
+    await settle();
+    clearRealtimeGateCache(); // stand in for the advisory entry expiring away
+
+    catalog(['uj-chat']);
+    expect(cachedRealtimeVerdict(hosted())).toBeNull();
+    await settle();
+    expect(cachedRealtimeVerdict(hosted())).toBe(false);
+  });
+
+  test('a failed refresh does NOT flip a known-excluded plan back to open', async () => {
+    // advisoryAllow used to overwrite unconditionally, so a stale definitive
+    // "excluded" whose background refresh failed read as available for 30s —
+    // flipping the browser into PCM capture and costing an utterance, which is
+    // the exact flap the asymmetric decay exists to prevent.
+    catalog(['uj-chat']);
+    warmRealtimeGate(hosted());
+    await settle();
+    expect(cachedRealtimeVerdict(hosted())).toBe(false);
+
+    ageRealtimeGateCacheForTest(60_000);
+    globalThis.fetch = (async () => { throw new Error('catalog down'); }) as unknown as typeof fetch;
+    expect(cachedRealtimeVerdict(hosted())).toBe(false); // kicks the refresh
+    await settle();
+    expect(cachedRealtimeVerdict(hosted())).toBe(false); // still excluded
   });
 });

--- a/src/daemon/realtime-gate-warm.test.ts
+++ b/src/daemon/realtime-gate-warm.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import {
+  cachedRealtimeVerdict,
+  clearRealtimeGateCache,
+  hostedRealtimeIncluded,
+  warmRealtimeGate,
+} from './realtime-gate.ts';
+import type { ResolvedRealtimeVoice } from '../config/realtime.ts';
+
+/**
+ * Warming exists because realtime is now on by default for hosted tenants, so
+ * the plan gate runs for EVERY hosted install. With a cold cache the browser
+ * captures raw PCM, the gate refuses, and those frames are dropped — the user
+ * speaks and nothing happens. One catalog request at boot removes it.
+ */
+
+const originalFetch = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  clearRealtimeGateCache();
+});
+
+const hosted = (over: Partial<ResolvedRealtimeVoice> = {}): ResolvedRealtimeVoice =>
+  ({
+    apiKey: 'sk-uj-x',
+    provider: 'usejarvis_ai',
+    url: 'wss://llm.example/v1/realtime',
+    modelsUrl: 'https://llm.example/v1/models',
+    model: 'uj-realtime',
+    reasoningEffort: 'low',
+    maxSessionMinutes: 10,
+    blockedCategories: [],
+    ...over,
+  }) as ResolvedRealtimeVoice;
+
+function catalog(ids: string[]) {
+  let calls = 0;
+  globalThis.fetch = (async () => {
+    calls++;
+    return new Response(JSON.stringify({ data: ids.map((id) => ({ id })) }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }) as unknown as typeof fetch;
+  return () => calls;
+}
+
+/** The warm is fire-and-forget; let its in-flight promise settle. */
+const settle = () => new Promise((r) => setTimeout(r, 0));
+
+describe('warming the plan gate', () => {
+  test('a plan WITHOUT realtime is known before anyone speaks', async () => {
+    // The point of the whole thing: without this, the first /api/config/voice
+    // says "available" (unknown reads as open), the browser captures PCM, and
+    // the utterance is refused and dropped.
+    const calls = catalog(['uj-chat', 'uj-low']);
+    expect(cachedRealtimeVerdict(hosted())).toBeNull();
+    warmRealtimeGate(hosted());
+    await settle();
+    expect(cachedRealtimeVerdict(hosted())).toBe(false);
+    expect(calls()).toBe(1);
+  });
+
+  test('a plan WITH realtime warms to included', async () => {
+    catalog(['uj-chat', 'uj-realtime']);
+    warmRealtimeGate(hosted());
+    await settle();
+    expect(cachedRealtimeVerdict(hosted())).toBe(true);
+  });
+
+  test('a voice_start racing the warm shares ONE request, not two', async () => {
+    // Both go through fetchVerdict's in-flight dedup. A second catalog request
+    // during boot would be pure waste, and on a cold proxy a slow one.
+    const calls = catalog(['uj-realtime']);
+    warmRealtimeGate(hosted());
+    expect(await hostedRealtimeIncluded(hosted())).toBe(true);
+    expect(calls()).toBe(1);
+  });
+
+  test('a BYO session is never gated, so never warmed', async () => {
+    // No modelsUrl = the user's own OpenAI key; there is no plan to consult.
+    const calls = catalog(['uj-realtime']);
+    warmRealtimeGate(hosted({ modelsUrl: undefined }));
+    await settle();
+    expect(calls()).toBe(0);
+  });
+
+  test('a failed warm does not pin an answer', async () => {
+    // It records an advisory (short-lived) entry, so the next real session
+    // re-asks rather than trusting a guess made at boot.
+    globalThis.fetch = (async () => { throw new Error('proxy not up yet'); }) as unknown as typeof fetch;
+    warmRealtimeGate(hosted());
+    await settle();
+    const calls = catalog(['uj-chat']);
+    warmRealtimeGate(hosted());
+    await settle();
+    expect(calls()).toBe(1);
+    expect(cachedRealtimeVerdict(hosted())).toBe(false);
+  });
+
+  test('a DEFINITIVE verdict is not re-fetched', async () => {
+    const calls = catalog(['uj-chat']);
+    warmRealtimeGate(hosted());
+    await settle();
+    warmRealtimeGate(hosted());
+    await settle();
+    expect(calls()).toBe(1);
+  });
+});

--- a/src/daemon/realtime-gate.test.ts
+++ b/src/daemon/realtime-gate.test.ts
@@ -156,14 +156,31 @@ describe('expired definitive refusals', () => {
 });
 
 describe('cachedRealtimeVerdict', () => {
-  test('never fetches, and reports unknown until the gate has run', async () => {
+  test('a MISS answers unknown at once, but starts a fetch so the next read knows', async () => {
+    // The contract changed deliberately. "Never fetch" made the boot warm the
+    // ONLY defence against a cold cache — and reloadAll clears this cache on
+    // every SIGHUP, which hosted ops do routinely. Starting a background fetch
+    // makes the dashboard poll self-healing instead.
     let called = 0;
     globalThis.fetch = (async () => { called++; return catalog('uj-chat'); }) as unknown as typeof fetch;
+    // Still null for THIS read: a poll must never stall on the catalog.
     expect(cachedRealtimeVerdict(hosted())).toBeNull();
-    expect(called).toBe(0);
-    await hostedRealtimeIncluded(hosted());
+    expect(called).toBe(1);
+    await hostedRealtimeIncluded(hosted()); // joins the in-flight request
     expect(cachedRealtimeVerdict(hosted())).toBe(false);
-    expect(called).toBe(1); // the cached read added no traffic
+    expect(called).toBe(1); // ...and added no traffic of its own
+  });
+
+  test('repeated misses while the fetch is in flight do not pile up requests', async () => {
+    // GET /api/config/voice is polled every ~15s per dashboard; a miss that
+    // issued a request per read would turn a UI refresh into catalog traffic,
+    // which is the reason this function is cache-only in the first place.
+    let called = 0;
+    globalThis.fetch = (async () => { called++; return catalog('uj-chat'); }) as unknown as typeof fetch;
+    cachedRealtimeVerdict(hosted());
+    cachedRealtimeVerdict(hosted());
+    cachedRealtimeVerdict(hosted());
+    expect(called).toBe(1);
   });
 
   test('BYO is known-allowed without any catalog', () => {

--- a/src/daemon/realtime-gate.ts
+++ b/src/daemon/realtime-gate.ts
@@ -94,6 +94,39 @@ function fetchVerdict(key: string, resolved: ResolvedRealtimeVoice): Promise<boo
   return p;
 }
 
+/**
+ * Prime the verdict before anyone speaks.
+ *
+ * Realtime is now ON by default for hosted tenants (usejarvis-ai.ts
+ * effectiveRealtimeEnabled), so the plan gate decides for EVERY hosted install
+ * rather than the few that had opted in. That made the cold-cache path a
+ * user-visible cost rather than a rare one:
+ *
+ * `GET /api/config/voice` reports `available` from the CACHE only, and an
+ * unknown verdict reads as available (the gate's advisory-open stance). The
+ * browser captures raw PCM when `enabled && available` (ui useVoice.ts:431).
+ * So on a plan WITHOUT realtime, the first utterance after every boot is
+ * captured as PCM, refused by the gate, and DROPPED — raw frames are useless
+ * to the WAV pipeline, which is why ws-service deletes the buffer rather than
+ * feeding Whisper headerless audio. The user says something and nothing
+ * happens; only the second utterance works.
+ *
+ * Warming costs one catalog request per boot and removes that entirely: by the
+ * time the dashboard first asks, the verdict is definitive and the browser
+ * never enters PCM mode on a plan that cannot serve it.
+ *
+ * Fire-and-forget by design — it shares fetchVerdict's in-flight dedup, so a
+ * voice_start racing the warm waits on the SAME request rather than issuing a
+ * second, and a failure is simply an advisory entry that expires in 30s.
+ */
+export function warmRealtimeGate(resolved: ResolvedRealtimeVoice): void {
+  if (!resolved.modelsUrl) return; // BYO sessions are never gated
+  const key = cacheKey(resolved);
+  const hit = cache.get(key);
+  if (hit && isFresh(hit) && !hit.advisory) return;
+  void fetchVerdict(key, resolved).catch(() => {});
+}
+
 /** Allow, but remember it only briefly — see ADVISORY_TTL_MS. */
 function advisoryAllow(key: string): boolean {
   cache.set(key, { verdict: true, at: Date.now(), advisory: true });

--- a/src/daemon/realtime-gate.ts
+++ b/src/daemon/realtime-gate.ts
@@ -94,6 +94,13 @@ function fetchVerdict(key: string, resolved: ResolvedRealtimeVoice): Promise<boo
   return p;
 }
 
+/**
+ * Warm from a config, resolving it first. The shape both callers need.
+ *
+ * `resolve` is injected because this module must not import the daemon's
+ * enablement view — usejarvis-ai.ts already imports nothing from here, and the
+ * reverse edge would close a cycle through config/realtime.ts.
+ */
 export function warmRealtimeGateFor(
   resolve: () => { ok: true; resolved: ResolvedRealtimeVoice } | { ok: false; reason: string },
 ): void {
@@ -109,7 +116,7 @@ export function warmRealtimeGateFor(
  * Prime the verdict before anyone speaks.
  *
  * Realtime is now ON by default for hosted tenants (usejarvis-ai.ts
- * effectiveRealtimeEnabled), so the plan gate decides for EVERY hosted install
+ * realtimeEnablement), so the plan gate decides for EVERY hosted install
  * rather than the few that had opted in. That made the cold-cache path a
  * user-visible cost rather than a rare one:
  *
@@ -136,13 +143,6 @@ export function warmRealtimeGateFor(
  * voice_start racing the warm waits on the SAME request rather than issuing a
  * second, and a failure is simply an advisory entry that expires in 30s.
  */
-/**
- * Warm from a config, resolving it first. The shape both callers need.
- *
- * `resolve` is injected because this module must not import the daemon's
- * enablement view — usejarvis-ai.ts already imports nothing from here, and the
- * reverse edge would close a cycle through config/realtime.ts.
- */
 export function warmRealtimeGate(resolved: ResolvedRealtimeVoice): void {
   if (!resolved.modelsUrl) return; // BYO sessions are never gated
   const key = cacheKey(resolved);
@@ -165,6 +165,15 @@ export function warmRealtimeGate(resolved: ResolvedRealtimeVoice): void {
  */
 function advisoryAllow(key: string): boolean {
   const hit = cache.get(key);
+  // A stale exclusion whose refresh keeps failing IS re-attempted on every
+  // read, and that is deliberate. Two tidier-looking options both break
+  // something: bumping `at` makes the entry fresh for the full CACHE_TTL_MS,
+  // so a plan UPGRADE would go unnoticed for ten minutes; marking it advisory
+  // gets the 30s retry cadence but then decays to "unknown", which reads as
+  // available and flips the browser into PCM capture — the exact flap the
+  // asymmetry at the top of this file exists to prevent. Retrying costs one
+  // 1.5s-timeout request per read against a catalog that is already down, and
+  // it stops the moment the catalog answers.
   if (hit && !hit.advisory && !hit.verdict) return false;
   cache.set(key, { verdict: true, at: Date.now(), advisory: true });
   return true;
@@ -194,7 +203,9 @@ function advisoryAllow(key: string): boolean {
  * those, and demotes the boot warm to an optimisation rather than the single
  * line of defence. It stays cheap: `fetchVerdict` dedups in flight, and a
  * result of any kind ends the misses, so the ceiling is one request per
- * cache-empty poll — not one per poll.
+ * cache-empty poll — not one per poll. The honest exception is a stale
+ * definitive exclusion whose refresh keeps failing: that one is re-attempted
+ * per read, for the reason spelled out on advisoryAllow.
  */
 export function cachedRealtimeVerdict(resolved: ResolvedRealtimeVoice): boolean | null {
   if (!resolved.modelsUrl) return true;

--- a/src/daemon/realtime-gate.ts
+++ b/src/daemon/realtime-gate.ts
@@ -94,6 +94,17 @@ function fetchVerdict(key: string, resolved: ResolvedRealtimeVoice): Promise<boo
   return p;
 }
 
+export function warmRealtimeGateFor(
+  resolve: () => { ok: true; resolved: ResolvedRealtimeVoice } | { ok: false; reason: string },
+): void {
+  try {
+    const res = resolve();
+    if (res.ok) warmRealtimeGate(res.resolved);
+  } catch (err) {
+    console.warn('[RealtimeGate] could not warm the plan verdict:', err);
+  }
+}
+
 /**
  * Prime the verdict before anyone speaks.
  *
@@ -132,17 +143,6 @@ function fetchVerdict(key: string, resolved: ResolvedRealtimeVoice): Promise<boo
  * enablement view — usejarvis-ai.ts already imports nothing from here, and the
  * reverse edge would close a cycle through config/realtime.ts.
  */
-export function warmRealtimeGateFor(
-  resolve: () => { ok: true; resolved: ResolvedRealtimeVoice } | { ok: false; reason: string },
-): void {
-  try {
-    const res = resolve();
-    if (res.ok) warmRealtimeGate(res.resolved);
-  } catch (err) {
-    console.warn('[RealtimeGate] could not warm the plan verdict:', err);
-  }
-}
-
 export function warmRealtimeGate(resolved: ResolvedRealtimeVoice): void {
   if (!resolved.modelsUrl) return; // BYO sessions are never gated
   const key = cacheKey(resolved);
@@ -200,17 +200,22 @@ export function cachedRealtimeVerdict(resolved: ResolvedRealtimeVoice): boolean 
   if (!resolved.modelsUrl) return true;
   const key = cacheKey(resolved);
   const hit = cache.get(key);
-  if (!hit) {
-    void fetchVerdict(key, resolved).catch(() => {});
-    // Still null for THIS read — the point is never to stall a poll. The next
-    // one, ~15s later, has an answer.
-    return null;
-  }
-  if (isFresh(hit)) return hit.verdict;
-  if (!hit.advisory && !hit.verdict) {
-    void fetchVerdict(key, resolved).catch(() => {});
-    return false;
-  }
+  if (hit && isFresh(hit)) return hit.verdict;
+  // Everything below is a miss or a STALE entry, and both start a fetch.
+  //
+  // Stale mattered more than it looked. Entries are never deleted, so an
+  // advisory one does not expire back to absent — it becomes a stale HIT, and
+  // returning null there without fetching was a dead end that swallowed the
+  // self-healing entirely: a re-warm whose fetch failed (the proxy restarting,
+  // which is exactly what correlates with a key-rotation SIGHUP) parked an
+  // advisory entry, and every poll from then on read "available" and never
+  // asked again. On an excluded plan that is the lost utterance, permanently.
+  void fetchVerdict(key, resolved).catch(() => {});
+  // A stale definitive EXCLUDED still answers excluded while that refresh
+  // runs — decaying it back to open would flip the browser into raw-PCM
+  // capture once per TTL and cost an utterance each time (see the header).
+  if (hit && !hit.advisory && !hit.verdict) return false;
+  // Never stall a poll: this read is unknown, the next one ~15s later is not.
   return null;
 }
 

--- a/src/daemon/realtime-gate.ts
+++ b/src/daemon/realtime-gate.ts
@@ -111,14 +111,38 @@ function fetchVerdict(key: string, resolved: ResolvedRealtimeVoice): Promise<boo
  * feeding Whisper headerless audio. The user says something and nothing
  * happens; only the second utterance works.
  *
- * Warming costs one catalog request per boot and removes that entirely: by the
- * time the dashboard first asks, the verdict is definitive and the browser
- * never enters PCM mode on a plan that cannot serve it.
+ * What warming actually guarantees, stated precisely because the next reader
+ * will rely on it: the request is ISSUED before the daemon binds its listener,
+ * so when the proxy answers within FETCH_TIMEOUT_MS the first
+ * `GET /api/config/voice` already has a definitive verdict and the browser
+ * never enters PCM mode on a plan that cannot serve it. It is not a guarantee
+ * for a proxy that is slow or still booting — there the entry is advisory and
+ * expires. That gap is covered separately: `cachedRealtimeVerdict` starts a
+ * fetch on a cache miss, so the dashboard poll heals it ~15s later. Warming is
+ * the fast path, not the only one.
  *
  * Fire-and-forget by design — it shares fetchVerdict's in-flight dedup, so a
  * voice_start racing the warm waits on the SAME request rather than issuing a
  * second, and a failure is simply an advisory entry that expires in 30s.
  */
+/**
+ * Warm from a config, resolving it first. The shape both callers need.
+ *
+ * `resolve` is injected because this module must not import the daemon's
+ * enablement view — usejarvis-ai.ts already imports nothing from here, and the
+ * reverse edge would close a cycle through config/realtime.ts.
+ */
+export function warmRealtimeGateFor(
+  resolve: () => { ok: true; resolved: ResolvedRealtimeVoice } | { ok: false; reason: string },
+): void {
+  try {
+    const res = resolve();
+    if (res.ok) warmRealtimeGate(res.resolved);
+  } catch (err) {
+    console.warn('[RealtimeGate] could not warm the plan verdict:', err);
+  }
+}
+
 export function warmRealtimeGate(resolved: ResolvedRealtimeVoice): void {
   if (!resolved.modelsUrl) return; // BYO sessions are never gated
   const key = cacheKey(resolved);
@@ -127,8 +151,21 @@ export function warmRealtimeGate(resolved: ResolvedRealtimeVoice): void {
   void fetchVerdict(key, resolved).catch(() => {});
 }
 
-/** Allow, but remember it only briefly — see ADVISORY_TTL_MS. */
+/**
+ * Allow, but remember it only briefly — see ADVISORY_TTL_MS.
+ *
+ * NEVER over a definitive "excluded". Both the session starter and the
+ * cache-only read kick a background refresh when a definitive exclusion goes
+ * stale; if that refresh fails, overwriting would replace a known exclusion
+ * with advisory-true and read as OPEN for the next 30 seconds — flipping the
+ * browser into raw-PCM capture and costing an utterance. That is precisely the
+ * flap the asymmetric decay at the top of this file exists to prevent, reached
+ * through the back door. A failed refresh teaches us nothing, so the old
+ * answer stands.
+ */
 function advisoryAllow(key: string): boolean {
+  const hit = cache.get(key);
+  if (hit && !hit.advisory && !hit.verdict) return false;
   cache.set(key, { verdict: true, at: Date.now(), advisory: true });
   return true;
 }
@@ -142,12 +179,33 @@ function advisoryAllow(key: string): boolean {
  * "excluded" still reads as excluded (with a background refresh) for the same
  * reason as in hostedRealtimeIncluded: this flag is what flips the browser
  * into raw-PCM capture, and a TTL flap would cost the user an utterance.
+ *
+ * ## A MISS starts a fetch too
+ *
+ * Answering null forever on an empty cache made the boot warm the only defence
+ * against the cold-cache lost utterance, and there are several ways back to an
+ * empty cache that boot does not cover: `reloadAll` calls
+ * clearRealtimeGateCache on every SIGHUP (settings-reload.ts) — which hosted
+ * ops do routinely, including the key rotation that delivers a plan change —
+ * and a warm issued while the proxy was still coming up leaves only an
+ * advisory entry that expires back to nothing.
+ *
+ * Kicking a background fetch here makes the poll SELF-HEALING for every one of
+ * those, and demotes the boot warm to an optimisation rather than the single
+ * line of defence. It stays cheap: `fetchVerdict` dedups in flight, and a
+ * result of any kind ends the misses, so the ceiling is one request per
+ * cache-empty poll — not one per poll.
  */
 export function cachedRealtimeVerdict(resolved: ResolvedRealtimeVoice): boolean | null {
   if (!resolved.modelsUrl) return true;
   const key = cacheKey(resolved);
   const hit = cache.get(key);
-  if (!hit) return null;
+  if (!hit) {
+    void fetchVerdict(key, resolved).catch(() => {});
+    // Still null for THIS read — the point is never to stall a poll. The next
+    // one, ~15s later, has an answer.
+    return null;
+  }
   if (isFresh(hit)) return hit.verdict;
   if (!hit.advisory && !hit.verdict) {
     void fetchVerdict(key, resolved).catch(() => {});
@@ -160,6 +218,19 @@ export function cachedRealtimeVerdict(resolved: ResolvedRealtimeVoice): boolean 
 export function clearRealtimeGateCache(): void {
   cache.clear();
   inFlight.clear();
+}
+
+/**
+ * Test seam: await whatever fetches are in flight.
+ *
+ * Tests of the fire-and-forget paths (warming, the miss-triggered refresh) must
+ * not settle them with a bare `setTimeout(0)` — that works only while the
+ * mocked body happens to resolve within one macrotask flush, and it fails
+ * SILENTLY the other way: an assertion that the cache is still empty passes
+ * just as well against a fetch that has not finished.
+ */
+export function settleRealtimeGateForTest(): Promise<unknown> {
+  return Promise.all([...inFlight.values()]);
 }
 
 /** Test seam: age every cached verdict by `ms` so TTL decay is testable

--- a/src/daemon/settings-reload.ts
+++ b/src/daemon/settings-reload.ts
@@ -179,6 +179,20 @@ export class SettingsReloadCoordinator {
   private postReloadAll: (() => Promise<void>) | null = null;
 
   /**
+   * Re-warm the realtime plan verdict right after the cache is cleared.
+   *
+   * Separate from postReloadAll on purpose: that hook runs AFTER every section
+   * applier, and the appliers take real time. The window this closes is the one
+   * between clearing the cache and the dashboard's next poll, so it has to fire
+   * at the clear, not at the end.
+   */
+  setWarmRealtime(fn: (() => void) | null): void {
+    this.warmRealtime = fn;
+  }
+
+  private warmRealtime: (() => void) | null = null;
+
+  /**
    * Fire-and-forget: schedule a coalesced apply for the section. No-op when
    * the section has no appliers. A repeat call while one is pending restarts
    * the debounce timer — appliers read live config, so latest state wins.
@@ -238,6 +252,14 @@ export class SettingsReloadCoordinator {
       // any cached realtime plan verdict is now suspect. Cheap to drop: the
       // next voice_start re-asks the catalog once and re-caches.
       clearRealtimeGateCache();
+      // ...but re-warm at once rather than waiting for that voice_start. With
+      // realtime default-on for hosted tenants, an empty cache reads as
+      // "available", which puts the browser into raw-PCM capture — and a
+      // refused PCM utterance is DROPPED. Hosted ops SIGHUP us routinely
+      // (Google deliver/revoke, and the key rotation that carries a plan
+      // change), so without this the lost utterance recurs on every one of
+      // them for any tenant with no pebble sidecar to re-advertise.
+      if (this.warmRealtime) this.warmRealtime();
 
       const changed = RELOAD_SECTIONS.filter((s) => this.snapshot(s) !== before.get(s));
       // The hosted deliver/revoke ops write the tokens file and SIGHUP us; the

--- a/src/daemon/usejarvis-ai.ts
+++ b/src/daemon/usejarvis-ai.ts
@@ -1,6 +1,7 @@
 import type { JarvisConfig, LLMConfig, STTConfig, TTSConfig } from '../config/types.ts';
 import type { HostedVoiceCredentials } from '../comms/voice.ts';
 import { loadUserSection } from './user-settings.ts';
+import { getSetting } from '../vault/settings.ts';
 
 /**
  * Hosted "Usejarvis AI" wiring (the platform's LLM proxy).
@@ -279,16 +280,29 @@ function storedProviderChoice(stored: unknown): boolean {
  * of `config.llm` to avoid: runtime defaults stay out of every persistence path
  * by construction.
  */
-export function effectiveRealtimeEnabled(
+export type RealtimeEnablement =
+  /** The user (or JARVIS_REALTIME_VOICE) said yes. Their BYO key may serve it. */
+  | 'user-on'
+  /** Nobody asked for it; it is on because the hosted plan may include it. A
+   *  session from this state MUST resolve to the hosted alias — see below. */
+  | 'hosted-default'
+  | 'off';
+
+export function realtimeEnablement(
   config: JarvisConfig,
-  loadStored: (section: 'voice') => unknown = loadUserSection,
-): boolean {
+  loadStored: (section: 'voice') => unknown = loadStoredVoice,
+): RealtimeEnablement {
   const configured = config.voice?.realtime?.enabled === true;
-  if (!hasUsejarvisAi(config)) return configured;
+  if (!hasUsejarvisAi(config)) return configured ? 'user-on' : 'off';
   // An explicit TRUE needs no disambiguation, and must not cost a vault read:
   // DEFAULT_CONFIG says false, so a true in the merged config can only have
   // come from the user or from JARVIS_REALTIME_VOICE. Only FALSE is ambiguous.
-  if (configured) return true;
+  if (configured) return 'user-on';
+  // ...except when the env var is SET, where false is not ambiguous at all:
+  // loader.ts documents "0"/"false" as an explicit disable, and the daemon
+  // re-applies env last over every merge. This is the operator's kill switch
+  // for the fleet where realtime just became default-on, so it must survive.
+  if (process.env.JARVIS_REALTIME_VOICE !== undefined) return 'off';
   let choice: boolean | null = null;
   try {
     choice = storedRealtimeChoice(loadStored('voice'));
@@ -297,11 +311,48 @@ export function effectiveRealtimeEnabled(
     // one means we cannot tell "declined" from "never asked". Fall back to the
     // merged config rather than the hosted default: turning realtime ON for
     // someone who may have switched it off is the worse of the two mistakes,
-    // and it opens a billed audio session to do it.
-    console.warn('[UsejarvisAI] could not read the stored voice section; leaving realtime as configured:', err);
-    return configured;
+    // and it opens a billed audio session to do it. Corrupt JSON reaches here
+    // too (loadStoredVoice throws rather than reading as silence), because a
+    // damaged row is not an answer either.
+    warnVaultOnce(err);
+    return configured ? 'user-on' : 'off';
   }
-  return choice ?? true;
+  if (choice === true) return 'user-on';
+  if (choice === false) return 'off';
+  return 'hosted-default';
+}
+
+/**
+ * Corruption must not read as "never asked".
+ *
+ * `loadUserSection` swallows a JSON parse error and returns undefined, which is
+ * indistinguishable from an absent row — and absent means "default it on". A
+ * tenant who explicitly declined, whose row later corrupts, would have realtime
+ * switched back on. Throwing routes it into the fail-closed catch instead.
+ */
+function loadStoredVoice(section: 'voice'): unknown {
+  const raw = getSetting(`cfg.${section}`);
+  if (raw === null) return undefined;
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed === null ? undefined : parsed;
+  } catch {
+    throw new Error(`corrupt JSON in cfg.${section}`);
+  }
+}
+
+/** Once, not per call: GET /api/config/voice is polled every 15s per dashboard
+ *  and every voice_start reads this, so a broken vault would flood the log. */
+let vaultWarned = false;
+function warnVaultOnce(err: unknown): void {
+  if (vaultWarned) return;
+  vaultWarned = true;
+  console.warn('[UsejarvisAI] could not read the stored voice section; leaving realtime as configured:', err);
+}
+
+/** Test seam for the warn-once latch. */
+export function resetRealtimeVaultWarningForTest(): void {
+  vaultWarned = false;
 }
 
 /**

--- a/src/daemon/usejarvis-ai.ts
+++ b/src/daemon/usejarvis-ai.ts
@@ -1,7 +1,6 @@
 import type { JarvisConfig, LLMConfig, STTConfig, TTSConfig } from '../config/types.ts';
 import type { HostedVoiceCredentials } from '../comms/voice.ts';
-import { loadUserSection } from './user-settings.ts';
-import { getSetting } from '../vault/settings.ts';
+import { loadUserSection, loadUserSectionStrict } from './user-settings.ts';
 
 /**
  * Hosted "Usejarvis AI" wiring (the platform's LLM proxy).
@@ -303,7 +302,7 @@ export type RealtimeEnablement =
 
 export function realtimeEnablement(
   config: JarvisConfig,
-  loadStored: (section: 'voice') => unknown = loadStoredVoice,
+  loadStored: (section: 'voice') => unknown = loadUserSectionStrict,
 ): RealtimeEnablement {
   const configured = config.voice?.realtime?.enabled === true;
   if (!hasUsejarvisAi(config)) return configured ? 'user-on' : 'off';
@@ -311,10 +310,15 @@ export function realtimeEnablement(
   // DEFAULT_CONFIG says false, so a true in the merged config can only have
   // come from the user or from JARVIS_REALTIME_VOICE. Only FALSE is ambiguous.
   if (configured) return 'user-on';
-  // ...except when the env var is SET, where false is not ambiguous at all:
-  // loader.ts documents "0"/"false" as an explicit disable, and the daemon
-  // re-applies env last over every merge. This is the operator's kill switch
-  // for the fleet where realtime just became default-on, so it must survive.
+  // ...except when the env var is SET, where false is not ambiguous at all.
+  //
+  // Read it as: applyEnvOverrides runs LAST over every merge (boot and reload),
+  // so if the var were a truthy value `configured` would be true and we would
+  // have returned above. Reaching here with it set therefore means the loader
+  // turned it into an explicit false — "0" / "false" / "no" / "" per loader.ts.
+  // That is the operator's kill switch on exactly the fleet where realtime just
+  // became default-on, so it has to outrank the default. (The truthiness table
+  // is deliberately NOT duplicated here; the loader owns it.)
   if (process.env.JARVIS_REALTIME_VOICE !== undefined) return 'off';
   let choice: boolean | null = null;
   try {
@@ -325,7 +329,7 @@ export function realtimeEnablement(
     // merged config rather than the hosted default: turning realtime ON for
     // someone who may have switched it off is the worse of the two mistakes,
     // and it opens a billed audio session to do it. Corrupt JSON reaches here
-    // too (loadStoredVoice throws rather than reading as silence), because a
+    // too (loadUserSectionStrict throws rather than reading as silence), because a
     // damaged row is not an answer either.
     warnVaultOnce(err);
     return configured ? 'user-on' : 'off';
@@ -335,24 +339,6 @@ export function realtimeEnablement(
   return 'hosted-default';
 }
 
-/**
- * Corruption must not read as "never asked".
- *
- * `loadUserSection` swallows a JSON parse error and returns undefined, which is
- * indistinguishable from an absent row — and absent means "default it on". A
- * tenant who explicitly declined, whose row later corrupts, would have realtime
- * switched back on. Throwing routes it into the fail-closed catch instead.
- */
-function loadStoredVoice(section: 'voice'): unknown {
-  const raw = getSetting(`cfg.${section}`);
-  if (raw === null) return undefined;
-  try {
-    const parsed = JSON.parse(raw);
-    return parsed === null ? undefined : parsed;
-  } catch {
-    throw new Error(`corrupt JSON in cfg.${section}`);
-  }
-}
 
 /** Once, not per call: GET /api/config/voice is polled every 15s per dashboard
  *  and every voice_start reads this, so a broken vault would flood the log. */

--- a/src/daemon/usejarvis-ai.ts
+++ b/src/daemon/usejarvis-ai.ts
@@ -58,6 +58,15 @@ function normalizeBlockUrl(value: string): string {
  * e.g. an unquoted YAML scalar parsed as number/boolean) is reported once per
  * read and treated as absent rather than throwing from inside the boot merge.
  */
+let malformedBlockWarned = false;
+function warnMalformedBlockOnce(): void {
+  if (malformedBlockWarned) return;
+  malformedBlockWarned = true;
+  console.warn(
+    '[UsejarvisAI] Ignoring malformed usejarvis_ai config block: base_url and api_key must be strings (quote them in config.yaml).',
+  );
+}
+
 function readUsejarvisAiBlock(
   config: JarvisConfig,
 ): { base_url: string; api_key: string } | null {
@@ -68,9 +77,11 @@ function readUsejarvisAiBlock(
     (base_url !== undefined && typeof base_url !== 'string')
     || (api_key !== undefined && typeof api_key !== 'string')
   ) {
-    console.warn(
-      '[UsejarvisAI] Ignoring malformed usejarvis_ai config block: base_url and api_key must be strings (quote them in config.yaml).',
-    );
+    // ONCE. This used to be reached rarely; now a hosted dashboard polls
+    // GET /api/config/voice every ~15s and each read runs hasUsejarvisAi, so a
+    // single mistyped line would print four times a minute for the life of the
+    // daemon and bury everything else. Same latch as warnVaultOnce below.
+    warnMalformedBlockOnce();
     return null;
   }
   const url = typeof base_url === 'string' ? normalizeBlockUrl(base_url) : '';
@@ -352,9 +363,10 @@ function warnVaultOnce(err: unknown): void {
   console.warn('[UsejarvisAI] could not read the stored voice section; leaving realtime as configured:', err);
 }
 
-/** Test seam for the warn-once latch. */
+/** Test seam for the warn-once latches. */
 export function resetRealtimeVaultWarningForTest(): void {
   vaultWarned = false;
+  malformedBlockWarned = false;
 }
 
 /**

--- a/src/daemon/usejarvis-ai.ts
+++ b/src/daemon/usejarvis-ai.ts
@@ -281,7 +281,9 @@ function storedProviderChoice(stored: unknown): boolean {
  * by construction.
  */
 export type RealtimeEnablement =
-  /** The user (or JARVIS_REALTIME_VOICE) said yes. Their BYO key may serve it. */
+  /** The user (or JARVIS_REALTIME_VOICE) said yes. On a SELF-HOSTED install
+   *  their own OpenAI key serves it; on a hosted one the plan does, whoever
+   *  asked — see realtimeServedByPlan in config/realtime.ts. */
   | 'user-on'
   /** Nobody asked for it; it is on because the hosted plan may include it. A
    *  session from this state MUST resolve to the hosted alias — see below. */

--- a/src/daemon/usejarvis-ai.ts
+++ b/src/daemon/usejarvis-ai.ts
@@ -240,6 +240,87 @@ function storedProviderChoice(stored: unknown): boolean {
  * two. `loadStored` is injectable for tests; the default reads the vault DB
  * (open in every runtime caller: boot, reload appliers, API routes).
  */
+/**
+ * The BINDING view of `voice.realtime.enabled`.
+ *
+ * Realtime is a paid slot on a hosted plan (`llm_profile_slots.slot =
+ * 'realtime'` — the one slot REQUIRED_LLM_SLOTS leaves optional). A tenant
+ * whose plan includes it should get it; today they never do, because
+ * `voice.realtime.enabled` defaults to false, the only thing that flips it is
+ * the JARVIS_REALTIME_VOICE env var, and the provisioner sets neither. The
+ * hosted branch of resolveRealtimeVoice — which derives the wss:// endpoint and
+ * dials the uj-realtime alias — has therefore never run in production.
+ *
+ * Same three rules as effectiveSttForBinding above, and for the same reasons:
+ *  - not hosted → untouched. A BYO-key user keeps the explicit opt-in; realtime
+ *    spends THEIR OpenAI money and must never switch itself on.
+ *  - the user recorded a choice → it wins, in both directions.
+ *  - otherwise → on, and the PLAN decides per session.
+ *
+ * ## Why the plan is not read here
+ *
+ * It cannot be, and it should not be. The `usejarvis_ai` block is
+ * plan-INDEPENDENT by design (see the renderer in the control plane): per-plan
+ * resolution happens at the proxy via aliases, so a plan change never rewrites
+ * an instance's config. Encoding the entitlement in the file would break that
+ * and require new machinery to re-render and push a config on every upgrade and
+ * downgrade — with an instance left silently wrong whenever that push failed.
+ *
+ * The authority is `hostedRealtimeIncluded` (daemon/realtime-gate.ts), which
+ * asks the key-scoped catalog whether the plan includes uj-realtime. It is
+ * already written, cached, and deliberately conservative about its own
+ * failures. This function only decides whether to ASK.
+ *
+ * ## Why a binding view rather than a mutation
+ *
+ * Writing the default into `config.voice` would let a dashboard voice save
+ * read-modify-write it back as an explicit user choice — pinning realtime on
+ * for a tenant who later loses it. Same hazard the tier defaults are kept out
+ * of `config.llm` to avoid: runtime defaults stay out of every persistence path
+ * by construction.
+ */
+export function effectiveRealtimeEnabled(
+  config: JarvisConfig,
+  loadStored: (section: 'voice') => unknown = loadUserSection,
+): boolean {
+  const configured = config.voice?.realtime?.enabled === true;
+  if (!hasUsejarvisAi(config)) return configured;
+  // An explicit TRUE needs no disambiguation, and must not cost a vault read:
+  // DEFAULT_CONFIG says false, so a true in the merged config can only have
+  // come from the user or from JARVIS_REALTIME_VOICE. Only FALSE is ambiguous.
+  if (configured) return true;
+  let choice: boolean | null = null;
+  try {
+    choice = storedRealtimeChoice(loadStored('voice'));
+  } catch (err) {
+    // The vault is the only place the user's answer lives, so an unreadable
+    // one means we cannot tell "declined" from "never asked". Fall back to the
+    // merged config rather than the hosted default: turning realtime ON for
+    // someone who may have switched it off is the worse of the two mistakes,
+    // and it opens a billed audio session to do it.
+    console.warn('[UsejarvisAI] could not read the stored voice section; leaving realtime as configured:', err);
+    return configured;
+  }
+  return choice ?? true;
+}
+
+/**
+ * The user's own answer, or null if they never gave one.
+ *
+ * Read from the STORED `cfg.voice` row, not the merged config: DEFAULT_CONFIG
+ * sets `enabled: false`, so the in-memory value cannot tell "turned it off"
+ * from "never touched" — the same trap effectiveTtsForBinding documents for
+ * Edge being the default TTS provider. Only a boolean actually persisted under
+ * `realtime.enabled` counts as an answer.
+ */
+function storedRealtimeChoice(stored: unknown): boolean | null {
+  if (typeof stored !== 'object' || stored === null || Array.isArray(stored)) return null;
+  const rt = (stored as Record<string, unknown>).realtime;
+  if (typeof rt !== 'object' || rt === null || Array.isArray(rt)) return null;
+  const enabled = (rt as Record<string, unknown>).enabled;
+  return typeof enabled === 'boolean' ? enabled : null;
+}
+
 export function effectiveSttForBinding(
   config: JarvisConfig,
   loadStored: (section: 'stt' | 'tts') => unknown = loadUserSection,

--- a/src/daemon/user-settings.ts
+++ b/src/daemon/user-settings.ts
@@ -27,7 +27,7 @@
 import { createHash } from 'node:crypto';
 import { getSetting, setSetting } from '../vault/settings.ts';
 import { deepMerge } from '../config/loader.ts';
-import { mergeSTTConfig, mergeTTSConfig } from './config-merge.ts';
+import { mergeSTTConfig, mergeTTSConfig, mergeVoiceConfig } from './config-merge.ts';
 import {
   SECRET_SECTIONS,
   SecretStorageError,
@@ -43,6 +43,7 @@ import {
   WORKFLOW_SYSTEM_KEYS,
   type JarvisConfig,
   type STTConfig,
+  type VoiceConfig,
   type TTSConfig,
   type UserOwnedSection,
 } from '../config/types.ts';
@@ -128,20 +129,34 @@ export function saveUserSection<K extends UserOwnedSection>(
  * absent credential as "delete it". Merging over the bare stripped row would
  * therefore destroy every stored key the patch does not carry (it did, once).
  */
-export function persistUserPatch(section: 'stt' | 'tts', patch: Record<string, unknown>): void {
+export function persistUserPatch(section: 'stt' | 'tts' | 'voice', patch: Record<string, unknown>): void {
   const stored = loadUserSection(section);
   // Cast, don't default: the merge helpers substitute a provider-carrying
   // default for an UNDEFINED base, which would stamp silence into the row.
   // A `{}` base merges cleanly and stays provider-free unless the patch
   // itself carries a choice. Secrets are injected only when a row exists —
   // same orphan rule as mergeUserSettingsIntoConfig.
-  const base = (typeof stored === 'object' && stored !== null && !Array.isArray(stored))
-    ? injectSectionSecrets(section, stored)
+  // `voice` holds no credentials, so it skips the hydration entirely — passing
+  // it to injectSectionSecrets would not type-check, and there is nothing to
+  // rehydrate. stt/tts rows ARE stripped, and merging over the bare row would
+  // destroy every stored key the patch does not carry (it did, once).
+  const usable = typeof stored === 'object' && stored !== null && !Array.isArray(stored);
+  const base = usable
+    ? (isSecretSection(section) ? injectSectionSecrets(section, stored) : stored)
     : {};
   if (section === 'stt') {
     saveUserSection('stt', mergeSTTConfig(base as STTConfig, patch));
-  } else {
+  } else if (section === 'tts') {
     saveUserSection('tts', mergeTTSConfig(base as TTSConfig, patch));
+  } else {
+    // `voice` joined this rule when hosted installs started defaulting
+    // realtime ON for a silent user (usejarvis-ai.ts realtimeEnablement).
+    // Merging a patch over the in-memory section stamps DEFAULT_CONFIG's
+    // `realtime.enabled: false` into the row, which then reads as an explicit
+    // decline — so changing the wake engine, or picking a realtime VOICE from
+    // the dropdown, silently switched realtime off while the user was in the
+    // middle of configuring it.
+    saveUserSection('voice', mergeVoiceConfig(base as VoiceConfig, patch));
   }
 }
 

--- a/src/daemon/user-settings.ts
+++ b/src/daemon/user-settings.ts
@@ -146,10 +146,15 @@ export function persistUserPatch(section: 'stt' | 'tts' | 'voice', patch: Record
   // default. The read path fails closed on corruption; the write path cannot
   // do the same without locking someone out of their own settings, so it says
   // so loudly instead and the operator has something to chase.
-  if (stored === undefined && getSetting(settingKey(section)) !== null) {
+  const usable = typeof stored === 'object' && stored !== null && !Array.isArray(stored);
+  // Keyed on "a row exists but is unusable", which covers both damage classes:
+  // JSON that will not parse (loadUserSection returns undefined) and JSON that
+  // parses to the wrong shape (an array, a number). A row legitimately holding
+  // `null` is NOT damage — saveUserSection writes that for an absent section —
+  // so it is excluded rather than warned about on every save.
+  if (!usable && getSetting(settingKey(section)) !== null && getSetting(settingKey(section)) !== 'null') {
     console.warn(`[UserSettings] cfg.${section} is unreadable and is being REPLACED by this save; any stored choice in it is lost`);
   }
-  const usable = typeof stored === 'object' && stored !== null && !Array.isArray(stored);
   const base = usable
     ? (isSecretSection(section) ? injectSectionSecrets(section, stored) : stored)
     : {};

--- a/src/daemon/user-settings.ts
+++ b/src/daemon/user-settings.ts
@@ -140,6 +140,15 @@ export function persistUserPatch(section: 'stt' | 'tts' | 'voice', patch: Record
   // it to injectSectionSecrets would not type-check, and there is nothing to
   // rehydrate. stt/tts rows ARE stripped, and merging over the bare row would
   // destroy every stored key the patch does not carry (it did, once).
+  // A row that will not parse reads as `undefined` here, indistinguishable
+  // from absent — so this save would quietly REPLACE it, erasing (for `voice`)
+  // an explicit realtime decline and reverting the tenant to the hosted
+  // default. The read path fails closed on corruption; the write path cannot
+  // do the same without locking someone out of their own settings, so it says
+  // so loudly instead and the operator has something to chase.
+  if (stored === undefined && getSetting(settingKey(section)) !== null) {
+    console.warn(`[UserSettings] cfg.${section} is unreadable and is being REPLACED by this save; any stored choice in it is lost`);
+  }
   const usable = typeof stored === 'object' && stored !== null && !Array.isArray(stored);
   const base = usable
     ? (isSecretSection(section) ? injectSectionSecrets(section, stored) : stored)

--- a/src/daemon/user-settings.ts
+++ b/src/daemon/user-settings.ts
@@ -134,27 +134,22 @@ export function persistUserPatch(section: 'stt' | 'tts' | 'voice', patch: Record
   // Cast, don't default: the merge helpers substitute a provider-carrying
   // default for an UNDEFINED base, which would stamp silence into the row.
   // A `{}` base merges cleanly and stays provider-free unless the patch
-  // itself carries a choice. Secrets are injected only when a row exists —
-  // same orphan rule as mergeUserSettingsIntoConfig.
-  // `voice` holds no credentials, so it skips the hydration entirely — passing
-  // it to injectSectionSecrets would not type-check, and there is nothing to
-  // rehydrate. stt/tts rows ARE stripped, and merging over the bare row would
-  // destroy every stored key the patch does not carry (it did, once).
-  // A row that will not parse reads as `undefined` here, indistinguishable
-  // from absent — so this save would quietly REPLACE it, erasing (for `voice`)
-  // an explicit realtime decline and reverting the tenant to the hosted
-  // default. The read path fails closed on corruption; the write path cannot
-  // do the same without locking someone out of their own settings, so it says
-  // so loudly instead and the operator has something to chase.
+  // itself carries a choice.
   const usable = typeof stored === 'object' && stored !== null && !Array.isArray(stored);
-  // Keyed on "a row exists but is unusable", which covers both damage classes:
-  // JSON that will not parse (loadUserSection returns undefined) and JSON that
-  // parses to the wrong shape (an array, a number). A row legitimately holding
-  // `null` is NOT damage — saveUserSection writes that for an absent section —
-  // so it is excluded rather than warned about on every save.
+  // An unusable row is about to be REPLACED, and for `voice` that erases an
+  // explicit realtime decline and reverts the tenant to the hosted default.
+  // The read path fails closed on corruption (loadUserSectionStrict); the write
+  // path cannot, without locking someone out of their own settings — so it is
+  // loud instead. Keyed on "exists but unusable" to catch both damage classes:
+  // JSON that will not parse, and JSON that parses to the wrong shape. A row
+  // legitimately holding `null` is not damage — saveUserSection writes that for
+  // an absent section — so it is excluded rather than warned about every save.
   if (!usable && getSetting(settingKey(section)) !== null && getSetting(settingKey(section)) !== 'null') {
     console.warn(`[UserSettings] cfg.${section} is unreadable and is being REPLACED by this save; any stored choice in it is lost`);
   }
+  // Secrets are injected only when a row exists (same orphan rule as
+  // mergeUserSettingsIntoConfig), and only for the sections that HAVE any:
+  // `voice` carries no credentials and would not even type-check here.
   const base = usable
     ? (isSecretSection(section) ? injectSectionSecrets(section, stored) : stored)
     : {};
@@ -217,6 +212,33 @@ export function loadUserSection(section: UserOwnedSection): unknown {
     console.warn(`[UserSettings] Corrupt JSON for ${settingKey(section)}; ignoring stored value`);
     return undefined;
   }
+}
+
+/**
+ * Like `loadUserSection`, but THROWS on a row that will not parse.
+ *
+ * The distinction matters wherever "absent" and "damaged" lead to different
+ * answers. `loadUserSection` maps both to `undefined`, which is right for a
+ * merge (there is nothing to merge either way) and wrong for a decision: the
+ * hosted realtime default reads an absent row as "never asked" and switches
+ * realtime ON, so a declining tenant whose row corrupted would have been opted
+ * back into billed audio sessions. Callers that must not make that mistake use
+ * this and fail closed on the throw.
+ *
+ * Lives HERE, beside settingKey, rather than at the call site: a copy of the
+ * `cfg.` prefix in another module reads the wrong key the day the prefix
+ * changes — silently, and in the direction that turns a feature on.
+ */
+export function loadUserSectionStrict(section: UserOwnedSection): unknown {
+  const raw = getSetting(settingKey(section));
+  if (raw === null) return undefined;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error(`corrupt JSON in ${settingKey(section)}`);
+  }
+  return parsed === null ? undefined : parsed;
 }
 
 /** Meta row remembering the file value each section was last imported from. */

--- a/src/daemon/ws-service.ts
+++ b/src/daemon/ws-service.ts
@@ -39,7 +39,7 @@ import { recordAgentActivity } from '../vault/agent-activity.ts';
 import { WebSocketServer, type WSMessage } from '../comms/websocket.ts';
 import { StreamRelay } from '../comms/streaming.ts';
 import { resolveRealtimeVoice, type ResolvedRealtimeVoice } from '../config/realtime.ts';
-import { effectiveRealtimeEnabled } from './usejarvis-ai.ts';
+import { realtimeEnablement } from './usejarvis-ai.ts';
 import { BrowserAudioTransport } from '../comms/audio-transport.ts';
 import { RealtimeVoiceSession } from './realtime-voice.ts';
 import { REALTIME_NAV_TOOLS, REALTIME_NAV_TOOL_NAMES } from './realtime-nav-tools.ts';
@@ -1488,7 +1488,7 @@ CRITICAL — when in genuine doubt between "make in a new project" vs "add to th
     let resolved: ResolvedRealtimeVoice;
     try {
       const cfg = this.agentService.getConfig();
-      const res = resolveRealtimeVoice(cfg, effectiveRealtimeEnabled(cfg));
+      const res = resolveRealtimeVoice(cfg, realtimeEnablement(cfg));
       if (!res.ok) return false;
       resolved = res.resolved;
     } catch (err) {

--- a/src/daemon/ws-service.ts
+++ b/src/daemon/ws-service.ts
@@ -39,6 +39,7 @@ import { recordAgentActivity } from '../vault/agent-activity.ts';
 import { WebSocketServer, type WSMessage } from '../comms/websocket.ts';
 import { StreamRelay } from '../comms/streaming.ts';
 import { resolveRealtimeVoice, type ResolvedRealtimeVoice } from '../config/realtime.ts';
+import { effectiveRealtimeEnabled } from './usejarvis-ai.ts';
 import { BrowserAudioTransport } from '../comms/audio-transport.ts';
 import { RealtimeVoiceSession } from './realtime-voice.ts';
 import { REALTIME_NAV_TOOLS, REALTIME_NAV_TOOL_NAMES } from './realtime-nav-tools.ts';
@@ -1486,7 +1487,8 @@ CRITICAL — when in genuine doubt between "make in a new project" vs "add to th
 
     let resolved: ResolvedRealtimeVoice;
     try {
-      const res = resolveRealtimeVoice(this.agentService.getConfig());
+      const cfg = this.agentService.getConfig();
+      const res = resolveRealtimeVoice(cfg, effectiveRealtimeEnabled(cfg));
       if (!res.ok) return false;
       resolved = res.resolved;
     } catch (err) {

--- a/ui/src/v2/rooms/settings/tabs/VoiceTab.tsx
+++ b/ui/src/v2/rooms/settings/tabs/VoiceTab.tsx
@@ -23,11 +23,17 @@ export function VoiceTab({
   const voice = data.voiceCfg;
   const rt = voice?.realtime;
 
+  // Unavailable means two different things, and the chip used to name only
+  // one of them: on a hosted install there is no key for the user to add, so
+  // "No OpenAI key" both misdiagnosed the problem and implied a bill they do
+  // not pay. The hint below says the same thing at length; this is its label.
   const statusChip = !rt?.enabled
     ? { label: "Off", tone: undefined }
     : rt.available
       ? { label: "Active", tone: "ok" as const }
-      : { label: "No OpenAI key", tone: "warn" as const };
+      : rt.served_by_plan
+        ? { label: "Not in your plan", tone: "warn" as const }
+        : { label: "No OpenAI key", tone: "warn" as const };
 
   return (
     <div className="v2-set__tabpane">
@@ -82,8 +88,12 @@ export function VoiceTab({
             )}
             {rt.available && rt.enabled_default && (
               <p className="v2-set__hint">
-                On because your plan includes it. Switch it off here and JARVIS goes back
-                to the standard voice pipeline.
+                {/* "may include" rather than "includes": available is true for an
+                    UNKNOWN plan verdict too (the gate defaults open until the
+                    catalog answers), so claiming inclusion here can be wrong for
+                    the first few seconds after a restart. */}
+                On because your plan may include it. Switch it off here and JARVIS goes
+                back to the standard voice pipeline.
               </p>
             )}
 

--- a/ui/src/v2/rooms/settings/tabs/VoiceTab.tsx
+++ b/ui/src/v2/rooms/settings/tabs/VoiceTab.tsx
@@ -36,10 +36,20 @@ export function VoiceTab({
           <div>
             <h3 className="v2-set__section-title">Premium Realtime Voice</h3>
             <div className="v2-set__section-sub">
-              Speech-to-speech via OpenAI&apos;s gpt-realtime-2 - lower latency, natural
-              turn-taking, reasons mid-conversation. Reuses the OpenAI provider key from
-              Settings &gt; LLM (you are billed by OpenAI, ~$0.30/min). Off by default;
-              the standard voice pipeline is unaffected.
+              Speech-to-speech - lower latency, natural turn-taking, reasons
+              mid-conversation.{" "}
+              {rt?.hosted ? (
+                <>
+                  Included with your plan and billed as part of it, so there is no
+                  separate key to add and nothing extra to pay.
+                </>
+              ) : (
+                <>
+                  Reuses the OpenAI provider key from Settings &gt; LLM (you are billed by
+                  OpenAI, ~$0.30/min). Off by default.
+                </>
+              )}{" "}
+              The standard voice pipeline is unaffected.
             </div>
           </div>
           <Chip tone={statusChip.tone}>{statusChip.label}</Chip>
@@ -64,8 +74,15 @@ export function VoiceTab({
           <>
             {!rt.available && (
               <p className="v2-set__hint" data-tone="warn">
-                Enabled, but no OpenAI provider is configured. Add one under Settings &gt; LLM.
-                Until then JARVIS uses the standard voice pipeline.
+                {rt.hosted
+                  ? "Live voice is not included in your current plan. JARVIS uses the standard voice pipeline instead."
+                  : "Enabled, but no OpenAI provider is configured. Add one under Settings > LLM. Until then JARVIS uses the standard voice pipeline."}
+              </p>
+            )}
+            {rt.available && rt.enabled_default && (
+              <p className="v2-set__hint">
+                On because your plan includes it. Switch it off here and JARVIS goes back
+                to the standard voice pipeline.
               </p>
             )}
 

--- a/ui/src/v2/rooms/settings/tabs/VoiceTab.tsx
+++ b/ui/src/v2/rooms/settings/tabs/VoiceTab.tsx
@@ -1,4 +1,11 @@
 import React from "react";
+import {
+  realtimeBillingCopy,
+  realtimeChip,
+  realtimeUnavailableReason,
+  showsPlanDefaultHint,
+  type RealtimeCopyInput,
+} from "./voice-realtime-copy";
 import type { RealtimeReasoningEffort, SettingsHook } from "../useSettingsData";
 import { Chip } from "../../../ui";
 
@@ -23,17 +30,18 @@ export function VoiceTab({
   const voice = data.voiceCfg;
   const rt = voice?.realtime;
 
-  // Unavailable means two different things, and the chip used to name only
-  // one of them: on a hosted install there is no key for the user to add, so
-  // "No OpenAI key" both misdiagnosed the problem and implied a bill they do
-  // not pay. The hint below says the same thing at length; this is its label.
-  const statusChip = !rt?.enabled
-    ? { label: "Off", tone: undefined }
-    : rt.available
-      ? { label: "Active", tone: "ok" as const }
-      : rt.served_by_plan
-        ? { label: "Not in your plan", tone: "warn" as const }
-        : { label: "No OpenAI key", tone: "warn" as const };
+  // Every "who pays" decision below comes from voice-realtime-copy.ts, where it
+  // is testable — this suite has no DOM, and each of these was a JSX ternary
+  // that a review round caught asserting the wrong billing model.
+  const copy: RealtimeCopyInput | null = rt
+    ? {
+        enabled: Boolean(rt.enabled),
+        available: Boolean(rt.available),
+        servedByPlan: Boolean(rt.served_by_plan),
+        enabledDefault: Boolean(rt.enabled_default),
+      }
+    : null;
+  const statusChip = realtimeChip(copy);
 
   return (
     <div className="v2-set__tabpane">
@@ -44,7 +52,7 @@ export function VoiceTab({
             <div className="v2-set__section-sub">
               Speech-to-speech - lower latency, natural turn-taking, reasons
               mid-conversation.{" "}
-              {rt?.served_by_plan ? (
+              {realtimeBillingCopy(copy) === "plan" ? (
                 <>
                   Runs on your Usejarvis plan - no separate key to add, and never billed
                   to an OpenAI account of your own. Whether it is included depends on
@@ -81,12 +89,12 @@ export function VoiceTab({
           <>
             {!rt.available && (
               <p className="v2-set__hint" data-tone="warn">
-                {rt.served_by_plan
+                {realtimeUnavailableReason(copy!) === "plan"
                   ? "Live voice is not included in your current plan. JARVIS uses the standard voice pipeline instead."
                   : "Enabled, but no OpenAI provider is configured. Add one under Settings > LLM. Until then JARVIS uses the standard voice pipeline."}
               </p>
             )}
-            {rt.available && rt.enabled_default && (
+            {showsPlanDefaultHint(copy!) && (
               <p className="v2-set__hint">
                 {/* "may include" rather than "includes": available is true for an
                     UNKNOWN plan verdict too (the gate defaults open until the
@@ -166,9 +174,11 @@ export function VoiceTab({
             </div>
 
             <p className="v2-set__hint" data-tone="warn">
-              Continuous audio is streamed to OpenAI while a realtime session is live. Tool calls
-              are auto-approved during realtime sessions (hard denies still apply). Monitor usage
-              at platform.openai.com.
+              Continuous audio is streamed while a realtime session is live. Tool calls are
+              auto-approved during realtime sessions (hard denies still apply).{" "}
+              {realtimeBillingCopy(copy) === "plan"
+                ? "Sessions count against your plan's usage - the Usage room shows how much of the window is left."
+                : "Audio goes to OpenAI on your own key; monitor usage at platform.openai.com."}
             </p>
           </>
         )}

--- a/ui/src/v2/rooms/settings/tabs/VoiceTab.tsx
+++ b/ui/src/v2/rooms/settings/tabs/VoiceTab.tsx
@@ -40,8 +40,9 @@ export function VoiceTab({
               mid-conversation.{" "}
               {rt?.served_by_plan ? (
                 <>
-                  Included with your plan and billed as part of it, so there is no
-                  separate key to add and nothing extra to pay.
+                  Runs on your Usejarvis plan - no separate key to add, and never billed
+                  to an OpenAI account of your own. Whether it is included depends on
+                  your plan.
                 </>
               ) : (
                 <>

--- a/ui/src/v2/rooms/settings/tabs/VoiceTab.tsx
+++ b/ui/src/v2/rooms/settings/tabs/VoiceTab.tsx
@@ -38,7 +38,7 @@ export function VoiceTab({
             <div className="v2-set__section-sub">
               Speech-to-speech - lower latency, natural turn-taking, reasons
               mid-conversation.{" "}
-              {rt?.hosted ? (
+              {rt?.served_by_plan ? (
                 <>
                   Included with your plan and billed as part of it, so there is no
                   separate key to add and nothing extra to pay.
@@ -74,7 +74,7 @@ export function VoiceTab({
           <>
             {!rt.available && (
               <p className="v2-set__hint" data-tone="warn">
-                {rt.hosted
+                {rt.served_by_plan
                   ? "Live voice is not included in your current plan. JARVIS uses the standard voice pipeline instead."
                   : "Enabled, but no OpenAI provider is configured. Add one under Settings > LLM. Until then JARVIS uses the standard voice pipeline."}
               </p>

--- a/ui/src/v2/rooms/settings/tabs/voice-realtime-copy.test.ts
+++ b/ui/src/v2/rooms/settings/tabs/voice-realtime-copy.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  realtimeBillingCopy,
+  realtimeChip,
+  realtimeUnavailableReason,
+  showsPlanDefaultHint,
+  type RealtimeCopyInput,
+} from './voice-realtime-copy.ts';
+
+const rt = (over: Partial<RealtimeCopyInput> = {}): RealtimeCopyInput => ({
+  enabled: true,
+  available: true,
+  servedByPlan: true,
+  enabledDefault: false,
+  ...over,
+});
+
+describe('the status chip', () => {
+  test('names the REAL reason a plan-served session is unavailable', () => {
+    // "No OpenAI key" told a hosted tenant to add a key that does not exist for
+    // them, and implied a bill they do not pay.
+    expect(realtimeChip(rt({ available: false })).label).toBe('Not in your plan');
+  });
+
+  test('still says "No OpenAI key" where that is actually the problem', () => {
+    expect(realtimeChip(rt({ available: false, servedByPlan: false })).label).toBe('No OpenAI key');
+  });
+
+  test('off and active read the same either way', () => {
+    expect(realtimeChip(rt({ enabled: false })).label).toBe('Off');
+    expect(realtimeChip(rt({ enabled: false, servedByPlan: false })).label).toBe('Off');
+    expect(realtimeChip(rt()).label).toBe('Active');
+    expect(realtimeChip(rt({ servedByPlan: false })).label).toBe('Active');
+    expect(realtimeChip(null).label).toBe('Off');
+  });
+});
+
+describe('the billing sentence', () => {
+  test('does not flip when the tenant turns realtime OFF', () => {
+    // It renders beside the toggle, i.e. to someone deciding whether to switch
+    // it on. Deriving it from the live resolution made it say "you are billed
+    // by OpenAI, ~$0.30/min" to a hosted tenant with realtime off.
+    expect(realtimeBillingCopy(rt({ enabled: false }))).toBe('plan');
+    expect(realtimeBillingCopy(rt({ enabled: true }))).toBe('plan');
+  });
+
+  test('does not flip when the plan turns out to exclude realtime', () => {
+    // Who would serve it and whether you may have it are different questions.
+    expect(realtimeBillingCopy(rt({ available: false }))).toBe('plan');
+  });
+
+  test('says BYO only where the user really is billed', () => {
+    expect(realtimeBillingCopy(rt({ servedByPlan: false }))).toBe('byo');
+    expect(realtimeBillingCopy(null)).toBe('byo');
+  });
+});
+
+describe('the remaining surfaces', () => {
+  test('the unavailable hint agrees with the chip', () => {
+    // Three surfaces disagreeing about the same fact is how this feature got
+    // through five review rounds still lying on one of them.
+    for (const servedByPlan of [true, false]) {
+      const input = rt({ available: false, servedByPlan });
+      const chipSaysPlan = realtimeChip(input).label === 'Not in your plan';
+      expect(realtimeUnavailableReason(input) === 'plan').toBe(chipSaysPlan);
+      expect(realtimeBillingCopy(input) === 'plan').toBe(servedByPlan);
+    }
+  });
+
+  test('the plan-default hint stays hidden while the verdict is still unknown-but-off', () => {
+    expect(showsPlanDefaultHint(rt({ enabledDefault: true }))).toBe(true);
+    expect(showsPlanDefaultHint(rt({ enabledDefault: true, available: false }))).toBe(false);
+    expect(showsPlanDefaultHint(rt({ enabledDefault: false }))).toBe(false);
+  });
+});

--- a/ui/src/v2/rooms/settings/tabs/voice-realtime-copy.ts
+++ b/ui/src/v2/rooms/settings/tabs/voice-realtime-copy.ts
@@ -1,0 +1,67 @@
+/**
+ * What the Voice tab says about realtime, as data.
+ *
+ * Extracted from the JSX for the reason `LLMTab.models.test.ts` exists: this
+ * suite has no DOM, so a decision left inside a component is a decision nothing
+ * checks — and these particular decisions are the ones that tell a user who
+ * pays for their voice sessions. Five rounds of review on this feature turned
+ * up three separate surfaces asserting the wrong billing model; each was a
+ * ternary in the JSX.
+ *
+ * The governing distinction is `servedByPlan` — whether a session would run on
+ * the platform proxy under the tenant's plan — NOT whether the install is
+ * hosted, and NOT whether realtime is currently switched on. See
+ * `realtimeServedByPlan` in src/config/realtime.ts.
+ */
+
+export interface RealtimeCopyInput {
+  /** Realtime is switched on (by the user, the env, or the hosted default). */
+  enabled: boolean;
+  /** A session would resolve, and the plan gate has not said no. */
+  available: boolean;
+  /** The plan would serve it — the user's own OpenAI key is never read. */
+  servedByPlan: boolean;
+  /** On because the plan may include it, rather than because anyone asked. */
+  enabledDefault: boolean;
+}
+
+export type ChipTone = "ok" | "warn" | undefined;
+
+/**
+ * Unavailable means two different things, and the chip used to name only one:
+ * on a plan-served install there is no key for the user to add, so "No OpenAI
+ * key" both misdiagnosed the problem and implied a bill they do not pay.
+ */
+export function realtimeChip(rt: RealtimeCopyInput | null): { label: string; tone: ChipTone } {
+  if (!rt?.enabled) return { label: "Off", tone: undefined };
+  if (rt.available) return { label: "Active", tone: "ok" };
+  return rt.servedByPlan
+    ? { label: "Not in your plan", tone: "warn" }
+    : { label: "No OpenAI key", tone: "warn" };
+}
+
+/**
+ * The billing sentence, shown beside the toggle — i.e. to someone deciding
+ * whether to switch realtime ON. It must therefore be true independently of
+ * the current toggle state, which is why it reads `servedByPlan` (a property of
+ * the install) rather than anything derived from the live resolution.
+ */
+export function realtimeBillingCopy(rt: RealtimeCopyInput | null): "plan" | "byo" {
+  return rt?.servedByPlan ? "plan" : "byo";
+}
+
+/** Why realtime is enabled but not working. */
+export function realtimeUnavailableReason(rt: RealtimeCopyInput): "plan" | "no-key" {
+  return rt.servedByPlan ? "plan" : "no-key";
+}
+
+/**
+ * Whether to claim the plan includes realtime.
+ *
+ * "may include", never "includes": `available` is true for an UNKNOWN plan
+ * verdict too — the gate defaults open until the catalog answers — so a
+ * definite claim is wrong for the first seconds after a restart.
+ */
+export function showsPlanDefaultHint(rt: RealtimeCopyInput): boolean {
+  return rt.available && rt.enabledDefault;
+}

--- a/ui/src/v2/rooms/settings/useSettingsData.ts
+++ b/ui/src/v2/rooms/settings/useSettingsData.ts
@@ -252,6 +252,10 @@ export interface VoiceConfig {
     enabled_default?: boolean;
     /** This install is hosted (a usejarvis_ai block is present). */
     hosted?: boolean;
+    /** A session would run on the platform proxy under the plan — so there is
+     *  nothing extra to pay. Distinct from `hosted`: the billing copy must
+     *  describe who would actually serve the session, not the install type. */
+    served_by_plan?: boolean;
   };
 }
 

--- a/ui/src/v2/rooms/settings/useSettingsData.ts
+++ b/ui/src/v2/rooms/settings/useSettingsData.ts
@@ -247,6 +247,11 @@ export interface VoiceConfig {
     blocked_categories: string[];
     /** true when enabled AND the OpenAI provider key resolves. */
     available: boolean;
+    /** On because the hosted PLAN may include it, not because anyone asked.
+     *  Such a session runs on the platform proxy, never on a BYO key. */
+    enabled_default?: boolean;
+    /** This install is hosted (a usejarvis_ai block is present). */
+    hosted?: boolean;
   };
 }
 


### PR DESCRIPTION
Premium realtime voice (`uj-realtime`) is a paid slot on a hosted plan, and it had never run for a single tenant. `voice.realtime.enabled` defaults to false, the only thing that ever flipped it was the `JARVIS_REALTIME_VOICE` env var, and the provisioner sets neither — so `resolveRealtimeVoice` bailed on its first line and the hosted branch below it, which derives the `wss://` endpoint and dials the alias, was dead code. Every voice turn fell through to STT → tiered LLM → TTS.

Hosted installs now get realtime on by default, with the existing key-scoped catalog gate deciding per session.

## What else is in here

- **Boot warm + self-healing poll.** `/api/config/voice` reports availability from the cache, and an unknown verdict reads as available — so a cold cache puts the browser into raw-PCM capture, the gate refuses, and those frames are dropped rather than fed headerless to Whisper. The user speaks once and nothing happens. Rare when realtime needed an opt-in nobody had; every hosted install now. The gate is warmed at boot and re-warmed after each SIGHUP (which clears its cache), and a cache miss or stale entry starts its own fetch so the poll heals gaps warming cannot reach.
- **Voice-tab copy.** Five surfaces asserted the wrong billing model. All now derive from `voice-realtime-copy.ts` and are pinned against each other.
- **`persistUserPatch` extended to `voice`.** The route merged patches over the in-memory section, which always carries `DEFAULT_CONFIG`'s `enabled: false` — so changing the wake engine, or picking a realtime voice, wrote that back as an explicit decline and switched realtime off mid-configuration.

## Testing

`bunx tsc --noEmit`, `bun test` (2583 tests, 0 fail), `bun run build:ui`, `go build ./...` in `sidecar/`.

Every behavioural change is pinned by a test verified to fail when only that change is reverted — checked individually, after an earlier round shipped a test that passed with its own fix reverted (it aged a cache entry 60s against a 600s TTL and never reached the guard it was written for).
