### PR TITLE
fix(sidecar): stop a reload from trapping a window that draws its own title bar

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -226,6 +226,17 @@ jobs:
           # The installer's wizard is webview-backed (cgo, same toolchain as
           # the sidecar) — cross-build it too so it can't rot unchecked.
           go build -o /tmp/jarvis-setup.exe ./installer/
+          # vet, not just build: internal/winchrome calls WebView2 through raw
+          # COM vtables, and `unsafeptr` is the only automatic check on that.
+          # Nothing else in CI vets GOOS=windows — the linux and darwin jobs
+          # never compile these files.
+          #
+          # Scoped to the package rather than ./... on purpose: notify_windows.go
+          # and tray_windows.go convert an incoming WM_COPYDATA LPARAM to a
+          # struct pointer, which is correct (it is a real address from another
+          # process) but is a known unsafeptr false positive. Widening this is a
+          # separate decision, not a side effect of the chrome work.
+          go vet ./internal/winchrome/
 
   # The windows-tagged tests (pebble draw-bounds crop invariant) are pure Go
   # but can only RUN on a Windows runner — the mingw cross-build above only

--- a/scripts/vendor-webview.sh
+++ b/scripts/vendor-webview.sh
@@ -91,6 +91,7 @@ grep -q "ShowWindow(m_window, SW_HIDE)" "$HEADER"           # win32: no open fla
 grep -q "isMainThread" "$HEADER"                            # cocoa: main-thread window
 grep -q "w->browser_controller()" "$HEADER"                 # reject half-built engines
 grep -q "PATCHED (jarvis)" "$VENDOR_DIR/webview.go"         # nil WebView on NULL handle
+grep -q "PATCHED (jarvis)" "$VENDOR_DIR/jarvis_native.go"   # browser controller accessor
 
 # Record the pinned version (single source of truth for the update workflow).
 printf '%s\n' "$VERSION" > "$VENDOR_DIR/UPSTREAM_VERSION"

--- a/sidecar/README.md
+++ b/sidecar/README.md
@@ -172,6 +172,16 @@ strip itself is shared markup in `internal/brand/titlebar.go`, rendered only
 when `winchrome.Install` has stamped `<html data-chrome="custom">` — so the
 same page keeps its native title bar on macOS and Linux.
 
+The caption is synced per document, not stripped once. Reloading a page that
+was loaded with `SetHtml` lands on `about:blank`, which on a captionless window
+leaves nothing to close it with — so every document reports whether the strip is
+in it and `syncCaption` puts the native caption back when it is not. On top of
+that `Install` turns WebView2's browser accelerator keys off for the window, so
+F5 and Ctrl+R never fire; that switch also takes Ctrl+F, Alt+arrows, Ctrl+P and
+keyboard zoom, which is accepted for windows this small. The default context
+menu keeps its Reload on purpose — killing it would cost right-click paste in
+the token form, and leaving it is what keeps the caption sync exercised.
+
 The page moves the window through a binding rather than CSS: the WebView2
 child HWND covers the client area and swallows the mouse, so `app-region:
 drag` does nothing and the drag is a `ReleaseCapture` +
