### PR TITLE
fix(installer): give the wizard the sidecar's Windows title bar and drop the version display

### DIFF
--- a/sidecar/README.md
+++ b/sidecar/README.md
@@ -163,8 +163,8 @@ why CI compiles all three targets rather than trusting a Linux build.
 ### Custom window chrome (Windows)
 
 The local webview windows — settings, logs, the first-run connect window and
-its token form, the onboarding slideshow — draw their own title bar on
-Windows instead of wearing the system one. `internal/winchrome` removes
+its token form, the onboarding slideshow, and the installer's wizard — draw
+their own title bar on Windows instead of wearing the system one. `internal/winchrome` removes
 `WS_CAPTION` from the HWND and nothing else: the window keeps its overlapped
 frame, so resize borders, Aero Snap, the maximized rect, minimize/restore and
 the taskbar entry all stay native, and no window procedure is subclassed. The
@@ -188,6 +188,24 @@ To eyeball the pages without a Windows machine:
 ```sh
 JARVIS_PAGE_DUMP_DIR=/tmp/pages go test -run TestDumpBrandPages .
 # then open /tmp/pages/chrome-*.html (and dark-chrome-*.html)
+```
+
+The installer is its own package and dumps separately — one file per wizard
+STATE (the plan screen alone has four), with the bindings stubbed, since the
+whole visible output of that window is a single status panel:
+
+```sh
+JARVIS_PAGE_DUMP_DIR=/tmp/wizard go test -run TestDumpWizardPage ./installer/
+```
+
+The same states are asserted rather than eyeballed by
+`TestWizardPanelSaysWhatIsOnTheMachine`, which renders the wizard through
+headless Chromium and reads the status row, subtitle and button back out of
+the DOM — the panel is fed from a snapshot, so what it SAYS is not something
+the Go tests can see:
+
+```sh
+JARVIS_BROWSER_TESTS=1 go test -run TestWizardPanel ./installer/
 ```
 
 `TestTitlebarGesture` covers the half of the interaction layer that is just

--- a/sidecar/installer/flow.go
+++ b/sidecar/installer/flow.go
@@ -87,7 +87,10 @@ func performInstall(registryURL string, silent bool, progress progressFn) instal
 	}
 	defer os.RemoveAll(workDir)
 
