### PR TITLE
Cp/1 honest desktop control

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -239,15 +239,17 @@ jobs:
           go vet ./internal/winchrome/
 
   # The windows-tagged tests (pebble draw-bounds crop invariant, global hotkey
-  # registration) are pure Go but can only RUN on a Windows runner — the mingw
-  # cross-build above only proves the package compiles. `go test` also compiles
-  # every _test.go under GOOS=windows, which the cross-build (build-only) never
-  # checks. Scoped to a named few to keep runtime bounded; the full logic suite
-  # is covered on linux. The TestHotkeys* prefix is matched as a group so a new
-  # hotkey test runs without editing this file; they live here rather than on
-  # linux because the file is windows-tagged and one of them needs the real
-  # RegisterHotKey — a refused registration is exactly what has to surface as an
-  # error, and no other platform can produce one.
+  # registration, desktop-control helpers) are pure Go but can only RUN on a
+  # Windows runner: the mingw cross-build above only proves the package
+  # compiles. `go test` also compiles every _test.go under GOOS=windows, which
+  # the cross-build (build-only) never checks. Scoped to a named few to keep
+  # runtime bounded; the full logic suite is covered on linux. Each group is
+  # matched as a prefix so a new sibling test runs without editing this file.
+  # They live here rather than on linux because the files are windows-tagged:
+  # one hotkey test needs the real RegisterHotKey, since a refused
+  # registration is exactly what has to surface as an error and no other
+  # platform can produce one, and the UIA and SendInput helpers do not exist
+  # in a linux build at all.
   sidecar-test-windows:
     runs-on: windows-latest
     steps:
@@ -256,7 +258,7 @@ jobs:
         with:
           go-version-file: sidecar/go.mod
           cache-dependency-path: sidecar/go.sum
-      - name: Run windows-tagged pebble tests (amd64, cgo)
+      - name: Run windows-tagged unit tests (amd64, cgo)
         working-directory: sidecar
         shell: bash
         env:
@@ -264,15 +266,15 @@ jobs:
         run: |
           set -euo pipefail
           export CGO_CFLAGS="-I$(pwd)/include" CGO_CXXFLAGS="-I$(pwd)/include"
-          pattern='^(TestMainPebbleDrawStaysInsideCrop|TestHotkeys.*)$'
+          pattern='^(TestMainPebbleDrawStaysInsideCrop|TestHotkeys.*|TestHresultText.*)$'
           # Same reason as the parity test above: `go test -run` with no match
           # prints "no tests to run" and exits 0. A floor rather than an exact
-          # count, so the TestHotkeys.* group can grow without editing this, but
-          # a rename that empties it still fails here instead of quietly
-          # skipping every windows-only test we have.
+          # count, so each group can grow without editing this, but a rename
+          # that empties one still fails here instead of quietly skipping every
+          # windows-only test we have.
           listed=$(go test -list "$pattern" . | grep -c '^Test' || true)
-          if [ "$listed" -lt 5 ]; then
-            echo "::error::windows test pattern matched $listed tests, expected at least 5"
+          if [ "$listed" -lt 7 ]; then
+            echo "::error::windows test pattern matched $listed tests, expected at least 7"
             exit 1
           fi
           go test -count=1 -run "$pattern" -v .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -266,15 +266,15 @@ jobs:
         run: |
           set -euo pipefail
           export CGO_CFLAGS="-I$(pwd)/include" CGO_CXXFLAGS="-I$(pwd)/include"
-          pattern='^(TestMainPebbleDrawStaysInsideCrop|TestHotkeys.*|TestHresultText.*|TestPickLaunchedWindow.*)$'
+          pattern='^(TestMainPebbleDrawStaysInsideCrop|TestHotkeys.*|TestHresultText.*|TestPickLaunchedWindow.*|TestVkScanShiftState.*|TestKeyEventsForRune.*)$'
           # Same reason as the parity test above: `go test -run` with no match
           # prints "no tests to run" and exits 0. A floor rather than an exact
           # count, so each group can grow without editing this, but a rename
           # that empties one still fails here instead of quietly skipping every
           # windows-only test we have.
           listed=$(go test -list "$pattern" . | grep -c '^Test' || true)
-          if [ "$listed" -lt 8 ]; then
-            echo "::error::windows test pattern matched $listed tests, expected at least 8"
+          if [ "$listed" -lt 10 ]; then
+            echo "::error::windows test pattern matched $listed tests, expected at least 10"
             exit 1
           fi
           go test -count=1 -run "$pattern" -v .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -266,15 +266,15 @@ jobs:
         run: |
           set -euo pipefail
           export CGO_CFLAGS="-I$(pwd)/include" CGO_CXXFLAGS="-I$(pwd)/include"
-          pattern='^(TestMainPebbleDrawStaysInsideCrop|TestHotkeys.*|TestHresultText.*)$'
+          pattern='^(TestMainPebbleDrawStaysInsideCrop|TestHotkeys.*|TestHresultText.*|TestPickLaunchedWindow.*)$'
           # Same reason as the parity test above: `go test -run` with no match
           # prints "no tests to run" and exits 0. A floor rather than an exact
           # count, so each group can grow without editing this, but a rename
           # that empties one still fails here instead of quietly skipping every
           # windows-only test we have.
           listed=$(go test -list "$pattern" . | grep -c '^Test' || true)
-          if [ "$listed" -lt 7 ]; then
-            echo "::error::windows test pattern matched $listed tests, expected at least 7"
+          if [ "$listed" -lt 8 ]; then
+            echo "::error::windows test pattern matched $listed tests, expected at least 8"
             exit 1
           fi
           go test -count=1 -run "$pattern" -v .

--- a/sidecar/browser.go
+++ b/sidecar/browser.go
@@ -505,6 +505,46 @@ func (c *cdpClient) waitForBrowserReady(budget time.Duration) error {
 	}
 }
 
