### PR TITLE
fix(llm): hosted provider retries the thinking-budget 400 so small calls (awareness) survive a reasoning tier

### DIFF
--- a/src/llm/usejarvis.test.ts
+++ b/src/llm/usejarvis.test.ts
@@ -87,6 +87,117 @@ describe('UsejarvisAIProvider', () => {
     expect('temperature' in sent!).toBe(false);
   });
 
+  it('retries a thinking-budget 400 once with a max_tokens that clears the budget (chat)', async () => {
+    // A tier that resolves to a thinking model rejects a max_tokens below its
+    // thinking budget; the small structured calls (awareness deltas etc.) hit
+    // this. The provider retries once with room, so the call succeeds.
+    const sent: Array<Record<string, unknown>> = [];
+    globalThis.fetch = (async (_input: any, init?: any) => {
+      sent.push(JSON.parse(String(init?.body)));
+      if (sent.length === 1) {
+        return jsonResponse(400, {
+          error: { message: 'litellm.BadRequestError: AnthropicException - `max_tokens` must be greater than `thinking.budget_tokens`.' },
+        });
+      }
+      return jsonResponse(200, {
+        id: 'x', object: 'chat.completion', model: 'uj-medium',
+        choices: [{ index: 0, finish_reason: 'stop', message: { role: 'assistant', content: 'ok' } }],
+        usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+      });
+    }) as unknown as typeof fetch;
+    const provider = new UsejarvisAIProvider('https://llm.usejarvis.host', 'sk-uj-abc');
+    const res = await provider.chat([{ role: 'user', content: 'hi' }], { model: 'uj-medium', max_tokens: 200 });
+    expect(res.content).toBe('ok');
+    expect(sent.length).toBe(2); // one retry, no more
+    expect(sent[0]!.max_completion_tokens).toBe(200); // first call kept the caller's tiny cap
+    expect(sent[1]!.max_completion_tokens as number).toBeGreaterThanOrEqual(16384); // retry cleared the budget
+  });
+
+  it('does NOT retry a 400 that is not a thinking-budget error', async () => {
+    let calls = 0;
+    globalThis.fetch = (async () => {
+      calls++;
+      return jsonResponse(400, { error: { message: 'some other invalid_request_error' } });
+    }) as unknown as typeof fetch;
+    const provider = new UsejarvisAIProvider('https://llm.usejarvis.host', 'sk-uj-abc');
+    await expect(provider.chat([{ role: 'user', content: 'hi' }], { model: 'uj-low', max_tokens: 5 })).rejects.toThrow();
+    expect(calls).toBe(1); // no retry — a tiny cap on a non-thinking tier is respected
+  });
+
+  it('restarts the STREAM once on a pre-stream thinking-budget 400, with a cleared max_tokens', async () => {
+    const sent: Array<Record<string, unknown>> = [];
+    globalThis.fetch = (async (_input: any, init?: any) => {
+      sent.push(JSON.parse(String(init?.body)));
+      if (sent.length === 1) {
+        return jsonResponse(400, {
+          error: { message: 'AnthropicException - `max_tokens` must be greater than `thinking.budget_tokens`.' },
+        });
+      }
+      return new Response(
+        'data: {"choices":[{"delta":{"content":"ok"}}]}\n\ndata: [DONE]\n\n',
+        { status: 200, headers: { 'Content-Type': 'text/event-stream' } },
+      );
+    }) as unknown as typeof fetch;
+    const provider = new UsejarvisAIProvider('https://llm.usejarvis.host', 'sk-uj-abc');
+    let text = '';
+    let sawError = false;
+    for await (const ev of provider.stream([{ role: 'user', content: 'hi' }], { model: 'uj-medium', max_tokens: 200 })) {
+      if (ev.type === 'error') sawError = true;
+      if (ev.type === 'text') text += ev.text;
+    }
+    expect(sawError).toBe(false); // the pre-stream error was swallowed by the restart
+    expect(text).toBe('ok');
+    expect(sent.length).toBe(2);
+    expect(sent[1]!.max_completion_tokens as number).toBeGreaterThanOrEqual(16384);
+  });
+
+  it('retries a thinking-budget 400 at most ONCE — a still-failing retry rejects, no loop (chat)', async () => {
+    let calls = 0;
+    globalThis.fetch = (async () => {
+      calls++;
+      return jsonResponse(400, {
+        error: { message: 'AnthropicException - `max_tokens` must be greater than `thinking.budget_tokens`.' },
+      });
+    }) as unknown as typeof fetch;
+    const provider = new UsejarvisAIProvider('https://llm.usejarvis.host', 'sk-uj-abc');
+    await expect(
+      provider.chat([{ role: 'user', content: 'hi' }], { model: 'uj-medium', max_tokens: 200 }),
+    ).rejects.toThrow();
+    expect(calls).toBe(2); // original + exactly one retry — the termination guard
+  });
+
+  it('does NOT retry when the caller already sent max_tokens >= the floor (retry would be identical)', async () => {
+    let calls = 0;
+    globalThis.fetch = (async () => {
+      calls++;
+      return jsonResponse(400, {
+        error: { message: 'AnthropicException - `max_tokens` must be greater than `thinking.budget_tokens`.' },
+      });
+    }) as unknown as typeof fetch;
+    const provider = new UsejarvisAIProvider('https://llm.usejarvis.host', 'sk-uj-abc');
+    await expect(
+      provider.chat([{ role: 'user', content: 'hi' }], { model: 'uj-medium', max_tokens: 32000 }),
+    ).rejects.toThrow();
+    expect(calls).toBe(1); // 32000 >= floor -> bumping wouldn't change the request, so no wasted retry
+  });
+
+  it('retries the STREAM at most once — a still-failing restart surfaces one error, no loop', async () => {
+    let calls = 0;
+    globalThis.fetch = (async () => {
+      calls++;
+      return jsonResponse(400, {
+        error: { message: 'AnthropicException - `max_tokens` must be greater than `thinking.budget_tokens`.' },
+      });
+    }) as unknown as typeof fetch;
+    const provider = new UsejarvisAIProvider('https://llm.usejarvis.host', 'sk-uj-abc');
+    let errorEvents = 0;
+    for await (const ev of provider.stream([{ role: 'user', content: 'hi' }], { model: 'uj-medium', max_tokens: 200 })) {
+      if (ev.type === 'error') errorEvents++;
+    }
+    expect(calls).toBe(2); // original + one restart
+    expect(errorEvents).toBe(1); // the second failure surfaces, rewritten, exactly once
+  });
+
   it('rewrites budget-exceeded into actionable copy, keeping the (status) marker', async () => {
     globalThis.fetch = (async () =>
       jsonResponse(400, { error: { message: 'ExceededBudget: budget has been exceeded for this key' } })) as unknown as typeof fetch;

--- a/src/llm/usejarvis.ts
+++ b/src/llm/usejarvis.ts
@@ -1,5 +1,5 @@
 import { OpenAIProvider, type OpenAIMessage } from './openai.ts';
-import type { LLMMessage } from './provider.ts';
+import type { LLMMessage, LLMOptions } from './provider.ts';
 import { hostedProxyError, isBudgetExhaustion } from '../util/hosted-error.ts';
 import { redactSecrets } from '../util/redact.ts';
 
@@ -201,12 +201,73 @@ export class UsejarvisAIProvider extends OpenAIProvider {
    * unreachable so tier pickers degrade instead of hanging or throwing. */
   static readonly FALLBACK_MODELS = ['uj-chat', 'uj-high', 'uj-low', 'uj-medium'] as const;
 
+  /** A hosted tier that resolves to a reasoning/thinking model rejects a
+   * `max_tokens` smaller than its thinking budget — Anthropic answers 400
+   * "`max_tokens` must be greater than `thinking.budget_tokens`" (observed
+   * budgets ~2–4k for reasoning_effort medium/high). Small structured calls
+   * (awareness deltas at max_tokens:200, one-word classifiers, etc.) hit this
+   * whenever an operator sets reasoning_effort on such a tier — which broke
+   * every awareness call once one was set on a Claude tier. Matched on the
+   * stable substring, not a status: the body arrives inside a wrapped message. */
+  private static isThinkingBudgetError(err: unknown): boolean {
+    const msg = err instanceof Error ? err.message : String(err);
+    return msg.includes('thinking.budget_tokens');
+  }
+  /** What to retry a budget-collision call with. Well above the thinking
+   * budgets litellm's reasoning_effort maps to (tops out ~4k for high), and
+   * inside every thinking-capable hosted model's output cap (>=32k), so the
+   * bump clears the budget without itself 400ing as too large. NOTE this
+   * REMOVES the caller's output cap: a call that asked for <=200 completion
+   * tokens can now return up to this many — unavoidable, since Anthropic
+   * requires max_tokens > budget and the budget is invisible behind the opaque
+   * alias. Downstream code must not rely on a tiny max_tokens as a hard length
+   * bound on a hosted tier; constrain via the prompt instead. */
+  private static readonly THINKING_RETRY_MAX_TOKENS = 16384;
+
+  /** Models already warned about this misconfig — one line per process, not
+   * per call (the awareness loop hits this constantly). */
+  private static readonly warnedThinkingTiers = new Set<string>();
+
+  /** Retry options with max_tokens raised above the thinking budget, or null
+   * when the caller already sent >= the floor — retrying identically is
+   * pointless (a custom proxy budget above the floor degrades cleanly to the
+   * rewritten throw). Warns ONCE per model: the retry hides a persistent
+   * misconfiguration (every small call then pays a doomed first request plus a
+   * thinking completion billed as output), so the operator needs a signal to
+   * drop reasoning_effort from a tier that runs short structured calls. */
+  private static bumpForThinkingBudget(options: LLMOptions | undefined): LLMOptions | null {
+    const current = options?.max_tokens ?? 0;
+    if (current >= UsejarvisAIProvider.THINKING_RETRY_MAX_TOKENS) return null;
+    const model = options?.model ?? '(default)';
+    if (!UsejarvisAIProvider.warnedThinkingTiers.has(model)) {
+      UsejarvisAIProvider.warnedThinkingTiers.add(model);
+      console.warn(
+        `[usejarvis] ${model} rejected max_tokens=${current || '(unset)'} below its thinking budget; ` +
+          `retried with ${UsejarvisAIProvider.THINKING_RETRY_MAX_TOKENS}. If this tier runs short ` +
+          `structured calls, drop reasoning_effort from its model.`,
+      );
+    }
+    return { ...options, max_tokens: UsejarvisAIProvider.THINKING_RETRY_MAX_TOKENS };
+  }
+
   override async chat(
     ...args: Parameters<OpenAIProvider['chat']>
   ): ReturnType<OpenAIProvider['chat']> {
     try {
       return await super.chat(...args);
     } catch (error) {
+      if (UsejarvisAIProvider.isThinkingBudgetError(error)) {
+        const [messages, options] = args;
+        const bumped = UsejarvisAIProvider.bumpForThinkingBudget(options);
+        if (bumped) {
+          try {
+            // super.chat, not this.chat: one retry only, no re-entry.
+            return await super.chat(messages, bumped);
+          } catch (retryError) {
+            throw await this.rewrite(retryError);
+          }
+        }
+      }
       throw await this.rewrite(error);
     }
   }
@@ -219,12 +280,32 @@ export class UsejarvisAIProvider extends OpenAIProvider {
     // rewrite must intercept EVENTS; a try/catch here is dead code, and the
     // raw proxy body — which can echo the bearer we presented — would reach
     // the chat bubble on the very path users talk through.
-    for await (const event of super.stream(...args)) {
-      if (event.type === 'error' && typeof event.error === 'string') {
-        yield { ...event, error: await this.rewriteText(event.error) };
-      } else {
-        yield event;
+    const [messages] = args;
+    let options = args[1];
+    let retried = false;
+    // Loop so a pre-stream thinking-budget 400 (see chat()) can restart the
+    // stream once with a max_tokens that clears the budget. Only BEFORE any
+    // content has been yielded — a mid-stream restart would replay output — but
+    // that error is always the first event, so the guard holds.
+    restart: for (;;) {
+      let yieldedContent = false;
+      for await (const event of super.stream(messages, options)) {
+        if (event.type === 'error' && typeof event.error === 'string') {
+          if (!retried && !yieldedContent && UsejarvisAIProvider.isThinkingBudgetError(event.error)) {
+            const bumped = UsejarvisAIProvider.bumpForThinkingBudget(options);
+            if (bumped) {
+              retried = true;
+              options = bumped;
+              continue restart;
+            }
+          }
+          yield { ...event, error: await this.rewriteText(event.error) };
+        } else {
+          yieldedContent = true;
+          yield event;
+        }
       }
+      break;
     }
   }
 


### PR DESCRIPTION
## What
The hosted `usejarvis_ai` provider now recovers from the "thinking budget vs. max_tokens" collision instead of failing the call. This is the durable brain-side defense behind the awareness "Bad request" incident.

## Why
A `uj-*` tier can resolve to a reasoning/thinking model. When an operator sets `reasoning_effort` on such a model, litellm turns on extended thinking with a token budget (~2–4k for medium/high). Anthropic then hard-requires `max_tokens > thinking.budget_tokens`. The brain's small structured calls — awareness delta analysis (`max_tokens: 200`), one-word classifiers, session summaries (150–600) — are all far below that, so **every** such call 400'd with `max_tokens must be greater than thinking.budget_tokens`. Live, this broke all awareness/intelligence calls the moment `reasoning_effort` landed on a Claude tier. The aliases are vendor-opaque, so the client can't see the budget up front.

## How
Catch that **specific** 400 (matched on the stable `thinking.budget_tokens` substring, not a status) on both `chat` and `stream`, and retry **once** with a `max_tokens` that clears the budget (16384; `Math.max`, so a caller's larger value is never lowered). It's surgical — it only fires on the actual error, so a correctly-configured **non-thinking** tier that legitimately caps output tiny (e.g. a `max_tokens: 5` classifier) is never touched. `stream` restarts only before any content is yielded (the error is always the first event).

## Note
This is defense-in-depth. The primary guard is operator config — the admin edit drawer now spells out "OpenAI/ChatGPT: set reasoning_effort; Anthropic/Claude: leave unset" (hosting side). This change means a misconfig degrades to a slightly costlier call rather than a hard failure.

## Test
5 new provider tests (chat retry with cleared max_tokens; no retry on a non-thinking-budget 400; stream restart) + `bun x tsc` clean; the full `src/llm` suite passes (230).
