### PR TITLE
fix(agents): don't accept a task tier's announcement as its finished result

### DIFF
--- a/src/agents/conv/task-dispatcher.ts
+++ b/src/agents/conv/task-dispatcher.ts
@@ -22,7 +22,9 @@ import type { TaskRegistry } from './task-registry.ts';
 // the summarizer stripping identifiers.
 const SUMMARY_THRESHOLD_CHARS = 3000;
 
-const TOOL_USE_INSTRUCTION = `IMPORTANT: You have access to real tools listed in your context. USE THEM to do the work - do not just describe what someone could do. If the user asked to create a workflow, use the workflow tools. If they asked to browse the web, use the browser. If they asked to read a file, use file-ops. Generic textual answers about "you could write a Python script" or "here is the general approach" are wrong when the right tool exists in your registry.`;
+const TOOL_USE_INSTRUCTION = `IMPORTANT: You have access to real tools listed in your context. USE THEM to do the work - do not just describe what someone could do. If the user asked to create a workflow, use the workflow tools. If they asked to browse the web, use the browser. If they asked to read a file, use file-ops. Generic textual answers about "you could write a Python script" or "here is the general approach" are wrong when the right tool exists in your registry.
+
+NEVER answer by announcing what you are about to do ("On it - I'll open Notepad, then verify it's in the foreground"). You are a background executor: nobody reads your text while you work, so an announcement reaches the user as the finished result and the work never happens. Call the tools first; your reply is the report of what they actually returned.`;
 
 const TEMPLATE_PROMPTS: Record<TaskTemplate, string> = {
   research: `[TASK TEMPLATE: RESEARCH] Gather information using your tools (web search, vault, docs). Stay on the user's intent. Cite sources where it matters. End with a clear conclusion the conversation agent can quote.\n\n${TOOL_USE_INSTRUCTION}`,
@@ -183,6 +185,23 @@ export class TaskDispatcher {
         };
         this.registry.transition(record.id, 'needs_input', envelope);
         return envelope;
+      }
+
+      // A task that finished without touching a single tool is the signature
+      // of a model that announced its plan instead of executing it - the
+      // result the conversation tier then reads out as a progress note. It is
+      // model-family dependent, so it can reappear on any upstream swap:
+      // log it loudly rather than letting it look like a normal completion.
+      // `grep 'completed without using any tool'` on the daemon log is the
+      // fastest check after changing which model backs a tier.
+      const usedTools = (result.conversation as { role?: string }[])
+        .some((m) => m?.role === 'tool');
+      if (!usedTools) {
+        console.warn(
+          `[TaskDispatcher] task ${record.id} (${request.template}, tier=${request.tier}) ` +
+          `completed without using any tool - the model answered with text only. ` +
+          `Result: ${JSON.stringify(result.text.slice(0, 160))}`,
+        );
       }
 
       const summary = await this.summarize(record, request, result.text);

