### PR TITLE
Fix the menu-bar-only sidecar's 'I connected and nothing happened' UX

### DIFF
--- a/sidecar/hosted_window.go
+++ b/sidecar/hosted_window.go
@@ -28,6 +28,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	webview "github.com/webview/webview_go"
 
@@ -119,6 +120,20 @@ const hostedShellHTML = `<!doctype html>
 </div>` + brandTitlebarHTML + `
 <script>
   window.__setStatus = function (text) { document.getElementById('status').textContent = text; };
+  // Success terminus: the token arrived and is stored; the window is about to
+  // close and the sidecar re-execs into its menu-bar-only self (no Dock icon,
+  // no window). Tell the user WHERE Jarvis went so the disappearance doesn't
+  // read as "nothing happened" — the whole reason for this state.
+  window.__setConnected = function () {
+    document.getElementById('drop').className = 'bdrop s-done';
+    document.getElementById('phase').textContent = 'Connected';
+    document.getElementById('status').textContent =
+      'Jarvis now lives in your menu bar, at the top-right of your screen. Click its drop up there any time to open it.';
+    document.getElementById('err').textContent = '';
+    document.getElementById('retry').style.display = 'none';
+    document.getElementById('reopen').style.display = 'none';
+    document.getElementById('url').style.display = 'none';
+  };
   window.__setError = function (text) {
     document.getElementById('drop').className = text ? 'bdrop s-err' : 'bdrop';
     document.getElementById('phase').textContent = text ? 'Setup failed' : 'Connecting';
@@ -172,6 +187,11 @@ func hostedShellWithSelfHostHint() string {
 // runFirstRunWindow drives the no-token first run: hosted connect by default,
 // self-host token form one click away. Returns the enrollment JWT ("" if the
 // user closed the window). Blocks; must run on the main OS thread.
+// connectedDwell is how long the Connect window holds the "Jarvis lives in
+// your menu bar" success message before it closes and the sidecar re-execs.
+// Long enough to read one sentence, short enough not to feel stuck.
+const connectedDwell = 3500 * time.Millisecond
+
 func runFirstRunWindow(cfg *SidecarConfig) (string, error) {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
@@ -258,6 +278,28 @@ func runFirstRunWindow(cfg *SidecarConfig) (string, error) {
 	// this flag instead (same pattern as webview_reveal's stopped flag).
 	// Atomic because the later loop may run on a different OS thread.
 	var torndown atomic.Bool
+
+	// connectedThenClose paints the "you're in the menu bar" success state and
+	// holds it briefly before closing, so the user learns where Jarvis went
+	// before the window vanishes and the sidecar re-execs into its menu-bar-only
+	// self. The token is already stored by the caller (correctness); this is
+	// best-effort UI, so a torn-down window just skips both steps. Runs on the
+	// caller's goroutine — the Sleep never touches the Cocoa run loop.
+	connectedThenClose := func() {
+		w.Dispatch(func() {
+			if torndown.Load() {
+				return
+			}
+			w.Eval("window.__setConnected && window.__setConnected()")
+		})
+		time.Sleep(connectedDwell)
+		w.Dispatch(func() {
+			if torndown.Load() {
+				return
+			}
+			w.Terminate()
+		})
+	}
 
 	// Self-host path: swap to the classic token form (its submitToken binding
 	// is installed below and only accepts input while this form is active).
@@ -482,7 +524,7 @@ func runFirstRunWindow(cfg *SidecarConfig) (string, error) {
 				token = jwt
 				tokenMu.Unlock()
 			}
-			w.Dispatch(func() { w.Terminate() })
+			connectedThenClose()
 		}()
 	}
 
@@ -546,12 +588,7 @@ func runFirstRunWindow(cfg *SidecarConfig) (string, error) {
 			tokenMu.Lock()
 			token = tok
 			tokenMu.Unlock()
-			w.Dispatch(func() {
-				if torndown.Load() {
-					return
-				}
-				w.Terminate()
-			})
+			connectedThenClose()
 		}()
 	})
 	if dlErr != nil {

--- a/sidecar/hosted_window.go
+++ b/sidecar/hosted_window.go
@@ -116,7 +116,7 @@ const hostedShellHTML = `<!doctype html>
       <div id="retry"><button class="btn" onclick="window.retryHosted()">Try again</button></div>
     </div>
   </div>