-	progress("download", fmt.Sprintf("Downloading sidecar %s…", rel.Version))
+	// No version in the detail line: it is what the wizard's stage row shows,
+	// and that row is not the place for a number the user did not pick. The
+	// console path still names the resolved version on its final line.
+	progress("download", "Downloading the latest sidecar…")
 	tgz, err := downloadTarball(rel, workDir)
 	if err != nil {
 		return fail(exitNetwork, err)

--- a/sidecar/installer/wizard.go
+++ b/sidecar/installer/wizard.go
@@ -22,19 +22,66 @@ func guiSupported() bool {
 }
 
 // wizardState is the page's poll snapshot.
+//
+// No version numbers cross into the page, by design. This installer only ever
+// fetches the `latest` dist-tag, so the version is not something the user
+// chooses or can act on — two hex-ish numbers to compare are a decision they
+// were never given. What they need to know is the state: whether a sidecar is
+// on this machine, and whether an update is waiting.
 type wizardState struct {
-	Phase        string `json:"phase"` // "resolving" | "plan" | "running" | "done" | "failed"
-	Stage        string `json:"stage"`
-	Detail       string `json:"detail"`
-	Error        string `json:"error"`
-	Installed    string `json:"installed_version"`
-	Latest       string `json:"latest_version"`
+	Phase  string `json:"phase"` // "resolving" | "plan" | "running" | "done" | "failed"
+	Stage  string `json:"stage"`
+	Detail string `json:"detail"`
+	Error  string `json:"error"`
+	// Detected says a plan actually inspected this machine. Without it the
+	// page cannot tell "no sidecar here" from "we never got to look" — and a
+	// registry failure would have it report "Not installed" to someone whose
+	// sidecar is sitting right there.
+	Detected  bool `json:"detected"`
+	Installed bool `json:"installed"`
+	// NpmManaged/UpToDate/FirstInstall describe the machine, not a release.
+	// FirstInstall keeps its plan-time meaning after the install completes —
+	// "this run was the first one" — which is what the macOS done screen and
+	// the autostart row are asking about.
 	NpmManaged   bool   `json:"npm_managed"`
 	UpToDate     bool   `json:"up_to_date"`
 	FirstInstall bool   `json:"first_install"`
 	Platform     string `json:"platform"`
 	// AutostartDefault seeds the wizard's checkbox (--no-autostart clears it).
 	AutostartDefault bool `json:"autostart_default"`
+}
+
+// applyPlan folds what detection found into the page's state. Pure, and split
+// out of the plan goroutine so the mapping from "what is on this machine" to
+// "what the panel says" is testable without a registry or a window.
+func applyPlan(s *wizardState, inst installedSidecar, latestVersion string) {
+	s.Phase = "plan"
+	s.Detected = true
+	s.Installed = inst.Version != ""
+	s.NpmManaged = inst.ManagedByNpm
+	s.UpToDate = inst.Version != "" && !versionLess(inst.Version, latestVersion)
+	// Updates must not re-apply autostart: the user's own choice is
+	// authoritative once installed.
+	s.FirstInstall = inst.Version == ""
+}
+
+// applyOutcome folds a finished install into the page's state.
+//
+// Installed = true is the point of it: the panel is fed from the PLAN
+// snapshot, so a first install that succeeded went on reporting "not
+// installed" on its own done screen until the state said otherwise.
+func applyOutcome(s *wizardState, out installOutcome) {
+	s.Phase = "done"
+	s.Detected = true
+	// The stage line is progress, and there is none left. Kept on the failed
+	// path (it says which step died, which is worth having beside the error);
+	// here it would leave "Installing to C:\…—" sitting under "Installed".
+	s.Stage, s.Detail = "", ""
+	// True on every path that gets here: we installed it, npm already had, or
+	// it was current to begin with.
+	s.Installed = true
+	s.NpmManaged = out.NpmManaged
+	s.UpToDate = out.UpToDate
 }
 
 func runWizard(registryURL string, noLaunch, autostartDefault bool) int {
@@ -73,10 +120,14 @@ func runWizard(registryURL string, noLaunch, autostartDefault bool) int {
 		return st
 	}
 
-	// NativeTitleBar on purpose: this is the first window a user ever sees from
-	// this project, run before anything is installed, so it wears the system's
-	// chrome rather than asking for trust with a title bar of our own.
-	opened := webviewui.RunWindow("Install Jarvis", 480, 560, webview.HintNone, winchrome.NativeTitleBar, func(w webview.WebView) {
+	// The same title bar the sidecar's own local windows draw (internal/brand +
+	// internal/winchrome, Windows-only; native everywhere else). This window is
+	// the first thing a user ever sees from the project, so it is the last one
+	// that should look like it belongs to a different product than the app it
+	// installs. Safe here for the same reason it is safe there: the page is
+	// local HTML compiled into this binary, and the window controls it binds
+	// are never reachable by a remote document.
+	opened := webviewui.RunWindow("Install Jarvis", 480, 560, webview.HintNone, winchrome.CustomTitleBar, func(w webview.WebView) {
 
 		// startPlan resolves versions on a goroutine. Bindings run ON the UI
 		// thread, so doing the (up to 60s) registry fetch inline would block
@@ -97,7 +148,7 @@ func runWizard(registryURL string, noLaunch, autostartDefault bool) int {
 				rel, err := fetchLatestRelease(registryURL)
 				if err != nil {
 					set(func(s *wizardState) {
-						if gen != planGen {
+						if gen != planGen || started {
 							return
 						}
 						s.Phase = "failed"
@@ -105,25 +156,33 @@ func runWizard(registryURL string, noLaunch, autostartDefault bool) int {
 					})
 					return
 				}
+				// A superseded (or overtaken-by-install) goroutine must not
+				// clobber the current phase — otherwise a double Retry can
+				// bounce a running install back to the plan screen.
+				stale := func(s *wizardState) bool { return gen != planGen || started }
+
 				inst, ierr := detectInstalled()
+				if ierr != nil {
+					// Fail rather than plan. A plan we could not verify has
+					// nothing honest to put in the panel — the page would
+					// have to either claim "not installed" or admit it is
+					// still checking, next to a live Install button — and
+					// performInstall would refuse this machine anyway
+					// (flow.go returns exitOther on the same error).
+					set(func(s *wizardState) {
+						if stale(s) {
+							return
+						}
+						s.Phase = "failed"
+						s.Error = fmt.Sprintf("could not inspect the existing installation: %v", ierr)
+					})
+					return
+				}
 				set(func(s *wizardState) {
-					// A superseded (or overtaken-by-install) goroutine must
-					// not clobber the current phase — otherwise a double
-					// Retry can bounce a running install back to the plan
-					// screen.
-					if gen != planGen || started {
+					if stale(s) {
 						return
 					}
-					s.Phase = "plan"
-					s.Latest = rel.Version
-					if ierr == nil {
-						s.Installed = inst.Version
-						s.NpmManaged = inst.ManagedByNpm
-						s.UpToDate = inst.Version != "" && !versionLess(inst.Version, rel.Version)
-						// Updates must not re-apply autostart: the user's own
-						// choice is authoritative once installed.
-						s.FirstInstall = inst.Version == ""
-					}
+					applyPlan(s, inst, rel.Version)
 				})
 			}()
 		}
@@ -188,14 +247,7 @@ func runWizard(registryURL string, noLaunch, autostartDefault bool) int {
 				mu.Lock()
 				exitCode = exitOK
 				mu.Unlock()
-				set(func(s *wizardState) {
-					s.Phase = "done"
-					s.NpmManaged = res.NpmManaged
-					s.UpToDate = res.UpToDate
-					if res.Rel != nil {
-						s.Latest = res.Rel.Version
-					}
-				})
+				set(func(s *wizardState) { applyOutcome(s, res) })
 			}()
 		})
 
@@ -237,8 +289,9 @@ func runWizard(registryURL string, noLaunch, autostartDefault bool) int {
 		return runInstall(registryURL, false, noLaunch, autostartDefault)
 	}
 
-	// The window can be closed with its native close button at any time,
-	// including mid-install (the JS only disables our own Cancel button).
+	// The window can be closed at any time — the native X on macOS, the strip's
+	// own close button on Windows — including mid-install, since the JS
+	// disables Cancel but never the window controls.
 	// Returning here would os.Exit the process — potentially between the two
 	// renames of the binary swap, leaving the machine with a .old and no
 	// installed binary — so let the install finish first.
@@ -258,10 +311,23 @@ const wizardHTML = `<!doctype html>
 <html>
 <head>
 <meta charset="utf-8">
+<title>Install Jarvis</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <style>` + brand.TokensCSS + brand.PebbleCSS + `
   html, body { height: 100%; }
-  body { padding: 30px 26px 24px; font-size: 13px; display: flex; flex-direction: column; }
+  /* No padding on body: under custom chrome the strip's offset REPLACES it,
+     which would leave the hero flush against the bar. The padding and the
+     column live on .pagebody, which is also the scroll container so its
+     scrollbar starts below the strip (PageBodyJS keeps it keyboard-scrollable
+     — a div takes no focus of its own). */
+  body { padding: 0; overflow: hidden; font-size: 13px; }
+  .pagebody {
+    height: 100%; overflow-y: auto;
+    padding: 30px 26px 24px; display: flex; flex-direction: column;
+  }
+  /* The strip already puts 34px of chrome above the hero; the full 30px on
+     top of that reads as a gap rather than as breathing room. */
+  html[data-chrome="custom"] .pagebody { padding-top: 20px; }
   .hero { display: flex; align-items: center; gap: 14px; }
   .hero .bdrop { width: 38px; height: 38px; flex: 0 0 auto; }
   h1 { font-size: 19px; font-weight: 650; letter-spacing: -.01em; margin: 0; }
@@ -288,18 +354,19 @@ const wizardHTML = `<!doctype html>
   .sbtn.pri:hover { filter: brightness(1.08); }
   .sbtn:disabled { opacity: .5; cursor: default; }
   .hidden { display: none !important; }
+` + brand.TitlebarCSS + `
 </style>
 </head>
 <body>
+<div class="pagebody" tabindex="-1">
   <div class="hero">
     <span class="bdrop" id="pebble"><span class="in"></span><span class="ring"></span></span>
     <h1><span class="word"><span class="u">use</span>jarvis</span> sidecar</h1>
   </div>
-  <p class="sub" id="subtitle">Checking versions…</p>
+  <p class="sub" id="subtitle">Checking for the latest sidecar…</p>
 
   <div class="panel">
-    <div class="kv"><span class="k">Installed</span><span class="v" id="vInstalled">…</span></div>
-    <div class="kv"><span class="k">Latest</span><span class="v" id="vLatest">…</span></div>
+    <div class="kv"><span class="k">Sidecar</span><span class="v" id="vStatus">…</span></div>
     <div class="stage" id="stage"></div>
     <div class="err hidden" id="error"></div>
   </div>
@@ -313,14 +380,41 @@ const wizardHTML = `<!doctype html>
     <button class="sbtn" id="btnCancel" onclick="window.closeInstaller(false)">Cancel</button>
     <button class="sbtn pri" id="btnMain" disabled>Install</button>
   </div>
+</div>` + brand.TitlebarHTML + `
 
 <script>
   var el = function (id) { return document.getElementById(id); };
   var autostartSeeded = false;
 
+  // The panel's one factual line. It says what this machine's sidecar IS, not
+  // which release it is pinned to: the installer always fetches the latest, so
+  // the version was never the user's decision to make.
+  //
+  // Every branch reads the CURRENT snapshot, which is why the done screen
+  // corrects itself — the plan said "Not installed", and the state that
+  // arrives with the finished install says otherwise.
+  function statusText(st) {
+    // Nothing was inspected yet (or the registry never answered): "Not
+    // installed" would be a claim we cannot make.
+    if (!st.detected) { return st.phase === 'failed' ? '—' : 'Checking…'; }
+    if (st.npm_managed) { return 'Managed by npm'; }
+    // Not "Installing…": the subtitle above already says that, and the stage
+    // line below says which part. What must NOT appear here mid-install is the
+    // plan's "Not installed" — true until the swap lands, and indistinguishable
+    // from the label having got stuck.
+    if (st.phase === 'running') { return 'In progress'; }
+    // "Updated", not "Installed", when the run replaced something: the button
+    // that started it said Update.
+    if (st.phase === 'done') {
+      if (st.up_to_date) { return 'Up to date'; }
+      return st.first_install ? 'Installed' : 'Updated';
+    }
+    if (!st.installed) { return 'Not installed'; }
+    return st.up_to_date ? 'Up to date' : 'Update available';
+  }
+
   function render(st) {
-    el('vInstalled').textContent = st.installed_version || 'not installed';
-    el('vLatest').textContent = st.latest_version || '…';
+    el('vStatus').textContent = statusText(st);
     el('stage').textContent = st.detail || '';
     el('error').classList.toggle('hidden', !st.error);
     el('error').textContent = st.error || '';
@@ -371,7 +465,7 @@ const wizardHTML = `<!doctype html>
         el('subtitle').textContent = st.up_to_date ? 'Already up to date.'
           : (st.platform === 'darwin' && st.first_install)
             ? 'Installed. Jarvis will now ask for its permissions.'
-            : 'Installed.';
+            : st.first_install ? 'Installed.' : 'Updated.';
         main.textContent = 'Launch Jarvis';
         main.onclick = function () { window.launchAndClose(); };
       }
@@ -389,10 +483,13 @@ const wizardHTML = `<!doctype html>
       main.textContent = 'Close';
       main.onclick = function () { window.closeInstaller(true); };
     } else {
-      el('subtitle').textContent = st.installed_version
-        ? 'An update is available.'
+      // The panel row is where "there is an update" is announced; saying it
+      // again here would leave the two lines of the screen agreeing with each
+      // other instead of telling the user two things.
+      el('subtitle').textContent = st.installed
+        ? 'This updates the Jarvis sidecar on this machine.'
         : 'This installs the Jarvis sidecar on this machine.';
-      main.textContent = st.installed_version ? 'Update' : 'Install';
+      main.textContent = st.installed ? 'Update' : 'Install';
       main.onclick = function () { window.startInstall(el('autostart').checked); };
     }
   }
@@ -405,5 +502,11 @@ const wizardHTML = `<!doctype html>
   window.startPlan();
   poll();
 </script>
+
+<!-- The chrome gets its own <script> on purpose. Everything above opens by
+     calling bindings, and a throw there would abort the rest of ITS block —
+     which, under custom chrome, is a window left with no title bar at all and
+     no native one to fall back on. A separate block still runs. -->
+<script>` + brand.TitlebarJS + brand.PageBodyJS + `</script>
 </body>
 </html>`

--- a/sidecar/installer/wizard_dump_test.go
+++ b/sidecar/installer/wizard_dump_test.go
@@ -1,0 +1,110 @@
+package main
+
+// Temporary helper, mirroring the sidecar's TestDumpBrandPages: dumps the
+// wizard to JARVIS_PAGE_DUMP_DIR for visual QA in a real browser. Not part of
+// the suite (skips without the env var).
+//
+// The wizard is a state machine whose whole visible output is one panel, so it
+// dumps one file per STATE rather than a single page (the plan phase alone has
+// four): "does the done screen still say Not installed?" is a question you
+// answer by looking at the done screen.
+//
+// For the same states asserted rather than eyeballed, see
+// TestWizardPanelSaysWhatIsOnTheMachine — it renders through `preview` too.
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// preview turns the compiled page into something a plain browser can render:
+// the bindings it polls are stubbed with a fixed snapshot, and chromed
+// variants get the marker winchrome.Install stamps on Windows.
+//
+// It fails rather than returning the page unchanged: a silent no-op would hand
+// visual QA a page that looks fine and proves nothing.
+func preview(t *testing.T, st wizardState, chromed bool) string {
+	t.Helper()
+	snap, err := json.Marshal(st)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stub := `<script>` +
+		`window.startPlan=function(){};window.retryPlan=function(){};` +
+		`window.startInstall=function(){};window.launchAndClose=function(){};` +
+		`window.closeInstaller=function(){};` +
+		`window.getProgress=function(){return Promise.resolve(` + string(snap) + `);};`
+	if chromed {
+		stub += `window.__jarvisCustomChrome=true;`
+	}
+	stub += `</script>`
+
+	html := wizardHTML
+	if chromed {
+		marked := strings.Replace(html, "<html>", `<html data-chrome="custom">`, 1)
+		if marked == html {
+			t.Fatal("no bare <html> tag to mark as custom-chromed")
+		}
+		html = marked
+	}
+	out := strings.Replace(html, "<body>", "<body>"+stub, 1)
+	if out == html {
+		t.Fatal("no bare <body> tag to inject the stubs into")
+	}
+	return out
+}
+
+func TestDumpWizardPage(t *testing.T) {
+	dir := os.Getenv("JARVIS_PAGE_DUMP_DIR")
+	if dir == "" {
+		t.Skip("set JARVIS_PAGE_DUMP_DIR to dump the wizard page")
+	}
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	// Windows throughout: it is the only platform with both the autostart row
+	// and the custom title bar.
+	base := wizardState{Platform: "windows", AutostartDefault: true}
+	with := func(fn func(*wizardState)) wizardState {
+		s := base
+		fn(&s)
+		return s
+	}
+	states := map[string]wizardState{
+		"resolving":    with(func(s *wizardState) { s.Phase = "resolving" }),
+		"plan-fresh":   with(func(s *wizardState) { s.Phase, s.Detected, s.FirstInstall = "plan", true, true }),
+		"plan-update":  with(func(s *wizardState) { s.Phase, s.Detected, s.Installed = "plan", true, true }),
+		"plan-current": with(func(s *wizardState) { s.Phase, s.Detected, s.Installed, s.UpToDate = "plan", true, true, true }),
+		"plan-npm":     with(func(s *wizardState) { s.Phase, s.Detected, s.Installed, s.NpmManaged = "plan", true, true, true }),
+		"running": with(func(s *wizardState) {
+			s.Phase, s.Detected, s.Detail = "running", true, "Verifying the payload (sha512 + code signature)…"
+		}),
+		"done": with(func(s *wizardState) { s.Phase, s.Detected, s.Installed, s.FirstInstall = "done", true, true, true }),
+		"failed": with(func(s *wizardState) {
+			s.Phase, s.Error = "failed", "could not reach the npm registry: dial tcp: lookup registry.npmjs.org: no such host"
+		}),
+	}
+
+	for name, st := range states {
+		for _, chromed := range []bool{false, true} {
+			file := name + ".html"
+			if chromed {
+				file = "chrome-" + file
+			}
+			html := preview(t, st, chromed)
+			if err := os.WriteFile(filepath.Join(dir, file), []byte(html), 0644); err != nil {
+				t.Fatal(err)
+			}
+			// Force the dark tokens AND dark UA form controls (color-scheme),
+			// so the switch and scrollbars match a real dark-OS window.
+			dark := strings.ReplaceAll(html, "@media (prefers-color-scheme: dark)", "@media all")
+			dark = strings.Replace(dark, "color-scheme: light dark", "color-scheme: dark", 1)
+			if err := os.WriteFile(filepath.Join(dir, "dark-"+file), []byte(dark), 0644); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+}

--- a/sidecar/installer/wizard_page_test.go
+++ b/sidecar/installer/wizard_page_test.go
@@ -1,0 +1,170 @@
+package main
+
+// The wizard is one page and one state struct, and both carry decisions that
+// compile fine when broken: a title bar spliced in three pieces (drop one and
+// Windows ships a window with no caption at all), and a status line fed from a
+// snapshot that a finished install has to correct.
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/jarvis/sidecar/internal/brand"
+)
+
+func TestWizardPageCarriesTheWholeTitlebar(t *testing.T) {
+	for name, piece := range map[string]string{
+		"markup": brand.TitlebarHTML,
+		"CSS":    brand.TitlebarCSS,
+		"script": brand.TitlebarJS,
+	} {
+		if !strings.Contains(wizardHTML, piece) {
+			t.Errorf("wizard page is missing the title bar %s — the Windows window would be broken chrome, not native chrome", name)
+		}
+	}
+	// The strip renders document.title; without one it shows an empty caption
+	// where the window's name belongs.
+	if !strings.Contains(wizardHTML, "<title>") {
+		t.Error("wizard page has no <title> for the strip to show")
+	}
+}
+
+// The wrapper is the scroll container, so its scrollbar starts below the strip
+// instead of running behind it — and because a div takes no focus of its own,
+// the page must carry PageBodyJS or the window is unscrollable without a mouse.
+func TestWizardPageWrapsItsScrollContainer(t *testing.T) {
+	if !strings.Contains(wizardHTML, `<div class="pagebody" tabindex="-1">`) {
+		t.Error("no focusable .pagebody scroll container")
+	}
+	if !strings.Contains(wizardHTML, "overflow-y: auto") {
+		t.Error(".pagebody does not scroll")
+	}
+	if !strings.Contains(wizardHTML, brand.PageBodyJS) {
+		t.Error("no PageBodyJS — Space/PageDown would not scroll the window")
+	}
+}
+
+var (
+	// bodyRule matches a real `body { … }` rule; the leading boundary is what
+	// stops it matching inside `.pagebody {`.
+	bodyRule    = regexp.MustCompile(`(?m)(^|[\s,])body\s*\{[^}]*\}`)
+	cssComment  = regexp.MustCompile(`(?s)/\*.*?\*/`)
+	paddingDecl = regexp.MustCompile(`padding[^:;{}]*:\s*([^;}]+)`)
+)
+
+// Padding on body is REPLACED by the strip's offset, not added to it, which
+// leaves the hero flush against the bar.
+func TestWizardPageDoesNotPadItsBody(t *testing.T) {
+	// Scan the page's own rules: the strip's CSS is the thing whose offset the
+	// page must not fight, and its comments quote `body { padding: … }`.
+	page := cssComment.ReplaceAllString(strings.Replace(wizardHTML, brand.TitlebarCSS, "", 1), "")
+	for _, rule := range bodyRule.FindAllString(page, -1) {
+		for _, m := range paddingDecl.FindAllStringSubmatch(rule, -1) {
+			if strings.TrimSpace(m[1]) != "0" {
+				t.Errorf("body sets %q — the strip offset will replace that, not add to it\n  in: %s",
+					strings.TrimSpace(m[0]), strings.TrimSpace(rule))
+			}
+		}
+	}
+}
+
+// Version numbers are deliberately not part of this page: the installer only
+// ever fetches `latest`, so a version is a number the user cannot act on. This
+// pins the removal — the fields are gone from wizardState, so a page reading
+// them would silently render "undefined" rather than fail to compile.
+func TestWizardPageShowsNoVersions(t *testing.T) {
+	for _, ref := range []string{"installed_version", "latest_version", "st.installed_version", "st.latest_version"} {
+		if strings.Contains(wizardHTML, ref) {
+			t.Errorf("page still reads %q — wizardState no longer carries it, so it would render as undefined", ref)
+		}
+	}
+}
+
+func TestApplyPlan(t *testing.T) {
+	const latest = "0.9.2"
+	cases := []struct {
+		name      string
+		inst      installedSidecar
+		installed bool
+		upToDate  bool
+		first     bool
+		npm       bool
+	}{
+		{name: "nothing installed", first: true},
+		{name: "older version", inst: installedSidecar{Version: "0.9.1"}, installed: true},
+		{name: "current version", inst: installedSidecar{Version: "0.9.2"}, installed: true, upToDate: true},
+		{name: "newer than latest", inst: installedSidecar{Version: "0.9.3"}, installed: true, upToDate: true},
+		{name: "npm managed", inst: installedSidecar{Version: "0.9.1", ManagedByNpm: true}, installed: true, npm: true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var s wizardState
+			applyPlan(&s, c.inst, latest)
+			if s.Phase != "plan" {
+				t.Errorf("phase = %q, want plan", s.Phase)
+			}
+			// Whatever else it says, the page has to know the machine was
+			// actually looked at.
+			if !s.Detected {
+				t.Error("detected = false after a plan that inspected the machine")
+			}
+			if s.Installed != c.installed {
+				t.Errorf("installed = %v, want %v", s.Installed, c.installed)
+			}
+			if s.UpToDate != c.upToDate {
+				t.Errorf("up_to_date = %v, want %v", s.UpToDate, c.upToDate)
+			}
+			if s.FirstInstall != c.first {
+				t.Errorf("first_install = %v, want %v", s.FirstInstall, c.first)
+			}
+			if s.NpmManaged != c.npm {
+				t.Errorf("npm_managed = %v, want %v", s.NpmManaged, c.npm)
+			}
+		})
+	}
+}
+
+// The regression this exists for: the panel is fed from the plan snapshot, so
+// a first install that succeeded kept reporting "not installed" on its own
+// done screen.
+func TestApplyOutcomeMarksTheSidecarInstalled(t *testing.T) {
+	cases := map[string]installOutcome{
+		"fresh install":   {InstallDir: "/opt/jarvis"},
+		"already current": {UpToDate: true},
+		"npm managed":     {NpmManaged: true},
+	}
+	for name, out := range cases {
+		t.Run(name, func(t *testing.T) {
+			// Start from the plan state of a machine with no sidecar — the
+			// only starting point where a stale flag is visible.
+			s := wizardState{
+				Phase: "running", Detected: true, FirstInstall: true,
+				Stage: "install", Detail: "Installing to C:\\Users\\x\\AppData\\Local\\Jarvis…",
+			}
+			applyOutcome(&s, out)
+			if s.Phase != "done" {
+				t.Errorf("phase = %q, want done", s.Phase)
+			}
+			if !s.Installed {
+				t.Error("installed = false on the done screen — the panel would still read \"Not installed\"")
+			}
+			if s.UpToDate != out.UpToDate {
+				t.Errorf("up_to_date = %v, want %v", s.UpToDate, out.UpToDate)
+			}
+			if s.NpmManaged != out.NpmManaged {
+				t.Errorf("npm_managed = %v, want %v", s.NpmManaged, out.NpmManaged)
+			}
+			// FirstInstall keeps its plan-time meaning: the macOS done screen
+			// and the autostart policy both ask "was this run the first one?".
+			if !s.FirstInstall {
+				t.Error("first_install was cleared by the outcome — the macOS permissions handoff copy depends on it")
+			}
+			// The stage line is progress, and there is none left. Leaving it
+			// puts "Installing to …" directly under "Installed".
+			if s.Stage != "" || s.Detail != "" {
+				t.Errorf("stage/detail survived into the done screen: %q / %q", s.Stage, s.Detail)
+			}
+		})
+	}
+}

--- a/sidecar/installer/wizard_render_test.go
+++ b/sidecar/installer/wizard_render_test.go
@@ -1,0 +1,201 @@
+package main
+
+// What the wizard's one panel actually SAYS, read out of a real browser.
+//
+// The Go side of this page is four fields and two pure functions, all of them
+// tested next door — and none of that catches the bug this exists for. The
+// panel read "not installed" on the done screen of a successful install
+// because of which field `render()` looked at, so the only test that would
+// have failed is one that renders the page and reads the label back.
+//
+// OPT-IN: set JARVIS_BROWSER_TESTS=1, the same gate as the sidecar's
+// TestTitlebarGesture. A headless browser is not a dependency this suite can
+// rely on, and a browser that launches but never exits must not be able to
+// take the package to its timeout — hence the gate and the hard deadline.
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+)
+
+// text pulls an element's rendered text out of --dump-dom output. The page
+// writes these with textContent, so what lands in the DOM is plain text.
+func text(t *testing.T, dom, id string) string {
+	t.Helper()
+	re := regexp.MustCompile(`id="` + id + `"[^>]*>([^<]*)<`)
+	m := re.FindStringSubmatch(dom)
+	if m == nil {
+		t.Fatalf("#%s is not in the rendered DOM", id)
+	}
+	return strings.TrimSpace(strings.ReplaceAll(m[1], "&nbsp;", " "))
+}
+
+// hidden reports whether an element carries the page's .hidden class.
+func hidden(t *testing.T, dom, id string) bool {
+	t.Helper()
+	re := regexp.MustCompile(`<[^>]*id="` + id + `"[^>]*>`)
+	m := re.FindString(dom)
+	if m == "" {
+		t.Fatalf("#%s is not in the rendered DOM", id)
+	}
+	return strings.Contains(m, "hidden")
+}
+
+func renderPage(t *testing.T, chrome string, st wizardState) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "wizard.html")
+	if err := os.WriteFile(path, []byte(preview(t, st, true)), 0600); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, chrome,
+		"--headless=new", "--disable-gpu", "--no-sandbox",
+		"--disable-dev-shm-usage", "--no-first-run", "--disable-extensions",
+		"--user-data-dir="+filepath.Join(dir, "profile"),
+		// The page polls every 500ms and renders on the first answer.
+		"--virtual-time-budget=2000", "--window-size=480,560",
+		"--dump-dom", "file://"+path,
+	)
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		t.Fatalf("%s never exited within 60s; stderr:\n%s", chrome, stderr.String())
+	}
+	if err != nil {
+		t.Fatalf("%s: %v; stderr:\n%s", chrome, err, stderr.String())
+	}
+	return string(out)
+}
+
+func TestWizardPanelSaysWhatIsOnTheMachine(t *testing.T) {
+	if os.Getenv("JARVIS_BROWSER_TESTS") == "" {
+		t.Skip("set JARVIS_BROWSER_TESTS=1 to render the wizard in a real browser")
+	}
+	chrome := findChromium()
+	if chrome == "" {
+		t.Skip("no chromium/chrome on PATH — the panel is browser-rendered")
+	}
+
+	// Windows throughout: the only platform with both the autostart row and
+	// the custom title bar.
+	base := wizardState{Platform: "windows", AutostartDefault: true}
+	with := func(fn func(*wizardState)) wizardState {
+		s := base
+		fn(&s)
+		return s
+	}
+
+	cases := []struct {
+		name string
+		st   wizardState
+		// What the panel row, the subtitle's opening and the main button say.
+		status    string
+		subtitle  string
+		button    string
+		autostart bool // the login-item row is visible
+	}{
+		{
+			name:      "nothing installed yet",
+			st:        with(func(s *wizardState) { s.Phase, s.Detected, s.FirstInstall = "plan", true, true }),
+			status:    "Not installed",
+			subtitle:  "This installs the Jarvis sidecar on this machine.",
+			button:    "Install",
+			autostart: true,
+		},
+		{
+			name:     "an update is waiting",
+			st:       with(func(s *wizardState) { s.Phase, s.Detected, s.Installed = "plan", true, true }),
+			status:   "Update available",
+			subtitle: "This updates the Jarvis sidecar on this machine.",
+			button:   "Update",
+		},
+		{
+			name:     "already current",
+			st:       with(func(s *wizardState) { s.Phase, s.Detected, s.Installed, s.UpToDate = "plan", true, true, true }),
+			status:   "Up to date",
+			subtitle: "You already have the latest sidecar.",
+			button:   "Close",
+		},
+		{
+			name:   "npm owns it",
+			st:     with(func(s *wizardState) { s.Phase, s.Detected, s.Installed, s.NpmManaged = "plan", true, true, true }),
+			status: "Managed by npm",
+			button: "Close",
+		},
+		{
+			name:   "mid-install",
+			st:     with(func(s *wizardState) { s.Phase, s.Detected = "running", true }),
+			status: "In progress",
+		},
+		// THE REGRESSION. A first install that finished must not still be
+		// reporting the plan's answer.
+		{
+			name:     "a first install that finished",
+			st:       with(func(s *wizardState) { s.Phase, s.Detected, s.Installed, s.FirstInstall = "done", true, true, true }),
+			status:   "Installed",
+			subtitle: "Installed.",
+			button:   "Launch Jarvis",
+		},
+		{
+			name:     "an update that finished",
+			st:       with(func(s *wizardState) { s.Phase, s.Detected, s.Installed = "done", true, true }),
+			status:   "Updated",
+			subtitle: "Updated.",
+			button:   "Launch Jarvis",
+		},
+		{
+			name:   "nothing could be checked",
+			st:     with(func(s *wizardState) { s.Phase, s.Error = "failed", "could not reach the npm registry" }),
+			status: "—",
+			button: "Retry",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			dom := renderPage(t, chrome, c.st)
+			if got := text(t, dom, "vStatus"); got != c.status {
+				t.Errorf("panel says %q, want %q", got, c.status)
+			}
+			if c.subtitle != "" {
+				if got := text(t, dom, "subtitle"); got != c.subtitle {
+					t.Errorf("subtitle says %q, want %q", got, c.subtitle)
+				}
+			}
+			if c.button != "" {
+				if got := text(t, dom, "btnMain"); got != c.button {
+					t.Errorf("main button says %q, want %q", got, c.button)
+				}
+			}
+			if got := !hidden(t, dom, "autostartRow"); got != c.autostart {
+				t.Errorf("autostart row visible = %v, want %v", got, c.autostart)
+			}
+			// The strip is what this window is closed and moved by on
+			// Windows; a page that rendered without it is a trapped window.
+			if !strings.Contains(dom, `id="wchrome-close"`) {
+				t.Error("no window controls in the rendered page")
+			}
+		})
+	}
+}
+
+// findChromium mirrors the sidecar's helper of the same name; the installer is
+// a separate package and cannot borrow it.
+func findChromium() string {
+	for _, name := range []string{"chromium", "chromium-browser", "google-chrome", "google-chrome-stable"} {
+		if p, err := exec.LookPath(name); err == nil {
+			return p
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
Three changes to the sidecar installer's GUI wizard.

### The Windows title bar

#382 gave every local webview window a title bar it draws itself, and deliberately left the installer on `winchrome.NativeTitleBar`. It now uses `CustomTitleBar` like the rest, so the first window a user sees does not look like a different product from the app it installs. The page takes the full contract from `internal/brand`: `TitlebarCSS`, `TitlebarHTML` last in the body, `TitlebarJS` + `PageBodyJS`, a `<title>`, and a `.pagebody` scroll wrapper (body padding moves onto it — the strip's offset replaces body padding rather than adding to it).

One deviation from the sidecar's pages: the chrome scripts get their own `<script>` block. This page opens by calling three bindings, and a throw there would abort the rest of its block — under custom chrome that is a window with no title bar and no native one to fall back on.

The security invariant holds unchanged: the page is local HTML compiled into the binary, set via `SetHtml`, with no link, form, iframe or `window.open`.

### No version numbers

The installer only ever fetches the `latest` dist-tag, so the version was never something the user picks or can act on. `wizardState` no longer carries version strings, and the two-row "Installed / Latest" panel is a single `Sidecar: <state>` row — *Not installed / Update available / Up to date / Managed by npm / In progress / Installed / Updated*. An available update is announced there instead of by a pair of numbers to compare. The download stage line drops the version too; console mode still names it on its final line.

### The status label no longer sticks

The panel was fed from the plan-time snapshot, which the done branch never updated — so a successful first install kept reporting "not installed" on its own done screen. The two state transitions are now pure `applyPlan` / `applyOutcome`; the latter marks the sidecar installed and clears the stale progress line that would otherwise sit under "Installed".

### Also, from review

- A `detectInstalled` failure used to render "Checking…" beside a live Install button. It now fails the plan the way a registry failure does, which is what `performInstall` already does with the same error.
- A finished update says "Updated", matching the button that started it.
- Fixed a comment claiming the window has a native close button.

### Testing

`go vet` and `go test` clean across the module. Three new files:

- `wizard_page_test.go` — the title-bar splice, the `.pagebody` contract, no body padding, no version references, both appliers.
- `wizard_render_test.go` — `JARVIS_BROWSER_TESTS`-gated: renders eight states through headless Chromium and reads the status row, subtitle and button back out of the DOM. The bug was in what the panel *said*, which no Go test can see. Both halves of the fix were mutation-checked: removing the done branch fails this, removing `Installed = true` fails the Go test.
- `wizard_dump_test.go` — the QA dump, mirroring `TestDumpBrandPages`, one file per state with bindings stubbed.

Rendered and eyeballed in light and dark, chromed and native. Windows cross-compilation was not checked locally (no Windows SDK headers for the mingw toolchain) — the only Windows-specific thing touched is the `CustomTitleBar` constant, which compiles everywhere.

### Known, not fixed here

- F5 / Ctrl+R reloads a `SetHtml` document to `about:blank`; under custom chrome that leaves a window with no caption or close button (Alt+F4 and the taskbar still work, `WS_SYSMENU` is kept). Pre-existing and shared with every chromed window since #382 — the fix belongs in `winchrome`/`webview2`, and needs a Windows box to confirm.
- Retry after a failed *install* is dead: `retryPlan` returns early because `started` is true. Untangling it touches `installDone` and the exit code.