--- a/src/agents/conv/task-dispatcher.ts
+++ b/src/agents/conv/task-dispatcher.ts
@@ -194,9 +194,12 @@ export class TaskDispatcher {
       // log it loudly rather than letting it look like a normal completion.
       // `grep 'completed without using any tool'` on the daemon log is the
       // fastest check after changing which model backs a tier.
+      // `write` is exempt: it drafts prose and is dispatched with
+      // requireToolUse off, so a tool-less completion is the expected shape -
+      // warning on it would bury the real signal in the log.
       const usedTools = (result.conversation as { role?: string }[])
         .some((m) => m?.role === 'tool');
-      if (!usedTools) {
+      if (!usedTools && request.template !== 'write') {
         console.warn(
           `[TaskDispatcher] task ${record.id} (${request.template}, tier=${request.tier}) ` +
           `completed without using any tool - the model answered with text only. ` +

--- a/src/agents/orchestrator-task-call.test.ts
+++ b/src/agents/orchestrator-task-call.test.ts
@@ -55,6 +55,20 @@ function toolCall(name: string, args: Record<string, unknown>): LLMResponse {
   };
 }
 
+function response(
+  content: string,
+  finish: LLMResponse['finish_reason'],
+  calls: LLMToolCall[] = [],
+): LLMResponse {
+  return {
+    content,
+    tool_calls: calls,
+    usage: { input_tokens: 10, output_tokens: 5 },
+    model: 'scripted',
+    finish_reason: finish,
+  };
+}
+
 function makeOrchestrator(provider: LLMProvider): AgentOrchestrator {
   const m = new LLMManager();
   m.registerProvider(provider);
@@ -155,6 +169,96 @@ describe('AgentOrchestrator.processTaskCall', () => {
     if (result.kind === 'completed') {
       expect(result.text).toBe('I am still about to get on that.');
     }
+  });
+
+  it('does not push back on a resumed task that already ran tools', async () => {
+    // The pre-pause buffer carries the tool results. Pushing back here would
+    // tell a model that already sent the mail that nothing has been done.
+    const provider = new ScriptedProvider([text('Already done - Notepad is open.')]);
+    const orch = makeOrchestrator(provider);
+
+    const result = await orch.processTaskCall({
+      systemPrompt: 'task system',
+      userMessage: 'yes, go ahead',
+      tier: 'medium',
+      subsystem: 'task_test',
+      requireToolUse: true,
+      history: [
+        { role: 'system', content: 'task system' },
+        { role: 'user', content: 'open notepad' },
+        { role: 'assistant', content: '', tool_calls: [{ id: 'c1', name: 'open_app', arguments: {} }] },
+        { role: 'tool', content: 'opened', tool_call_id: 'c1' },
+      ],
+    });
+
+    expect(result.kind).toBe('completed');
+    if (result.kind === 'completed') {
+      expect(result.text).toBe('Already done - Notepad is open.');
+    }
+  });
+
+  it('does not push back when the provider reported calls without a tool_use finish', async () => {
+    // Gemini marks every function call STOP, so its calls arrive here.
+    const provider = new ScriptedProvider([
+      response('Opening notepad.', 'stop', [{ id: 'c1', name: 'open_app', arguments: { name: 'notepad' } }]),
+      text('SHOULD NOT BE REACHED'),
+    ]);
+    const orch = makeOrchestrator(provider);
+
+    const result = await orch.processTaskCall({
+      systemPrompt: 'task system',
+      userMessage: 'open notepad',
+      tier: 'medium',
+      subsystem: 'task_test',
+      requireToolUse: true,
+    });
+    expect(result.kind).toBe('completed');
+    if (result.kind === 'completed') expect(result.text).toBe('Opening notepad.');
+  });
+
+  it('does not push back on a truncated answer', async () => {
+    const provider = new ScriptedProvider([
+      response('A very long draft that ran out of', 'length'),
+      text('SHOULD NOT BE REACHED'),
+    ]);
+    const orch = makeOrchestrator(provider);
+
+    const result = await orch.processTaskCall({
+      systemPrompt: 'task system',
+      userMessage: 'summarise the vault',
+      tier: 'medium',
+      subsystem: 'task_test',
+      requireToolUse: true,
+    });
+    expect(result.kind).toBe('completed');
+    if (result.kind === 'completed') {
+      expect(result.text).toContain('A very long draft that ran out of');
+      expect(result.text).toContain('truncated');
+    }
+  });
+
+  it('never re-sends an empty assistant message when pushing back', async () => {
+    // Providers reject empty assistant content once the buffer is re-sent.
+    const provider = new ScriptedProvider([
+      response('', 'stop'),
+      toolCall('open_app', { name: 'notepad' }),
+      text('Notepad is open.'),
+    ]);
+    const orch = makeOrchestrator(provider);
+
+    const result = await orch.processTaskCall({
+      systemPrompt: 'task system',
+      userMessage: 'open notepad',
+      tier: 'medium',
+      subsystem: 'task_test',
+      requireToolUse: true,
+    });
+    expect(result.kind).toBe('completed');
+    if (result.kind !== 'completed') return;
+    expect(result.text).toBe('Notepad is open.');
+    const empties = (result.conversation as { role: string; content: string }[])
+      .filter((m) => m.role === 'assistant' && !m.content?.trim() && !('tool_calls' in m));
+    expect(empties.length).toBe(0);
   });
 
   it('returns paused when LLM calls ask_for_clarification', async () => {

--- a/src/agents/orchestrator-task-call.test.ts
+++ b/src/agents/orchestrator-task-call.test.ts
@@ -94,6 +94,69 @@ describe('AgentOrchestrator.processTaskCall', () => {
     }
   });
 
+  it('accepts a tool-less answer unchanged when requireToolUse is off', async () => {
+    const provider = new ScriptedProvider([text('done')]);
+    const orch = makeOrchestrator(provider);
+
+    const result = await orch.processTaskCall({
+      systemPrompt: 'task system',
+      userMessage: 'draft a thank-you note',
+      tier: 'medium',
+      subsystem: 'task_test',
+    });
+    expect(result.kind).toBe('completed');
+    if (result.kind === 'completed') expect(result.text).toBe('done');
+  });
+
+  it('pushes back once when the model announces work instead of doing it', async () => {
+    // What the hosted medium tier actually did: an announcement, no tool call,
+    // ~2s. Without the push-back this string becomes the task's result and the
+    // conversation tier reads it to the user as a progress note.
+    const provider = new ScriptedProvider([
+      text("On it - I'll open Notepad, then verify it's in the foreground."),
+      toolCall('open_app', { name: 'notepad' }),
+      text('Notepad is open and focused (PID 16672).'),
+    ]);
+    const orch = makeOrchestrator(provider);
+
+    const result = await orch.processTaskCall({
+      systemPrompt: 'task system',
+      userMessage: 'open notepad',
+      tier: 'medium',
+      subsystem: 'task_test',
+      requireToolUse: true,
+    });
+
+    expect(result.kind).toBe('completed');
+    if (result.kind !== 'completed') return;
+    expect(result.text).toBe('Notepad is open and focused (PID 16672).');
+    // The announcement and the push-back are both in the buffer, so a resume
+    // replays why the model was told to act.
+    const roles = (result.conversation as { role: string }[]).map((m) => m.role);
+    expect(roles.filter((r) => r === 'user').length).toBe(2);
+  });
+
+  it('gives up after a bounded number of push-backs', async () => {
+    const provider = new ScriptedProvider([
+      text('I will get right on that.'),
+      text('Getting on it now.'),
+      text('I am still about to get on that.'),
+    ]);
+    const orch = makeOrchestrator(provider);
+
+    const result = await orch.processTaskCall({
+      systemPrompt: 'task system',
+      userMessage: 'open notepad',
+      tier: 'medium',
+      subsystem: 'task_test',
+      requireToolUse: true,
+    });
+    expect(result.kind).toBe('completed');
+    if (result.kind === 'completed') {
+      expect(result.text).toBe('I am still about to get on that.');
+    }
+  });
+
   it('returns paused when LLM calls ask_for_clarification', async () => {
     const provider = new ScriptedProvider([
       toolCall('ask_for_clarification', { question: 'Which Sarah?' }),

--- a/src/agents/orchestrator.ts
+++ b/src/agents/orchestrator.ts
@@ -508,7 +508,12 @@ export class AgentOrchestrator {
     const tools: LLMTool[] = [...baseTools, ASK_FOR_CLARIFICATION_TOOL];
 
     let finalText = '';
-    let toolsExecuted = 0;
+    // Seeded from the resumed buffer, not 0: a task that ran tools before it
+    // paused HAS done work, and the push-back below would otherwise tell it
+    // "nothing has been done yet ... do the work now" - an instruction to
+    // re-run side-effecting tools it already ran (re-send the mail, re-create
+    // the workflow).
+    let toolsExecuted = opts.history?.some((m) => m.role === 'tool') ? 1 : 0;
     let nudges = 0;
 
     for (let iteration = 0; iteration < MAX_TOOL_ITERATIONS; iteration++) {
@@ -570,9 +575,32 @@ export class AgentOrchestrator {
       // Bounded, and only when the caller asked for it: a task that
       // legitimately needs no tools (drafting prose) must still be able to
       // answer in a single call.
-      if (opts.requireToolUse && toolsExecuted === 0 && nudges < MAX_NO_WORK_NUDGES) {
+      const strandedToolCalls = (llmResponse.tool_calls?.length ?? 0) > 0;
+      if (
+        opts.requireToolUse
+        && toolsExecuted === 0
+        && nudges < MAX_NO_WORK_NUDGES
+        // Calls the provider reported without a `tool_use` finish reason land
+        // here (Gemini marks every function call `STOP` - see its
+        // `tool_calls_present`). The model DID call a tool, so telling it that
+        // it did not is both false and destructive: the push-back would drop
+        // the calls from the buffer it re-sends.
+        && !strandedToolCalls
+        // A truncated or filtered turn is not an announcement. Nudging burns
+        // two more expensive generations and loses the truncation marker
+        // appended below.
+        && llmResponse.finish_reason !== 'length'
+        && llmResponse.finish_reason !== 'error'
+      ) {
         nudges++;
-        messages.push({ role: 'assistant', content: llmResponse.content });
+        // Only when it actually said something: an empty assistant message is
+        // re-sent on the next iteration, and providers reject empty content
+        // (AnthropicProvider.convertMessages passes assistant turns through
+        // verbatim). Before this loop re-sent the buffer, an empty final
+        // message was harmless.
+        if (llmResponse.content.trim()) {
+          messages.push({ role: 'assistant', content: llmResponse.content });
+        }
         messages.push({ role: 'user', content: NO_WORK_NUDGE });
         continue;
       }

--- a/src/agents/orchestrator.ts
+++ b/src/agents/orchestrator.ts
@@ -73,6 +73,52 @@ const ASK_FOR_CLARIFICATION_TOOL: LLMTool = {
 };
 
 /**
+ * Prepended to the task tier's own system prompt (fresh calls only, and only
+ * when the caller sets `requireToolUse`). The task tier is handed the FULL
+ * conversational role prompt - persona included - and some model families
+ * anchor on that persona and answer the way a chat assistant would: by
+ * acknowledging the request. This says, at the position closest to the user
+ * message, that there is nobody to acknowledge.
+ */
+const TASK_EXECUTOR_FRAMING =
+  'You are not talking to anyone right now. You are running as a BACKGROUND ' +
+  'TASK EXECUTOR: the text you produce is stored as this task\'s result and is ' +
+  'read only once you stop. Nothing you merely announce gets carried out ' +
+  'afterwards - if you end your turn without calling a tool, the task ends ' +
+  'having done nothing at all. Call the tools you need first; your final ' +
+  'message reports what they actually returned. If one detail is genuinely ' +
+  'missing, call ask_for_clarification.';
+
+/**
+ * Pushed back at a task-tier model that answered without calling a single
+ * tool while nothing had been done yet. Such an answer is almost always an
+ * ANNOUNCEMENT of intent ("On it - I'll open Notepad, then verify it's in the
+ * foreground"), and `processTaskCall` would otherwise hand it to the
+ * dispatcher as the task's result - which the conversation tier then reads
+ * back to the user as a progress note instead of an outcome.
+ *
+ * Measured against the hosted medium tier while its upstream was swapped
+ * between families: across 25 tasks the split is clean and model-determined,
+ * not random. Every GPT-era task returned an announcement after ONE call in
+ * 1.9-6.4s; every task on the other families ran a real tool loop (3 or more
+ * calls, 7-147s) on the same intents, including the same "open notepad"
+ * wording. So the tools, the prompt and the wire format are all fine - the
+ * behaviour has to be corrected in the loop rather than assumed away.
+ */
+const NO_WORK_NUDGE =
+  'You replied with a message and did not call a single tool, so nothing has ' +
+  'been done yet. You are running as a BACKGROUND TASK EXECUTOR: nobody sees ' +
+  'this text while the task runs and there is no one to reply to it - it is ' +
+  'stored verbatim as the task result. Do the work now using the tools in ' +
+  'your registry, then report only what actually happened (what you called, ' +
+  'what came back). If one detail is genuinely missing, call ' +
+  'ask_for_clarification instead. If your previous message really was the ' +
+  'complete final result and no tool was needed, repeat it as your answer.';
+
+/** How many times a single task may be pushed back before its answer stands. */
+const MAX_NO_WORK_NUDGES = 2;
+
+/**
  * Result of a task-tier call. Either completed (final assistant text +
  * the whole conversation buffer) or paused (the LLM called the
  * `ask_for_clarification` tool; the conversation is captured so the task
@@ -431,6 +477,14 @@ export class AgentOrchestrator {
     /** When resuming, pass the conversation captured at the pause + the new user reply. */
     history?: LLMMessage[];
     signal?: AbortSignal;
+    /**
+     * Opt in to the two anti-announcement layers: TASK_EXECUTOR_FRAMING on
+     * the way in, and the bounded NO_WORK_NUDGE push-back when the model
+     * still produces final text before any tool has run. Off by default so
+     * callers that expect a pure text answer keep their single-call
+     * behaviour.
+     */
+    requireToolUse?: boolean;
   }): Promise<TaskCallResult> {
     if (!this.llmManager) {
       return { kind: 'completed', text: '[No LLM configured]', conversation: [] };
@@ -443,6 +497,9 @@ export class AgentOrchestrator {
       ? [...opts.history, { role: 'user', content: opts.userMessage }]
       : [
           ...toSystemMessages(opts.systemPrompt),
+          ...(opts.requireToolUse
+            ? [{ role: 'system', content: TASK_EXECUTOR_FRAMING } satisfies LLMMessage]
+            : []),
           { role: 'user', content: opts.userMessage },
         ];
 
@@ -451,6 +508,8 @@ export class AgentOrchestrator {
     const tools: LLMTool[] = [...baseTools, ASK_FOR_CLARIFICATION_TOOL];
 
     let finalText = '';
+    let toolsExecuted = 0;
+    let nudges = 0;
 
     for (let iteration = 0; iteration < MAX_TOOL_ITERATIONS; iteration++) {
       if (opts.signal?.aborted) {
@@ -497,12 +556,24 @@ export class AgentOrchestrator {
 
         for (const tc of llmResponse.tool_calls) {
           const result = await this.executeTool(tc, opts.signal);
+          toolsExecuted++;
           messages.push({
             role: 'tool',
             content: result,
             tool_call_id: tc.id,
           });
         }
+        continue;
+      }
+
+      // Final text before anything was actually done - see NO_WORK_NUDGE.
+      // Bounded, and only when the caller asked for it: a task that
+      // legitimately needs no tools (drafting prose) must still be able to
+      // answer in a single call.
+      if (opts.requireToolUse && toolsExecuted === 0 && nudges < MAX_NO_WORK_NUDGES) {
+        nudges++;
+        messages.push({ role: 'assistant', content: llmResponse.content });
+        messages.push({ role: 'user', content: NO_WORK_NUDGE });
         continue;
       }
 

--- a/src/daemon/agent-service.ts
+++ b/src/daemon/agent-service.ts
@@ -707,6 +707,11 @@ export class AgentService implements Service, IAgentService {
           subsystem,
           history: history as import('../llm/provider.ts').LLMMessage[] | undefined,
           signal,
+          // Every template but `write` exists to DO something, so a final
+          // answer that ran no tools is a model that announced its plan and
+          // stopped - push back once rather than storing the announcement as
+          // the result. `write` drafts prose and legitimately needs no tools.
+          requireToolUse: template !== 'write',
         });
         return result;
       };


### PR DESCRIPTION
## Problem

Every delegated task answered with a progress note instead of a result:

> The setup task checked for an existing AI-news workflow but didn't confirm whether the workflow was created or activated.

The conversation tier was reporting faithfully. The task tier really had returned an announcement: one LLM call, ~2s, no tool call, and a summary like *"On it—I'll open Notepad without changing any existing content, then verify it's in the foreground."* `processTaskCall` treats any tool-less response as the finished task, so the announcement became the task result.

It is model-family dependent. Across 25 tasks on one instance the split is clean and bands exactly against upstream model swaps — every GPT-era task returned an announcement after one call in 1.9–6.4s; every task on other families ran a real tool loop (3+ calls, 7–147s) on the same intents, including the identical "open notepad" wording.

Not a wire-level bug: the proxy maps `finish_reason` correctly, arguments parse, and there are no dropped tool calls in the logs.

## Fix

Two layers in `processTaskCall`, both opt-in via `requireToolUse` (set for every template except `write`, which legitimately drafts prose with no tools):

- **Prevention** — `TASK_EXECUTOR_FRAMING` system message immediately before the user message, plus a reworded `TOOL_USE_INSTRUCTION` in the task templates. The task tier is handed the full conversational role prompt, persona included, and anchors on it.
- **Recovery** — `NO_WORK_NUDGE`: when the model returns final text before any tool has run, push back and re-enter the loop. Bounded at 2.

Plus a `[TaskDispatcher] ... completed without using any tool` warning, so `grep` on the daemon log is a one-message check after any model swap.

The push-back is scoped to real announcements only. It is skipped when the provider reported tool calls without a `tool_use` finish reason (Gemini marks every function call `STOP`), on `finish_reason` `length` or `error`, and on resumed tasks that already ran tools before pausing — that last one would otherwise instruct a model to re-run side-effecting tools it had already run. An empty assistant message is never re-sent, since providers reject empty content once the buffer goes back out.

## Validation

Measured against a GPT-backed model with the real role prompt and the real 28-tool surface, n=5 per arm per case, replicated:

| arm | notepad | reddit |
|---|---|---|
| as shipped today | 0/5 | 0/5 |
| + framing message only | 0/5 | 0/5 |
| + framing + template (this PR) | 5/5 | 5/5 |
| + template only | 5/5 | 4/5 |
| push-back on an announcement | 5/5 recovered | 5/5 recovered |

The baseline arm reproduced the production string verbatim. The framing message does nothing on its own; the template rewording carries the prevention, and the push-back recovered every announcement it was shown. Framing is retained because ~90 tokens/call is the cheap side of the bet against a ~6–16K retry, though n=5 cannot separate it from template-only.

854 tests pass across `src/agents/`, `src/llm/`, `src/daemon/`; 7 new tests cover the push-back and each exclusion.

## Not covered

Two latent issues in the same family, unfixed and unrelated to current routes: `finish_reason === 'tool_use' && tool_calls.length > 0` silently drops Gemini's tool calls in three orchestrator loops and `sub-agent-runner.ts`, and `openai/groq/nvidia/openrouter` parse tool arguments without the `|| '{}'` guard Anthropic has, so an empty-argument call is dropped with only a `console.error`.