-  <p class="footer">Self-hosting your own brain? <a onclick="window.chooseSelfHost()">Paste your enrollment token</a></p>
+  <p class="footer" id="footer">Self-hosting your own brain? <a onclick="window.chooseSelfHost()">Paste your enrollment token</a></p>
 </div>` + brandTitlebarHTML + `
 <script>
   window.__setStatus = function (text) { document.getElementById('status').textContent = text; };
@@ -133,6 +133,9 @@ const hostedShellHTML = `<!doctype html>
     document.getElementById('retry').style.display = 'none';
     document.getElementById('reopen').style.display = 'none';
     document.getElementById('url').style.display = 'none';
+    // The token is already stored; don't offer the self-host form during the
+    // dwell only to Terminate it out from under the user mid-typing.
+    document.getElementById('footer').style.display = 'none';
   };
   window.__setError = function (text) {
     document.getElementById('drop').className = text ? 'bdrop s-err' : 'bdrop';
@@ -184,14 +187,14 @@ func hostedShellWithSelfHostHint() string {
 	return strings.Replace(hostedShellHTML, "/*__BOOT__*/", "window.__setSelfHostHint();", 1)
 }
 
-// runFirstRunWindow drives the no-token first run: hosted connect by default,
-// self-host token form one click away. Returns the enrollment JWT ("" if the
-// user closed the window). Blocks; must run on the main OS thread.
 // connectedDwell is how long the Connect window holds the "Jarvis lives in
 // your menu bar" success message before it closes and the sidecar re-execs.
 // Long enough to read one sentence, short enough not to feel stuck.
 const connectedDwell = 3500 * time.Millisecond
 
+// runFirstRunWindow drives the no-token first run: hosted connect by default,
+// self-host token form one click away. Returns the enrollment JWT ("" if the
+// user closed the window). Blocks; must run on the main OS thread.
 func runFirstRunWindow(cfg *SidecarConfig) (string, error) {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
@@ -292,7 +295,14 @@ func runFirstRunWindow(cfg *SidecarConfig) (string, error) {
 			}
 			w.Eval("window.__setConnected && window.__setConnected()")
 		})
-		time.Sleep(connectedDwell)
+		// Cancellable dwell: if the user closes the window (or teardown fires)
+		// mid-message, ctx is cancelled before the post-Run handshakeWG.Wait(),
+		// so waking here immediately keeps runFirstRunWindow from stalling the
+		// re-exec for the full dwell. The Terminate below is torndown-guarded.
+		select {
+		case <-time.After(connectedDwell):
+		case <-ctx.Done():
+		}
 		w.Dispatch(func() {
 			if torndown.Load() {
 				return

--- a/sidecar/installer/wizard.go
+++ b/sidecar/installer/wizard.go
@@ -198,19 +198,22 @@ func runWizard(registryURL string, noLaunch, autostartDefault bool) int {
 						return
 					}
 					applyPlan(s, inst, rel.Version)
-				})
-				// Already current: no install goroutine will run to populate
-				// `out`, but the up-to-date screen offers a Launch button (a
-				// menu-bar-only app the user re-ran the installer to find).
-				// Seed the launch target from the plan so launchAndClose can
-				// start the existing install.
-				if inst.Version != "" && !versionLess(inst.Version, rel.Version) {
-					mu.Lock()
-					if gen == planGen && !started {
+					// Already current: no install goroutine will run to set
+					// `out`/exitCode, but the up-to-date screen offers a Launch
+					// button (a menu-bar-only app the user re-ran the installer
+					// to find). Seed the launch target so launchAndClose can
+					// start the installed sidecar, and mark exit 0 — "already
+					// current" is a benign terminal state however the window is
+					// closed (matches the console flow and closeInstaller's
+					// contract). This runs inside set()'s mu-held section, past
+					// the stale() guard, so it can neither clobber nor be
+					// clobbered by a real install, and there is no window in
+					// which the Launch button is live before `out` is seeded.
+					if s.UpToDate {
 						out = installOutcome{Rel: rel, Inst: inst, InstallDir: inst.InstallDir, UpToDate: true}
+						exitCode = exitOK
 					}
-					mu.Unlock()
-				}
+				})
 			}()
 		}
 		_ = w.Bind("startPlan", startPlan)
@@ -304,7 +307,9 @@ func runWizard(registryURL string, noLaunch, autostartDefault bool) int {
 
 		// closeInstaller ends a run the user is done with. success=true for
 		// benign terminal states (already current, npm-managed) which exit 0;
-		// Cancel passes false and keeps the non-zero "did not install" code.
+		// Cancel passes false and keeps the non-zero "did not install" code —
+		// except on the up-to-date screen, where the plan already seeded exitOK
+		// (the machine is in the desired state however this window is closed).
 		_ = w.Bind("closeInstaller", func(success bool) {
 			if success {
 				mu.Lock()

--- a/sidecar/installer/wizard.go
+++ b/sidecar/installer/wizard.go
@@ -84,6 +84,21 @@ func applyOutcome(s *wizardState, out installOutcome) {
 	s.UpToDate = out.UpToDate
 }
 
+// launchHomeSpot names, for the current OS, where the sidecar lives once
+// running, plus how to open it by hand — used in the launch-failure alert so a
+// user of this Dock/taskbar-less app isn't left with a vanished window and no
+// Jarvis. Mirrors the JS `homeSpot` phrasing in the done screen.
+func launchHomeSpot() string {
+	switch runtime.GOOS {
+	case "darwin":
+		return "the menu bar at the top-right of your screen (open Jarvis from your Applications folder)"
+	case "windows":
+		return "the system tray near the clock (open Jarvis from the Start menu)"
+	default:
+		return "the menu bar"
+	}
+}
+
 func runWizard(registryURL string, noLaunch, autostartDefault bool) int {
 	// The wizard itself is WebView2-backed on Windows; internal/webview2
 	// prompts + waits when the runtime is missing (no-op elsewhere). The
@@ -184,6 +199,18 @@ func runWizard(registryURL string, noLaunch, autostartDefault bool) int {
 					}
 					applyPlan(s, inst, rel.Version)
 				})
+				// Already current: no install goroutine will run to populate
+				// `out`, but the up-to-date screen offers a Launch button (a
+				// menu-bar-only app the user re-ran the installer to find).
+				// Seed the launch target from the plan so launchAndClose can
+				// start the existing install.
+				if inst.Version != "" && !versionLess(inst.Version, rel.Version) {
+					mu.Lock()
+					if gen == planGen && !started {
+						out = installOutcome{Rel: rel, Inst: inst, InstallDir: inst.InstallDir, UpToDate: true}
+					}
+					mu.Unlock()
+				}
 			}()
 		}
 		_ = w.Bind("startPlan", startPlan)
@@ -261,6 +288,15 @@ func runWizard(registryURL string, noLaunch, autostartDefault bool) int {
 				firstInstall := res.Inst.Version == ""
 				if err := launchInstalled(res.InstallDir, res.Rel.Version, firstInstall); err != nil {
 					logf("warning: could not launch the sidecar: %v", err)
+					// A GUI user never sees the log: without this the window
+					// just closes and Jarvis never appears — the same
+					// "nothing happened" the rest of this work fixes. Say so,
+					// and point them at where to start it by hand. Leave the
+					// window open (no Terminate) so the Launch button retries.
+					notify("Jarvis could not start",
+						"Jarvis is installed but could not be started automatically. Open it yourself — it runs in "+launchHomeSpot()+".",
+						true)
+					return
 				}
 			}
 			w.Dispatch(w.Terminate)
@@ -420,6 +456,12 @@ const wizardHTML = `<!doctype html>
     el('error').textContent = st.error || '';
     var pebble = el('pebble');
     var main = el('btnMain');