+// evalJSON evaluates a page script that returns a JSON string and unmarshals
+// it, surfacing page exceptions as errors instead of swallowing them.
+func (c *cdpClient) evalJSON(script string) (map[string]any, error) {
+	raw, err := c.send("Runtime.evaluate", map[string]any{
+		"expression":    script,
+		"returnByValue": true,
+	})
+	if err != nil {
+		return nil, err
+	}
+	var res struct {
+		Result struct {
+			Value string `json:"value"`
+		} `json:"result"`
+		ExceptionDetails *struct {
+			Text      string `json:"text"`
+			Exception struct {
+				Description string `json:"description"`
+			} `json:"exception"`
+		} `json:"exceptionDetails"`
+	}
+	if err := json.Unmarshal(raw, &res); err != nil {
+		return nil, fmt.Errorf("unexpected evaluate reply: %w", err)
+	}
+	if res.ExceptionDetails != nil {
+		desc := res.ExceptionDetails.Exception.Description
+		if desc == "" {
+			desc = res.ExceptionDetails.Text
+		}
+		return nil, fmt.Errorf("page script threw: %s", desc)
+	}
+	out := map[string]any{}
+	if res.Result.Value != "" {
+		if err := json.Unmarshal([]byte(res.Result.Value), &out); err != nil {
+			return nil, fmt.Errorf("page script returned non-JSON result: %q", res.Result.Value)
+		}
+	}
+	return out, nil
+}
+
 // shutdown tears down the connection and the browser process. Idempotent. Does
 // NOT touch activeCDP, so it is safe to call while holding activeCDP.mu.
 func (c *cdpClient) shutdown() {
@@ -578,8 +618,21 @@ func makeBrowserNavigateHandler(cfg *SidecarConfig) RPCHandler {
 		// Register the waiter BEFORE navigating so the event can't be missed
 		loaded := cdp.waitForEvent("Page.loadEventFired")
 
-		if _, err := cdp.send("Page.navigate", map[string]any{"url": url}); err != nil {
+		result, err := cdp.send("Page.navigate", map[string]any{"url": url})
+		if err != nil {
 			return nil, fmt.Errorf("navigate failed: %w", err)
+		}
+
+		// Page.navigate reports network-level failures (DNS, blocked, ERR_*)
+		// in errorText, NOT as a protocol error. Returning success while
+		// ignoring it is how the agent ends up claiming it opened a page it
+		// never reached.
+		var nav struct {
+			ErrorText string `json:"errorText"`
+		}
+		_ = json.Unmarshal(result, &nav)
+		if nav.ErrorText != "" {
+			return nil, fmt.Errorf("navigation to %s failed: %s", url, nav.ErrorText)
 		}
 
 		select {

--- a/sidecar/browser.go
+++ b/sidecar/browser.go
@@ -505,46 +505,6 @@ func (c *cdpClient) waitForBrowserReady(budget time.Duration) error {
 	}
 }
 
-// evalJSON evaluates a page script that returns a JSON string and unmarshals
-// it, surfacing page exceptions as errors instead of swallowing them.
-func (c *cdpClient) evalJSON(script string) (map[string]any, error) {
-	raw, err := c.send("Runtime.evaluate", map[string]any{
-		"expression":    script,
-		"returnByValue": true,
-	})
-	if err != nil {
-		return nil, err
-	}
-	var res struct {
-		Result struct {
-			Value string `json:"value"`
-		} `json:"result"`
-		ExceptionDetails *struct {
-			Text      string `json:"text"`
-			Exception struct {
-				Description string `json:"description"`
-			} `json:"exception"`
-		} `json:"exceptionDetails"`
-	}
-	if err := json.Unmarshal(raw, &res); err != nil {
-		return nil, fmt.Errorf("unexpected evaluate reply: %w", err)
-	}
-	if res.ExceptionDetails != nil {
-		desc := res.ExceptionDetails.Exception.Description
-		if desc == "" {
-			desc = res.ExceptionDetails.Text
-		}
-		return nil, fmt.Errorf("page script threw: %s", desc)
-	}
-	out := map[string]any{}
-	if res.Result.Value != "" {
-		if err := json.Unmarshal([]byte(res.Result.Value), &out); err != nil {
-			return nil, fmt.Errorf("page script returned non-JSON result: %q", res.Result.Value)
-		}
-	}
-	return out, nil
-}
-
 // shutdown tears down the connection and the browser process. Idempotent. Does
 // NOT touch activeCDP, so it is safe to call while holding activeCDP.mu.
 func (c *cdpClient) shutdown() {

--- a/sidecar/browser_parity_test.go
+++ b/sidecar/browser_parity_test.go
@@ -3,9 +3,11 @@ package main
 import (
 	"fmt"
 	"net/url"
+	"os"
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 )
 
 // Integration test: drives the real browser RPC handlers against a headless
@@ -80,9 +82,29 @@ func TestBrowserHandlerParityIntegration(t *testing.T) {
 	if _, err := findChromiumExecutable(cfg); err != nil {
 		t.Skipf("no Chromium available: %v", err)
 	}
-	cfg.Browser.ProfileDir = t.TempDir()
+	// Not t.TempDir(): its RemoveAll cleanup fails the test if Chromium's
+	// children are still releasing profile files. Remove with retries instead,
+	// and only warn if the dir survives — leftover tmp files are not a test
+	// failure.
+	profileDir, err := os.MkdirTemp("", "jarvis-parity-profile-*")
+	if err != nil {
+		t.Fatalf("create profile dir: %v", err)
+	}
+	t.Cleanup(func() {
+		var rmErr error
+		for i := 0; i < 20; i++ {
+			if rmErr = os.RemoveAll(profileDir); rmErr == nil {
+				return
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+		t.Logf("warning: profile dir cleanup failed after retries: %v", rmErr)
+	})
+	cfg.Browser.ProfileDir = profileDir
 
 	// All handlers share the process-global activeCDP; launch headless.
+	// The deferred close runs before the cleanup above, so the browser is
+	// dead (and reaped) before the profile dir is removed.
 	defer closeActiveCDP()
 	headless := map[string]any{"headless": true}
 	withHeadless := func(extra map[string]any) map[string]any {

--- a/sidecar/desktop_darwin.go
+++ b/sidecar/desktop_darwin.go
@@ -339,9 +339,6 @@ func handleLaunchApp(params map[string]any) (*RPCResult, error) {
 			return nil, fmt.Errorf("launch_app: open -a %q failed: %w", executable, err)
 		}
 
-		// Wait briefly for the app to register, then resolve its PID
-		time.Sleep(500 * time.Millisecond)
-
 		name := executable
 		if strings.HasSuffix(name, ".app") {
 			name = name[:len(name)-4]
@@ -350,13 +347,14 @@ func handleLaunchApp(params map[string]any) (*RPCResult, error) {
 			name = name[idx+1:]
 		}
 
-		pgrepOut, _ := exec.Command("pgrep", "-n", name).Output()
-		pidStr := strings.TrimSpace(string(pgrepOut))
-		pid, _ := strconv.Atoi(pidStr)
+		// Poll for the process AND a visible window instead of a fixed
+		// 500ms sleep — returning before the window exists made the next
+		// tool call fail ("no window found") or, worse, act on the wrong app.
+		pid, hasWindow := waitForAppWindowDarwin(name, 0, 5*time.Second)
 		if pid == 0 {
-			return nil, fmt.Errorf("launch_app: open -a %q succeeded but process PID could not be resolved via pgrep %q", executable, name)
+			return nil, fmt.Errorf("launch_app: open -a %q succeeded but the process never appeared in pgrep %q within 5s", executable, name)
 		}
-		return &RPCResult{Result: map[string]any{"success": true, "pid": pid, "name": name}}, nil
+		return launchResultDarwin(pid, name, hasWindow), nil
 	}
 
 	// Absolute/relative path to a binary — start detached
@@ -387,7 +385,49 @@ func handleLaunchApp(params map[string]any) (*RPCResult, error) {
 		name = executable[idx+1:]
 	}
 
-	return &RPCResult{Result: map[string]any{"success": true, "pid": pid, "name": name}}, nil
+	_, hasWindow := waitForAppWindowDarwin("", pid, 5*time.Second)
+	return launchResultDarwin(pid, name, hasWindow), nil
+}
+
+// waitForAppWindowDarwin polls until the app has a visible window, up to
+// timeout. When pid is 0 it is first resolved via `pgrep -n name`. Returns
+// the pid (0 if the process never appeared) and whether a window exists.
+func waitForAppWindowDarwin(name string, pid int, timeout time.Duration) (int, bool) {
+	deadline := time.Now().Add(timeout)
+	for {
+		if pid == 0 && name != "" {
+			out, _ := exec.Command("pgrep", "-n", name).Output()
+			pid, _ = strconv.Atoi(strings.TrimSpace(string(out)))
+		}
+		if pid != 0 {
+			script := fmt.Sprintf(`tell application "System Events" to count windows of (first process whose unix id is %d)`, pid)
+			if out, err := exec.Command("osascript", "-e", script).Output(); err == nil {
+				if n, _ := strconv.Atoi(strings.TrimSpace(string(out))); n > 0 {
+					return pid, true
+				}
+			}
+		}
+		if time.Now().After(deadline) {
+			return pid, false
+		}
+		time.Sleep(300 * time.Millisecond)
+	}
+}
+
+// launchResultDarwin builds the launch_app result with an honest
+// window_visible flag: success means "the app is on screen", not merely
+// "a process was spawned".
+func launchResultDarwin(pid int, name string, hasWindow bool) *RPCResult {
+	res := map[string]any{
+		"success":        hasWindow,
+		"pid":            pid,
+		"name":           name,
+		"window_visible": hasWindow,
+	}
+	if !hasWindow {
+		res["note"] = fmt.Sprintf("process started (pid %d) but no window appeared within 5s — the app may still be starting, be windowless, or have exited. Run desktop_list_windows to check before interacting; do NOT assume it is open.", pid)
+	}
+	return &RPCResult{Result: res}
 }
 
 // ── focus_window ─────────────────────────────────────────────────────

--- a/sidecar/desktop_darwin.go
+++ b/sidecar/desktop_darwin.go
@@ -3,8 +3,10 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os/exec"
 	"strconv"
@@ -71,13 +73,13 @@ end tell`
 		isFG := strings.TrimSpace(parts[7]) == "true"
 
 		windows = append(windows, map[string]any{
-			"title":        title,
-			"pid":          pid,
-			"process_name": procName,
-			"left":         left,
-			"top":          top,
-			"right":        left + width,
-			"bottom":       top + height,
+			"title":         title,
+			"pid":           pid,
+			"process_name":  procName,
+			"left":          left,
+			"top":           top,
+			"right":         left + width,
+			"bottom":        top + height,
 			"is_foreground": isFG,
 		})
 	}
@@ -350,11 +352,11 @@ func handleLaunchApp(params map[string]any) (*RPCResult, error) {
 		// Poll for the process AND a visible window instead of a fixed
 		// 500ms sleep — returning before the window exists made the next
 		// tool call fail ("no window found") or, worse, act on the wrong app.
-		pid, hasWindow := waitForAppWindowDarwin(name, 0, 5*time.Second)
+		pid, probe, probeErr := waitForAppWindowDarwin(name, 0, 5*time.Second)
 		if pid == 0 {
 			return nil, fmt.Errorf("launch_app: open -a %q succeeded but the process never appeared in pgrep %q within 5s", executable, name)
 		}
-		return launchResultDarwin(pid, name, hasWindow), nil
+		return launchResultDarwin(pid, name, probe, probeErr), nil
 	}
 
 	// Absolute/relative path to a binary — start detached
@@ -385,30 +387,94 @@ func handleLaunchApp(params map[string]any) (*RPCResult, error) {
 		name = executable[idx+1:]
 	}
 
-	_, hasWindow := waitForAppWindowDarwin("", pid, 5*time.Second)
-	return launchResultDarwin(pid, name, hasWindow), nil
+	_, probe, probeErr := waitForAppWindowDarwin("", pid, 5*time.Second)
+	return launchResultDarwin(pid, name, probe, probeErr), nil
+}
+
+// countWindowsDarwin asks System Events how many windows pid owns.
+//
+// A denied automation prompt is not "zero windows", it is no answer at all,
+// and the two have to stay distinguishable: the caller reports the first as
+// a failed launch and the second as an unverified one.
+func countWindowsDarwin(pid int) (int, error) {
+	script := fmt.Sprintf(`tell application "System Events" to count windows of (first process whose unix id is %d)`, pid)
+
+	// Bounded on purpose: the first automation attempt can raise a consent
+	// dialog, and osascript blocks behind it for as long as the dialog is
+	// up. Without a deadline the whole launch_app RPC would hang there.
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "osascript", "-e", script)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		return 0, fmt.Errorf("%w: System Events did not answer in time, which usually means an automation consent dialog is waiting to be answered", errWindowCheckUnavailable)
+	}
+	if err != nil {
+		msg := strings.TrimSpace(stderr.String())
+		if isPermissionErrorDarwin(msg) {
+			return 0, fmt.Errorf("%w: %s", errWindowCheckUnavailable, firstLine(msg))
+		}
+		if msg == "" {
+			msg = err.Error()
+		}
+		// Anything else (the process is not registered with System Events
+		// yet, most often) may still resolve on a later poll.
+		return 0, fmt.Errorf("System Events could not count windows: %s", firstLine(msg))
+	}
+	n, convErr := strconv.Atoi(strings.TrimSpace(string(out)))
+	if convErr != nil {
+		return 0, fmt.Errorf("System Events returned a non-numeric window count %q", strings.TrimSpace(string(out)))
+	}
+	return n, nil
+}
+
+// isPermissionErrorDarwin recognises the AppleScript failures that mean the
+// sidecar will never be allowed to look, rather than that it looked and saw
+// nothing: -1743 (automation not authorized), -25211 (assistive access not
+// granted), and -1728 on System Events itself when it is blocked outright.
+func isPermissionErrorDarwin(stderr string) bool {
+	if stderr == "" {
+		return false
+	}
+	lower := strings.ToLower(stderr)
+	for _, marker := range []string{"-1743", "-25211", "not authorized", "not allowed assistive access", "assistive access"} {
+		if strings.Contains(lower, marker) {
+			return true
+		}
+	}
+	return false
 }
 
 // waitForAppWindowDarwin polls until the app has a visible window, up to
 // timeout. When pid is 0 it is first resolved via `pgrep -n name`. Returns
-// the pid (0 if the process never appeared) and whether a window exists.
-func waitForAppWindowDarwin(name string, pid int, timeout time.Duration) (int, bool) {
+// the pid (0 if the process never appeared), what the window check
+// established, and the last probe error for the caller's note.
+func waitForAppWindowDarwin(name string, pid int, timeout time.Duration) (int, launchProbe, error) {
 	deadline := time.Now().Add(timeout)
+	var lastErr error
 	for {
 		if pid == 0 && name != "" {
 			out, _ := exec.Command("pgrep", "-n", name).Output()
 			pid, _ = strconv.Atoi(strings.TrimSpace(string(out)))
 		}
 		if pid != 0 {
-			script := fmt.Sprintf(`tell application "System Events" to count windows of (first process whose unix id is %d)`, pid)
-			if out, err := exec.Command("osascript", "-e", script).Output(); err == nil {
-				if n, _ := strconv.Atoi(strings.TrimSpace(string(out))); n > 0 {
-					return pid, true
-				}
+			n, err := countWindowsDarwin(pid)
+			switch {
+			case err == nil && n > 0:
+				return pid, probeWindowFound, nil
+			case errors.Is(err, errWindowCheckUnavailable):
+				// Permission will not appear mid-poll; stop rather than
+				// spend the whole timeout re-asking the same question.
+				return pid, probeUncheckable, err
+			case err != nil:
+				lastErr = err
 			}
 		}
 		if time.Now().After(deadline) {
-			return pid, false
+			return pid, probeWindowAbsent, lastErr
 		}
 		time.Sleep(300 * time.Millisecond)
 	}
@@ -417,16 +483,30 @@ func waitForAppWindowDarwin(name string, pid int, timeout time.Duration) (int, b
 // launchResultDarwin builds the launch_app result with an honest
 // window_visible flag: success means "the app is on screen", not merely
 // "a process was spawned".
-func launchResultDarwin(pid int, name string, hasWindow bool) *RPCResult {
-	res := map[string]any{
-		"success":        hasWindow,
-		"pid":            pid,
-		"name":           name,
-		"window_visible": hasWindow,
+//
+// The unverified case is kept separate from the failed one. Reporting
+// success:false when the automation permission was refused would mark every
+// working launch on an unprompted Mac as a failure, and the model would
+// launch the app again on the strength of it.
+func launchResultDarwin(pid int, name string, probe launchProbe, probeErr error) *RPCResult {
+	res := map[string]any{"pid": pid, "name": name}
+
+	switch probe {
+	case probeWindowFound:
+		res["success"] = true
+		res["window_visible"] = true
+
+	case probeUncheckable:
+		res["success"] = true
+		res["window_visible"] = nil
+		res["note"] = fmt.Sprintf("app started (pid %d) but whether a window opened could NOT be checked: %v. This is not a failure report - the app may well be on screen. Run desktop_list_windows to see what is actually open before interacting, and do not launch it again on the strength of this result.", pid, probeErr)
+
+	default: // probeWindowAbsent
+		res["success"] = false
+		res["window_visible"] = false
+		res["note"] = fmt.Sprintf("process started (pid %d) but no window appeared within 5s - the app may still be starting, be windowless, or have exited. Run desktop_list_windows to check before interacting; do NOT assume it is open.", pid)
 	}
-	if !hasWindow {
-		res["note"] = fmt.Sprintf("process started (pid %d) but no window appeared within 5s — the app may still be starting, be windowless, or have exited. Run desktop_list_windows to check before interacting; do NOT assume it is open.", pid)
-	}
+
 	return &RPCResult{Result: res}
 }
 
@@ -642,36 +722,36 @@ func convertKeysToOsascript(keys string) string {
 // Returns (keyCode, true) for known special keys, (0, false) otherwise.
 func osascriptKeyCode(key string) (int, bool) {
 	keyCodes := map[string]int{
-		"enter":    36,
-		"return":   36,
-		"tab":      48,
-		"escape":   53,
-		"esc":      53,
-		"delete":   51,
+		"enter":     36,
+		"return":    36,
+		"tab":       48,
+		"escape":    53,
+		"esc":       53,
+		"delete":    51,
 		"backspace": 51,
-		"space":    49,
-		"up":       126,
-		"down":     125,
-		"left":     123,
-		"right":    124,
-		"home":     115,
-		"end":      119,
-		"pageup":   116,
-		"pgup":     116,
-		"pagedown": 121,
-		"pgdn":     121,
-		"f1":       122,
-		"f2":       120,
-		"f3":       99,
-		"f4":       118,
-		"f5":       96,
-		"f6":       97,
-		"f7":       98,
-		"f8":       100,
-		"f9":       101,
-		"f10":      109,
-		"f11":      103,
-		"f12":      111,
+		"space":     49,
+		"up":        126,
+		"down":      125,
+		"left":      123,
+		"right":     124,
+		"home":      115,
+		"end":       119,
+		"pageup":    116,
+		"pgup":      116,
+		"pagedown":  121,
+		"pgdn":      121,
+		"f1":        122,
+		"f2":        120,
+		"f3":        99,
+		"f4":        118,
+		"f5":        96,
+		"f6":        97,
+		"f7":        98,
+		"f8":        100,
+		"f9":        101,
+		"f10":       109,
+		"f11":       103,
+		"f12":       111,
 	}
 	if code, ok := keyCodes[strings.ToLower(key)]; ok {
 		return code, true
@@ -692,5 +772,3 @@ func toInt(v any) int {
 	}
 	return 0
 }
-
-

--- a/sidecar/desktop_darwin.go
+++ b/sidecar/desktop_darwin.go
@@ -73,13 +73,13 @@ end tell`
 		isFG := strings.TrimSpace(parts[7]) == "true"
 
 		windows = append(windows, map[string]any{
-			"title":         title,
-			"pid":           pid,
-			"process_name":  procName,
-			"left":          left,
-			"top":           top,
-			"right":         left + width,
-			"bottom":        top + height,
+			"title":        title,
+			"pid":          pid,
+			"process_name": procName,
+			"left":         left,
+			"top":          top,
+			"right":        left + width,
+			"bottom":       top + height,
 			"is_foreground": isFG,
 		})
 	}
@@ -722,36 +722,36 @@ func convertKeysToOsascript(keys string) string {
 // Returns (keyCode, true) for known special keys, (0, false) otherwise.
 func osascriptKeyCode(key string) (int, bool) {
 	keyCodes := map[string]int{
-		"enter":     36,
-		"return":    36,
-		"tab":       48,
-		"escape":    53,
-		"esc":       53,
-		"delete":    51,
+		"enter":    36,
+		"return":   36,
+		"tab":      48,
+		"escape":   53,
+		"esc":      53,
+		"delete":   51,
 		"backspace": 51,
-		"space":     49,
-		"up":        126,
-		"down":      125,
-		"left":      123,
-		"right":     124,
-		"home":      115,
-		"end":       119,
-		"pageup":    116,
-		"pgup":      116,
-		"pagedown":  121,
-		"pgdn":      121,
-		"f1":        122,
-		"f2":        120,
-		"f3":        99,
-		"f4":        118,
-		"f5":        96,
-		"f6":        97,
-		"f7":        98,
-		"f8":        100,
-		"f9":        101,
-		"f10":       109,
-		"f11":       103,
-		"f12":       111,
+		"space":    49,
+		"up":       126,
+		"down":     125,
+		"left":     123,
+		"right":    124,
+		"home":     115,
+		"end":      119,
+		"pageup":   116,
+		"pgup":     116,
+		"pagedown": 121,
+		"pgdn":     121,
+		"f1":       122,
+		"f2":       120,
+		"f3":       99,
+		"f4":       118,
+		"f5":       96,
+		"f6":       97,
+		"f7":       98,
+		"f8":       100,
+		"f9":       101,
+		"f10":      109,
+		"f11":      103,
+		"f12":      111,
 	}
 	if code, ok := keyCodes[strings.ToLower(key)]; ok {
 		return code, true
@@ -772,3 +772,5 @@ func toInt(v any) int {
 	}
 	return 0
 }
+
+

--- a/sidecar/desktop_linux.go
+++ b/sidecar/desktop_linux.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 )
 
@@ -472,11 +473,59 @@ func handleLaunchApp(params map[string]any) (*RPCResult, error) {
 		name = executable[idx+1:]
 	}
 
+	// A spawned process is not an open app: returning immediately made the
+	// next tool call race the window ("no window found"). Poll for a visible
+	// window owned by this PID before declaring success.
+	win, procAlive := waitForWindowLinux(pid, 5*time.Second)
+	if win != nil {
+		return &RPCResult{Result: map[string]any{
+			"success":        true,
+			"pid":            pid,
+			"name":           name,
+			"window_visible": true,
+			"window_title":   win["title"],
+		}}, nil
+	}
+
+	note := fmt.Sprintf("process started (pid %d) but no window appeared within 5s — the app may still be starting, be windowless, or have exited. Run desktop_list_windows to check before interacting; do NOT assume it is open.", pid)
+	if !procAlive {
+		note = fmt.Sprintf("process (pid %d) exited without showing a window — it may be a short-lived launcher, a CLI tool, or it crashed. Run desktop_list_windows to see what is actually open.", pid)
+	}
 	return &RPCResult{Result: map[string]any{
-		"success": true,
-		"pid":     pid,
-		"name":    name,
+		"success":        false,
+		"pid":            pid,
+		"name":           name,
+		"window_visible": false,
+		"note":           note,
 	}}, nil
+}
+
+// waitForWindowLinux polls xdotool for a visible window owned by pid. It
+// returns early when the process disappears (no point waiting the full
+// timeout for a window that can no longer appear). The second return
+// reports whether the process was still alive when polling stopped.
+func waitForWindowLinux(pid int, timeout time.Duration) (map[string]any, bool) {
+	deadline := time.Now().Add(timeout)
+	for {
+		out, err := runWithTimeout(2*time.Second, "xdotool", "search", "--onlyvisible", "--pid", strconv.Itoa(pid))
+		if err == nil {
+			ids := strings.Fields(strings.TrimSpace(out))
+			if len(ids) > 0 {
+				title := ""
+				if t, err := runWithTimeout(2*time.Second, "xdotool", "getwindowname", ids[0]); err == nil {
+					title = strings.TrimSpace(t)
+				}
+				return map[string]any{"title": title}, true
+			}
+		}
+		if syscall.Kill(pid, 0) != nil {
+			return nil, false // process gone; a window can no longer appear
+		}
+		if time.Now().After(deadline) {
+			return nil, true
+		}
+		time.Sleep(150 * time.Millisecond)
+	}
 }
 
 // splitArgs splits a string into arguments, respecting double-quoted groups.

--- a/sidecar/desktop_linux.go
+++ b/sidecar/desktop_linux.go
@@ -3,8 +3,10 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -108,14 +110,14 @@ func parseWmctrlOutput(output, activeWID string) ([]map[string]any, error) {
 		}
 
 		windows = append(windows, map[string]any{
-			"hwnd":         widInt,
-			"title":        title,
-			"pid":          pid,
-			"process_name": procName,
-			"left":         x,
-			"top":          y,
-			"right":        x + w,
-			"bottom":       y + h,
+			"hwnd":          widInt,
+			"title":         title,
+			"pid":           pid,
+			"process_name":  procName,
+			"left":          x,
+			"top":           y,
+			"right":         x + w,
+			"bottom":        y + h,
 			"is_foreground": wid == activeWID || fmt.Sprintf("%d", widInt) == activeWID,
 		})
 	}
@@ -476,53 +478,111 @@ func handleLaunchApp(params map[string]any) (*RPCResult, error) {
 	// A spawned process is not an open app: returning immediately made the
 	// next tool call race the window ("no window found"). Poll for a visible
 	// window owned by this PID before declaring success.
-	win, procAlive := waitForWindowLinux(pid, 5*time.Second)
-	if win != nil {
-		return &RPCResult{Result: map[string]any{
-			"success":        true,
-			"pid":            pid,
-			"name":           name,
-			"window_visible": true,
-			"window_title":   win["title"],
-		}}, nil
-	}
-
-	note := fmt.Sprintf("process started (pid %d) but no window appeared within 5s — the app may still be starting, be windowless, or have exited. Run desktop_list_windows to check before interacting; do NOT assume it is open.", pid)
-	if !procAlive {
-		note = fmt.Sprintf("process (pid %d) exited without showing a window — it may be a short-lived launcher, a CLI tool, or it crashed. Run desktop_list_windows to see what is actually open.", pid)
-	}
-	return &RPCResult{Result: map[string]any{
-		"success":        false,
-		"pid":            pid,
-		"name":           name,
-		"window_visible": false,
-		"note":           note,
-	}}, nil
+	win, probe, probeErr := waitForWindowLinux(pid, 5*time.Second)
+	return launchResultLinux(pid, name, win, probe, probeErr), nil
 }
 
-// waitForWindowLinux polls xdotool for a visible window owned by pid. It
-// returns early when the process disappears (no point waiting the full
-// timeout for a window that can no longer appear). The second return
-// reports whether the process was still alive when polling stopped.
-func waitForWindowLinux(pid int, timeout time.Duration) (map[string]any, bool) {
+// launchResultLinux turns a window probe into the launch_app result.
+//
+// The three outcomes stay distinct on purpose. "A window appeared" and "no
+// window appeared" are both observations, and success reports them. "The
+// window could not be looked for" is not an observation at all, and
+// reporting it as success:false would be exactly the kind of confident
+// wrong answer this handler exists to stop: on a Wayland session or a box
+// without xdotool that would mark every successful GUI launch as a failure,
+// and the model would launch the app a second time.
+func launchResultLinux(pid int, name string, win map[string]any, probe launchProbe, probeErr error) *RPCResult {
+	res := map[string]any{"pid": pid, "name": name}
+
+	switch probe {
+	case probeWindowFound:
+		res["success"] = true
+		res["window_visible"] = true
+		res["window_title"] = win["title"]
+
+	case probeProcessGone:
+		res["success"] = false
+		res["window_visible"] = false
+		res["note"] = fmt.Sprintf("process (pid %d) exited without showing a window - it may be a short-lived launcher, a CLI tool, or it crashed. Run desktop_list_windows to see what is actually open.", pid)
+
+	case probeUncheckable:
+		// The process is alive and nothing contradicts the launch, so this is
+		// not a failure; it is an unverified success, and the note has to say
+		// so rather than let the flag speak for it.
+		res["success"] = true
+		res["window_visible"] = nil
+		res["note"] = fmt.Sprintf("process started (pid %d) but whether a window opened could NOT be checked: %v. This is not a failure report - the app may well be on screen. Run desktop_list_windows to see what is actually open before interacting, and do not launch it again on the strength of this result.", pid, probeErr)
+
+	default: // probeWindowAbsent
+		res["success"] = false
+		res["window_visible"] = false
+		res["note"] = fmt.Sprintf("process started (pid %d) but no window appeared within 5s - the app may still be starting, be windowless, or have exited. Run desktop_list_windows to check before interacting; do NOT assume it is open.", pid)
+	}
+
+	return &RPCResult{Result: res}
+}
+
+// classifyWindowSearch reads one `xdotool search` run.
+//
+// The exit status alone cannot answer the question: xdotool exits 1 both
+// when it matched nothing and when it could not run at all (no DISPLAY, for
+// instance). What separates them is that a clean no-match is silent and
+// exits exactly 1, while a failure either says something on stderr, exits
+// with another status, or never returns. Returning (nil, nil) claims "there
+// is no window", so every other shape has to come back as an error.
+func classifyWindowSearch(r probeRun) ([]string, error) {
+	switch {
+	case r.timedOut:
+		return nil, fmt.Errorf("%w: xdotool search did not return in time", errWindowCheckUnavailable)
+	case strings.TrimSpace(r.stderr) != "":
+		return nil, fmt.Errorf("%w: xdotool search failed: %s", errWindowCheckUnavailable, firstLine(strings.TrimSpace(r.stderr)))
+	case r.exitCode == 1:
+		return nil, nil // ran cleanly and matched nothing
+	case r.err != nil:
+		return nil, fmt.Errorf("%w: could not run xdotool (exit %d): %v", errWindowCheckUnavailable, r.exitCode, r.err)
+	}
+	return strings.Fields(r.stdout), nil
+}
+
+// probeWindowOnce asks xdotool for a visible window owned by pid. A nil
+// window with a nil error means "looked, found none"; a non-nil error means
+// the question could not be put at all.
+func probeWindowOnce(pid int) (map[string]any, error) {
+	if _, err := exec.LookPath("xdotool"); err != nil {
+		return nil, fmt.Errorf("%w: xdotool is not installed", errWindowCheckUnavailable)
+	}
+
+	ids, err := classifyWindowSearch(runProbe(2*time.Second, "xdotool", "search", "--onlyvisible", "--pid", strconv.Itoa(pid)))
+	if err != nil || len(ids) == 0 {
+		return nil, err
+	}
+
+	title := ""
+	if t := runProbe(2*time.Second, "xdotool", "getwindowname", ids[0]); t.err == nil {
+		title = t.stdout
+	}
+	return map[string]any{"title": title}, nil
+}
+
+// waitForWindowLinux polls for a visible window owned by pid. It stops early
+// when the process disappears (no point waiting out the timeout for a window
+// that can no longer appear) and when the check itself is unusable.
+func waitForWindowLinux(pid int, timeout time.Duration) (map[string]any, launchProbe, error) {
 	deadline := time.Now().Add(timeout)
 	for {
-		out, err := runWithTimeout(2*time.Second, "xdotool", "search", "--onlyvisible", "--pid", strconv.Itoa(pid))
-		if err == nil {
-			ids := strings.Fields(strings.TrimSpace(out))
-			if len(ids) > 0 {
-				title := ""
-				if t, err := runWithTimeout(2*time.Second, "xdotool", "getwindowname", ids[0]); err == nil {
-					title = strings.TrimSpace(t)
-				}
-				return map[string]any{"title": title}, true
-			}
+		win, err := probeWindowOnce(pid)
+		if win != nil {
+			return win, probeWindowFound, nil
 		}
+		// A dead process settles the question whether or not xdotool worked.
 		if syscall.Kill(pid, 0) != nil {
-			return nil, false // process gone; a window can no longer appear
+			return nil, probeProcessGone, err
+		}
+		if errors.Is(err, errWindowCheckUnavailable) {
+			return nil, probeUncheckable, err
 		}
 		if time.Now().After(deadline) {
-			return nil, true
+			return nil, probeWindowAbsent, nil
 		}
 		time.Sleep(150 * time.Millisecond)
 	}
@@ -619,6 +679,44 @@ func handleFindElement(params map[string]any) (*RPCResult, error) {
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────
+
+// probeRun is everything needed to tell a tool that ran and found nothing
+// apart from one that could not run. runWithTimeout throws all of it away
+// except stdout, which is why the window check cannot use it.
+type probeRun struct {
+	stdout   string
+	stderr   string
+	exitCode int // 0 on success, the tool's status on exit, -1 if it never ran
+	timedOut bool
+	err      error
+}
+
+// runProbe runs a command with a timeout and keeps the full outcome.
+func runProbe(timeout time.Duration, name string, args ...string) probeRun {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, name, args...)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+
+	r := probeRun{
+		stdout:   strings.TrimSpace(string(out)),
+		stderr:   stderr.String(),
+		timedOut: errors.Is(ctx.Err(), context.DeadlineExceeded),
+		err:      err,
+	}
+	var exitErr *exec.ExitError
+	switch {
+	case err == nil:
+		r.exitCode = 0
+	case errors.As(err, &exitErr):
+		r.exitCode = exitErr.ExitCode()
+	default:
+		r.exitCode = -1
+	}
+	return r
+}
 
 // runWithTimeout runs a command with a timeout and returns trimmed stdout.
 // Stderr is discarded; only stdout is returned.
@@ -748,5 +846,3 @@ func mapKeyToXdotool(key string) string {
 		return key
 	}
 }
-
-

--- a/sidecar/desktop_linux.go
+++ b/sidecar/desktop_linux.go
@@ -110,14 +110,14 @@ func parseWmctrlOutput(output, activeWID string) ([]map[string]any, error) {
 		}
 
 		windows = append(windows, map[string]any{
-			"hwnd":          widInt,
-			"title":         title,
-			"pid":           pid,
-			"process_name":  procName,
-			"left":          x,
-			"top":           y,
-			"right":         x + w,
-			"bottom":        y + h,
+			"hwnd":         widInt,
+			"title":        title,
+			"pid":          pid,
+			"process_name": procName,
+			"left":         x,
+			"top":          y,
+			"right":        x + w,
+			"bottom":       y + h,
 			"is_foreground": wid == activeWID || fmt.Sprintf("%d", widInt) == activeWID,
 		})
 	}
@@ -846,3 +846,5 @@ func mapKeyToXdotool(key string) string {
 		return key
 	}
 }
+
+

--- a/sidecar/desktop_linux_test.go
+++ b/sidecar/desktop_linux_test.go
@@ -1,0 +1,208 @@
+//go:build linux
+
+package main
+
+import (
+	"errors"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// launch_app's whole point is that the caller can trust what it says, so the
+// mapping from "what the probe established" to "what the model is told" is
+// pinned here rather than left to the handler's branches.
+func TestLaunchResultLinuxReportsEachProbeHonestly(t *testing.T) {
+	probeErr := errors.New("window check unavailable: xdotool is not installed")
+
+	tests := []struct {
+		name          string
+		win           map[string]any
+		probe         launchProbe
+		probeErr      error
+		wantSuccess   any
+		wantVisible   any
+		wantNote      bool
+		noteMustCarry string
+	}{
+		{
+			name:        "window observed",
+			win:         map[string]any{"title": "Text Editor"},
+			probe:       probeWindowFound,
+			wantSuccess: true,
+			wantVisible: true,
+		},
+		{
+			name:          "probe ran and saw nothing",
+			probe:         probeWindowAbsent,
+			wantSuccess:   false,
+			wantVisible:   false,
+			wantNote:      true,
+			noteMustCarry: "no window appeared",
+		},
+		{
+			name:          "process died before showing a window",
+			probe:         probeProcessGone,
+			wantSuccess:   false,
+			wantVisible:   false,
+			wantNote:      true,
+			noteMustCarry: "exited without showing a window",
+		},
+		{
+			// The one that matters most: an unreadable probe must not be
+			// dressed up as a failed launch, or every GUI app started on a
+			// Wayland session gets reported as broken and relaunched.
+			name:          "probe could not run",
+			probe:         probeUncheckable,
+			probeErr:      probeErr,
+			wantSuccess:   true,
+			wantVisible:   nil,
+			wantNote:      true,
+			noteMustCarry: "could NOT be checked",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			res := launchResultLinux(4242, "gedit", tc.win, tc.probe, tc.probeErr)
+			m, ok := res.Result.(map[string]any)
+			if !ok {
+				t.Fatalf("result is not a map: %T", res.Result)
+			}
+			if m["success"] != tc.wantSuccess {
+				t.Errorf("success = %v, want %v", m["success"], tc.wantSuccess)
+			}
+			// Assert presence separately: a missing key also reads as nil,
+			// and "we could not tell" has to be stated, not left out.
+			got, present := m["window_visible"]
+			if !present {
+				t.Error("window_visible must always be reported, even when unknown")
+			}
+			if got != tc.wantVisible {
+				t.Errorf("window_visible = %v, want %v", got, tc.wantVisible)
+			}
+			if m["pid"] != 4242 {
+				t.Errorf("pid = %v, want 4242", m["pid"])
+			}
+			note, _ := m["note"].(string)
+			if tc.wantNote {
+				if note == "" {
+					t.Fatal("expected an explanatory note")
+				}
+				if !strings.Contains(note, tc.noteMustCarry) {
+					t.Errorf("note %q does not explain %q", note, tc.noteMustCarry)
+				}
+			} else if note != "" {
+				t.Errorf("a confirmed window needs no caveat, got note %q", note)
+			}
+		})
+	}
+}
+
+// An unverified launch must not read as a failed one. The note is the only
+// thing standing between the model and a duplicate launch, so it has to say
+// out loud that this is not a failure and name what to do instead.
+func TestUncheckableLaunchNoteDoesNotReadAsFailure(t *testing.T) {
+	res := launchResultLinux(7, "gimp", nil, probeUncheckable, errors.New("xdotool is not installed"))
+	note := res.Result.(map[string]any)["note"].(string)
+
+	for _, want := range []string{"not a failure", "desktop_list_windows", "do not launch it again"} {
+		if !strings.Contains(note, want) {
+			t.Errorf("note is missing %q: %s", want, note)
+		}
+	}
+	if strings.Contains(note, "xdotool is not installed") == false {
+		t.Errorf("note should carry the underlying reason: %s", note)
+	}
+}
+
+// The whole three-state contract rests on reading one xdotool run
+// correctly, and the trap is that a clean no-match and a total failure both
+// exit 1. Returning no error means "there is no window", so anything the
+// classifier is not certain about has to come back as unavailable instead.
+func TestClassifyWindowSearchSeparatesNoMatchFromNoAnswer(t *testing.T) {
+	tests := []struct {
+		name        string
+		run         probeRun
+		wantIDs     int
+		wantUnavail bool
+		wantReason  string
+	}{
+		{
+			name:    "windows found",
+			run:     probeRun{stdout: "12582917 12582919", exitCode: 0},
+			wantIDs: 2,
+		},
+		{
+			name:    "ran cleanly and matched nothing",
+			run:     probeRun{exitCode: 1, err: &exec.ExitError{}},
+			wantIDs: 0,
+		},
+		{
+			// No X to talk to. xdotool still exits 1, so only stderr tells
+			// us this was not an answer.
+			name:        "no display",
+			run:         probeRun{stderr: "Error: Can't open display: (null)\n", exitCode: 1, err: &exec.ExitError{}},
+			wantUnavail: true,
+			wantReason:  "Can't open display",
+		},
+		{
+			name:        "killed by the timeout",
+			run:         probeRun{exitCode: -1, timedOut: true, err: errors.New("signal: killed")},
+			wantUnavail: true,
+			wantReason:  "did not return in time",
+		},
+		{
+			// A timeout that still managed to exit 1 must not be read as a
+			// no-match just because the status happens to line up.
+			name:        "timed out with a matching exit status",
+			run:         probeRun{exitCode: 1, timedOut: true, err: errors.New("signal: killed")},
+			wantUnavail: true,
+			wantReason:  "did not return in time",
+		},
+		{
+			name:        "unexpected exit status",
+			run:         probeRun{exitCode: 2, err: &exec.ExitError{}},
+			wantUnavail: true,
+			wantReason:  "could not run xdotool",
+		},
+		{
+			name:        "never started",
+			run:         probeRun{exitCode: -1, err: errors.New("fork/exec: permission denied")},
+			wantUnavail: true,
+			wantReason:  "could not run xdotool",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ids, err := classifyWindowSearch(tc.run)
+			if tc.wantUnavail {
+				if !errors.Is(err, errWindowCheckUnavailable) {
+					t.Fatalf("want an unavailable check, got ids=%v err=%v", ids, err)
+				}
+				if !strings.Contains(err.Error(), tc.wantReason) {
+					t.Errorf("error %q should explain %q", err, tc.wantReason)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(ids) != tc.wantIDs {
+				t.Errorf("got %d window ids %v, want %d", len(ids), ids, tc.wantIDs)
+			}
+		})
+	}
+}
+
+// A missing xdotool is the commonest way the check cannot run, and it must
+// not be reported as the absence of a window.
+func TestProbeWindowOnceFlagsAMissingToolAsUnavailable(t *testing.T) {
+	if _, err := exec.LookPath("xdotool"); err == nil {
+		t.Skip("xdotool is installed here; the missing-tool branch cannot be exercised")
+	}
+	if _, err := probeWindowOnce(1); !errors.Is(err, errWindowCheckUnavailable) {
+		t.Fatalf("a missing xdotool must be unavailable, not absence of a window: %v", err)
+	}
+}

--- a/sidecar/desktop_probe.go
+++ b/sidecar/desktop_probe.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"errors"
+	"strings"
+)
+
+// Shared vocabulary for the post-launch window check.
+//
+// launch_app used to answer "did a process spawn?", which is not the
+// question the caller is asking: a spawned process that never puts a window
+// on screen makes the next tool call fail with "no window found". The
+// handlers now look for the window before reporting success, and that check
+// has three possible outcomes, not two. Collapsing "I looked and there is no
+// window" together with "I was not able to look" would trade the old
+// false positive for an equally misleading false negative, so every platform
+// keeps them apart.
+
+// launchProbe records what a post-launch window check actually established.
+type launchProbe int
+
+const (
+	probeWindowFound  launchProbe = iota // a visible window was observed
+	probeWindowAbsent                    // the check ran and saw no window
+	probeProcessGone                     // the process exited, so no window can appear
+	probeUncheckable                     // the check could not run; nothing was established
+)
+
+// errWindowCheckUnavailable marks a probe failure that says nothing about
+// the app itself: the tooling is missing, or permission to use it was
+// refused. Waiting longer cannot change the answer, so poll loops stop on
+// it instead of burning the whole timeout.
+var errWindowCheckUnavailable = errors.New("window check unavailable")
+
+// firstLine keeps a multi-line tool complaint to its useful first line.
+func firstLine(s string) string {
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		return strings.TrimSpace(s[:i])
+	}
+	return s
+}
+
+// processBaseNameOf reduces an executable argument to the bare name a
+// running process reports, so the two can be compared.
+//
+// launch_app documents its parameter as "executable path or name", and the
+// Windows launcher matches it against windowInfo.ProcessName, which is
+// always the stem: no directory, no .exe. Comparing the raw argument means
+// the match only ever succeeds for the bare-name form, and silently never
+// fires for a path - which is what anything outside System32 is given as.
+//
+// It lives here rather than beside its Windows caller because it is nothing
+// but string handling, and that is worth being able to test on any host.
+// Windows separators are accepted in both directions and a drive-relative
+// path ("C:app.exe") carries no separator at all, so neither is left to
+// filepath, whose answer depends on the platform it was compiled for.
+func processBaseNameOf(executable string) string {
+	name := strings.TrimSpace(executable)
+	if i := strings.LastIndexAny(name, `\/`); i >= 0 {
+		name = name[i+1:]
+	}
+	if len(name) > 1 && name[1] == ':' {
+		name = name[2:]
+	}
+	return strings.TrimSuffix(strings.ToLower(name), ".exe")
+}

--- a/sidecar/desktop_probe_test.go
+++ b/sidecar/desktop_probe_test.go
@@ -1,0 +1,41 @@
+package main
+
+import "testing"
+
+func TestFirstLineKeepsOnlyTheLeadingLine(t *testing.T) {
+	cases := map[string]string{
+		"":                             "",
+		"single":                       "single",
+		"Error: Can't open display\n":  "Error: Can't open display",
+		"first\nsecond\nthird":         "first",
+		"  padded first  \n  second  ": "padded first",
+	}
+	for in, want := range cases {
+		if got := firstLine(in); got != want {
+			t.Errorf("firstLine(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// launch_app documents its parameter as "executable path or name", and the
+// packaged-app fallback compares it against windowInfo.ProcessName, which is
+// always the bare stem. Without reducing the argument to that same shape the
+// fallback silently never fires for the path form - which is exactly the
+// form used for anything outside System32.
+func TestProcessBaseNameOfReducesPathsToProcessNames(t *testing.T) {
+	cases := map[string]string{
+		"notepad.exe":                     "notepad",
+		"Notepad.EXE":                     "notepad",
+		`C:\Windows\System32\notepad.exe`: "notepad",
+		`C:/Program Files/App/App.exe`:    "app",
+		`  C:\Windows\notepad.exe  `:      "notepad",
+		"calc":                            "calc",
+		`\\server\share\tool.exe`:         "tool",
+		"":                                "",
+	}
+	for in, want := range cases {
+		if got := processBaseNameOf(in); got != want {
+			t.Errorf("processBaseNameOf(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/sidecar/desktop_windows.go
+++ b/sidecar/desktop_windows.go
@@ -15,72 +15,9 @@ import (
 // ── list_windows ──────────────────────────────────────────────────────
 
 func handleListWindows(params map[string]any) (*RPCResult, error) {
-	script := `
-Add-Type @'
-using System;
-using System.Collections.Generic;
-using System.Runtime.InteropServices;
-using System.Text;
-using System.Diagnostics;
-public class WinEnum {
-    [DllImport("user32.dll")] public static extern bool EnumWindows(EnumWindowsProc lpEnumFunc, IntPtr lParam);
-    [DllImport("user32.dll")] public static extern bool IsWindowVisible(IntPtr hWnd);
-    [DllImport("user32.dll", CharSet=CharSet.Unicode)] public static extern int GetWindowText(IntPtr hWnd, StringBuilder sb, int nMaxCount);
-    [DllImport("user32.dll")] public static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint pid);
-    [DllImport("user32.dll", CharSet=CharSet.Unicode)] public static extern int GetClassName(IntPtr hWnd, StringBuilder sb, int nMaxCount);
-    [DllImport("user32.dll")] public static extern bool GetWindowRect(IntPtr hWnd, out RECT lpRect);
-    [DllImport("user32.dll")] public static extern IntPtr GetForegroundWindow();
-    public delegate bool EnumWindowsProc(IntPtr hWnd, IntPtr lParam);
-    [StructLayout(LayoutKind.Sequential)] public struct RECT { public int Left, Top, Right, Bottom; }
-    public static List<Dictionary<string,object>> List() {
-        var result = new List<Dictionary<string,object>>();
-        var fg = GetForegroundWindow();
-        EnumWindows((hWnd, _) => {
-            if (!IsWindowVisible(hWnd)) return true;
-            var sb = new StringBuilder(256);
-            GetWindowText(hWnd, sb, 256);
-            var title = sb.ToString();
-            if (string.IsNullOrWhiteSpace(title)) return true;
-            uint pid; GetWindowThreadProcessId(hWnd, out pid);
-            var cls = new StringBuilder(256);
-            GetClassName(hWnd, cls, 256);
-            RECT r; GetWindowRect(hWnd, out r);
-            string procName = "";
-            try { procName = Process.GetProcessById((int)pid).ProcessName; } catch {}
-            var d = new Dictionary<string,object>();
-            d["hwnd"] = (long)hWnd;
-            d["title"] = title;
-            d["pid"] = pid;
-            d["process_name"] = procName;
-            d["class_name"] = cls.ToString();
-            d["left"] = r.Left; d["top"] = r.Top; d["right"] = r.Right; d["bottom"] = r.Bottom;
-            d["is_foreground"] = hWnd == fg;
-            result.Add(d);
-            return true;
-        }, IntPtr.Zero);
-        return result;
-    }
-}
-'@
-[WinEnum]::List() | ConvertTo-Json -Depth 3 -Compress
-`
-	out, err := runPS(script, 10*time.Second)
-	if err != nil {
-		return nil, fmt.Errorf("list_windows failed: %w", err)
-	}
-
-	var windows []map[string]any
-	if err := json.Unmarshal([]byte(out), &windows); err != nil {
-		// Single window comes as object, not array
-		var single map[string]any
-		if err2 := json.Unmarshal([]byte(out), &single); err2 == nil {
-			windows = []map[string]any{single}
-		} else {
-			return nil, fmt.Errorf("parse windows: %w", err)
-		}
-	}
-
-	return &RPCResult{Result: map[string]any{"windows": windows}}, nil
+	// Native EnumWindows — the previous implementation recompiled embedded
+	// C# in a fresh PowerShell on every call (~0.7-1.5s); this is ~1ms.
+	return &RPCResult{Result: map[string]any{"windows": enumTopWindows()}}, nil
 }
 
 // ── get_window_tree (desktop_snapshot) — uses UIAutomation COM ───────
@@ -151,25 +88,13 @@ func handleTypeText(params map[string]any) (*RPCResult, error) {
 		time.Sleep(100 * time.Millisecond)
 	}
 
-	// Use SendKeys for typing
-	escaped := strings.ReplaceAll(text, "'", "''")
-
-	script := fmt.Sprintf(`
-Add-Type -AssemblyName System.Windows.Forms
-[System.Windows.Forms.SendKeys]::SendWait('%s')
-Write-Output '{"success":true}'
-`, escapeSendKeys(escaped))
-
-	out, err := runPS(script, 5*time.Second)
-	if err != nil {
+	// Native SendInput — replaces a per-call PowerShell spawn running
+	// SendKeys, which was slow (~250-500ms overhead), lossy on long/fast
+	// text, and required metacharacter escaping.
+	if err := typeTextNative(text); err != nil {
 		return nil, fmt.Errorf("type_text failed: %w", err)
 	}
-
-	var result map[string]any
-	if err := json.Unmarshal([]byte(out), &result); err != nil {
-		return &RPCResult{Result: map[string]any{"success": true}}, nil
-	}
-	return &RPCResult{Result: result}, nil
+	return &RPCResult{Result: map[string]any{"success": true, "chars": len([]rune(text))}}, nil
 }
 
 // ── press_keys ───────────────────────────────────────────────────────
@@ -180,24 +105,13 @@ func handlePressKeys(params map[string]any) (*RPCResult, error) {
 		return nil, fmt.Errorf("missing required parameter: keys")
 	}
 
-	sendKeysStr := convertToSendKeys(keys)
-
-	script := fmt.Sprintf(`
-Add-Type -AssemblyName System.Windows.Forms
-[System.Windows.Forms.SendKeys]::SendWait('%s')
-Write-Output '{"success":true,"keys":"%s"}'
-`, sendKeysStr, strings.ReplaceAll(keys, `"`, `\"`))
-
-	out, err := runPS(script, 5*time.Second)
-	if err != nil {
+	// Native SendInput chords — replaces per-call PowerShell SendKeys. This
+	// also makes the `win` modifier a real Windows-key chord (SendKeys had
+	// no Windows key; the old code sent an approximate ctrl+esc).
+	if err := pressKeysNative(keys); err != nil {
 		return nil, fmt.Errorf("press_keys failed: %w", err)
 	}
-
-	var result map[string]any
-	if err := json.Unmarshal([]byte(out), &result); err != nil {
-		return &RPCResult{Result: map[string]any{"success": true, "keys": keys}}, nil
-	}
-	return &RPCResult{Result: result}, nil
+	return &RPCResult{Result: map[string]any{"success": true, "keys": keys}}, nil
 }
 
 // ── launch_app ───────────────────────────────────────────────────────
@@ -220,7 +134,7 @@ func handleLaunchApp(params map[string]any) (*RPCResult, error) {
 
 	script := fmt.Sprintf(`
 $p = Start-Process -FilePath '%s' %s -PassThru
-@{ success=$true; pid=$p.Id; name=$p.ProcessName } | ConvertTo-Json -Compress
+@{ pid=$p.Id; name=$p.ProcessName } | ConvertTo-Json -Compress
 `, escaped, argsClause)
 
 	out, err := runPS(script, 10*time.Second)
@@ -231,6 +145,31 @@ $p = Start-Process -FilePath '%s' %s -PassThru
 	var result map[string]any
 	if err := json.Unmarshal([]byte(out), &result); err != nil {
 		return nil, fmt.Errorf("parse result: %w", err)
+	}
+
+	// A spawned process is not an open app. The old handler returned success
+	// immediately, so the very next tool call ("type into it") raced the
+	// window and failed with "no window found for PID". Wait for a visible
+	// window before declaring success — matching by PID first, then by
+	// process name (packaged apps hand the window to a broker process, e.g.
+	// calc.exe -> Calculator.exe).
+	pid := toInt(result["pid"])
+	win, matchedBy := waitForWindow(pid, executable, 5*time.Second)
+	if win == nil {
+		result["success"] = false
+		result["window_visible"] = false
+		result["note"] = fmt.Sprintf(
+			"process started (pid %d) but no window appeared within 5s — the app may still be starting, be windowless, or have exited. Run desktop_list_windows to check before interacting; do NOT assume it is open.",
+			pid)
+		return &RPCResult{Result: result}, nil
+	}
+
+	result["success"] = true
+	result["window_visible"] = true
+	result["window_title"] = win.Title
+	result["window_pid"] = win.Pid // may differ from launch pid for packaged apps
+	if matchedBy == "process_name" {
+		result["note"] = fmt.Sprintf("window belongs to pid %d (matched by process name; the launcher pid %d handed off) — use pid %d with desktop_snapshot/desktop_focus_window", win.Pid, pid, win.Pid)
 	}
 	return &RPCResult{Result: result}, nil
 }
@@ -244,36 +183,17 @@ func handleFocusWindow(params map[string]any) (*RPCResult, error) {
 	}
 	pid := int(pidF)
 
-	script := fmt.Sprintf(`
-Add-Type @'
-using System;
-using System.Runtime.InteropServices;
-using System.Diagnostics;
-public class Focuser {
-    [DllImport("user32.dll")] public static extern bool SetForegroundWindow(IntPtr hWnd);
-    [DllImport("user32.dll")] public static extern bool ShowWindow(IntPtr hWnd, int nCmdShow);
-    public static bool Focus(int pid) {
-        var p = Process.GetProcessById(pid);
-        if (p == null || p.MainWindowHandle == IntPtr.Zero) return false;
-        ShowWindow(p.MainWindowHandle, 9); // SW_RESTORE
-        return SetForegroundWindow(p.MainWindowHandle);
-    }
-}
-'@
-$ok = [Focuser]::Focus(%d)
-@{ success=$ok; pid=%d } | ConvertTo-Json -Compress
-`, pid, pid)
-
-	out, err := runPS(script, 5*time.Second)
+	// Native — the previous implementation recompiled embedded C# in a fresh
+	// PowerShell per call, and returned a bare boolean with no explanation.
+	win, err := focusWindowNative(pid)
 	if err != nil {
 		return nil, fmt.Errorf("focus_window failed: %w", err)
 	}
-
-	var result map[string]any
-	if err := json.Unmarshal([]byte(out), &result); err != nil {
-		return &RPCResult{Result: map[string]any{"success": true, "pid": pid}}, nil
-	}
-	return &RPCResult{Result: result}, nil
+	return &RPCResult{Result: map[string]any{
+		"success": true,
+		"pid":     pid,
+		"title":   win.Title,
+	}}, nil
 }
 
 // ── find_element — uses UIAutomation COM ─────────────────────────────
@@ -313,98 +233,6 @@ func runPS(script string, timeout time.Duration) (string, error) {
 		return "", err
 	}
 	return strings.TrimSpace(string(out)), nil
-}
-
-// convertToSendKeys converts "ctrl,s" → "^s", "alt,f4" → "%{F4}", etc.
-func convertToSendKeys(keys string) string {
-	parts := strings.Split(strings.ToLower(strings.TrimSpace(keys)), ",")
-	for i := range parts {
-		parts[i] = strings.TrimSpace(parts[i])
-	}
-
-	modifiers := ""
-	keyParts := []string{}
-
-	for _, part := range parts {
-		switch part {
-		case "ctrl", "control":
-			modifiers += "^"
-		case "alt":
-			modifiers += "%"
-		case "shift":
-			modifiers += "+"
-		case "win":
-			modifiers += "^{ESC}" // approximate
-		default:
-			keyParts = append(keyParts, part)
-		}
-	}
-
-	if len(keyParts) == 0 {
-		return modifiers
-	}
-
-	key := keyParts[0]
-	mapped := mapKey(key)
-
-	return modifiers + mapped
-}
-
-func mapKey(key string) string {
-	switch strings.ToLower(key) {
-	case "enter", "return":
-		return "{ENTER}"
-	case "tab":
-		return "{TAB}"
-	case "escape", "esc":
-		return "{ESC}"
-	case "backspace", "bs":
-		return "{BACKSPACE}"
-	case "delete", "del":
-		return "{DELETE}"
-	case "up":
-		return "{UP}"
-	case "down":
-		return "{DOWN}"
-	case "left":
-		return "{LEFT}"
-	case "right":
-		return "{RIGHT}"
-	case "home":
-		return "{HOME}"
-	case "end":
-		return "{END}"
-	case "pageup", "pgup":
-		return "{PGUP}"
-	case "pagedown", "pgdn":
-		return "{PGDN}"
-	case "space":
-		return " "
-	case "f1", "f2", "f3", "f4", "f5", "f6", "f7", "f8", "f9", "f10", "f11", "f12":
-		return "{" + strings.ToUpper(key) + "}"
-	default:
-		if len(key) == 1 {
-			return key
-		}
-		return "{" + strings.ToUpper(key) + "}"
-	}
-}
-
-// escapeSendKeys escapes special SendKeys characters in user text.
-func escapeSendKeys(text string) string {
-	r := strings.NewReplacer(
-		"+", "{+}",
-		"^", "{^}",
-		"%", "{%}",
-		"~", "{~}",
-		"(", "{(}",
-		")", "{)}",
-		"{", "{{}",
-		"}", "{}}",
-		"[", "{[}",
-		"]", "{]}",
-	)
-	return r.Replace(text)
 }
 
 func toInt(v any) int {

--- a/sidecar/desktop_windows.go
+++ b/sidecar/desktop_windows.go
@@ -137,6 +137,11 @@ $p = Start-Process -FilePath '%s' %s -PassThru
 @{ pid=$p.Id; name=$p.ProcessName } | ConvertTo-Json -Compress
 `, escaped, argsClause)
 
+	// Snapshot what is on screen before starting anything, so the
+	// process-name fallback below cannot hand back a window that belongs to
+	// an instance the user already had open.
+	preexisting := visibleWindowHandles()
+
 	out, err := runPS(script, 10*time.Second)
 	if err != nil {
 		return nil, fmt.Errorf("launch_app failed: %w", err)
@@ -154,12 +159,12 @@ $p = Start-Process -FilePath '%s' %s -PassThru
 	// process name (packaged apps hand the window to a broker process, e.g.
 	// calc.exe -> Calculator.exe).
 	pid := toInt(result["pid"])
-	win, matchedBy := waitForWindow(pid, executable, 5*time.Second)
+	win, matchedBy := waitForWindow(pid, executable, 5*time.Second, preexisting)
 	if win == nil {
 		result["success"] = false
 		result["window_visible"] = false
 		result["note"] = fmt.Sprintf(
-			"process started (pid %d) but no window appeared within 5s — the app may still be starting, be windowless, or have exited. Run desktop_list_windows to check before interacting; do NOT assume it is open.",
+			"process started (pid %d) but no window appeared within 5s - the app may still be starting, be windowless, or have exited. Run desktop_list_windows to check before interacting; do NOT assume it is open.",
 			pid)
 		return &RPCResult{Result: result}, nil
 	}
@@ -169,7 +174,7 @@ $p = Start-Process -FilePath '%s' %s -PassThru
 	result["window_title"] = win.Title
 	result["window_pid"] = win.Pid // may differ from launch pid for packaged apps
 	if matchedBy == "process_name" {
-		result["note"] = fmt.Sprintf("window belongs to pid %d (matched by process name; the launcher pid %d handed off) — use pid %d with desktop_snapshot/desktop_focus_window", win.Pid, pid, win.Pid)
+		result["note"] = fmt.Sprintf("window belongs to pid %d (matched by process name; the launcher pid %d handed off) - use pid %d with desktop_snapshot/desktop_focus_window", win.Pid, pid, win.Pid)
 	}
 	return &RPCResult{Result: result}, nil
 }

--- a/sidecar/handlers_test.go
+++ b/sidecar/handlers_test.go
@@ -268,7 +268,10 @@ func TestLaunchAppNonexistentBinary(t *testing.T) {
 }
 
 func TestLaunchAppSuccessReturnsNonZeroPid(t *testing.T) {
-	// Use a real binary that exists and exits quickly
+	// Use a real binary that exists and exits quickly. It is windowless, so
+	// under launch_app's honest contract (success == "a window is visible",
+	// not "a process was spawned") this must report success: false with an
+	// explanatory note — while still returning the real pid.
 	result, err := handleLaunchApp(map[string]any{
 		"executable": "/bin/sleep",
 		"args":       "0.1",
@@ -282,10 +285,17 @@ func TestLaunchAppSuccessReturnsNonZeroPid(t *testing.T) {
 		t.Fatalf("pid is not int: %T", m["pid"])
 	}
 	if pid == 0 {
-		t.Error("expected non-zero pid on success")
+		t.Error("expected non-zero pid")
 	}
-	if m["success"] != true {
-		t.Error("expected success: true")
+	if m["success"] != false {
+		t.Errorf("expected success: false for a windowless process, got %v", m["success"])
+	}
+	if m["window_visible"] != false {
+		t.Errorf("expected window_visible: false, got %v", m["window_visible"])
+	}
+	note, _ := m["note"].(string)
+	if note == "" {
+		t.Error("expected an explanatory note for the windowless launch")
 	}
 }
 

--- a/sidecar/handlers_test.go
+++ b/sidecar/handlers_test.go
@@ -268,10 +268,17 @@ func TestLaunchAppNonexistentBinary(t *testing.T) {
 }
 
 func TestLaunchAppSuccessReturnsNonZeroPid(t *testing.T) {
-	// Use a real binary that exists and exits quickly. It is windowless, so
-	// under launch_app's honest contract (success == "a window is visible",
-	// not "a process was spawned") this must report success: false with an
-	// explanatory note — while still returning the real pid.
+	// /bin/sleep exists, starts, and never opens a window, so it pins both
+	// halves of launch_app's contract: the real pid still comes back, and
+	// success is not allowed to mean "a process was spawned".
+	//
+	// Which of the two honest answers we get depends on the machine, so the
+	// assertions cover both. On a desktop with working window tooling the
+	// probe runs and reports a definite "no window" (success: false). On a
+	// headless runner it cannot run at all, and reporting that as a failure
+	// would be its own lie, so the result is an unverified success with
+	// window_visible left nil. What must never happen, in either
+	// environment, is a claim that a window is visible.
 	result, err := handleLaunchApp(map[string]any{
 		"executable": "/bin/sleep",
 		"args":       "0.1",
@@ -287,15 +294,23 @@ func TestLaunchAppSuccessReturnsNonZeroPid(t *testing.T) {
 	if pid == 0 {
 		t.Error("expected non-zero pid")
 	}
-	if m["success"] != false {
-		t.Errorf("expected success: false for a windowless process, got %v", m["success"])
+
+	switch m["window_visible"] {
+	case false:
+		if m["success"] != false {
+			t.Errorf("the probe ran and saw no window, so success must be false, got %v", m["success"])
+		}
+	case nil:
+		if m["success"] != true {
+			t.Errorf("the probe could not run, so this must not be reported as a failed launch, got success: %v", m["success"])
+		}
+	default:
+		t.Errorf("a windowless process must never report window_visible: %v", m["window_visible"])
 	}
-	if m["window_visible"] != false {
-		t.Errorf("expected window_visible: false, got %v", m["window_visible"])
-	}
+
 	note, _ := m["note"].(string)
 	if note == "" {
-		t.Error("expected an explanatory note for the windowless launch")
+		t.Error("expected an explanatory note whenever no window was confirmed")
 	}
 }
 

--- a/sidecar/uia_actions_windows.go
+++ b/sidecar/uia_actions_windows.go
@@ -17,7 +17,7 @@ import (
 func uiaPerformAction(state *uiaState, elementID int, action, value string) (map[string]any, error) {
 	elem := state.cache.get(elementID)
 	if elem == nil {
-		return nil, fmt.Errorf("element %d not found in cache — run desktop_snapshot first", elementID)
+		return nil, fmt.Errorf("element %d is not in the current element cache — every desktop_snapshot invalidates all previous ids, so only ids from the MOST RECENT snapshot/find_element are valid; take a fresh desktop_snapshot and use an id from that result", elementID)
 	}
 
 	result := map[string]any{

--- a/sidecar/uia_patterns_windows.go
+++ b/sidecar/uia_patterns_windows.go
@@ -16,11 +16,35 @@ import (
 	"github.com/go-ole/go-ole"
 )
 
+// uiaOpError converts a failed UIA call into an error the model can act on.
+// Raw HRESULTs ("Invoke failed: HRESULT 0x80004005") gave the LLM nothing to
+// correct with; these map the common failures to concrete next steps.
+func uiaOpError(op string, hr uintptr) error {
+	return fmt.Errorf("%s failed: %s", op, hresultText(hr))
+}
+
+func hresultText(hr uintptr) string {
+	switch uint32(hr) {
+	case 0x80040201: // UIA_E_ELEMENTNOTAVAILABLE
+		return "the element no longer exists — the UI changed or the window closed since the last snapshot; take a fresh desktop_snapshot and use a new element id"
+	case 0x80040200: // UIA_E_ELEMENTNOTENABLED
+		return "the element is disabled and cannot be interacted with right now — something in the app must enable it first"
+	case 0x80040202: // UIA_E_NOCLICKABLEPOINT
+		return "the element has no clickable point — it is offscreen or covered by another element; try action=scroll_into_view first"
+	case 0x80070005: // E_ACCESSDENIED
+		return "access denied — the target app likely runs elevated (as administrator) while the sidecar does not; Windows blocks UI automation across that boundary"
+	case 0x80004005: // E_FAIL
+		return "the control rejected the action — it may be busy, mid-update, or not truly support this operation; take a fresh desktop_snapshot and retry once"
+	default:
+		return fmt.Sprintf("HRESULT 0x%08x — take a fresh desktop_snapshot and retry once; if it persists the control does not support this action", uint32(hr))
+	}
+}
+
 // patternInvoke calls IUIAutomationInvokePattern::Invoke.
 func patternInvoke(elem *ole.IDispatch) error {
 	pattern, err := uiaElementGetPattern(elem, UIA_InvokePatternId)
 	if err != nil {
-		return fmt.Errorf("element does not support Invoke pattern: %w", err)
+		return fmt.Errorf("element does not support the Invoke action — run desktop_snapshot and check the element's listed patterns/actions before retrying: %w", err)
 	}
 	defer pattern.Release()
 
@@ -30,7 +54,7 @@ func patternInvoke(elem *ole.IDispatch) error {
 		uintptr(unsafe.Pointer(pattern)),
 	)
 	if hr != 0 {
-		return fmt.Errorf("Invoke failed: HRESULT 0x%x", hr)
+		return uiaOpError("Invoke", hr)
 	}
 	return nil
 }
@@ -39,7 +63,7 @@ func patternInvoke(elem *ole.IDispatch) error {
 func patternGetValue(elem *ole.IDispatch) (string, error) {
 	pattern, err := uiaElementGetPattern(elem, UIA_ValuePatternId)
 	if err != nil {
-		return "", fmt.Errorf("element does not support Value pattern: %w", err)
+		return "", fmt.Errorf("element does not support the Value action — run desktop_snapshot and check the element's listed patterns/actions before retrying: %w", err)
 	}
 	defer pattern.Release()
 
@@ -51,7 +75,7 @@ func patternGetValue(elem *ole.IDispatch) (string, error) {
 		uintptr(unsafe.Pointer(&bstr)),
 	)
 	if hr != 0 {
-		return "", fmt.Errorf("get_CurrentValue failed: HRESULT 0x%x", hr)
+		return "", uiaOpError("get_CurrentValue", hr)
 	}
 	if bstr == nil {
 		return "", nil
@@ -65,7 +89,7 @@ func patternGetValue(elem *ole.IDispatch) (string, error) {
 func patternSetValue(elem *ole.IDispatch, value string) error {
 	pattern, err := uiaElementGetPattern(elem, UIA_ValuePatternId)
 	if err != nil {
-		return fmt.Errorf("element does not support Value pattern: %w", err)
+		return fmt.Errorf("element does not support the Value action — run desktop_snapshot and check the element's listed patterns/actions before retrying: %w", err)
 	}
 	defer pattern.Release()
 
@@ -79,7 +103,7 @@ func patternSetValue(elem *ole.IDispatch, value string) error {
 		uintptr(unsafe.Pointer(bstr)),
 	)
 	if hr != 0 {
-		return fmt.Errorf("SetValue failed: HRESULT 0x%x", hr)
+		return uiaOpError("SetValue", hr)
 	}
 	return nil
 }
@@ -88,7 +112,7 @@ func patternSetValue(elem *ole.IDispatch, value string) error {
 func patternToggle(elem *ole.IDispatch) error {
 	pattern, err := uiaElementGetPattern(elem, UIA_TogglePatternId)
 	if err != nil {
-		return fmt.Errorf("element does not support Toggle pattern: %w", err)
+		return fmt.Errorf("element does not support the Toggle action — run desktop_snapshot and check the element's listed patterns/actions before retrying: %w", err)
 	}
 	defer pattern.Release()
 
@@ -98,7 +122,7 @@ func patternToggle(elem *ole.IDispatch) error {
 		uintptr(unsafe.Pointer(pattern)),
 	)
 	if hr != 0 {
-		return fmt.Errorf("Toggle failed: HRESULT 0x%x", hr)
+		return uiaOpError("Toggle", hr)
 	}
 	return nil
 }
@@ -108,7 +132,7 @@ func patternToggle(elem *ole.IDispatch) error {
 func patternGetToggleState(elem *ole.IDispatch) (int, error) {
 	pattern, err := uiaElementGetPattern(elem, UIA_TogglePatternId)
 	if err != nil {
-		return 0, fmt.Errorf("element does not support Toggle pattern: %w", err)
+		return 0, fmt.Errorf("element does not support the Toggle action — run desktop_snapshot and check the element's listed patterns/actions before retrying: %w", err)
 	}
 	defer pattern.Release()
 
@@ -120,7 +144,7 @@ func patternGetToggleState(elem *ole.IDispatch) (int, error) {
 		uintptr(unsafe.Pointer(&state)),
 	)
 	if hr != 0 {
-		return 0, fmt.Errorf("get_CurrentToggleState failed: HRESULT 0x%x", hr)
+		return 0, uiaOpError("get_CurrentToggleState", hr)
 	}
 	return int(state), nil
 }
@@ -129,7 +153,7 @@ func patternGetToggleState(elem *ole.IDispatch) (int, error) {
 func patternExpand(elem *ole.IDispatch) error {
 	pattern, err := uiaElementGetPattern(elem, UIA_ExpandCollapsePatternId)
 	if err != nil {
-		return fmt.Errorf("element does not support ExpandCollapse pattern: %w", err)
+		return fmt.Errorf("element does not support the ExpandCollapse action — run desktop_snapshot and check the element's listed patterns/actions before retrying: %w", err)
 	}
 	defer pattern.Release()
 
@@ -139,7 +163,7 @@ func patternExpand(elem *ole.IDispatch) error {
 		uintptr(unsafe.Pointer(pattern)),
 	)
 	if hr != 0 {
-		return fmt.Errorf("Expand failed: HRESULT 0x%x", hr)
+		return uiaOpError("Expand", hr)
 	}
 	return nil
 }
@@ -148,7 +172,7 @@ func patternExpand(elem *ole.IDispatch) error {
 func patternCollapse(elem *ole.IDispatch) error {
 	pattern, err := uiaElementGetPattern(elem, UIA_ExpandCollapsePatternId)
 	if err != nil {
-		return fmt.Errorf("element does not support ExpandCollapse pattern: %w", err)
+		return fmt.Errorf("element does not support the ExpandCollapse action — run desktop_snapshot and check the element's listed patterns/actions before retrying: %w", err)
 	}
 	defer pattern.Release()
 
@@ -158,7 +182,7 @@ func patternCollapse(elem *ole.IDispatch) error {
 		uintptr(unsafe.Pointer(pattern)),
 	)
 	if hr != 0 {
-		return fmt.Errorf("Collapse failed: HRESULT 0x%x", hr)
+		return uiaOpError("Collapse", hr)
 	}
 	return nil
 }
@@ -167,7 +191,7 @@ func patternCollapse(elem *ole.IDispatch) error {
 func patternSelectItem(elem *ole.IDispatch) error {
 	pattern, err := uiaElementGetPattern(elem, UIA_SelectionItemPatternId)
 	if err != nil {
-		return fmt.Errorf("element does not support SelectionItem pattern: %w", err)
+		return fmt.Errorf("element does not support the SelectionItem action — run desktop_snapshot and check the element's listed patterns/actions before retrying: %w", err)
 	}
 	defer pattern.Release()
 
@@ -177,7 +201,7 @@ func patternSelectItem(elem *ole.IDispatch) error {
 		uintptr(unsafe.Pointer(pattern)),
 	)
 	if hr != 0 {
-		return fmt.Errorf("Select failed: HRESULT 0x%x", hr)
+		return uiaOpError("Select", hr)
 	}
 	return nil
 }
@@ -186,7 +210,7 @@ func patternSelectItem(elem *ole.IDispatch) error {
 func patternScrollIntoView(elem *ole.IDispatch) error {
 	pattern, err := uiaElementGetPattern(elem, UIA_ScrollItemPatternId)
 	if err != nil {
-		return fmt.Errorf("element does not support ScrollItem pattern: %w", err)
+		return fmt.Errorf("element does not support the ScrollItem action — run desktop_snapshot and check the element's listed patterns/actions before retrying: %w", err)
 	}
 	defer pattern.Release()
 
@@ -196,7 +220,7 @@ func patternScrollIntoView(elem *ole.IDispatch) error {
 		uintptr(unsafe.Pointer(pattern)),
 	)
 	if hr != 0 {
-		return fmt.Errorf("ScrollIntoView failed: HRESULT 0x%x", hr)
+		return uiaOpError("ScrollIntoView", hr)
 	}
 	return nil
 }

--- a/sidecar/uia_patterns_windows.go
+++ b/sidecar/uia_patterns_windows.go
@@ -25,6 +25,13 @@ func uiaOpError(op string, hr uintptr) error {
 
 func hresultText(hr uintptr) string {
 	switch uint32(hr) {
+	case 0:
+		// Reached via uiaElementGetPattern, which also fails when UIA
+		// answers S_OK with a null pattern - its way of saying the control
+		// does not implement it. That is the single most common failure
+		// here, and rendering it as "HRESULT 0x00000000, retry once" told
+		// the model to keep retrying something that can never work.
+		return "the control does not expose this pattern, so this action is not available on it - take a desktop_snapshot and use one of the actions it lists for this element, or pick a different element"
 	case 0x80040201: // UIA_E_ELEMENTNOTAVAILABLE
 		return "the element no longer exists — the UI changed or the window closed since the last snapshot; take a fresh desktop_snapshot and use a new element id"
 	case 0x80040200: // UIA_E_ELEMENTNOTENABLED

--- a/sidecar/uia_windows.go
+++ b/sidecar/uia_windows.go
@@ -11,6 +11,8 @@ import (
 	"fmt"
 	"log"
 	"runtime"
+	"sort"
+	"strings"
 	"sync"
 	"syscall"
 	"unsafe"
@@ -187,7 +189,7 @@ func uiaGetRootElement(automation *ole.IDispatch) (*ole.IDispatch, error) {
 		uintptr(unsafe.Pointer(&elem)),
 	)
 	if hr != 0 {
-		return nil, fmt.Errorf("GetRootElement failed: HRESULT 0x%x", hr)
+		return nil, uiaOpError("GetRootElement", hr)
 	}
 	return elem, nil
 }
@@ -201,7 +203,7 @@ func uiaCreateTrueCondition(automation *ole.IDispatch) (*ole.IDispatch, error) {
 		uintptr(unsafe.Pointer(&cond)),
 	)
 	if hr != 0 {
-		return nil, fmt.Errorf("CreateTrueCondition failed: HRESULT 0x%x", hr)
+		return nil, uiaOpError("CreateTrueCondition", hr)
 	}
 	return cond, nil
 }
@@ -228,7 +230,7 @@ func uiaCreatePropertyCondition(automation *ole.IDispatch, propertyId int, value
 		uintptr(unsafe.Pointer(&cond)),
 	)
 	if hr != 0 {
-		return nil, fmt.Errorf("CreatePropertyCondition(%d) failed: HRESULT 0x%x", propertyId, hr)
+		return nil, uiaOpError(fmt.Sprintf("CreatePropertyCondition(%d)", propertyId), hr)
 	}
 	return cond, nil
 }
@@ -244,7 +246,7 @@ func uiaCreateAndCondition(automation *ole.IDispatch, cond1, cond2 *ole.IDispatc
 		uintptr(unsafe.Pointer(&cond)),
 	)
 	if hr != 0 {
-		return nil, fmt.Errorf("CreateAndCondition failed: HRESULT 0x%x", hr)
+		return nil, uiaOpError("CreateAndCondition", hr)
 	}
 	return cond, nil
 }
@@ -354,7 +356,7 @@ func uiaElementSetFocus(elem *ole.IDispatch) error {
 		uintptr(unsafe.Pointer(elem)),
 	)
 	if hr != 0 {
-		return fmt.Errorf("SetFocus failed: HRESULT 0x%x", hr)
+		return uiaOpError("SetFocus", hr)
 	}
 	return nil
 }
@@ -371,7 +373,7 @@ func uiaElementFindFirst(elem *ole.IDispatch, scope int, condition *ole.IDispatc
 		uintptr(unsafe.Pointer(&found)),
 	)
 	if hr != 0 {
-		return nil, fmt.Errorf("FindFirst failed: HRESULT 0x%x", hr)
+		return nil, uiaOpError("FindFirst", hr)
 	}
 	return found, nil
 }
@@ -388,7 +390,7 @@ func uiaElementFindAll(elem *ole.IDispatch, scope int, condition *ole.IDispatch)
 		uintptr(unsafe.Pointer(&arr)),
 	)
 	if hr != 0 {
-		return nil, fmt.Errorf("FindAll failed: HRESULT 0x%x", hr)
+		return nil, uiaOpError("FindAll", hr)
 	}
 	return arr, nil
 }
@@ -404,7 +406,7 @@ func uiaElementGetPattern(elem *ole.IDispatch, patternId int) (*ole.IDispatch, e
 		uintptr(unsafe.Pointer(&pattern)),
 	)
 	if hr != 0 || pattern == nil {
-		return nil, fmt.Errorf("GetCurrentPattern(%d) failed: HRESULT 0x%x", patternId, hr)
+		return nil, uiaOpError(fmt.Sprintf("GetCurrentPattern(%d)", patternId), hr)
 	}
 	return pattern, nil
 }
@@ -709,26 +711,119 @@ func uiaFindElements(state *uiaState, pid int, automationId, name, className, co
 	if err != nil {
 		return nil, err
 	}
-	if arr == nil {
-		return map[string]any{"match_count": 0, "elements": []any{}}, nil
+	if arr != nil {
+		defer arr.Release()
 	}
-	defer arr.Release()
 
 	// Don't clear cache — allow mixing inspect + find results (matches C# behavior)
 	var results []map[string]any
-	length := uiaArrayLength(arr)
-	for i := 0; i < length; i++ {
-		elem := uiaArrayGetElement(arr, i)
-		if elem != nil {
-			id := state.cache.add(elem)
-			results = append(results, buildElementInfo(elem, id, 0))
+	if arr != nil {
+		length := uiaArrayLength(arr)
+		for i := 0; i < length; i++ {
+			elem := uiaArrayGetElement(arr, i)
+			if elem != nil {
+				id := state.cache.add(elem)
+				results = append(results, buildElementInfo(elem, id, 0))
+			}
 		}
 	}
 
-	return map[string]any{
+	out := map[string]any{
 		"match_count": len(results),
 		"elements":    results,
-	}, nil
+	}
+	if len(results) == 0 {
+		// An empty result gave the model nothing to correct with (it would
+		// blindly retry the same query). Surface the closest-named elements
+		// in the window so it can fix its search terms — exact-match Name
+		// conditions miss "Save As…" when asked for "Save".
+		if similar := collectNearMisses(state, window, name, controlType); len(similar) > 0 {
+			out["similar"] = similar
+			out["hint"] = "no exact match; 'similar' lists close elements in this window — Name matching is exact and case-sensitive, so retry with one of those exact names, or use desktop_snapshot to see everything"
+		} else {
+			out["hint"] = "no match and nothing similar found in this window — the target may not exist yet (still loading?) or lives in another window; run desktop_list_windows and desktop_snapshot to orient"
+		}
+	}
+	return out, nil
+}
+
+// collectNearMisses walks the window subtree and returns up to 8 elements
+// whose name loosely matches the requested one (or whose control type
+// matches when no name was given). Read-only: nothing is cached.
+func collectNearMisses(state *uiaState, window *ole.IDispatch, wantName, wantType string) []map[string]any {
+	trueCond, err := uiaCreateTrueCondition(state.automation)
+	if err != nil {
+		return nil
+	}
+	defer trueCond.Release()
+
+	arr, err := uiaElementFindAll(window, TreeScope_Descendants, trueCond)
+	if err != nil || arr == nil {
+		return nil
+	}
+	defer arr.Release()
+
+	type scored struct {
+		info  map[string]any
+		score int
+	}
+	want := strings.ToLower(strings.TrimSpace(wantName))
+	wantTokens := strings.Fields(want)
+
+	var candidates []scored
+	length := uiaArrayLength(arr)
+	const scanCap = 500 // bound the walk on huge trees
+	if length > scanCap {
+		length = scanCap
+	}
+	for i := 0; i < length; i++ {
+		elem := uiaArrayGetElement(arr, i)
+		if elem == nil {
+			continue
+		}
+		elemName := uiaElementGetPropertyStr(elem, UIA_NamePropertyId)
+		ctrlType := controlTypeNames[uiaElementGetPropertyInt(elem, UIA_ControlTypePropertyId)]
+		autoID := uiaElementGetPropertyStr(elem, UIA_AutomationIdPropertyId)
+		elem.Release()
+
+		if strings.TrimSpace(elemName) == "" {
+			continue
+		}
+		score := 0
+		if want != "" {
+			lower := strings.ToLower(elemName)
+			switch {
+			case strings.Contains(lower, want) || strings.Contains(want, lower):
+				score = 3
+			default:
+				for _, tok := range wantTokens {
+					if len(tok) >= 3 && strings.Contains(lower, tok) {
+						score = 2
+						break
+					}
+				}
+			}
+		} else if wantType != "" && ctrlType == wantType {
+			score = 1
+		}
+		if score == 0 {
+			continue
+		}
+		candidates = append(candidates, scored{
+			info:  map[string]any{"name": elemName, "control_type": ctrlType, "automation_id": autoID},
+			score: score,
+		})
+	}
+
+	sort.SliceStable(candidates, func(i, j int) bool { return candidates[i].score > candidates[j].score })
+	if len(candidates) > 8 {
+		candidates = candidates[:8]
+	}
+	out := make([]map[string]any, len(candidates))
+	for i, c := range candidates {
+		out[i] = c.info
+	}
+	return out
 }
 
 // controlTypeIdFromName maps a human-readable control type name to its UIAutomation ID.

--- a/sidecar/uia_windows.go
+++ b/sidecar/uia_windows.go
@@ -29,14 +29,14 @@ var (
 
 // UIAutomation property IDs
 const (
-	UIA_BoundingRectanglePropertyId  = 30001
-	UIA_ProcessIdPropertyId          = 30002
-	UIA_ControlTypePropertyId        = 30003
-	UIA_NamePropertyId               = 30005
+	UIA_BoundingRectanglePropertyId   = 30001
+	UIA_ProcessIdPropertyId           = 30002
+	UIA_ControlTypePropertyId         = 30003
+	UIA_NamePropertyId                = 30005
 	UIA_IsKeyboardFocusablePropertyId = 30009
-	UIA_IsEnabledPropertyId          = 30010
-	UIA_AutomationIdPropertyId       = 30011
-	UIA_ClassNamePropertyId          = 30012
+	UIA_IsEnabledPropertyId           = 30010
+	UIA_AutomationIdPropertyId        = 30011
+	UIA_ClassNamePropertyId           = 30012
 )
 
 // UIAutomation pattern IDs
@@ -737,29 +737,76 @@ func uiaFindElements(state *uiaState, pid int, automationId, name, className, co
 		// blindly retry the same query). Surface the closest-named elements
 		// in the window so it can fix its search terms — exact-match Name
 		// conditions miss "Save As…" when asked for "Save".
-		if similar := collectNearMisses(state, window, name, controlType); len(similar) > 0 {
+		similar, truncated := collectNearMisses(state, window, name, controlType)
+		switch {
+		case len(similar) > 0:
 			out["similar"] = similar
-			out["hint"] = "no exact match; 'similar' lists close elements in this window — Name matching is exact and case-sensitive, so retry with one of those exact names, or use desktop_snapshot to see everything"
-		} else {
-			out["hint"] = "no match and nothing similar found in this window — the target may not exist yet (still loading?) or lives in another window; run desktop_list_windows and desktop_snapshot to orient"
+			out["hint"] = "no exact match; 'similar' lists close elements in this window - Name matching is exact and case-sensitive, so retry with one of those exact names, or use desktop_snapshot to see everything"
+		case truncated:
+			// Only part of a large window was scanned, so "nothing similar"
+			// is not something we are in a position to say.
+			out["hint"] = "no exact match, and the search for similar elements stopped partway through a large window without finding one - that is not the same as there being none; run desktop_snapshot to see what this window actually contains"
+		default:
+			out["hint"] = "no match and nothing similar found in this window - the target may not exist yet (still loading?) or lives in another window; run desktop_list_windows and desktop_snapshot to orient"
 		}
 	}
 	return out, nil
 }
 
+// nearMissCondition narrows the near-miss walk where doing so cannot change
+// the answer.
+//
+// Only the nameless search qualifies. With no name, scoring keeps an element
+// solely for having the requested control type, so asking UIA for that type
+// up front returns the same candidates over a fraction of the tree. As soon
+// as a name is in play the walk has to stay wide: "you asked for a button
+// called Save, but there is a menu item called Save As" is the single most
+// useful correction this can offer, and filtering by control type first is
+// exactly what would throw it away.
+func nearMissCondition(state *uiaState, wantName, wantType string) (*ole.IDispatch, error) {
+	if wantName == "" && wantType != "" {
+		if ctrlID := controlTypeIdFromName(wantType); ctrlID > 0 {
+			if cond, err := uiaCreatePropertyCondition(state.automation, UIA_ControlTypePropertyId, ctrlID); err == nil {
+				return cond, nil
+			}
+		}
+	}
+	return uiaCreateTrueCondition(state.automation)
+}
+
 // collectNearMisses walks the window subtree and returns up to 8 elements
 // whose name loosely matches the requested one (or whose control type
 // matches when no name was given). Read-only: nothing is cached.
-func collectNearMisses(state *uiaState, window *ole.IDispatch, wantName, wantType string) []map[string]any {
-	trueCond, err := uiaCreateTrueCondition(state.automation)
-	if err != nil {
-		return nil
-	}
-	defer trueCond.Release()
+//
+// This runs on the failure path, and the walk is not free: FindAll over a
+// window's descendants materialises the whole subtree before any of the
+// scoring below happens, which is the real cost here (scanCap only bounds
+// what we then inspect). So the search is narrowed as far as the caller's
+// own criteria allow, and skipped outright when they leave nothing to score
+// against.
+// The second return says whether the scan was cut short by scanCap. An
+// empty result then means "nothing similar in the part we looked at", which
+// is not the same claim as "nothing similar in this window", and the caller
+// has to phrase its hint accordingly.
+func collectNearMisses(state *uiaState, window *ole.IDispatch, wantName, wantType string) ([]map[string]any, bool) {
+	want := strings.ToLower(strings.TrimSpace(wantName))
 
-	arr, err := uiaElementFindAll(window, TreeScope_Descendants, trueCond)
+	// Scoring needs either a name to be near or a control type to share.
+	// Searches by automation_id or class_name alone give neither, and every
+	// candidate would score zero after a full-tree walk.
+	if want == "" && wantType == "" {
+		return nil, false
+	}
+
+	cond, err := nearMissCondition(state, want, wantType)
+	if err != nil {
+		return nil, false
+	}
+	defer cond.Release()
+
+	arr, err := uiaElementFindAll(window, TreeScope_Descendants, cond)
 	if err != nil || arr == nil {
-		return nil
+		return nil, false
 	}
 	defer arr.Release()
 
@@ -767,13 +814,13 @@ func collectNearMisses(state *uiaState, window *ole.IDispatch, wantName, wantTyp
 		info  map[string]any
 		score int
 	}
-	want := strings.ToLower(strings.TrimSpace(wantName))
 	wantTokens := strings.Fields(want)
 
 	var candidates []scored
 	length := uiaArrayLength(arr)
 	const scanCap = 500 // bound the walk on huge trees
-	if length > scanCap {
+	truncated := length > scanCap
+	if truncated {
 		length = scanCap
 	}
 	for i := 0; i < length; i++ {
@@ -823,7 +870,7 @@ func collectNearMisses(state *uiaState, window *ole.IDispatch, wantName, wantTyp
 	for i, c := range candidates {
 		out[i] = c.info
 	}
-	return out
+	return out, truncated
 }
 
 // controlTypeIdFromName maps a human-readable control type name to its UIAutomation ID.
@@ -839,15 +886,15 @@ func controlTypeIdFromName(name string) int {
 // ── Win32 helpers ────────────────────────────────────────────────────
 
 var (
-	user32                   = syscall.NewLazyDLL("user32.dll")
-	kernel32                 = syscall.NewLazyDLL("kernel32.dll")
-	procGetForegroundWindow  = user32.NewProc("GetForegroundWindow")
+	user32                    = syscall.NewLazyDLL("user32.dll")
+	kernel32                  = syscall.NewLazyDLL("kernel32.dll")
+	procGetForegroundWindow   = user32.NewProc("GetForegroundWindow")
 	procGetWindowThreadProcId = user32.NewProc("GetWindowThreadProcessId")
-	procSetCursorPos         = user32.NewProc("SetCursorPos")
-	procMouseEvent           = user32.NewProc("mouse_event")
-	procSetForegroundWindow  = user32.NewProc("SetForegroundWindow")
-	procShowWindow           = user32.NewProc("ShowWindow")
-	procSleep                = kernel32.NewProc("Sleep")
+	procSetCursorPos          = user32.NewProc("SetCursorPos")
+	procMouseEvent            = user32.NewProc("mouse_event")
+	procSetForegroundWindow   = user32.NewProc("SetForegroundWindow")
+	procShowWindow            = user32.NewProc("ShowWindow")
+	procSleep                 = kernel32.NewProc("Sleep")
 )
 
 func win32GetForegroundWindow() uintptr {

--- a/sidecar/win32_native_windows.go
+++ b/sidecar/win32_native_windows.go
@@ -326,7 +326,9 @@ var extendedKeys = map[uint16]bool{
 	vkInsert: true, vkDelete: true, vkLWin: true,
 }
 
-var namedKeys = map[string]uint16{
+// winNamedKeys maps key names to Windows virtual-key codes. Distinct from the
+// CDP-oriented namedKeys in browser_input.go, which carries keyDef metadata.
+var winNamedKeys = map[string]uint16{
 	"enter": vkReturn, "return": vkReturn,
 	"tab":       vkTab,
 	"escape":    vkEscape,
@@ -351,7 +353,7 @@ var modifierKeys = map[string]uint16{
 // resolveVk maps a key name to a virtual-key code.
 func resolveVk(key string) (uint16, error) {
 	k := strings.ToLower(strings.TrimSpace(key))
-	if vk, ok := namedKeys[k]; ok {
+	if vk, ok := winNamedKeys[k]; ok {
 		return vk, nil
 	}
 	if len(k) >= 2 && k[0] == 'f' {
@@ -367,8 +369,8 @@ func resolveVk(key string) (uint16, error) {
 		}
 		return 0, fmt.Errorf("no virtual key for character %q on the current keyboard layout", key)
 	}
-	known := make([]string, 0, len(namedKeys))
-	for name := range namedKeys {
+	known := make([]string, 0, len(winNamedKeys))
+	for name := range winNamedKeys {
 		known = append(known, name)
 	}
 	return 0, fmt.Errorf("unknown key %q — use a single character, f1-f24, or one of: %s", key, strings.Join(known, ", "))

--- a/sidecar/win32_native_windows.go
+++ b/sidecar/win32_native_windows.go
@@ -1,0 +1,426 @@
+//go:build windows
+
+package main
+
+// Native Win32 window enumeration, focus, and keyboard input.
+//
+// These replace the previous PowerShell implementations, which spawned a new
+// powershell.exe per call and — for list_windows/focus_window — recompiled
+// embedded C# via Add-Type on every single call (~0.7-1.5s each). The
+// direct syscalls below complete in microseconds and cannot silently lose
+// keystrokes the way SendKeys could (SendInput injects Unicode directly, no
+// metacharacter escaping needed).
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+	"unicode/utf16"
+	"unsafe"
+)
+
+var (
+	procEnumWindows        = user32.NewProc("EnumWindows")
+	procIsWindowVisible    = user32.NewProc("IsWindowVisible")
+	procIsIconic           = user32.NewProc("IsIconic")
+	procGetWindowTextW     = user32.NewProc("GetWindowTextW")
+	procGetClassNameW      = user32.NewProc("GetClassNameW")
+	procSendInput          = user32.NewProc("SendInput")
+	procVkKeyScanW         = user32.NewProc("VkKeyScanW")
+	procOpenProcess        = kernel32.NewProc("OpenProcess")
+	procNativeCloseHandle  = kernel32.NewProc("CloseHandle")
+	procQueryFullImageName = kernel32.NewProc("QueryFullProcessImageNameW")
+)
+
+// windowInfo describes one visible top-level window. JSON keys match the
+// shape the previous PowerShell implementation produced, so daemon-side
+// consumers see no change.
+type windowInfo struct {
+	Hwnd         uintptr `json:"hwnd"`
+	Title        string  `json:"title"`
+	Pid          uint32  `json:"pid"`
+	ProcessName  string  `json:"process_name"`
+	ClassName    string  `json:"class_name"`
+	Left         int32   `json:"left"`
+	Top          int32   `json:"top"`
+	Right        int32   `json:"right"`
+	Bottom       int32   `json:"bottom"`
+	IsForeground bool    `json:"is_foreground"`
+}
+
+type win32Rect struct {
+	Left, Top, Right, Bottom int32
+}
+
+// EnumWindows delivers results through a C-style callback with no closure
+// support, so the collector is package state guarded by a mutex.
+// syscall.NewCallback registrations are permanent, hence the sync.Once.
+var (
+	enumMu      sync.Mutex
+	enumResults []windowInfo
+	enumFg      uintptr
+	enumCbOnce  sync.Once
+	enumCb      uintptr
+)
+
+func enumWindowsCallback(hwnd uintptr, _ uintptr) uintptr {
+	visible, _, _ := procIsWindowVisible.Call(hwnd)
+	if visible == 0 {
+		return 1 // continue enumeration
+	}
+
+	var titleBuf [256]uint16
+	procGetWindowTextW.Call(hwnd, uintptr(unsafe.Pointer(&titleBuf[0])), uintptr(len(titleBuf)))
+	title := syscall.UTF16ToString(titleBuf[:])
+	if strings.TrimSpace(title) == "" {
+		return 1
+	}
+
+	var classBuf [256]uint16
+	procGetClassNameW.Call(hwnd, uintptr(unsafe.Pointer(&classBuf[0])), uintptr(len(classBuf)))
+
+	var rect win32Rect
+	procGetWindowRect.Call(hwnd, uintptr(unsafe.Pointer(&rect)))
+
+	pid := win32GetWindowPid(hwnd)
+
+	enumResults = append(enumResults, windowInfo{
+		Hwnd:         hwnd,
+		Title:        title,
+		Pid:          pid,
+		ProcessName:  processBaseName(pid),
+		ClassName:    syscall.UTF16ToString(classBuf[:]),
+		Left:         rect.Left,
+		Top:          rect.Top,
+		Right:        rect.Right,
+		Bottom:       rect.Bottom,
+		IsForeground: hwnd == enumFg,
+	})
+	return 1
+}
+
+// enumTopWindows returns all visible, titled top-level windows in z-order
+// (topmost first). Safe to call from any goroutine; no COM required.
+func enumTopWindows() []windowInfo {
+	enumCbOnce.Do(func() {
+		enumCb = syscall.NewCallback(enumWindowsCallback)
+	})
+
+	enumMu.Lock()
+	defer enumMu.Unlock()
+	enumResults = nil
+	enumFg = win32GetForegroundWindow()
+	procEnumWindows.Call(enumCb, 0)
+	out := make([]windowInfo, len(enumResults))
+	copy(out, enumResults)
+	enumResults = nil
+	return out
+}
+
+// processBaseName resolves a PID to its executable base name (without .exe),
+// mirroring .NET's Process.ProcessName. Empty string when access is denied.
+func processBaseName(pid uint32) string {
+	const PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+	h, _, _ := procOpenProcess.Call(PROCESS_QUERY_LIMITED_INFORMATION, 0, uintptr(pid))
+	if h == 0 {
+		return ""
+	}
+	defer procNativeCloseHandle.Call(h)
+
+	var buf [512]uint16
+	size := uint32(len(buf))
+	ok, _, _ := procQueryFullImageName.Call(h, 0, uintptr(unsafe.Pointer(&buf[0])), uintptr(unsafe.Pointer(&size)))
+	if ok == 0 {
+		return ""
+	}
+	full := syscall.UTF16ToString(buf[:size])
+	base := full
+	if i := strings.LastIndexAny(full, `\/`); i >= 0 {
+		base = full[i+1:]
+	}
+	return strings.TrimSuffix(base, ".exe")
+}
+
+// windowsForPid returns the visible windows owned by pid, z-order first.
+func windowsForPid(pid int) []windowInfo {
+	var out []windowInfo
+	for _, w := range enumTopWindows() {
+		if int(w.Pid) == pid {
+			out = append(out, w)
+		}
+	}
+	return out
+}
+
+// focusWindowNative restores (if minimized) and foregrounds the topmost
+// window of pid. Returns the focused window, or an error naming what exists
+// instead so the model can correct itself.
+func focusWindowNative(pid int) (*windowInfo, error) {
+	wins := windowsForPid(pid)
+	if len(wins) == 0 {
+		return nil, fmt.Errorf("no visible window for PID %d — %s", pid, windowInventoryHint())
+	}
+	w := wins[0]
+
+	const SW_RESTORE = 9
+	if minimized, _, _ := procIsIconic.Call(w.Hwnd); minimized != 0 {
+		procShowWindow.Call(w.Hwnd, SW_RESTORE)
+	}
+	ok, _, _ := procSetForegroundWindow.Call(w.Hwnd)
+	if ok == 0 {
+		return &w, fmt.Errorf("could not bring %q (PID %d) to the foreground — Windows blocks focus stealing while the user is interacting with another app; ask the user to click the window, or retry after their input goes idle", w.Title, pid)
+	}
+	return &w, nil
+}
+
+// windowInventoryHint summarizes the current desktop for not-found errors.
+func windowInventoryHint() string {
+	wins := enumTopWindows()
+	if len(wins) == 0 {
+		return "no visible windows found at all"
+	}
+	max := len(wins)
+	if max > 5 {
+		max = 5
+	}
+	parts := make([]string, 0, max)
+	for _, w := range wins[:max] {
+		parts = append(parts, fmt.Sprintf("%q (pid %d, %s)", w.Title, w.Pid, w.ProcessName))
+	}
+	return "visible windows are: " + strings.Join(parts, ", ")
+}
+
+// waitForWindow polls for a visible window owned by pid, up to timeout.
+// Modern Windows apps often hand the real window to a different process
+// (packaged apps, brokers — e.g. calc.exe spawns Calculator.exe), so after
+// half the timeout it also accepts a window whose process name matches
+// exeBase. Returns the window and how it was matched, or nil.
+func waitForWindow(pid int, exeBase string, timeout time.Duration) (*windowInfo, string) {
+	exeBase = strings.TrimSuffix(strings.ToLower(strings.TrimSpace(exeBase)), ".exe")
+	deadline := time.Now().Add(timeout)
+	half := time.Now().Add(timeout / 2)
+
+	for {
+		if wins := windowsForPid(pid); len(wins) > 0 {
+			return &wins[0], "pid"
+		}
+		if exeBase != "" && time.Now().After(half) {
+			for _, w := range enumTopWindows() {
+				if strings.ToLower(w.ProcessName) == exeBase {
+					return &w, "process_name"
+				}
+			}
+		}
+		if time.Now().After(deadline) {
+			return nil, ""
+		}
+		time.Sleep(150 * time.Millisecond)
+	}
+}
+
+// ── SendInput keyboard injection ─────────────────────────────────────
+
+const (
+	inputKeyboard         = 1
+	keyeventfExtendedKey  = 0x0001
+	keyeventfKeyUp        = 0x0002
+	keyeventfUnicode      = 0x0004
+)
+
+// kbdInput is the Win32 INPUT struct specialized for keyboard events on
+// amd64/arm64: 8-byte header (type + alignment padding), KEYBDINPUT payload,
+// then padding out to the full 40-byte union size (MOUSEINPUT is larger).
+type kbdInput struct {
+	inputType uint32
+	_         uint32
+	vk        uint16
+	scan      uint16
+	flags     uint32
+	time      uint32
+	extraInfo uintptr
+	_         [8]byte
+}
+
+func sendInputs(inputs []kbdInput) error {
+	if len(inputs) == 0 {
+		return nil
+	}
+	n, _, callErr := procSendInput.Call(
+		uintptr(len(inputs)),
+		uintptr(unsafe.Pointer(&inputs[0])),
+		unsafe.Sizeof(inputs[0]),
+	)
+	if int(n) != len(inputs) {
+		return fmt.Errorf("SendInput injected %d of %d events: %v", n, len(inputs), callErr)
+	}
+	return nil
+}
+
+// typeTextNative types arbitrary text into the focused window as Unicode
+// key events. No SendKeys metacharacters, no escaping, full Unicode
+// (surrogate pairs included).
+func typeTextNative(text string) error {
+	units := utf16.Encode([]rune(text))
+	inputs := make([]kbdInput, 0, len(units)*2)
+	for _, u := range units {
+		// '\n' arrives as a Unicode LF which most controls ignore; send a
+		// real Enter keypress instead so multi-line text works.
+		if u == '\n' {
+			inputs = append(inputs,
+				kbdInput{inputType: inputKeyboard, vk: vkReturn},
+				kbdInput{inputType: inputKeyboard, vk: vkReturn, flags: keyeventfKeyUp},
+			)
+			continue
+		}
+		if u == '\r' {
+			continue
+		}
+		inputs = append(inputs,
+			kbdInput{inputType: inputKeyboard, scan: u, flags: keyeventfUnicode},
+			kbdInput{inputType: inputKeyboard, scan: u, flags: keyeventfUnicode | keyeventfKeyUp},
+		)
+	}
+	// Inject in bounded chunks: a single huge SendInput call is atomic and
+	// can starve the receiving app's input queue.
+	const chunk = 256
+	for i := 0; i < len(inputs); i += chunk {
+		end := i + chunk
+		if end > len(inputs) {
+			end = len(inputs)
+		}
+		if err := sendInputs(inputs[i:end]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Virtual-key codes for named keys.
+const (
+	vkBack     = 0x08
+	vkTab      = 0x09
+	vkReturn   = 0x0D
+	vkShift    = 0x10
+	vkMenu     = 0x12 // alt
+	vkEscape   = 0x1B
+	vkPageUp   = 0x21
+	vkPageDown = 0x22
+	vkEnd      = 0x23
+	vkHome     = 0x24
+	vkLeft     = 0x25
+	vkUp       = 0x26
+	vkRight    = 0x27
+	vkDown     = 0x28
+	vkInsert   = 0x2D
+	vkDelete   = 0x2E
+	vkLWin     = 0x5B
+	vkF1       = 0x70
+)
+
+// extendedKeys need KEYEVENTF_EXTENDEDKEY for correct behavior.
+var extendedKeys = map[uint16]bool{
+	vkPageUp: true, vkPageDown: true, vkEnd: true, vkHome: true,
+	vkLeft: true, vkUp: true, vkRight: true, vkDown: true,
+	vkInsert: true, vkDelete: true, vkLWin: true,
+}
+
+var namedKeys = map[string]uint16{
+	"enter": vkReturn, "return": vkReturn,
+	"tab":       vkTab,
+	"escape":    vkEscape,
+	"esc":       vkEscape,
+	"backspace": vkBack, "bs": vkBack,
+	"delete": vkDelete, "del": vkDelete,
+	"insert": vkInsert, "ins": vkInsert,
+	"up": vkUp, "down": vkDown, "left": vkLeft, "right": vkRight,
+	"home": vkHome, "end": vkEnd,
+	"pageup": vkPageUp, "pgup": vkPageUp,
+	"pagedown": vkPageDown, "pgdn": vkPageDown,
+	"space": vkSpace,
+}
+
+var modifierKeys = map[string]uint16{
+	"ctrl": vkControl, "control": vkControl,
+	"alt":   vkMenu,
+	"shift": vkShift,
+	"win": vkLWin, "windows": vkLWin, "meta": vkLWin, "super": vkLWin,
+}
+
+// resolveVk maps a key name to a virtual-key code.
+func resolveVk(key string) (uint16, error) {
+	k := strings.ToLower(strings.TrimSpace(key))
+	if vk, ok := namedKeys[k]; ok {
+		return vk, nil
+	}
+	if len(k) >= 2 && k[0] == 'f' {
+		var n int
+		if _, err := fmt.Sscanf(k, "f%d", &n); err == nil && n >= 1 && n <= 24 {
+			return uint16(vkF1 + n - 1), nil
+		}
+	}
+	if runes := []rune(k); len(runes) == 1 {
+		res, _, _ := procVkKeyScanW.Call(uintptr(uint16(runes[0])))
+		if low := uint16(res & 0xFF); low != 0xFF {
+			return low, nil
+		}
+		return 0, fmt.Errorf("no virtual key for character %q on the current keyboard layout", key)
+	}
+	known := make([]string, 0, len(namedKeys))
+	for name := range namedKeys {
+		known = append(known, name)
+	}
+	return 0, fmt.Errorf("unknown key %q — use a single character, f1-f24, or one of: %s", key, strings.Join(known, ", "))
+}
+
+// pressKeysNative presses a modifier+key combination (e.g. ctrl+s, alt+f4,
+// win+r) via SendInput. This makes the previously-broken `win` modifier a
+// real Windows-key chord.
+func pressKeysNative(keys string) error {
+	parts := strings.Split(keys, ",")
+
+	var mods []uint16
+	var mains []uint16
+	for _, part := range parts {
+		p := strings.ToLower(strings.TrimSpace(part))
+		if p == "" {
+			continue
+		}
+		if vk, ok := modifierKeys[p]; ok {
+			mods = append(mods, vk)
+			continue
+		}
+		vk, err := resolveVk(p)
+		if err != nil {
+			return err
+		}
+		mains = append(mains, vk)
+	}
+	if len(mods) == 0 && len(mains) == 0 {
+		return fmt.Errorf("no keys to press in %q", keys)
+	}
+
+	keyFlags := func(vk uint16) uint32 {
+		if extendedKeys[vk] {
+			return keyeventfExtendedKey
+		}
+		return 0
+	}
+
+	inputs := make([]kbdInput, 0, (len(mods)+len(mains))*2)
+	for _, vk := range mods {
+		inputs = append(inputs, kbdInput{inputType: inputKeyboard, vk: vk, flags: keyFlags(vk)})
+	}
+	for _, vk := range mains {
+		inputs = append(inputs,
+			kbdInput{inputType: inputKeyboard, vk: vk, flags: keyFlags(vk)},
+			kbdInput{inputType: inputKeyboard, vk: vk, flags: keyFlags(vk) | keyeventfKeyUp},
+		)
+	}
+	for i := len(mods) - 1; i >= 0; i-- {
+		vk := mods[i]
+		inputs = append(inputs, kbdInput{inputType: inputKeyboard, vk: vk, flags: keyFlags(vk) | keyeventfKeyUp})
+	}
+	return sendInputs(inputs)
+}

--- a/sidecar/win32_native_windows.go
+++ b/sidecar/win32_native_windows.go
@@ -477,9 +477,12 @@ func resolveVk(key string) (uint16, []uint16, error) {
 	return 0, nil, fmt.Errorf("unknown key %q - use a single character, f1-f24, or one of: %s", key, strings.Join(known, ", "))
 }
 
-// pressKeysNative presses a modifier+key combination (e.g. ctrl+s, alt+f4,
-// win+r) via SendInput. This makes the previously-broken `win` modifier a
-// real Windows-key chord.
+// pressKeysNative presses a key combination via SendInput. The parts are
+// comma-separated, which is the format desktop_press_keys documents and the
+// one the other platforms accept: "ctrl,s", "alt,f4", "win,r".
+//
+// This makes the previously-broken `win` modifier a real Windows-key chord;
+// SendKeys had no Windows key and the old code sent ctrl+esc instead.
 func pressKeysNative(keys string) error {
 	parts := strings.Split(keys, ",")
 

--- a/sidecar/win32_native_windows.go
+++ b/sidecar/win32_native_windows.go
@@ -192,32 +192,69 @@ func windowInventoryHint() string {
 	return "visible windows are: " + strings.Join(parts, ", ")
 }
 
+// visibleWindowHandles snapshots which windows are already on screen.
+// Taken before a launch, it is what lets the process-name fallback below
+// tell a window this launch produced from one that was already there.
+func visibleWindowHandles() map[uintptr]bool {
+	open := map[uintptr]bool{}
+	for _, w := range enumTopWindows() {
+		open[w.Hwnd] = true
+	}
+	return open
+}
+
 // waitForWindow polls for a visible window owned by pid, up to timeout.
 // Modern Windows apps often hand the real window to a different process
-// (packaged apps, brokers — e.g. calc.exe spawns Calculator.exe), so after
+// (packaged apps, brokers, e.g. calc.exe spawns Calculator.exe), so after
 // half the timeout it also accepts a window whose process name matches
 // exeBase. Returns the window and how it was matched, or nil.
-func waitForWindow(pid int, exeBase string, timeout time.Duration) (*windowInfo, string) {
+//
+// preexisting holds the windows that were already open when the launch
+// started, and the name fallback skips them. Without that, launching an app
+// that is already running and then fails to open a second window hands back
+// the window from the first instance, and the caller reports a success it
+// had no part in - against a PID the model will then try to drive.
+func waitForWindow(pid int, exeBase string, timeout time.Duration, preexisting map[uintptr]bool) (*windowInfo, string) {
 	exeBase = processBaseNameOf(exeBase)
 	deadline := time.Now().Add(timeout)
 	half := time.Now().Add(timeout / 2)
 
 	for {
-		if wins := windowsForPid(pid); len(wins) > 0 {
-			return &wins[0], "pid"
-		}
-		if exeBase != "" && time.Now().After(half) {
-			for _, w := range enumTopWindows() {
-				if strings.ToLower(w.ProcessName) == exeBase {
-					return &w, "process_name"
-				}
-			}
+		// One enumeration per poll feeds both matches; asking twice was pure
+		// duplicated work.
+		if w, how := pickLaunchedWindow(enumTopWindows(), pid, exeBase, time.Now().After(half), preexisting); w != nil {
+			return w, how
 		}
 		if time.Now().After(deadline) {
 			return nil, ""
 		}
 		time.Sleep(150 * time.Millisecond)
 	}
+}
+
+// pickLaunchedWindow chooses, from the windows currently on screen, the one
+// a launch produced. Split out from the polling so the matching rules can be
+// tested without a desktop.
+func pickLaunchedWindow(wins []windowInfo, pid int, exeBase string, allowNameMatch bool, preexisting map[uintptr]bool) (*windowInfo, string) {
+	// A window owned by the PID we just started is ours by construction, so
+	// this match needs no pre-existing guard.
+	for i := range wins {
+		if int(wins[i].Pid) == pid {
+			return &wins[i], "pid"
+		}
+	}
+	if !allowNameMatch || exeBase == "" {
+		return nil, ""
+	}
+	for i := range wins {
+		if preexisting[wins[i].Hwnd] {
+			continue
+		}
+		if strings.ToLower(wins[i].ProcessName) == exeBase {
+			return &wins[i], "process_name"
+		}
+	}
+	return nil, ""
 }
 
 // ── SendInput keyboard injection ─────────────────────────────────────

--- a/sidecar/win32_native_windows.go
+++ b/sidecar/win32_native_windows.go
@@ -280,6 +280,16 @@ type kbdInput struct {
 	_         [8]byte
 }
 
+// The layout above is the 64-bit INPUT union. SendInput rejects any cbSize
+// that is not the real size of the struct, so a build whose layout differs
+// would fail on every single call at runtime. These fail to compile instead:
+// both are [0]byte when the size is right, and one or the other blows up
+// when it is not (a 32-bit windows build packs the union to 28 bytes).
+var (
+	_ [unsafe.Sizeof(kbdInput{}) - 40]byte
+	_ [40 - unsafe.Sizeof(kbdInput{})]byte
+)
+
 func sendInputs(inputs []kbdInput) error {
 	if len(inputs) == 0 {
 		return nil
@@ -295,43 +305,68 @@ func sendInputs(inputs []kbdInput) error {
 	return nil
 }
 
-// typeTextNative types arbitrary text into the focused window as Unicode
-// key events. No SendKeys metacharacters, no escaping, full Unicode
-// (surrogate pairs included).
-func typeTextNative(text string) error {
-	units := utf16.Encode([]rune(text))
-	inputs := make([]kbdInput, 0, len(units)*2)
-	for _, u := range units {
-		// '\n' arrives as a Unicode LF which most controls ignore; send a
-		// real Enter keypress instead so multi-line text works.
-		if u == '\n' {
-			inputs = append(inputs,
-				kbdInput{inputType: inputKeyboard, vk: vkReturn},
-				kbdInput{inputType: inputKeyboard, vk: vkReturn, flags: keyeventfKeyUp},
-			)
-			continue
-		}
-		if u == '\r' {
-			continue
-		}
-		inputs = append(inputs,
+// keyEventsForRune renders one source character as SendInput events,
+// appended to dst.
+func keyEventsForRune(dst []kbdInput, r rune) []kbdInput {
+	// '\n' arrives as a Unicode LF which most controls ignore; send a real
+	// Enter keypress instead so multi-line text works.
+	if r == '\n' {
+		return append(dst,
+			kbdInput{inputType: inputKeyboard, vk: vkReturn},
+			kbdInput{inputType: inputKeyboard, vk: vkReturn, flags: keyeventfKeyUp},
+		)
+	}
+	if r == '\r' {
+		return dst
+	}
+	for _, u := range utf16.Encode([]rune{r}) {
+		dst = append(dst,
 			kbdInput{inputType: inputKeyboard, scan: u, flags: keyeventfUnicode},
 			kbdInput{inputType: inputKeyboard, scan: u, flags: keyeventfUnicode | keyeventfKeyUp},
 		)
 	}
-	// Inject in bounded chunks: a single huge SendInput call is atomic and
-	// can starve the receiving app's input queue.
-	const chunk = 256
-	for i := 0; i < len(inputs); i += chunk {
-		end := i + chunk
-		if end > len(inputs) {
-			end = len(inputs)
+	return dst
+}
+
+// typeTextNative types arbitrary text into the focused window as Unicode
+// key events. No SendKeys metacharacters, no escaping, full Unicode
+// (surrogate pairs included).
+//
+// The text goes out in bounded chunks because a single huge SendInput call
+// is atomic and can starve the receiving app's input queue. Chunk boundaries
+// fall between source characters, never inside one: anything outside the BMP
+// is a UTF-16 surrogate pair, and Windows expects both halves to arrive in
+// the same SendInput call. Splitting one across two calls is how an emoji
+// turns into a pair of replacement characters.
+func typeTextNative(text string) error {
+	const chunkTarget = 256
+
+	inputs := make([]kbdInput, 0, chunkTarget+4)
+	flush := func() error {
+		if len(inputs) == 0 {
+			return nil
 		}
-		if err := sendInputs(inputs[i:end]); err != nil {
+		if err := sendInputs(inputs); err != nil {
 			return err
 		}
+		inputs = inputs[:0]
+		return nil
 	}
-	return nil
+
+	var events []kbdInput
+	for _, r := range text {
+		events = keyEventsForRune(events[:0], r)
+		if len(events) == 0 {
+			continue
+		}
+		if len(inputs)+len(events) > chunkTarget {
+			if err := flush(); err != nil {
+				return err
+			}
+		}
+		inputs = append(inputs, events...)
+	}
+	return flush()
 }
 
 // Virtual-key codes for named keys.
@@ -387,30 +422,59 @@ var modifierKeys = map[string]uint16{
 	"win":   vkLWin, "windows": vkLWin, "meta": vkLWin, "super": vkLWin,
 }
 
-// resolveVk maps a key name to a virtual-key code.
-func resolveVk(key string) (uint16, error) {
+// vkScanShiftState decodes the modifier bits VkKeyScanW packs into the high
+// byte of its result.
+func vkScanShiftState(state uint16) []uint16 {
+	var implied []uint16
+	if state&0x01 != 0 {
+		implied = append(implied, vkShift)
+	}
+	if state&0x02 != 0 {
+		implied = append(implied, vkControl)
+	}
+	if state&0x04 != 0 {
+		implied = append(implied, vkMenu)
+	}
+	return implied
+}
+
+// resolveVk maps a key name to a virtual-key code, plus any modifiers the
+// current keyboard layout needs held to produce it.
+//
+// There is no virtual key for "?" on a US layout: it is shift and the "/"
+// key. VkKeyScanW says so in the high byte of its result, and dropping that
+// byte is why asking for "?" used to press "/" - the wrong key, with no
+// error to say so. Layouts differ in which characters need this, so the
+// answer has to come from the layout rather than a table.
+//
+// The character is lowercased first, which is what keeps this from changing
+// what a chord means. press_keys names keys, not text: "ctrl,S" is the same
+// shortcut as "ctrl,s", so an uppercase letter must not quietly acquire the
+// shift its capital form would need. Lowercasing leaves symbols untouched,
+// so "?" still reports the shift it genuinely requires.
+func resolveVk(key string) (uint16, []uint16, error) {
 	k := strings.ToLower(strings.TrimSpace(key))
 	if vk, ok := winNamedKeys[k]; ok {
-		return vk, nil
+		return vk, nil, nil
 	}
 	if len(k) >= 2 && k[0] == 'f' {
 		var n int
 		if _, err := fmt.Sscanf(k, "f%d", &n); err == nil && n >= 1 && n <= 24 {
-			return uint16(vkF1 + n - 1), nil
+			return uint16(vkF1 + n - 1), nil, nil
 		}
 	}
 	if runes := []rune(k); len(runes) == 1 {
 		res, _, _ := procVkKeyScanW.Call(uintptr(uint16(runes[0])))
 		if low := uint16(res & 0xFF); low != 0xFF {
-			return low, nil
+			return low, vkScanShiftState(uint16(res>>8) & 0xFF), nil
 		}
-		return 0, fmt.Errorf("no virtual key for character %q on the current keyboard layout", key)
+		return 0, nil, fmt.Errorf("no virtual key for character %q on the current keyboard layout", key)
 	}
 	known := make([]string, 0, len(winNamedKeys))
 	for name := range winNamedKeys {
 		known = append(known, name)
 	}
-	return 0, fmt.Errorf("unknown key %q — use a single character, f1-f24, or one of: %s", key, strings.Join(known, ", "))
+	return 0, nil, fmt.Errorf("unknown key %q - use a single character, f1-f24, or one of: %s", key, strings.Join(known, ", "))
 }
 
 // pressKeysNative presses a modifier+key combination (e.g. ctrl+s, alt+f4,
@@ -421,18 +485,31 @@ func pressKeysNative(keys string) error {
 
 	var mods []uint16
 	var mains []uint16
-	for _, part := range parts {
-		p := strings.ToLower(strings.TrimSpace(part))
-		if p == "" {
-			continue
-		}
-		if vk, ok := modifierKeys[p]; ok {
+	held := map[uint16]bool{}
+	addMod := func(vk uint16) {
+		if !held[vk] {
+			held[vk] = true
 			mods = append(mods, vk)
+		}
+	}
+
+	for _, part := range parts {
+		raw := strings.TrimSpace(part)
+		if raw == "" {
 			continue
 		}
-		vk, err := resolveVk(p)
+		if vk, ok := modifierKeys[strings.ToLower(raw)]; ok {
+			addMod(vk)
+			continue
+		}
+		vk, implied, err := resolveVk(raw)
 		if err != nil {
 			return err
+		}
+		// A character that needs shift on this layout brings its own
+		// modifier; an explicitly named one must not be pressed twice.
+		for _, m := range implied {
+			addMod(m)
 		}
 		mains = append(mains, vk)
 	}

--- a/sidecar/win32_native_windows.go
+++ b/sidecar/win32_native_windows.go
@@ -388,8 +388,13 @@ const (
 	vkInsert   = 0x2D
 	vkDelete   = 0x2E
 	vkLWin     = 0x5B
-	vkF1       = 0x70
 )
+
+// vkSpace, vkControl and vkF1 are deliberately not repeated here: they are
+// declared by hotkeys_windows.go and mouse_hook_windows.go, which are part of
+// the same package, so a second declaration is a build error rather than a
+// shadow. This file has already collided that way twice (namedKeys, then
+// vkF1), so borrow rather than redeclare.
 
 // extendedKeys need KEYEVENTF_EXTENDEDKEY for correct behavior.
 var extendedKeys = map[uint16]bool{

--- a/sidecar/win32_native_windows.go
+++ b/sidecar/win32_native_windows.go
@@ -198,7 +198,7 @@ func windowInventoryHint() string {
 // half the timeout it also accepts a window whose process name matches
 // exeBase. Returns the window and how it was matched, or nil.
 func waitForWindow(pid int, exeBase string, timeout time.Duration) (*windowInfo, string) {
-	exeBase = strings.TrimSuffix(strings.ToLower(strings.TrimSpace(exeBase)), ".exe")
+	exeBase = processBaseNameOf(exeBase)
 	deadline := time.Now().Add(timeout)
 	half := time.Now().Add(timeout / 2)
 
@@ -223,10 +223,10 @@ func waitForWindow(pid int, exeBase string, timeout time.Duration) (*windowInfo,
 // ── SendInput keyboard injection ─────────────────────────────────────
 
 const (
-	inputKeyboard         = 1
-	keyeventfExtendedKey  = 0x0001
-	keyeventfKeyUp        = 0x0002
-	keyeventfUnicode      = 0x0004
+	inputKeyboard        = 1
+	keyeventfExtendedKey = 0x0001
+	keyeventfKeyUp       = 0x0002
+	keyeventfUnicode     = 0x0004
 )
 
 // kbdInput is the Win32 INPUT struct specialized for keyboard events on
@@ -347,7 +347,7 @@ var modifierKeys = map[string]uint16{
 	"ctrl": vkControl, "control": vkControl,
 	"alt":   vkMenu,
 	"shift": vkShift,
-	"win": vkLWin, "windows": vkLWin, "meta": vkLWin, "super": vkLWin,
+	"win":   vkLWin, "windows": vkLWin, "meta": vkLWin, "super": vkLWin,
 }
 
 // resolveVk maps a key name to a virtual-key code.

--- a/sidecar/win32_native_windows_test.go
+++ b/sidecar/win32_native_windows_test.go
@@ -1,0 +1,45 @@
+//go:build windows
+
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// UIA answers S_OK with a null pattern when a control simply does not
+// implement one, and uiaElementGetPattern funnels that through hresultText
+// with hr = 0. Rendering it as a raw zero HRESULT plus "retry once" sent the
+// model back around a loop that could never succeed.
+func TestHresultTextExplainsAnUnsupportedPattern(t *testing.T) {
+	got := hresultText(0)
+	if strings.Contains(got, "0x00000000") {
+		t.Errorf("a null pattern is not an error code to show the model: %s", got)
+	}
+	if strings.Contains(strings.ToLower(got), "retry") {
+		t.Errorf("an unsupported pattern will never start working, so do not ask for a retry: %s", got)
+	}
+	if !strings.Contains(got, "does not expose this pattern") {
+		t.Errorf("should name the actual problem: %s", got)
+	}
+}
+
+// The mapped failures each need to survive as actionable text rather than a
+// bare code, and the fallback must still say what to do with an unknown one.
+func TestHresultTextMapsKnownUiaFailures(t *testing.T) {
+	cases := map[uintptr]string{
+		0x80040201: "no longer exists",
+		0x80040200: "disabled",
+		0x80040202: "scroll_into_view",
+		0x80070005: "elevated",
+		0x80004005: "rejected the action",
+	}
+	for hr, want := range cases {
+		if got := hresultText(hr); !strings.Contains(got, want) {
+			t.Errorf("hresultText(0x%08x) = %q, want it to mention %q", uint32(hr), got, want)
+		}
+	}
+	if got := hresultText(0x8000FFFF); !strings.Contains(got, "0x8000ffff") {
+		t.Errorf("an unmapped HRESULT should still be reported verbatim: %s", got)
+	}
+}

--- a/sidecar/win32_native_windows_test.go
+++ b/sidecar/win32_native_windows_test.go
@@ -94,3 +94,81 @@ func TestPickLaunchedWindowIgnoresWindowsThatWereAlreadyOpen(t *testing.T) {
 		}
 	})
 }
+
+// VkKeyScanW answers with the virtual key in the low byte and the modifiers
+// that key needs in the high byte. Dropping the high byte is how asking for
+// "?" ends up typing "/" - the wrong character, and silently.
+func TestVkScanShiftStateDecodesTheModifierBits(t *testing.T) {
+	tests := []struct {
+		name  string
+		state uint16
+		want  []uint16
+	}{
+		{"unmodified", 0x00, nil},
+		{"shift", 0x01, []uint16{vkShift}},
+		{"ctrl", 0x02, []uint16{vkControl}},
+		{"alt", 0x04, []uint16{vkMenu}},
+		{"altgr is ctrl and alt together", 0x06, []uint16{vkControl, vkMenu}},
+		{"all three", 0x07, []uint16{vkShift, vkControl, vkMenu}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := vkScanShiftState(tc.state)
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Fatalf("got %v, want %v", got, tc.want)
+				}
+			}
+		})
+	}
+}
+
+// Windows wants both halves of a surrogate pair in one SendInput call, so a
+// chunk boundary must never fall inside a character. keyEventsForRune is
+// what makes that possible: it renders a whole character at a time.
+func TestKeyEventsForRuneKeepsACharacterWhole(t *testing.T) {
+	t.Run("a BMP character is one down/up pair", func(t *testing.T) {
+		got := keyEventsForRune(nil, 'a')
+		if len(got) != 2 {
+			t.Fatalf("got %d events, want 2", len(got))
+		}
+		if got[0].flags&keyeventfUnicode == 0 {
+			t.Error("text should be injected as Unicode, not as a virtual key")
+		}
+		if got[0].flags&keyeventfKeyUp != 0 || got[1].flags&keyeventfKeyUp == 0 {
+			t.Error("expected a keydown followed by a keyup")
+		}
+	})
+
+	t.Run("an astral character stays a single indivisible group", func(t *testing.T) {
+		got := keyEventsForRune(nil, '\U0001F600')
+		if len(got) != 4 {
+			t.Fatalf("got %d events, want 4 (two UTF-16 units, down and up each)", len(got))
+		}
+		if got[0].scan < 0xD800 || got[0].scan > 0xDBFF {
+			t.Errorf("first unit %#04x is not a high surrogate", got[0].scan)
+		}
+		if got[2].scan < 0xDC00 || got[2].scan > 0xDFFF {
+			t.Errorf("third unit %#04x is not a low surrogate", got[2].scan)
+		}
+	})
+
+	t.Run("a newline becomes a real Enter, not a literal LF", func(t *testing.T) {
+		got := keyEventsForRune(nil, '\n')
+		if len(got) != 2 || got[0].vk != vkReturn {
+			t.Fatalf("got %+v, want an Enter keypress", got)
+		}
+		if got[0].flags&keyeventfUnicode != 0 {
+			t.Error("Enter must be a virtual key; most controls ignore a Unicode LF")
+		}
+	})
+
+	t.Run("a carriage return is dropped", func(t *testing.T) {
+		if got := keyEventsForRune(nil, '\r'); len(got) != 0 {
+			t.Fatalf("got %d events, want none", len(got))
+		}
+	})
+}

--- a/sidecar/win32_native_windows_test.go
+++ b/sidecar/win32_native_windows_test.go
@@ -43,3 +43,54 @@ func TestHresultTextMapsKnownUiaFailures(t *testing.T) {
 		t.Errorf("an unmapped HRESULT should still be reported verbatim: %s", got)
 	}
 }
+
+// The process-name fallback exists because packaged apps hand their window
+// to a broker, but it is also the one match that can pick up a window this
+// launch had nothing to do with. Reporting a window from an instance the
+// user already had open is a false success, and worse, it hands back a PID
+// the model will then try to drive.
+func TestPickLaunchedWindowIgnoresWindowsThatWereAlreadyOpen(t *testing.T) {
+	existing := windowInfo{Hwnd: 0x100, Title: "Calculator", Pid: 900, ProcessName: "Calculator"}
+	fresh := windowInfo{Hwnd: 0x200, Title: "Calculator", Pid: 901, ProcessName: "Calculator"}
+	ownWindow := windowInfo{Hwnd: 0x300, Title: "Notepad", Pid: 42, ProcessName: "notepad"}
+	preexisting := map[uintptr]bool{existing.Hwnd: true}
+
+	t.Run("a window owned by the launched pid wins outright", func(t *testing.T) {
+		got, how := pickLaunchedWindow([]windowInfo{existing, ownWindow}, 42, "notepad", true, preexisting)
+		if got == nil || got.Hwnd != ownWindow.Hwnd {
+			t.Fatalf("got %+v, want the pid-owned window", got)
+		}
+		if how != "pid" {
+			t.Errorf("matched by %q, want \"pid\"", how)
+		}
+	})
+
+	t.Run("an already-open window is never claimed as the launch result", func(t *testing.T) {
+		got, how := pickLaunchedWindow([]windowInfo{existing}, 42, "calc", true, preexisting)
+		if got != nil {
+			t.Fatalf("claimed a pre-existing window %+v (matched by %q)", got, how)
+		}
+	})
+
+	t.Run("a new window from the broker process is claimed", func(t *testing.T) {
+		got, how := pickLaunchedWindow([]windowInfo{existing, fresh}, 42, "calculator", true, preexisting)
+		if got == nil || got.Hwnd != fresh.Hwnd {
+			t.Fatalf("got %+v, want the newly opened window", got)
+		}
+		if how != "process_name" {
+			t.Errorf("matched by %q, want \"process_name\"", how)
+		}
+	})
+
+	t.Run("the name fallback stays shut until it is allowed", func(t *testing.T) {
+		if got, _ := pickLaunchedWindow([]windowInfo{fresh}, 42, "calculator", false, preexisting); got != nil {
+			t.Fatalf("name matching ran before its turn: %+v", got)
+		}
+	})
+
+	t.Run("no executable name means no name matching", func(t *testing.T) {
+		if got, _ := pickLaunchedWindow([]windowInfo{fresh}, 42, "", true, preexisting); got != nil {
+			t.Fatalf("matched %+v with nothing to match against", got)
+		}
+	})
+}

--- a/src/actions/tools/builtin.ts
+++ b/src/actions/tools/builtin.ts
@@ -551,6 +551,24 @@ function formatSnapshot(snap: PageSnapshot): string {
 
 // --- Browser Tool Implementations ---
 
+/**
+ * Resolve which browser stack serves this call and log the decision.
+ * Two divergent implementations exist (Go sidecar over CDP pipe vs local
+ * TS over CDP websocket) and selection was previously silent, which made
+ * "sometimes works, sometimes doesn't" undiagnosable. One line per call
+ * names the stack so failures can be attributed.
+ */
+function resolveBrowserTarget(params: Record<string, unknown>, tool: string): string | null {
+  const explicit = (params.target as string | undefined)?.trim() || null;
+  const target = explicit || autoTargetForCapability('browser');
+  if (target) {
+    console.log(`[browser] ${tool} → sidecar stack (target=${target}${explicit ? ', explicit' : ', auto'})`);
+  } else {
+    console.log(`[browser] ${tool} → local TS stack`);
+  }
+  return target;
+}
+
 export const browserNavigateTool: ToolDefinition = {
   name: 'browser_navigate',
   description: 'Navigate the browser to a URL. Returns page text content and a list of interactive elements with [id] numbers you can reference in browser_click and browser_type. Optionally specify a "target" sidecar to use a remote browser. By default the browser opens visibly so the user can watch and interact; set "headless" to true to run it hidden in the background (useful for research, or when the user is focused on something else and a popping browser window would be intrusive).',
@@ -573,7 +591,7 @@ export const browserNavigateTool: ToolDefinition = {
     },
   },
   execute: async (params) => {
-    const target = (params.target as string | undefined) || autoTargetForCapability("browser");
+    const target = resolveBrowserTarget(params, 'browser_navigate');
     if (target) {
       const result = await routeToSidecar(target, 'browser_navigate', { url: params.url, headless: params.headless }, 'browser');
       return globalWebappTemplateDelivery.withInstructions(result, params.url as string);
@@ -601,7 +619,7 @@ export const browserSnapshotTool: ToolDefinition = {
     },
   },
   execute: async (params) => {
-    const target = (params.target as string | undefined) || autoTargetForCapability("browser");
+    const target = resolveBrowserTarget(params, 'browser_snapshot');
     if (target) {
       const result = await routeToSidecar(target, 'browser_snapshot', {}, 'browser');
       return globalWebappTemplateDelivery.withInstructions(result);
@@ -682,7 +700,7 @@ export const browserHoverTool: ToolDefinition = {
     },
   },
   execute: async (params) => {
-    const target = (params.target as string | undefined) || autoTargetForCapability("browser");
+    const target = resolveBrowserTarget(params, 'browser_hover');
     if (target) {
       return routeToSidecar(target, 'browser_hover', { element_id: params.element_id }, 'browser');
     }
@@ -759,7 +777,7 @@ export const browserTypeTool: ToolDefinition = {
     },
   },
   execute: async (params) => {
-    const target = (params.target as string | undefined) || autoTargetForCapability("browser");
+    const target = resolveBrowserTarget(params, 'browser_type');
     if (target) {
       return routeToSidecar(target, 'browser_type', {
         element_id: params.element_id,
@@ -795,7 +813,7 @@ export const browserScreenshotTool: ToolDefinition = {
     },
   },
   execute: async (params) => {
-    const target = (params.target as string | undefined) || autoTargetForCapability("browser");
+    const target = resolveBrowserTarget(params, 'browser_screenshot');
     if (target) {
       return routeToSidecar(target, 'browser_screenshot', {}, 'browser');
     }
@@ -871,7 +889,7 @@ export const browserScrollTool: ToolDefinition = {
     },
   },
   execute: async (params) => {
-    const target = (params.target as string | undefined) || autoTargetForCapability("browser");
+    const target = resolveBrowserTarget(params, 'browser_scroll');
     if (target) {
       return routeToSidecar(target, 'browser_scroll', {
         direction: params.direction,
@@ -907,7 +925,7 @@ export const browserEvaluateTool: ToolDefinition = {
     },
   },
   execute: async (params) => {
-    const target = (params.target as string | undefined) || autoTargetForCapability("browser");
+    const target = resolveBrowserTarget(params, 'browser_evaluate');
     if (target) {
       return routeToSidecar(target, 'browser_evaluate', { expression: params.expression }, 'browser');
     }

--- a/src/actions/tools/builtin.ts
+++ b/src/actions/tools/builtin.ts
@@ -15,7 +15,7 @@ import { WSLBridge } from '../terminal/wsl-bridge.ts';
 import { BrowserController, type PageSnapshot } from '../browser/session.ts';
 import type { ToolDefinition, ToolResult } from './registry.ts';
 import type { LLMTool } from '../../llm/provider.ts';
-import { routeToSidecar, autoTargetForCapability } from './sidecar-route.ts';
+import { routeToSidecar, autoTargetForCapability, resolveToolTarget } from './sidecar-route.ts';
 import { WebappTemplateDelivery, globalWebappTemplateDelivery } from './webapp-template-injection.ts';
 import { listSidecarsTool } from './sidecar-list.ts';
 import { DESKTOP_TOOLS } from './desktop.ts';
@@ -552,21 +552,11 @@ function formatSnapshot(snap: PageSnapshot): string {
 // --- Browser Tool Implementations ---
 
 /**
- * Resolve which browser stack serves this call and log the decision.
- * Two divergent implementations exist (Go sidecar over CDP pipe vs local
- * TS over CDP websocket) and selection was previously silent, which made
- * "sometimes works, sometimes doesn't" undiagnosable. One line per call
- * names the stack so failures can be attributed.
+ * Resolve which browser stack serves this call and log the decision. Thin
+ * wrapper over the shared resolver so each call site names only its tool.
  */
 function resolveBrowserTarget(params: Record<string, unknown>, tool: string): string | null {
-  const explicit = (params.target as string | undefined)?.trim() || null;
-  const target = explicit || autoTargetForCapability('browser');
-  if (target) {
-    console.log(`[browser] ${tool} → sidecar stack (target=${target}${explicit ? ', explicit' : ', auto'})`);
-  } else {
-    console.log(`[browser] ${tool} → local TS stack`);
-  }
-  return target;
+  return resolveToolTarget(params.target, 'browser', tool);
 }
 
 export const browserNavigateTool: ToolDefinition = {

--- a/src/actions/tools/builtin.ts
+++ b/src/actions/tools/builtin.ts
@@ -662,7 +662,7 @@ export const browserClickTool: ToolDefinition = {
     },
   },
   execute: async (params) => {
-    const target = (params.target as string | undefined) || autoTargetForCapability("browser");
+    const target = resolveBrowserTarget(params, 'browser_click');
     if (target) {
       return routeToSidecar(target, 'browser_click', {
         element_id: params.element_id,
@@ -731,7 +731,7 @@ export const browserPressKeyTool: ToolDefinition = {
     },
   },
   execute: async (params) => {
-    const target = (params.target as string | undefined) || autoTargetForCapability("browser");
+    const target = resolveBrowserTarget(params, 'browser_press_key');
     if (target) {
       return routeToSidecar(target, 'browser_press_key', { key: params.key }, 'browser');
     }

--- a/src/actions/tools/desktop.ts
+++ b/src/actions/tools/desktop.ts
@@ -12,7 +12,7 @@
 import type { AppController, UIElement, WindowInfo } from '../app-control/interface.ts';
 import { getAppController } from '../app-control/interface.ts';
 import type { ToolDefinition, ToolResult } from './registry.ts';
-import { routeToSidecar, autoTargetForCapability } from './sidecar-route.ts';
+import { routeToSidecar, resolveToolTarget } from './sidecar-route.ts';
 import type { SidecarCapability } from '../../sidecar/types.ts';
 
 /**
@@ -27,13 +27,13 @@ import type { SidecarCapability } from '../../sidecar/types.ts';
 function resolveDesktopTarget(
   explicit?: unknown,
   capability: SidecarCapability = 'desktop',
+  tool = 'desktop',
 ): string | null {
-  if (typeof explicit === 'string' && explicit.trim()) return explicit;
   // Auto-target by the capability the RPC actually requires. Most desktop_*
-  // RPCs need 'desktop', but capture_screen needs 'screenshot' — resolving
+  // RPCs need 'desktop', but capture_screen needs 'screenshot' - resolving
   // against 'desktop' there could pick a sidecar that lacks 'screenshot' and
   // then hard-fail in routeToSidecar with a "do NOT retry" error.
-  return autoTargetForCapability(capability);
+  return resolveToolTarget(explicit, capability, tool);
 }
 import { isNoLocalTools, LOCAL_DISABLED_MSG } from './local-tools-guard.ts';
 
@@ -310,7 +310,7 @@ export const desktopListWindowsTool: ToolDefinition = {
     },
   },
   execute: async (params) => {
-    const target = resolveDesktopTarget(params.target);
+    const target = resolveDesktopTarget(params.target, 'desktop', 'desktop_list_windows');
     if (target) {
       return routeToSidecar(target, 'list_windows', params, 'desktop');
     }
@@ -340,7 +340,7 @@ export const desktopSnapshotTool: ToolDefinition = {
     },
   },
   execute: async (params) => {
-    const target = resolveDesktopTarget(params.target);
+    const target = resolveDesktopTarget(params.target, 'desktop', 'desktop_snapshot');
     if (target) {
       return routeToSidecar(target, 'get_window_tree', params, 'desktop');
     }
@@ -378,7 +378,7 @@ export const desktopClickTool: ToolDefinition = {
     },
   },
   execute: async (params) => {
-    const target = resolveDesktopTarget(params.target);
+    const target = resolveDesktopTarget(params.target, 'desktop', 'desktop_click');
     if (target) {
       return routeToSidecar(target, 'click_element', params, 'desktop');
     }
@@ -422,7 +422,7 @@ export const desktopTypeTool: ToolDefinition = {
     },
   },
   execute: async (params) => {
-    const target = resolveDesktopTarget(params.target);
+    const target = resolveDesktopTarget(params.target, 'desktop', 'desktop_type');
     if (target) {
       return routeToSidecar(target, 'type_text', params, 'desktop');
     }
@@ -460,7 +460,7 @@ export const desktopPressKeysTool: ToolDefinition = {
     },
   },
   execute: async (params) => {
-    const target = resolveDesktopTarget(params.target);
+    const target = resolveDesktopTarget(params.target, 'desktop', 'desktop_press_keys');
     if (target) {
       return routeToSidecar(target, 'press_keys', params, 'desktop');
     }
@@ -494,7 +494,7 @@ export const desktopLaunchAppTool: ToolDefinition = {
     },
   },
   execute: async (params) => {
-    const target = resolveDesktopTarget(params.target);
+    const target = resolveDesktopTarget(params.target, 'desktop', 'desktop_launch_app');
     if (target) {
       return routeToSidecar(target, 'launch_app', params, 'desktop');
     }
@@ -525,7 +525,7 @@ export const desktopScreenshotTool: ToolDefinition = {
     },
   },
   execute: async (params) => {
-    const target = resolveDesktopTarget(params.target, 'screenshot');
+    const target = resolveDesktopTarget(params.target, 'screenshot', 'desktop_screenshot');
     if (target) {
       return routeToSidecar(target, 'capture_screen', params, 'screenshot');
     }
@@ -571,7 +571,7 @@ export const desktopFocusWindowTool: ToolDefinition = {
     },
   },
   execute: async (params) => {
-    const target = resolveDesktopTarget(params.target);
+    const target = resolveDesktopTarget(params.target, 'desktop', 'desktop_focus_window');
     if (target) {
       return routeToSidecar(target, 'focus_window', params, 'desktop');
     }
@@ -619,7 +619,7 @@ export const desktopFindElementTool: ToolDefinition = {
     },
   },
   execute: async (params) => {
-    const target = resolveDesktopTarget(params.target);
+    const target = resolveDesktopTarget(params.target, 'desktop', 'desktop_find_element');
     if (target) {
       return routeToSidecar(target, 'find_element', params, 'desktop');
     }

--- a/src/actions/tools/desktop.ts
+++ b/src/actions/tools/desktop.ts
@@ -474,7 +474,7 @@ export const desktopPressKeysTool: ToolDefinition = {
 
 export const desktopLaunchAppTool: ToolDefinition = {
   name: 'desktop_launch_app',
-  description: 'Launch an application by name or executable path. Use the name as it exists on the TARGET machine\'s OS -- e.g. "notepad" on Windows, "TextEdit" on macOS, "gedit" on Linux. Call list_sidecars first if you are unsure which OS the target runs. Returns the PID of the launched process.',
+  description: 'Launch an application by name or executable path. Use the name as it exists on the TARGET machine\'s OS -- e.g. "notepad" on Windows, "TextEdit" on macOS, "gedit" on Linux. Call list_sidecars first if you are unsure which OS the target runs. Returns the PID plus what is known about the app\'s window. When routed to a sidecar, "success" answers "is the app on screen?", not "did a process start?": success true with window_visible true means a window was seen and you can interact with it; success false with window_visible false means the process started but no window appeared (still loading, windowless, or it exited) - read the "note" and check desktop_list_windows rather than launching again; window_visible null means the window could NOT be checked on this machine, which is not a failure - the app may well be open, so verify with desktop_list_windows instead of relaunching.',
   category: 'desktop',
   parameters: {
     target: {

--- a/src/actions/tools/sidecar-route.test.ts
+++ b/src/actions/tools/sidecar-route.test.ts
@@ -102,3 +102,58 @@ describe("routeToSidecar error messages", () => {
     expect(await routeToSidecar("sc-mac", "run_command", {}, "terminal")).toBe("total 8\\ndrwx");
   });
 });
+
+/**
+ * A timed-out ("detached") RPC must never be reported as background success
+ * for an interactive tool: detached results are only console-logged by
+ * manager.ts's onDetachedComplete and never reach the model, so the old
+ * "running in the background" was a plain false success.
+ */
+describe("routeToSidecar detached handling", () => {
+  const pc: SidecarInfo = {
+    ...mac,
+    id: "sc-pc",
+    name: "Desk PC",
+    os: "windows",
+    platform: "amd64",
+    capabilities: ["terminal", "desktop", "browser"],
+  };
+  const detached = () => stubManager([pc], async () => "detached");
+
+  test("reports an honest timeout for a desktop tool instead of background success", async () => {
+    setSidecarManagerRef(detached());
+    const out = await routeToSidecar("sc-pc", "launch_app", { executable: "notepad.exe" }, "desktop");
+    expect(out).toContain("Error");
+    expect(out).toContain("do NOT assume it succeeded");
+    expect(out).not.toContain("running in the background");
+  });
+
+  test("names the machine and its OS in the timeout, as every other error does", async () => {
+    setSidecarManagerRef(detached());
+    const out = await routeToSidecar("sc-pc", "launch_app", {}, "desktop");
+    expect(out).toContain("Desk PC, Windows");
+  });
+
+  test("reports an honest timeout for a browser tool", async () => {
+    setSidecarManagerRef(detached());
+    const out = await routeToSidecar("sc-pc", "browser_navigate", { url: "https://x.test" }, "browser");
+    expect(out).toContain("Error");
+    expect(out).not.toContain("running in the background");
+  });
+
+  test("keeps fire-and-forget for run_command, with an explicit no-output caveat", async () => {
+    // The one method whose result genuinely does not have to come back, so
+    // it keeps the old behaviour - but says out loud that no output follows.
+    setSidecarManagerRef(detached());
+    const out = await routeToSidecar("sc-pc", "run_command", { command: "sleep 60" }, "terminal");
+    expect(out).toContain("still running in the background");
+    expect(out).toContain("will NOT be reported back");
+    expect(out).not.toContain("Error");
+  });
+
+  test("passes a real object result through as JSON", async () => {
+    setSidecarManagerRef(stubManager([pc], async () => ({ success: true, pid: 42 })));
+    const out = await routeToSidecar("sc-pc", "launch_app", {}, "desktop");
+    expect(JSON.parse(out)).toEqual({ success: true, pid: 42 });
+  });
+});

--- a/src/actions/tools/sidecar-route.test.ts
+++ b/src/actions/tools/sidecar-route.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import type { SidecarManager } from "../../sidecar/manager.ts";
 import type { SidecarInfo } from "../../sidecar/types.ts";
 import { setNoLocalTools } from "./local-tools-guard.ts";
-import { collectExecutionTargets, routeToSidecar, setSidecarManagerRef } from "./sidecar-route.ts";
+import { collectExecutionTargets, resolveToolTarget, routeToSidecar, setSidecarManagerRef } from "./sidecar-route.ts";
 
 const mac: SidecarInfo = {
   id: "sc-mac",
@@ -155,5 +155,59 @@ describe("routeToSidecar detached handling", () => {
     setSidecarManagerRef(stubManager([pc], async () => ({ success: true, pid: 42 })));
     const out = await routeToSidecar("sc-pc", "launch_app", {}, "desktop");
     expect(JSON.parse(out)).toEqual({ success: true, pid: 42 });
+  });
+});
+
+/**
+ * Every desktop_* and browser_* tool is backed by two implementations - the
+ * Go sidecar and the daemon's local controllers - and which one answers used
+ * to be decided in silence.
+ */
+describe("resolveToolTarget", () => {
+  const pc: SidecarInfo = {
+    ...mac,
+    id: "sc-pc",
+    name: "Desk PC",
+    os: "windows",
+    platform: "amd64",
+    capabilities: ["terminal", "desktop", "browser"],
+  };
+
+  test("passes an explicit target through verbatim", () => {
+    setSidecarManagerRef(stubManager([pc]));
+    expect(resolveToolTarget("  Desk PC  ", "desktop", "desktop_click")).toBe("  Desk PC  ");
+  });
+
+  test("treats a blank target as no target and auto-selects", () => {
+    setSidecarManagerRef(stubManager([pc]));
+    expect(resolveToolTarget("   ", "desktop", "desktop_click")).toBe("sc-pc");
+    expect(resolveToolTarget(undefined, "desktop", "desktop_click")).toBe("sc-pc");
+  });
+
+  test("resolves against the capability the RPC needs, not a default", () => {
+    // pc advertises desktop/browser/terminal but not screenshot. Resolving a
+    // screenshot call against 'desktop' would pick it and then hard-fail in
+    // routeToSidecar with a "do NOT retry" error, so it must fall through to
+    // the local stack instead.
+    setSidecarManagerRef(stubManager([pc]));
+    expect(resolveToolTarget(undefined, "screenshot", "desktop_screenshot")).toBeNull();
+  });
+
+  test("names the stack that served the call", () => {
+    setSidecarManagerRef(stubManager([pc]));
+    const lines: string[] = [];
+    const original = console.log;
+    console.log = (...args: unknown[]) => {
+      lines.push(args.join(" "));
+    };
+    try {
+      resolveToolTarget(undefined, "browser", "browser_click");
+      resolveToolTarget(undefined, "screenshot", "desktop_screenshot");
+    } finally {
+      console.log = original;
+    }
+    expect(lines[0]).toContain("browser_click -> sidecar stack");
+    expect(lines[0]).toContain("auto");
+    expect(lines[1]).toContain("desktop_screenshot -> local stack");
   });
 });

--- a/src/actions/tools/sidecar-route.ts
+++ b/src/actions/tools/sidecar-route.ts
@@ -155,7 +155,15 @@ export async function routeToSidecar(
     const result = await sidecarManager.dispatchRPC(sidecar.id, method, params);
 
     if (result === 'detached') {
-      return `Task dispatched to "${sidecar.name}" and running in the background.`;
+      // The RPC outlived the initial timeout. Detached completions are only
+      // console-logged (manager.ts onDetachedComplete) — the result never
+      // reaches the model — so claiming background success would be a lie
+      // for anything interactive. Only run_command keeps fire-and-forget
+      // semantics; everything else reports an honest timeout.
+      if (method === 'run_command') {
+        return `Command dispatched to "${sidecar.name}" and still running in the background. Its output will NOT be reported back — verify its effect yourself if it matters.`;
+      }
+      return `Error [${sidecar.name}]: "${method}" did not complete within the timeout. The action may or may not have taken effect — do NOT assume it succeeded; verify the current state (e.g. take a snapshot) before continuing.`;
     }
 
     return typeof result === 'string' ? result : JSON.stringify(result, null, 2);

--- a/src/actions/tools/sidecar-route.ts
+++ b/src/actions/tools/sidecar-route.ts
@@ -190,9 +190,9 @@ export async function routeToSidecar(
       // for anything interactive. Only run_command keeps fire-and-forget
       // semantics; everything else reports an honest timeout.
       if (method === 'run_command') {
-        return `Command dispatched to "${sidecar.name}" and still running in the background. Its output will NOT be reported back — verify its effect yourself if it matters.`;
+        return `Command dispatched to "${describeMachine(sidecar)}" and still running in the background. Its output will NOT be reported back — verify its effect yourself if it matters.`;
       }
-      return `Error [${sidecar.name}]: "${method}" did not complete within the timeout. The action may or may not have taken effect — do NOT assume it succeeded; verify the current state (e.g. take a snapshot) before continuing.`;
+      return `Error [${describeMachine(sidecar)}]: "${method}" did not complete within the timeout. The action may or may not have taken effect — do NOT assume it succeeded; verify the current state (e.g. take a snapshot) before continuing.`;
     }
 
     return typeof result === 'string' ? result : JSON.stringify(result, null, 2);

--- a/src/actions/tools/sidecar-route.ts
+++ b/src/actions/tools/sidecar-route.ts
@@ -90,6 +90,34 @@ function describeMachine(sidecar: SidecarInfo): string {
 }
 
 /**
+ * Pick the stack that will serve one tool call, and say which it was.
+ *
+ * Two implementations back every desktop_* and browser_* tool: the Go
+ * sidecar, and the daemon's own local controllers. Which one runs depends on
+ * whether a sidecar is connected, and the choice used to be made in silence,
+ * so "it works sometimes" was untraceable after the fact. One line per call
+ * names the stack that answered.
+ *
+ * An explicit target is returned verbatim rather than trimmed, because it is
+ * matched by name downstream and quietly rewriting it would hide a typo
+ * rather than surface it. Blank is treated as absent.
+ */
+export function resolveToolTarget(
+  explicit: unknown,
+  capability: SidecarCapability,
+  tool: string,
+): string | null {
+  const named = typeof explicit === 'string' && explicit.trim() ? explicit : null;
+  const target = named ?? autoTargetForCapability(capability);
+  console.log(
+    target
+      ? `[${capability}] ${tool} -> sidecar stack (target=${target}, ${named ? 'explicit' : 'auto'})`
+      : `[${capability}] ${tool} -> local stack`,
+  );
+  return target;
+}
+
+/**
  * Find a sidecar by name or ID.
  * Priority: exact ID → exact name (case-insensitive) → contains match.
  */

--- a/src/actions/tools/sidecar-route.ts
+++ b/src/actions/tools/sidecar-route.ts
@@ -98,9 +98,10 @@ function describeMachine(sidecar: SidecarInfo): string {
  * so "it works sometimes" was untraceable after the fact. One line per call
  * names the stack that answered.
  *
- * An explicit target is returned verbatim rather than trimmed, because it is
- * matched by name downstream and quietly rewriting it would hide a typo
- * rather than surface it. Blank is treated as absent.
+ * An explicit target is passed through verbatim; findSidecar trims before
+ * matching, so there is nothing to gain by doing it twice, and the log line
+ * then shows exactly what the caller asked for. A blank string counts as no
+ * target at all and falls through to auto-selection.
  */
 export function resolveToolTarget(
   explicit: unknown,


### PR DESCRIPTION
Desktop and browser control currently reports things it has not checked. This makes each answer match what was actually observed.

## What was lying

- A timed-out sidecar RPC came back as "running in the background". Detached results are only console-logged (`manager.ts` `onDetachedComplete`), so for anything interactive that was a plain false success. Interactive tools now get an honest timeout; `run_command` keeps fire-and-forget with an explicit no-output caveat.
- `launch_app` returned success the instant a process spawned. A spawned process is not an open app, so the next call raced the window and failed with "no window found". It now waits for the window, and reports three distinct outcomes: a window was seen, no window appeared, or the check could not run at all. The third is not a failure and does not say it is - on a Wayland box, a machine without xdotool, or a Mac that has not been granted automation, marking every working launch as failed would just make the model launch the app twice.
- `browser_navigate` ignored `Page.navigate`'s `errorText`, so DNS failures and blocked URLs were reported as successful navigations.
- UIA errors reached the model as raw HRESULTs, including `0x00000000` for the commonest case of all (a control that simply does not implement the pattern), along with advice to retry something that can never work. `find_element` with no matches returned an empty array and nothing to correct with.

## What got faster

The Windows window/input layer no longer shells out. `list_windows` and `focus_window` recompiled embedded C# in a fresh `powershell.exe` on every call (~0.7-1.5s each); they are now direct syscalls. `type_text` and `press_keys` use SendInput instead of SendKeys, which drops the per-call spawn, the metacharacter escaping, and the lossiness on long text - and makes the `win` modifier a real Windows-key chord rather than the `ctrl+esc` approximation.

## Notes for review

- Windows and macOS behaviour is covered by cross-compilation, `go vet`, and unit tests; it has not been exercised on real hardware from this environment.
- The windows-only unit tests run in `sidecar-test-windows`, which is the only job that can execute them.
