### PR TITLE
feat: add cinematic command deck and opt-in continuous wake

### DIFF
--- a/.github/workflows/sidecar-release.yml
+++ b/.github/workflows/sidecar-release.yml
@@ -433,7 +433,6 @@ jobs:
       - name: Publish platform packages
         run: |
           FLAGS=""
-          if [ "$DRY_RUN" = "true" ]; then FLAGS="$FLAGS --dry-run"; fi
           if echo "${{ steps.version.outputs.VERSION }}" | grep -q '-'; then FLAGS="$FLAGS --tag next"; fi
           VERSION="${{ steps.version.outputs.VERSION }}"
 
@@ -441,8 +440,13 @@ jobs:
             pkg="@usejarvis/sidecar-${platform}"
             echo "Publishing ${pkg}@${VERSION}... ${FLAGS}"
             cd "sidecar/npm/${platform}"
-            if ! npm publish --access public $FLAGS; then
-              if [ "$DRY_RUN" != "true" ] && npm view "${pkg}@${VERSION}" version >/dev/null 2>&1; then
+            if [ "$DRY_RUN" = "true" ]; then
+              # `npm publish --dry-run` still rejects versions that already
+              # exist on npm. `npm pack --dry-run` validates the exact package
+              # contents without consulting publish-version uniqueness.
+              npm pack --dry-run
+            elif ! npm publish --access public $FLAGS; then
+              if npm view "${pkg}@${VERSION}" version >/dev/null 2>&1; then
                 echo "${pkg}@${VERSION} is already on npm; treating as success."
               else
                 exit 1
@@ -454,14 +458,15 @@ jobs:
       - name: Publish wrapper package
         run: |
           FLAGS=""
-          if [ "$DRY_RUN" = "true" ]; then FLAGS="$FLAGS --dry-run"; fi
           if echo "${{ steps.version.outputs.VERSION }}" | grep -q '-'; then FLAGS="$FLAGS --tag next"; fi
           VERSION="${{ steps.version.outputs.VERSION }}"
           pkg="@usejarvis/sidecar"
 
           cd sidecar/npm/jarvis-sidecar
-          if ! npm publish --access public $FLAGS; then
-            if [ "$DRY_RUN" != "true" ] && npm view "${pkg}@${VERSION}" version >/dev/null 2>&1; then
+          if [ "$DRY_RUN" = "true" ]; then
+            npm pack --dry-run
+          elif ! npm publish --access public $FLAGS; then
+            if npm view "${pkg}@${VERSION}" version >/dev/null 2>&1; then
               echo "${pkg}@${VERSION} is already on npm; treating as success."
             else
               exit 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -87,6 +87,12 @@ COPY --from=build /app/ui/public ./ui/public
 COPY --from=build /app/package.json ./
 COPY tsconfig.json ./
 
+# NAS shared folders may provide a restrictive source umask. Ensure the
+# runtime user can traverse and read every copied application asset while
+# preserving the non-root container boundary.
+RUN chmod -R a+rX /app/src /app/bin /app/roles /app/ui && \
+    chmod a+r /app/package.json /app/tsconfig.json
+
 # Install jarvis as a global command
 # Note: `bun link` can't be used here — it symlinks through /root/.bun/ which
 # is inaccessible to the non-root jarvis user. Direct symlink works because
@@ -114,7 +120,7 @@ VOLUME ["/data"]
 USER jarvis
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-    CMD bun -e "fetch('http://localhost:3142/api/health').then(r=>{if(!r.ok)process.exit(1)}).catch(()=>process.exit(1))"
+    CMD bun -e "fetch('http://localhost:3142/api/health').then(r=>{if(r.status!==200&&r.status!==401)process.exit(1)}).catch(()=>process.exit(1))"
 
 ENTRYPOINT ["jarvis"]
 CMD ["start", "--no-open", "--data-dir", "/data", "--no-local-tools"]

--- a/sidecar/clap_calibration.go
+++ b/sidecar/clap_calibration.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"sync"
+	"time"
+)
+
+type clapEnergySample struct {
+	Offset time.Duration
+	RMS    float64
+}
+
+type clapCalibrationSummary struct {
+	Samples int
+	P50     float64
+	P95     float64
+	P99     float64
+	Max     float64
+}
+
+// runClapCalibration is an explicit, terminal-only mic session. The capture
+// service is stream-only, so PCM is never accumulated or written to disk; the
+// callback retains only one RMS number and timestamp per audio chunk.
+func runClapCalibration(duration time.Duration, out io.Writer) error {
+	if duration <= 0 {
+		return fmt.Errorf("duration must be positive")
+	}
+
+	svc := NewStreamingCaptureService(pebbleAudioSampleRate)
+	started := time.Now()
+	var mu sync.Mutex
+	samples := make([]clapEnergySample, 0, int(duration/(30*time.Millisecond))+1)
+	svc.SetChunkListener(func(chunk []byte) {
+		mu.Lock()
+		samples = append(samples, clapEnergySample{Offset: time.Since(started), RMS: pcmRMSint16(chunk)})
+		mu.Unlock()
+	})
+	defer svc.SetChunkListener(nil)
+
+	fmt.Fprintf(out, "Local clap calibration: %.1fs. Clap twice naturally; audio is not saved or sent.\n", duration.Seconds())
+	if err := svc.Start("clap-calibration"); err != nil {
+		return err
+	}
+	time.Sleep(duration)
+	if _, _, err := svc.Stop(); err != nil {
+		return err
+	}
+
+	mu.Lock()
+	snapshot := append([]clapEnergySample(nil), samples...)
+	mu.Unlock()
+	summary := summarizeClapEnergy(snapshot)
+	if summary.Samples == 0 {
+		return fmt.Errorf("microphone returned no audio metrics")
+	}
+	if summary.Max <= 0 {
+		return fmt.Errorf("microphone returned only silence; calibration is invalid")
+	}
+	fmt.Fprintf(out, "RMS metrics only: samples=%d p50=%.0f p95=%.0f p99=%.0f max=%.0f\n",
+		summary.Samples, summary.P50, summary.P95, summary.P99, summary.Max)
+	return nil
+}
+
+func summarizeClapEnergy(samples []clapEnergySample) clapCalibrationSummary {
+	if len(samples) == 0 {
+		return clapCalibrationSummary{}
+	}
+	values := make([]float64, len(samples))
+	for i, sample := range samples {
+		values[i] = sample.RMS
+	}
+	sort.Float64s(values)
+	percentile := func(p float64) float64 {
+		index := int(float64(len(values)-1) * p)
+		return values[index]
+	}
+	return clapCalibrationSummary{
+		Samples: len(values),
+		P50:     percentile(0.50),
+		P95:     percentile(0.95),
+		P99:     percentile(0.99),
+		Max:     values[len(values)-1],
+	}
+}

