### PR TITLE
fix(cli): ignore a git tag that is not a version when reporting --version

### DIFF
--- a/src/cli/version.test.ts
+++ b/src/cli/version.test.ts
@@ -88,6 +88,26 @@ fi`,
     );
   });
 
+  test('ignores an exact tag that is not a version and uses package.json', async () => {
+    // The state that made `jarvis --version` print `vinstaller-v0.1.1`: HEAD
+    // sitting exactly on the installer's release tag. Both git probes return
+    // it, so both must reject it.
+    await withFakeGit(
+      'non-version-exact-tag',
+      `if [ "$3" = "describe" ] && [ "$4" = "--tags" ] && [ "$5" = "--exact-match" ]; then
+  printf 'installer-v0.1.1\\n'
+  exit 0
+fi
+if [ "$3" = "describe" ] && [ "$4" = "--tags" ] && [ "$5" = "--always" ]; then
+  printf 'installer-v0.1.1\\n'
+  exit 0
+fi`,
+      async (dir) => {
+        expect(getInstalledVersion(dir)).toBe('0.4.0');
+      },
+    );
+  });
+
   test('falls back to git describe when HEAD is ahead of the last tag', async () => {
     await withFakeGit(
       'described-version',
@@ -163,6 +183,16 @@ fi`,
 
   test('selectInstalledVersion: described wins when no exact tag (v stripped)', () => {
     expect(selectInstalledVersion(null, 'v1.2.3-1-gabc123', '0.4.0')).toBe('1.2.3-1-gabc123');
+  });
+
+  test('selectInstalledVersion: a non-version exact tag falls back to package.json', () => {
+    // The installer releases as `installer-v0.1.1`; reporting the tag verbatim
+    // printed `vinstaller-v0.1.1`.
+    expect(selectInstalledVersion('installer-v0.1.1', null, '0.13.0')).toBe('0.13.0');
+  });
+
+  test('selectInstalledVersion: a non-version describe result falls back to package.json', () => {
+    expect(selectInstalledVersion(null, 'installer-v0.1.1-2-gabc123', '0.13.0')).toBe('0.13.0');
   });
 
   test('selectInstalledVersion: package.json wins when neither git source resolves', () => {

--- a/src/cli/version.ts
+++ b/src/cli/version.ts
@@ -53,13 +53,24 @@ function looksLikeVersion(s: string): boolean {
   return /^v?\d+\.\d+/.test(s);
 }
 
+/**
+ * Pick the version to report, preferring the most specific git source that
+ * actually looks like one.
+ *
+ * BOTH git sources are validated, not just `describedVersion`. This repo also
+ * carries tags that are not bare versions - the installer releases as
+ * `installer-v0.1.1` - and an unvalidated exact match returned the whole tag
+ * name, so a checkout sitting on such a tag printed `vinstaller-v0.1.1` from
+ * `jarvis --version` (the caller adds the `v`). package.json is the right
+ * answer there.
+ */
 export function selectInstalledVersion(
   exactTag: string | null,
   describedVersion: string | null,
   packageVersion: string,
 ): string {
-  if (exactTag) return stripLeadingV(exactTag);
-  if (describedVersion) return stripLeadingV(describedVersion);
+  if (exactTag && looksLikeVersion(exactTag)) return stripLeadingV(exactTag);
+  if (describedVersion && looksLikeVersion(describedVersion)) return stripLeadingV(describedVersion);
   return packageVersion;
 }
 
@@ -71,11 +82,12 @@ export function getInstalledVersion(packageRoot: string): string {
   }
 
   const exactTag = runGit(['describe', '--tags', '--exact-match'], packageRoot);
-  if (exactTag) {
+  if (exactTag && looksLikeVersion(exactTag)) {
     return selectInstalledVersion(exactTag, null, pkgVersion);
   }
 
+  // A non-version exact tag falls through: describe returns that same tag,
+  // selectInstalledVersion rejects it in turn, and package.json wins.
   const describedRaw = runGit(['describe', '--tags', '--always'], packageRoot);
-  const described = describedRaw && looksLikeVersion(describedRaw) ? describedRaw : null;
-  return selectInstalledVersion(null, described, pkgVersion);
+  return selectInstalledVersion(null, describedRaw, pkgVersion);
 }


### PR DESCRIPTION
## Problem

`jarvis --version` prints `vinstaller-v0.1.1` on any checkout sitting exactly on an installer release tag, and the `src/cli/version.test.ts` assertion `/^v\d+\.\d+/` fails — which red-lights the pre-commit hook for everyone committing from that state.

`getInstalledVersion` validates only one of its two git sources:

```ts
const exactTag = runGit(['describe', '--tags', '--exact-match'], packageRoot);
if (exactTag) return selectInstalledVersion(exactTag, null, pkgVersion);   // no guard

const describedRaw = runGit(['describe', '--tags', '--always'], packageRoot);
const described = describedRaw && looksLikeVersion(describedRaw) ? describedRaw : null;  // guarded
```

The repo tags installer releases as `installer-v0.1.1`, which is not a bare version. `stripLeadingV` leaves it alone (it starts with `i`), the call site prepends `v`, and the whole tag name ships as the version.

## Fix

Move the policy into `selectInstalledVersion` and apply it to both sources. A non-version exact tag now falls through to `describe`, which returns the same tag, has it rejected in turn, and lands on `package.json` — the right answer for a checkout at an installer release.

## Tests

Two unit tests for the rejected shapes, plus one end-to-end through the existing `withFakeGit` harness stubbing both probes to return `installer-v0.1.1`. 16 pass.

Committed with the pre-commit hook enabled from the state that used to fail it.