+    // Where Jarvis lives after it starts. It has no Dock/taskbar presence and
+    // no persistent window — only a menu-bar (macOS) / system-tray (Windows)
+    // icon — so a done screen that doesn't say this reads as "nothing happened".
+    var homeSpot = st.platform === 'darwin' ? 'the menu bar, at the top-right of your screen'
+      : st.platform === 'windows' ? 'the system tray, near the clock'
+      : 'the menu bar';
     // Autostart applies on first install only; on updates the user's own
     // choice (Jarvis settings / setup wizard) stands.
     var showAutostart = st.phase === 'plan' && st.platform === 'windows' &&
@@ -462,10 +504,11 @@ const wizardHTML = `<!doctype html>
         main.textContent = 'Close';
         main.onclick = function () { window.closeInstaller(true); };
       } else {
-        el('subtitle').textContent = st.up_to_date ? 'Already up to date.'
+        el('subtitle').textContent = st.up_to_date ? 'Already up to date. Jarvis lives in ' + homeSpot + '.'
           : (st.platform === 'darwin' && st.first_install)
-            ? 'Installed. Jarvis will now ask for its permissions.'
-            : st.first_install ? 'Installed.' : 'Updated.';
+            ? 'Installed. Jarvis will ask for its permissions, then live in ' + homeSpot + '.'
+            : st.first_install ? 'Installed. Jarvis lives in ' + homeSpot + '.'
+              : 'Updated. Jarvis lives in ' + homeSpot + '.';
         main.textContent = 'Launch Jarvis';
         main.onclick = function () { window.launchAndClose(); };
       }
@@ -479,9 +522,11 @@ const wizardHTML = `<!doctype html>
       main.textContent = 'Close';
       main.onclick = function () { window.closeInstaller(true); };
     } else if (st.up_to_date) {
-      el('subtitle').textContent = 'You already have the latest sidecar.';
-      main.textContent = 'Close';
-      main.onclick = function () { window.closeInstaller(true); };
+      // Menu-bar-only app: a user who re-ran the installer to "get Jarvis
+      // back" needs a way to start it, not just a dead-end Close. Launch it.
+      el('subtitle').textContent = 'You already have the latest sidecar — it runs in ' + homeSpot + '.';
+      main.textContent = 'Launch Jarvis';
+      main.onclick = function () { window.launchAndClose(); };
     } else {
       // The panel row is where "there is an update" is announced; saying it
       // again here would leave the two lines of the screen agreeing with each

--- a/sidecar/installer/wizard_render_test.go
+++ b/sidecar/installer/wizard_render_test.go
@@ -146,6 +146,18 @@ func TestWizardPanelSaysWhatIsOnTheMachine(t *testing.T) {
 			subtitle: "Installed. Jarvis lives in the system tray, near the clock.",
 			button:   "Launch Jarvis",
 		},
+		// The one macOS case: the done screen there routes through the
+		// permissions handoff AND names the menu bar, and both live on this
+		// exact-string surface, so pin the darwin homeSpot too.
+		{
+			name: "a first install that finished, on macOS",
+			st: with(func(s *wizardState) {
+				s.Phase, s.Detected, s.Installed, s.FirstInstall, s.Platform = "done", true, true, true, "darwin"
+			}),
+			status:   "Installed",
+			subtitle: "Installed. Jarvis will ask for its permissions, then live in the menu bar, at the top-right of your screen.",
+			button:   "Launch Jarvis",
+		},
 		{
 			name:     "an update that finished",
 			st:       with(func(s *wizardState) { s.Phase, s.Detected, s.Installed = "done", true, true }),

--- a/sidecar/installer/wizard_render_test.go
+++ b/sidecar/installer/wizard_render_test.go
@@ -123,8 +123,8 @@ func TestWizardPanelSaysWhatIsOnTheMachine(t *testing.T) {
 			name:     "already current",
 			st:       with(func(s *wizardState) { s.Phase, s.Detected, s.Installed, s.UpToDate = "plan", true, true, true }),
 			status:   "Up to date",
-			subtitle: "You already have the latest sidecar.",
-			button:   "Close",
+			subtitle: "You already have the latest sidecar — it runs in the system tray, near the clock.",
+			button:   "Launch Jarvis",
 		},
 		{
 			name:   "npm owns it",
@@ -143,14 +143,14 @@ func TestWizardPanelSaysWhatIsOnTheMachine(t *testing.T) {
 			name:     "a first install that finished",
 			st:       with(func(s *wizardState) { s.Phase, s.Detected, s.Installed, s.FirstInstall = "done", true, true, true }),
 			status:   "Installed",
-			subtitle: "Installed.",
+			subtitle: "Installed. Jarvis lives in the system tray, near the clock.",
 			button:   "Launch Jarvis",
 		},
 		{
 			name:     "an update that finished",
 			st:       with(func(s *wizardState) { s.Phase, s.Detected, s.Installed = "done", true, true }),
 			status:   "Updated",
-			subtitle: "Updated.",
+			subtitle: "Updated. Jarvis lives in the system tray, near the clock.",
 			button:   "Launch Jarvis",
 		},
 		{

--- a/sidecar/tray_bridge_darwin.go
+++ b/sidecar/tray_bridge_darwin.go
@@ -84,3 +84,12 @@ func goTrayWaiting() {
 		go trayOpenChatDarwin()
 	}
 }
+
+//export goTrayReopen
+func goTrayReopen() {
+	// Cocoa main thread (reopen event); the handler opens a panel (mint token +
+	// spawn webview), so run it off-thread like the menu actions.
+	if trayOnReopenDarwin != nil {
+		go trayOnReopenDarwin()
+	}
+}

--- a/sidecar/tray_darwin.go
+++ b/sidecar/tray_darwin.go
@@ -40,6 +40,7 @@ extern void goTrayOpenLogs(void);
 extern void goTrayPause(void);
 extern void goTrayMute(void);
 extern void goTrayWaiting(void);
+extern void goTrayReopen(void);
 
 // Menu action target: forwards clicks back into Go. Also acts as the
 // NSApplication delegate (set in jarvisTraySetup) so that webview_go's panel
@@ -56,6 +57,7 @@ extern void goTrayWaiting(void);
 - (void)onPause:(id)sender;
 - (void)onMute:(id)sender;
 - (void)onWaiting:(id)sender;
+- (BOOL)applicationShouldHandleReopen:(NSApplication*)sender hasVisibleWindows:(BOOL)flag;
 @end
 @implementation JarvisTrayTarget
 - (void)onClose:(id)sender    { (void)sender; goTrayClose(); }
@@ -66,6 +68,23 @@ extern void goTrayWaiting(void);
 - (void)onPause:(id)sender    { (void)sender; goTrayPause(); }
 - (void)onMute:(id)sender     { (void)sender; goTrayMute(); }
 - (void)onWaiting:(id)sender  { (void)sender; goTrayWaiting(); }
+// A LSUIElement/Accessory app has no windows and no Dock icon, so when the user
+// re-launches Jarvis.app (or double-clicks it after "You're connected"),
+// LaunchServices sends this reopen event instead of starting a new process.
+// Without a handler AppKit does nothing and the app looks dead — the #1 "I
+// connected and nothing happened" report. Bring ourselves to the front first:
+// an Accessory app is not auto-activated on reopen, so a panel opened here can
+// otherwise order in BEHIND the frontmost app — the softer version of the same
+// bug. Then forward to Go, which opens the dashboard (or local settings when
+// the brain is unreachable). Return NO — we fully handled the reopen; an
+// Accessory app has no default windows for AppKit to restore, and the comment/
+// contract must not claim otherwise (NO = "handled, do nothing further").
+- (BOOL)applicationShouldHandleReopen:(NSApplication*)sender hasVisibleWindows:(BOOL)flag {
+    (void)sender; (void)flag;
+    [NSApp activateIgnoringOtherApps:YES];
+    goTrayReopen();
+    return NO;
+}
 @end
 
 static NSStatusItem*     gStatusItem = nil;
@@ -308,6 +327,7 @@ var (
 	trayOpenAccountDarwin  func()
 	trayOpenSettingsDarwin func()
 	trayOpenLogsDarwin     func()
+	trayOnReopenDarwin     func()                                         // Jarvis.app re-launched / double-clicked (Dock-less reopen)
 	trayEmitDarwin         func(eventType string, payload map[string]any) // tray → brain (pause/mute)
 	trayClientDarwin       *SidecarClient
 )
@@ -396,6 +416,17 @@ func runWithTray(ctx context.Context, cancel context.CancelFunc, client *Sidecar
 	trayOpenAccountDarwin = client.OpenAccount
 	trayOpenSettingsDarwin = client.OpenSettings
 	trayOpenLogsDarwin = client.OpenLogViewer
+	// Re-launch/double-click of the Dock-less app: bring the user somewhere
+	// visible. The dashboard when the brain is up; local settings when it is not
+	// (openRoom would otherwise fail to mint a panel token and, again, show
+	// nothing — see openRoom's brain-origin/token guards).
+	trayOnReopenDarwin = func() {
+		if client.Connected() {
+			client.OpenChat()
+		} else {
+			client.OpenSettings()
+		}
+	}
 	trayClientDarwin = client
 	trayEmitDarwin = func(et string, p map[string]any) {
 		_ = client.sendEvent(context.Background(), SidecarEvent{


### PR DESCRIPTION
## Why

The macOS sidecar is an `LSUIElement` / `NSApplicationActivationPolicyAccessory` app — no Dock icon, no persistent window, only an 18px menu-bar "drop" at the top-right. That produced a family of *"I connected/installed and nothing happened"* reports: after enrollment the setup window vanishes and the app slips into the menu bar with nothing telling the user where it went, and re-launching `Jarvis.app` (or the login item) did nothing at all. This addresses the four fixes from the on-device analysis, in impact order, each behind its own commit.

## What

**1 — Reopen handler (`tray_darwin.go`, `tray_bridge_darwin.go`).** Adds `applicationShouldHandleReopen:hasVisibleWindows:` to `JarvisTrayTarget`: activates the app (Accessory apps aren't auto-fronted on reopen, so a window could otherwise open behind) and opens the dashboard when the brain is connected, else local settings (minting a panel token against an unreachable brain would itself show nothing). Returns `NO` (fully handled). Previously the delegate ignored the reopen event and AppKit did nothing.

**2 — Connect-time "you're in the menu bar" message (`hosted_window.go`).** When the enrollment token arrives, the Connect window no longer vanishes instantly: it paints a green success state — *"Jarvis now lives in your menu bar, at the top-right of your screen…"* — holds it briefly, then closes and re-execs. The token is still captured **unconditionally before** the UI/close (it's spent and must never be lost); the message + dwell are best-effort UI, guarded by the existing teardown flag, cancellable on close, and the self-host link is hidden during the dwell. Wired into both the handshake and deep-link success paths.

**3 — Installer copy (`installer/wizard.go`).** The done screen and up-to-date screen now say where Jarvis lives — "the menu bar, at the top-right" on macOS, "the system tray, near the clock" on Windows.

**4 — Installer Launch + alert (`installer/wizard.go`).** When already up-to-date, the button is now **"Launch Jarvis"** instead of a dead-end "Close" (the launch target is seeded from the plan, under the state lock, so it actually works and stays race-free). A failed auto-launch now raises a native alert pointing the user at where to start Jarvis by hand, and leaves the window open to retry, instead of a silent log line a GUI user never sees. The up-to-date path now exits `0` on all closes (matching the console flow).

## Testing

- `go build ./...`, `go vet ./...`, `gofmt` clean across the sidecar and installer packages.
- Installer copy validated against a real headless Chromium via the opt-in render suite (`JARVIS_BROWSER_TESTS=1`) — all subtests pass; a macOS case was added to pin the new darwin copy.
- **Not verifiable here:** the darwin tray path (`tray_darwin.go` / `tray_bridge_darwin.go`) is CGO/ObjC and compile-unverified on the Linux dev box, per the files' own headers — it needs a real Mac build + a manual pass of the reopen action, both connect success paths, and the close-during-dwell case.
