### PR TITLE
fix(llm): never send a custom temperature to the hosted usejarvis_ai provider (reasoning models reject it)

### DIFF
--- a/src/llm/openai.ts
+++ b/src/llm/openai.ts
@@ -154,6 +154,15 @@ export class OpenAIProvider implements LLMProvider {
     return false;
   }
 
+  /** Whether to omit a caller-supplied `temperature` for this model. Delegates
+   * to the by-name check by default; overridable because a provider whose model
+   * ids are OPAQUE (the hosted proxy's `uj-*` aliases) cannot tell from the name
+   * that the alias resolves to a reasoning model, so the name check never fires
+   * and every request 400s with "temperature does not support …". */
+  protected rejectsCustomTemperature(model: string): boolean {
+    return modelRejectsCustomTemperature(model);
+  }
+
   constructor(apiKey: string, defaultModel = 'gpt-4o', baseUrl = 'https://api.openai.com/v1', authHeader = 'Authorization') {
     this.apiKey = apiKey;
     this.defaultModel = defaultModel;
@@ -199,7 +208,7 @@ export class OpenAIProvider implements LLMProvider {
       messages: this.convertMessages(compactedMessages),
     };
 
-    if (temperature !== undefined && !modelRejectsCustomTemperature(model)) {
+    if (temperature !== undefined && !this.rejectsCustomTemperature(model)) {
       body.temperature = temperature;
     }
     if (max_tokens !== undefined) body.max_completion_tokens = max_tokens;
@@ -233,7 +242,7 @@ export class OpenAIProvider implements LLMProvider {
     };
     if (this.streamIncludeUsage) body.stream_options = { include_usage: true };
 
-    if (temperature !== undefined && !modelRejectsCustomTemperature(model)) {
+    if (temperature !== undefined && !this.rejectsCustomTemperature(model)) {
       body.temperature = temperature;
     }
     if (max_tokens !== undefined) body.max_completion_tokens = max_tokens;

--- a/src/llm/usejarvis.test.ts
+++ b/src/llm/usejarvis.test.ts
@@ -47,6 +47,46 @@ describe('UsejarvisAIProvider', () => {
     expect(auth ?? '').toBe('Bearer sk-uj-abc');
   });
 
+  it('never sends a custom temperature — the uj-* aliases resolve to reasoning models that reject it', async () => {
+    // The base OpenAIProvider skips temperature only for names it recognises as
+    // reasoning models; the hosted aliases are opaque, so without the override a
+    // temperature=0.4 reached the proxy and 400'd ("claude-opus-5 does not
+    // support temperature=0.4"). This proves the override strips it on the wire.
+    let sent: Record<string, unknown> | null = null;
+    globalThis.fetch = (async (_input: any, init?: any) => {
+      sent = JSON.parse(String(init?.body));
+      return jsonResponse(200, {
+        id: 'x',
+        object: 'chat.completion',
+        model: 'uj-high',
+        choices: [{ index: 0, finish_reason: 'stop', message: { role: 'assistant', content: 'hi' } }],
+        usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+      });
+    }) as unknown as typeof fetch;
+    const provider = new UsejarvisAIProvider('https://llm.usejarvis.host', 'sk-uj-abc');
+    await provider.chat([{ role: 'user', content: 'hi' }], { model: 'uj-high', temperature: 0.4 });
+    expect(sent!.model).toBe('uj-high');
+    expect('temperature' in sent!).toBe(false);
+  });
+
+  it('never sends a custom temperature on the STREAM path either', async () => {
+    // The stream() builder carries its own copy of the temperature guard, so it
+    // gets its own wire-level assertion — a regression in just one path would
+    // otherwise slip through.
+    let sent: Record<string, unknown> | null = null;
+    globalThis.fetch = (async (_input: any, init?: any) => {
+      sent = JSON.parse(String(init?.body));
+      return new Response('data: [DONE]\n\n', { status: 200, headers: { 'Content-Type': 'text/event-stream' } });
+    }) as unknown as typeof fetch;
+    const provider = new UsejarvisAIProvider('https://llm.usejarvis.host', 'sk-uj-abc');
+    try {
+      for await (const _ of provider.stream([{ role: 'user', content: 'hi' }], { model: 'uj-high', temperature: 0.4 })) { /* drain */ }
+    } catch { /* the body is captured before any stream parsing */ }
+    expect(sent!.model).toBe('uj-high');
+    expect(sent!.stream).toBe(true);
+    expect('temperature' in sent!).toBe(false);
+  });
+
   it('rewrites budget-exceeded into actionable copy, keeping the (status) marker', async () => {
     globalThis.fetch = (async () =>
       jsonResponse(400, { error: { message: 'ExceededBudget: budget has been exceeded for this key' } })) as unknown as typeof fetch;

--- a/src/llm/usejarvis.ts
+++ b/src/llm/usejarvis.ts
@@ -47,6 +47,18 @@ export class UsejarvisAIProvider extends OpenAIProvider {
     return true;
   }
 
+  /** Every hosted chat alias (uj-chat / uj-low / uj-medium / uj-high) resolves
+   * to a premium REASONING model (gpt-5.6-*, claude-opus-*) that accepts only
+   * the default temperature (1). The aliases are vendor-opaque by design, so the
+   * base class's by-name check can never see it — the brain must assume the
+   * strictest rule and never send a custom temperature. Confirmed live: `uj-high`
+   * + temperature 0.4 → 400 "claude-opus-5 does not support temperature=0.4;
+   * only temperature=1 is supported". If a future plan adds a non-reasoning
+   * alias, this becomes model-aware; today omitting it is always correct. */
+  protected override rejectsCustomTemperature(_model: string): boolean {
+    return true;
+  }
+
   /**
    * Attach Anthropic prompt-cache breakpoints, in OpenAI wire format.
    *


### PR DESCRIPTION
## What
Never send a custom `temperature` to the hosted `usejarvis_ai` provider.

## Why
The `uj-*` aliases are vendor-opaque and all resolve to reasoning models (gpt-5.6-*, claude-opus-*) that accept only `temperature=1`. The base `OpenAIProvider`'s by-name reasoning-model guard (`modelRejectsCustomTemperature`) can't see through the aliases, so every hosted request 400'd ("Unsupported value: 'temperature' does not support 0.4 with this model. Only the default (1) value is supported").

## How
`rejectsCustomTemperature()` is now an overridable protected method; `UsejarvisAIProvider` overrides it to always strip `temperature`, on both the `chat` and `stream` paths.

## Tests
Wire-level assertions on both `chat` and `stream` that the request body omits `temperature`. Full pre-commit suite green; `tsc --noEmit` clean under strict + noImplicitOverride.

## Note
This is one half of the hosted tool-calling fix; the other half (pinning `reasoning_effort` on the gpt-5.6 tiers) lives in the control plane.
