### PR TITLE
fix(workflows): manual run of a non-manual (e.g. schedule) trigger no longer fails at engine start

### DIFF
--- a/scripts/sync-activepieces.ts
+++ b/scripts/sync-activepieces.ts
@@ -401,23 +401,29 @@ const PATCH_INSERTIONS: Record<
     },
   ],
   // Upstream's `flow-executor.executeFromTrigger` always calls
-  // `triggerHelper.executeOnStart`, which throws `TriggerNameNotSetError`
-  // when the trigger has no piece (the EMPTY / "Manual" type). Without this
-  // patch, manually-triggered runs from the editor's Run button fail
-  // before step 1. Anchor on the `BEGIN` branch's opening brace and insert
-  // an EMPTY-trigger short-circuit that runs the bookkeeping (initial
-  // backup + sendUpdate) and then walks straight into the action chain.
+  // `triggerHelper.executeOnStart`, which reads `settings.triggerName` and
+  // throws `TriggerNameNotSetError` when it is nil. That is nil for the EMPTY
+  // "Manual" trigger AND for a non-manual trigger (e.g. SCHEDULE) invoked
+  // MANUALLY from the Run button — both must run anyway. Without this patch
+  // those runs fail before step 1. Anchor on the `BEGIN` branch's opening
+  // brace and insert a no-triggerName short-circuit that runs the bookkeeping
+  // (initial backup + sendUpdate) and then walks straight into the action chain.
   "packages/server/engine/src/lib/handler/flow-executor.ts": [
     {
       anchor: /^\s*if \(input\.executionType === ExecutionType\.BEGIN\) \{\s*$/,
       insert:
-        "            // === JARVIS PATCH: short-circuit for manual (EMPTY) triggers ===\n" +
+        "            // === JARVIS PATCH: short-circuit when there is no piece trigger to start ===\n" +
         "            // Upstream unconditionally calls `triggerHelper.executeOnStart`,\n" +
-        "            // which throws `TriggerNameNotSetError` whenever the trigger has\n" +
-        "            // no piece (i.e. type === 'EMPTY' -- our user-facing \"Manual\"\n" +
-        "            // trigger). Replicate the surrounding bookkeeping (initial-state\n" +
-        "            // backup + progress update) and skip straight into the action chain.\n" +
-        "            if ((trigger as { type?: string }).type === 'EMPTY') {\n" +
+        "            // which reads `settings.triggerName` and throws\n" +
+        "            // `TriggerNameNotSetError` whenever it is nil -- true for the EMPTY\n" +
+        "            // \"Manual\" trigger AND for a non-manual trigger (e.g. SCHEDULE)\n" +
+        "            // invoked MANUALLY from the Run button. Both must run: skip straight\n" +
+        "            // into the action chain after the same bookkeeping (backup +\n" +
+        "            // sendUpdate). A real trigger firing carries a triggerName and still\n" +
+        "            // runs executeOnStart below, unchanged.\n" +
+        "            const jarvisTriggerName = (trigger as { settings?: { triggerName?: unknown } }).settings\n" +
+        "                ?.triggerName\n" +
+        "            if (isNil(jarvisTriggerName)) {\n" +
         "                void runProgressService.backup({\n" +
         "                    engineConstants: constants,\n" +
         "                    flowExecutorContext: executionState,\n" +

--- a/src/workflows/activepieces/packages/server/engine/src/lib/handler/flow-executor.ts
+++ b/src/workflows/activepieces/packages/server/engine/src/lib/handler/flow-executor.ts
@@ -39,16 +39,18 @@ export const flowExecutor = {
     }): Promise<FlowExecutorContext> {
         const trigger = input.flowVersion.trigger
         if (input.executionType === ExecutionType.BEGIN) {
-            // === JARVIS PATCH: short-circuit for manual (EMPTY) triggers ===
+            // === JARVIS PATCH: short-circuit when there is no piece trigger to start ===
             // Upstream unconditionally calls `triggerHelper.executeOnStart`,
-            // which throws `TriggerNameNotSetError` whenever the trigger has
-            // no piece (i.e. type === 'EMPTY' — our user-facing "Manual"
-            // trigger). Replicate the surrounding bookkeeping (initial-state
-            // backup + progress update) and skip straight into the action
-            // chain. The mirror of this patch lives in PATCH_INSERTIONS in
-            // `scripts/sync-activepieces.ts` so future upstream re-syncs
-            // restore it automatically.
-            if ((trigger as { type?: string }).type === 'EMPTY') {
+            // which reads `settings.triggerName` and throws
+            // `TriggerNameNotSetError` whenever it is nil -- true for the EMPTY
+            // "Manual" trigger AND for a non-manual trigger (e.g. SCHEDULE)
+            // invoked MANUALLY from the Run button. Both must run: skip straight
+            // into the action chain after the same bookkeeping (backup +
+            // sendUpdate). A real trigger firing carries a triggerName and still
+            // runs executeOnStart below, unchanged.
+            const jarvisTriggerName = (trigger as { settings?: { triggerName?: unknown } }).settings
+                ?.triggerName
+            if (isNil(jarvisTriggerName)) {
                 void runProgressService.backup({
                     engineConstants: constants,
                     flowExecutorContext: executionState,

--- a/src/workflows/runner/engine-runtime/build.ts
+++ b/src/workflows/runner/engine-runtime/build.ts
@@ -219,6 +219,13 @@ const PATCHED_VENDOR_SOURCES = [
   // doesn't ship the OLD operator list / executor.
   "shared/src/lib/automation/flows/actions/action.ts",
   "server/engine/src/lib/handler/router-executor.ts",
+  // Jarvis: the executeFromTrigger short-circuit that runs a flow's steps when
+  // its trigger has no piece to start (the EMPTY "Manual" trigger, AND a
+  // non-manual trigger — e.g. SCHEDULE — invoked manually from the Run button).
+  // Without registering it here, editing that patch left the OLD engine cached
+  // and the fix never shipped — which is exactly how a stale bundle kept
+  // throwing TriggerNameNotSetError after the patch was generalized.
+  "server/engine/src/lib/handler/flow-executor.ts",
   // Jarvis: upstream sets process.env.NODE_TLS_REJECT_UNAUTHORIZED='0'
   // on every HTTP-node request, which disables TLS verification for the
   // entire Node process (not just the one request). We strip that line
@@ -226,6 +233,15 @@ const PATCHED_VENDOR_SOURCES = [
   // it, the file content here changes and the bundle hash invalidates so
   // the cached engine doesn't keep shipping the OLD bypass.
   "pieces/common/src/lib/http/axios/axios-http-client.ts",
+  // The remaining files sync-activepieces.ts patches (STUB_FILES / STRIP_LINES /
+  // PATCH_INSERTIONS) — registered so ANY of them changing invalidates the
+  // bundle, closing the same stale-engine gap flow-executor.ts hit. Keep this
+  // set in sync with the sync script's patch tables; a file it patches but this
+  // list omits is served stale from cache.
+  "server/engine/src/lib/core/code/v8-isolate-code-sandbox.ts", // STUB_FILES
+  "pieces/framework/src/lib/context/index.ts", // PATCH_INSERTIONS
+  "shared/src/index.ts", // STRIP_LINES
+  "pieces/framework/src/lib/index.ts", // STRIP_LINES
 ] as const;
 
 /**

--- a/src/workflows/runner/engine-runtime/end-to-end.test.ts
+++ b/src/workflows/runner/engine-runtime/end-to-end.test.ts
@@ -149,6 +149,73 @@ describe("Engine end-to-end (F gate)", () => {
   );
 
   test.skipIf(skipE2eTests)(
+    "a trigger with NO triggerName (e.g. a schedule run manually) still runs its steps, not TriggerNameNotSetError",
+    async () => {
+      // Regression: running a workflow MANUALLY whose trigger is not the manual
+      // one (a SCHEDULE trigger came through with a nil triggerName) used to die
+      // at engine start with `TriggerNameNotSetError` / "FAILED at engine, no
+      // per-step trace". The engine now short-circuits executeOnStart when there
+      // is no triggerName and walks straight into the action chain.
+      const flow = createFlow({ projectId: DEFAULT_IDS.project });
+      const trigger: FlowTriggerNode = {
+        name: "trigger",
+        type: "PIECE_TRIGGER",
+        displayName: "Schedule",
+        settings: {
+          pieceName: PIECE_TEST_NAME,
+          pieceVersion: PIECE_VERSION,
+          // triggerName DELIBERATELY absent — the exact shape a manual run of a
+          // non-manual trigger produced.
+          input: {},
+        },
+        nextAction: {
+          name: "step_1",
+          type: "PIECE",
+          displayName: "Echo",
+          settings: {
+            pieceName: PIECE_TEST_NAME,
+            pieceVersion: PIECE_VERSION,
+            actionName: "echo",
+            input: { value: { from: "schedule-manual" } },
+          },
+        },
+      };
+      const v = createDraftVersion({
+        flowId: flow.id,
+        displayName: "schedule-manual-echo",
+        trigger,
+      });
+      updateDraftVersion(v.id, { trigger, valid: true });
+      lockVersion(v.id);
+
+      const run = createFlowRun({
+        flowId: flow.id,
+        flowVersionId: v.id,
+        environment: "TESTING",
+      });
+      const handle = await runtime!.acquire({
+        runId: run.id,
+        projectId: DEFAULT_IDS.project,
+      });
+      let stderrBuf = "";
+      handle.stderr?.on("data", (d) => { stderrBuf += d.toString(); });
+      try {
+        const finalRun = await handle.executeFlow({
+          flowVersion: getFlowVersion(v.id)!,
+        });
+        if (finalRun.status !== "SUCCEEDED") {
+          console.error(`[engine stderr]\n${stderrBuf.slice(0, 4000)}`);
+        }
+        expect(finalRun.status).toBe("SUCCEEDED");
+      } finally {
+        await handle.release();
+      }
+      expect(getFlowRun(run.id)?.status).toBe("SUCCEEDED");
+    },
+    45_000,
+  );
+
+  test.skipIf(skipE2eTests)(
     "manual trigger + jarvis-ask action calls daemon's /v1/jarvis/llm/chat",
     async () => {
       llmCalls = [];


### PR DESCRIPTION
## What
Manually running a workflow whose trigger is **not** the Manual one (e.g. a **schedule**) failed at engine start with `TriggerNameNotSetError` — surfaced to the user as "FAILED at engine — no per-step trace recorded". Changing the trigger to Manual made it run. This fixes the manual-run path for any trigger type.

## Why
`executeFromTrigger` (BEGIN branch) has a JARVIS PATCH that skips `triggerHelper.executeOnStart` — which throws `TriggerNameNotSetError` when `settings.triggerName` is nil — but it only did so for `trigger.type === 'EMPTY'`. A schedule/piece trigger run manually is `PIECE_TRIGGER` with a **nil** `triggerName`, so it fell through to `executeOnStart` and died before step 1.

## How
- Gate the short-circuit on **`isNil(triggerName)`** instead of `type === 'EMPTY'`. This covers the Manual trigger *and* any non-manual trigger invoked manually; a real trigger firing (triggerName set) still runs `executeOnStart` unchanged. `executeOnStart` cannot do anything without `triggerName`, so skipping when it's nil is strictly safe.
- Register `flow-executor.ts` in `PATCHED_VENDOR_SOURCES` so edits to this patch invalidate the engine-bundle content hash. It **wasn't** there, so the fix would have shipped stale (verified: rebuild reused the old bundle until this was added). Also registered the other four sync-patched files still missing from the list, closing the same gap fleet-wide.
- Mirror the generalized patch in `scripts/sync-activepieces.ts` so a future upstream re-sync restores it — verified byte-identical to the vendored file, so a re-sync produces no spurious diff.
- Add an e2e regression test (a `PIECE_TRIGGER` with no `triggerName` → run reaches SUCCEEDED). Verified: fails on the old bundle, passes on the rebuilt one; the existing Manual-trigger test still passes.

## Test
`bun x tsc` clean; engine rebuilt and `end-to-end.test.ts` passes 4/4 (incl. the new regression); non-e2e workflow suites green.
