### PR TITLE
feat(sidecar): draw our own title bar on the local Windows webview windows

### DIFF
--- a/sidecar/.gitignore
+++ b/sidecar/.gitignore
@@ -5,9 +5,10 @@ dist/
 /jarvis-test
 /jarvis-test.exe
 /sidecar
-# `go build .` with no -o names its output after the directory.
+# `go build .` with no -o names its output after the directory. Deliberately no
+# bare `/installer` entry: that is a TRACKED source directory, and ignoring it
+# would hide every new file added to the installer package from git status.
 /sidecar.exe
-/installer
 /installer.exe
 
 # npm platform package binaries (built by make npm-pack)

--- a/sidecar/.gitignore
+++ b/sidecar/.gitignore
@@ -5,6 +5,10 @@ dist/
 /jarvis-test
 /jarvis-test.exe
 /sidecar
+# `go build .` with no -o names its output after the directory.
+/sidecar.exe
+/installer
+/installer.exe
 
 # npm platform package binaries (built by make npm-pack)
 npm/darwin-arm64/bin/

--- a/sidecar/README.md
+++ b/sidecar/README.md
@@ -134,7 +134,7 @@ this is a map of **subsystems by filename prefix**, not a file list.
 
 | Directory | Contents |
 |---|---|
-| `internal/` | packages shared with the installer: `brand` (CSS), `webviewui` (window host), `autostart` (login items), `webview2` (runtime bootstrap) |
+| `internal/` | packages shared with the installer: `brand` (CSS + the custom title bar), `webviewui` (window host), `winchrome` (Windows custom window chrome), `autostart` (login items), `webview2` (runtime bootstrap) |
 | `installer/` | the standalone desktop installer — see its own package docs |
 | `npm/` | per-platform npm packages plus the `@usejarvis/sidecar` wrapper |
 | `packaging/` | macOS `.app` bundle assets; Windows manifest/icon resources |
@@ -159,6 +159,61 @@ compiles. Each set exports identical signatures, so callers are OS-agnostic:
 
 Anything compiled only for one OS is invisible to the others' builds — which is
 why CI compiles all three targets rather than trusting a Linux build.
+
+### Custom window chrome (Windows)
+
+The local webview windows -- settings, logs, the first-run connect window and
+its token form, the onboarding slideshow -- draw their own title bar on
+Windows instead of wearing the system one. `internal/winchrome` removes
+`WS_CAPTION` from the HWND and nothing else: the window keeps its overlapped
+frame, so resize borders, Aero Snap, the maximized rect, minimize/restore and
+the taskbar entry all stay native, and no window procedure is subclassed. The
+strip itself is shared markup in `internal/brand/titlebar.go`, rendered only
+when `winchrome.Install` has stamped `<html data-chrome="custom">` -- so the
+same page keeps its native title bar on macOS and Linux.
+
+The page moves the window through a binding rather than CSS: the WebView2
+child HWND covers the client area and swallows the mouse, so `app-region:
+drag` does nothing and the drag is a `ReleaseCapture` +
+`WM_NCLBUTTONDOWN`/`HTCAPTION` handshake instead. Two consequences worth
+knowing: the Win11 Snap Layouts flyout does not appear on the page's maximize
+button (it needs `HTMAXBUTTON` from a window procedure we do not own), and
+custom chrome must never be given to a window showing REMOTE content -- those
+bindings move, minimize, maximize and close the window. That is why the
+account window (`account_window.go`, end-to-end remote) and the dashboard
+panels stay natively framed.
+
+To eyeball the pages without a Windows machine:
+
+```sh
+JARVIS_PAGE_DUMP_DIR=/tmp/pages go test -run TestDumpBrandPages .
+# then open /tmp/pages/chrome-*.html (and dark-chrome-*.html)
+```
+
+The dumps cannot exercise the interaction layer -- the bindings do not exist
+in a browser -- and none of it is reachable from a Go test, so this much needs
+a real Windows box at least once per change to `winchrome` or the strip's
+script:
+
+- [ ] Drag the strip: the window follows, and does not stay glued to the
+      cursor after the drop.
+- [ ] Drag to a screen edge (snap), and drag a maximized window (it restores
+      into the drag).
+- [ ] Double-click the strip maximizes, again restores. Then drag, drop, and
+      immediately press again -- that must NOT maximize.
+- [ ] Maximize: the taskbar stays visible and nothing is clipped, on a
+      secondary monitor with a different resolution and DPI too.
+- [ ] The maximize glyph tracks the state after Win+Up/Down and a taskbar
+      snap, not just after the button.
+- [ ] Minimize and close; Alt+Space and Alt+F4; right-click the strip for the
+      system menu.
+- [ ] Resize from all four edges and corners.
+- [ ] Scroll settings and onboarding: the scrollbar starts below the strip and
+      its top arrow is clickable, and Space / PageDown / Home / End scroll the
+      window with nothing focused (the page scrolls an inner container, so this
+      is script, not the browser).
+- [ ] Drag a URL or a file onto the window: nothing navigates. Drag selected
+      text into the token form's textarea: it drops.
 
 ### Preflight checks
 

--- a/sidecar/README.md
+++ b/sidecar/README.md
@@ -194,7 +194,14 @@ JARVIS_PAGE_DUMP_DIR=/tmp/pages go test -run TestDumpBrandPages .
 DOM: it stubs the five bindings, drives real PointerEvents through headless
 Chromium, and asserts what the page would have asked the window to do (a click
 never drags, one drag per gesture, drag-then-regrab is not a double-click, a
-lost mouseup starts nothing). It skips when no Chromium is on PATH.
+lost mouseup starts nothing). It is opt-in, because a headless browser is not a
+dependency this suite relies on:
+
+```sh
+JARVIS_BROWSER_TESTS=1 go test -run TestTitlebarGesture .
+```
+
+Run it after any change to `TitlebarJS`.
 
 What that cannot reach is Win32 itself — the modal move loop, snap, maximize
 geometry — so this much still needs a real Windows box at least once per change

--- a/sidecar/README.md
+++ b/sidecar/README.md
@@ -162,14 +162,14 @@ why CI compiles all three targets rather than trusting a Linux build.
 
 ### Custom window chrome (Windows)
 
-The local webview windows -- settings, logs, the first-run connect window and
-its token form, the onboarding slideshow -- draw their own title bar on
+The local webview windows — settings, logs, the first-run connect window and
+its token form, the onboarding slideshow — draw their own title bar on
 Windows instead of wearing the system one. `internal/winchrome` removes
 `WS_CAPTION` from the HWND and nothing else: the window keeps its overlapped
 frame, so resize borders, Aero Snap, the maximized rect, minimize/restore and
 the taskbar entry all stay native, and no window procedure is subclassed. The
 strip itself is shared markup in `internal/brand/titlebar.go`, rendered only
-when `winchrome.Install` has stamped `<html data-chrome="custom">` -- so the
+when `winchrome.Install` has stamped `<html data-chrome="custom">` — so the
 same page keeps its native title bar on macOS and Linux.
 
 The page moves the window through a binding rather than CSS: the WebView2
@@ -178,7 +178,7 @@ drag` does nothing and the drag is a `ReleaseCapture` +
 `WM_NCLBUTTONDOWN`/`HTCAPTION` handshake instead. Two consequences worth
 knowing: the Win11 Snap Layouts flyout does not appear on the page's maximize
 button (it needs `HTMAXBUTTON` from a window procedure we do not own), and
-custom chrome must never be given to a window showing REMOTE content -- those
+custom chrome must never be given to a window showing REMOTE content — those
 bindings move, minimize, maximize and close the window. That is why the
 account window (`account_window.go`, end-to-end remote) and the dashboard
 panels stay natively framed.
@@ -190,17 +190,22 @@ JARVIS_PAGE_DUMP_DIR=/tmp/pages go test -run TestDumpBrandPages .
 # then open /tmp/pages/chrome-*.html (and dark-chrome-*.html)
 ```
 
-The dumps cannot exercise the interaction layer -- the bindings do not exist
-in a browser -- and none of it is reachable from a Go test, so this much needs
-a real Windows box at least once per change to `winchrome` or the strip's
-script:
+`TestTitlebarGesture` covers the half of the interaction layer that is just
+DOM: it stubs the five bindings, drives real PointerEvents through headless
+Chromium, and asserts what the page would have asked the window to do (a click
+never drags, one drag per gesture, drag-then-regrab is not a double-click, a
+lost mouseup starts nothing). It skips when no Chromium is on PATH.
+
+What that cannot reach is Win32 itself — the modal move loop, snap, maximize
+geometry — so this much still needs a real Windows box at least once per change
+to `winchrome` or the strip's script:
 
 - [ ] Drag the strip: the window follows, and does not stay glued to the
       cursor after the drop.
 - [ ] Drag to a screen edge (snap), and drag a maximized window (it restores
       into the drag).
 - [ ] Double-click the strip maximizes, again restores. Then drag, drop, and
-      immediately press again -- that must NOT maximize.
+      immediately press again — that must NOT maximize.
 - [ ] Maximize: the taskbar stays visible and nothing is clipped, on a
       secondary monitor with a different resolution and DPI too.
 - [ ] The maximize glyph tracks the state after Win+Up/Down and a taskbar

--- a/sidecar/account_window.go
+++ b/sidecar/account_window.go
@@ -18,6 +18,8 @@ package main
 
 import (
 	webview "github.com/webview/webview_go"
+
+	"github.com/jarvis/sidecar/internal/winchrome"
 )
 
 // accountShellHTML is the local first document, shown while the hosted page
