### PR TITLE
fix(sidecar): make mute a gate on every path that opens the microphone

### DIFF
--- a/sidecar/client.go
+++ b/sidecar/client.go
@@ -563,6 +563,9 @@ func (c *SidecarClient) connectAndServe(ctx context.Context) error {
 		// regex-matches "jarvis". Pauses around Ctrl+Space session
 		// captures so it doesn't fight for the mic device.
 		wakeListener := NewWakeListenerService(audioSvc, sendFn, DefaultWakeListenerOpts())
+		// Start() itself consults micMuted(), so a reconnect while muted comes up
+		// with the device closed instead of silently re-arming always-on
+		// listening behind a menu that still says muted.
 		if err := wakeListener.Start(ctx); err != nil {
 			log.Printf("[wake] failed to start: %v", err)
 			wakeListener = nil
@@ -591,7 +594,42 @@ func (c *SidecarClient) connectAndServe(ctx context.Context) error {
 		// path (when the daemon dispatches `pebble.start_listening` after
 		// matching a wake phrase that had no trailing command).
 		var sessionInFlight atomic.Bool
-		runSessionCapture := func(sessionID string) {
+
+		// micRefused is the visible consequence of a mute-blocked mic. An early
+		// return with no feedback reads as a broken hotkey, so say it twice: on
+		// the pebble (local, immediate — mic state is sidecar-owned) and to the
+		// brain, which can explain it in conversation rather than waiting for
+		// audio that is never coming.
+		micRefused := func(source, sessionID string) {
+			log.Printf("[audio] %s refused — microphone muted (session=%s)", source, sessionID)
+			if c.pebble != nil {
+				flashMutedPebble(c.pebble)
+			}
+			evt := SidecarEvent{
+				Type:      "sidecar_event",
+				EventType: "pebble.mic_blocked",
+				Timestamp: time.Now().UnixMilli(),
+				Priority:  "normal",
+				Payload: map[string]any{
+					"reason":     "muted",
+					"source":     source,
+					"session_id": sessionID,
+				},
+			}
+			if err := sendFn(ctx, evt, nil); err != nil {
+				log.Printf("[audio] failed to emit mic_blocked event: %v", err)
+			}
+		}
+
+		runSessionCapture := func(sessionID, source string) {
+			// Mute is a gate, not a pause: checked here, where the mic is opened,
+			// rather than left to whoever paused the wake listener. Before the
+			// in-flight CAS and before audio.session_start, so a refused session
+			// leaves no state behind and the daemon never sees a start with no end.
+			if micMuted() {
+				micRefused(source, sessionID)
+				return
+			}
 			if !sessionInFlight.CompareAndSwap(false, true) {
 				log.Printf("[audio] session %s skipped — capture already in flight", sessionID)
 				return
@@ -619,6 +657,16 @@ func (c *SidecarClient) connectAndServe(ctx context.Context) error {
 			pcm, dur, err := pebbleCaptureWithVAD(audioSvc, sessionID, DefaultVADOpts())
 			if err != nil {
 				log.Printf("[audio] capture failed: %v", err)
+				return
+			}
+			// Muted mid-capture: the tray closure above already released the
+			// device, so this is whatever was recorded BEFORE the user muted.
+			// Drop it rather than ship it — mute has to mean the audio doesn't
+			// leave the machine, not just that the next capture is refused.
+			// micRefused also unwinds the summon the brain is holding.
+			if micMuted() {
+				log.Printf("[audio] session %s discarded (%d PCM bytes) — muted mid-capture", sessionID, len(pcm))
+				micRefused(source, sessionID)
 				return
 			}
 
@@ -738,20 +786,35 @@ func (c *SidecarClient) connectAndServe(ctx context.Context) error {
 			log.Printf("[realtime] dedicated audio channel open")
 			return writePCM, closeFn, true
 		}
-		rt := newRealtimeVoice(realtimeCapture, wakeListener, emit, setStream, setPebbleState, resumeWake, openAudio)
+		rt := newRealtimeVoice(realtimeCapture, wakeListener, emit, setStream, setPebbleState, resumeWake, openAudio,
+			func() { micRefused("realtime", "") })
 		c.realtime.Store(rt)
 		// Tear the session down when this connection ends.
 		defer rt.Stop(false)
 
-		// Tray "Mute microphone" toggle → gate the mic locally. Muting ends any
-		// live realtime session (which re-arms the wake listener), then releases
-		// the always-on wake mic and shows the muted pebble; unmuting re-arms the
-		// wake listener and clears the pebble. Note the Stop-then-Pause order:
-		// realtime.Stop() calls resumeWake internally, so Pause must come after.
+		// Tray "Mute microphone" toggle → apply the gate locally. The tray thread
+		// writes TrayStatus.Muted before this runs, so micMuted() is already
+		// authoritative and every path that would OPEN the mic is already closed.
+		// What's left for this closure is the mic that is open right now: end a
+		// live realtime session, cut off an in-flight one-shot capture, release
+		// the always-on wake mic, and show the muted pebble. Unmuting re-arms the
+		// wake listener and clears the pebble. (Stop() calls resumeWake
+		// internally, but that Resume is now refused by the mute gate rather than
+		// defeated by call ordering.)
 		setTrayApplyMute(func(muted bool) {
 			if muted {
 				if rt := c.realtime.Load(); rt != nil {
 					rt.Stop(true)
+				}
+				// A one-shot capture already holds the device — the gate below
+				// only stops the NEXT one. Cut this one off now rather than at
+				// the VAD's 15 s hard cap: wakeListener.Pause() won't do it (the
+				// capture already set paused, so its audioSvc.Stop() is skipped)
+				// and they share one AudioCaptureService. The capture's own
+				// post-mute check then drops whatever PCM it had.
+				if sessionInFlight.Load() {
+					log.Printf("[audio] mute during capture — releasing the device now")
+					_, _, _ = audioSvc.Stop()
 				}
 				if wakeListener != nil {
 					wakeListener.Pause()
@@ -765,6 +828,16 @@ func (c *SidecarClient) connectAndServe(ctx context.Context) error {
 			}
 		})
 		defer setTrayApplyMute(func(bool) {})
+
+		// A reconnect rebuilds the pebble, the wake listener and the realtime
+		// controller from scratch, none of which know about a mute set on the
+		// previous connection. Re-apply it through the closure just registered so
+		// the device and the menu agree from the first frame. Through trayCtlQ,
+		// and re-reading the flag inside the queued func: a toggle racing the
+		// reconnect must win, or we'd re-mute a mic the user just unmuted.
+		if micMuted() {
+			trayCtlAsync(func() { trayApplyMute(micMuted()) })
+		}
 
 		// Long-answer overflow — click on the "open full ↗" button emits
 		// pebble.open_answer with the answer id stored via SetAnswerOverflow.
@@ -812,17 +885,29 @@ func (c *SidecarClient) connectAndServe(ctx context.Context) error {
 				return
 			}
 			sessionID := fmt.Sprintf("%d", time.Now().UnixMilli())
+			// The summon event goes out even when muted, because this hotkey is
+			// ALSO the dismiss gesture: the daemon's handler is a toggle, and a
+			// second press cancels an in-flight turn and cuts off TTS. Swallowing
+			// it here would leave a muted user unable to shut JARVIS up. The
+			// `muted` flag tells the daemon not to open a listening cycle it
+			// would then have to wait out.
+			muted := micMuted()
 			summonEvt := SidecarEvent{
 				Type:      "sidecar_event",
 				EventType: "pebble.summon",
 				Timestamp: time.Now().UnixMilli(),
 				Priority:  "normal",
-				Payload:   map[string]any{"session_id": sessionID},
+				Payload:   map[string]any{"session_id": sessionID, "muted": muted},
 			}
 			if err := sendFn(ctx, summonEvt, nil); err != nil {
 				log.Printf("[pebble] failed to emit summon event: %v", err)
 			}
-			go runSessionCapture(sessionID)
+			if muted {
+				log.Printf("[audio] summon refused — microphone muted (session=%s)", sessionID)
+				flashMutedPebble(c.pebble) // the brain is told by the event's muted flag
+				return
+			}
+			go runSessionCapture(sessionID, "summon")
 		})
 
 		// W4 — palette hotkey (Ctrl+K) emits a "pebble.palette" event with
@@ -939,7 +1024,19 @@ func (c *SidecarClient) connectAndServe(ctx context.Context) error {
 		c.mu.Lock()
 		c.handlers["pebble.start_listening"] = func(_ map[string]any) (*RPCResult, error) {
 			sessionID := fmt.Sprintf("listen-%d", time.Now().UnixMilli())
-			go runSessionCapture(sessionID)
+			// Muted: answer the daemon rather than silently dropping the request.
+			// It has already flipped the bubble to "listening" and armed a
+			// fallback timer; told no, it can reset immediately instead of
+			// waiting out audio that will never arrive.
+			if micMuted() {
+				micRefused("start_listening", sessionID)
+				return &RPCResult{Result: map[string]any{
+					"session_id": sessionID,
+					"started":    false,
+					"reason":     "muted",
+				}}, nil
+			}
+			go runSessionCapture(sessionID, "start_listening")
 			return &RPCResult{Result: map[string]any{"session_id": sessionID, "started": true}}, nil
 		}
 

--- a/sidecar/mute_gate_test.go
+++ b/sidecar/mute_gate_test.go
@@ -1,0 +1,234 @@
+package main
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+// setMutedForTest flips the process-global mic gate and restores it after the
+// test, so an ordering change in the file can't leak a muted mic into the next
+// test's expectations.
+func setMutedForTest(t *testing.T, muted bool) {
+	t.Helper()
+	prev := getTrayStatus()
+	s := prev
+	s.Muted = muted
+	setTrayStatus(s)
+	t.Cleanup(func() { setTrayStatus(prev) })
+}
+
+// chunkListenerSet reports whether the capture service currently has a chunk
+// listener installed — the observable proof that Resume() reached the device
+// work rather than short-circuiting on the mute gate.
+func chunkListenerSet(s *AudioCaptureService) bool {
+	s.onChunkMu.RLock()
+	defer s.onChunkMu.RUnlock()
+	return s.onChunk != nil
+}
+
+// TestWakeResumeRefusedWhileMuted is the regression for the mute/summon
+// divergence: displayed state and device state must not drift apart.
+//
+// mute → summon → capture completes used to leave the always-on wake listener
+// running (the capture's deferred Resume cleared the pause the mute handler had
+// set, since both wrote the same bit) while TrayStatus.Muted stayed true — so
+// the menu said muted with a live mic, until you toggled mute twice.
+func TestWakeResumeRefusedWhileMuted(t *testing.T) {
+	svc := NewAudioCaptureService() // never Start()ed: no real device is touched
+	w := NewWakeListenerService(svc, nil, DefaultWakeListenerOpts())
+	w.running.Store(true) // as if Start() had opened the device
+
+	w.Pause() // a session capture borrows the mic
+	if !w.paused.Load() {
+		t.Fatalf("paused = false after Pause(), want true")
+	}
+
+	setMutedForTest(t, true) // user mutes from the tray mid-capture
+
+	w.Resume(context.Background()) // the capture's deferred Resume on the way out
+
+	if !w.paused.Load() {
+		t.Errorf("wake listener resumed while muted — mic is live behind a muted menu")
+	}
+	if chunkListenerSet(svc) {
+		t.Errorf("Resume() reinstalled the chunk listener while muted")
+	}
+	if !micMuted() {
+		t.Errorf("TrayStatus.Muted = false, want true — the displayed state must survive a capture")
+	}
+}
+
+// TestWakeResumeRestoresWhenNotMuted guards the other half: with no mute in
+// place, a consumer's Resume must still get past the gate and go do device
+// work. The context is pre-cancelled so the retry loop bails before opening a
+// real device — the installed chunk listener is the marker that it got there.
+func TestWakeResumeRestoresWhenNotMuted(t *testing.T) {
+	setMutedForTest(t, false)
+	svc := NewAudioCaptureService()
+	w := NewWakeListenerService(svc, nil, DefaultWakeListenerOpts())
+	w.running.Store(true)
+	w.Pause()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	w.Resume(ctx)
+
+	if !chunkListenerSet(svc) {
+		t.Errorf("Resume() short-circuited with no mute in place")
+	}
+}
+
+// TestWakeStartsPausedWhileMuted covers the reconnect path: connectAndServe
+// builds a fresh listener per connection, and coming up live would re-arm
+// always-on listening while the tray still says muted.
+func TestWakeStartsPausedWhileMuted(t *testing.T) {
+	setMutedForTest(t, true)
+	svc := NewAudioCaptureService()
+	w := NewWakeListenerService(svc, nil, DefaultWakeListenerOpts())
+
+	if err := w.Start(context.Background()); err != nil {
+		t.Fatalf("Start() while muted: %v", err)
+	}
+	defer w.Stop()
+
+	if !w.running.Load() {
+		t.Errorf("running = false, want true — the listener must stay armed so unmuting recovers it")
+	}
+	if !w.paused.Load() {
+		t.Errorf("paused = false — a muted sidecar reopened the mic on reconnect")
+	}
+	if chunkListenerSet(svc) {
+		t.Errorf("Start() installed the chunk listener while muted")
+	}
+}
+
+// TestRealtimeStartRefusedWhileMuted covers the second door into the mic: with
+// realtime voice enabled the summon hotkey routes here instead of the one-shot
+// capture, so it needs the same gate — and must say why rather than no-op.
+func TestRealtimeStartRefusedWhileMuted(t *testing.T) {
+	setMutedForTest(t, true)
+
+	refusals := 0
+	var states []PebbleState
+	r := newRealtimeVoice(
+		nil, nil,
+		func(string, map[string]any) {},
+		func(*AudioStreamPlayer) {},
+		func(s PebbleState) { states = append(states, s) },
+		func() {},
+		nil,
+		func() { refusals++ },
+	)
+
+	r.Start()
+
+	if r.active.Load() {
+		t.Errorf("realtime session went active while muted")
+	}
+	if refusals != 1 {
+		t.Errorf("micRefused called %d times, want 1 — a silent refusal reads as a broken hotkey", refusals)
+	}
+	// Re-asserting PebbleMuted would paint nothing (the tray toggle already put
+	// the pebble there), which is why the refusal goes through micRefused.
+	if len(states) != 0 {
+		t.Errorf("pebble states = %v, want none — the refusal is micRefused's job", states)
+	}
+}
+
+// nudgePebbleStub records bubble-text writes; everything else is a no-op.
+type nudgePebbleStub struct {
+	mu    sync.Mutex
+	texts []string
+}
+
+func (p *nudgePebbleStub) SetText(text string) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.texts = append(p.texts, text)
+	return nil
+}
+
+func (p *nudgePebbleStub) lastText() string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if len(p.texts) == 0 {
+		return ""
+	}
+	return p.texts[len(p.texts)-1]
+}
+
+func (p *nudgePebbleStub) Spawn(PebbleSpec) error              { return nil }
+func (p *nudgePebbleStub) SetState(PebbleState) error          { return nil }
+func (p *nudgePebbleStub) PointAt(int, int, string, int) error { return nil }
+func (p *nudgePebbleStub) SetEye(bool) error                   { return nil }
+func (p *nudgePebbleStub) SetAnswerOverflow(string) error      { return nil }
+func (p *nudgePebbleStub) SetBlinded(bool) error               { return nil }
+func (p *nudgePebbleStub) SetEthereal(bool, int)               {}
+func (p *nudgePebbleStub) Close() error                        { return nil }
+func (p *nudgePebbleStub) OnSummon(func())                     {}
+func (p *nudgePebbleStub) OnPalette(func())                    {}
+func (p *nudgePebbleStub) OnBlindToggle(func())                {}
+func (p *nudgePebbleStub) OnAnswerOpen(func(string))           {}
+
+// TestMutedNudgeExpiryClearsOwnText covers the nudge's normal life: it puts the
+// reason in the bubble and takes it back out again.
+func TestMutedNudgeExpiryClearsOwnText(t *testing.T) {
+	shortenNudge(t)
+	p := &nudgePebbleStub{}
+
+	flashMutedPebble(p)
+	if p.lastText() == "" {
+		t.Fatalf("nudge wrote no bubble text")
+	}
+	time.Sleep(10 * mutedNudgeDur)
+
+	if p.lastText() != "" {
+		t.Errorf("bubble text = %q after expiry, want cleared", p.lastText())
+	}
+}
+
+// TestMutedNudgeExpirySparesOtherText is the one that matters: a nudge armed
+// moments before the brain streams an answer into the bubble must not blank it
+// when the timer fires. pebble.set_state claims the text via
+// invalidateMutedNudge; this asserts the claim holds.
+func TestMutedNudgeExpirySparesOtherText(t *testing.T) {
+	shortenNudge(t)
+	p := &nudgePebbleStub{}
+
+	flashMutedPebble(p)
+	handler := makePebbleSetStateHandler(p)
+	if _, err := handler(map[string]any{"state": "speaking", "text": "here's the answer"}); err != nil {
+		t.Fatalf("set_state: %v", err)
+	}
+	time.Sleep(10 * mutedNudgeDur)
+
+	if p.lastText() != "here's the answer" {
+		t.Errorf("bubble text = %q, want the brain's text — a stale nudge blanked it", p.lastText())
+	}
+}
+
+func shortenNudge(t *testing.T) {
+	t.Helper()
+	prev := mutedNudgeDur
+	mutedNudgeDur = 5 * time.Millisecond
+	t.Cleanup(func() { mutedNudgeDur = prev })
+}
+
+// TestTrayStatusIgnoresRemoteMuted pins the decision that mute is sidecar-owned:
+// the brain's tray.status heartbeat can no longer flip it. Honoring it would
+// make micMuted() — now the authoritative gate on every mic-opening path —
+// remotely settable, in both directions.
+func TestTrayStatusIgnoresRemoteMuted(t *testing.T) {
+	setMutedForTest(t, true)
+
+	s := trayStatusFromParams(map[string]any{"muted": false, "waiting": float64(3)})
+
+	if !s.Muted {
+		t.Errorf("tray.status payload un-muted the microphone remotely")
+	}
+	if s.Waiting != 3 {
+		t.Errorf("Waiting = %d, want 3 — the rest of the payload must still merge", s.Waiting)
+	}
+}

--- a/sidecar/pebble_handlers.go
+++ b/sidecar/pebble_handlers.go
@@ -52,6 +52,9 @@ func makePebbleSetStateHandler(svc PebbleService) RPCHandler {
 		// body line — avoids one frame of stale "speaking…" placeholder.
 		if rawText, hasText := params["text"]; hasText {
 			text, _ := rawText.(string)
+			// The brain owns the bubble from here: cancel any pending muted
+			// nudge so its expiry doesn't blank this text a second later.
+			invalidateMutedNudge()
 			if err := svc.SetText(text); err != nil {
 				return nil, err
 			}

--- a/sidecar/pebble_overlay.go
+++ b/sidecar/pebble_overlay.go
@@ -14,6 +14,11 @@ package main
 // The implementation lives in pebble_overlay_<os>.go behind build tags. This
 // file is the cross-platform interface + state types only.
 
+import (
+	"sync/atomic"
+	"time"
+)
+
 // PebbleState mirrors the React state machine used in the design mock.
 type PebbleState string
 
@@ -122,6 +127,41 @@ type PebbleService interface {
 	// the answer id that SetAnswerOverflow was called with. Threading:
 	// runs on a fresh goroutine.
 	OnAnswerOpen(callback func(answerID string))
+}
+
+// mutedNudgeGen serializes claims on the bubble text: a nudge only clears the
+// text it wrote, and any later writer (another nudge, or the brain via
+// pebble.set_state) takes ownership by bumping the counter.
+var mutedNudgeGen atomic.Int64
+
+// mutedNudgeDur is how long the "muted" explanation stays in the bubble before
+// the state's default copy comes back. A var so tests can shrink it.
+var mutedNudgeDur = 2500 * time.Millisecond
+
+// flashMutedPebble is the visible consequence of a mic request turned away by
+// mute. Re-asserting the muted state alone is invisible when the pebble is
+// already showing it, so the bubble carries the reason for a moment — a
+// silently ignored hotkey is indistinguishable from a broken one.
+// invalidateMutedNudge takes the bubble text away from any pending muted nudge.
+// Callers that set bubble text through some other route must call it, or a
+// nudge armed moments earlier will blank their text when it expires.
+func invalidateMutedNudge() { mutedNudgeGen.Add(1) }
+
+func flashMutedPebble(p PebbleService) {
+	if p == nil {
+		return
+	}
+	gen := mutedNudgeGen.Add(1)
+	_ = p.SetText("Microphone muted — unmute from the tray menu")
+	_ = p.SetState(PebbleMuted)
+	go func() {
+		time.Sleep(mutedNudgeDur)
+		// Only the most recent claim clears the text; if anything else has
+		// written to the bubble since (invalidateMutedNudge), it owns it now.
+		if mutedNudgeGen.Load() == gen {
+			_ = p.SetText("") // back to the per-state default copy
+		}
+	}()
 }
 
 // NewPebbleService returns the platform-specific implementation. Defined in

--- a/sidecar/pebble_realtime.go
+++ b/sidecar/pebble_realtime.go
@@ -6,6 +6,7 @@ package main
 // when the daemon has reported realtime is enabled (pebble.configure_realtime).
 // The sidecar is the audio DEVICE; the daemon runs the OpenAI realtime session.
 //
+//   gate:   refused outright while the user has the mic muted (micMuted)
 //   start:  pause wake listener → open streaming playback → stream 24 kHz mic
 //           PCM up as `pebble.audio_frame` events → emit `pebble.realtime_start`
 //   live:   daemon streams output PCM down via `pebble.play_pcm` (readLoop
@@ -43,6 +44,10 @@ type realtimeVoice struct {
 	setStream  func(*AudioStreamPlayer)                       // install/clear the readLoop's playback target
 	setState   func(PebbleState)                              // drive the pebble visual
 	resumeWake func()                                         // re-arm the wake listener (ctx-bound, self-guarded)
+	// micRefused reports a mic request turned away by mute — one shared path
+	// with the capture doors so the refusal is actually visible (pebble bubble)
+	// instead of a state re-assert the pebble is already showing.
+	micRefused func()
 	// openAudio dials the dedicated audio WebSocket; onBinary plays inbound PCM,
 	// onFlush is barge-in. Returns (writePCM, close, ok=false on dial failure).
 	openAudio func(onBinary func([]byte), onFlush func()) (func([]byte) error, func(), bool)
@@ -60,6 +65,7 @@ func newRealtimeVoice(
 	setState func(PebbleState),
 	resumeWake func(),
 	openAudio func(onBinary func([]byte), onFlush func()) (func([]byte) error, func(), bool),
+	micRefused func(),
 ) *realtimeVoice {
 	return &realtimeVoice{
 		capture:    capture,
@@ -69,6 +75,7 @@ func newRealtimeVoice(
 		setState:   setState,
 		resumeWake: resumeWake,
 		openAudio:  openAudio,
+		micRefused: micRefused,
 	}
 }
 
@@ -84,8 +91,23 @@ func (r *realtimeVoice) Toggle() {
 }
 
 // Start opens the local audio path and asks the daemon to open the session.
+// Refused while the microphone is muted — this is the second door into the mic
+// (the summon hotkey routes here instead of the one-shot capture when realtime
+// is enabled), so it has to check the same gate. Stop() is deliberately NOT
+// gated: ending a session that was already live must always work.
 func (r *realtimeVoice) Start() {
 	log.Printf("[realtime] Start() invoked (enabled=%v active=%v)", r.enabled.Load(), r.active.Load())
+	if micMuted() {
+		// Not just setState(PebbleMuted): the pebble is ALREADY muted-looking
+		// (the tray toggle put it there), so re-asserting it paints nothing and
+		// the hotkey reads as dead. micRefused puts the reason in the bubble and
+		// tells the brain.
+		log.Printf("[realtime] start refused — microphone muted")
+		if r.micRefused != nil {
+			r.micRefused()
+		}
+		return
+	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if !r.active.CompareAndSwap(false, true) {

--- a/sidecar/pebble_wake.go
+++ b/sidecar/pebble_wake.go
@@ -21,6 +21,14 @@ package main
 // Resume() restarts the continuous capture once the session ends. The
 // daemon also gates wake_segment processing during TTS playback so JARVIS
 // saying his own name doesn't re-trigger the loop.
+//
+// Three independent reasons the mic can be off, deliberately kept apart:
+//   - paused        — a consumer borrowed the device and will hand it back
+//   - suppressDepth — the device stays open but chunks are dropped (TTS echo,
+//                     region-select chord); a counter, since sources overlap
+//   - micMuted()    — the USER turned the mic off, indefinitely, from the tray
+//
+// Only the user clears the last one. Pause/Resume must never lift it.
 
 import (
 	"context"
@@ -115,6 +123,17 @@ func (w *WakeListenerService) Start(ctx context.Context) error {
 	w.doneCh = make(chan struct{})
 	w.resetSegment()
 
+	// Muted: come up armed but with the device closed. A reconnect builds a
+	// fresh listener, and opening the mic here would re-arm always-on listening
+	// while the tray menu still says muted. The coordinator still runs so
+	// unmuting (Resume) recovers without a restart.
+	if micMuted() {
+		w.paused.Store(true)
+		log.Printf("[wake] listener started paused — microphone muted")
+		go w.coordinate(ctx)
+		return nil
+	}
+
 	// Hook the chunk listener BEFORE Start so we don't miss any audio.
 	w.audioSvc.SetChunkListener(w.onChunk)
 	if err := w.audioSvc.Start(fmt.Sprintf("wake-%d", time.Now().UnixMilli())); err != nil {
@@ -132,6 +151,12 @@ func (w *WakeListenerService) Start(ctx context.Context) error {
 
 // Pause releases the mic device so a session-capture or other consumer
 // can take over. Safe to call when not running. Use Resume() to restart.
+//
+// Pause/Resume is the CONSUMER's momentary device handoff: "off while I use
+// the mic, and I'll put it back". It is not the user's mute — mute is a gate
+// the user owns indefinitely (micMuted), and Resume refuses to lift it. Those
+// two intents used to share this single bit, so a session capture's deferred
+// Resume re-armed a mic the user had muted mid-capture.
 func (w *WakeListenerService) Pause() {
 	if !w.running.Load() {
 		return
@@ -144,10 +169,18 @@ func (w *WakeListenerService) Pause() {
 	log.Printf("[wake] paused (mic released)")
 }
 
-// Resume restarts capture after a Pause(). No-op if not paused or not
-// running.
+// Resume restarts capture after a Pause(). No-op if not paused, not running,
+// or while the user has the microphone muted.
+//
+// The mute check comes BEFORE the paused CAS on purpose: a refused resume must
+// leave paused set, so the listener stays consistently off and unmuting (which
+// calls Resume once the gate is clear) is what brings it back.
 func (w *WakeListenerService) Resume(ctx context.Context) {
 	if !w.running.Load() {
+		return
+	}
+	if micMuted() {
+		log.Printf("[wake] resume refused — microphone muted")
 		return
 	}
 	if !w.paused.CompareAndSwap(true, false) {

--- a/sidecar/tray_status.go
+++ b/sidecar/tray_status.go
@@ -77,6 +77,20 @@ func setTrayStatus(s TrayStatus) {
 	trayRefresh()
 }
 
+// micMuted reports whether the user has muted the microphone from the tray.
+//
+// This is THE gate every path that opens the mic must consult — one-shot
+// session capture, realtime voice, and the always-on wake listener. Mute is a
+// gate the user owns indefinitely, not a momentary pause a consumer restores
+// on its way out; representing it in one place is what keeps the menu, the
+// pebble and the device from drifting apart. Cheaper than getTrayStatus()
+// (no Recent copy) and safe to call from any goroutine.
+func micMuted() bool {
+	trayStatusMu.RLock()
+	defer trayStatusMu.RUnlock()
+	return trayStatusCur.Muted
+}
+
 func getTrayStatus() TrayStatus {
 	trayStatusMu.RLock()
 	defer trayStatusMu.RUnlock()
@@ -122,9 +136,13 @@ func trayStatusFromParams(params map[string]any) TrayStatus {
 	if v, ok := params["paused"].(bool); ok {
 		s.Paused = v
 	}
-	if v, ok := params["muted"].(bool); ok {
-		s.Muted = v
-	}
+	// NOTE: `muted` is deliberately NOT read from this payload. The microphone
+	// is sidecar-owned local state (the brain's own tray heartbeat says as
+	// much) and micMuted() is now the authoritative gate on every mic-opening
+	// path — so honoring a `muted` field here would turn a best-effort status
+	// heartbeat into remote mic control, and a brain that echoed muted:false
+	// would silently un-gate a mic the user muted. Mute changes only via the
+	// tray toggle.
 	if v, ok := params["brain_online"].(bool); ok {
 		s.BrainOnline = v
 	}

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -676,7 +676,11 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
       // Per-sidecar in-flight summon control. Tracks whether a summon is
       // active and lets us cancel mid-flight when the user dismisses with
       // a second hotkey press.
-      const pendingSummons = new Map<string, { cancelled: boolean }>();
+      // `sessionId` is set only for hotkey summons (the sidecar mints it and
+      // stamps it on both `pebble.summon` and any later `pebble.mic_blocked`),
+      // so a mic refusal can unwind exactly the slot it belongs to and never a
+      // turn that happens to be in flight.
+      const pendingSummons = new Map<string, { cancelled: boolean; sessionId?: string }>();
 
       // Fallback timers for the bare-"Jarvis" listening state. If the sidecar's
       // session capture never produces an `audio.session_end` (dropped event,
@@ -1628,7 +1632,19 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
           console.log(`[ambient-ui] pebble.summon (dismiss) on ${sidecarId}`);
           return;
         }
-        pendingSummons.set(sidecarId, { cancelled: false });
+        const payload = (event.payload as { session_id?: string; muted?: boolean } | undefined) ?? {};
+        if (payload.muted === true) {
+          // The sidecar sends the press even when the mic is muted, because
+          // this hotkey doubles as the dismiss gesture (handled above). With
+          // nothing to dismiss there's no cycle to open: claiming a summon slot
+          // here would strand the pebble in `listening` waiting on audio the
+          // sidecar has already refused to capture. No text argument — the
+          // sidecar's bubble already says why.
+          setState(sidecarId, 'muted');
+          console.log(`[ambient-ui] pebble.summon on ${sidecarId} — ignored, microphone muted`);
+          return;
+        }
+        pendingSummons.set(sidecarId, { cancelled: false, sessionId: payload.session_id });
         setState(sidecarId, 'listening', '');
         console.log(`[ambient-ui] pebble.summon on ${sidecarId} — listening for audio…`);
       });
@@ -3585,7 +3601,24 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
           // instant a session is actually consumed, so it never cuts a response).
           await setState(sidecarId, 'listening', '');
           try {
-            await sidecarManager.dispatchRPC(sidecarId, 'pebble.start_listening', {});
+            const res = (await sidecarManager.dispatchRPC(sidecarId, 'pebble.start_listening', {})) as
+              | { started?: boolean; reason?: string }
+              | undefined;
+            if (res?.started === false) {
+              // The sidecar refused to open the mic — the user muted it between
+              // the wake segment being captured and this call landing. Give the
+              // slot back now instead of holding `listening` until the fallback
+              // timer fires, and leave the pebble showing why.
+              console.log(`[ambient-ui] wake → start_listening refused (${res.reason ?? 'unknown'})`);
+              ctrl.cancelled = true;
+              clearSummon(sidecarId, ctrl);
+              // No text argument for the muted case: the sidecar has already
+              // put the reason in the bubble, and passing text here would
+              // overwrite it with the default per-state copy.
+              if (res.reason === 'muted') await setState(sidecarId, 'muted');
+              else await setState(sidecarId, 'idle', '');
+              return;
+            }
             console.log(`[ambient-ui] wake → listening (capture started)`);
             clearListenTimer(sidecarId);
             pendingListenTimers.set(sidecarId, setTimeout(() => {
@@ -3618,6 +3651,32 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
         } finally {
           wakeInFlight.delete(sidecarId);
         }
+      });
+
+      // The sidecar turned a mic request away because the user has the mic muted
+      // from the tray. Mute is sidecar-owned local state, so mostly this is
+      // informational — the two paths that could open a cycle already handle
+      // their own refusal (`pebble.summon` carries a `muted` flag, and
+      // `pebble.start_listening` answers `started: false`).
+      //
+      // What's left is the narrow race: mute landing AFTER a press was reported
+      // unmuted, or mid-capture, which leaves a summon slot with no audio ever
+      // coming. Unwind it — but only when the session id matches the slot's, so
+      // an unrelated in-flight turn can't be interrupted by a stray event (the
+      // hazard the stray-region.captured comment below spells out).
+      sidecarManager.onEvent((sidecarId, event) => {
+        if (event.event_type !== 'pebble.mic_blocked') return;
+        const payload = (event.payload as { reason?: string; source?: string; session_id?: string } | undefined) ?? {};
+        console.log(
+          `[ambient-ui] mic blocked on ${sidecarId} ` +
+          `(source=${payload.source ?? '?'}, reason=${payload.reason ?? '?'})`,
+        );
+        const ctrl = pendingSummons.get(sidecarId);
+        if (!ctrl || !payload.session_id || ctrl.sessionId !== payload.session_id) return;
+        ctrl.cancelled = true;
+        clearListenTimer(sidecarId);
+        clearSummon(sidecarId, ctrl);
+        void setState(sidecarId, 'muted'); // no text — the sidecar's bubble already says why
       });
 
       // T19 — region.captured / region.cancelled. The user said "help

--- a/src/sidecar/manager.ts
+++ b/src/sidecar/manager.ts
@@ -190,7 +190,7 @@ export class SidecarManager implements Service {
       });
 
       // Register handlers for each sidecar observer event type
-      const sidecarEventTypes = ['screen_capture', 'context_changed', 'idle_detected', 'clipboard_change', 'file_change', 'process_started', 'process_stopped', 'notification', 'pebble.summon', 'pebble.palette', 'pebble.blind_toggle', 'pebble.open_answer', 'panel.bounds_changed', 'panel.closed', 'audio.session_start', 'audio.session_end', 'audio.wake_segment', 'region.captured', 'region.cancelled', 'sub_pebble.clicked', 'sub_pebble.open_full', 'pebble.realtime_start', 'pebble.realtime_stop', 'pebble.audio_frame', 'tray.set_pause', 'tray.set_mute', 'notify.action'];
+      const sidecarEventTypes = ['screen_capture', 'context_changed', 'idle_detected', 'clipboard_change', 'file_change', 'process_started', 'process_stopped', 'notification', 'pebble.summon', 'pebble.palette', 'pebble.blind_toggle', 'pebble.open_answer', 'panel.bounds_changed', 'panel.closed', 'audio.session_start', 'audio.session_end', 'audio.wake_segment', 'region.captured', 'region.cancelled', 'sub_pebble.clicked', 'sub_pebble.open_full', 'pebble.realtime_start', 'pebble.realtime_stop', 'pebble.audio_frame', 'pebble.mic_blocked', 'tray.set_pause', 'tray.set_mute', 'notify.action'];
       const sidecarEventHandler = async (sidecarId: string, event: SidecarEvent) => {
         for (const listener of this.eventListeners) {
           listener(sidecarId, event);


### PR DESCRIPTION
## The bug

Three paths open the microphone; only one of them knew mute existed.

`Pause()`/`Resume()` on the wake listener are backed by a single `paused` bool, and `Resume()` was unconditional. Two callers wrote that bit with incompatible intents: **mute** ("off indefinitely — the user owns it") and **session capture** ("off for a moment while I use the device, and I'll restore it"). So while muted, one press of the summon hotkey opened the mic for that request and, on the way out, its `defer Resume()` re-armed the always-on wake listener. `TrayStatus.Muted` was never written back, so the menu still said muted and the pebble still showed muted — the UI and the device disagreed until you toggled mute twice.

The hand-ordered `Stop`-then-`Pause` workaround in the mute handler was the tell: sequencing calls to defeat a `Resume` nobody asked for.

## The fix

Mute is now a **gate**, not a pause — `micMuted()`, one source of truth, checked where the mic is actually opened:

- **One-shot capture** (`runSessionCapture`) — before the in-flight CAS and before `audio.session_start`, so a refused session leaves no state and the daemon never sees a start with no end.
- **Realtime voice** (`realtimeVoice.Start`) — refused; `Stop()` deliberately is not gated, so ending a live session always works.
- **Wake listener** — `Resume()` refuses while muted, *before* the `paused` CAS, so a refused resume stays consistently off. `Start()` also comes up paused when muted, which closes a divergence nobody had hit yet: a reconnect builds a fresh listener per connection and used to re-open the mic behind a muted menu.

The give-up path in `Resume()` (five failed reopens → `paused=true`, drop the chunk listener) is untouched. `Pause`/`Resume` stays a bool because, with mute out of it, only one consumer ever holds it.

Related fixes along the same seam:

- **Mute now cuts off a capture already in flight.** `wakeListener.Pause()` couldn't — the capture had already set `paused`, so its `audioSvc.Stop()` was skipped, and the mic ran to the VAD's 15 s hard cap and shipped the PCM. The tray closure now releases the shared device, and the capture drops its buffered audio instead of emitting `audio.session_end`. Mute means the audio doesn't leave the machine.
- **Refusals are visible.** A silently ignored hotkey is indistinguishable from a broken one, so the pebble bubble carries the reason for ~2.5 s and a `pebble.mic_blocked` event goes to the brain.
- **The daemon is told no.** `pebble.start_listening` answers `{started: false, reason: "muted"}` instead of letting the daemon wait out its fallback timer on audio that is never coming.
- **The summon hotkey keeps working while muted.** It doubles as the dismiss gesture — the daemon's handler is a toggle, and a second press cancels an in-flight turn and cuts off TTS. The event still goes out, now carrying a `muted` flag so the daemon dismisses as before but doesn't open a listening cycle it would have to wait out. Summon slots carry their `session_id`, so a mic refusal unwinds only the slot it can prove is its own, never an unrelated in-flight turn.

## One decision worth flagging

`tray.status` no longer reads `muted` from the payload. The brain's own heartbeat never sends the field and the daemon's comment already says mic control is sidecar-owned — but with `micMuted()` now a real gate, honoring it would have turned a best-effort status push into remote mic control in both directions, including a brain echoing `muted: false` silently un-gating a mic the user muted.

(Before this PR, `tray.status` could already make the menu say "muted" while the mic was fully live, with no user action at all.)

## Tests

`sidecar/mute_gate_test.go` asserts the divergence rather than the call: after pause → mute → resume, the wake listener is still off *and* `TrayStatus.Muted` is still true. Plus the reconnect, realtime-refusal, bubble-text-ownership, and `tray.status` cases. Verified they fail against the old code.

Full suite green (2582 pass / 0 fail), `go vet` + `gofmt` + `tsc` clean. `go test -race` can't build locally (missing `webkit2gtk-4.0` for the cgo webview dep), so the concurrency paths are reasoned, not race-detector-verified.