--- a/sidecar/clap_calibration.go
+++ b/sidecar/clap_calibration.go
@@ -11,6 +11,9 @@ import (
 type clapEnergySample struct {
 	Offset time.Duration
 	RMS    float64
+	Peak   float64
+	Crest  float64
+	ZCR    float64
 }
 
 type clapCalibrationSummary struct {
@@ -35,8 +38,12 @@ func runClapCalibration(duration time.Duration, out io.Writer) error {
 	var mu sync.Mutex
 	samples := make([]clapEnergySample, 0, int(duration/(30*time.Millisecond))+1)
 	svc.SetChunkListener(func(chunk []byte) {
+		features := pcmTransientFeatures(chunk)
 		mu.Lock()
-		samples = append(samples, clapEnergySample{Offset: time.Since(started), RMS: pcmRMSint16(chunk)})
+		samples = append(samples, clapEnergySample{
+			Offset: time.Since(started), RMS: features.RMS, Peak: features.PeakAbs,
+			Crest: features.CrestFactor, ZCR: features.ZeroCrossingRate,
+		})
 		mu.Unlock()
 	})
 	defer svc.SetChunkListener(nil)
@@ -64,7 +71,8 @@ func runClapCalibration(duration time.Duration, out io.Writer) error {
 		summary.Samples, summary.P50, summary.P95, summary.P99, summary.Max)
 	fmt.Fprint(out, "p99 peak times:")
 	for _, peak := range summary.P99Peaks {
-		fmt.Fprintf(out, " %.2fs=%.0f", peak.Offset.Seconds(), peak.RMS)
+		fmt.Fprintf(out, " %.2fs[rms=%.0f peak=%.0f crest=%.2f zcr=%.3f]",
+			peak.Offset.Seconds(), peak.RMS, peak.Peak, peak.Crest, peak.ZCR)
 	}
 	fmt.Fprintln(out)
 	return nil
@@ -85,13 +93,20 @@ func runClapVerification(duration time.Duration, opts DoubleClapDetectorOpts, ou
 	started := time.Now()
 	var mu sync.Mutex
 	detections := make([]time.Duration, 0, 4)
+	samples := make([]clapEnergySample, 0, int(duration/(30*time.Millisecond))+1)
 	svc.SetChunkListener(func(chunk []byte) {
 		now := time.Now()
-		if detector.ObservePCM(chunk, now) {
-			mu.Lock()
+		features := pcmTransientFeatures(chunk)
+		matched := detector.ObserveFeatures(features, now)
+		mu.Lock()
+		samples = append(samples, clapEnergySample{
+			Offset: now.Sub(started), RMS: features.RMS, Peak: features.PeakAbs,
+			Crest: features.CrestFactor, ZCR: features.ZeroCrossingRate,
+		})
+		if matched {
 			detections = append(detections, now.Sub(started))
-			mu.Unlock()
 		}
+		mu.Unlock()
 	})
 	defer svc.SetChunkListener(nil)
 
@@ -106,10 +121,20 @@ func runClapVerification(duration time.Duration, opts DoubleClapDetectorOpts, ou
 
 	mu.Lock()
 	snapshot := append([]time.Duration(nil), detections...)
+	metricSnapshot := append([]clapEnergySample(nil), samples...)
 	mu.Unlock()
 	fmt.Fprintf(out, "Double-clap detections: %d", len(snapshot))
 	for _, offset := range snapshot {
 		fmt.Fprintf(out, " %.2fs", offset.Seconds())
+	}
+	fmt.Fprintln(out)
+	summary := summarizeClapEnergy(metricSnapshot)
+	fmt.Fprintf(out, "Verification metrics: samples=%d p95=%.0f p99=%.0f max=%.0f\n",
+		summary.Samples, summary.P95, summary.P99, summary.Max)
+	fmt.Fprint(out, "Verification p99 peaks:")
+	for _, peak := range summary.P99Peaks {
+		fmt.Fprintf(out, " %.2fs[rms=%.0f peak=%.0f crest=%.2f zcr=%.3f]",
+			peak.Offset.Seconds(), peak.RMS, peak.Peak, peak.Crest, peak.ZCR)
 	}
 	fmt.Fprintln(out)
 	return nil

--- a/sidecar/clap_calibration.go
+++ b/sidecar/clap_calibration.go
@@ -70,6 +70,51 @@ func runClapCalibration(duration time.Duration, out io.Writer) error {
 	return nil
 }
 
+// runClapVerification feeds live PCM to an explicitly calibrated detector and
+// reports detections only. It does not retain PCM and has no action callback.
+func runClapVerification(duration time.Duration, opts DoubleClapDetectorOpts, out io.Writer) error {
+	if duration <= 0 {
+		return fmt.Errorf("duration must be positive")
+	}
+	detector, err := NewDoubleClapDetector(opts)
+	if err != nil {
+		return err
+	}
+
+	svc := NewStreamingCaptureService(pebbleAudioSampleRate)
+	started := time.Now()
+	var mu sync.Mutex
+	detections := make([]time.Duration, 0, 4)
+	svc.SetChunkListener(func(chunk []byte) {
+		now := time.Now()
+		if detector.ObservePCM(chunk, now) {
+			mu.Lock()
+			detections = append(detections, now.Sub(started))
+			mu.Unlock()
+		}
+	})
+	defer svc.SetChunkListener(nil)
+
+	fmt.Fprintf(out, "Local double-clap verification: %.1fs. No audio is saved or sent.\n", duration.Seconds())
+	if err := svc.Start("clap-verification"); err != nil {
+		return err
+	}
+	time.Sleep(duration)
+	if _, _, err := svc.Stop(); err != nil {
+		return err
+	}
+
+	mu.Lock()
+	snapshot := append([]time.Duration(nil), detections...)
+	mu.Unlock()
+	fmt.Fprintf(out, "Double-clap detections: %d", len(snapshot))
+	for _, offset := range snapshot {
+		fmt.Fprintf(out, " %.2fs", offset.Seconds())
+	}
+	fmt.Fprintln(out)
+	return nil
+}
+
 func summarizeClapEnergy(samples []clapEnergySample) clapCalibrationSummary {
 	if len(samples) == 0 {
 		return clapCalibrationSummary{}

--- a/sidecar/clap_calibration.go
+++ b/sidecar/clap_calibration.go
@@ -14,11 +14,12 @@ type clapEnergySample struct {
 }
 
 type clapCalibrationSummary struct {
-	Samples int
-	P50     float64
-	P95     float64
-	P99     float64
-	Max     float64
+	Samples  int
+	P50      float64
+	P95      float64
+	P99      float64
+	Max      float64
+	P99Peaks []clapEnergySample
 }
 
 // runClapCalibration is an explicit, terminal-only mic session. The capture
@@ -61,6 +62,11 @@ func runClapCalibration(duration time.Duration, out io.Writer) error {
 	}
 	fmt.Fprintf(out, "RMS metrics only: samples=%d p50=%.0f p95=%.0f p99=%.0f max=%.0f\n",
 		summary.Samples, summary.P50, summary.P95, summary.P99, summary.Max)
+	fmt.Fprint(out, "p99 peak times:")
+	for _, peak := range summary.P99Peaks {
+		fmt.Fprintf(out, " %.2fs=%.0f", peak.Offset.Seconds(), peak.RMS)
+	}
+	fmt.Fprintln(out)
 	return nil
 }
 
@@ -77,11 +83,17 @@ func summarizeClapEnergy(samples []clapEnergySample) clapCalibrationSummary {
 		index := int(float64(len(values)-1) * p)
 		return values[index]
 	}
-	return clapCalibrationSummary{
+	summary := clapCalibrationSummary{
 		Samples: len(values),
 		P50:     percentile(0.50),
 		P95:     percentile(0.95),
 		P99:     percentile(0.99),
 		Max:     values[len(values)-1],
 	}
+	for _, sample := range samples {
+		if sample.RMS >= summary.P99 {
+			summary.P99Peaks = append(summary.P99Peaks, sample)
+		}
+	}
+	return summary
 }

--- a/sidecar/clap_calibration_test.go
+++ b/sidecar/clap_calibration_test.go
@@ -14,10 +14,13 @@ func TestSummarizeClapEnergy(t *testing.T) {
 	if got.Samples != 100 || got.P50 != 50 || got.P95 != 95 || got.P99 != 99 || got.Max != 100 {
 		t.Fatalf("unexpected summary: %+v", got)
 	}
+	if len(got.P99Peaks) != 2 || got.P99Peaks[0].RMS != 99 || got.P99Peaks[1].RMS != 100 {
+		t.Fatalf("unexpected p99 peaks: %+v", got.P99Peaks)
+	}
 }
 
 func TestSummarizeClapEnergyEmpty(t *testing.T) {
-	if got := summarizeClapEnergy(nil); got != (clapCalibrationSummary{}) {
+	if got := summarizeClapEnergy(nil); got.Samples != 0 || got.P50 != 0 || got.P95 != 0 || got.P99 != 0 || got.Max != 0 || len(got.P99Peaks) != 0 {
 		t.Fatalf("empty summary = %+v", got)
 	}
 }

--- a/sidecar/clap_calibration_test.go
+++ b/sidecar/clap_calibration_test.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSummarizeClapEnergy(t *testing.T) {
+	samples := make([]clapEnergySample, 100)
+	for i := range samples {
+		samples[i] = clapEnergySample{Offset: time.Duration(i) * time.Millisecond, RMS: float64(i + 1)}
+	}
+	got := summarizeClapEnergy(samples)
+	if got.Samples != 100 || got.P50 != 50 || got.P95 != 95 || got.P99 != 99 || got.Max != 100 {
+		t.Fatalf("unexpected summary: %+v", got)
+	}
+}
+
+func TestSummarizeClapEnergyEmpty(t *testing.T) {
+	if got := summarizeClapEnergy(nil); got != (clapCalibrationSummary{}) {
+		t.Fatalf("empty summary = %+v", got)
+	}
+}

--- a/sidecar/client.go
+++ b/sidecar/client.go
@@ -561,8 +561,19 @@ func (c *SidecarClient) connectAndServe(ctx context.Context) error {
 		// enabled. An omitted setting is intentionally false. Ctrl+Space remains
 		// available independently for deliberate, one-shot capture.
 		var wakeListener *WakeListenerService
-		if c.Preferences().ContinuousWake {
+		var clapDetector *DoubleClapDetector
+		prefs := c.Preferences()
+		if prefs.ContinuousWake {
 			wakeListener = NewWakeListenerService(audioSvc, sendFn, DefaultWakeListenerOpts())
+			if prefs.DoubleClap {
+				var clapErr error
+				clapDetector, clapErr = NewDoubleClapDetector(CalibratedDoubleClapOpts())
+				if clapErr != nil {
+					log.Printf("[clap] disabled — invalid calibration: %v", clapErr)
+				} else {
+					wakeListener.ConfigureDoubleClap(clapDetector, nil, doubleClapCooldown)
+				}
+			}
 			// Start() also consults micMuted(), so a reconnect while muted keeps
 			// the device closed even when continuous wake is opted in.
 			if err := wakeListener.Start(ctx); err != nil {
@@ -875,13 +886,13 @@ func (c *SidecarClient) connectAndServe(ctx context.Context) error {
 			}
 		})
 
-		c.pebble.OnSummon(func() {
+		handleSummon := func(source string) {
 			// When realtime voice is enabled, the summon hotkey toggles a
 			// perpetual speech-to-speech session (press again to end) instead
 			// of the one-shot capture → STT → LLM → TTS loop.
 			rt := c.realtime.Load()
 			rtEnabled := rt != nil && rt.enabled.Load()
-			log.Printf("[pebble] summon (realtime_enabled=%v)", rtEnabled)
+			log.Printf("[pebble] summon (source=%s realtime_enabled=%v)", source, rtEnabled)
 			if rtEnabled {
 				rt.Toggle()
 				return
@@ -899,7 +910,7 @@ func (c *SidecarClient) connectAndServe(ctx context.Context) error {
 				EventType: "pebble.summon",
 				Timestamp: time.Now().UnixMilli(),
 				Priority:  "normal",
-				Payload:   map[string]any{"session_id": sessionID, "muted": muted},
+				Payload:   map[string]any{"session_id": sessionID, "muted": muted, "source": source},
 			}
 			if err := sendFn(ctx, summonEvt, nil); err != nil {
 				log.Printf("[pebble] failed to emit summon event: %v", err)
@@ -909,8 +920,16 @@ func (c *SidecarClient) connectAndServe(ctx context.Context) error {
 				flashMutedPebble(c.pebble) // the brain is told by the event's muted flag
 				return
 			}
-			go runSessionCapture(sessionID, "summon")
-		})
+			go runSessionCapture(sessionID, source)
+		}
+		c.pebble.OnSummon(func() { handleSummon("hotkey") })
+		if wakeListener != nil && clapDetector != nil {
+			wakeListener.ConfigureDoubleClap(clapDetector, func() {
+				log.Printf("[clap] calibrated double clap detected locally")
+				handleSummon("double_clap")
+			}, doubleClapCooldown)
+			log.Printf("[clap] local double-clap summon enabled (cooldown=%s)", doubleClapCooldown)
+		}
 
 		// W4 — palette hotkey (Ctrl+K) emits a "pebble.palette" event with
 		// the current cursor position. The daemon owns the open/close

--- a/sidecar/client.go
+++ b/sidecar/client.go
@@ -521,25 +521,28 @@ func (c *SidecarClient) connectAndServe(ctx context.Context) error {
 	if c.pebble != nil {
 		audioSvc := NewAudioCaptureService()
 
-		// Sidecar-native wake-word listener (T16). Always on whenever the
-		// pebble is — no separate config gate, since the pebble is the
-		// whole reason wake-word matters. Emits one `audio.wake_segment`
-		// per VAD-detected utterance to the daemon, which transcribes +
-		// regex-matches "jarvis". Pauses around Ctrl+Space session
-		// captures so it doesn't fight for the mic device.
-		wakeListener := NewWakeListenerService(audioSvc, sendFn, DefaultWakeListenerOpts())
-		if err := wakeListener.Start(ctx); err != nil {
-			log.Printf("[wake] failed to start: %v", err)
-			wakeListener = nil
+		// Sidecar-native wake-word listener (T16). This continuously captures
+		// speech segments, so it is privacy-sensitive and must be explicitly
+		// enabled. An omitted setting is intentionally false. Ctrl+Space remains
+		// available independently for deliberate, one-shot capture.
+		var wakeListener *WakeListenerService
+		if c.Preferences().ContinuousWake {
+			wakeListener = NewWakeListenerService(audioSvc, sendFn, DefaultWakeListenerOpts())
+			if err := wakeListener.Start(ctx); err != nil {
+				log.Printf("[wake] failed to start: %v", err)
+				wakeListener = nil
+			} else {
+				// Tear the listener down when this connection ends. audioSvc and
+				// wakeListener are constructed fresh per connectAndServe, so without
+				// this every reconnect leaked a coordinate() goroutine and a held mic
+				// device — after N reconnects, N listeners fight over the microphone.
+				// Stop() works via stopCh (not ctx), so it's safe that Start uses the
+				// parent ctx (reloadConfig cancels obsCtx and must NOT kill the wake
+				// listener). The receiver is bound now, while wakeListener is non-nil.
+				defer wakeListener.Stop()
+			}
 		} else {
-			// Tear the listener down when this connection ends. audioSvc and
-			// wakeListener are constructed fresh per connectAndServe, so without
-			// this every reconnect leaked a coordinate() goroutine and a held mic
-			// device — after N reconnects, N listeners fight over the microphone.
-			// Stop() works via stopCh (not ctx), so it's safe that Start uses the
-			// parent ctx (reloadConfig cancels obsCtx and must NOT kill the wake
-			// listener). The receiver is bound now, while wakeListener is non-nil.
-			defer wakeListener.Stop()
+			log.Printf("[wake] continuous listener disabled by privacy preference")
 		}
 
 		// Suppress wake captures while TTS is playing so JARVIS's own

--- a/sidecar/config_test.go
+++ b/sidecar/config_test.go
@@ -62,6 +62,28 @@ func TestContinuousWakeRequiresExplicitOptIn(t *testing.T) {
 	}
 }
 
+func TestDoubleClapRequiresExplicitOptIn(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		yaml string
+		want bool
+	}{
+		{"omitted", "preferences:\n  continuous_wake: true\n", false},
+		{"explicit false", "preferences:\n  double_clap: false\n", false},
+		{"explicit true", "preferences:\n  double_clap: true\n", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := defaultConfig()
+			if err := yaml.Unmarshal([]byte(tc.yaml), &cfg); err != nil {
+				t.Fatalf("yaml: %v", err)
+			}
+			if cfg.Preferences.DoubleClap != tc.want {
+				t.Fatalf("DoubleClap = %v, want %v", cfg.Preferences.DoubleClap, tc.want)
+			}
+		})
+	}
+}
+
 func TestAwarenessCaptureDirDefault(t *testing.T) {
 	cfg := defaultConfig()
 	want := filepath.Join(homeDir(), ".jarvis", "captures")

--- a/sidecar/config_test.go
+++ b/sidecar/config_test.go
@@ -38,6 +38,30 @@ func TestAwarenessOCRDefault(t *testing.T) {
 	}
 }
 
+func TestContinuousWakeRequiresExplicitOptIn(t *testing.T) {
+	cases := []struct {
+		name string
+		yaml string
+		want bool
+	}{
+		{"omitted", "preferences:\n  start_at_startup: true\n", false},
+		{"explicit false", "preferences:\n  continuous_wake: false\n", false},
+		{"explicit true", "preferences:\n  continuous_wake: true\n", true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := defaultConfig()
+			if err := yaml.Unmarshal([]byte(tc.yaml), &cfg); err != nil {
+				t.Fatalf("yaml: %v", err)
+			}
+			if cfg.Preferences.ContinuousWake != tc.want {
+				t.Fatalf("ContinuousWake = %v, want %v", cfg.Preferences.ContinuousWake, tc.want)
+			}
+		})
+	}
+}
+
 func TestAwarenessCaptureDirDefault(t *testing.T) {
 	cfg := defaultConfig()
 	want := filepath.Join(homeDir(), ".jarvis", "captures")

--- a/sidecar/config_test.go
+++ b/sidecar/config_test.go
@@ -38,6 +38,39 @@ func TestAwarenessOCRDefault(t *testing.T) {
 	}
 }
 
+func TestAwarenessEnabledDefaultsOnAndCanBeDisabled(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		yaml string
+		want bool
+	}{
+		{"omitted", "awareness:\n  screen_interval_ms: 7000\n", true},
+		{"explicit true", "awareness:\n  enabled: true\n", true},
+		{"explicit false", "awareness:\n  enabled: false\n", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := defaultConfig()
+			if err := yaml.Unmarshal([]byte(tc.yaml), &cfg); err != nil {
+				t.Fatalf("yaml: %v", err)
+			}
+			if got := cfg.Awareness.IsEnabled(); got != tc.want {
+				t.Fatalf("Awareness.IsEnabled() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDisabledAwarenessRemovesScreenCapabilitiesBeforePreflight(t *testing.T) {
+	off := false
+	cfg := defaultConfig()
+	cfg.Awareness.Enabled = &off
+	cfg.Capabilities = []SidecarCapability{CapScreenshot, CapAwareness, CapOCR}
+	available, unavailable := CheckCapabilities(&cfg)
+	if len(available) != 0 || len(unavailable) != 0 {
+		t.Fatalf("disabled awareness capabilities must be skipped: available=%v unavailable=%v", available, unavailable)
+	}
+}
+
 func TestContinuousWakeRequiresExplicitOptIn(t *testing.T) {
 	cases := []struct {
 		name string

--- a/sidecar/double_clap.go
+++ b/sidecar/double_clap.go
@@ -1,15 +1,61 @@
 package main
 
 import (
+	"encoding/binary"
 	"errors"
+	"math"
 	"time"
 )
+
+type PCMTransientFeatures struct {
+	RMS              float64
+	PeakAbs          float64
+	CrestFactor      float64
+	ZeroCrossingRate float64
+}
+
+// pcmTransientFeatures reduces a PCM chunk to non-reversible numeric metrics.
+// No samples leave the callback and no audio is retained.
+func pcmTransientFeatures(pcm []byte) PCMTransientFeatures {
+	if len(pcm) < 2 {
+		return PCMTransientFeatures{}
+	}
+	n := len(pcm) / 2
+	var sumSq float64
+	var peak float64
+	var crossings int
+	var previous int16
+	for i := 0; i < n; i++ {
+		sample := int16(binary.LittleEndian.Uint16(pcm[i*2 : i*2+2]))
+		value := float64(sample)
+		abs := math.Abs(value)
+		if abs > peak {
+			peak = abs
+		}
+		sumSq += value * value
+		if i > 0 && ((sample >= 0 && previous < 0) || (sample < 0 && previous >= 0)) {
+			crossings++
+		}
+		previous = sample
+	}
+	rms := math.Sqrt(sumSq / float64(n))
+	crest := 0.0
+	if rms > 0 {
+		crest = peak / rms
+	}
+	zcr := 0.0
+	if n > 1 {
+		zcr = float64(crossings) / float64(n-1)
+	}
+	return PCMTransientFeatures{RMS: rms, PeakAbs: peak, CrestFactor: crest, ZeroCrossingRate: zcr}
+}
 
 // DoubleClapDetectorOpts contains calibration values supplied by the caller.
 // There are deliberately no production defaults yet: real microphone samples
 // must determine them before this detector is connected to capture or actions.
 type DoubleClapDetectorOpts struct {
 	PeakThreshold  float64
+	MinPeakAbs     float64
 	ResetThreshold float64
 	MinGap         time.Duration
 	MaxGap         time.Duration
@@ -26,7 +72,7 @@ type DoubleClapDetector struct {
 }
 
 func NewDoubleClapDetector(opts DoubleClapDetectorOpts) (*DoubleClapDetector, error) {
-	if opts.PeakThreshold <= 0 || opts.ResetThreshold < 0 {
+	if opts.PeakThreshold <= 0 || opts.MinPeakAbs < 0 || opts.ResetThreshold < 0 {
 		return nil, errors.New("clap thresholds must be non-negative and peak must be positive")
 	}
 	if opts.ResetThreshold >= opts.PeakThreshold {
@@ -42,7 +88,16 @@ func NewDoubleClapDetector(opts DoubleClapDetectorOpts) (*DoubleClapDetector, er
 // Hysteresis requires energy to fall below ResetThreshold before another peak
 // can count, so one sustained sound cannot masquerade as multiple claps.
 func (d *DoubleClapDetector) ObservePCM(pcm []byte, at time.Time) bool {
-	return d.ObserveEnergy(pcmRMSint16(pcm), at)
+	return d.ObserveFeatures(pcmTransientFeatures(pcm), at)
+}
+
+// ObserveFeatures applies the calibrated impulse floor before the existing
+// RMS hysteresis. A loud but non-impulsive chunk cannot become a clap peak.
+func (d *DoubleClapDetector) ObserveFeatures(features PCMTransientFeatures, at time.Time) bool {
+	if features.RMS >= d.opts.PeakThreshold && features.PeakAbs < d.opts.MinPeakAbs {
+		features.RMS = math.Nextafter(d.opts.PeakThreshold, 0)
+	}
+	return d.ObserveEnergy(features.RMS, at)
 }
 
 // ObserveEnergy is exposed for deterministic tests and later calibration.

--- a/sidecar/double_clap.go
+++ b/sidecar/double_clap.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"errors"
+	"time"
+)
+
+// DoubleClapDetectorOpts contains calibration values supplied by the caller.
+// There are deliberately no production defaults yet: real microphone samples
+// must determine them before this detector is connected to capture or actions.
+type DoubleClapDetectorOpts struct {
+	PeakThreshold  float64
+	ResetThreshold float64
+	MinGap         time.Duration
+	MaxGap         time.Duration
+}
+
+// DoubleClapDetector is a pure, local PCM classifier. It owns no microphone,
+// sends no audio, and performs no action. A caller may eventually feed it the
+// same chunks already captured by the Sidecar, but that wiring is intentionally
+// absent until privacy controls and calibration are approved.
+type DoubleClapDetector struct {
+	opts      DoubleClapDetectorOpts
+	abovePeak bool
+	firstPeak time.Time
+}
+
+func NewDoubleClapDetector(opts DoubleClapDetectorOpts) (*DoubleClapDetector, error) {
+	if opts.PeakThreshold <= 0 || opts.ResetThreshold < 0 {
+		return nil, errors.New("clap thresholds must be non-negative and peak must be positive")
+	}
+	if opts.ResetThreshold >= opts.PeakThreshold {
+		return nil, errors.New("clap reset threshold must be below peak threshold")
+	}
+	if opts.MinGap <= 0 || opts.MaxGap <= opts.MinGap {
+		return nil, errors.New("clap gap window must be positive and ordered")
+	}
+	return &DoubleClapDetector{opts: opts}, nil
+}
+
+// ObservePCM returns true only on the rising edge of a qualifying second peak.
+// Hysteresis requires energy to fall below ResetThreshold before another peak
+// can count, so one sustained sound cannot masquerade as multiple claps.
+func (d *DoubleClapDetector) ObservePCM(pcm []byte, at time.Time) bool {
+	return d.ObserveEnergy(pcmRMSint16(pcm), at)
+}
+
+// ObserveEnergy is exposed for deterministic tests and later calibration.
+func (d *DoubleClapDetector) ObserveEnergy(energy float64, at time.Time) bool {
+	if energy <= d.opts.ResetThreshold {
+		d.abovePeak = false
+		if !d.firstPeak.IsZero() && at.Sub(d.firstPeak) > d.opts.MaxGap {
+			d.firstPeak = time.Time{}
+		}
+		return false
+	}
+	if energy < d.opts.PeakThreshold || d.abovePeak {
+		return false
+	}
+
+	d.abovePeak = true
+	if d.firstPeak.IsZero() || at.Before(d.firstPeak) {
+		d.firstPeak = at
+		return false
+	}
+
+	gap := at.Sub(d.firstPeak)
+	if gap < d.opts.MinGap {
+		return false
+	}
+	if gap > d.opts.MaxGap {
+		d.firstPeak = at
+		return false
+	}
+
+	d.firstPeak = time.Time{}
+	return true
+}
+
+func (d *DoubleClapDetector) Reset() {
+	d.abovePeak = false
+	d.firstPeak = time.Time{}
+}

--- a/sidecar/double_clap.go
+++ b/sidecar/double_clap.go
@@ -61,6 +61,16 @@ type DoubleClapDetectorOpts struct {
 	MaxGap         time.Duration
 }
 
+// CalibratedDoubleClapOpts returns the locally verified MacBook profile.
+// It is used only after the user explicitly enables both continuous wake and
+// double-clap summon; there is no implicit always-listening path.
+func CalibratedDoubleClapOpts() DoubleClapDetectorOpts {
+	return DoubleClapDetectorOpts{
+		PeakThreshold: 5000, MinPeakAbs: 15000, ResetThreshold: 2500,
+		MinGap: 150 * time.Millisecond, MaxGap: 600 * time.Millisecond,
+	}
+}
+
 // DoubleClapDetector is a pure, local PCM classifier. It owns no microphone,
 // sends no audio, and performs no action. A caller may eventually feed it the
 // same chunks already captured by the Sidecar, but that wiring is intentionally

--- a/sidecar/double_clap_test.go
+++ b/sidecar/double_clap_test.go
@@ -40,6 +40,91 @@ func TestDoubleClapDetectorRejectsSustainedSound(t *testing.T) {
 	}
 }
 
+func TestDoubleClapDetectorRequiresCalibratedImpulsePeak(t *testing.T) {
+	d, err := NewDoubleClapDetector(DoubleClapDetectorOpts{
+		PeakThreshold:  1000,
+		MinPeakAbs:     5000,
+		ResetThreshold: 200,
+		MinGap:         100 * time.Millisecond,
+		MaxGap:         600 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t0 := time.Unix(1, 0)
+	if d.ObserveFeatures(PCMTransientFeatures{RMS: 4000, PeakAbs: 4500}, t0) {
+		t.Fatal("first non-impulsive peak must not trigger")
+	}
+	d.ObserveFeatures(PCMTransientFeatures{}, t0.Add(40*time.Millisecond))
+	if d.ObserveFeatures(PCMTransientFeatures{RMS: 4000, PeakAbs: 4500}, t0.Add(250*time.Millisecond)) {
+		t.Fatal("two loud chunks below the impulse floor must not trigger")
+	}
+}
+
+func TestDoubleClapDetectorMatchesCalibratedPositiveSession(t *testing.T) {
+	d, err := NewDoubleClapDetector(DoubleClapDetectorOpts{
+		PeakThreshold:  5000,
+		MinPeakAbs:     15000,
+		ResetThreshold: 2500,
+		MinGap:         150 * time.Millisecond,
+		MaxGap:         600 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t0 := time.Unix(1, 0)
+	sequence := []struct {
+		offset time.Duration
+		rms    float64
+		peak   float64
+	}{
+		{0, 7896, 32768},
+		{40 * time.Millisecond, 1000, 4000},
+		{390 * time.Millisecond, 6200, 24000},
+		{430 * time.Millisecond, 1000, 4000},
+		{2 * time.Second, 10761, 32768},
+		{2040 * time.Millisecond, 1000, 4000},
+		{2360 * time.Millisecond, 7887, 32768},
+		{2400 * time.Millisecond, 1000, 4000},
+		{4 * time.Second, 7669, 32768},
+		{4040 * time.Millisecond, 1000, 4000},
+		{4390 * time.Millisecond, 14499, 32768},
+		{4430 * time.Millisecond, 1000, 4000},
+	}
+	detections := 0
+	for _, sample := range sequence {
+		if d.ObserveFeatures(PCMTransientFeatures{RMS: sample.rms, PeakAbs: sample.peak}, t0.Add(sample.offset)) {
+			detections++
+		}
+	}
+	if detections != 3 {
+		t.Fatalf("calibrated positive session detections = %d, want 3", detections)
+	}
+}
+
+func TestDoubleClapDetectorRejectsCalibratedNegativeTransient(t *testing.T) {
+	d, err := NewDoubleClapDetector(DoubleClapDetectorOpts{
+		PeakThreshold:  5000,
+		MinPeakAbs:     15000,
+		ResetThreshold: 2500,
+		MinGap:         150 * time.Millisecond,
+		MaxGap:         600 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t0 := time.Unix(1, 0)
+	// The negative control contained a sharp peak (29498) with low RMS (2169).
+	// Requiring both metrics prevents that isolated household sound from counting.
+	if d.ObserveFeatures(PCMTransientFeatures{RMS: 2169, PeakAbs: 29498}, t0) {
+		t.Fatal("high absolute peak with sub-threshold RMS must not trigger")
+	}
+	d.ObserveFeatures(PCMTransientFeatures{}, t0.Add(40*time.Millisecond))
+	if d.ObserveFeatures(PCMTransientFeatures{RMS: 2169, PeakAbs: 29498}, t0.Add(390*time.Millisecond)) {
+		t.Fatal("two low-RMS transients must not form a double clap")
+	}
+}
+
 func TestDoubleClapDetectorHonorsGapWindow(t *testing.T) {
 	d := testDoubleClapDetector(t)
 	t0 := time.Unix(1, 0)
@@ -67,5 +152,12 @@ func TestDoubleClapDetectorRejectsInvalidCalibration(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("invalid calibration must be rejected")
+	}
+}
+
+func TestPCMTransientFeatures(t *testing.T) {
+	features := pcmTransientFeatures(pcmChunk(160, 4000))
+	if features.RMS != 4000 || features.PeakAbs != 4000 || features.CrestFactor != 1 || features.ZeroCrossingRate != 0 {
+		t.Fatalf("constant PCM features = %+v", features)
 	}
 }

--- a/sidecar/double_clap_test.go
+++ b/sidecar/double_clap_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func testDoubleClapDetector(t *testing.T) *DoubleClapDetector {
+	t.Helper()
+	d, err := NewDoubleClapDetector(DoubleClapDetectorOpts{
+		PeakThreshold:  1000,
+		ResetThreshold: 200,
+		MinGap:         100 * time.Millisecond,
+		MaxGap:         600 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return d
+}
+
+func TestDoubleClapDetectorRecognizesTwoSeparatedPeaks(t *testing.T) {
+	d := testDoubleClapDetector(t)
+	t0 := time.Unix(1, 0)
+	if d.ObservePCM(pcmChunk(160, 4000), t0) {
+		t.Fatal("first peak must not trigger")
+	}
+	d.ObservePCM(pcmChunk(160, 0), t0.Add(40*time.Millisecond))
+	if !d.ObservePCM(pcmChunk(160, 5000), t0.Add(250*time.Millisecond)) {
+		t.Fatal("second separated peak inside the gap window must trigger")
+	}
+}
+
+func TestDoubleClapDetectorRejectsSustainedSound(t *testing.T) {
+	d := testDoubleClapDetector(t)
+	t0 := time.Unix(1, 0)
+	d.ObserveEnergy(4000, t0)
+	if d.ObserveEnergy(5000, t0.Add(250*time.Millisecond)) {
+		t.Fatal("sustained energy without a reset edge must not trigger")
+	}
+}
+
+func TestDoubleClapDetectorHonorsGapWindow(t *testing.T) {
+	d := testDoubleClapDetector(t)
+	t0 := time.Unix(1, 0)
+	d.ObserveEnergy(4000, t0)
+	d.ObserveEnergy(0, t0.Add(20*time.Millisecond))
+	if d.ObserveEnergy(4000, t0.Add(50*time.Millisecond)) {
+		t.Fatal("peaks closer than MinGap must not trigger")
+	}
+	d.ObserveEnergy(0, t0.Add(70*time.Millisecond))
+	if d.ObserveEnergy(4000, t0.Add(800*time.Millisecond)) {
+		t.Fatal("peaks farther apart than MaxGap must not trigger")
+	}
+	d.ObserveEnergy(0, t0.Add(820*time.Millisecond))
+	if !d.ObserveEnergy(4000, t0.Add(1100*time.Millisecond)) {
+		t.Fatal("a new pair inside the gap window must trigger")
+	}
+}
+
+func TestDoubleClapDetectorRejectsInvalidCalibration(t *testing.T) {
+	_, err := NewDoubleClapDetector(DoubleClapDetectorOpts{
+		PeakThreshold:  100,
+		ResetThreshold: 100,
+		MinGap:         time.Second,
+		MaxGap:         500 * time.Millisecond,
+	})
+	if err == nil {
+		t.Fatal("invalid calibration must be rejected")
+	}
+}

--- a/sidecar/main.go
+++ b/sidecar/main.go
@@ -40,6 +40,7 @@ func main() {
 	clapCalibration := flag.Duration("calibrate-clap", 0, "Measure local microphone RMS for clap calibration, then exit (for example 10s)")
 	clapVerification := flag.Duration("verify-clap", 0, "Run local double-clap detection without triggering actions, then exit")
 	clapPeak := flag.Float64("clap-peak", 0, "Verification peak RMS threshold (required with --verify-clap)")
+	clapMinPeak := flag.Float64("clap-min-peak", 0, "Verification minimum absolute PCM peak")
 	clapReset := flag.Float64("clap-reset", 0, "Verification reset RMS threshold (required with --verify-clap)")
 	clapMinGap := flag.Duration("clap-min-gap", 0, "Verification minimum gap between claps")
 	clapMaxGap := flag.Duration("clap-max-gap", 0, "Verification maximum gap between claps")
@@ -60,7 +61,7 @@ Usage:
   jarvis --test <cmd>     Run a built-in platform test (test build only)
   jarvis --calibrate-clap=10s
                           Measure local clap RMS metrics, then exit (no audio saved or sent)
-  jarvis --verify-clap=10s --clap-peak=N --clap-reset=N --clap-min-gap=150ms --clap-max-gap=600ms
+  jarvis --verify-clap=10s --clap-peak=N --clap-min-peak=N --clap-reset=N --clap-min-gap=150ms --clap-max-gap=600ms
                           Detect calibrated double claps locally without triggering actions
   jarvis --version        Print the sidecar version and exit
   jarvis --help           Show this help`)
@@ -80,7 +81,7 @@ Usage:
 	}
 	if *clapVerification > 0 {
 		opts := DoubleClapDetectorOpts{
-			PeakThreshold: *clapPeak, ResetThreshold: *clapReset,
+			PeakThreshold: *clapPeak, MinPeakAbs: *clapMinPeak, ResetThreshold: *clapReset,
 			MinGap: *clapMinGap, MaxGap: *clapMaxGap,
 		}
 		if err := runClapVerification(*clapVerification, opts, os.Stdout); err != nil {

--- a/sidecar/main.go
+++ b/sidecar/main.go
@@ -37,6 +37,7 @@ func main() {
 	showVersion := flag.Bool("version", false, "Print the sidecar version and exit")
 	testMode := flag.Bool("test", false, "Run built-in platform tests (requires build with -tags sidecartest)")
 	setupMode := flag.Bool("setup", false, "Run first-launch onboarding (permissions, autostart), then start")
+	clapCalibration := flag.Duration("calibrate-clap", 0, "Measure local microphone RMS for clap calibration, then exit (for example 10s)")
 	flag.Parse()
 
 	if *showVersion {
@@ -52,6 +53,8 @@ Usage:
   jarvis                  Start using saved token
   jarvis --setup          Run first-launch onboarding (permissions, autostart), then start
   jarvis --test <cmd>     Run a built-in platform test (test build only)
+  jarvis --calibrate-clap=10s
+                          Measure local clap RMS metrics, then exit (no audio saved or sent)
   jarvis --version        Print the sidecar version and exit
   jarvis --help           Show this help`)
 		os.Exit(0)
@@ -59,6 +62,14 @@ Usage:
 
 	if *testMode {
 		os.Exit(runTests(flag.Args()))
+	}
+
+	if *clapCalibration > 0 {
+		if err := runClapCalibration(*clapCalibration, os.Stdout); err != nil {
+			fmt.Fprintf(os.Stderr, "Clap calibration failed: %v\n", err)
+			os.Exit(1)
+		}
+		return
 	}
 
 	// Route logs to ~/.jarvis/sidecar.log so the GUI-subsystem Windows build runs

--- a/sidecar/main.go
+++ b/sidecar/main.go
@@ -38,6 +38,11 @@ func main() {
 	testMode := flag.Bool("test", false, "Run built-in platform tests (requires build with -tags sidecartest)")
 	setupMode := flag.Bool("setup", false, "Run first-launch onboarding (permissions, autostart), then start")
 	clapCalibration := flag.Duration("calibrate-clap", 0, "Measure local microphone RMS for clap calibration, then exit (for example 10s)")
+	clapVerification := flag.Duration("verify-clap", 0, "Run local double-clap detection without triggering actions, then exit")
+	clapPeak := flag.Float64("clap-peak", 0, "Verification peak RMS threshold (required with --verify-clap)")
+	clapReset := flag.Float64("clap-reset", 0, "Verification reset RMS threshold (required with --verify-clap)")
+	clapMinGap := flag.Duration("clap-min-gap", 0, "Verification minimum gap between claps")
+	clapMaxGap := flag.Duration("clap-max-gap", 0, "Verification maximum gap between claps")
 	flag.Parse()
 
 	if *showVersion {
@@ -55,6 +60,8 @@ Usage:
   jarvis --test <cmd>     Run a built-in platform test (test build only)
   jarvis --calibrate-clap=10s
                           Measure local clap RMS metrics, then exit (no audio saved or sent)
+  jarvis --verify-clap=10s --clap-peak=N --clap-reset=N --clap-min-gap=150ms --clap-max-gap=600ms
+                          Detect calibrated double claps locally without triggering actions
   jarvis --version        Print the sidecar version and exit
   jarvis --help           Show this help`)
 		os.Exit(0)
@@ -67,6 +74,17 @@ Usage:
 	if *clapCalibration > 0 {
 		if err := runClapCalibration(*clapCalibration, os.Stdout); err != nil {
 			fmt.Fprintf(os.Stderr, "Clap calibration failed: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
+	if *clapVerification > 0 {
+		opts := DoubleClapDetectorOpts{
+			PeakThreshold: *clapPeak, ResetThreshold: *clapReset,
+			MinGap: *clapMinGap, MaxGap: *clapMaxGap,
+		}
+		if err := runClapVerification(*clapVerification, opts, os.Stdout); err != nil {
+			fmt.Fprintf(os.Stderr, "Clap verification failed: %v\n", err)
 			os.Exit(1)
 		}
 		return

--- a/sidecar/pebble_wake.go
+++ b/sidecar/pebble_wake.go
@@ -87,6 +87,12 @@ type WakeListenerService struct {
 	paused        atomic.Bool
 	suppressDepth atomic.Int32
 
+	clapMu            sync.Mutex
+	clapDetector      *DoubleClapDetector
+	clapCallback      func()
+	clapCooldown      time.Duration
+	clapCooldownUntil time.Time
+
 	stopCh chan struct{}
 	doneCh chan struct{}
 
@@ -101,6 +107,8 @@ type WakeListenerService struct {
 	segStartedAt    time.Time
 }
 
+const doubleClapCooldown = 2 * time.Second
+
 // NewWakeListenerService wires up a wake listener that uses the given
 // audio service for capture and the given sender to emit segments. The
 // listener does NOT start automatically — call Start() once the websocket
@@ -111,6 +119,43 @@ func NewWakeListenerService(audioSvc *AudioCaptureService, sender EventSender, o
 		sender:   sender,
 		opts:     opts,
 	}
+}
+
+// ConfigureDoubleClap attaches a local-only detector to this listener's
+// existing PCM stream. It never opens a second microphone device.
+func (w *WakeListenerService) ConfigureDoubleClap(detector *DoubleClapDetector, callback func(), cooldown time.Duration) {
+	w.clapMu.Lock()
+	defer w.clapMu.Unlock()
+	w.clapDetector = detector
+	w.clapCallback = callback
+	w.clapCooldown = cooldown
+	w.clapCooldownUntil = time.Time{}
+}
+
+func (w *WakeListenerService) resetDoubleClap() {
+	w.clapMu.Lock()
+	defer w.clapMu.Unlock()
+	if w.clapDetector != nil {
+		w.clapDetector.Reset()
+	}
+}
+
+func (w *WakeListenerService) observeDoubleClap(features PCMTransientFeatures, now time.Time) (bool, func()) {
+	w.clapMu.Lock()
+	defer w.clapMu.Unlock()
+	if w.clapDetector == nil {
+		return false, nil
+	}
+	if now.Before(w.clapCooldownUntil) {
+		w.clapDetector.Reset()
+		return false, nil
+	}
+	if !w.clapDetector.ObserveFeatures(features, now) {
+		return false, nil
+	}
+	w.clapDetector.Reset()
+	w.clapCooldownUntil = now.Add(w.clapCooldown)
+	return true, w.clapCallback
 }
 
 // Start kicks off the continuous capture + segmentation loop. Idempotent.
@@ -165,6 +210,7 @@ func (w *WakeListenerService) Pause() {
 		return
 	}
 	w.audioSvc.SetChunkListener(nil)
+	w.resetDoubleClap()
 	_, _, _ = w.audioSvc.Stop()
 	log.Printf("[wake] paused (mic released)")
 }
@@ -235,6 +281,7 @@ func (w *WakeListenerService) Suppress(yes bool) {
 	if yes {
 		if w.suppressDepth.Add(1) == 1 {
 			w.resetSegment() // 0 -> 1 edge
+			w.resetDoubleClap()
 		}
 		return
 	}
@@ -258,11 +305,15 @@ func (w *WakeListenerService) Suppress(yes bool) {
 // 30 ms buffer is ~480 multiplies. Keep work here minimal so we don't
 // stall the audio thread.
 func (w *WakeListenerService) onChunk(buf []byte) {
-	if w.paused.Load() || w.suppressDepth.Load() > 0 {
+	if w.paused.Load() || w.suppressDepth.Load() > 0 || micMuted() {
 		return
 	}
-	rms := pcmRMSint16(buf)
+	features := pcmTransientFeatures(buf)
+	rms := features.RMS
 	now := time.Now()
+	if detected, callback := w.observeDoubleClap(features, now); detected && callback != nil {
+		go callback()
+	}
 
 	w.mu.Lock()
 	defer w.mu.Unlock()

--- a/sidecar/pebble_wake_test.go
+++ b/sidecar/pebble_wake_test.go
@@ -22,8 +22,8 @@ func pcmChunk(n int, amp int16) []byte {
 func TestWakeOnChunkCountsSpeech(t *testing.T) {
 	w := NewWakeListenerService(nil, nil, DefaultWakeListenerOpts())
 
-	loud := pcmChunk(160, 8000)  // RMS 8000 >> 500 threshold -> speech
-	quiet := pcmChunk(160, 5)    // RMS ~5 << threshold -> silence
+	loud := pcmChunk(160, 8000) // RMS 8000 >> 500 threshold -> speech
+	quiet := pcmChunk(160, 5)   // RMS ~5 << threshold -> silence
 
 	w.onChunk(loud)
 	w.onChunk(loud)
@@ -72,5 +72,76 @@ func TestWakeEmitGate(t *testing.T) {
 	}
 	if !emit(minWakeSpeechChunks) {
 		t.Errorf("segment with %d chunks should be emitted (clipped wake word)", minWakeSpeechChunks)
+	}
+}
+
+func TestWakeDoubleClapCooldown(t *testing.T) {
+	detector, err := NewDoubleClapDetector(CalibratedDoubleClapOpts())
+	if err != nil {
+		t.Fatal(err)
+	}
+	w := NewWakeListenerService(nil, nil, DefaultWakeListenerOpts())
+	w.ConfigureDoubleClap(detector, func() {}, 2*time.Second)
+	t0 := time.Unix(1, 0)
+	clap := PCMTransientFeatures{RMS: 8000, PeakAbs: 32768}
+	silence := PCMTransientFeatures{RMS: 1000, PeakAbs: 4000}
+
+	w.observeDoubleClap(clap, t0)
+	w.observeDoubleClap(silence, t0.Add(40*time.Millisecond))
+	if detected, _ := w.observeDoubleClap(clap, t0.Add(350*time.Millisecond)); !detected {
+		t.Fatal("calibrated pair must trigger")
+	}
+	w.observeDoubleClap(silence, t0.Add(390*time.Millisecond))
+	w.observeDoubleClap(clap, t0.Add(time.Second))
+	w.observeDoubleClap(silence, t0.Add(1040*time.Millisecond))
+	if detected, _ := w.observeDoubleClap(clap, t0.Add(1350*time.Millisecond)); detected {
+		t.Fatal("pair inside cooldown must not trigger")
+	}
+	w.observeDoubleClap(clap, t0.Add(3*time.Second))
+	w.observeDoubleClap(silence, t0.Add(3040*time.Millisecond))
+	if detected, _ := w.observeDoubleClap(clap, t0.Add(3350*time.Millisecond)); !detected {
+		t.Fatal("pair after cooldown must trigger")
+	}
+}
+
+func TestWakeDoubleClapSuppressionResetsPartialPair(t *testing.T) {
+	detector, err := NewDoubleClapDetector(CalibratedDoubleClapOpts())
+	if err != nil {
+		t.Fatal(err)
+	}
+	w := NewWakeListenerService(nil, nil, DefaultWakeListenerOpts())
+	w.ConfigureDoubleClap(detector, func() {}, 2*time.Second)
+	t0 := time.Unix(1, 0)
+	clap := PCMTransientFeatures{RMS: 8000, PeakAbs: 32768}
+	silence := PCMTransientFeatures{RMS: 1000, PeakAbs: 4000}
+
+	w.observeDoubleClap(clap, t0)
+	w.observeDoubleClap(silence, t0.Add(40*time.Millisecond))
+	w.Suppress(true)
+	w.Suppress(false)
+	if detected, _ := w.observeDoubleClap(clap, t0.Add(350*time.Millisecond)); detected {
+		t.Fatal("a clap before suppression must not pair with one after suppression")
+	}
+}
+
+func TestWakeDoubleClapDoesNotObserveWhileMuted(t *testing.T) {
+	original := getTrayStatus()
+	muted := original
+	muted.Muted = true
+	setTrayStatus(muted)
+	t.Cleanup(func() { setTrayStatus(original) })
+
+	detector, err := NewDoubleClapDetector(CalibratedDoubleClapOpts())
+	if err != nil {
+		t.Fatal(err)
+	}
+	w := NewWakeListenerService(nil, nil, DefaultWakeListenerOpts())
+	w.ConfigureDoubleClap(detector, func() {}, 2*time.Second)
+	w.onChunk(pcmChunk(160, 20000))
+
+	w.clapMu.Lock()
+	defer w.clapMu.Unlock()
+	if !detector.firstPeak.IsZero() {
+		t.Fatal("muted listener must not feed PCM into the clap detector")
 	}
 }

--- a/sidecar/preflight.go
+++ b/sidecar/preflight.go
@@ -12,6 +12,9 @@ type UnavailableCapability struct {
 // unavailable along with a human-readable reason.
 func CheckCapabilities(cfg *SidecarConfig) (available []SidecarCapability, unavailable []UnavailableCapability) {
 	for _, cap := range cfg.Capabilities {
+		if !cfg.Awareness.IsEnabled() && (cap == CapScreenshot || cap == CapAwareness || cap == CapOCR) {
+			continue
+		}
 		reason := ""
 		switch cap {
 		case CapTerminal:

--- a/sidecar/settings_window.go
+++ b/sidecar/settings_window.go
@@ -30,6 +30,7 @@ type settingsState struct {
 	Status string `json:"status"` // "connected" | "connecting" | "error"
 	Prefs  struct {
 		StartAtStartup      bool `json:"start_at_startup"`
+		ContinuousWake      bool `json:"continuous_wake"`
 		EtherealPebble      bool `json:"ethereal_pebble"`
 		EtherealIdleSeconds int  `json:"ethereal_idle_seconds"`
 		TelemetryEnabled    bool `json:"telemetry_enabled"`
@@ -66,6 +67,7 @@ func (c *SidecarClient) runSettingsWindow() {
 			var st settingsState
 			st.Status = connStateString(c.ConnState())
 			st.Prefs.StartAtStartup = prefs.StartAtStartup
+			st.Prefs.ContinuousWake = prefs.ContinuousWake
 			st.Prefs.EtherealPebble = prefs.EtherealPebble
 			st.Prefs.EtherealIdleSeconds = prefs.EtherealIdleSeconds
 			if st.Prefs.EtherealIdleSeconds <= 0 {
@@ -142,6 +144,8 @@ func (c *SidecarClient) runSettingsWindow() {
 					return fmt.Errorf("Could not %s start-at-startup: %v", verb, err)
 				}
 				return c.editConfig(func(cfg *SidecarConfig) { cfg.Preferences.StartAtStartup = enabled })
+			case "continuous_wake":
+				return c.editConfig(func(cfg *SidecarConfig) { cfg.Preferences.ContinuousWake = enabled })
 			case "ethereal_pebble":
 				if err := c.editConfig(func(cfg *SidecarConfig) { cfg.Preferences.EtherealPebble = enabled }); err != nil {
 					return err
@@ -301,6 +305,10 @@ const settingsWindowHTML = `<!doctype html>
   <div class="sec">Privacy</div>
   <div class="panel">
     <div class="srow">
+      <div class="sl7"><div class="a">Continuous wake-word listening</div><div class="b">Keep the microphone open and send detected speech segments to your Brain to find “Jarvis”. Off by default. Takes effect after restarting the sidecar.</div></div>
+      <div class="sv7"><label class="sw"><input type="checkbox" id="continuous_wake" onchange="togglePref(this)"><span class="track"></span></label></div>
+    </div>
+    <div class="srow">
       <div class="sl7"><div class="a">Send anonymous usage metrics</div><div class="b">A small anonymous ping (hashed machine id, version, OS, capabilities) at startup and hourly, so the project can measure usage. No personal data or screen content. On by default; turn off here anytime.</div></div>
       <div class="sv7"><label class="sw"><input type="checkbox" id="telemetry_enabled" onchange="togglePref(this)"><span class="track"></span></label></div>
     </div>
@@ -341,6 +349,7 @@ const settingsWindowHTML = `<!doctype html>
     var st = await window.getState();
     paintStatus(st.status);
     document.getElementById('start_at_startup').checked = !!st.prefs.start_at_startup;
+    document.getElementById('continuous_wake').checked = !!st.prefs.continuous_wake;
     document.getElementById('ethereal_pebble').checked = !!st.prefs.ethereal_pebble;
     document.getElementById('ethereal_idle_seconds').value = st.prefs.ethereal_idle_seconds || 5;
     document.getElementById('telemetry_enabled').checked = !!st.prefs.telemetry_enabled;

--- a/sidecar/settings_window.go
+++ b/sidecar/settings_window.go
@@ -31,6 +31,7 @@ type settingsState struct {
 	Prefs  struct {
 		StartAtStartup         bool `json:"start_at_startup"`
 		ContinuousWake         bool `json:"continuous_wake"`
+		DoubleClap             bool `json:"double_clap"`
 		OpenDashboardAtStartup bool `json:"open_dashboard_at_startup"`
 		EtherealPebble         bool `json:"ethereal_pebble"`
 		EtherealIdleSeconds    int  `json:"ethereal_idle_seconds"`
@@ -69,6 +70,7 @@ func (c *SidecarClient) runSettingsWindow() {
 			st.Status = connStateString(c.ConnState())
 			st.Prefs.StartAtStartup = prefs.StartAtStartup
 			st.Prefs.ContinuousWake = prefs.ContinuousWake
+			st.Prefs.DoubleClap = prefs.DoubleClap
 			st.Prefs.OpenDashboardAtStartup = prefs.OpenDashboardAtStartup
 			st.Prefs.EtherealPebble = prefs.EtherealPebble
 			st.Prefs.EtherealIdleSeconds = prefs.EtherealIdleSeconds
@@ -147,7 +149,17 @@ func (c *SidecarClient) runSettingsWindow() {
 				}
 				return c.editConfig(func(cfg *SidecarConfig) { cfg.Preferences.StartAtStartup = enabled })
 			case "continuous_wake":
-				return c.editConfig(func(cfg *SidecarConfig) { cfg.Preferences.ContinuousWake = enabled })
+				return c.editConfig(func(cfg *SidecarConfig) {
+					cfg.Preferences.ContinuousWake = enabled
+					if !enabled {
+						cfg.Preferences.DoubleClap = false
+					}
+				})
+			case "double_clap":
+				if enabled && !c.Preferences().ContinuousWake {
+					return fmt.Errorf("Enable continuous wake-word listening first.")
+				}
+				return c.editConfig(func(cfg *SidecarConfig) { cfg.Preferences.DoubleClap = enabled })
 			case "open_dashboard_at_startup":
 				// Read once per launch (shouldOpenDashboardAtStartup), so there
 				// is no live state to apply here — just persist the choice.
@@ -319,6 +331,10 @@ const settingsWindowHTML = `<!doctype html>
       <div class="sv7"><label class="sw"><input type="checkbox" id="continuous_wake" onchange="togglePref(this)"><span class="track"></span></label></div>
     </div>
     <div class="srow">
+      <div class="sl7"><div class="a">ダブルクラップで呼び出す</div><div class="b">継続待機のマイクを共有し、2回の拍手を端末内で判定します。初期値はOFF。判定器は音声を保存せず、再起動後に有効になります。</div></div>
+      <div class="sv7"><label class="sw"><input type="checkbox" id="double_clap" onchange="togglePref(this)"><span class="track"></span></label></div>
+    </div>
+    <div class="srow">
       <div class="sl7"><div class="a">Send anonymous usage metrics</div><div class="b">A small anonymous ping (hashed machine id, version, OS, capabilities) at startup and hourly, so the project can measure usage. No personal data or screen content. On by default; turn off here anytime.</div></div>
       <div class="sv7"><label class="sw"><input type="checkbox" id="telemetry_enabled" onchange="togglePref(this)"><span class="track"></span></label></div>
     </div>
@@ -360,6 +376,7 @@ const settingsWindowHTML = `<!doctype html>
     paintStatus(st.status);
     document.getElementById('start_at_startup').checked = !!st.prefs.start_at_startup;
     document.getElementById('continuous_wake').checked = !!st.prefs.continuous_wake;
+    document.getElementById('double_clap').checked = !!st.prefs.double_clap;
     document.getElementById('open_dashboard_at_startup').checked = !!st.prefs.open_dashboard_at_startup;
     document.getElementById('ethereal_pebble').checked = !!st.prefs.ethereal_pebble;
     document.getElementById('ethereal_idle_seconds').value = st.prefs.ethereal_idle_seconds || 5;

--- a/sidecar/types.go
+++ b/sidecar/types.go
@@ -152,6 +152,7 @@ type PreferencesConfig struct {
 	StartAtStartup bool `yaml:"start_at_startup"` // register the sidecar to launch on login
 	// Privacy
 	ContinuousWake bool `yaml:"continuous_wake"` // continuously capture speech segments for wake-word detection; default off
+	DoubleClap     bool `yaml:"double_clap"`     // local double-clap summon; requires ContinuousWake and defaults off
 	// OpenDashboardAtStartup opens the dashboard window on every sidecar
 	// startup (once the brain connection is up, since the panel needs a
 	// minted access token). Off by default: normally only the pebble appears.

--- a/sidecar/types.go
+++ b/sidecar/types.go
@@ -26,12 +26,17 @@ const (
 
 // AwarenessConfig controls screen and window observer behavior.
 type AwarenessConfig struct {
+	Enabled            *bool   `yaml:"enabled,omitempty"`
 	ScreenIntervalMs   int     `yaml:"screen_interval_ms"`
 	WindowIntervalMs   int     `yaml:"window_interval_ms"`
 	MinChangeThreshold float64 `yaml:"min_change_threshold"`
 	StuckThresholdMs   int     `yaml:"stuck_threshold_ms"`
 	OCREnabled         bool    `yaml:"ocr_enabled"`
 	CaptureDir         string  `yaml:"capture_dir"`
+}
+
+func (c AwarenessConfig) IsEnabled() bool {
+	return c.Enabled == nil || *c.Enabled
 }
 
 // SidecarTokenClaims is the JWT payload from the brain.

--- a/sidecar/types.go
+++ b/sidecar/types.go
@@ -150,6 +150,8 @@ type TelemetryConfig struct {
 type PreferencesConfig struct {
 	// General
 	StartAtStartup bool `yaml:"start_at_startup"` // register the sidecar to launch on login
+	// Privacy
+	ContinuousWake bool `yaml:"continuous_wake"` // continuously capture speech segments for wake-word detection; default off
 	// Style
 	EtherealPebble      bool `yaml:"ethereal_pebble"`       // fade the pebble out while idle, pop it back on activity
 	EtherealIdleSeconds int  `yaml:"ethereal_idle_seconds"` // idle time before the pebble fades out (default 5)

--- a/src/daemon/agent-service.ts
+++ b/src/daemon/agent-service.ts
@@ -568,7 +568,7 @@ export class AgentService implements Service, IAgentService {
     const parts: string[] = [];
     const name = this.config.user?.name;
     if (name) parts.push(`Name: ${name}`);
-		parts.push(`Local date and time (authoritative): ${new Date().toString()}`);
+    parts.push(`Local date and time (authoritative): ${new Date().toString()}`);
     return parts.join('. ');
   }
 

--- a/src/daemon/agent-service.ts
+++ b/src/daemon/agent-service.ts
@@ -568,7 +568,7 @@ export class AgentService implements Service, IAgentService {
     const parts: string[] = [];
     const name = this.config.user?.name;
     if (name) parts.push(`Name: ${name}`);
-    parts.push(`Local time: ${new Date().toLocaleString()}`);
+		parts.push(`Local date and time (authoritative): ${new Date().toString()}`);
     return parts.join('. ');
   }
 

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -4667,9 +4667,9 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
       bgAgent = bgAgentService;
       console.log('[Daemon] Background agent started (separate browser for heartbeat/reactions)');
 
-		// 10c. Wire reactor + executor to background agent
-		// JARVIS_LOCAL: automatic EventReactor to BackgroundAgent disabled
-		executor.setAgentService(bgAgentService);
+      // 10c. Wire reactor + executor to background agent
+      // JARVIS_LOCAL: automatic EventReactor to BackgroundAgent disabled
+      executor.setAgentService(bgAgentService);
 
       // 10d. Wire executor broadcast (needs wsServer running) and start
       executor.setBroadcast((msg) => wsService.getServer().broadcast(msg));

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -4667,9 +4667,9 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
       bgAgent = bgAgentService;
       console.log('[Daemon] Background agent started (separate browser for heartbeat/reactions)');
 
-      // 10c. Wire reactor + executor to background agent
-      reactor.setAgentService(bgAgentService);
-      executor.setAgentService(bgAgentService);
+		// 10c. Wire reactor + executor to background agent
+		// JARVIS_LOCAL: automatic EventReactor to BackgroundAgent disabled
+		executor.setAgentService(bgAgentService);
 
       // 10d. Wire executor broadcast (needs wsServer running) and start
       executor.setBroadcast((msg) => wsService.getServer().broadcast(msg));

--- a/src/sidecar/manager.ts
+++ b/src/sidecar/manager.ts
@@ -199,11 +199,22 @@ export class SidecarManager implements Service {
       for (const type of sidecarEventTypes) {
         this.scheduler.on(type, sidecarEventHandler);
       }
-      // Realtime voice events bypass the 1-per-tick queue: realtime_start must
-      // open the session before mic frames arrive, and audio_frame streams at
-      // ~25/s (faster than the queue drains). Direct dispatch keeps them
-      // real-time and in receive order.
-      this.scheduler.setDirectTypes(['pebble.realtime_start', 'pebble.realtime_stop', 'pebble.audio_frame']);
+      // Voice-control events bypass the shared observer queue. Besides realtime
+      // mic frames, the one-shot summon transaction must remain contiguous:
+      // pebble.summon claims the turn, session_start establishes its audio
+      // buffer, and session_end starts STT -> LLM -> TTS. File/process/wake
+      // observer bursts can otherwise leave these events behind seconds of
+      // unrelated work, making a correctly captured command appear ignored.
+      // Direct dispatch starts handlers synchronously and preserves receive
+      // order, while the expensive async response cycle continues normally.
+      this.scheduler.setDirectTypes([
+        'pebble.summon',
+        'audio.session_start',
+        'audio.session_end',
+        'pebble.realtime_start',
+        'pebble.realtime_stop',
+        'pebble.audio_frame',
+      ]);
 
       this.rpcTracker.onDetachedComplete((rpcId, result, error) => {
         if (error) {

--- a/src/sidecar/scheduler.test.ts
+++ b/src/sidecar/scheduler.test.ts
@@ -126,4 +126,32 @@ describe('EventScheduler queue bounds', () => {
     await drainOnce(scheduler);
     expect(seen).toEqual(['c1', 'h1', 'n1', 'n2']);
   });
+
+  test('direct voice transaction bypasses observer backlog in receive order', () => {
+    const scheduler = new EventScheduler();
+    const seen: string[] = [];
+    scheduler.on('*', async (_id, event) => {
+      seen.push(event.event_type);
+    });
+    scheduler.setDirectTypes([
+      'pebble.summon',
+      'audio.session_start',
+      'audio.session_end',
+    ]);
+
+    for (let i = 0; i < 100; i++) {
+      scheduler.enqueue('sc-1', makeEvent('file_change'));
+    }
+    scheduler.enqueue('sc-1', makeEvent('pebble.summon'));
+    scheduler.enqueue('sc-1', makeEvent('audio.session_start'));
+    scheduler.enqueue('sc-1', makeEvent('audio.session_end'));
+
+    expect(seen).toEqual([
+      'pebble.summon',
+      'audio.session_start',
+      'audio.session_end',
+    ]);
+    const queues = (scheduler as unknown as { queues: Map<string, unknown[]> }).queues;
+    expect(queues.get('sc-1')!.length).toBe(100);
+  });
 });

--- a/src/sidecar/scheduler.ts
+++ b/src/sidecar/scheduler.ts
@@ -81,11 +81,11 @@ export class EventScheduler {
 
   /**
    * Mark event types that bypass the round-robin queue and dispatch
-   * synchronously on enqueue, in receive order. The queue drains only one
-   * event per ~50 ms tick — fine for discrete events, but it would back up a
-   * high-rate stream (e.g. realtime mic audio at ~25 frames/s) into seconds of
-   * latency. Direct types skip the queue entirely so they stay real-time and
-   * in order.
+   * synchronously on enqueue, in receive order. The queue drains a bounded
+   * batch per ~50 ms tick — fine for discrete events, but observer bursts can
+   * still back up a latency-sensitive transaction (or a high-rate realtime mic
+   * stream) into seconds of delay. Direct types skip the queue entirely so
+   * they stay real-time and in order.
    */
   setDirectTypes(types: string[]): void {
     for (const t of types) this.directTypes.add(t);

--- a/ui/src/v2/core/JapaneseDateTime.tsx
+++ b/ui/src/v2/core/JapaneseDateTime.tsx
@@ -1,0 +1,44 @@
+import React, { useEffect, useMemo, useState } from "react";
+
+const TIME_ZONE = "Asia/Tokyo";
+
+export function JapaneseDateTime() {
+  const [now, setNow] = useState(() => new Date());
+  const formatters = useMemo(() => ({
+    date: new Intl.DateTimeFormat("ja-JP", {
+      timeZone: TIME_ZONE,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      weekday: "short",
+    }),
+    time: new Intl.DateTimeFormat("ja-JP", {
+      timeZone: TIME_ZONE,
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+      hour12: false,
+    }),
+  }), []);
+
+  useEffect(() => {
+    const tick = () => setNow(new Date());
+    const timeout = window.setTimeout(() => {
+      tick();
+      const interval = window.setInterval(tick, 1000);
+      intervalRef = interval;
+    }, 1000 - (Date.now() % 1000));
+    let intervalRef: number | undefined;
+    return () => {
+      window.clearTimeout(timeout);
+      if (intervalRef !== undefined) window.clearInterval(intervalRef);
+    };
+  }, []);
+
+  return (
+    <time className="rs-jp-clock" dateTime={now.toISOString()} aria-label={`${formatters.date.format(now)} ${formatters.time.format(now)}`}>
+      <span>{formatters.date.format(now)}</span>
+      <b>{formatters.time.format(now)}</b>
+    </time>
+  );
+}

--- a/ui/src/v2/core/coreState.test.ts
+++ b/ui/src/v2/core/coreState.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { deriveJarvisCoreState } from "./coreState";
+import { deriveJarvisCoreState, hasActiveAgentWork } from "./coreState";
 
 const base = { connection: "live" as const, voiceState: "idle" as const };
 
@@ -20,5 +20,21 @@ describe("deriveJarvisCoreState", () => {
   test("represents lifecycle states without inventing activity", () => {
     expect(deriveJarvisCoreState({ ...base, isBooting: true })).toBe("AWAKENING");
     expect(deriveJarvisCoreState({ ...base, voiceState: "muted" })).toBe("SLEEPING");
+  });
+});
+
+describe("hasActiveAgentWork", () => {
+  test("uses only the newest event for each agent", () => {
+    expect(hasActiveAgentWork([
+      { agentName: "planner", eventType: "tool_call", timestamp: 10 },
+      { agentName: "planner", eventType: "done", timestamp: 20 },
+    ])).toBe(false);
+  });
+
+  test("stays active while any agent's newest event is unfinished", () => {
+    expect(hasActiveAgentWork([
+      { agentName: "planner", eventType: "done", timestamp: 20 },
+      { agentName: "executor", eventType: "tool_call", timestamp: 15 },
+    ])).toBe(true);
   });
 });

--- a/ui/src/v2/core/coreState.test.ts
+++ b/ui/src/v2/core/coreState.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test";
+import { deriveJarvisCoreState } from "./coreState";
+
+const base = { connection: "live" as const, voiceState: "idle" as const };
+
+describe("deriveJarvisCoreState", () => {
+  test("uses safety-first priority", () => {
+    expect(deriveJarvisCoreState({ ...base, hasError: true, hasPendingApproval: true })).toBe("ERROR");
+    expect(deriveJarvisCoreState({ ...base, hasPendingApproval: true, hasActiveWork: true })).toBe("WAITING_APPROVAL");
+  });
+
+  test("maps live voice and work signals", () => {
+    expect(deriveJarvisCoreState({ ...base, voiceState: "listening" })).toBe("LISTENING");
+    expect(deriveJarvisCoreState({ ...base, voiceState: "thinking" })).toBe("THINKING");
+    expect(deriveJarvisCoreState({ ...base, voiceState: "speaking" })).toBe("SPEAKING");
+    expect(deriveJarvisCoreState({ ...base, hasActiveWork: true })).toBe("WORKING");
+    expect(deriveJarvisCoreState(base)).toBe("IDLE");
+  });
+
+  test("represents lifecycle states without inventing activity", () => {
+    expect(deriveJarvisCoreState({ ...base, isBooting: true })).toBe("AWAKENING");
+    expect(deriveJarvisCoreState({ ...base, voiceState: "muted" })).toBe("SLEEPING");
+  });
+});

--- a/ui/src/v2/core/coreState.ts
+++ b/ui/src/v2/core/coreState.ts
@@ -25,6 +25,28 @@ export interface JarvisCoreSignals {
   hasError?: boolean;
 }
 
+export interface JarvisAgentActivitySignal {
+  agentName: string;
+  eventType: string;
+  timestamp: number;
+}
+
+/**
+ * Agent activity is an append-only event stream. Only the newest event for
+ * each agent is authoritative; an older tool_call must not keep CORE in
+ * WORKING after that agent has emitted done.
+ */
+export function hasActiveAgentWork(events: JarvisAgentActivitySignal[]): boolean {
+  const latestByAgent = new Map<string, JarvisAgentActivitySignal>();
+  for (const event of events) {
+    const current = latestByAgent.get(event.agentName);
+    if (!current || event.timestamp > current.timestamp) {
+      latestByAgent.set(event.agentName, event);
+    }
+  }
+  return [...latestByAgent.values()].some((event) => event.eventType !== "done");
+}
+
 /**
  * One deterministic priority order for every CORE consumer. Keep this pure:
  * animation, copy, Activity and accessibility must never disagree about the

--- a/ui/src/v2/core/coreState.ts
+++ b/ui/src/v2/core/coreState.ts
@@ -1,0 +1,53 @@
+import type { ConnectionState } from "../shell/Header";
+import type { VoiceState } from "../shell/VoiceRail";
+
+export const JARVIS_CORE_STATES = [
+  "SLEEPING",
+  "AWAKENING",
+  "IDLE",
+  "LISTENING",
+  "THINKING",
+  "WORKING",
+  "WAITING_APPROVAL",
+  "SPEAKING",
+  "ERROR",
+] as const;
+
+export type JarvisCoreState = (typeof JARVIS_CORE_STATES)[number];
+
+export interface JarvisCoreSignals {
+  connection: ConnectionState;
+  voiceState: VoiceState;
+  isBooting?: boolean;
+  isSleeping?: boolean;
+  hasActiveWork?: boolean;
+  hasPendingApproval?: boolean;
+  hasError?: boolean;
+}
+
+/**
+ * One deterministic priority order for every CORE consumer. Keep this pure:
+ * animation, copy, Activity and accessibility must never disagree about the
+ * state Jarvis is in.
+ */
+export function deriveJarvisCoreState(signals: JarvisCoreSignals): JarvisCoreState {
+  if (signals.hasError || signals.connection === "offline") return "ERROR";
+  if (signals.isBooting || signals.connection === "degraded") return "AWAKENING";
+  if (signals.isSleeping) return "SLEEPING";
+  if (signals.hasPendingApproval || signals.voiceState === "awaiting-approval") {
+    return "WAITING_APPROVAL";
+  }
+
+  switch (signals.voiceState) {
+    case "speaking":
+      return "SPEAKING";
+    case "listening":
+      return "LISTENING";
+    case "thinking":
+      return "THINKING";
+    case "muted":
+      return "SLEEPING";
+    case "idle":
+      return signals.hasActiveWork ? "WORKING" : "IDLE";
+  }
+}

--- a/ui/src/v2/palette/CommandPalette.tsx
+++ b/ui/src/v2/palette/CommandPalette.tsx
@@ -223,7 +223,7 @@ export function CommandPalette({
               setActiveIdx(0);
             }}
             onKeyDown={onKeyDown}
-            placeholder="Search workflows, memory, tools, agents, authority, logs…"
+            placeholder="ワークフロー、メモリー、ツール、エージェントを検索…"
             aria-label="Palette search"
           />
           <KBD>Esc</KBD>
@@ -238,7 +238,7 @@ export function CommandPalette({
 
           {/* Rooms group */}
           {navEntries.length > 0 && (
-            <Group label="Rooms">
+            <Group label="ルーム">
               {navEntries.map((entry, i) => {
                 const idx = i;
                 return (
@@ -251,7 +251,7 @@ export function CommandPalette({
                     icon={NAV_ICON[entry.key]}
                     title={entry.label}
                     hint={entry.hint}
-                    typeLabel="Open Room"
+                    typeLabel="ルームを開く"
                   />
                 );
               })}
@@ -300,16 +300,16 @@ export function CommandPalette({
         <div className="v2-palette__foot">
           <span className="v2-palette__hint">
             <KBD>↑</KBD>
-            <KBD>↓</KBD> navigate
+            <KBD>↓</KBD> 移動
           </span>
           <span className="v2-palette__hint">
-            <KBD>↵</KBD> insert as card
+            <KBD>↵</KBD> カードとして追加
           </span>
           <span className="v2-palette__hint">
-            <KBD>⇧↵</KBD> open Room
+            <KBD>⇧↵</KBD> ルームを開く
           </span>
           <span className="v2-palette__hint v2-palette__hint--right">
-            <KBD>Esc</KBD> close
+            <KBD>Esc</KBD> 閉じる
           </span>
         </div>
       </div>

--- a/ui/src/v2/palette/types.ts
+++ b/ui/src/v2/palette/types.ts
@@ -47,19 +47,19 @@ export type PaletteNavEntry = {
 };
 
 export const ROOM_NAV_ENTRIES: PaletteNavEntry[] = [
-  { key: "workflows", label: "Workflows", hint: "Run or edit saved agent flows" },
-  { key: "memory", label: "Memory", hint: "Recall what Jarvis knows" },
-  { key: "agents", label: "Agents", hint: "Roster, status, last run" },
-  { key: "authority", label: "Authority", hint: "Scopes, allowlists, approvals" },
-  { key: "tools", label: "Tools", hint: "Catalog + capability flags" },
-  { key: "logs", label: "Logs", hint: "Filterable event stream" },
-  { key: "calendar", label: "Calendar", hint: "This week + commitments" },
-  { key: "goals", label: "Goals", hint: "OKR hierarchy + scoring" },
-  { key: "tasks", label: "Tasks", hint: "Kanban + due dates + priority" },
-  { key: "content", label: "Content", hint: "Drafts, scheduled, published" },
-  { key: "workspaces", label: "Workspaces", hint: "Dev projects, git, dev servers" },
-  { key: "usage", label: "Usage", hint: "LLM token usage, filterable by tier/model/task/date" },
-  { key: "settings", label: "Settings", hint: "Providers, voice, shortcuts" },
+  { key: "workflows", label: "ワークフロー", hint: "保存したAIフローの実行と編集" },
+  { key: "memory", label: "メモリー", hint: "JARVISが記憶している情報" },
+  { key: "agents", label: "エージェント", hint: "担当・状態・直近の実行" },
+  { key: "authority", label: "権限と承認", hint: "操作範囲・許可リスト・承認" },
+  { key: "tools", label: "ツール", hint: "利用可能な機能と設定" },
+  { key: "logs", label: "アクティビティ", hint: "絞り込み可能なイベント履歴" },
+  { key: "calendar", label: "カレンダー", hint: "今週の予定とコミットメント" },
+  { key: "goals", label: "ゴール", hint: "目標の階層と進捗スコア" },
+  { key: "tasks", label: "タスク", hint: "期限・優先度・進行状況" },
+  { key: "content", label: "コンテンツ", hint: "下書き・予約・公開済み" },
+  { key: "workspaces", label: "ワークスペース", hint: "開発プロジェクトとGit状態" },
+  { key: "usage", label: "使用状況", hint: "モデル別のLLM利用状況" },
+  { key: "settings", label: "設定", hint: "AI・音声・ショートカット" },
 ];
 
 /**

--- a/ui/src/v2/shell/AppShell.css
+++ b/ui/src/v2/shell/AppShell.css
@@ -39,3 +39,18 @@
   display: flex;
   flex-direction: column;
 }
+.rs-jp-clock {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 8px;
+  color: var(--ink2);
+  font: 500 11px/1 var(--mono);
+  white-space: nowrap;
+}
+
+.rs-jp-clock b {
+  color: var(--ink);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: .04em;
+}

--- a/ui/src/v2/shell/AppShell.tsx
+++ b/ui/src/v2/shell/AppShell.tsx
@@ -529,6 +529,7 @@ function AppShellLive() {
             : "Waiting for daemon…"
         }
         composerResponding={live.isResponding || live.thinking || voice.voiceState === "speaking"}
+        hasCoreError={voice.voiceState === "error"}
         onStopResponse={stopCurrentResponse}
         onSubmit={handleChatSubmit}
         onApprove={handleApprove}
@@ -780,6 +781,8 @@ interface ShellLayoutProps {
   composerDisabled?: boolean;
   composerPlaceholder?: string;
   composerResponding?: boolean;
+  /** Raw runtime error signal kept separate from the simplified rail state. */
+  hasCoreError?: boolean;
   onStopResponse?: () => void;
   onSubmit: (text: string) => void;
   onApprove: (id: string) => void;
@@ -834,6 +837,7 @@ function ShellLayout({
   composerDisabled,
   composerPlaceholder,
   composerResponding,
+  hasCoreError = false,
   onStopResponse,
   onSubmit,
   onApprove,
@@ -865,14 +869,20 @@ function ShellLayout({
   const [arranging, setArranging] = useState(false);
   const [talkOpen, setTalkOpen] = useState(false);
   const [talkIn, setTalkIn] = useState(false);
+  // The existing outage grace period doubles as CORE's AWAKENING window.
+  // A stable outage still becomes ERROR and triggers the takeover below.
+  const offlineStable = useStableOffline(connection === "offline");
+  const coreConnection: ConnectionState =
+    connection === "offline" && !offlineStable ? "degraded" : connection;
   const liveData = useLiveData();
   const hasAgentWork = useMemo(
     () => hasActiveAgentWork(liveData.agentActivity),
     [liveData.agentActivity],
   );
   const coreState = deriveJarvisCoreState({
-    connection,
+    connection: coreConnection,
     voiceState,
+    hasError: hasCoreError,
     hasActiveWork: Boolean(composerResponding) || hasAgentWork,
     hasPendingApproval: liveData.approvals.length > 0 || voiceState === "awaiting-approval",
   });
@@ -910,7 +920,6 @@ function ShellLayout({
   // connection has been down for a few seconds — a WS blip (or the initial
   // pre-connect state on mount) must not flash a takeover.
   const sysOverride = useSystemStateOverride();
-  const offlineStable = useStableOffline(connection === "offline");
   const takeover: TakeoverKind | null = offlineStable ? "offline" : sysOverride.takeover;
   const sysHandlers = useMemo(
     () => ({

--- a/ui/src/v2/shell/AppShell.tsx
+++ b/ui/src/v2/shell/AppShell.tsx
@@ -29,6 +29,7 @@ import { useRoomActionDispatcher } from "../rooms/useRoomActionBus";
 import { IndexSidebar, useIndexCollapsed } from "./IndexSidebar";
 import { TopBar } from "./TopBar";
 import { NowRoom } from "./NowRoom";
+import { deriveJarvisCoreState } from "../core/coreState";
 import "./AppShell.css";
 import "./roomShell.css";
 
@@ -863,6 +864,12 @@ function ShellLayout({
   const [arranging, setArranging] = useState(false);
   const [talkOpen, setTalkOpen] = useState(false);
   const [talkIn, setTalkIn] = useState(false);
+  const coreState = deriveJarvisCoreState({
+    connection,
+    voiceState,
+    hasActiveWork: composerResponding,
+    hasPendingApproval: voiceState === "awaiting-approval",
+  });
 
   // awaiting-approval renders as the "asking" (amber) pebble state.
   const dataState = voiceState === "awaiting-approval" ? "asking" : voiceState;
@@ -918,7 +925,7 @@ function ShellLayout({
 
       <TopBar
         connection={connection}
-        voiceState={voiceState}
+        coreState={coreState}
         arranging={arranging}
         onArrange={() => setArranging((a) => !a)}
         onOpenPalette={onOpenPalette}

--- a/ui/src/v2/shell/AppShell.tsx
+++ b/ui/src/v2/shell/AppShell.tsx
@@ -23,13 +23,13 @@ import type { LayoutRect } from "../rooms/useRoomLayout";
 import { useSpacebarPTT } from "../voice/useSpacebarPTT";
 import { useNotificationCenter } from "../../hooks/useNotificationCenter";
 import { NotificationDrawer } from "../notifications/NotificationDrawer";
-import { LiveDataProvider } from "./LiveDataContext";
+import { LiveDataProvider, useLiveData } from "./LiveDataContext";
 import { PausedTasksBanner } from "./PausedTasksBanner";
 import { useRoomActionDispatcher } from "../rooms/useRoomActionBus";
 import { IndexSidebar, useIndexCollapsed } from "./IndexSidebar";
 import { TopBar } from "./TopBar";
 import { NowRoom } from "./NowRoom";
-import { deriveJarvisCoreState } from "../core/coreState";
+import { deriveJarvisCoreState, hasActiveAgentWork } from "../core/coreState";
 import "./AppShell.css";
 import "./roomShell.css";
 import { modKey } from "../ui/platform";
@@ -865,11 +865,16 @@ function ShellLayout({
   const [arranging, setArranging] = useState(false);
   const [talkOpen, setTalkOpen] = useState(false);
   const [talkIn, setTalkIn] = useState(false);
+  const liveData = useLiveData();
+  const hasAgentWork = useMemo(
+    () => hasActiveAgentWork(liveData.agentActivity),
+    [liveData.agentActivity],
+  );
   const coreState = deriveJarvisCoreState({
     connection,
     voiceState,
-    hasActiveWork: composerResponding,
-    hasPendingApproval: voiceState === "awaiting-approval",
+    hasActiveWork: Boolean(composerResponding) || hasAgentWork,
+    hasPendingApproval: liveData.approvals.length > 0 || voiceState === "awaiting-approval",
   });
 
   // awaiting-approval renders as the "asking" (amber) pebble state.

--- a/ui/src/v2/shell/AppShell.tsx
+++ b/ui/src/v2/shell/AppShell.tsx
@@ -951,7 +951,7 @@ function ShellLayout({
             <RoomSurface roomKey={route.key} />
           </div>
         ) : (
-          <NowRoom connection={connection} arranging={arranging} onApprove={onApprove} onCancel={onCancel} />
+          <NowRoom connection={connection} coreState={coreState} arranging={arranging} onApprove={onApprove} onCancel={onCancel} />
         )}
       </div>
 

--- a/ui/src/v2/shell/IndexSidebar.tsx
+++ b/ui/src/v2/shell/IndexSidebar.tsx
@@ -18,24 +18,24 @@ type Row =
   | { kind: "now"; label: string; kbd: string };
 
 const ROWS: Row[] = [
-  { kind: "now", label: "Now", kbd: "⌘1" },
-  { kind: "heading", label: "run" },
-  { kind: "room", key: "workflows", label: "Workflows", kbd: "⌘2" },
-  { kind: "room", key: "agents", label: "Agents", kbd: "⌘3" },
-  { kind: "room", key: "tasks", label: "Tasks", kbd: "⌘4" },
-  { kind: "heading", label: "know" },
-  { kind: "room", key: "memory", label: "Memory", kbd: "⌘5" },
-  { kind: "room", key: "goals", label: "Goals", kbd: "⌘6" },
-  { kind: "room", key: "calendar", label: "Calendar", kbd: "⌘7" },
-  { kind: "room", key: "content", label: "Content", kbd: "⌘8" },
-  { kind: "heading", label: "guard" },
-  { kind: "room", key: "authority", label: "Authority" },
-  { kind: "room", key: "logs", label: "Logs" },
-  { kind: "room", key: "usage", label: "Usage" },
-  { kind: "heading", label: "build" },
-  { kind: "room", key: "workspaces", label: "Workspaces" },
-  { kind: "room", key: "tools", label: "Tools" },
-  { kind: "room", key: "settings", label: "Settings", kbd: "⌘9", spaced: true },
+  { kind: "now", label: "現在", kbd: "⌘1" },
+  { kind: "heading", label: "実行" },
+  { kind: "room", key: "workflows", label: "ワークフロー", kbd: "⌘2" },
+  { kind: "room", key: "agents", label: "エージェント", kbd: "⌘3" },
+  { kind: "room", key: "tasks", label: "タスク", kbd: "⌘4" },
+  { kind: "heading", label: "知識" },
+  { kind: "room", key: "memory", label: "メモリー", kbd: "⌘5" },
+  { kind: "room", key: "goals", label: "ゴール", kbd: "⌘6" },
+  { kind: "room", key: "calendar", label: "カレンダー", kbd: "⌘7" },
+  { kind: "room", key: "content", label: "コンテンツ", kbd: "⌘8" },
+  { kind: "heading", label: "安全" },
+  { kind: "room", key: "authority", label: "権限と承認" },
+  { kind: "room", key: "logs", label: "アクティビティ" },
+  { kind: "room", key: "usage", label: "使用状況" },
+  { kind: "heading", label: "構築" },
+  { kind: "room", key: "workspaces", label: "ワークスペース" },
+  { kind: "room", key: "tools", label: "ツール" },
+  { kind: "room", key: "settings", label: "設定", kbd: "⌘9", spaced: true },
 ];
 
 /** Cluster → its rooms, for collapsed tiles + hover-peek. */
@@ -181,7 +181,7 @@ export function IndexSidebar({
           );
         })}
         <div style={{ flex: 1 }} />
-        <button className="rs-clps" onClick={onToggleCollapse}>« collapse</button>
+        <button className="rs-clps" onClick={onToggleCollapse}>« 折りたたむ</button>
       </div>
 
       {/* Collapsed cluster tiles */}

--- a/ui/src/v2/shell/NowRoom.tsx
+++ b/ui/src/v2/shell/NowRoom.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { openRoom, type RoomKey } from "../router";
 import { useLiveData, type LiveData } from "./LiveDataContext";
 import type { ConnectionState } from "./Header";
+import type { JarvisCoreState } from "../core/coreState";
 
 /**
  * Now — the home surface you compose. A grid of widgets, each a room's
@@ -25,6 +26,44 @@ type WidgetDef = {
 };
 
 const LAYOUT_KEY = "jarvis-now-layout-v2";
+
+const CORE_JA: Record<JarvisCoreState, { label: string; message: string }> = {
+  SLEEPING: { label: "休止中", message: "呼びかけを待っています" },
+  AWAKENING: { label: "起動中", message: "システムを同期しています" },
+  IDLE: { label: "待機中", message: "いつでも指示をどうぞ" },
+  LISTENING: { label: "聞いています", message: "声を認識しています" },
+  THINKING: { label: "思考中", message: "最適な答えを組み立てています" },
+  WORKING: { label: "実行中", message: "タスクを進めています" },
+  WAITING_APPROVAL: { label: "承認待ち", message: "重要操作の確認が必要です" },
+  SPEAKING: { label: "応答中", message: "回答を伝えています" },
+  ERROR: { label: "要確認", message: "システム状態を確認してください" },
+};
+
+function CoreHero({ state, live }: { state: JarvisCoreState; live: LiveData }) {
+  const copy = CORE_JA[state];
+  const latest = [...live.agentActivity].sort((a, b) => b.timestamp - a.timestamp)[0];
+  const activity = latest
+    ? `${latest.agentName} · ${latest.eventType === "done" ? "完了" : latest.eventType === "tool_call" ? "ツール実行中" : "処理中"}`
+    : "アクティビティなし";
+
+  return (
+    <section className="jarvis-core-hero" data-core-state={state} aria-label={`JARVIS CORE ${copy.label}`}>
+      <div className="jarvis-core-visual" aria-hidden="true">
+        <span className="jarvis-core-orbit orbit-a" />
+        <span className="jarvis-core-orbit orbit-b" />
+        <span className="jarvis-core-orbit orbit-c" />
+        <span className="jarvis-core-sphere"><i /></span>
+      </div>
+      <div className="jarvis-core-copy">
+        <span className="eyebrow">JARVIS CORE</span>
+        <strong>{copy.label}</strong>
+        <p>{copy.message}</p>
+        <div className="jarvis-core-activity"><span />最新Activity　{activity}</div>
+      </div>
+      <span className="jarvis-core-code">{state}</span>
+    </section>
+  );
+}
 
 function rel(ts: number): string {
   const d = Date.now() - ts;
@@ -356,9 +395,10 @@ function loadLayout(): LayoutItem[] {
 }
 
 export function NowRoom({
-  connection, arranging, onApprove, onCancel,
+  connection, coreState, arranging, onApprove, onCancel,
 }: {
   connection: ConnectionState;
+  coreState: JarvisCoreState;
   arranging: boolean;
   onApprove: (id: string) => void;
   onCancel: (id: string) => void;
@@ -423,6 +463,8 @@ export function NowRoom({
           <span className="mono2">jarvis start</span>
         </div>
       )}
+
+      {!offline && !arranging && <CoreHero state={coreState} live={live} />}
 
       {items.map((item) => {
         const def = WIDGETS[item.id];

--- a/ui/src/v2/shell/NowRoom.tsx
+++ b/ui/src/v2/shell/NowRoom.tsx
@@ -58,7 +58,7 @@ function CoreHero({ state, live }: { state: JarvisCoreState; live: LiveData }) {
         <span className="eyebrow">JARVIS CORE</span>
         <strong>{copy.label}</strong>
         <p>{copy.message}</p>
-        <div className="jarvis-core-activity"><span />最新Activity　{activity}</div>
+        <div className="jarvis-core-activity"><span />最新アクティビティ　{activity}</div>
       </div>
       <span className="jarvis-core-code">{state}</span>
     </section>
@@ -69,11 +69,11 @@ function rel(ts: number): string {
   const d = Date.now() - ts;
   if (d < 0) return "";
   const m = Math.floor(d / 60000);
-  if (m < 1) return "now";
-  if (m < 60) return `${m}m`;
+  if (m < 1) return "たった今";
+  if (m < 60) return `${m}分前`;
   const h = Math.floor(m / 60);
-  if (h < 24) return `${h}h`;
-  return `${Math.floor(h / 24)}d`;
+  if (h < 24) return `${h}時間前`;
+  return `${Math.floor(h / 24)}日前`;
 }
 
 /* ── shared header + empty-state helpers ── */
@@ -155,17 +155,17 @@ function useWidgetData<T>(url: string, pollMs = 15000): { data: T | null; loaded
 
 function relPast(ts: number): string {
   const s = Math.max(0, Math.round((Date.now() - ts) / 1000));
-  if (s < 60) return "just now";
-  const m = Math.round(s / 60); if (m < 60) return `${m}m ago`;
-  const h = Math.round(m / 60); if (h < 24) return `${h}h ago`;
-  return `${Math.round(h / 24)}d ago`;
+  if (s < 60) return "たった今";
+  const m = Math.round(s / 60); if (m < 60) return `${m}分前`;
+  const h = Math.round(m / 60); if (h < 24) return `${h}時間前`;
+  return `${Math.round(h / 24)}日前`;
 }
 function relSoon(ts: number): string {
   const s = Math.round((ts - Date.now()) / 1000);
-  if (s < 60) return "now";
-  const m = Math.round(s / 60); if (m < 60) return `in ${m}m`;
-  const h = Math.round(m / 60); if (h < 24) return `in ${h}h`;
-  return `in ${Math.round(h / 24)}d`;
+  if (s < 60) return "まもなく";
+  const m = Math.round(s / 60); if (m < 60) return `${m}分後`;
+  const h = Math.round(m / 60); if (h < 24) return `${h}時間後`;
+  return `${Math.round(h / 24)}日後`;
 }
 const deslug = (s: string) => s.replace(/[_-]+/g, " ").trim();
 
@@ -177,7 +177,7 @@ function Stat({ n, unit, sub }: { n: React.ReactNode; unit?: string; sub?: React
     </div>
   );
 }
-function Loading() { return <Empty><span className="dim">Loading…</span></Empty>; }
+function Loading() { return <Empty><span className="dim">読み込み中…</span></Empty>; }
 
 function CalendarWidget() {
   const now = Date.now();
@@ -185,18 +185,18 @@ function CalendarWidget() {
     `/api/calendar?range_start=${now}&range_end=${now + 7 * 86400000}`);
   const up = Array.isArray(data) ? data.filter((e) => e.timestamp >= now).sort((a, b) => a.timestamp - b.timestamp) : [];
   const next = up[0];
-  return (<><WHeader label="calendar · next" room="calendar" />
-    {next ? <Stat n={up.length} unit={up.length === 1 ? "commitment" : "commitments"} sub={<>Next: <b>{next.title}</b> · {relSoon(next.timestamp)}</>} />
-      : loaded ? <Empty>No commitments this week. <span className="dim">Connect a calendar in Settings.</span></Empty> : <Loading />}</>);
+  return (<><WHeader label="カレンダー · 次の予定" room="calendar" />
+    {next ? <Stat n={up.length} unit="件の予定" sub={<>次: <b>{next.title}</b> · {relSoon(next.timestamp)}</>} />
+      : loaded ? <Empty>今週の予定はありません。<span className="dim">設定からカレンダーを接続できます。</span></Empty> : <Loading />}</>);
 }
 
 function MemoryWidget() {
   const { data, loaded } = useWidgetData<Array<{ predicate: string; object: string; created_at: number }>>("/api/vault/facts");
   const facts = Array.isArray(data) ? [...data].sort((a, b) => b.created_at - a.created_at) : [];
   const newest = facts[0];
-  return (<><WHeader label="memory · new" room="memory" />
-    {newest ? <Stat n={facts.length} unit={facts.length === 1 ? "fact" : "facts"} sub={<>Newest: {deslug(newest.predicate)} <b>{newest.object}</b></>} />
-      : loaded ? <Empty>New facts Jarvis learns surface here. <span className="dim">Browse the vault in Memory.</span></Empty> : <Loading />}</>);
+  return (<><WHeader label="メモリー · 最新" room="memory" />
+    {newest ? <Stat n={facts.length} unit="件の記憶" sub={<>最新: {deslug(newest.predicate)} <b>{newest.object}</b></>} />
+      : loaded ? <Empty>JARVISが学習した新しい情報がここに表示されます。<span className="dim">メモリーで確認できます。</span></Empty> : <Loading />}</>);
 }
 
 function GoalsWidget() {
@@ -204,18 +204,18 @@ function GoalsWidget() {
   const goals = Array.isArray(data) ? data : [];
   const active = goals.filter((g) => g.status === "active");
   const onTrack = active.filter((g) => g.health === "on_track").length;
-  return (<><WHeader label="goals · health" room="goals" />
-    {goals.length ? <Stat n={active.length} unit={active.length === 1 ? "active goal" : "active goals"} sub={active.length ? <>{onTrack} on track · {active.length - onTrack} need attention</> : "None active"} />
-      : loaded ? <Empty>No goals set yet. <span className="dim">Define objectives in Goals to track them here.</span></Empty> : <Loading />}</>);
+  return (<><WHeader label="ゴール · 状況" room="goals" />
+    {goals.length ? <Stat n={active.length} unit="件が進行中" sub={active.length ? <>順調 {onTrack}件 · 要確認 {active.length - onTrack}件</> : "進行中なし"} />
+      : loaded ? <Empty>ゴールはまだありません。<span className="dim">ゴールを設定すると進捗を確認できます。</span></Empty> : <Loading />}</>);
 }
 
 function WorkflowsWidget() {
   const { data, loaded } = useWidgetData<Array<Record<string, unknown>>>("/api/workflows");
   const flows = Array.isArray(data) ? data : [];
   const live = flows.filter((f) => f.enabled === true || f.published === true || f.status === "published").length;
-  return (<><WHeader label="workflows" room="workflows" />
-    {flows.length ? <Stat n={flows.length} unit={flows.length === 1 ? "workflow" : "workflows"} sub={live ? `${live} enabled` : "None enabled yet"} />
-      : loaded ? <Empty>Saved automations show their status here. <span className="dim">Open Workflows to build one.</span></Empty> : <Loading />}</>);
+  return (<><WHeader label="ワークフロー" room="workflows" />
+    {flows.length ? <Stat n={flows.length} unit="件" sub={live ? `${live}件が有効` : "有効なものはありません"} />
+      : loaded ? <Empty>保存した自動化の状態がここに表示されます。<span className="dim">ワークフローから作成できます。</span></Empty> : <Loading />}</>);
 }
 
 function AuthorityAuditWidget() {

--- a/ui/src/v2/shell/NowRoom.tsx
+++ b/ui/src/v2/shell/NowRoom.tsx
@@ -81,10 +81,15 @@ function WHeader({ label, room, tone }: { label: string; room?: RoomKey; tone?: 
   return (
     <div className={`rs-ch${tone ? " " + tone : ""}`}>
       {label}
-      {room && <button className="lnk" onClick={() => openRoom(room)}>{room} →</button>}
+      {room && <button className="lnk" onClick={() => openRoom(room)}>{ROOM_JA[room]} →</button>}
     </div>
   );
 }
+const ROOM_JA: Record<RoomKey, string> = {
+  workflows: "ワークフロー", agents: "エージェント", agent_strip: "エージェント状況", tasks: "タスク", memory: "メモリー",
+  goals: "ゴール", calendar: "カレンダー", content: "コンテンツ", authority: "権限と承認",
+  logs: "履歴", usage: "使用状況", workspaces: "ワークスペース", tools: "ツール", settings: "設定",
+};
 function Empty({ children }: { children: React.ReactNode }) {
   return <div className="rs-empty">{children}</div>;
 }
@@ -102,7 +107,7 @@ function Row({ dot, room, children, tm }: { dot: string; room: RoomKey; children
 function agentRows(live: LiveData) {
   const byAgent = new Map<string, { name: string; what: string; ts: number; running: boolean }>();
   for (const e of live.agentActivity) {
-    const what = e.eventType === "tool_call" ? "running a tool" : e.eventType === "done" ? "finished" : "working";
+    const what = e.eventType === "tool_call" ? "ツール実行中" : e.eventType === "done" ? "完了" : "処理中";
     byAgent.set(e.agentName, { name: e.agentName, what, ts: e.timestamp, running: e.eventType !== "done" });
   }
   return [...byAgent.values()].sort((a, b) => b.ts - a.ts).slice(0, 4);
@@ -272,29 +277,29 @@ const WIDGETS: Record<string, WidgetDef> = {
     id: "right-now", group: "run", dot: "var(--speak)", desc: "Active agents and what each is doing.", defaultSize: 1,
     render: ({ live }) => {
       const a = agentRows(live);
-      return (<><WHeader label="right now" room="agents" />
+      return (<><WHeader label="現在の稼働状況" room="agents" />
         {a.length ? a.map((x) => <Row key={x.name} dot={x.running ? "var(--speak)" : "var(--faint)"} room="agents" tm={rel(x.ts)}><b>{x.name}</b> · {x.what}</Row>)
-          : <Empty>Nothing running yet. Say <b>“Hey Jarvis”</b> and hand it something, or start in <b>Workflows</b>.</Empty>}</>);
+          : <Empty>現在実行中の処理はありません。<b>“Hey Jarvis”</b> と呼びかけるか、ワークフローを開始してください。</Empty>}</>);
     },
   },
   waiting: {
     id: "waiting", group: "guard", dot: "var(--hold)", desc: "Pending approvals, resolvable in place. Pins to the top while amber.", defaultSize: 1,
-    render: ({ live, onApprove, onCancel }) => (<><WHeader label={`waiting on you · ${live.approvals.length}`} room="authority" tone="hold" />
+    render: ({ live, onApprove, onCancel }) => (<><WHeader label={`承認待ち · ${live.approvals.length}`} room="authority" tone="hold" />
       {live.approvals.length ? live.approvals.slice(0, 3).map((a) => (
         <div className="rs-apr" key={a.id}>
           <div className="t1"><span className="rs-dot" />{a.category} · {a.toolName}</div>
           <div className="t2">{a.intent}</div>
-          <div className="bs"><button className="b1" onClick={() => onApprove(a.id)}>Yes · approve</button><button className="b2" onClick={() => onCancel(a.id)}>Cancel</button></div>
+          <div className="bs"><button className="b1" onClick={() => onApprove(a.id)}>承認する</button><button className="b2" onClick={() => onCancel(a.id)}>キャンセル</button></div>
         </div>
-      )) : <Empty>Approvals land here when an action needs your yes. <span className="dim">Nothing waits right now.</span></Empty>}</>),
+      )) : <Empty>重要操作の確認が必要な場合、ここに表示されます。<span className="dim">現在、承認待ちはありません。</span></Empty>}</>),
   },
   today: {
     id: "today", group: "guard", dot: "var(--ok)", desc: "Runs and outcomes since midnight, tones included.", defaultSize: 2,
     render: ({ live }) => {
       const r = todayRows(live);
-      return (<><WHeader label="today" room="logs" />
+      return (<><WHeader label="今日" room="logs" />
         {r.length ? r.map((x) => <Row key={x.id} dot={x.dot} room="logs" tm={rel(x.ts)}>{x.text}</Row>)
-          : <Empty>Day one. The first morning brief is scheduled for <b>07:00 tomorrow</b>; it will report here.</Empty>}</>);
+          : <Empty>本日のアクティビティはまだありません。次回のモーニングブリーフは<b>明日07:00</b>です。</Empty>}</>);
     },
   },
   calendar: {
@@ -305,10 +310,10 @@ const WIDGETS: Record<string, WidgetDef> = {
     id: "vitals", group: "system", dot: "var(--faint)", desc: "Agents active, approvals waiting, events today.", defaultSize: 1,
     render: ({ live }) => {
       const active = agentRows(live).filter((a) => a.running).length;
-      return (<><WHeader label="vitals" /><div className="rs-vit">
-        <div className="v"><span className="k">agents</span><div className="n">{active}<span> active</span></div></div>
-        <div className="v"><span className="k">waiting</span><div className="n">{live.approvals.length}</div></div>
-        <div className="v"><span className="k">events</span><div className="n">{todayRows(live).length}<span> today</span></div></div>
+      return (<><WHeader label="システム状況" /><div className="rs-vit">
+        <div className="v"><span className="k">エージェント</span><div className="n">{active}<span> 稼働中</span></div></div>
+        <div className="v"><span className="k">承認待ち</span><div className="n">{live.approvals.length}</div></div>
+        <div className="v"><span className="k">イベント</span><div className="n">{todayRows(live).length}<span> 本日</span></div></div>
       </div></>);
     },
   },

--- a/ui/src/v2/shell/TopBar.tsx
+++ b/ui/src/v2/shell/TopBar.tsx
@@ -29,9 +29,9 @@ const CORE_HUE: Record<JarvisCoreState, string> = {
 };
 
 const DAEMON: Record<ConnectionState, { cls: string; hue: string; label: string }> = {
-  live: { cls: "", hue: "var(--ok)", label: "daemon · online" },
-  degraded: { cls: "hold", hue: "var(--hold)", label: "daemon · degraded · reconnecting" },
-  offline: { cls: "bad", hue: "var(--listen)", label: "offline" },
+  live: { cls: "", hue: "var(--ok)", label: "システム · オンライン" },
+  degraded: { cls: "hold", hue: "var(--hold)", label: "システム · 再接続中" },
+  offline: { cls: "bad", hue: "var(--listen)", label: "オフライン" },
 };
 
 export function TopBar({
@@ -56,7 +56,7 @@ export function TopBar({
   const route = useV2Route();
   const [theme, toggleTheme] = useTheme();
   const isNow = route.kind !== "room";
-  const title = route.kind === "room" ? ROOM_TITLES[route.key] ?? route.key : "Now";
+  const title = route.kind === "room" ? ROOM_TITLES[route.key] ?? route.key : "現在";
   const daemon = DAEMON[connection];
   const count = notificationCount ?? 0;
 
@@ -65,7 +65,7 @@ export function TopBar({
       <span className="rm">{title}</span>
       {isNow && (
         <button className={`rs-abtn${arranging ? " on" : ""}`} onClick={onArrange} aria-pressed={arranging}>
-          {arranging ? "Done" : "Arrange"}
+          {arranging ? "完了" : "配置変更"}
         </button>
       )}
 
@@ -86,13 +86,13 @@ export function TopBar({
         <button
           className="rs-chip"
           onClick={() => toggleTheme()}
-          aria-label={`Switch to ${theme === "dark" ? "light" : "dark"} mode`}
-          title={`Switch to ${theme === "dark" ? "light" : "dark"} mode`}
+          aria-label={`${theme === "dark" ? "ライト" : "ダーク"}モードへ切り替え`}
+          title={`${theme === "dark" ? "ライト" : "ダーク"}モードへ切り替え`}
         >
           {theme === "dark" ? "● dark" : "○ light"}
         </button>
 
-        <button className="rs-chip" onClick={onOpenPalette} aria-label="Quick open">⌘K</button>
+        <button className="rs-chip" onClick={onOpenPalette} aria-label="クイックオープン">⌘K</button>
 
         {onToggleNotifications && (
           <button

--- a/ui/src/v2/shell/TopBar.tsx
+++ b/ui/src/v2/shell/TopBar.tsx
@@ -2,8 +2,9 @@ import React from "react";
 import { useV2Route } from "../router";
 import { ROOM_NAV_ENTRIES } from "../palette/types";
 import type { ConnectionState } from "./Header";
-import type { VoiceState } from "./VoiceRail";
 import { useTheme } from "./useTheme";
+import { JapaneseDateTime } from "../core/JapaneseDateTime";
+import type { JarvisCoreState } from "../core/coreState";
 
 /**
  * Top bar — 44px, never two rows. Left: room name + contextual actions
@@ -15,22 +16,16 @@ const ROOM_TITLES: Record<string, string> = Object.fromEntries(
   ROOM_NAV_ENTRIES.map((e) => [e.key, e.label]),
 );
 
-const STATE_LABEL: Record<VoiceState, string> = {
-  idle: "idle",
-  listening: "listening",
-  thinking: "thinking",
-  speaking: "speaking",
-  "awaiting-approval": "asking",
-  muted: "muted",
-};
-
-const STATE_HUE: Record<VoiceState, string> = {
-  idle: "var(--faint)",
-  listening: "var(--listen)",
-  thinking: "var(--ink2)",
-  speaking: "var(--speak)",
-  "awaiting-approval": "var(--hold)",
-  muted: "var(--faint)",
+const CORE_HUE: Record<JarvisCoreState, string> = {
+  SLEEPING: "var(--faint)",
+  AWAKENING: "var(--ink2)",
+  IDLE: "var(--faint)",
+  LISTENING: "var(--listen)",
+  THINKING: "var(--ink2)",
+  WORKING: "var(--speak)",
+  WAITING_APPROVAL: "var(--hold)",
+  SPEAKING: "var(--speak)",
+  ERROR: "var(--listen)",
 };
 
 const DAEMON: Record<ConnectionState, { cls: string; hue: string; label: string }> = {
@@ -41,7 +36,7 @@ const DAEMON: Record<ConnectionState, { cls: string; hue: string; label: string 
 
 export function TopBar({
   connection,
-  voiceState,
+  coreState,
   arranging,
   onArrange,
   onOpenPalette,
@@ -50,7 +45,7 @@ export function TopBar({
   onToggleNotifications,
 }: {
   connection: ConnectionState;
-  voiceState: VoiceState;
+  coreState: JarvisCoreState;
   arranging: boolean;
   onArrange: () => void;
   onOpenPalette: () => void;
@@ -75,6 +70,7 @@ export function TopBar({
       )}
 
       <div className="right">
+        <JapaneseDateTime />
         <span className={`rs-chip ${daemon.cls}`}>
           <span className="rs-dot" style={{ background: daemon.hue }} />
           {daemon.label}
@@ -82,8 +78,8 @@ export function TopBar({
 
         {connection !== "offline" && (
           <span className="rs-chip hold" aria-live="polite">
-            <span className="rs-dot" style={{ background: STATE_HUE[voiceState] }} />
-            <span className="rs-stl">{STATE_LABEL[voiceState]}</span>
+            <span className="rs-dot" style={{ background: CORE_HUE[coreState] }} />
+            <span className="rs-stl">CORE · {coreState}</span>
           </span>
         )}
 

--- a/ui/src/v2/shell/roomShell.css
+++ b/ui/src/v2/shell/roomShell.css
@@ -171,6 +171,54 @@ button.rs-chip:hover { color: var(--ink); border-color: var(--ink3); }
 .rs-surface.rs-room { display: block; padding: 0; background: var(--bg); position: relative; }
 .rs-surface.rs-room > * { min-height: 100%; }
 
+.jarvis-core-hero {
+  --core-hue: var(--speak);
+  grid-column: span 2;
+  min-height: 190px;
+  display: grid;
+  grid-template-columns: 170px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 26px;
+  padding: 24px 28px;
+  position: relative;
+  overflow: hidden;
+  border: 1px solid var(--rule);
+  border-radius: var(--corner);
+  background:
+    radial-gradient(circle at 16% 50%, color-mix(in srgb, var(--core-hue) 12%, transparent), transparent 30%),
+    linear-gradient(135deg, var(--raise), var(--panel2));
+  box-shadow: var(--sh-md);
+}
+.jarvis-core-hero[data-core-state="SLEEPING"],
+.jarvis-core-hero[data-core-state="IDLE"] { --core-hue: var(--faint); }
+.jarvis-core-hero[data-core-state="LISTENING"],
+.jarvis-core-hero[data-core-state="ERROR"] { --core-hue: var(--listen); }
+.jarvis-core-hero[data-core-state="WAITING_APPROVAL"] { --core-hue: var(--hold); }
+.jarvis-core-hero[data-core-state="WORKING"],
+.jarvis-core-hero[data-core-state="SPEAKING"] { --core-hue: var(--speak); }
+
+.jarvis-core-visual { width: 150px; height: 150px; position: relative; display: grid; place-items: center; }
+.jarvis-core-orbit { position: absolute; inset: 14px; border: 1px solid color-mix(in srgb, var(--core-hue) 46%, transparent); border-radius: 50%; animation: core-spin 12s linear infinite; }
+.jarvis-core-orbit::after { content: ""; position: absolute; width: 6px; height: 6px; border-radius: 50%; background: var(--core-hue); top: 9px; left: 23px; box-shadow: 0 0 14px var(--core-hue); }
+.jarvis-core-orbit.orbit-b { inset: 27px; animation-duration: 8s; animation-direction: reverse; transform: rotate(58deg); }
+.jarvis-core-orbit.orbit-c { inset: 4px; border-style: dashed; opacity: .45; animation-duration: 22s; }
+.jarvis-core-sphere { width: 68px; height: 68px; border-radius: 50% 10% 50% 50%; transform: rotate(45deg); display: grid; place-items: center; background: color-mix(in srgb, var(--core-hue) 18%, var(--raise)); border: 1px solid color-mix(in srgb, var(--core-hue) 66%, transparent); box-shadow: 0 0 28px color-mix(in srgb, var(--core-hue) 28%, transparent), inset 0 0 22px color-mix(in srgb, var(--core-hue) 20%, transparent); animation: core-breathe 2.8s var(--ease) infinite; }
+.jarvis-core-sphere i { width: 24px; height: 24px; border-radius: 50%; background: var(--core-hue); box-shadow: 0 0 22px var(--core-hue); }
+.jarvis-core-copy .eyebrow, .jarvis-core-code { font: 500 9px/1 var(--mono); letter-spacing: .18em; color: var(--ink3); }
+.jarvis-core-copy strong { display: block; margin-top: 10px; font-size: clamp(26px, 3vw, 42px); line-height: 1; letter-spacing: -.04em; color: var(--ink); }
+.jarvis-core-copy p { margin: 9px 0 16px; color: var(--ink2); font-size: 13px; }
+.jarvis-core-activity { display: flex; align-items: center; gap: 8px; color: var(--ink3); font: 500 10px/1.4 var(--mono); }
+.jarvis-core-activity span { width: 6px; height: 6px; border-radius: 50%; background: var(--core-hue); box-shadow: 0 0 8px var(--core-hue); }
+.jarvis-core-code { align-self: start; padding-top: 2px; color: var(--core-hue); }
+@keyframes core-spin { to { transform: rotate(360deg); } }
+@keyframes core-breathe { 0%, 100% { scale: .96; opacity: .76; } 50% { scale: 1.04; opacity: 1; } }
+@media (prefers-reduced-motion: reduce) { .jarvis-core-orbit, .jarvis-core-sphere { animation: none; } }
+@media (max-width: 860px) {
+  .jarvis-core-hero { grid-column: span 1; grid-template-columns: 110px minmax(0, 1fr); min-height: 160px; padding: 20px; gap: 18px; }
+  .jarvis-core-visual { width: 104px; height: 104px; }
+  .jarvis-core-code { display: none; }
+}
+
 .rs-wid { border: 1px solid var(--rule); border-radius: var(--corner); background: var(--raise); box-shadow: var(--sh-sm); position: relative; overflow: hidden; }
 .rs-wid.w2 { grid-column: span 2; }
 .rs-ch {


### PR DESCRIPTION
## Summary

- add a Japanese-first cinematic command deck with Dark/Light support
- add an authoritative local date, weekday, and time display
- model the JARVIS CORE states: SLEEPING, AWAKENING, IDLE, LISTENING, THINKING, WORKING, WAITING_APPROVAL, SPEAKING, and ERROR
- add initial activity visualization and responsive/reduced-motion styling
- gate continuous wake listening behind an explicit preference that defaults to off
- keep manual Ctrl+Space capture and microphone mute safeguards intact
- make Sidecar release dry runs validate existing package versions without publishing

## Safety

- preserves the local EventReactor automatic-LLM disable patch
- preserves authoritative local date/time injection
- does not change or deploy the existing NAS Brain, OpenRouter configuration, or installed Sidecar
- important external operations remain approval-gated

## Validation

- targeted Sidecar continuous-wake, mute, realtime, and dashboard-preference tests pass
- 18 targeted UI/core/platform/realtime tests pass
- UI production build passes
- macOS arm64 build passes
- GitHub Actions Sidecar Release dry run passes for macOS arm64/x64, Linux arm64/x64, and Windows x64
- npm publication is not performed during the dry run

CI dry run: https://github.com/ume0117/jarvis/actions/runs/33348116564