@@ -70,7 +72,7 @@ func (c *SidecarClient) runAccountWindow() {
 	base := resolveHostedBaseURL(c.config.HostedBaseURL)
 	c.mu.Unlock()
 
-	runLocalWebview("JARVIS — Account", 920, 720, webview.HintNone, func(w webview.WebView) func() {
+	runLocalWebview("JARVIS — Account", 920, 720, webview.HintNone, winchrome.NativeTitleBar, func(w webview.WebView) func() {
 		w.SetHtml(accountShellHTML)
 		// Dispatch rather than a direct call: the dispatch queue runs after
 		// SetHtml's string navigation has been issued, so the shell is the

--- a/sidecar/brand_css.go
+++ b/sidecar/brand_css.go
@@ -9,4 +9,16 @@ import "github.com/jarvis/sidecar/internal/brand"
 const (
 	brandTokensCSS = brand.TokensCSS
 	brandPebbleCSS = brand.PebbleCSS
+
+	// Custom window chrome (Windows): the title bar a page draws for itself
+	// once winchrome.Install has removed the native one. Inert everywhere
+	// else — see internal/brand/titlebar.go for the markup contract.
+	brandTitlebarCSS  = brand.TitlebarCSS
+	brandTitlebarHTML = brand.TitlebarHTML
+	brandTitlebarJS   = brand.TitlebarJS
+
+	// Keyboard scrolling for the pages whose scroll container is the inner
+	// .pagebody wrapper the custom title bar requires. Not Windows-specific:
+	// the wrapper is there on every platform.
+	brandPageBodyJS = brand.PageBodyJS
 )

--- a/sidecar/brand_pages_dump_test.go
+++ b/sidecar/brand_pages_dump_test.go
@@ -10,6 +10,23 @@ import (
 	"testing"
 )
 
+// withCustomChrome fakes what winchrome.Install does to a document on Windows.
+// It fails the test rather than returning the document unchanged: a silent
+// no-op here would hand visual QA an UNchromed page that looks fine, which is
+// the one outcome worse than no dump at all.
+func withCustomChrome(t *testing.T, name, html string) string {
+	t.Helper()
+	out := strings.Replace(html, "<html>", `<html data-chrome="custom">`, 1)
+	if out == html {
+		t.Fatalf("%s: no bare <html> tag to mark as custom-chromed", name)
+	}
+	marked := strings.Replace(out, "<body>", "<body><script>window.__jarvisCustomChrome=true;</script>", 1)
+	if marked == out {
+		t.Fatalf("%s: no bare <body> tag to inject the chrome flag into", name)
+	}
+	return marked
+}
+
 func TestDumpBrandPages(t *testing.T) {
 	dir := os.Getenv("JARVIS_PAGE_DUMP_DIR")
 	if dir == "" {
@@ -29,6 +46,16 @@ func TestDumpBrandPages(t *testing.T) {
 		"account.html":              accountShellHTML,
 		"settings.html":             settingsWindowHTML,
 		"logs.html":                 logViewerHTML,
+		"onboarding.html":           onboardingWindowHTML,
+	}
+	// Pages that draw their own title bar on Windows also dump a chromed
+	// variant: the strip is invisible without the marker winchrome.Install
+	// stamps, so without this the new chrome could never be eyeballed off
+	// Windows. The bindings are absent here — TitlebarJS guards every call.
+	// Driven off customChromePages (titlebar_pages_test.go) so the QA dump and
+	// the set of chromed windows cannot drift apart.
+	for name, html := range customChromePages {
+		pages["chrome-"+name+".html"] = withCustomChrome(t, name, html)
 	}
 	for name, html := range pages {
 		if err := os.WriteFile(filepath.Join(dir, name), []byte(html), 0644); err != nil {

--- a/sidecar/hosted_window.go
+++ b/sidecar/hosted_window.go
@@ -30,6 +30,8 @@ import (
 	"sync/atomic"
 
 	webview "github.com/webview/webview_go"
+
+	"github.com/jarvis/sidecar/internal/winchrome"
 )
 
 // hostedShellHTML is the local page shown while the handshake registers (and
@@ -44,10 +46,23 @@ const hostedShellHTML = `<!doctype html>
 <html>
 <head>
 <meta charset="utf-8">
+<title>JARVIS - Connect</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <style>` + brandTokensCSS + brandPebbleCSS + `
-  body { min-height: 100vh; display: flex; flex-direction: column; padding: 26px 30px; }
+  html, body { height: 100%; }
+  /* No padding on body: the strip's offset would replace it, not add to it.
+     .pagebody carries the padding and the centred column, and is the scroll
+     container so its scrollbar starts below the strip — PageBodyJS is what
+     keeps it scrollable by keyboard. */
+  body { padding: 0; overflow: hidden; }
+  .pagebody {
+    height: 100%; overflow-y: auto;
+    display: flex; flex-direction: column; padding: 26px 30px;
+  }
   .bhead .word { font-size: 16px; }
+  /* Under custom chrome the strip already carries the mark and the window
+     name; a wordmark directly beneath it reads as a doubled header. */
+  html[data-chrome="custom"] .bhead { display: none; }
   .center { flex: 1; display: flex; align-items: center; justify-content: center; }
   .statusbox { width: 100%; max-width: 380px; text-align: center; position: relative; }
   .dropwrap { display: flex; justify-content: center; margin-bottom: 20px; position: relative; }
@@ -79,9 +94,11 @@ const hostedShellHTML = `<!doctype html>
   .btn:focus-visible { outline: 2px solid var(--ink2); outline-offset: 2px; }
   .footer { margin: 0; font-size: 11.5px; color: var(--faint); text-align: center; }
   .footer a { color: var(--listen-tx); cursor: pointer; text-decoration: underline; }
+` + brandTitlebarCSS + `
 </style>
 </head>
-<body>
+<body>` + brandTitlebarHTML + `
+<div class="pagebody" tabindex="-1">
   <div class="bhead"><span class="word"><span class="u">use</span>jarvis</span></div>
   <div class="center">
     <div class="statusbox">
@@ -99,6 +116,7 @@ const hostedShellHTML = `<!doctype html>
     </div>
   </div>
   <p class="footer">Self-hosting your own brain? <a onclick="window.chooseSelfHost()">Paste your enrollment token</a></p>
+</div>
 <script>
   window.__setStatus = function (text) { document.getElementById('status').textContent = text; };
   window.__setError = function (text) {
@@ -132,6 +150,7 @@ const hostedShellHTML = `<!doctype html>
     u.style.display = 'block';
   };
   /*__BOOT__*/
+` + brandTitlebarJS + brandPageBodyJS + `
 </script>
 </body>
 </html>`
@@ -540,6 +559,11 @@ func runFirstRunWindow(cfg *SidecarConfig) (string, error) {
 	}
 	defer dl.Close() // idempotent backstop for early returns (nil-safe)
 
+	// Custom chrome before the reveal hook: the window is still hidden, so the
+	// native title bar is never composited. Safe here because every document
+	// this window shows is LOCAL (the hosted connect page opens in the user's
+	// browser, not in here) — see winchrome.Install on why that matters.
+	winchrome.Install(w)
 	stopReveal := revealWebviewOnLoad(w)
 	// LIFO with the deferred Destroy at the top: joining the reveal-timeout
 	// goroutine before the engine is freed prevents its pending Dispatch from

--- a/sidecar/hosted_window.go
+++ b/sidecar/hosted_window.go
@@ -97,7 +97,7 @@ const hostedShellHTML = `<!doctype html>
 ` + brandTitlebarCSS + `
 </style>
 </head>
-<body>` + brandTitlebarHTML + `
+<body>
 <div class="pagebody" tabindex="-1">
   <div class="bhead"><span class="word"><span class="u">use</span>jarvis</span></div>
   <div class="center">
@@ -116,7 +116,7 @@ const hostedShellHTML = `<!doctype html>
     </div>
   </div>
   <p class="footer">Self-hosting your own brain? <a onclick="window.chooseSelfHost()">Paste your enrollment token</a></p>
-</div>
+</div>` + brandTitlebarHTML + `
 <script>
   window.__setStatus = function (text) { document.getElementById('status').textContent = text; };
   window.__setError = function (text) {

--- a/sidecar/installer/wizard.go
+++ b/sidecar/installer/wizard.go
@@ -14,6 +14,7 @@ import (
 	"github.com/jarvis/sidecar/internal/brand"
 	"github.com/jarvis/sidecar/internal/webview2"
 	"github.com/jarvis/sidecar/internal/webviewui"
+	"github.com/jarvis/sidecar/internal/winchrome"
 )
 
 func guiSupported() bool {
@@ -72,7 +73,7 @@ func runWizard(registryURL string, noLaunch, autostartDefault bool) int {
 		return st
 	}
 
-	opened := webviewui.RunWindow("Install Jarvis", 480, 560, webview.HintNone, func(w webview.WebView) {
+	opened := webviewui.RunWindow("Install Jarvis", 480, 560, webview.HintNone, winchrome.NativeTitleBar, func(w webview.WebView) {
 
 		// startPlan resolves versions on a goroutine. Bindings run ON the UI
 		// thread, so doing the (up to 60s) registry fetch inline would block

--- a/sidecar/installer/wizard.go
+++ b/sidecar/installer/wizard.go
@@ -73,6 +73,9 @@ func runWizard(registryURL string, noLaunch, autostartDefault bool) int {
 		return st
 	}
 
+	// NativeTitleBar on purpose: this is the first window a user ever sees from
+	// this project, run before anything is installed, so it wears the system's
+	// chrome rather than asking for trust with a title bar of our own.
 	opened := webviewui.RunWindow("Install Jarvis", 480, 560, webview.HintNone, winchrome.NativeTitleBar, func(w webview.WebView) {
 
 		// startPlan resolves versions on a goroutine. Bindings run ON the UI

--- a/sidecar/internal/brand/titlebar.go
+++ b/sidecar/internal/brand/titlebar.go
@@ -6,15 +6,21 @@ package brand
 // Markup contract, for every page that opts in:
 //
 //	<style> TokensCSS … page rules … TitlebarCSS </style>
-//	<body> TitlebarHTML … page … <script> TitlebarJS </script> </body>
+//	<body> … page … TitlebarHTML <script> TitlebarJS </script> </body>
+//
+// TitlebarHTML goes LAST in the body, after the page's content. It is fixed
+// positioned, so the position in the source costs it nothing visually — and it
+// puts the window controls at the end of the tab order, where chrome belongs.
+// A native caption's buttons are not tab stops at all; first Tab landing on
+// Minimize instead of the page is the next closest thing to wrong.
 //
 // Nothing here renders unless <html data-chrome="custom"> is set, and only
 // winchrome.Install sets it — so the same page keeps its native title bar on
 // macOS and Linux with no per-platform branching in the page itself.
 //
 // The strip is `position: fixed`, spanning the full window width the way a
-// real title bar does. Sticky was the tempting alternative -- it keeps the
-// viewport as the scroller, so keyboard scrolling comes free -- but next to a
+// real title bar does. Sticky was the tempting alternative — it keeps the
+// viewport as the scroller, so keyboard scrolling comes free — but next to a
 // classic scrollbar it stops ~15px short of the right edge, which reads as a
 // page element rather than as chrome.
 //
@@ -24,7 +30,7 @@ package brand
 //     leaving the first element flush against the bar). Page padding goes on
 //     an inner `.pagebody` wrapper.
 //   - `.pagebody` is the scroll container, so its scrollbar starts below the
-//     strip rather than running behind it -- and because a div is not
+//     strip rather than running behind it — and because a div is not
 //     focusable, the page must also carry PageBodyJS, which is what keeps
 //     Space/PageDown scrolling for someone without a mouse.
 
@@ -40,7 +46,7 @@ const TitlebarCSS = `
   }
   html[data-chrome="custom"] body {
     /* Specificity, not order, is what makes this win over a page's own
-       "body { padding: … }" -- which is why a chromed page must not have one.
+       "body { padding: … }" — which is why a chromed page must not have one.
        box-sizing:border-box (TokensCSS) means a 100%/100vh body keeps its
        height and gives the strip its share of it. */
     padding-top: var(--wchrome-h);
@@ -52,7 +58,7 @@ const TitlebarCSS = `
     user-select: none; -webkit-user-select: none; cursor: default;
   }
   /* The inner scroll container. Focusable, so a click inside it carries the
-     keyboard with it, but never ringed -- it is a viewport, not a control. */
+     keyboard with it, but never ringed — it is a viewport, not a control. */
   .pagebody:focus { outline: none; }
   /* The drag region is everything the controls don't claim. */
   .wchrome-drag {
@@ -253,7 +259,7 @@ const TitlebarJS = `
 // inner .pagebody wrapper rather than its body.
 //
 // A div does not take focus, and an unfocused container ignores Space,
-// PageUp/PageDown, the arrows, Home and End -- so without this, a window that
+// PageUp/PageDown, the arrows, Home and End — so without this, a window that
 // overflows (the 520x560 settings window does) is unreachable to anyone not
 // holding a mouse. Two halves: a click inside the container hands it focus, and
 // a document-level fallback forwards the paging keys whatever has focus, since
@@ -262,7 +268,7 @@ const TitlebarJS = `
 // It stays out of the way of the page: keys are ignored while a form control or
 // a button has focus (Space there belongs to the control), and it never steals
 // focus from a field the page autofocused. Not chrome-specific and not
-// Windows-specific -- the wrapper exists on every platform, so this ships with
+// Windows-specific — the wrapper exists on every platform, so this ships with
 // it.
 const PageBodyJS = `
 (function () {
@@ -271,7 +277,7 @@ const PageBodyJS = `
     if (!p) return;
     if (!p.hasAttribute('tabindex')) p.setAttribute('tabindex', '-1');
 
-    // A click into the content should carry the keyboard with it -- but not
+    // A click into the content should carry the keyboard with it — but not
     // away from whatever the user actually clicked.
     p.addEventListener('mousedown', function (e) {
       // p itself matches the selector (it carries the tabindex above), so the

--- a/sidecar/internal/brand/titlebar.go
+++ b/sidecar/internal/brand/titlebar.go
@@ -1,0 +1,308 @@
+package brand
+
+// Custom window chrome — the title bar the page draws for itself when the
+// native one has been removed (Windows only; see internal/winchrome).
+//
+// Markup contract, for every page that opts in:
+//
+//	<style> TokensCSS … page rules … TitlebarCSS </style>
+//	<body> TitlebarHTML … page … <script> TitlebarJS </script> </body>
+//
+// Nothing here renders unless <html data-chrome="custom"> is set, and only
+// winchrome.Install sets it — so the same page keeps its native title bar on
+// macOS and Linux with no per-platform branching in the page itself.
+//
+// The strip is `position: fixed`, spanning the full window width the way a
+// real title bar does. Sticky was the tempting alternative -- it keeps the
+// viewport as the scroller, so keyboard scrolling comes free -- but next to a
+// classic scrollbar it stops ~15px short of the right edge, which reads as a
+// page element rather than as chrome.
+//
+// Fixed costs two things, and a page that opts in owes both:
+//
+//   - No padding on `body` (it would be replaced by the strip's offset below,
+//     leaving the first element flush against the bar). Page padding goes on
+//     an inner `.pagebody` wrapper.
+//   - `.pagebody` is the scroll container, so its scrollbar starts below the
+//     strip rather than running behind it -- and because a div is not
+//     focusable, the page must also carry PageBodyJS, which is what keeps
+//     Space/PageDown scrolling for someone without a mouse.
+
+// TitlebarCSS styles the strip and its window controls. The metrics follow
+// the Windows convention (46×34 controls, close turns red on hover) so the
+// buttons stay where a Windows user's muscle memory puts them; everything
+// else is Monochrome Lab.
+const TitlebarCSS = `
+  .wchrome { display: none; }
+  html[data-chrome="custom"] {
+    /* Consumed by the body offset below, and by pages that need the metric. */
+    --wchrome-h: 34px;
+  }
+  html[data-chrome="custom"] body {
+    /* Specificity, not order, is what makes this win over a page's own
+       "body { padding: … }" -- which is why a chromed page must not have one.
+       box-sizing:border-box (TokensCSS) means a 100%/100vh body keeps its
+       height and gives the strip its share of it. */
+    padding-top: var(--wchrome-h);
+  }
+  html[data-chrome="custom"] .wchrome {
+    position: fixed; top: 0; left: 0; right: 0; height: var(--wchrome-h);
+    display: flex; align-items: stretch; z-index: 2147483000;
+    background: var(--raise); border-bottom: 1px solid var(--rule);
+    user-select: none; -webkit-user-select: none; cursor: default;
+  }
+  /* The inner scroll container. Focusable, so a click inside it carries the
+     keyboard with it, but never ringed -- it is a viewport, not a control. */
+  .pagebody:focus { outline: none; }
+  /* The drag region is everything the controls don't claim. */
+  .wchrome-drag {
+    flex: 1 1 auto; display: flex; align-items: center; gap: 8px;
+    touch-action: none;
+    padding-left: 11px; min-width: 0; overflow: hidden;
+  }
+  /* The Pebble's silhouette at favicon scale — self-contained on purpose, so
+     a page that never includes PebbleCSS still gets the brand mark. */
+  .wchrome-mark {
+    flex: 0 0 auto; width: 9px; height: 9px;
+    border-radius: 50% 50% 50% 2px; transform: rotate(45deg);
+    background: radial-gradient(circle at 50% 40%, #ff6e60, #e63b2e 62%, #b81e16);
+  }
+  .wchrome-title {
+    font-family: var(--mono); font-size: 10.5px; letter-spacing: .07em;
+    text-transform: uppercase; color: var(--ink3);
+    white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  }
+  .wchrome-controls { flex: 0 0 auto; display: flex; align-items: stretch; }
+  .wchrome-btn {
+    /* Overlaps the strip's bottom border: a close hover that stops 1px short
+       of the edge is the tell that the bar is not the system's. */
+    width: 46px; height: var(--wchrome-h); margin-bottom: -1px;
+    padding: 0; border: 0; background: transparent;
+    color: var(--ink2); display: flex; align-items: center; justify-content: center;
+    cursor: default; transition: background .12s, color .12s;
+  }
+  .wchrome-btn:hover { background: var(--panel); color: var(--ink); }
+  .wchrome-btn:active { background: var(--rule2); }
+  .wchrome-btn:focus-visible { outline: 2px solid var(--speak); outline-offset: -3px; }
+  .wchrome-close:hover { background: #C42B1C; color: #fff; }
+  .wchrome-close:active { background: #B4271A; color: #fff; }
+  /* Crisp 1px glyphs — but only for the axis-aligned ones. Turning off
+     anti-aliasing on the close glyph's diagonals gives a pixel staircase, on
+     the one button with a filled hover where the glyph is most looked at. */
+  #wchrome-min svg, #wchrome-max svg { shape-rendering: crispEdges; }
+  .wchrome-glyph-restore { display: none; }
+  .wchrome.is-max .wchrome-glyph-max { display: none; }
+  .wchrome.is-max .wchrome-glyph-restore { display: block; }
+  /* Forced colors: the system owns every surface, so drop the brand paint and
+     lean on the system keywords, including for the close hover. */
+  @media (forced-colors: active) {
+    html[data-chrome="custom"] .wchrome { border-bottom-color: CanvasText; }
+    .wchrome-btn { color: ButtonText; }
+    .wchrome-btn:hover, .wchrome-close:hover { background: Highlight; color: HighlightText; }
+    .wchrome-mark { background: CanvasText; }
+  }
+`
+
+// TitlebarHTML is the strip's markup: a drag region carrying the mark and the
+// window title (filled from document.title by TitlebarJS), then the three
+// controls. The maximize button ships both glyphs and swaps them on .is-max
+// rather than rewriting its contents, so the state change can't lose the
+// button's accessible name.
+//
+// role="presentation" on the header is deliberate: the strip is window chrome,
+// not page content, and the only things in it a screen reader should reach are
+// the three named buttons.
+const TitlebarHTML = `<header class="wchrome" id="wchrome" role="presentation">
+  <div class="wchrome-drag" id="wchrome-drag">
+    <span class="wchrome-mark" aria-hidden="true"></span>
+    <span class="wchrome-title" id="wchrome-title"></span>
+  </div>
+  <div class="wchrome-controls">
+    <button type="button" class="wchrome-btn" id="wchrome-min" aria-label="Minimize" title="Minimize">
+      <svg width="10" height="10" viewBox="0 0 10 10" aria-hidden="true"><path d="M0 5h10" stroke="currentColor" stroke-width="1"/></svg>
+    </button>
+    <button type="button" class="wchrome-btn" id="wchrome-max" aria-label="Maximize" title="Maximize">
+      <svg class="wchrome-glyph-max" width="10" height="10" viewBox="0 0 10 10" aria-hidden="true"><rect x="0.5" y="0.5" width="9" height="9" fill="none" stroke="currentColor" stroke-width="1"/></svg>
+      <svg class="wchrome-glyph-restore" width="10" height="10" viewBox="0 0 10 10" aria-hidden="true"><path d="M2.5 2.5V0.5h7v7h-2" fill="none" stroke="currentColor" stroke-width="1"/><rect x="0.5" y="2.5" width="7" height="7" fill="none" stroke="currentColor" stroke-width="1"/></svg>
+    </button>
+    <button type="button" class="wchrome-btn wchrome-close" id="wchrome-close" aria-label="Close" title="Close">
+      <svg width="10" height="10" viewBox="0 0 10 10" aria-hidden="true"><path d="M0.5 0.5l9 9M9.5 0.5l-9 9" stroke="currentColor" stroke-width="1"/></svg>
+    </button>
+  </div>
+</header>`
+
+// TitlebarJS wires the strip to the window. Inert unless winchrome.Install ran
+// (it is what defines __jarvisCustomChrome and the bindings), so a page can
+// carry it on every platform.
+//
+// The gesture runs on POINTER events, not mouse events, so a Windows tablet
+// can drag the window the way a native caption does (`touch-action: none` on
+// the drag region keeps the browser from panning instead). Everything below
+// says "press" rather than "mousedown" for that reason.
+//
+// The gesture model is the part worth reading. A binding call is a message
+// round trip, not a synchronous call inside the press, so handing every
+// press straight to the native move loop risks the loop starting after the
+// button is already up — the window then follows the cursor until the next
+// click. So a press only ARMS the drag, and the first real movement (4px, with
+// the button still down) starts it. A press-and-release that never moved never
+// enters the loop at all, which also makes press-to-press timing an honest
+// signal for the double-click.
+//
+// Double-click is timed here rather than taken from the dblclick event,
+// because the native move loop owns the mouse for the whole first gesture and
+// no dblclick is guaranteed to arrive. It compares SCREEN coordinates: a drag
+// carries the viewport with it, so client coordinates would call a 300px
+// window move "the same spot" under a hand that never left it. The window
+// picks up the user's real double-click speed from __jarvisDblClickMs.
+const TitlebarJS = `
+(function () {
+  if (!window.__jarvisCustomChrome) return;
+  try {
+    var bar = document.getElementById('wchrome');
+    var drag = document.getElementById('wchrome-drag');
+    var titleEl = document.getElementById('wchrome-title');
+    if (!bar || !drag) return;
+
+    if (titleEl) {
+      var setTitle = function () { titleEl.textContent = document.title || ''; };
+      setTitle();
+      // Pages that set document.title later (or swap it for a state) keep the
+      // strip in sync without having to know the strip exists.
+      var titleNode = document.querySelector('title');
+      if (titleNode && window.MutationObserver) {
+        new MutationObserver(setTitle).observe(titleNode, { childList: true });
+      }
+    }
+
+    var syncMax = function (isMax) {
+      if (typeof isMax === 'boolean') { bar.classList.toggle('is-max', isMax); return; }
+      if (!window.__jarvis_chrome_is_maximized) return;
+      window.__jarvis_chrome_is_maximized().then(function (m) {
+        bar.classList.toggle('is-max', !!m);
+      }).catch(function () {});
+    };
+
+    var toggleMax = function () {
+      if (!window.__jarvis_chrome_toggle_maximize) return;
+      window.__jarvis_chrome_toggle_maximize().then(syncMax).catch(function () {});
+    };
+
+    var dblMs = window.__jarvisDblClickMs || 500;
+    var armed = false, downX = 0, downY = 0;
+    var lastDownAt = 0, lastDownX = 0, lastDownY = 0;
+
+    drag.addEventListener('pointerdown', function (e) {
+      if (e.button !== 0) return;
+      var now = Date.now();
+      if (now - lastDownAt < dblMs &&
+          Math.abs(e.screenX - lastDownX) < 6 && Math.abs(e.screenY - lastDownY) < 6) {
+        lastDownAt = 0; armed = false;
+        toggleMax();
+        return;
+      }
+      lastDownAt = now; lastDownX = e.screenX; lastDownY = e.screenY;
+      armed = true; downX = e.screenX; downY = e.screenY;
+    });
+
+    window.addEventListener('pointermove', function (e) {
+      if (!armed) return;
+      // A release delivered outside the window can be missed; the button state
+      // on the next move is the reliable way to notice the gesture is over.
+      if (!(e.buttons & 1)) { armed = false; return; }
+      if (Math.abs(e.screenX - downX) < 4 && Math.abs(e.screenY - downY) < 4) return;
+      armed = false;
+      if (!window.__jarvis_chrome_drag) return;
+      window.__jarvis_chrome_drag().then(function () {
+        // Resolves when the window is dropped. Forget the press that started
+        // it (it must not pair with the next one into a double-click) and
+        // re-read the state, since a drag off a maximized window restores it.
+        lastDownAt = 0;
+        syncMax();
+      }).catch(function () {});
+    });
+
+    window.addEventListener('pointerup', function () { armed = false; });
+    window.addEventListener('pointercancel', function () { armed = false; });
+
+    // Right-click on the caption is the system menu, the way it is on a native
+    // title bar. Alt+Space still works either way (WS_SYSMENU is kept).
+    bar.addEventListener('contextmenu', function (e) {
+      if (!window.__jarvis_chrome_sysmenu) return;
+      e.preventDefault();
+      window.__jarvis_chrome_sysmenu();
+    });
+
+    var on = function (id, fn) {
+      var el = document.getElementById(id);
+      if (el) el.addEventListener('click', fn);
+    };
+    on('wchrome-min', function () { if (window.__jarvis_chrome_minimize) window.__jarvis_chrome_minimize(); });
+    on('wchrome-max', toggleMax);
+    on('wchrome-close', function () { if (window.__jarvis_chrome_close) window.__jarvis_chrome_close(); });
+
+    // Snap, Win+Arrow, the taskbar and a drag off a maximized window all change
+    // the state behind our back; resize is the one event they share.
+    window.addEventListener('resize', function () { syncMax(); });
+    syncMax();
+  } catch (e) {}
+})();
+`
+
+// PageBodyJS keeps the keyboard working on a page whose scroll container is the
+// inner .pagebody wrapper rather than its body.
+//
+// A div does not take focus, and an unfocused container ignores Space,
+// PageUp/PageDown, the arrows, Home and End -- so without this, a window that
+// overflows (the 520x560 settings window does) is unreachable to anyone not
+// holding a mouse. Two halves: a click inside the container hands it focus, and
+// a document-level fallback forwards the paging keys whatever has focus, since
+// the very first keypress of a freshly opened window arrives before any click.
+//
+// It stays out of the way of the page: keys are ignored while a form control or
+// a button has focus (Space there belongs to the control), and it never steals
+// focus from a field the page autofocused. Not chrome-specific and not
+// Windows-specific -- the wrapper exists on every platform, so this ships with
+// it.
+const PageBodyJS = `
+(function () {
+  try {
+    var p = document.querySelector('.pagebody');
+    if (!p) return;
+    if (!p.hasAttribute('tabindex')) p.setAttribute('tabindex', '-1');
+
+    // A click into the content should carry the keyboard with it -- but not
+    // away from whatever the user actually clicked.
+    p.addEventListener('mousedown', function (e) {
+      // p itself matches the selector (it carries the tabindex above), so the
+      // container must be excluded or this returns on every click.
+      var hit = e.target.closest('input, textarea, select, button, a, [tabindex]');
+      if (hit && hit !== p) return;
+      p.focus({ preventScroll: true });
+    });
+
+    var typing = function (el) {
+      return !!el && (el.isContentEditable ||
+        /^(INPUT|TEXTAREA|SELECT|BUTTON|A)$/.test(el.tagName));
+    };
+    document.addEventListener('keydown', function (e) {
+      if (e.ctrlKey || e.altKey || e.metaKey) return;
+      if (e.defaultPrevented) return; // the page handled it first
+      if (typing(e.target)) return;
+      var page = Math.max(40, p.clientHeight - 40), d = null;
+      switch (e.key) {
+        case ' ': d = e.shiftKey ? -page : page; break;
+        case 'PageDown': d = page; break;
+        case 'PageUp': d = -page; break;
+        case 'ArrowDown': d = 48; break;
+        case 'ArrowUp': d = -48; break;
+        case 'Home': p.scrollTop = 0; e.preventDefault(); return;
+        case 'End': p.scrollTop = p.scrollHeight; e.preventDefault(); return;
+      }
+      if (d === null) return;
+      p.scrollBy(0, d);
+      e.preventDefault();
+    });
+  } catch (e) {}
+})();
+`

--- a/sidecar/internal/brand/titlebar_test.go
+++ b/sidecar/internal/brand/titlebar_test.go
@@ -1,0 +1,91 @@
+package brand
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// The strip must be invisible until winchrome.Install stamps the marker —
+// otherwise macOS and Linux would show a second title bar under the native one.
+func TestTitlebarIsHiddenWithoutTheChromeMarker(t *testing.T) {
+	if !strings.Contains(TitlebarCSS, ".wchrome { display: none; }") {
+		t.Fatal("TitlebarCSS must hide .wchrome by default")
+	}
+	// Every rule that gives the strip layout or reserves space for it has to be
+	// behind the marker, or an un-chromed page loses 34px to nothing.
+	for _, gated := range []string{
+		`html[data-chrome="custom"] body`,
+		`html[data-chrome="custom"] .wchrome`,
+	} {
+		if !strings.Contains(TitlebarCSS, gated) {
+			t.Errorf("TitlebarCSS is missing the gated rule %q", gated)
+		}
+	}
+	if !strings.Contains(TitlebarJS, "if (!window.__jarvisCustomChrome) return;") {
+		t.Error("TitlebarJS must no-op when custom chrome is not installed")
+	}
+}
+
+// Element ids are the contract between the markup and the script; a rename on
+// one side alone leaves a dead control that looks fine.
+func TestTitlebarScriptOnlyReachesIdsTheMarkupDefines(t *testing.T) {
+	defined := map[string]bool{}
+	for _, m := range regexp.MustCompile(`id="([^"]+)"`).FindAllStringSubmatch(TitlebarHTML, -1) {
+		defined[m[1]] = true
+	}
+	used := regexp.MustCompile(`getElementById\('([^']+)'\)`).FindAllStringSubmatch(TitlebarJS, -1)
+	if len(used) == 0 {
+		t.Fatal("no getElementById calls found — the extraction regexp has rotted")
+	}
+	for _, m := range used {
+		if !defined[m[1]] {
+			t.Errorf("TitlebarJS reaches for id %q, which TitlebarHTML does not define", m[1])
+		}
+	}
+}
+
+// The controls are the only reason the strip exists; each needs an accessible
+// name, since its glyph is an aria-hidden SVG.
+func TestTitlebarControlsAreNamed(t *testing.T) {
+	for _, want := range []string{
+		`id="wchrome-min" aria-label="Minimize"`,
+		`id="wchrome-max" aria-label="Maximize"`,
+		`id="wchrome-close" aria-label="Close"`,
+	} {
+		if !strings.Contains(TitlebarHTML, want) {
+			t.Errorf("TitlebarHTML is missing %q", want)
+		}
+	}
+	if n := strings.Count(TitlebarHTML, "<button"); n != 3 {
+		t.Errorf("expected exactly 3 window controls, found %d", n)
+	}
+}
+
+// The maximize button keeps both glyphs in the DOM and swaps them with a class,
+// so the restore state can never be reached without a rule to render it.
+func TestTitlebarHasBothMaximizeGlyphs(t *testing.T) {
+	for _, cls := range []string{"wchrome-glyph-max", "wchrome-glyph-restore"} {
+		if !strings.Contains(TitlebarHTML, cls) {
+			t.Errorf("TitlebarHTML is missing the %s glyph", cls)
+		}
+		if !strings.Contains(TitlebarCSS, cls) {
+			t.Errorf("TitlebarCSS never rules on %s", cls)
+		}
+	}
+	if !strings.Contains(TitlebarCSS, ".wchrome.is-max .wchrome-glyph-restore") {
+		t.Error("TitlebarCSS must show the restore glyph on .is-max")
+	}
+	if !strings.Contains(TitlebarJS, "'is-max'") {
+		t.Error("TitlebarJS must toggle the is-max class")
+	}
+}
+
+// A raw string constant that contains a backtick does not compile; these are
+// concatenated into page HTML, so a stray one is a build break, not a bug — but
+// an unescaped </script> inside TitlebarJS would silently truncate the page.
+func TestTitlebarJSCannotCloseItsScriptTag(t *testing.T) {
+	if strings.Contains(strings.ToLower(TitlebarJS), "</script") {
+		t.Fatal("TitlebarJS contains </script, which would end the page's script block early")
+	}
+}

--- a/sidecar/internal/webviewui/run.go
+++ b/sidecar/internal/webviewui/run.go
@@ -19,6 +19,7 @@ import (
 // sidecar uses its piggybacking darwin runner instead (local_webview_darwin.go).
 // Standalone processes (the installer, the sidecar's pre-tray --setup mode)
 // call this from the main goroutine.
+//
 // titleBar chooses between the system title bar and one the page draws itself
 // (winchrome; custom is Windows-only and degrades to native elsewhere). Ask
 // for winchrome.CustomTitleBar only for a window showing LOCAL html: it binds

--- a/sidecar/internal/webviewui/run.go
+++ b/sidecar/internal/webviewui/run.go
@@ -5,6 +5,8 @@ import (
 	"runtime"
 
 	webview "github.com/webview/webview_go"
+
+	"github.com/jarvis/sidecar/internal/winchrome"
 )
 
 // RunWindow hosts a small local-HTML webview window, owning its creation,
@@ -17,9 +19,14 @@ import (
 // sidecar uses its piggybacking darwin runner instead (local_webview_darwin.go).
 // Standalone processes (the installer, the sidecar's pre-tray --setup mode)
 // call this from the main goroutine.
+// titleBar chooses between the system title bar and one the page draws itself
+// (winchrome; custom is Windows-only and degrades to native elsewhere). Ask
+// for winchrome.CustomTitleBar only for a window showing LOCAL html: it binds
+// window controls, which a remote document must never reach.
+//
 // Returns false when no window could be opened, so callers can degrade to a
 // non-GUI path instead of exiting silently.
-func RunWindow(title string, width, height int, hint webview.Hint, build func(webview.WebView)) bool {
+func RunWindow(title string, width, height int, hint webview.Hint, titleBar winchrome.TitleBar, build func(webview.WebView)) bool {
 	runtime.LockOSThread()
 	// Unlock on the way out: the sidecar's Windows --setup path returns here
 	// and continues into normal startup, and leaving the main goroutine pinned
@@ -41,6 +48,12 @@ func RunWindow(title string, width, height int, hint webview.Hint, build func(we
 	defer wv.Destroy()
 	wv.SetTitle(title)
 	wv.SetSize(width, height, hint)
+	if titleBar == winchrome.CustomTitleBar {
+		// Before RevealOnLoad and before build's SetHtml: the window is still
+		// hidden, so the native bar is never composited, and the marker script
+		// Install injects only reaches documents loaded after it.
+		winchrome.Install(wv)
+	}
 	stop := RevealOnLoad(wv)
 	// LIFO with the Destroy above: a window closed within the reveal timeout
 	// must join the timeout goroutine BEFORE the engine is freed, or its

--- a/sidecar/internal/winchrome/chrome_other.go
+++ b/sidecar/internal/winchrome/chrome_other.go
@@ -1,0 +1,11 @@
+//go:build !windows
+
+package winchrome
+
+import webview "github.com/webview/webview_go"
+
+// Install is a no-op off Windows: macOS and Linux keep their native window
+// decoration, and the page keeps its native title bar because the
+// data-chrome="custom" marker is never stamped. Reports false so callers can
+// tell whether custom chrome is live.
+func Install(w webview.WebView) bool { return false }

--- a/sidecar/internal/winchrome/chrome_windows.go
+++ b/sidecar/internal/winchrome/chrome_windows.go
@@ -82,8 +82,8 @@ type point struct {
 // page needs to replace it. Reports whether custom chrome is live; on false the
 // window keeps its native decoration and the page keeps its native title bar.
 //
-// Call it from the window HOST -- not from a build/setup callback, which both
-// hosts run after the reveal hook is already installed -- AFTER SetTitle and
+// Call it from the window HOST — not from a build/setup callback, which both
+// hosts run after the reveal hook is already installed — AFTER SetTitle and
 // SetSize (the size is re-derived from the new frame here) and BEFORE the
 // reveal hook and the first SetHtml/Navigate: the window is still hidden at
 // that point, so the native bar is never composited, and the injected marker
@@ -132,8 +132,8 @@ func Install(w webview.WebView) bool {
 func stripCaption(hwnd uintptr) bool {
 	style := getWindowLong(hwnd, gwlStyle)
 	if style == 0 {
-		// GetWindowLong failed. Ambiguous in principle -- WS_OVERLAPPED is 0,
-		// so a style-less window reads the same -- but webview always creates
+		// GetWindowLong failed. Ambiguous in principle — WS_OVERLAPPED is 0,
+		// so a style-less window reads the same — but webview always creates
 		// WS_OVERLAPPEDWINDOW, and treating the ambiguous case as failure only
 		// ever costs us the native title bar staying put.
 		return false
@@ -160,7 +160,7 @@ func stripCaption(hwnd uintptr) bool {
 // adjustWindowRect grows a client rect into the window rect that style needs,
 // at the window's own DPI where the OS can tell us (Win10 1607+). The
 // DPI-blind AdjustWindowRectEx is the fallback: it uses the system DPI, so on
-// a per-monitor-DPI setup it can be off by a few pixels of border -- visible
+// a per-monitor-DPI setup it can be off by a few pixels of border — visible
 // as a slightly wrong window size, never as broken chrome.
 func adjustWindowRect(hwnd uintptr, r *rect, style, exStyle uintptr) {
 	if procGetDpiForWindow.Find() == nil && procAdjustWindowRectExForDpi.Find() == nil {
@@ -198,7 +198,7 @@ func roundCorners(hwnd uintptr) {
 // them are live.
 //
 // Every one of them runs on the webview's UI thread (that is where bindings are
-// dispatched), which is the thread that owns the window -- so ReleaseCapture,
+// dispatched), which is the thread that owns the window — so ReleaseCapture,
 // the modal move loop entered by WM_NCLBUTTONDOWN, and ShowWindow all target
 // the right thread without a Dispatch hop.
 func bindControls(w webview.WebView, hwnd uintptr) bool {
@@ -214,7 +214,7 @@ func bindControls(w webview.WebView, hwnd uintptr) bool {
 	// the frame the press landed on its caption hands the gesture to Windows,
 	// which then gives us the real thing: snap to edges, snap-back off a
 	// maximised window, and multi-monitor drag. SendMessage (not Post) on
-	// purpose -- the modal move loop must start inside the user gesture.
+	// purpose — the modal move loop must start inside the user gesture.
 	// It returns when the drag ends, so the page must not await this.
 	bind("__jarvis_chrome_drag", func() {
 		procReleaseCapture.Call()
@@ -247,7 +247,7 @@ func bindControls(w webview.WebView, hwnd uintptr) bool {
 
 	// Right-click on the caption. DefWindowProc turns WM_NCRBUTTONUP/HTCAPTION
 	// into the system menu, so the menu, its item states and its commands are
-	// all the OS's -- we only say where. The position comes from GetCursorPos
+	// all the OS's — we only say where. The position comes from GetCursorPos
 	// rather than the page: the click just happened, and screen pixels from Go
 	// need no CSS-pixel-to-DPI conversion. Modal like the drag, and on the same
 	// thread, for the same reason.

--- a/sidecar/internal/winchrome/chrome_windows.go
+++ b/sidecar/internal/winchrome/chrome_windows.go
@@ -1,0 +1,296 @@
+//go:build windows
+
+package winchrome
+
+import (
+	"log"
+	"syscall"
+	"unsafe"
+
+	webview "github.com/webview/webview_go"
+)
+
+// GetWindowLong / SetWindowLong indices.
+const gwlStyle = -16
+const gwlExStyle = -20
+
+// SetWindowPos flags.
+const (
+	swpNoMove       = 0x0002
+	swpNoZOrder     = 0x0004
+	swpNoActivate   = 0x0010
+	swpFrameChanged = 0x0020
+)
+
+// Messages and hit-test codes used by the caption drag / close path.
+const (
+	wmNCLButtonDown = 0x00A1
+	wmNCRButtonUp   = 0x00A5
+	wmClose         = 0x0010
+	htCaption       = 2
+)
+
+// ShowWindow commands.
+const (
+	swMaximize = 3
+	swMinimize = 6
+	swRestore  = 9
+)
+
+// DWMWA_WINDOW_CORNER_PREFERENCE (33) with DWMWCP_ROUND (2). Windows 11 21H2
+// (build 22000) and newer; older builds return E_INVALIDARG for the unknown
+// attribute and keep square corners, which is the fallback we want.
+const (
+	dwmWaWindowCornerPreference = 33
+	dwmwcpRound                 = 2
+)
+
+var (
+	user32                       = syscall.NewLazyDLL("user32.dll")
+	procGetWindowLongW           = user32.NewProc("GetWindowLongW")
+	procSetWindowLongW           = user32.NewProc("SetWindowLongW")
+	procGetWindowLongPtrW        = user32.NewProc("GetWindowLongPtrW") // 64-bit only
+	procSetWindowLongPtrW        = user32.NewProc("SetWindowLongPtrW") // 64-bit only
+	procSetWindowPos             = user32.NewProc("SetWindowPos")
+	procGetClientRect            = user32.NewProc("GetClientRect")
+	procAdjustWindowRectEx       = user32.NewProc("AdjustWindowRectEx")
+	procAdjustWindowRectExForDpi = user32.NewProc("AdjustWindowRectExForDpi") // Win10 1607+
+	procGetDpiForWindow          = user32.NewProc("GetDpiForWindow")          // Win10 1607+
+	procReleaseCapture           = user32.NewProc("ReleaseCapture")
+	procSendMessageW             = user32.NewProc("SendMessageW")
+	procPostMessageW             = user32.NewProc("PostMessageW")
+	procShowWindow               = user32.NewProc("ShowWindow")
+	procIsZoomed                 = user32.NewProc("IsZoomed")
+	procGetCursorPos             = user32.NewProc("GetCursorPos")
+	procGetDoubleClickTime       = user32.NewProc("GetDoubleClickTime")
+
+	dwmapi                    = syscall.NewLazyDLL("dwmapi.dll")
+	procDwmSetWindowAttribute = dwmapi.NewProc("DwmSetWindowAttribute")
+)
+
+// rect mirrors Win32 RECT (four LONGs).
+type rect struct {
+	Left, Top, Right, Bottom int32
+}
+
+// point mirrors Win32 POINT (two LONGs).
+type point struct {
+	X, Y int32
+}
+
+// Install removes the native title bar from w's window and binds the calls the
+// page needs to replace it. Reports whether custom chrome is live; on false the
+// window keeps its native decoration and the page keeps its native title bar.
+//
+// Call it from the window HOST -- not from a build/setup callback, which both
+// hosts run after the reveal hook is already installed -- AFTER SetTitle and
+// SetSize (the size is re-derived from the new frame here) and BEFORE the
+// reveal hook and the first SetHtml/Navigate: the window is still hidden at
+// that point, so the native bar is never composited, and the injected marker
+// script only applies to documents loaded after Init.
+//
+// Only ever give custom chrome to a window showing LOCAL html. These bindings
+// move, minimise, maximise and close the window; exposing them to a remote
+// document hands that page control of the window.
+//
+// Custom chrome implies a resizable window: it does not add WS_THICKFRAME, so
+// pairing it with SetSize(..., HintFixed) leaves a page whose maximize button
+// the OS will refuse.
+func Install(w webview.WebView) bool {
+	if w == nil {
+		return false
+	}
+	handle := w.Window()
+	if handle == nil {
+		return false
+	}
+	hwnd := uintptr(handle)
+	// Controls first: a captionless window whose buttons failed to bind can
+	// only be moved or closed through the taskbar, so a failed Bind must leave
+	// the native title bar in place rather than take it away.
+	if !bindControls(w, hwnd) {
+		return false
+	}
+	if !stripCaption(hwnd) {
+		log.Printf("[chrome] could not remove the native title bar; keeping it")
+		return false
+	}
+	roundCorners(hwnd)
+	w.Init(initJS(doubleClickTime()))
+	return true
+}
+
+// stripCaption swaps the window over to the captionless style and restores the
+// client size the caller asked for.
+//
+// The size step matters: the caption's height becomes client area the moment
+// WS_CAPTION goes, so a window sized before the strip would grow its page by
+// the bar height. We read the client rect first, then re-derive the window rect
+// the new style needs for exactly that client size. The same SetWindowPos is
+// also what makes Windows recompute the frame (SWP_FRAMECHANGED) and what
+// delivers the WM_SIZE that moves the WebView2 child onto the new client area.
+func stripCaption(hwnd uintptr) bool {
+	style := getWindowLong(hwnd, gwlStyle)
+	if style == 0 {
+		// GetWindowLong failed. Ambiguous in principle -- WS_OVERLAPPED is 0,
+		// so a style-less window reads the same -- but webview always creates
+		// WS_OVERLAPPEDWINDOW, and treating the ambiguous case as failure only
+		// ever costs us the native title bar staying put.
+		return false
+	}
+	var client rect
+	if ok, _, _ := procGetClientRect.Call(hwnd, uintptr(unsafe.Pointer(&client))); ok == 0 {
+		return false
+	}
+
+	newStyle := uintptr(captionlessStyle(uint32(style)))
+	setWindowLong(hwnd, gwlStyle, newStyle)
+
+	want := rect{Right: client.Right, Bottom: client.Bottom}
+	adjustWindowRect(hwnd, &want, newStyle, getWindowLong(hwnd, gwlExStyle))
+	procSetWindowPos.Call(
+		hwnd, 0,
+		0, 0,
+		uintptr(want.Right-want.Left), uintptr(want.Bottom-want.Top),
+		swpNoMove|swpNoZOrder|swpNoActivate|swpFrameChanged,
+	)
+	return true
+}
+
+// adjustWindowRect grows a client rect into the window rect that style needs,
+// at the window's own DPI where the OS can tell us (Win10 1607+). The
+// DPI-blind AdjustWindowRectEx is the fallback: it uses the system DPI, so on
+// a per-monitor-DPI setup it can be off by a few pixels of border -- visible
+// as a slightly wrong window size, never as broken chrome.
+func adjustWindowRect(hwnd uintptr, r *rect, style, exStyle uintptr) {
+	if procGetDpiForWindow.Find() == nil && procAdjustWindowRectExForDpi.Find() == nil {
+		if dpi, _, _ := procGetDpiForWindow.Call(hwnd); dpi != 0 {
+			// On a scratch copy: the API does not promise to leave the rect
+			// untouched when it fails, and inflating an already-inflated rect
+			// with the fallback would size the window tens of pixels too big.
+			try := *r
+			ok, _, _ := procAdjustWindowRectExForDpi.Call(
+				uintptr(unsafe.Pointer(&try)), style, 0, exStyle, dpi,
+			)
+			if ok != 0 {
+				*r = try
+				return
+			}
+		}
+	}
+	procAdjustWindowRectEx.Call(uintptr(unsafe.Pointer(r)), style, 0, exStyle)
+}
+
+// roundCorners asks DWM for Win11's rounded corners explicitly. Captionless
+// windows still get them by default, but a window whose style we rewrote after
+// creation is exactly the case where being explicit costs one ignored call.
+func roundCorners(hwnd uintptr) {
+	corner := int32(dwmwcpRound)
+	procDwmSetWindowAttribute.Call(
+		hwnd,
+		uintptr(dwmWaWindowCornerPreference),
+		uintptr(unsafe.Pointer(&corner)),
+		unsafe.Sizeof(corner),
+	)
+}
+
+// bindControls installs the page's window controls and reports whether all of
+// them are live.
+//
+// Every one of them runs on the webview's UI thread (that is where bindings are
+// dispatched), which is the thread that owns the window -- so ReleaseCapture,
+// the modal move loop entered by WM_NCLBUTTONDOWN, and ShowWindow all target
+// the right thread without a Dispatch hop.
+func bindControls(w webview.WebView, hwnd uintptr) bool {
+	ok := true
+	bind := func(name string, fn any) {
+		if err := w.Bind(name, fn); err != nil {
+			log.Printf("[chrome] Bind(%s) failed: %v", name, err)
+			ok = false
+		}
+	}
+	// Caption drag. The mouse is over the WebView2 child, which holds capture
+	// and would keep every subsequent move to itself; releasing it and telling
+	// the frame the press landed on its caption hands the gesture to Windows,
+	// which then gives us the real thing: snap to edges, snap-back off a
+	// maximised window, and multi-monitor drag. SendMessage (not Post) on
+	// purpose -- the modal move loop must start inside the user gesture.
+	// It returns when the drag ends, so the page must not await this.
+	bind("__jarvis_chrome_drag", func() {
+		procReleaseCapture.Call()
+		procSendMessageW.Call(hwnd, wmNCLButtonDown, htCaption, 0)
+	})
+
+	bind("__jarvis_chrome_minimize", func() {
+		procShowWindow.Call(hwnd, swMinimize)
+	})
+
+	// Reports the state the window is in AFTER the toggle so the page can
+	// swap its maximise/restore glyph without a second round trip.
+	bind("__jarvis_chrome_toggle_maximize", func() bool {
+		if isZoomed(hwnd) {
+			procShowWindow.Call(hwnd, swRestore)
+			return false
+		}
+		procShowWindow.Call(hwnd, swMaximize)
+		return true
+	})
+
+	bind("__jarvis_chrome_is_maximized", func() bool { return isZoomed(hwnd) })
+
+	// Post, never Send: WM_CLOSE tears the window (and the engine) down, and
+	// this binding is running inside that engine's dispatch. Queuing the
+	// message lets the call return first.
+	bind("__jarvis_chrome_close", func() {
+		procPostMessageW.Call(hwnd, wmClose, 0, 0)
+	})
+
+	// Right-click on the caption. DefWindowProc turns WM_NCRBUTTONUP/HTCAPTION
+	// into the system menu, so the menu, its item states and its commands are
+	// all the OS's -- we only say where. The position comes from GetCursorPos
+	// rather than the page: the click just happened, and screen pixels from Go
+	// need no CSS-pixel-to-DPI conversion. Modal like the drag, and on the same
+	// thread, for the same reason.
+	bind("__jarvis_chrome_sysmenu", func() {
+		var pt point
+		if ok, _, _ := procGetCursorPos.Call(uintptr(unsafe.Pointer(&pt))); ok == 0 {
+			return
+		}
+		// MAKELPARAM: low word x, high word y, both truncated to 16 bits --
+		// which is what GET_X_LPARAM sign-extends back on a negative
+		// (left-of-primary) monitor.
+		lparam := uintptr(uint32(uint16(pt.X)) | uint32(uint16(pt.Y))<<16)
+		procSendMessageW.Call(hwnd, wmNCRButtonUp, htCaption, lparam)
+	})
+
+	return ok
+}
+
+// doubleClickTime is the user's configured double-click speed in ms (0 if the
+// call fails, which initJS reads as "use the default").
+func doubleClickTime() uint32 {
+	ms, _, _ := procGetDoubleClickTime.Call()
+	return uint32(ms)
+}
+
+func isZoomed(hwnd uintptr) bool {
+	z, _, _ := procIsZoomed.Call(hwnd)
+	return z != 0
+}
+
+func getWindowLong(hwnd uintptr, idx int32) uintptr {
+	if proc := procGetWindowLongPtrW; proc.Find() == nil {
+		v, _, _ := proc.Call(hwnd, uintptr(idx))
+		return v
+	}
+	v, _, _ := procGetWindowLongW.Call(hwnd, uintptr(idx))
+	return v
+}
+
+func setWindowLong(hwnd uintptr, idx int32, val uintptr) {
+	if proc := procSetWindowLongPtrW; proc.Find() == nil {
+		proc.Call(hwnd, uintptr(idx), val)
+		return
+	}
+	procSetWindowLongW.Call(hwnd, uintptr(idx), val)
+}

--- a/sidecar/internal/winchrome/style.go
+++ b/sidecar/internal/winchrome/style.go
@@ -5,7 +5,7 @@
 //
 // The trick is to remove ONLY WS_CAPTION. The window keeps its overlapped
 // frame, so Windows keeps computing the non-client area, the maximized rect
-// and the snap behaviour exactly as it does for any other app -- we never
+// and the snap behaviour exactly as it does for any other app — we never
 // touch WM_NCCALCSIZE and never subclass the window procedure the vendored
 // webview owns. What is left of the frame is the 1px system border.
 //
@@ -27,8 +27,8 @@ package winchrome
 import "strconv"
 
 // TitleBar says which title bar a window wears. It exists so the choice reads
-// as itself at a call site -- `winchrome.CustomTitleBar` rather than a bare
-// `true` six arguments deep -- because the choice carries a security
+// as itself at a call site — `winchrome.CustomTitleBar` rather than a bare
+// `true` six arguments deep — because the choice carries a security
 // invariant: custom chrome binds window controls into the document, so only a
 // window showing LOCAL html may ask for it. It also makes "which windows have
 // chrome bindings?" a one-line grep.
@@ -43,7 +43,7 @@ const (
 // panels_windows.go so this package stays self-contained (the installer binary
 // links it too, and the values are ABI constants that cannot drift).
 const (
-	wsCaption     = 0x00C00000 // WS_BORDER | WS_DLGFRAME -- the title bar
+	wsCaption     = 0x00C00000 // WS_BORDER | WS_DLGFRAME — the title bar
 	wsThickFrame  = 0x00040000 // sizing border: resize + Aero Snap eligibility
 	wsSysMenu     = 0x00080000 // Alt+Space menu, taskbar close entry
 	wsMinimizeBox = 0x00020000
@@ -58,7 +58,7 @@ const (
 // ShowWindow(SW_MINIMIZE) and the taskbar minimise as they would for a framed
 // window. Keeping the overlapped frame (i.e. NOT switching to WS_POPUP) is
 // deliberate: a maximized WS_POPUP covers the taskbar and needs a
-// WM_GETMINMAXINFO handler -- and a handler means a window procedure.
+// WM_GETMINMAXINFO handler — and a handler means a window procedure.
 //
 // WS_THICKFRAME (resize border, and with it Aero Snap eligibility) and
 // WS_MAXIMIZEBOX are deliberately NOT forced on: webview's own SetSize sets
@@ -85,18 +85,18 @@ func captionlessStyle(style uint32) uint32 {
 // It runs at document-creation time, before any page markup exists, so it
 // cannot assume document.documentElement is there yet: it stamps the attribute
 // immediately when it can and again on DOMContentLoaded, both idempotent. No
-// visible flash either way -- the window stays hidden until the reveal hook
+// visible flash either way — the window stays hidden until the reveal hook
 // fires on load (internal/webviewui.RevealOnLoad).
 // It also refuses navigating drops. Dropping a URL or a file onto a WebView2
-// document navigates it by default, and the window's bindings -- these window
-// controls, and whatever else the page's host bound -- survive into whatever
+// document navigates it by default, and the window's bindings — these window
+// controls, and whatever else the page's host bound — survive into whatever
 // lands there, since bind() re-injects its stubs on every document. Cancelling
 // the drag lets Chromium's default never run. Scoped to drags that actually
 // carry a URL or a file: a plain-text drag into the token form's textarea is
 // a different, harmless payload, and stays working.
 //
 // This is a guard for the windows that took on window-control bindings, not a
-// complete answer -- the real fix is refusing foreign origins in the engine
+// complete answer — the real fix is refusing foreign origins in the engine
 // (NavigationStarting, or AllowExternalDrop=false), which means a change to
 // the vendored webview and its patch file.
 func initJS(dblClickMs uint32) string {

--- a/sidecar/internal/winchrome/style.go
+++ b/sidecar/internal/winchrome/style.go
@@ -1,0 +1,116 @@
+// Package winchrome replaces a webview window's native Windows title bar with
+// one the page draws itself, without giving up the behaviours a real window
+// has: resize borders, Aero Snap, native maximize, minimize/restore
+// animations, the Alt+Space system menu and the taskbar entry.
+//
+// The trick is to remove ONLY WS_CAPTION. The window keeps its overlapped
+// frame, so Windows keeps computing the non-client area, the maximized rect
+// and the snap behaviour exactly as it does for any other app -- we never
+// touch WM_NCCALCSIZE and never subclass the window procedure the vendored
+// webview owns. What is left of the frame is the 1px system border.
+//
+// The page drives the window through four bindings (see Install); the caption
+// drag is the ReleaseCapture + WM_NCLBUTTONDOWN/HTCAPTION handshake, because
+// the WebView2 child HWND covers the client area and swallows the mouse
+// before any hit-test of ours could see it (CSS app-region is an Electron
+// feature; stock WebView2 does not honour it).
+//
+// Known limitation: the Win11 Snap Layouts flyout does not appear when
+// hovering the page's maximize button. The OS offers it only to a window whose
+// WM_NCHITTEST answers HTMAXBUTTON, which needs the window procedure we
+// deliberately do not own. Win+Z and edge-snap are unaffected.
+//
+// On every non-Windows platform Install is a no-op that reports false, so the
+// shared page markup keeps its native title bar there.
+package winchrome
+
+import "strconv"
+
+// TitleBar says which title bar a window wears. It exists so the choice reads
+// as itself at a call site -- `winchrome.CustomTitleBar` rather than a bare
+// `true` six arguments deep -- because the choice carries a security
+// invariant: custom chrome binds window controls into the document, so only a
+// window showing LOCAL html may ask for it. It also makes "which windows have
+// chrome bindings?" a one-line grep.
+type TitleBar bool
+
+const (
+	NativeTitleBar TitleBar = false
+	CustomTitleBar TitleBar = true
+)
+
+// Win32 window styles. Duplicated here rather than imported from the sidecar's
+// panels_windows.go so this package stays self-contained (the installer binary
+// links it too, and the values are ABI constants that cannot drift).
+const (
+	wsCaption     = 0x00C00000 // WS_BORDER | WS_DLGFRAME -- the title bar
+	wsThickFrame  = 0x00040000 // sizing border: resize + Aero Snap eligibility
+	wsSysMenu     = 0x00080000 // Alt+Space menu, taskbar close entry
+	wsMinimizeBox = 0x00020000
+	wsMaximizeBox = 0x00010000
+)
+
+// captionlessStyle is the WS_* mask for a window that draws its own title bar.
+//
+// Dropping WS_CAPTION is what hides the native bar. The two styles added back
+// are invisible without a caption but are what Windows consults for behaviour:
+// WS_SYSMENU for Alt+Space and the taskbar context menu, WS_MINIMIZEBOX so
+// ShowWindow(SW_MINIMIZE) and the taskbar minimise as they would for a framed
+// window. Keeping the overlapped frame (i.e. NOT switching to WS_POPUP) is
+// deliberate: a maximized WS_POPUP covers the taskbar and needs a
+// WM_GETMINMAXINFO handler -- and a handler means a window procedure.
+//
+// WS_THICKFRAME (resize border, and with it Aero Snap eligibility) and
+// WS_MAXIMIZEBOX are deliberately NOT forced on: webview's own SetSize sets
+// them for WEBVIEW_HINT_NONE and strips them for WEBVIEW_HINT_FIXED, so
+// preserving whatever is there keeps a fixed-size window fixed instead of
+// silently handing it a resize border. A page that draws a maximize button on
+// a window whose caller asked for HintFixed gets a button the OS refuses --
+// which is the caller's contradiction to resolve, not this mask's.
+//
+// Pure so it can be unit-tested on any host.
+func captionlessStyle(style uint32) uint32 {
+	style &^= wsCaption
+	style |= wsSysMenu | wsMinimizeBox
+	return style
+}
+
+// initJS marks the document as custom-chromed so the shared title bar CSS
+// (internal/brand) can reveal itself only where the native bar is gone, and
+// hands the page the user's real double-click speed: the strip times
+// double-clicks itself (the native move loop owns the mouse, so no dblclick
+// event is guaranteed), and a user who has slowed the setting down in
+// accessibility settings would otherwise never manage one.
+//
+// It runs at document-creation time, before any page markup exists, so it
+// cannot assume document.documentElement is there yet: it stamps the attribute
+// immediately when it can and again on DOMContentLoaded, both idempotent. No
+// visible flash either way -- the window stays hidden until the reveal hook
+// fires on load (internal/webviewui.RevealOnLoad).
+// It also refuses navigating drops. Dropping a URL or a file onto a WebView2
+// document navigates it by default, and the window's bindings -- these window
+// controls, and whatever else the page's host bound -- survive into whatever
+// lands there, since bind() re-injects its stubs on every document. Cancelling
+// the drag lets Chromium's default never run. Scoped to drags that actually
+// carry a URL or a file: a plain-text drag into the token form's textarea is
+// a different, harmless payload, and stays working.
+//
+// This is a guard for the windows that took on window-control bindings, not a
+// complete answer -- the real fix is refusing foreign origins in the engine
+// (NavigationStarting, or AllowExternalDrop=false), which means a change to
+// the vendored webview and its patch file.
+func initJS(dblClickMs uint32) string {
+	if dblClickMs == 0 {
+		dblClickMs = 500 // the Windows default, if the OS would not say
+	}
+	return `(function(){try{` +
+		`window.__jarvisCustomChrome=true;` +
+		`window.__jarvisDblClickMs=` + strconv.FormatUint(uint64(dblClickMs), 10) + `;` +
+		`var a=function(){if(document.documentElement)document.documentElement.setAttribute('data-chrome','custom');};` +
+		`a();document.addEventListener('DOMContentLoaded',a);` +
+		`var navigating=function(e){var t=e.dataTransfer&&e.dataTransfer.types;if(!t)return false;` +
+		`for(var i=0;i<t.length;i++){if(t[i]==='Files'||t[i]==='text/uri-list')return true;}return false;};` +
+		`var block=function(e){if(navigating(e)){e.preventDefault();}};` +
+		`document.addEventListener('dragover',block,true);document.addEventListener('drop',block,true);` +
+		`}catch(e){}})();`
+}

--- a/sidecar/internal/winchrome/style_test.go
+++ b/sidecar/internal/winchrome/style_test.go
@@ -1,0 +1,118 @@
+package winchrome
+
+import (
+	"strings"
+	"testing"
+)
+
+// WS_OVERLAPPEDWINDOW, as webview creates its window and as its SetSize leaves
+// it for WEBVIEW_HINT_NONE.
+const wsOverlappedWindow = 0x00CF0000
+
+func TestCaptionlessStyleDropsOnlyTheCaption(t *testing.T) {
+	got := captionlessStyle(wsOverlappedWindow)
+	if got&wsCaption != 0 {
+		t.Fatalf("WS_CAPTION still set: %#08x", got)
+	}
+	// Everything the OS consults for behaviour must survive, or the window
+	// silently loses resize, snap, Alt+Space or its taskbar entry.
+	for _, want := range []struct {
+		name string
+		bit  uint32
+	}{
+		{"WS_THICKFRAME", wsThickFrame},
+		{"WS_SYSMENU", wsSysMenu},
+		{"WS_MINIMIZEBOX", wsMinimizeBox},
+		{"WS_MAXIMIZEBOX", wsMaximizeBox},
+	} {
+		if got&want.bit == 0 {
+			t.Errorf("%s missing from %#08x", want.name, got)
+		}
+	}
+}
+
+// A fixed-size window (webview's HINT_FIXED strips WS_THICKFRAME and
+// WS_MAXIMIZEBOX) must stay fixed: handing it a resize border back would
+// quietly break the size contract its caller asked for.
+func TestCaptionlessStyleKeepsAFixedWindowFixed(t *testing.T) {
+	fixed := uint32(wsOverlappedWindow) &^ (wsThickFrame | wsMaximizeBox)
+	got := captionlessStyle(fixed)
+	if got&wsThickFrame != 0 {
+		t.Errorf("WS_THICKFRAME was added to a fixed-size window: %#08x", got)
+	}
+	if got&wsMaximizeBox != 0 {
+		t.Errorf("WS_MAXIMIZEBOX was added to a fixed-size window: %#08x", got)
+	}
+	// The two that are always needed are still added: without WS_SYSMENU the
+	// window loses Alt+Space and its taskbar close entry, and the page's
+	// minimize button needs WS_MINIMIZEBOX to do anything.
+	if got&wsSysMenu == 0 || got&wsMinimizeBox == 0 {
+		t.Errorf("WS_SYSMENU/WS_MINIMIZEBOX missing from %#08x", got)
+	}
+}
+
+func TestCaptionlessStyleIsIdempotent(t *testing.T) {
+	once := captionlessStyle(wsOverlappedWindow)
+	if twice := captionlessStyle(once); twice != once {
+		t.Fatalf("not idempotent: %#08x then %#08x", once, twice)
+	}
+}
+
+// The marker script runs before the document exists, so it must not assume
+// documentElement is there and must re-apply once it is. Matching the whole
+// call, not just the event name, so a rewrite that drops the listener cannot
+// keep the test green on a leftover mention.
+func TestChromeInitJSDefersUntilTheDocumentExists(t *testing.T) {
+	js := initJS(500)
+	for _, want := range []string{
+		"window.__jarvisCustomChrome=true",
+		"if(document.documentElement)",
+		"setAttribute('data-chrome','custom')",
+		"document.addEventListener('DOMContentLoaded',a)",
+	} {
+		if !strings.Contains(js, want) {
+			t.Errorf("initJS is missing %q", want)
+		}
+	}
+}
+
+// A dropped URL or file would otherwise navigate the document and carry the
+// window-control bindings into whatever landed there. Plain text must still
+// drop (the token form is a textarea), so the guard has to inspect the payload
+// rather than cancel every drag.
+func TestChromeInitJSRefusesNavigatingDropsOnly(t *testing.T) {
+	js := initJS(500)
+	for _, want := range []string{
+		"'dragover'",
+		"'drop'",
+		"'Files'",
+		"'text/uri-list'",
+		"e.preventDefault()",
+	} {
+		if !strings.Contains(js, want) {
+			t.Errorf("the drop guard is missing %s", want)
+		}
+	}
+	if strings.Contains(js, "var block=function(e){e.preventDefault") {
+		t.Error("the drop guard cancels every drag; plain-text drops must still work")
+	}
+}
+
+// The script is injected verbatim into the page; an unescaped </script> would
+// truncate whatever document it lands in.
+func TestChromeInitJSCannotCloseAScriptTag(t *testing.T) {
+	if strings.Contains(strings.ToLower(initJS(500)), "</script") {
+		t.Fatal("initJS contains </script")
+	}
+}
+
+// The page times its own double-clicks, so it needs the user's real setting —
+// and a sane number even when the OS call fails.
+func TestInitJSCarriesTheDoubleClickTime(t *testing.T) {
+	if !strings.Contains(initJS(900), "window.__jarvisDblClickMs=900;") {
+		t.Error("initJS did not carry the configured double-click time")
+	}
+	if !strings.Contains(initJS(0), "window.__jarvisDblClickMs=500;") {
+		t.Error("initJS must fall back to the Windows default of 500ms")
+	}
+}

--- a/sidecar/local_webview_darwin.go
+++ b/sidecar/local_webview_darwin.go
@@ -7,6 +7,8 @@ import (
 	"runtime"
 
 	webview "github.com/webview/webview_go"
+
+	"github.com/jarvis/sidecar/internal/winchrome"
 )
 
 // runLocalWebview hosts a small local-HTML webview window (settings, logs) on
@@ -24,7 +26,10 @@ import (
 // goroutine a binding spawned. On macOS the engine is leaked, not freed (see
 // below), so a late Dispatch is not a use-after-free; the join still bounds
 // the goroutine's lifetime to the window's.
-func runLocalWebview(title string, width, height int, hint webview.Hint, build func(webview.WebView) (cleanup func())) {
+//
+// titleBar is accepted for signature parity with the other platforms and
+// ignored: macOS keeps its native title bar (winchrome is Windows-only).
+func runLocalWebview(title string, width, height int, hint webview.Hint, titleBar winchrome.TitleBar, build func(webview.WebView) (cleanup func())) {
 	runtime.LockOSThread()
 	wv := webview.New(false)
 	if wv == nil {

--- a/sidecar/local_webview_other.go
+++ b/sidecar/local_webview_other.go
@@ -7,6 +7,8 @@ import (
 	"runtime"
 
 	webview "github.com/webview/webview_go"
+
+	"github.com/jarvis/sidecar/internal/winchrome"
 )
 
 // runLocalWebview hosts a small local-HTML webview window (settings, logs) on
@@ -17,7 +19,12 @@ import (
 // may return a cleanup (nil if none) that runs after the loop exits but
 // BEFORE the engine is freed — the join point for any goroutine a binding
 // spawned, so a pending Dispatch can never land on a dangling pointer.
-func runLocalWebview(title string, width, height int, hint webview.Hint, build func(webview.WebView) (cleanup func())) {
+//
+// titleBar chooses between the system title bar and one the page draws itself
+// (winchrome; custom is Windows-only and degrades to native elsewhere). Ask
+// for winchrome.CustomTitleBar only for a window showing LOCAL html: it binds
+// window controls, which a remote document must never reach.
+func runLocalWebview(title string, width, height int, hint webview.Hint, titleBar winchrome.TitleBar, build func(webview.WebView) (cleanup func())) {
 	runtime.LockOSThread()
 	wv := webview.New(false)
 	if wv == nil {
@@ -27,6 +34,13 @@ func runLocalWebview(title string, width, height int, hint webview.Hint, build f
 	defer wv.Destroy()
 	wv.SetTitle(title)
 	wv.SetSize(width, height, hint)
+	if titleBar == winchrome.CustomTitleBar {
+		// Before the reveal hook and before build's SetHtml/Navigate: the
+		// window is still hidden, so the native bar is never composited, and
+		// the marker script Install injects only reaches documents loaded
+		// after it.
+		winchrome.Install(wv)
+	}
 	stop := revealWebviewOnLoad(wv)
 	// LIFO with the Destroy above: a window closed within the reveal timeout
 	// must join the timeout goroutine BEFORE the engine is freed, or its

--- a/sidecar/log_viewer.go
+++ b/sidecar/log_viewer.go
@@ -113,7 +113,7 @@ const logViewerHTML = `<!doctype html>
 ` + brandTitlebarCSS + `
 </style>
 </head>
-<body>` + brandTitlebarHTML + `
+<body>
   <div class="bar">
     <span class="eyebrow">Logs</span>
     <input id="q" placeholder="Search logs…" autofocus>
@@ -123,7 +123,7 @@ const logViewerHTML = `<!doctype html>
     <button class="primary" onclick="refresh()">Refresh</button>
   </div>
   <pre id="logs"></pre>
-  <div id="msg"></div>
+  <div id="msg"></div>` + brandTitlebarHTML + `
 <script>
   var raw = "";
   var pre = document.getElementById('logs');

--- a/sidecar/log_viewer.go
+++ b/sidecar/log_viewer.go
@@ -14,6 +14,8 @@ import (
 	"time"
 
 	webview "github.com/webview/webview_go"
+
+	"github.com/jarvis/sidecar/internal/winchrome"
 )
 
 // OpenLogViewer opens the log viewer window on its own OS-locked goroutine
@@ -23,7 +25,7 @@ func (c *SidecarClient) OpenLogViewer() {
 }
 
 func runLogViewer(logPath string) {
-	runLocalWebview("JARVIS — Logs", 900, 600, webview.HintNone, func(w webview.WebView) func() {
+	runLocalWebview("JARVIS — Logs", 900, 600, webview.HintNone, winchrome.CustomTitleBar, func(w webview.WebView) func() {
 
 		// loadLogs returns the current log file contents.
 		_ = w.Bind("loadLogs", func() string {
@@ -58,6 +60,7 @@ const logViewerHTML = `<!doctype html>
 <html>
 <head>
 <meta charset="utf-8">
+<title>JARVIS — Logs</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <style>` + brandTokensCSS + `
   /* Monochrome Lab (Brand Book III) — shared tokens from brand_css.go,
@@ -107,9 +110,10 @@ const logViewerHTML = `<!doctype html>
     min-height: 22px; color: var(--ink3); border-top: 1px solid var(--rule);
     background: var(--raise);
   }
+` + brandTitlebarCSS + `
 </style>
 </head>
-<body>
+<body>` + brandTitlebarHTML + `
   <div class="bar">
     <span class="eyebrow">Logs</span>
     <input id="q" placeholder="Search logs…" autofocus>
@@ -159,6 +163,7 @@ const logViewerHTML = `<!doctype html>
     setTimeout(function () { if (m.textContent === t) m.textContent = ""; }, 5000);
   }
   refresh();
+` + brandTitlebarJS + `
 </script>
 </body>
 </html>`

--- a/sidecar/settings_window.go
+++ b/sidecar/settings_window.go
@@ -270,7 +270,7 @@ const settingsWindowHTML = `<!doctype html>
 ` + brandTitlebarCSS + `
 </style>
 </head>
-<body>` + brandTitlebarHTML + `
+<body>
 <div class="pagebody" tabindex="-1">
   <h1>Sidecar Settings</h1>
   <p class="sub">Connection, enrollment, and how the pebble behaves on this machine.</p>
@@ -326,7 +326,7 @@ const settingsWindowHTML = `<!doctype html>
     </div>
   </div>
 
-</div>
+</div>` + brandTitlebarHTML + `
 <script>
   var dot = document.getElementById('dot');
   var statusText = document.getElementById('statusText');

--- a/sidecar/settings_window.go
+++ b/sidecar/settings_window.go
@@ -16,6 +16,8 @@ import (
 	"sync/atomic"
 
 	webview "github.com/webview/webview_go"
+
+	"github.com/jarvis/sidecar/internal/winchrome"
 )
 
 // OpenSettings opens the local sidecar settings window on its own OS-locked
@@ -49,7 +51,7 @@ func connStateString(s int32) string {
 }
 
 func (c *SidecarClient) runSettingsWindow() {
-	runLocalWebview("JARVIS — Sidecar Settings", 520, 560, webview.HintNone, func(w webview.WebView) func() {
+	runLocalWebview("JARVIS — Sidecar Settings", 520, 560, webview.HintNone, winchrome.CustomTitleBar, func(w webview.WebView) func() {
 		// Lifecycle plumbing for the async token check (bindings run on the
 		// webview main thread, so the network probe must not run inline —
 		// it would freeze the window for up to the probe timeout).
@@ -205,6 +207,7 @@ const settingsWindowHTML = `<!doctype html>
 <html>
 <head>
 <meta charset="utf-8">
+<title>JARVIS — Sidecar Settings</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <style>` + brandTokensCSS + `
   /* Monochrome Lab (Brand Book III) — sidecar settings, shared tokens from
@@ -212,7 +215,12 @@ const settingsWindowHTML = `<!doctype html>
      design: label + consequence left, control right, inside raised panels
      with the asymmetric corner. */
   html, body { height: 100%; }
-  body { padding: 24px 22px 28px; overflow-y: auto; font-size: 13px; }
+  /* No padding on body: the strip's offset would replace it, not add to it,
+     leaving the first element flush against the bar. The padding lives on
+     .pagebody, which is also the scroll container so its scrollbar starts
+     below the strip — and which PageBodyJS keeps scrollable by keyboard. */
+  body { padding: 0; overflow: hidden; font-size: 13px; }
+  .pagebody { height: 100%; overflow-y: auto; padding: 24px 22px 28px; }
   h1 { font-size: 19px; font-weight: 650; letter-spacing: -.01em; margin: 0 0 3px; }
   .sub { font-size: 12px; color: var(--ink3); margin: 0 0 18px; }
   .sec { font-family: var(--mono); font-size: 10px; letter-spacing: .1em; text-transform: uppercase; color: var(--ink3); margin: 20px 4px 8px; }
@@ -259,9 +267,11 @@ const settingsWindowHTML = `<!doctype html>
   .unit { font-size: 12px; color: var(--ink3); }
   #prefMsg { font-size: 11.5px; min-height: 16px; padding: 2px 16px 12px; color: var(--ink3); }
   #prefMsg.err { color: var(--listen-tx); }
+` + brandTitlebarCSS + `
 </style>
 </head>
-<body>
+<body>` + brandTitlebarHTML + `
+<div class="pagebody" tabindex="-1">
   <h1>Sidecar Settings</h1>
   <p class="sub">Connection, enrollment, and how the pebble behaves on this machine.</p>
 
@@ -316,6 +326,7 @@ const settingsWindowHTML = `<!doctype html>
     </div>
   </div>
 
+</div>
 <script>
   var dot = document.getElementById('dot');
   var statusText = document.getElementById('statusText');
@@ -452,6 +463,7 @@ const settingsWindowHTML = `<!doctype html>
   }
 
   init();
+` + brandTitlebarJS + brandPageBodyJS + `
 </script>
 </body>
 </html>`

--- a/sidecar/setup_onboarding.go
+++ b/sidecar/setup_onboarding.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/jarvis/sidecar/internal/autostart"
 	"github.com/jarvis/sidecar/internal/webviewui"
+	"github.com/jarvis/sidecar/internal/winchrome"
 )
 
 // setupPermState is the wizard's poll snapshot (JSON via webview binding).
@@ -72,7 +73,7 @@ func runOnboarding(cfg *SidecarConfig) {
 		}
 	}()
 
-	if !webviewui.RunWindow("Welcome to JARVIS", 520, 620, webview.HintNone, func(w webview.WebView) {
+	if !webviewui.RunWindow("Welcome to JARVIS", 520, 620, webview.HintNone, winchrome.CustomTitleBar, func(w webview.WebView) {
 
 		_ = w.Bind("getPermissions", func() setupPermState {
 			permMu.Lock()
@@ -141,10 +142,16 @@ const onboardingWindowHTML = `<!doctype html>
 <html>
 <head>
 <meta charset="utf-8">
+<title>Welcome to JARVIS</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <style>` + brandTokensCSS + brandPebbleCSS + `
   html, body { height: 100%; }
-  body { padding: 26px 22px 24px; overflow-y: auto; font-size: 13px; }
+  /* No padding on body: the strip's offset would replace it, not add to it,
+     leaving the first element flush against the bar. The padding lives on
+     .pagebody, which is also the scroll container so its scrollbar starts
+     below the strip — and which PageBodyJS keeps scrollable by keyboard. */
+  body { padding: 0; overflow: hidden; font-size: 13px; }
+  .pagebody { height: 100%; overflow-y: auto; padding: 26px 22px 24px; }
   .hero { display: flex; align-items: center; gap: 14px; margin-bottom: 4px; }
   .hero .bdrop { width: 34px; height: 34px; flex: 0 0 auto; }
   h1 { font-size: 19px; font-weight: 650; letter-spacing: -.01em; margin: 0; }
@@ -175,9 +182,11 @@ const onboardingWindowHTML = `<!doctype html>
   .foot { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin-top: 20px; }
   .msg { font-size: 11.5px; min-height: 16px; flex: 1; color: var(--ink3); }
   .msg.err { color: var(--listen-tx); }
+` + brandTitlebarCSS + `
 </style>
 </head>
-<body>
+<body>` + brandTitlebarHTML + `
+<div class="pagebody" tabindex="-1">
   <div class="hero">
     <span class="bdrop" id="pebble"><span class="in"></span><span class="ring"></span></span>
     <h1>Welcome to <span class="word"><span class="u">use</span>jarvis</span></h1>
@@ -217,6 +226,7 @@ const onboardingWindowHTML = `<!doctype html>
     <button class="sbtn pri" id="finishBtn" onclick="finish()">Finish setup</button>
   </div>
 
+</div>
 <script>
   var rows = ['notifications', 'microphone', 'screen', 'accessibility'];
 
@@ -281,6 +291,7 @@ const onboardingWindowHTML = `<!doctype html>
   }
 
   init();
+` + brandTitlebarJS + brandPageBodyJS + `
 </script>
 </body>
 </html>`

--- a/sidecar/setup_onboarding.go
+++ b/sidecar/setup_onboarding.go
@@ -185,7 +185,7 @@ const onboardingWindowHTML = `<!doctype html>
 ` + brandTitlebarCSS + `
 </style>
 </head>
-<body>` + brandTitlebarHTML + `
+<body>
 <div class="pagebody" tabindex="-1">
   <div class="hero">
     <span class="bdrop" id="pebble"><span class="in"></span><span class="ring"></span></span>
@@ -226,7 +226,7 @@ const onboardingWindowHTML = `<!doctype html>
     <button class="sbtn pri" id="finishBtn" onclick="finish()">Finish setup</button>
   </div>
 
-</div>
+</div>` + brandTitlebarHTML + `
 <script>
   var rows = ['notifications', 'microphone', 'screen', 'accessibility'];
 

--- a/sidecar/setup_window.go
+++ b/sidecar/setup_window.go
@@ -82,7 +82,7 @@ const setupWindowHTML = `<!doctype html>
 ` + brandTitlebarCSS + `
 </style>
 </head>
-<body>` + brandTitlebarHTML + `
+<body>
 <div class="pagebody" tabindex="-1">
   <div class="bhead"><span class="word"><span class="u">use</span>jarvis</span></div>
   <div class="center">
@@ -102,7 +102,7 @@ const setupWindowHTML = `<!doctype html>
       </div>
     </div>
   </div>
-</div>
+</div>` + brandTitlebarHTML + `
 <script>
   var tok = document.getElementById('tok');
   var err = document.getElementById('err');

--- a/sidecar/setup_window.go
+++ b/sidecar/setup_window.go
@@ -26,10 +26,23 @@ const setupWindowHTML = `<!doctype html>
 <html>
 <head>
 <meta charset="utf-8">
+<title>JARVIS - Connect</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <style>` + brandTokensCSS + brandPebbleCSS + `
-  body { min-height: 100vh; display: flex; flex-direction: column; padding: 26px 30px; }
+  html, body { height: 100%; }
+  /* No padding on body: the strip's offset would replace it, not add to it.
+     .pagebody carries the padding and the centred column, and is the scroll
+     container so its scrollbar starts below the strip — PageBodyJS is what
+     keeps it scrollable by keyboard. */
+  body { padding: 0; overflow: hidden; }
+  .pagebody {
+    height: 100%; overflow-y: auto;
+    display: flex; flex-direction: column; padding: 26px 30px;
+  }
   .bhead .word { font-size: 16px; }
+  /* Under custom chrome the strip already carries the mark and the window
+     name; a wordmark directly beneath it reads as a doubled header. */
+  html[data-chrome="custom"] .bhead { display: none; }
   .center { flex: 1; display: flex; align-items: center; justify-content: center; }
   .formbox {
     width: 100%; max-width: 440px; padding: 24px 24px 20px;
@@ -66,9 +79,11 @@ const setupWindowHTML = `<!doctype html>
   button:not(:disabled):hover { filter: brightness(1.08); }
   button:focus-visible { outline: 2px solid var(--ink2); outline-offset: 2px; }
   button:disabled { opacity: 0.5; cursor: default; }
+` + brandTitlebarCSS + `
 </style>
 </head>
-<body>
+<body>` + brandTitlebarHTML + `
+<div class="pagebody" tabindex="-1">
   <div class="bhead"><span class="word"><span class="u">use</span>jarvis</span></div>
   <div class="center">
     <div class="formbox">
@@ -87,6 +102,7 @@ const setupWindowHTML = `<!doctype html>
       </div>
     </div>
   </div>
+</div>
 <script>
   var tok = document.getElementById('tok');
   var err = document.getElementById('err');
@@ -119,6 +135,7 @@ const setupWindowHTML = `<!doctype html>
     if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') { e.preventDefault(); submit(); }
   });
   tok.focus();
+` + brandTitlebarJS + brandPageBodyJS + `
 </script>
 </body>
 </html>`

--- a/sidecar/titlebar_gesture_test.go
+++ b/sidecar/titlebar_gesture_test.go
@@ -11,16 +11,25 @@ package main
 // drives real PointerEvents through Chromium, and reads back what the page
 // would have asked the window to do.
 //
-// Skips when no Chromium is installed, so it costs a CI runner nothing.
+// OPT-IN: set JARVIS_BROWSER_TESTS=1 to run it, the same shape of gate as the
+// page dump's JARVIS_PAGE_DUMP_DIR. It is not in the default suite because a
+// headless browser is not a dependency this suite can rely on: on a CI runner
+// Chrome was found, launched, and then never exited, taking the whole package
+// to its 10-minute timeout. The hard timeout below means the worst case is now
+// a failed test rather than a wedged suite, but the gate is what keeps a
+// browser out of CI entirely.
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 )
 
 // gestureDriver stubs the window-control bindings, then plays each scenario and
@@ -147,6 +156,9 @@ type gestureResults struct {
 }
 
 func TestTitlebarGesture(t *testing.T) {
+	if os.Getenv("JARVIS_BROWSER_TESTS") == "" {
+		t.Skip("set JARVIS_BROWSER_TESTS=1 to drive the title bar in a real browser")
+	}
 	chrome := findChromium()
 	if chrome == "" {
 		t.Skip("no chromium/chrome on PATH — the gesture machine is browser-driven")
@@ -160,14 +172,26 @@ func TestTitlebarGesture(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	out, err := exec.Command(chrome,
+	// The driver needs a few seconds of virtual time; anything beyond this is a
+	// browser that is not going to finish, and it must not become the suite's
+	// problem.
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, chrome,
 		"--headless=new", "--disable-gpu", "--no-sandbox",
+		"--disable-dev-shm-usage", "--no-first-run", "--disable-extensions",
 		"--user-data-dir="+filepath.Join(dir, "profile"),
 		"--virtual-time-budget=8000", "--window-size=520,560",
 		"--dump-dom", "file://"+path,
-	).Output()
+	)
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		t.Fatalf("%s never exited within 90s; stderr:\n%s", chrome, stderr.String())
+	}
 	if err != nil {
-		t.Fatalf("chromium: %v", err)
+		t.Fatalf("%s: %v; stderr:\n%s", chrome, err, stderr.String())
 	}
 	m := gestureProbe.FindSubmatch(out)
 	if m == nil {

--- a/sidecar/titlebar_gesture_test.go
+++ b/sidecar/titlebar_gesture_test.go
@@ -1,0 +1,218 @@
+package main
+
+// The title bar's gesture machine, driven in a real browser engine.
+//
+// TitlebarJS is the riskiest code in the custom-chrome feature and the only
+// part with no Go surface to test: it decides, from a stream of pointer events,
+// whether the user meant a click, a drag, or a double-click, and a wrong answer
+// is a window that maximizes when it should move or sticks to the cursor. The
+// Win32 half (the modal move loop itself) needs Windows, but everything above
+// the bindings is ordinary DOM behaviour — so this stubs the five bindings,
+// drives real PointerEvents through Chromium, and reads back what the page
+// would have asked the window to do.
+//
+// Skips when no Chromium is installed, so it costs a CI runner nothing.
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// gestureDriver stubs the window-control bindings, then plays each scenario and
+// records which bindings the page called. Appended after TitlebarJS so the
+// listeners it installs are already live.
+const gestureDriver = `
+<script>
+(async function () {
+  var calls = [];
+  var maximized = false;
+  var stub = function (name, fn) {
+    window['__jarvis_chrome_' + name] = function () {
+      calls.push(name);
+      return Promise.resolve(fn ? fn() : undefined);
+    };
+  };
+  stub('drag');
+  stub('minimize');
+  stub('close');
+  stub('sysmenu');
+  stub('is_maximized', function () { return maximized; });
+  stub('toggle_maximize', function () { maximized = !maximized; return maximized; });
+
+  var bar = document.getElementById('wchrome-drag');
+  var wait = function (ms) { return new Promise(function (r) { setTimeout(r, ms); }); };
+  var at = function (type, x, y, buttons) {
+    var e = new PointerEvent(type, {
+      bubbles: true, cancelable: true, button: 0,
+      buttons: buttons === undefined ? 1 : buttons,
+      clientX: x, clientY: y, screenX: x, screenY: y, pointerType: 'mouse'
+    });
+    (type === 'pointerdown' ? bar : window).dispatchEvent(e);
+  };
+
+  var results = {};
+  var since = function () { return calls.length; };
+  var taken = function (n) { return calls.slice(n); };
+
+  // A press and release that never moved is a click, not a drag.
+  var n = since();
+  at('pointerdown', 60, 17); at('pointermove', 62, 18); at('pointerup', 62, 18, 0);
+  results.click = taken(n);
+
+  // Past the threshold, with the button still down, it is a drag -- once.
+  await wait(600);
+  n = since();
+  at('pointerdown', 60, 17); at('pointermove', 90, 17); at('pointermove', 140, 17);
+  at('pointerup', 140, 17, 0);
+  await wait(0);
+  results.drag = taken(n);
+
+  // Dropping and grabbing again straight away must NOT read as a double-click.
+  n = since();
+  at('pointerdown', 141, 17); at('pointerup', 141, 17, 0);
+  results.regrabAfterDrag = taken(n);
+
+  // Two presses in the same place, inside the double-click window, maximize.
+  await wait(600);
+  n = since();
+  at('pointerdown', 200, 17); at('pointerup', 200, 17, 0);
+  await wait(40);
+  at('pointerdown', 202, 17); at('pointerup', 202, 17, 0);
+  results.doubleClick = taken(n);
+  results.maximizedAfterDoubleClick = maximized;
+
+  // ... and again to restore.
+  await wait(600);
+  n = since();
+  at('pointerdown', 200, 17); at('pointerup', 200, 17, 0);
+  await wait(40);
+  at('pointerdown', 200, 17); at('pointerup', 200, 17, 0);
+  results.restore = taken(n);
+  results.maximizedAfterRestore = maximized;
+
+  // Two presses far apart in time are two clicks, not a double-click.
+  await wait(900);
+  n = since();
+  at('pointerdown', 300, 17); at('pointerup', 300, 17, 0);
+  await wait(700);
+  at('pointerdown', 300, 17); at('pointerup', 300, 17, 0);
+  results.slowClicks = taken(n);
+
+  // A press whose release was missed (released outside the window) must not
+  // start a drag on the next stray move.
+  await wait(600);
+  n = since();
+  at('pointerdown', 400, 17);
+  at('pointermove', 460, 17, 0); // button already up
+  results.lostRelease = taken(n);
+  at('pointerup', 460, 17, 0);
+
+  // The controls are not part of the drag region.
+  await wait(600);
+  n = since();
+  document.getElementById('wchrome-min').click();
+  document.getElementById('wchrome-close').click();
+  results.controls = taken(n);
+
+  // Right-click anywhere on the caption opens the system menu.
+  n = since();
+  document.getElementById('wchrome').dispatchEvent(
+    new MouseEvent('contextmenu', { bubbles: true, cancelable: true }));
+  results.contextMenu = taken(n);
+
+  document.body.setAttribute('data-gesture', JSON.stringify(results));
+})();
+</script>
+`
+
+var gestureProbe = regexp.MustCompile(`data-gesture="([^"]*)"`)
+
+type gestureResults struct {
+	Click                     []string `json:"click"`
+	Drag                      []string `json:"drag"`
+	RegrabAfterDrag           []string `json:"regrabAfterDrag"`
+	DoubleClick               []string `json:"doubleClick"`
+	MaximizedAfterDoubleClick bool     `json:"maximizedAfterDoubleClick"`
+	Restore                   []string `json:"restore"`
+	MaximizedAfterRestore     bool     `json:"maximizedAfterRestore"`
+	SlowClicks                []string `json:"slowClicks"`
+	LostRelease               []string `json:"lostRelease"`
+	Controls                  []string `json:"controls"`
+	ContextMenu               []string `json:"contextMenu"`
+}
+
+func TestTitlebarGesture(t *testing.T) {
+	chrome := findChromium()
+	if chrome == "" {
+		t.Skip("no chromium/chrome on PATH — the gesture machine is browser-driven")
+	}
+
+	page := withCustomChrome(t, "settings", settingsWindowHTML)
+	page = strings.Replace(page, "</body>", gestureDriver+"</body>", 1)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "gesture.html")
+	if err := os.WriteFile(path, []byte(page), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := exec.Command(chrome,
+		"--headless=new", "--disable-gpu", "--no-sandbox",
+		"--user-data-dir="+filepath.Join(dir, "profile"),
+		"--virtual-time-budget=8000", "--window-size=520,560",
+		"--dump-dom", "file://"+path,
+	).Output()
+	if err != nil {
+		t.Fatalf("chromium: %v", err)
+	}
+	m := gestureProbe.FindSubmatch(out)
+	if m == nil {
+		t.Fatal("the driver never reported — TitlebarJS or the harness threw before finishing")
+	}
+	var got gestureResults
+	if err := json.Unmarshal([]byte(strings.ReplaceAll(string(m[1]), "&quot;", `"`)), &got); err != nil {
+		t.Fatalf("probe: %v", err)
+	}
+
+	eq := func(name string, got []string, want ...string) {
+		t.Helper()
+		if strings.Join(got, ",") != strings.Join(want, ",") {
+			t.Errorf("%s: called %v, want %v", name, got, want)
+		}
+	}
+	// A click must not move the window: entering the modal move loop on a
+	// press that never moved is what glues a window to the cursor.
+	eq("plain click", got.Click)
+	// Exactly one drag per gesture, however many moves it takes — followed by a
+	// state re-read, because dropping a maximized window restores it and the
+	// page's glyph has to follow.
+	eq("drag", got.Drag, "drag", "is_maximized")
+	// The press that ended a drag must not pair with the next one.
+	eq("regrab after drag", got.RegrabAfterDrag)
+	eq("double-click", got.DoubleClick, "toggle_maximize")
+	if !got.MaximizedAfterDoubleClick {
+		t.Error("double-click did not maximize")
+	}
+	eq("double-click again", got.Restore, "toggle_maximize")
+	if got.MaximizedAfterRestore {
+		t.Error("the second double-click did not restore")
+	}
+	// Two deliberate clicks are two clicks.
+	eq("slow clicks", got.SlowClicks)
+	eq("press whose release was lost", got.LostRelease)
+	eq("window controls", got.Controls, "minimize", "close")
+	eq("right-click", got.ContextMenu, "sysmenu")
+}
+
+func findChromium() string {
+	for _, name := range []string{"chromium", "chromium-browser", "google-chrome", "google-chrome-stable"} {
+		if p, err := exec.LookPath(name); err == nil {
+			return p
+		}
+	}
+	return ""
+}

--- a/sidecar/titlebar_pages_test.go
+++ b/sidecar/titlebar_pages_test.go
@@ -12,9 +12,12 @@ import (
 )
 
 // customChromePages are the local pages that draw their own title bar on
-// Windows, keyed by the name the QA dump uses. Every window built from one of
-// these passes winchrome.CustomTitleBar; brand_pages_dump_test.go dumps a
-// chromed variant of exactly this set, so the two cannot drift.
+// Windows, keyed by the name the QA dump uses. Their windows get there two
+// ways: settings, logs and onboarding pass winchrome.CustomTitleBar to their
+// window host, while hosted and setup are shown by runFirstRunWindow, which
+// builds its webview itself and calls winchrome.Install directly.
+// brand_pages_dump_test.go dumps a chromed variant of exactly this set, so the
+// two cannot drift.
 var customChromePages = map[string]string{
 	"settings":   settingsWindowHTML,
 	"logs":       logViewerHTML,

--- a/sidecar/titlebar_pages_test.go
+++ b/sidecar/titlebar_pages_test.go
@@ -1,0 +1,111 @@
+package main
+
+// The splice, not the strip. internal/brand tests what the title bar IS; these
+// test that the pages actually carry it — dropping one of the three pieces from
+// a page compiles, passes every other test, and ships a Windows window with no
+// title bar at all (or one whose buttons do nothing).
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// customChromePages are the local pages that draw their own title bar on
+// Windows, keyed by the name the QA dump uses. Every window built from one of
+// these passes winchrome.CustomTitleBar; brand_pages_dump_test.go dumps a
+// chromed variant of exactly this set, so the two cannot drift.
+var customChromePages = map[string]string{
+	"settings":   settingsWindowHTML,
+	"logs":       logViewerHTML,
+	"hosted":     hostedShellHTML,
+	"setup":      setupWindowHTML,
+	"onboarding": onboardingWindowHTML,
+}
+
+// wrappedPages are the chromed pages that scroll an inner .pagebody. Logs is
+// the exception: its body is a flex column that never scrolls (its <pre> does),
+// and it was already designed flush to the window edge.
+var wrappedPages = []string{"settings", "hosted", "setup", "onboarding"}
+
+func TestCustomChromePagesCarryTheWholeTitlebar(t *testing.T) {
+	for name, html := range customChromePages {
+		if !strings.Contains(html, brandTitlebarHTML) {
+			t.Errorf("%s: no title bar markup — the window would have no title bar at all on Windows", name)
+		}
+		if !strings.Contains(html, brandTitlebarCSS) {
+			t.Errorf("%s: no title bar CSS — the strip would render unstyled", name)
+		}
+		if !strings.Contains(html, brandTitlebarJS) {
+			t.Errorf("%s: no title bar script — the window controls would be dead", name)
+		}
+		// The strip renders document.title; without one it shows an empty
+		// caption where the window's name belongs.
+		if !strings.Contains(html, "<title>") {
+			t.Errorf("%s: no <title> for the strip to show", name)
+		}
+	}
+}
+
+// The account window shows a remote origin end to end, so it must never get
+// custom chrome: the bindings that move, minimise and close the window would
+// be reachable from that page. account_window.go passes NativeTitleBar; this
+// pins the other half of that decision.
+func TestRemotePagesHaveNoTitlebar(t *testing.T) {
+	if strings.Contains(accountShellHTML, brandTitlebarHTML) {
+		t.Error("the account shell carries the title bar; that window shows remote content and must stay natively framed")
+	}
+}
+
+// bodyRule matches a real `body { … }` rule. The leading boundary is what stops
+// it matching inside `.pagebody {`.
+var bodyRule = regexp.MustCompile(`(?m)(^|[\s,])body\s*\{[^}]*\}`)
+
+// cssComment strips /* … */ before any rule is scanned: the title bar's own CSS
+// explains itself by quoting "body { padding: … }", and a test that reads prose
+// as code fails on the documentation instead of on the page.
+var cssComment = regexp.MustCompile(`(?s)/\*.*?\*/`)
+
+// Padding on body is REPLACED by the strip's offset, not added to it, which
+// leaves the page's first element flush against the bar. Whatever padding a
+// chromed page wants goes on .pagebody instead. Checked generically: pinning
+// the three literal declarations this replaced would pass again the moment
+// someone writes a fourth.
+func TestChromedPagesDoNotPadTheirBody(t *testing.T) {
+	pad := regexp.MustCompile(`padding[^:;{}]*:\s*([^;}]+)`)
+	for name, html := range customChromePages {
+		// The strip's own CSS is not under test here — it is the thing whose
+		// body offset the page must not fight — so scan the page's rules only.
+		page := cssComment.ReplaceAllString(strings.Replace(html, brandTitlebarCSS, "", 1), "")
+		for _, rule := range bodyRule.FindAllString(page, -1) {
+			for _, m := range pad.FindAllStringSubmatch(rule, -1) {
+				if strings.TrimSpace(m[1]) != "0" {
+					t.Errorf("%s: body sets %q — the strip offset will replace that, not add to it\n  in: %s",
+						name, strings.TrimSpace(m[0]), strings.TrimSpace(rule))
+				}
+			}
+		}
+	}
+}
+
+// The wrapper is the scroll container, so its scrollbar starts below the strip
+// instead of running behind it — and because a div takes no focus of its own,
+// the page must carry PageBodyJS or the window becomes unscrollable for anyone
+// without a mouse.
+func TestWrappedPagesCarryTheScrollContainerAndItsKeyboard(t *testing.T) {
+	for _, name := range wrappedPages {
+		html, ok := customChromePages[name]
+		if !ok {
+			t.Fatalf("%s is not one of the chromed pages", name)
+		}
+		if !strings.Contains(html, `<div class="pagebody" tabindex="-1">`) {
+			t.Errorf("%s: no focusable .pagebody scroll container", name)
+		}
+		if !strings.Contains(html, "overflow-y: auto") {
+			t.Errorf("%s: .pagebody does not scroll", name)
+		}
+		if !strings.Contains(html, brandPageBodyJS) {
+			t.Errorf("%s: no PageBodyJS — Space/PageDown would not scroll the window", name)
+		}
+	}
+}


### PR DESCRIPTION
The sidecar's local webview windows wore the classic Windows title bar. They now
draw their own, in the same Monochrome Lab language as the pages themselves.

## Approach

`internal/winchrome` removes **only `WS_CAPTION`**. The window keeps its
overlapped frame, so resize borders, Aero Snap, maximize geometry,
minimize/restore, the taskbar entry and Alt+Space all stay native, and no window
procedure is subclassed — the vendored webview keeps owning its own. The page
moves the window through a binding rather than CSS: the WebView2 child HWND
covers the client area and swallows the mouse, so `app-region: drag` does
nothing and the drag is a `ReleaseCapture` + `WM_NCLBUTTONDOWN`/`HTCAPTION`
handshake instead.

The strip itself is shared markup in `internal/brand/titlebar.go`, rendered only
when `winchrome.Install` has stamped `<html data-chrome="custom">` — so the same
pages keep their native title bar on macOS and Linux with no per-platform
branching in the page.

## Scope

Custom chrome: settings, logs, the first-run connect window and its self-host
token form, and the onboarding slideshow.

Natively framed, deliberately: the **account window** (remote origin end to end —
these bindings move, minimize and close the window, and `account_window.go`
documents that no bindings may reach remote content), the dashboard panels, and
the installer wizard.

## Notes on the pages

Each chromed page moves its padding onto an inner `.pagebody` wrapper: the
strip's body offset replaces body padding rather than adding to it, and the
wrapper is also the scroll container so its scrollbar starts below the strip
instead of running behind it. `brand.PageBodyJS` keeps Space/PageDown/Home/End
scrolling that wrapper, which a bare div would otherwise ignore.

## Testing

- Manually verified on Windows against the checklist added to `sidecar/README.md`
  (drag, snap, maximize vs. the taskbar, double-click, the controls, resize,
  scrolling, drop behaviour).
- `TestTitlebarGesture` drives real PointerEvents through headless Chromium with
  the five bindings stubbed: a click never drags, one drag per gesture,
  drag-then-regrab is not a double-click, a lost mouseup starts nothing. Skips
  when no Chrome/Chromium is on PATH — note it will *run* on the Linux CI runner,
  which ships one.
- Unit tests for the style math, the marker/gating contract, and the page splices;
  `JARVIS_PAGE_DUMP_DIR=… go test -run TestDumpBrandPages .` now also dumps
  `chrome-*.html` variants for visual QA off Windows.
- Windows cross-build (sidecar + installer), `go vet`, full suite green.

## Known limitations

- The Win11 Snap Layouts flyout does not appear on the page's maximize button: it
  needs `WM_NCHITTEST` to answer `HTMAXBUTTON`, which requires the window
  procedure this approach deliberately does not own. Win+Z and edge-snap work.
- The local-content-only invariant rests on call-site discipline plus a test. The
  marker script refuses navigating drops as a guard, but the real fix is refusing
  foreign origins in the engine (`NavigationStarting`, or `AllowExternalDrop`),
  which means a change to the vendored webview and its patch file. Worth a
  follow-up.