@@ -219,7 +229,10 @@ dependency this suite relies on:
 JARVIS_BROWSER_TESTS=1 go test -run TestTitlebarGesture .
 ```
 
-Run it after any change to `TitlebarJS`.
+Run it after any change to `TitlebarJS`. Note that the caption sync lives in
+`winchrome`'s injected `initJS`, not in `TitlebarJS`, and that
+`JARVIS_BROWSER_TESTS` is never set in CI — these browser tests are a developer
+tool, not a gate.
 
 What that cannot reach is Win32 itself — the modal move loop, snap, maximize
 geometry — so this much still needs a real Windows box at least once per change
@@ -244,6 +257,21 @@ to `winchrome` or the strip's script:
       is script, not the browser).
 - [ ] Drag a URL or a file onto the window: nothing navigates. Drag selected
       text into the token form's textarea: it drops.
+- [ ] F5, Ctrl+R, Ctrl+Shift+R and Ctrl+F5 do nothing. The log viewer's own
+      Refresh and the connect window's Try again still work.
+- [ ] Right-click the page and choose Reload — that route is deliberately left
+      open, so the document DOES go blank: the native title bar must come back
+      and the window must be movable and closable. Do it twice: still one title
+      bar, no crash.
+- [ ] Same reload on a maximized window: caption returns, window stays
+      maximized.
+- [ ] On the connect window, reload and then force an error document (pull the
+      network): exactly ONE title bar, not two.
+- [ ] Ctrl+A/C/V/X still work in the token textarea and the log search box.
+      Ctrl+F and Ctrl +/-/0 are inert — that is the accepted cost of switching
+      the browser accelerator keys off.
+- [ ] Negative control: F5 still reloads the account window and a dashboard
+      panel normally.
 
 ### Preflight checks
 

--- a/sidecar/internal/winchrome/chrome_windows.go
+++ b/sidecar/internal/winchrome/chrome_windows.go
@@ -16,6 +16,7 @@ const gwlExStyle = -20
 
 // SetWindowPos flags.
 const (
+	swpNoSize       = 0x0001
 	swpNoMove       = 0x0002
 	swpNoZOrder     = 0x0004
 	swpNoActivate   = 0x0010
@@ -96,6 +97,29 @@ type point struct {
 // Custom chrome implies a resizable window: it does not add WS_THICKFRAME, so
 // pairing it with SetSize(..., HintFixed) leaves a page whose maximize button
 // the OS will refuse.
+//
+// The caption is SYNCED PER DOCUMENT, not stripped once. Reloading a document
+// that was loaded with SetHtml lands on about:blank, and a captionless window
+// with no page to draw a strip is one the user cannot move or close. So every
+// document reports whether our strip is in it (initJS) and syncCaption puts
+// the native caption back when it is not. Install still does the first strip
+// itself, before anything is loaded, so the native bar is never composited.
+//
+// It also turns WebView2's browser accelerator keys off, so the reload never
+// happens in the first place. That switch is a FAMILY switch, and the cost is
+// accepted deliberately: Ctrl+F, Alt+←/→, Ctrl+P and keyboard zoom
+// (Ctrl +/−/0) go with it. These are small fixed-purpose task windows rather
+// than documents, Windows display scaling still applies and the windows size
+// themselves at their own DPI, and the one page anyone would search — the log
+// viewer — has its own search box. Ctrl+A/C/V/X are untouched.
+//
+// The default context menu — whose Reload is the other way to land on a blank
+// document — is left ALONE on purpose. Turning it off is cheaper than the
+// engine-level fix and would close that route, but it also takes away
+// right-click→Paste in the token form's textarea and right-click→Copy on a log
+// line, which people use. The caption sync already covers the route, and
+// leaving it reachable is what keeps that recovery path exercised instead of
+// rotting.
 func Install(w webview.WebView) bool {
 	if w == nil {
 		return false
@@ -116,6 +140,16 @@ func Install(w webview.WebView) bool {
 		return false
 	}
 	roundCorners(hwnd)
+	// Success path only. A window whose caption could not be removed is an
+	// ordinary framed window that was never at risk, and taking F5, Ctrl+F and
+	// keyboard zoom away from it would be a regression bought for nothing.
+	//
+	// After the strip and before Init/SetHtml: WebView2 applies a settings
+	// change from the next navigation onward, and Install's contract already
+	// puts it ahead of the first SetHtml.
+	disableBrowserAccelerators(w)
+	// Init last, after every Bind: the sync script gives up if its binding is
+	// not there, and this ordering means it never has to.
 	w.Init(initJS(doubleClickTime()))
 	return true
 }
@@ -155,6 +189,49 @@ func stripCaption(hwnd uintptr) bool {
 		swpNoMove|swpNoZOrder|swpNoActivate|swpFrameChanged,
 	)
 	return true
+}
+
+// syncCaption makes the window's caption match the document that just loaded:
+// present when the page draws no strip of its own, gone when it does.
+//
+// Unlike stripCaption this does NOT re-derive the size, and must not. That
+// dance exists to honour the size the CALLER asked for, once, at Install time;
+// running it on every document would accumulate the DPI fallback's few pixels
+// of error across each strip→restore→strip cycle, and would fight the OS over
+// a maximized window's rect. SWP_NOSIZE|SWP_NOMOVE keeps the window rect
+// exactly where it is and lets the client area gain or lose the caption's
+// height — which is the right answer for a document that is either empty or
+// about to lay itself out anyway.
+func syncCaption(hwnd uintptr, custom bool) {
+	style := getWindowLong(hwnd, gwlStyle)
+	if style == 0 {
+		// GetWindowLong failed; same ambiguity (and same conservative
+		// reading) as stripCaption.
+		return
+	}
+	want := uintptr(captionedStyle(uint32(style)))
+	if custom {
+		want = uintptr(captionlessStyle(uint32(style)))
+	}
+	if want == style {
+		// The steady state: every normal document of a chromed window lands
+		// here, so the whole mechanism costs one binding round trip and one
+		// GetWindowLong per page.
+		return
+	}
+	setWindowLong(hwnd, gwlStyle, want)
+	procSetWindowPos.Call(
+		hwnd, 0,
+		0, 0, 0, 0,
+		swpNoMove|swpNoSize|swpNoZOrder|swpNoActivate|swpFrameChanged,
+	)
+	// Only on a real transition, and say which way: this is what turns "the
+	// settings window went weird" into something diagnosable from a log.
+	if custom {
+		log.Printf("[chrome] document draws its own title bar; caption removed")
+		return
+	}
+	log.Printf("[chrome] document has no title bar of its own (a reload lands on about:blank); native caption restored")
 }
 
 // adjustWindowRect grows a client rect into the window rect that style needs,
@@ -244,6 +321,12 @@ func bindControls(w webview.WebView, hwnd uintptr) bool {
 	bind("__jarvis_chrome_close", func() {
 		procPostMessageW.Call(hwnd, wmClose, 0, 0)
 	})
+
+	// The caption sync (see initJS). Deliberately inside the same `ok`
+	// accumulator as the window controls: a window whose recovery net could
+	// not be installed must keep its native title bar rather than have it
+	// taken away with nothing able to give it back.
+	bind("__jarvis_chrome_sync", func(custom bool) { syncCaption(hwnd, custom) })
 
 	// Right-click on the caption. DefWindowProc turns WM_NCRBUTTONUP/HTCAPTION
 	// into the system menu, so the menu, its item states and its commands are

--- a/sidecar/internal/winchrome/style.go
+++ b/sidecar/internal/winchrome/style.go
@@ -75,6 +75,20 @@ func captionlessStyle(style uint32) uint32 {
 	return style
 }
 
+// captionedStyle is the inverse of captionlessStyle: it puts WS_CAPTION back.
+//
+// It does NOT take WS_SYSMENU and WS_MINIMIZEBOX away again. Those are not
+// ours to remove — captionlessStyle adds them because a captionless window
+// needs them to behave, and a framed window wants them just as much. So the
+// pair round-trips for any window webview actually creates (WS_SYSMENU and
+// WS_MINIMIZEBOX are in WS_OVERLAPPEDWINDOW, and SetSize's HintFixed strips
+// neither), which is what the round-trip test pins.
+//
+// Pure, so it can be unit-tested on any host.
+func captionedStyle(style uint32) uint32 {
+	return style | wsCaption
+}
+
 // initJS marks the document as custom-chromed so the shared title bar CSS
 // (internal/brand) can reveal itself only where the native bar is gone, and
 // hands the page the user's real double-click speed: the strip times
@@ -99,6 +113,38 @@ func captionlessStyle(style uint32) uint32 {
 // complete answer — the real fix is refusing foreign origins in the engine
 // (NavigationStarting, or AllowExternalDrop=false), which means a change to
 // the vendored webview and its patch file.
+//
+// Finally it keeps the WINDOW'S CAPTION IN SYNC WITH THE DOCUMENT, which is
+// what stops a reload from trapping the window. Reloading a document loaded
+// with SetHtml lands on about:blank: no strip, and — since the caption was
+// removed once at Install time — no way to move or close the window either.
+// So every document reports whether our strip is in it, and the host puts the
+// native caption back when it is not (syncCaption). Three details are load
+// bearing:
+//
+//   - It asks for '#wchrome', not for location. A NavigateToString document
+//     ALREADY reports about:blank as its URI, identical to the blank one a
+//     reload leaves behind, so the URL cannot tell the two apart. The strip
+//     is the only honest discriminator.
+//   - It waits for DOMContentLoaded. The strip is the last element in <body>
+//     (internal/brand's markup contract), so at document-creation time — when
+//     this script runs — it does not exist yet. Waiting for `load` instead
+//     would hang on a page with a stalled subresource, which is the same
+//     reason webviewui.RevealOnLoad carries a timeout. Deferring is also what
+//     guarantees the binding stub is there: bind() registers each stub as its
+//     own document-created script, and WebView2 does not promise those run in
+//     registration order.
+//   - Top frame only. init_impl is AddScriptToExecuteOnDocumentCreated, which
+//     WebView2 injects into EVERY frame. No chromed page has an iframe today,
+//     but the day one does, a subframe with no strip of its own would
+//     otherwise tell the host to un-chrome a perfectly good window.
+//
+// It is a two-way sync rather than a one-way restore on purpose. The first-run
+// window swaps documents from a goroutine (hosted_window.go's showShellError /
+// showSelfHostHint), so a reload mid-handshake is followed by a fresh chromed
+// document — and a host that only ever restored would leave that window
+// wearing two title bars. Syncing both ways is also idempotent, so a second
+// reload of an already-blank document changes nothing.
 func initJS(dblClickMs uint32) string {
 	if dblClickMs == 0 {
 		dblClickMs = 500 // the Windows default, if the OS would not say
@@ -112,5 +158,11 @@ func initJS(dblClickMs uint32) string {
 		`for(var i=0;i<t.length;i++){if(t[i]==='Files'||t[i]==='text/uri-list')return true;}return false;};` +
 		`var block=function(e){if(navigating(e)){e.preventDefault();}};` +
 		`document.addEventListener('dragover',block,true);document.addEventListener('drop',block,true);` +
+		`if(window.top===window){var done=false,tries=0;` +
+		`var chk=function(){if(done)return;` +
+		`if(!window.__jarvis_chrome_sync){if(tries++<20)setTimeout(chk,0);return;}` +
+		`done=true;try{window.__jarvis_chrome_sync(!!document.getElementById('wchrome'));}catch(e){}};` +
+		`if(document.readyState==='loading'){document.addEventListener('DOMContentLoaded',chk);}` +
+		`else{setTimeout(chk,0);}}` +
 		`}catch(e){}})();`
 }

--- a/sidecar/internal/winchrome/style_test.go
+++ b/sidecar/internal/winchrome/style_test.go
@@ -3,6 +3,8 @@ package winchrome
 import (
 	"strings"
 	"testing"
+
+	"github.com/jarvis/sidecar/internal/brand"
 )
 
 // WS_OVERLAPPEDWINDOW, as webview creates its window and as its SetSize leaves
@@ -48,6 +50,42 @@ func TestCaptionlessStyleKeepsAFixedWindowFixed(t *testing.T) {
 	// minimize button needs WS_MINIMIZEBOX to do anything.
 	if got&wsSysMenu == 0 || got&wsMinimizeBox == 0 {
 		t.Errorf("WS_SYSMENU/WS_MINIMIZEBOX missing from %#08x", got)
+	}
+}
+
+// The caption sync is only as good as its inverse: a window that could not get
+// its caption back is exactly the trap the sync exists to prevent.
+func TestCaptionedStyleRestoresWhatCaptionlessStyleRemoved(t *testing.T) {
+	for name, style := range map[string]uint32{
+		// HintNone, as webview's SetSize leaves it.
+		"resizable": wsOverlappedWindow,
+		// HintFixed: SetSize strips the resize border and the maximize box.
+		"fixed": wsOverlappedWindow &^ (wsThickFrame | wsMaximizeBox),
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got := captionedStyle(captionlessStyle(style)); got != style {
+				t.Errorf("round trip gave %#08x, want %#08x", got, style)
+			}
+			// The sync calls whichever direction the document asks for, on a
+			// style that may already be in that state, so both halves must be
+			// no-ops the second time.
+			once := captionedStyle(style)
+			if twice := captionedStyle(once); twice != once {
+				t.Errorf("captionedStyle not idempotent: %#08x then %#08x", once, twice)
+			}
+		})
+	}
+}
+
+func TestCaptionedStyleAddsTheCaption(t *testing.T) {
+	got := captionedStyle(captionlessStyle(wsOverlappedWindow))
+	if got&wsCaption == 0 {
+		t.Fatalf("WS_CAPTION not restored: %#08x", got)
+	}
+	// It must not take back what captionlessStyle added: a restored window
+	// still wants Alt+Space and a working taskbar minimise.
+	if got&wsSysMenu == 0 || got&wsMinimizeBox == 0 {
+		t.Errorf("WS_SYSMENU/WS_MINIMIZEBOX lost on the way back: %#08x", got)
 	}
 }
 
@@ -114,5 +152,42 @@ func TestInitJSCarriesTheDoubleClickTime(t *testing.T) {
 	}
 	if !strings.Contains(initJS(0), "window.__jarvisDblClickMs=500;") {
 		t.Error("initJS must fall back to the Windows default of 500ms")
+	}
+}
+
+// The caption sync's JS half. The Go half (syncCaption) is Windows-only; this
+// is what pins the contract between them.
+func TestChromeInitJSSyncsTheCaptionToTheDocument(t *testing.T) {
+	js := initJS(500)
+	for _, want := range []string{
+		// The discriminator. Not location: a NavigateToString document already
+		// reports about:blank, exactly like the blank one a reload leaves.
+		"getElementById('wchrome')",
+		"window.__jarvis_chrome_sync",
+		// Deferred, because the strip is the last element in <body> and does
+		// not exist when this script runs.
+		"DOMContentLoaded",
+		// Top frame only: init runs in every frame, and a subframe without a
+		// strip of its own must not un-chrome the window.
+		"window.top===window",
+	} {
+		if !strings.Contains(js, want) {
+			t.Errorf("initJS is missing %q — the caption sync would not work", want)
+		}
+	}
+}
+
+// initJS asks for '#wchrome' and internal/brand's markup is what provides it.
+// Nothing else couples those two strings: rename the id in the strip's markup
+// and every chromed document starts reporting "no title bar here", so the sync
+// hands back a native caption on top of a page that is already drawing its own.
+// Test-only import, so no production dependency and no cycle.
+func TestTheIDInitJSLooksForIsTheOneTheStripDefines(t *testing.T) {
+	const id = "wchrome"
+	if !strings.Contains(initJS(500), "getElementById('"+id+"')") {
+		t.Fatalf("initJS no longer looks for #%s", id)
+	}
+	if !strings.Contains(brand.TitlebarHTML, `id="`+id+`"`) {
+		t.Errorf("the title bar markup has no id=%q — the caption sync would fire on every chromed document", id)
 	}
 }

--- a/sidecar/internal/winchrome/webview2_ids.go
+++ b/sidecar/internal/winchrome/webview2_ids.go
@@ -1,0 +1,47 @@
+package winchrome
+
+// COM identifiers for the one WebView2 setting this package changes.
+//
+// Deliberately in a file with NO build tag. The values are ABI facts about
+// Microsoft's SDK header, not Windows code, so keeping them here lets
+// webview2_ids_test.go re-derive them from the vendored WebView2.h on any
+// host — which is the only thing standing between a mistyped hex digit and a
+// call through the wrong vtable slot on a user's machine.
+
+// guid mirrors Win32 GUID (and REFIID): a DWORD, two WORDs, then 8 bytes.
+type guid struct {
+	Data1 uint32
+	Data2 uint16
+	Data3 uint16
+	Data4 [8]byte
+}
+
+// iidCoreWebView2Settings3 is IID_ICoreWebView2Settings3, the lowest settings
+// interface carrying AreBrowserAcceleratorKeysEnabled. Later revisions
+// (Settings4 and up) all derive from it, so this is the one to ask for: it is
+// the most widely available runtime that can answer.
+var iidCoreWebView2Settings3 = guid{
+	0xfdb5ab74, 0xaf33, 0x4854,
+	[8]byte{0x84, 0xf0, 0x0a, 0x63, 0x1d, 0xeb, 0x5e, 0xba},
+}
+
+// Vtable slots, counted from the C-style `…Vtbl` structs in the vendored
+// libs/mswebview2/include/WebView2.h. Slots 0, 1 and 2 are IUnknown's
+// QueryInterface, AddRef and Release on every COM interface; everything below
+// is that offset plus the interface's own declaration order, inherited
+// methods first.
+//
+// webview2_ids_test.go parses those structs and fails if any of these drifts —
+// including after an SDK header bump that inserts a method.
+const (
+	idxIUnknownRelease = 2
+
+	// ICoreWebView2ControllerVtbl
+	idxControllerGetCoreWebView2 = 25
+
+	// ICoreWebView2Vtbl
+	idxCoreWebView2GetSettings = 3
+
+	// ICoreWebView2Settings3Vtbl
+	idxSettings3PutBrowserAcceleratorKeys = 24
+)

--- a/sidecar/internal/winchrome/webview2_ids_test.go
+++ b/sidecar/internal/winchrome/webview2_ids_test.go
@@ -1,0 +1,143 @@
+package winchrome
+
+// The vtable slots in webview2_ids.go are magic numbers that no compiler
+// checks and no Linux test could otherwise reach: get them wrong and the code
+// calls through the wrong function pointer on a user's machine, with the
+// arguments of a different method. So rather than trusting the constants, this
+// re-derives them from the vendored SDK header on every run, on every host.
+//
+// It also catches the case that would otherwise be invisible: Microsoft adding
+// a method to an interface in a header bump, which shifts every slot after it.
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+const webView2Header = "../../third_party/webview_go/libs/mswebview2/include/WebView2.h"
+
+func readWebView2Header(t *testing.T) string {
+	t.Helper()
+	b, err := os.ReadFile(filepath.FromSlash(webView2Header))
+	if err != nil {
+		// Never Skip: a missing header means the vendored SDK moved, and
+		// silently passing would leave the slots unchecked from then on.
+		t.Fatalf("cannot read the vendored WebView2 header: %v", err)
+	}
+	// .gitattributes forces eol=lf, but the file arrives from Microsoft with
+	// CRLF; strip defensively so the parse never depends on that holding.
+	return strings.ReplaceAll(string(b), "\r", "")
+}
+
+// vtableMethods returns an interface's vtable slots in declaration order.
+var vtblMethod = regexp.MustCompile(`\*\s*(\w+)\s*\)\s*\(`)
+
+func vtableMethods(t *testing.T, src, iface string) []string {
+	t.Helper()
+	// The trailing boundary matters: without it "ICoreWebView2Vtbl" also
+	// matches inside "ICoreWebView2ControllerVtbl" and the whole parse silently
+	// reads the wrong interface.
+	open := regexp.MustCompile(`typedef struct ` + iface + `Vtbl\b`)
+	loc := open.FindStringIndex(src)
+	if loc == nil {
+		t.Fatalf("%s: no Vtbl struct in the vendored header", iface)
+	}
+	rest := src[loc[1]:]
+	end := strings.Index(rest, "} "+iface+"Vtbl;")
+	if end < 0 {
+		t.Fatalf("%s: unterminated Vtbl struct", iface)
+	}
+	var methods []string
+	for _, m := range vtblMethod.FindAllStringSubmatch(rest[:end], -1) {
+		methods = append(methods, m[1])
+	}
+	// Self-check the parser before trusting a single index off it. Every COM
+	// vtable starts with IUnknown; a parse that does not see those three has
+	// mis-aligned, and mis-aligned indices are worse than no test at all.
+	if len(methods) < 3 || methods[0] != "QueryInterface" || methods[1] != "AddRef" || methods[2] != "Release" {
+		t.Fatalf("%s: parse looks wrong — first slots are %v, want QueryInterface/AddRef/Release", iface, methods)
+	}
+	return methods
+}
+
+func TestVtableIndicesMatchTheVendoredSDK(t *testing.T) {
+	src := readWebView2Header(t)
+	for _, c := range []struct {
+		iface  string
+		method string
+		want   int
+	}{
+		{"ICoreWebView2Controller", "get_CoreWebView2", idxControllerGetCoreWebView2},
+		{"ICoreWebView2", "get_Settings", idxCoreWebView2GetSettings},
+		{"ICoreWebView2Settings3", "put_AreBrowserAcceleratorKeysEnabled", idxSettings3PutBrowserAcceleratorKeys},
+		// Pinned through the same parser so a bad derivation shows up here
+		// rather than as a wrong answer for the three above.
+		{"ICoreWebView2Settings3", "Release", idxIUnknownRelease},
+	} {
+		methods := vtableMethods(t, src, c.iface)
+		got := -1
+		for i, m := range methods {
+			if m == c.method {
+				got = i
+				break
+			}
+		}
+		if got < 0 {
+			t.Errorf("%s::%s is not in the vendored header at all", c.iface, c.method)
+			continue
+		}
+		if got != c.want {
+			// Name what the wrong slot actually holds: that is the call the
+			// shipped binary would make, and it is the fastest way to see how
+			// far the vtable has shifted.
+			at := "past the end of the vtable"
+			if c.want >= 0 && c.want < len(methods) {
+				at = strconv.Quote(methods[c.want])
+			}
+			t.Errorf("%s::%s is vtable slot %d, but webview2_ids.go says %d — slot %d is %s",
+				c.iface, c.method, got, c.want, c.want, at)
+		}
+	}
+}
+
+// iidDecl matches the header's EXTERN_C IID definition, e.g.
+// const IID IID_ICoreWebView2Settings3 = {0xfdb5ab74,0xaf33,0x4854,{0x84,...}};
+var iidDecl = regexp.MustCompile(
+	`IID_ICoreWebView2Settings3\s*=\s*\{\s*(0x[0-9a-fA-F]+)\s*,\s*(0x[0-9a-fA-F]+)\s*,\s*(0x[0-9a-fA-F]+)\s*,\s*\{([^}]*)\}`)
+
+func TestSettings3IIDMatchesTheVendoredSDK(t *testing.T) {
+	m := iidDecl.FindStringSubmatch(readWebView2Header(t))
+	if m == nil {
+		t.Fatal("IID_ICoreWebView2Settings3 is not declared in the vendored header")
+	}
+	hex := func(s string) uint64 {
+		v, err := strconv.ParseUint(strings.TrimPrefix(strings.TrimSpace(s), "0x"), 16, 64)
+		if err != nil {
+			t.Fatalf("bad literal %q: %v", s, err)
+		}
+		return v
+	}
+	var want guid
+	want.Data1 = uint32(hex(m[1]))
+	want.Data2 = uint16(hex(m[2]))
+	want.Data3 = uint16(hex(m[3]))
+	parts := strings.Split(m[4], ",")
+	if len(parts) != 8 {
+		t.Fatalf("Data4 has %d bytes, want 8", len(parts))
+	}
+	for i, p := range parts {
+		want.Data4[i] = byte(hex(p))
+	}
+	if want != iidCoreWebView2Settings3 {
+		t.Errorf("IID drift:\n  header: %s\n  ours:   %s", fmtGUID(want), fmtGUID(iidCoreWebView2Settings3))
+	}
+}
+
+func fmtGUID(g guid) string {
+	return fmt.Sprintf("{%#x,%#x,%#x,%#v}", g.Data1, g.Data2, g.Data3, g.Data4)
+}

--- a/sidecar/internal/winchrome/webview2_windows.go
+++ b/sidecar/internal/winchrome/webview2_windows.go
@@ -1,0 +1,113 @@
+//go:build windows
+
+package winchrome
+
+import (
+	"log"
+	"syscall"
+	"unsafe"
+
+	webview "github.com/webview/webview_go"
+)
+
+// vtblSlot returns the address of a COM object's nth vtable entry.
+//
+// Pointer arithmetic only, and no uintptr round trip: obj is an interface
+// pointer whose first word is the vtable, and what comes back is a code
+// address, never a Go pointer. Keeping it that way is what lets the callers
+// stay clean under `go vet -unsafeptr`.
+func vtblSlot(obj unsafe.Pointer, i int) uintptr {
+	return (*(**[64]uintptr)(obj))[i]
+}
+
+// release drops a reference taken by a propget or a QueryInterface.
+func release(obj unsafe.Pointer) {
+	if obj == nil {
+		return
+	}
+	syscall.SyscallN(vtblSlot(obj, idxIUnknownRelease), uintptr(obj))
+}
+
+// disableBrowserAccelerators turns off WebView2's browser accelerator keys for
+// this one window, which is what stops F5 and Ctrl+R from reloading a document
+// that was loaded with SetHtml — a reload of one of those lands on about:blank
+// and leaves a custom-chromed window with no page and, until syncCaption
+// notices, no title bar.
+//
+// Scoped to the window rather than set globally in the engine on purpose: the
+// dashboard panels and the account window show remote pages at real URLs where
+// reload works and is wanted, and the panels are frameless WS_POPUP windows
+// that syncCaption never touches.
+//
+// Failure is never fatal. Every step logs and returns, leaving the window with
+// working accelerators — the caption sync is still there to catch the reload.
+//
+// Threading: bindings and Install both run on the OS thread that created the
+// engine (every host calls runtime.LockOSThread before webview.New), which is
+// the STA WebView2 lives on, so there is no Dispatch hop and no CoInitialize
+// to do here.
+func disableBrowserAccelerators(w webview.WebView) {
+	ctrl := webview.BrowserController(w)
+	if ctrl == nil {
+		log.Printf("[chrome] no browser controller; leaving the browser accelerator keys on")
+		return
+	}
+
+	// Each call below is written inline rather than through a shared helper.
+	// syscall.SyscallN carries //go:uintptrkeepalive, which only covers
+	// uintptr(unsafe.Pointer(x)) conversions written directly in the call's
+	// own argument list; routing the out-params through a variadic helper
+	// would drop both that guarantee and the protection against the stack
+	// moving under them.
+
+	var core unsafe.Pointer
+	hr, _, _ := syscall.SyscallN(
+		vtblSlot(ctrl, idxControllerGetCoreWebView2),
+		uintptr(ctrl),
+		uintptr(unsafe.Pointer(&core)),
+	)
+	// Both checks, every time: a NULL out-param behind an S_OK would be
+	// dereferenced as a vtable, and that is an access violation no recover()
+	// can catch.
+	if hr != 0 || core == nil {
+		log.Printf("[chrome] get_CoreWebView2 failed (hr=%#x); leaving the browser accelerator keys on", hr)
+		return
+	}
+	defer release(core)
+
+	var settings unsafe.Pointer
+	hr, _, _ = syscall.SyscallN(
+		vtblSlot(core, idxCoreWebView2GetSettings),
+		uintptr(core),
+		uintptr(unsafe.Pointer(&settings)),
+	)
+	if hr != 0 || settings == nil {
+		log.Printf("[chrome] get_Settings failed (hr=%#x); leaving the browser accelerator keys on", hr)
+		return
+	}
+	defer release(settings)
+
+	// ICoreWebView2Settings3 arrived in runtime 1.0.864.35. An older
+	// fixed-version runtime answers E_NOINTERFACE, which is a clean no.
+	var settings3 unsafe.Pointer
+	hr, _, _ = syscall.SyscallN(
+		vtblSlot(settings, 0), // IUnknown::QueryInterface
+		uintptr(settings),
+		uintptr(unsafe.Pointer(&iidCoreWebView2Settings3)),
+		uintptr(unsafe.Pointer(&settings3)),
+	)
+	if hr != 0 || settings3 == nil {
+		log.Printf("[chrome] this WebView2 runtime has no ICoreWebView2Settings3 (hr=%#x); leaving the browser accelerator keys on", hr)
+		return
+	}
+	defer release(settings3)
+
+	hr, _, _ = syscall.SyscallN(
+		vtblSlot(settings3, idxSettings3PutBrowserAcceleratorKeys),
+		uintptr(settings3),
+		0, // FALSE
+	)
+	if hr != 0 {
+		log.Printf("[chrome] could not disable the browser accelerator keys (hr=%#x)", hr)
+	}
+}

--- a/sidecar/third_party/webview_go/JARVIS_PATCH.md
+++ b/sidecar/third_party/webview_go/JARVIS_PATCH.md
@@ -2,9 +2,10 @@
 
 This is a local copy of `github.com/webview/webview_go` (the pinned version is
 in `UPSTREAM_VERSION`), wired in via a `replace` directive in `sidecar/go.mod`,
-with **four patches**, all carried by `jarvis.patch`: a Win32 one for the open
+with **five patches**, all carried by `jarvis.patch`: a Win32 one for the open
 flash, a Cocoa one to create the window on the main thread, a `webview_create`
-check that rejects a half-built engine, and a NULL-handle guard in `webview.go`.
+check that rejects a half-built engine, a NULL-handle guard in `webview.go`,
+and a browser-controller accessor in a file of our own, `jarvis_native.go`.
 
 `jarvis.patch` must carry EVERY vendored edit. `vendor-webview.sh` deletes the
 vendor directory and copies pristine upstream over it, keeping only
@@ -141,3 +142,37 @@ The stray WM_QUIT that made this reachable came from the sidecar calling
 `Terminate()` (`PostQuitMessage(0)`, which targets the *calling* thread) from
 a foreign goroutine; `panels_runtime.go` now dispatches it onto the engine's
 own thread. This patch is the backstop for any other source.
+
+## The browser-controller accessor (`jarvis_native.go`)
+
+Upstream's C library has implemented `webview_get_native_handle` since 0.11,
+but its Go binding never bound it: `Window()` hands out the HWND and nothing
+else. That leaves the engine's own object graph — and with it every WebView2
+setting the library does not already set inside `embed()` — unreachable from
+Go.
+
+`internal/winchrome` needs exactly one of those settings.
+`AreBrowserAcceleratorKeysEnabled` is what stops F5 and Ctrl+R from reloading a
+document loaded with `SetHtml`; such a reload lands on `about:blank`, and on a
+window that draws its own title bar that means no page AND no caption. Reaching
+`ICoreWebView2Settings3` to turn it off starts from the controller pointer this
+accessor returns.
+
+Two shape decisions worth keeping:
+
+- **A new file, not a hunk in `webview.go` or `webview.h`.** It touches no
+  upstream source, so it has nothing to conflict with when the monthly bot
+  re-vendors — unlike `webview.h`, which already carries five hunks and whose
+  win32 constructor context this file explicitly warns about above. `patch`
+  creates it from a `--- /dev/null` hunk, and it must NOT go in `KEEP_FILES`:
+  the whole point is that the patch carries it.
+- **A free function, not a method on the `WebView` interface.** Nothing in this
+  repo implements that interface today, but upstream may well add its own
+  `NativeHandle` with a different signature, and a package-level function has
+  a far smaller collision surface.
+
+Unlike the other four, this patch cannot be silently reverted: `internal/winchrome`
+*calls* `webview.BrowserController`, so losing it is a **build failure** on the
+Windows cross-build in `test.yml` and `update-webview.yml`, not a green PR that
+quietly dropped a behavior. The sanity grep in `vendor-webview.sh` is kept
+anyway, both for consistency and because it names the intent.

--- a/sidecar/third_party/webview_go/jarvis.patch
+++ b/sidecar/third_party/webview_go/jarvis.patch
@@ -130,3 +130,50 @@
  	return w
  }
  
+--- /dev/null
++++ b/jarvis_native.go
+@@ -0,0 +1,44 @@
++package webview
++
++/*
++#include "webview.h"
++*/
++import "C"
++
++import "unsafe"
++
++// PATCHED (jarvis): expose the native browser controller.
++//
++// The C library has implemented webview_get_native_handle since 0.11 (see
++// webview.h), but upstream's Go binding never bound it — Window() surrenders
++// the HWND and nothing else. That leaves the engine's own object graph
++// unreachable from Go, and with it every WebView2 setting: the library sets
++// AreDevToolsEnabled and IsStatusBarEnabled inside embed() and offers no way
++// to touch the rest.
++//
++// internal/winchrome needs exactly one of them. A window that draws its own
++// title bar is trapped by a reload — the document loaded with SetHtml comes
++// back as about:blank, with no strip and no caption — so it turns
++// AreBrowserAcceleratorKeysEnabled off, which needs ICoreWebView2Settings3,
++// which needs this pointer.
++//
++// A new FILE rather than a hunk in webview.go, and a free function rather than
++// a method on the WebView interface: this touches no upstream source, so it
++// has nothing to conflict with when the monthly bot re-vendors, and it cannot
++// collide with an upstream NativeHandle of a different shape.
++//
++// What comes back is the platform's controller object, unretained and owned by
++// the engine — ICoreWebView2Controller* on Windows, WKWebView* on macOS,
++// WebKitWebView* on GTK. Callers must not Release it, and must not outlive w.
++//
++// nil when there is none. On Windows there always is one after a successful
++// New: the jarvis patch to webview_create already refuses to build an engine
++// whose browser_controller() is NULL, so a non-nil WebView means a live
++// controller.
++func BrowserController(w WebView) unsafe.Pointer {
++	iw, ok := w.(*webview)
++	if !ok || iw == nil || iw.w == nil {
++		return nil
++	}
++	return unsafe.Pointer(C.webview_get_native_handle(iw.w, C.WEBVIEW_NATIVE_HANDLE_KIND_BROWSER_CONTROLLER))
++}

--- a/sidecar/third_party/webview_go/jarvis_native.go
+++ b/sidecar/third_party/webview_go/jarvis_native.go
@@ -1,0 +1,44 @@
+package webview
+
+/*
+#include "webview.h"
+*/
+import "C"
+
+import "unsafe"
+
+// PATCHED (jarvis): expose the native browser controller.
+//
+// The C library has implemented webview_get_native_handle since 0.11 (see
+// webview.h), but upstream's Go binding never bound it — Window() surrenders
+// the HWND and nothing else. That leaves the engine's own object graph
+// unreachable from Go, and with it every WebView2 setting: the library sets
+// AreDevToolsEnabled and IsStatusBarEnabled inside embed() and offers no way
+// to touch the rest.
+//
+// internal/winchrome needs exactly one of them. A window that draws its own
+// title bar is trapped by a reload — the document loaded with SetHtml comes
+// back as about:blank, with no strip and no caption — so it turns
+// AreBrowserAcceleratorKeysEnabled off, which needs ICoreWebView2Settings3,
+// which needs this pointer.
+//
+// A new FILE rather than a hunk in webview.go, and a free function rather than
+// a method on the WebView interface: this touches no upstream source, so it
+// has nothing to conflict with when the monthly bot re-vendors, and it cannot
+// collide with an upstream NativeHandle of a different shape.
+//
+// What comes back is the platform's controller object, unretained and owned by
+// the engine — ICoreWebView2Controller* on Windows, WKWebView* on macOS,
+// WebKitWebView* on GTK. Callers must not Release it, and must not outlive w.
+//
+// nil when there is none. On Windows there always is one after a successful
+// New: the jarvis patch to webview_create already refuses to build an engine
+// whose browser_controller() is NULL, so a non-nil WebView means a live
+// controller.
+func BrowserController(w WebView) unsafe.Pointer {
+	iw, ok := w.(*webview)
+	if !ok || iw == nil || iw.w == nil {
+		return nil
+	}
+	return unsafe.Pointer(C.webview_get_native_handle(iw.w, C.WEBVIEW_NATIVE_HANDLE_KIND_BROWSER_CONTROLLER))
+}


### PR DESCRIPTION
Pressing **F5** or **Ctrl+R** in a window that draws its own title bar reloads the document — and reloading a document loaded with `SetHtml` lands on `about:blank`. What's left is a window with no page, no page-drawn close button, and no caption. `Alt+F4` and the taskbar still work, so it isn't truly stuck, but to anyone who doesn't know that it is.

Affects settings, logs, onboarding, the first-run connect window and its token form, and the installer wizard. The wizard's own `retryPlan` comment has documented the mechanism since #383. The account window and the dashboard panels are untouched — both show remote pages at real URLs where reload works and is wanted, and the panels are frameless `WS_POPUP` windows that would be genuinely unrecoverable — so this is per-window, never global.

### Two layers

**The caption follows the document.** `initJS` is injected with `AddScriptToExecuteOnDocumentCreated`, so it runs on every document, `about:blank` included. Each one reports whether our strip is present and `syncCaption` matches the window style to it. A lost document therefore leaves an ordinary framed window you can move and close.

It syncs both ways rather than only restoring. The connect window swaps documents from a goroutine (`showShellError` / `showSelfHostHint`), so a reload mid-handshake is followed by a fresh chromed document — restore-only would leave that window wearing two title bars.

Three details are load-bearing, and all three are commented: it keys on `#wchrome` rather than `location` (a `NavigateToString` document *already* reports `about:blank`, so the URL can't discriminate); it defers to `DOMContentLoaded` (the strip is the last element in `<body>`, and deferring is also what guarantees the binding stub exists, since WebView2 doesn't promise ordering across document-created scripts); and it is top-frame only (that API injects into every frame, so a future `<iframe>` would otherwise un-chrome a working window).

**The keys are turned off.** Per-window `put_AreBrowserAcceleratorKeysEnabled(FALSE)` via `ICoreWebView2Settings3`, so the reload never fires. This also fixes a second latent bug for free: those five `SetHtml` calls create real session-history entries, so `Alt+←` on the connect window currently navigates back into a stale shell with a cancelled handshake — and *that* document has a valid strip, so the caption sync alone would not have caught it.

The two layers are deliberately kept separate. The default context menu keeps its Reload: disabling it is cheaper than the engine fix, but costs right-click→Paste in the token textarea and right-click→Copy on log lines. Leaving that route open is also what keeps the caption sync exercised rather than rotting into dead code.

### Accepted cost

`AreBrowserAcceleratorKeysEnabled` is a family switch: **Ctrl+F, Alt+←/→, Ctrl+P and keyboard zoom (Ctrl +/−/0) go with it.** Accepted for windows this small — display scaling still applies, they size themselves at their own DPI, and the one page anyone would search has its own search box. Ctrl+A/C/V/X are unaffected. Documented in `Install`'s contract comment.

### The vendored patch

Go had no route to `ICoreWebView2Settings3`: the C library has implemented `webview_get_native_handle` since 0.11, but upstream's Go binding never bound it. So `jarvis.patch` gains a fifth hunk — a new file, `jarvis_native.go`, exposing `BrowserController`.

A new file rather than a hunk in `webview.go` or `webview.h`: it touches no upstream source, so it has nothing to conflict with when the monthly re-vendor bot runs, unlike `webview.h` which already carries five hunks. And because `internal/winchrome` *calls* it, losing the patch is a build failure on the Windows cross-build rather than a green PR that quietly dropped a behaviour — stronger than the grep marker, which is added anyway for consistency.

I verified the patch reproduces the committed tree exactly: reconstructing pristine upstream from the module cache and applying `jarvis.patch` gives files byte-identical to what's checked in.

### The magic numbers check themselves

The COM walk uses three vtable slots that no compiler verifies. `webview2_ids_test.go` re-derives them, and the IID, from the vendored `WebView2.h` on every run on any platform, and fails on drift — including a header bump that inserts a method and shifts every slot after it. It self-checks its own parse by asserting slots 0/1/2 are `QueryInterface`/`AddRef`/`Release`, because a silently mis-aligned parser is worse than no test.

All three acquired pointers are `Release`d. Upstream's `embed()` leaks its `settings` pointer; that is not copied here.

### Testing

CI proves: the vtable indices and IID against the vendored header; the sync script's contract; that `brand.TitlebarHTML`'s id is exactly the one `initJS` looks for (nothing coupled those two strings before — a rename would have made every chromed document un-chrome its own window); `captionedStyle`/`captionlessStyle` round-trip and idempotence; and that the COM file compiles **and vets** under `GOOS=windows`.

That last one is new. CI vets linux and darwin but only *built* Windows, so `unsafeptr` never saw these files. The step is scoped to `./internal/winchrome/` rather than `./...` because `notify_windows.go` and `tray_windows.go` convert an incoming `WM_COPYDATA` `LPARAM` to a struct pointer — correct, since it is a real address from another process, but a known `unsafeptr` false positive. Widening it is a separate decision.

I also drove the shipped `initJS` string through headless Chromium over HTTP: a chromed page reports `true`, a blank document reports `false`, and a page with a strip-less subframe reports only `true` — while the same script with the top-frame guard removed reports `true,false`, which is the failure the guard prevents.

**Not proven here, and needs the Windows box** — the reload behaviour itself. New checklist items are in `sidecar/README.md`. The gating one: reload the settings window and confirm the native title bar comes back. The whole caption-sync layer rests on document-created scripts firing on the post-reload `about:blank`; the indirect evidence is strong (every binding on every chromed page works today, and those documents also report an `about:blank` URI) but a real reload is a different code path.

### Road not taken

Switching the five pages from `SetHtml` to a `data:` URL would make reload harmless with no COM and no patch at all. It turns a contained problem into a content-delivery change across five windows, adds a history entry per document, and needs its own Windows check for `window.chrome.webview` on an opaque origin. Worth revisiting, not worth bundling here. A JS `preventDefault` on F5 is not an option — Chromium treats reload as browser-reserved.
