### PR TITLE
Capped, redacted log file behind daemon.log_file_path

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,16 @@ credential redactor, so the file is safe to hand to someone debugging. It is
 capped: past `log_file_max_bytes` the oldest lines are dropped, so it settles at
 roughly that size instead of filling the disk. Unset means no file.
 
+The cap is an in-memory ring as well as a file size, so `log_file_max_bytes` is
+an RSS budget too - 1 MiB of log is 1 MiB of daemon memory. It is clamped to
+4 KiB..64 MiB.
+
+One thing to expect from `jarvis logs -f`: it runs `tail -F`, and every time the
+cap is enforced the file is replaced, so `tail` reopens it and reprints the
+whole window. At the default size that is ~1 MiB of already-seen lines about
+every 256 KiB of new output. That is inherent to capping one file in place, not
+a bug.
+
 ### Updating
 
 `jarvis update` detects how you installed JARVIS and runs the right update command. Equivalent manual commands per install method:

--- a/README.md
+++ b/README.md
@@ -217,6 +217,26 @@ jarvis logs -f          # Follow live logs
 
 The dashboard is available at `http://localhost:3142` once the daemon is running.
 
+### Logs
+
+`jarvis start -d` writes the daemon's output to `~/.jarvis/logs/jarvis.log`, and
+`jarvis logs -f` follows it. Started any other way - in the foreground, under
+systemd, in Docker - there is no file: output goes to the terminal, `journalctl`
+or `docker logs`. To get the same file in every launch mode, add to
+`~/.jarvis/config.yaml`:
+
+```yaml
+daemon:
+  log_file_path: "~/.jarvis/logs/jarvis.log"
+  log_file_max_bytes: 1048576   # optional, defaults to 1 MiB
+```
+
+The daemon mirrors its output there in addition to wherever it already goes.
+Lines are timestamped, stripped of terminal colour codes, and run through the
+credential redactor, so the file is safe to hand to someone debugging. It is
+capped: past `log_file_max_bytes` the oldest lines are dropped, so it settles at
+roughly that size instead of filling the disk. Unset means no file.
+
 ### Updating
 
 `jarvis update` detects how you installed JARVIS and runs the right update command. Equivalent manual commands per install method:

--- a/bin/jarvis.ts
+++ b/bin/jarvis.ts
@@ -16,8 +16,8 @@
  * after `jarvis start` — there is no longer a CLI wizard.
  */
 
-import { join } from 'node:path';
-import { existsSync, openSync } from 'node:fs';
+import { basename, dirname, join, resolve as resolvePath } from 'node:path';
+import { existsSync, openSync, realpathSync } from 'node:fs';
 import { spawn } from 'node:child_process';
 import { acquireLock, releaseLock, releaseLockIfUnheld, isLocked, getLogPath, isProcessAlive, waitForProcessExit } from '../src/daemon/pid.ts';
 import { c } from '../src/cli/helpers.ts';
@@ -89,6 +89,40 @@ function assertSupportedPlatform(): void {
   console.error(c.dim('Use WSL2 for the Bun install, or run JARVIS with Docker on Windows.'));
   console.error(c.dim('The Windows sidecar is still supported separately.'));
   process.exit(1);
+}
+
+/**
+ * Resolve `p` to an absolute real path for comparison. Falls back to resolving
+ * the parent and re-joining the basename, because the file we are asking about
+ * may not exist yet (nothing has written it) while its directory does.
+ */
+function realPathForCompare(p: string): string {
+  const abs = resolvePath(p);
+  try {
+    return realpathSync(abs);
+  } catch {
+    try {
+      return join(realpathSync(dirname(abs)), basename(abs));
+    } catch {
+      return abs;
+    }
+  }
+}
+
+function samePath(a: string | null, b: string | null): boolean {
+  if (!a || !b) return false;
+  return realPathForCompare(a) === realPathForCompare(b);
+}
+
+/** `daemon.log_file_path` as the daemon would see it, or null if unset. */
+async function configuredLogFilePath(): Promise<string | null> {
+  try {
+    const cfg = await loadConfig();
+    return cfg.daemon.log_file_path?.trim() || null;
+  } catch {
+    // A broken config is the child's problem to report, not ours.
+    return null;
+  }
 }
 
 async function cmdStart(args: string[]): Promise<void> {
@@ -163,16 +197,26 @@ async function cmdStart(args: string[]): Promise<void> {
     console.log(c.cyan('Starting J.A.R.V.I.S. daemon...'));
 
     const logPath = getLogPath();
-    const logFile = Bun.file(logPath);
 
     const daemonArgs = [join(PACKAGE_ROOT, 'bin/jarvis.ts'), 'start', '--no-open'];
     if (port) daemonArgs.push('--port', String(port));
+
+    // We redirect the child's stdout AND stderr into logPath below. If the
+    // child then also installs its own file sink (daemon.log_file_path) on the
+    // same file, every line lands twice - once through the fd we handed it,
+    // once through the sink. Compare RESOLVED paths, not the configured
+    // strings: `~/.jarvis/logs/jarvis.log`, `$JARVIS_HOME/logs/jarvis.log` and
+    // a symlinked home are all the same file with three spellings.
+    const childEnv: Record<string, string | undefined> = { ...process.env };
+    if (existsSync(cfgPath) && samePath(await configuredLogFilePath(), logPath)) {
+      childEnv.JARVIS_NO_LOG_FILE_SINK = '1';
+    }
 
     const logFd = openSync(logPath, 'a');
     const child = spawn('bun', daemonArgs, {
       detached: true,
       stdio: ['ignore', logFd, logFd],
-      env: { ...process.env },
+      env: childEnv,
     });
     child.unref();
 
@@ -402,7 +446,10 @@ function cmdLogs(args: string[]): void {
 
   if (follow) {
     // tail -f equivalent
-    const tailProc = Bun.spawn(['tail', '-f', '-n', String(lines), logPath], {
+    // -F, not -f: the daemon's file sink caps the log by rewriting it through
+    // a temp file + rename, so the inode changes and a plain `tail -f` would
+    // keep following a deleted inode and go silent. -F follows by NAME.
+    const tailProc = Bun.spawn(['tail', '-F', '-n', String(lines), logPath], {
       stdio: ['ignore', 'inherit', 'inherit'],
     });
 

--- a/bin/jarvis.ts
+++ b/bin/jarvis.ts
@@ -16,8 +16,8 @@
  * after `jarvis start` — there is no longer a CLI wizard.
  */
 
-import { basename, dirname, join, resolve as resolvePath } from 'node:path';
-import { existsSync, openSync, realpathSync } from 'node:fs';
+import { join } from 'node:path';
+import { existsSync, openSync } from 'node:fs';
 import { spawn } from 'node:child_process';
 import { acquireLock, releaseLock, releaseLockIfUnheld, isLocked, getLogPath, isProcessAlive, waitForProcessExit } from '../src/daemon/pid.ts';
 import { c } from '../src/cli/helpers.ts';
@@ -89,40 +89,6 @@ function assertSupportedPlatform(): void {
   console.error(c.dim('Use WSL2 for the Bun install, or run JARVIS with Docker on Windows.'));
   console.error(c.dim('The Windows sidecar is still supported separately.'));
   process.exit(1);
-}
-
-/**
- * Resolve `p` to an absolute real path for comparison. Falls back to resolving
- * the parent and re-joining the basename, because the file we are asking about
- * may not exist yet (nothing has written it) while its directory does.
- */
-function realPathForCompare(p: string): string {
-  const abs = resolvePath(p);
-  try {
-    return realpathSync(abs);
-  } catch {
-    try {
-      return join(realpathSync(dirname(abs)), basename(abs));
-    } catch {
-      return abs;
-    }
-  }
-}
-
-function samePath(a: string | null, b: string | null): boolean {
-  if (!a || !b) return false;
-  return realPathForCompare(a) === realPathForCompare(b);
-}
-
-/** `daemon.log_file_path` as the daemon would see it, or null if unset. */
-async function configuredLogFilePath(): Promise<string | null> {
-  try {
-    const cfg = await loadConfig();
-    return cfg.daemon.log_file_path?.trim() || null;
-  } catch {
-    // A broken config is the child's problem to report, not ours.
-    return null;
-  }
 }
 
 async function cmdStart(args: string[]): Promise<void> {
@@ -201,22 +167,18 @@ async function cmdStart(args: string[]): Promise<void> {
     const daemonArgs = [join(PACKAGE_ROOT, 'bin/jarvis.ts'), 'start', '--no-open'];
     if (port) daemonArgs.push('--port', String(port));
 
-    // We redirect the child's stdout AND stderr into logPath below. If the
-    // child then also installs its own file sink (daemon.log_file_path) on the
-    // same file, every line lands twice - once through the fd we handed it,
-    // once through the sink. Compare RESOLVED paths, not the configured
-    // strings: `~/.jarvis/logs/jarvis.log`, `$JARVIS_HOME/logs/jarvis.log` and
-    // a symlinked home are all the same file with three spellings.
-    const childEnv: Record<string, string | undefined> = { ...process.env };
-    if (existsSync(cfgPath) && samePath(await configuredLogFilePath(), logPath)) {
-      childEnv.JARVIS_NO_LOG_FILE_SINK = '1';
-    }
-
+    // We redirect the child's stdout AND stderr into logPath. If
+    // daemon.log_file_path names this same file the child does NOT install its
+    // in-process sink on top: it fstats fds 1/2 against the configured path and
+    // skips (src/daemon/index.ts). That check lives in the daemon rather than
+    // here because it is the only place that covers every launcher - this one,
+    // `jarvis update`'s restart, and the launchd plist - and because comparing
+    // inodes catches spellings a string compare cannot.
     const logFd = openSync(logPath, 'a');
     const child = spawn('bun', daemonArgs, {
       detached: true,
       stdio: ['ignore', logFd, logFd],
-      env: childEnv,
+      env: { ...process.env },
     });
     child.unref();
 
@@ -449,6 +411,14 @@ function cmdLogs(args: string[]): void {
     // -F, not -f: the daemon's file sink caps the log by rewriting it through
     // a temp file + rename, so the inode changes and a plain `tail -f` would
     // keep following a deleted inode and go silent. -F follows by NAME.
+    //
+    // The cost of that, and it is visible: on every compaction GNU tail says
+    // "has been replaced; following new file" and reprints the ENTIRE new
+    // file, so a follower sees ~1 MiB of already-seen lines about every
+    // 256 KiB of new output at the default cap. Inherent to capping one file
+    // in place - rotation and truncate-in-place restart a tailer too - and
+    // documented in README.md / docs/SELF_HOSTING.md rather than worked
+    // around, because every workaround costs more than the noise does.
     const tailProc = Bun.spawn(['tail', '-F', '-n', String(lines), logPath], {
       stdio: ['ignore', 'inherit', 'inherit'],
     });

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -23,7 +23,12 @@ daemon:
   # through the credential redactor before they are written.
   # The file is a RING: once it passes log_file_max_bytes (default 1 MiB) the
   # oldest lines are dropped from the top, so it settles at roughly that size
-  # and never grows without bound. `jarvis logs -f` follows it either way.
+  # and never grows without bound. `jarvis logs -f` follows it either way -
+  # expect it to reprint the window each time the cap is enforced, since the
+  # file is replaced and `tail -F` reopens it.
+  # The ring is held IN MEMORY as well as on disk, so this is an RSS budget
+  # too. Clamped to 4 KiB..64 MiB; anything outside that (`.inf` included) is
+  # brought back into range with a warning.
   # log_file_path: "~/.jarvis/logs/jarvis.log"
   # log_file_max_bytes: 1048576
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -15,6 +15,17 @@ daemon:
   # Bind a unix domain socket INSTEAD of a TCP port (for a reverse proxy on
   # the same host). When set, nothing listens on TCP. See docs/SELF_HOSTING.md.
   # listen: "unix:/run/jarvis/jarvis.sock"
+  # Mirror stdout/stderr into a log file. Unset = no file, which is the
+  # default: `jarvis start -d` already redirects into ~/.jarvis/logs/jarvis.log,
+  # but under systemd or Docker there is no file at all and the only record is
+  # journald / the container runtime. Set this to get the same file in every
+  # launch mode. `~` is expanded. Lines are stripped of ANSI escapes and passed
+  # through the credential redactor before they are written.
+  # The file is a RING: once it passes log_file_max_bytes (default 1 MiB) the
+  # oldest lines are dropped from the top, so it settles at roughly that size
+  # and never grows without bound. `jarvis logs -f` follows it either way.
+  # log_file_path: "~/.jarvis/logs/jarvis.log"
+  # log_file_max_bytes: 1048576
 
 # IANA timezone for cron triggers and morning/evening routines. Set this when
 # the server clock is not your local time (e.g. a UTC-hosted VPS).

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -308,6 +308,33 @@ morning/evening routines fire at your wall-clock time:
 timezone: "Europe/Rome"
 ```
 
+### Logs
+
+`jarvis start -d` redirects the detached daemon's output into
+`~/.jarvis/logs/jarvis.log`, and `jarvis logs [-f]` tails it. Under **systemd**
+or **Docker** that redirection does not happen: output goes to journald
+(`journalctl -u jarvis`) or `docker logs`, and there is no file. To get the same
+file in every launch mode, point the daemon at one:
+
+```yaml
+daemon:
+  log_file_path: "~/.jarvis/logs/jarvis.log"
+  log_file_max_bytes: 1048576   # optional, defaults to 1 MiB
+```
+
+The daemon then mirrors its own stdout and stderr into that file, on top of
+whatever the terminal or the service manager already receives. Lines are
+stripped of ANSI escapes, run through the credential redactor, and stamped with
+an ISO-8601 timestamp. The file is a ring: past `log_file_max_bytes` the oldest
+lines are dropped from the top, so it settles at roughly that size and never
+fills the disk. Leave `log_file_path` unset and no file is written.
+
+Two caveats. Set it to the SAME path `jarvis start -d` uses and the CLI notices
+and disables the sink in the child, so lines are not written twice - but any
+other duplicate redirection (a `StandardOutput=append:` in your own unit file,
+say) will double up. And output from subprocesses that inherit the daemon's file
+descriptors reaches the terminal and journald but not this file.
+
 ## Quick reference
 
 | | Single machine | LAN via IP | VPS + domain |

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -329,11 +329,31 @@ an ISO-8601 timestamp. The file is a ring: past `log_file_max_bytes` the oldest
 lines are dropped from the top, so it settles at roughly that size and never
 fills the disk. Leave `log_file_path` unset and no file is written.
 
-Two caveats. Set it to the SAME path `jarvis start -d` uses and the CLI notices
-and disables the sink in the child, so lines are not written twice - but any
-other duplicate redirection (a `StandardOutput=append:` in your own unit file,
-say) will double up. And output from subprocesses that inherit the daemon's file
-descriptors reaches the terminal and journald but not this file.
+`log_file_max_bytes` is a MEMORY budget too, not only a disk one: the window is
+kept in the daemon's heap so the file can be rewritten from it, so a 64 MiB cap
+costs ~64 MiB of RSS. Values below 4 KiB are raised and values above 64 MiB (or
+a non-finite one, which is what `log_file_max_bytes: .inf` gives you) are
+lowered, with a warning on stderr.
+
+Three caveats.
+
+- If something else already writes the daemon's stdout/stderr into that same
+  file - `jarvis start -d`, the launchd plist's `StandardOutPath`, a
+  `StandardOutput=append:` in your own unit - the daemon detects it (it compares
+  the inode behind fds 1 and 2 with the configured path) and does NOT install
+  the in-process sink. You get the launcher's file, uncapped and unredacted, and
+  the log says so at startup. That check exists because the two together are
+  actively harmful: the sink caps by renaming a fresh file over the path, which
+  would leave the launcher's descriptors appending to a deleted inode that grows
+  forever and that `ls` cannot show.
+- `jarvis logs -f` uses `tail -F`, and every compaction replaces the file, so
+  `tail` reopens it and re-prints the whole window. With the defaults that is
+  ~1 MiB of already-seen lines roughly every 256 KiB of new output. It is
+  inherent to capping a single file in place (rotation and truncate-in-place
+  make a tailer restart too). Raise `log_file_max_bytes` if it bothers you, or
+  follow journald instead.
+- Output from subprocesses that inherit the daemon's file descriptors reaches
+  the terminal and journald but not this file.
 
 ## Quick reference
 

--- a/src/cli/autostart.ts
+++ b/src/cli/autostart.ts
@@ -260,6 +260,12 @@ export function generateLaunchdPlist(): string {
   // getLogDir() so the plist's StandardOutPath matches where the daemon itself
   // resolves its log file (both honor JARVIS_HOME) — and the plist exports the
   // var below, so the launched daemon agrees with this path.
+  //
+  // launchd opens these two paths and hands the daemon the descriptors as fds
+  // 1/2. If daemon.log_file_path names the same file, the daemon detects that
+  // by inode (src/daemon/index.ts) and skips its in-process sink: the sink caps
+  // by renaming a fresh file over the path, which would leave launchd's
+  // descriptors appending to an unlinked inode that grows without bound.
   const logDir = getLogDir();
 
   return `<?xml version="1.0" encoding="UTF-8"?>

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -83,6 +83,12 @@ function defaultSpawn(cmd: string[], options: { cwd?: string } = {}): SpawnResul
  * Spawn the daemon in a detached process, same pattern as `jarvis start -d`.
  * Not in daemon-control.ts because it's update-specific: we only need to
  * restart after a successful update.
+ *
+ * The child gets fds 1/2 on getLogPath(). If daemon.log_file_path names that
+ * same file, the daemon compares the inode behind those fds with the configured
+ * path and skips its in-process sink (src/daemon/index.ts) - otherwise the
+ * sink's first compaction would rename a new file over the path and leave this
+ * descriptor appending to an unlinked inode forever.
  */
 function restartDaemonDetached(packageRoot: string): void {
   const logPath = getLogPath();

--- a/src/config/README.md
+++ b/src/config/README.md
@@ -134,12 +134,26 @@ file:
 - Every line is stripped of ANSI escapes, passed through `src/util/redact.ts`,
   and prefixed with an ISO-8601 timestamp, so the file carries no credentials
   and is safe for an operator to read.
-- The file is a ring capped at `log_file_max_bytes` (default 1 MiB, minimum
-  4 KiB). Past the cap the oldest lines are dropped from the top on line
-  boundaries; the rewrite is atomic (temp file + `rename`), which is why
-  `jarvis logs -f` uses `tail -F`.
+- The file is a ring capped at `log_file_max_bytes` (default 1 MiB, clamped to
+  4 KiB..64 MiB - `.inf` and other non-finite values fall back to the default).
+  Past the cap the oldest lines are dropped from the top on line boundaries; the
+  rewrite is atomic (temp file + `rename`), which is why `jarvis logs -f` uses
+  `tail -F` - and why a follower sees the whole window reprinted on every
+  compaction.
+- The ring lives in the daemon's heap, so the cap is an RSS budget as much as a
+  disk budget. The window is seeded from the tail of the existing file at
+  startup, so a restart (or a crash loop) does not throw away the previous run.
+- A single line is truncated to a quarter of the cap before it enters the ring,
+  so one huge payload cannot evict the whole window.
 - A path that cannot be opened or written degrades to "no file sink" with one
-  warning. The daemon never dies over its log file.
+  warning, and a file lost at runtime is retried and rebuilt from the ring. The
+  daemon never dies over its log file.
+- A FIFO or a symlink at the path is refused: `open(2)` on a FIFO with no reader
+  blocks forever, and the sink runs before anything else boots.
+- If the launcher already has the daemon's stdout/stderr open on that same file
+  (`jarvis start -d`, launchd's `StandardOutPath`, a `StandardOutput=append:`),
+  the daemon fstats fds 1/2 against the path and skips the sink entirely - the
+  two together would leave those descriptors writing to an unlinked inode.
 - Subprocesses spawned with `stdio: 'inherit'` write to the inherited
   descriptors from another process, so their output reaches the terminal and
   journald but not this file.

--- a/src/config/README.md
+++ b/src/config/README.md
@@ -116,8 +116,40 @@ daemon: {
   data_dir: string;      // Data directory path (default: ~/.jarvis)
   db_path: string;       // SQLite database path (default: ~/.jarvis/jarvis.db)
   public_url?: string;   // Public HTTPS origin behind a reverse proxy
+  log_file_path?: string;      // Mirror stdout/stderr to this file (unset = none)
+  log_file_max_bytes?: number; // Ring size for that file (default: 1 MiB)
 }
 ```
+
+#### `log_file_path`
+
+Jarvis only ever wrote a log file under `jarvis start -d` (the CLI redirects the
+detached child's file descriptors) and under launchd. Under systemd - how hosted
+instances run - and under Docker there is no file at all, so the only record is
+journald or the container runtime. Setting `log_file_path` installs an
+in-process sink (`src/util/log-file.ts`) that gives every launch mode the same
+file:
+
+- `~` is expanded on load; the parent directory is created if missing.
+- Every line is stripped of ANSI escapes, passed through `src/util/redact.ts`,
+  and prefixed with an ISO-8601 timestamp, so the file carries no credentials
+  and is safe for an operator to read.
+- The file is a ring capped at `log_file_max_bytes` (default 1 MiB, minimum
+  4 KiB). Past the cap the oldest lines are dropped from the top on line
+  boundaries; the rewrite is atomic (temp file + `rename`), which is why
+  `jarvis logs -f` uses `tail -F`.
+- A path that cannot be opened or written degrades to "no file sink" with one
+  warning. The daemon never dies over its log file.
+- Subprocesses spawned with `stdio: 'inherit'` write to the inherited
+  descriptors from another process, so their output reaches the terminal and
+  journald but not this file.
+
+Both keys live under `daemon:` rather than in a section of their own because
+`loadConfig` discards everything outside the system-owned sections - a
+top-level `logging:` block would be dropped on every load. Neither has an entry
+in `DEFAULT_CONFIG` (same as `drain_deadline_ms`): absent has to stay
+distinguishable from "set to the default", and the fallback is applied where
+the value is consumed.
 
 ### `llm`
 

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -191,6 +191,35 @@ google:
     expect(loaded.google?.client_id).toBe('company-client.apps.googleusercontent.com');
   });
 
+  test('log_file_path / log_file_max_bytes survive the user-section discard', async () => {
+    // They live under `daemon:` precisely because of that discard - a
+    // top-level `logging:` block would be dropped on every load (docs/LOGS.md,
+    // "The brain's side").
+    await Bun.write(
+      TEST_CONFIG_PATH,
+      'daemon:\n  log_file_path: /home/u_abc123/.jarvis/logs/jarvis.log\n  log_file_max_bytes: 2097152\n',
+    );
+    const loaded = await loadConfig(TEST_CONFIG_PATH);
+    expect(loaded.daemon.log_file_path).toBe('/home/u_abc123/.jarvis/logs/jarvis.log');
+    expect(loaded.daemon.log_file_max_bytes).toBe(2097152);
+  });
+
+  test('log_file_path is absent by default (no DEFAULT_CONFIG entry, no file written)', async () => {
+    expect(DEFAULT_CONFIG.daemon.log_file_path).toBeUndefined();
+    expect(DEFAULT_CONFIG.daemon.log_file_max_bytes).toBeUndefined();
+    await Bun.write(TEST_CONFIG_PATH, 'daemon:\n  port: 3142\n');
+    const loaded = await loadConfig(TEST_CONFIG_PATH);
+    expect(loaded.daemon.log_file_path).toBeUndefined();
+  });
+
+  test('expands ~ in log_file_path (openSync does not understand it)', async () => {
+    await Bun.write(TEST_CONFIG_PATH, 'daemon:\n  log_file_path: "~/.jarvis/logs/jarvis.log"\n');
+    const loaded = await loadConfig(TEST_CONFIG_PATH);
+    expect(loaded.daemon.log_file_path).not.toContain('~');
+    expect(isAbsolute(loaded.daemon.log_file_path!)).toBe(true);
+    expect(loaded.daemon.log_file_path).toEndWith('/.jarvis/logs/jarvis.log');
+  });
+
   test('loadConfig does not mutate DEFAULT_CONFIG', async () => {
     // Regression test: a previous implementation of deepMerge returned
     // DEFAULT_CONFIG by reference when the parsed YAML was empty/null, so

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -220,6 +220,19 @@ google:
     expect(loaded.daemon.log_file_path).toEndWith('/.jarvis/logs/jarvis.log');
   });
 
+  test('a non-string log_file_path is dropped, not fatal', async () => {
+    // `log_file_path: true` made expandTilde throw "filepath.startsWith is not
+    // a function", and the daemon then exited reporting "Failed to parse config
+    // file" - which is not what was wrong with it.
+    for (const value of ['true', '42', '[a, b]']) {
+      await Bun.write(TEST_CONFIG_PATH, `daemon:\n  log_file_path: ${value}\n`);
+      const loaded = await loadConfig(TEST_CONFIG_PATH);
+      expect(loaded.daemon.log_file_path).toBeUndefined();
+      // And the rest of the config still loads.
+      expect(loaded.daemon.port).toBe(DEFAULT_CONFIG.daemon.port);
+    }
+  });
+
   test('loadConfig does not mutate DEFAULT_CONFIG', async () => {
     // Regression test: a previous implementation of deepMerge returned
     // DEFAULT_CONFIG by reference when the parsed YAML was empty/null, so

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -5,10 +5,36 @@ import type { JarvisConfig } from './types.ts';
 import { DEFAULT_CONFIG, USER_OWNED_SECTIONS, WORKFLOW_SYSTEM_KEYS } from './types.ts';
 
 function expandTilde(filepath: string): string {
+  // YAML happily produces a boolean, a number or null for a key that LOOKS
+  // like a path (`log_file_path: true`, `log_file_path: 42`), and this used to
+  // throw `filepath.startsWith is not a function` from inside loadConfig - so
+  // the daemon died reporting "Failed to parse config file", which is not what
+  // went wrong. Hand a non-string straight back and let the caller decide.
+  if (typeof filepath !== 'string') return filepath;
   if (filepath.startsWith('~/')) {
     return join(homedir(), filepath.slice(2));
   }
   return filepath;
+}
+
+/**
+ * Drop `daemon.log_file_path` unless it is actually a string. Everything
+ * downstream calls `.trim()` and `openSync()` on it, and a YAML `true` or `42`
+ * would take the daemon down at boot with a misleading parse error.
+ */
+function normalizeLogFilePath(config: JarvisConfig): void {
+  const value = config.daemon.log_file_path as unknown;
+  if (value === undefined || value === null) {
+    config.daemon.log_file_path = undefined;
+    return;
+  }
+  if (typeof value !== 'string') {
+    console.warn(`daemon.log_file_path must be a string, got ${typeof value}; ignoring it (no log file will be written)`);
+    config.daemon.log_file_path = undefined;
+    return;
+  }
+  // The sink opens this with openSync, which does not understand `~`.
+  config.daemon.log_file_path = expandTilde(value);
 }
 
 export function deepMerge(target: any, source: any): any {
@@ -111,9 +137,7 @@ export async function loadConfig(configPath?: string): Promise<JarvisConfig> {
     // log_file_path has no default, so there is nothing to expand here - but
     // the two branches must stay symmetrical or the next key added to one of
     // them gets expanded in only half the cases.
-    if (config.daemon.log_file_path) {
-      config.daemon.log_file_path = expandTilde(config.daemon.log_file_path);
-    }
+    normalizeLogFilePath(config);
     applyEnvOverrides(config);
     return config;
   }
@@ -140,10 +164,7 @@ export async function loadConfig(configPath?: string): Promise<JarvisConfig> {
   // Expand tilde in paths
   config.daemon.data_dir = expandTilde(config.daemon.data_dir);
   config.daemon.db_path = expandTilde(config.daemon.db_path);
-  // The sink opens this with openSync, which does not understand `~`.
-  if (config.daemon.log_file_path) {
-    config.daemon.log_file_path = expandTilde(config.daemon.log_file_path);
-  }
+  normalizeLogFilePath(config);
 
   // Apply environment variable overrides
   applyEnvOverrides(config);

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -108,6 +108,12 @@ export async function loadConfig(configPath?: string): Promise<JarvisConfig> {
     const config = structuredClone(DEFAULT_CONFIG);
     config.daemon.data_dir = expandTilde(config.daemon.data_dir);
     config.daemon.db_path = expandTilde(config.daemon.db_path);
+    // log_file_path has no default, so there is nothing to expand here - but
+    // the two branches must stay symmetrical or the next key added to one of
+    // them gets expanded in only half the cases.
+    if (config.daemon.log_file_path) {
+      config.daemon.log_file_path = expandTilde(config.daemon.log_file_path);
+    }
     applyEnvOverrides(config);
     return config;
   }
@@ -134,6 +140,10 @@ export async function loadConfig(configPath?: string): Promise<JarvisConfig> {
   // Expand tilde in paths
   config.daemon.data_dir = expandTilde(config.daemon.data_dir);
   config.daemon.db_path = expandTilde(config.daemon.db_path);
+  // The sink opens this with openSync, which does not understand `~`.
+  if (config.daemon.log_file_path) {
+    config.daemon.log_file_path = expandTilde(config.daemon.log_file_path);
+  }
 
   // Apply environment variable overrides
   applyEnvOverrides(config);

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -577,7 +577,15 @@ export type JarvisConfig = {
      * Ring size for `log_file_path`, in bytes. Default 1 MiB, which is also
      * the control plane's per-read cap. Once the file passes the cap the
      * oldest lines are dropped from the top, so it settles at roughly this
-     * size and never grows without bound. Values under 4 KiB are raised.
+     * size and never grows without bound.
+     *
+     * The ring is held IN MEMORY - that is what the file is rewritten from -
+     * so this is an RSS budget as much as a disk budget. Clamped to
+     * 4 KiB..64 MiB at the point of use: below the floor a rewrite costs more
+     * than it saves, and above the ceiling the daemon pays for a window nobody
+     * reads. Non-finite values fall back to the default, because
+     * `log_file_max_bytes: .inf` is legal YAML and used to mean "never
+     * compact, grow until the OOM killer arrives".
      */
     log_file_max_bytes?: number;
   };

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -550,6 +550,36 @@ export type JarvisConfig = {
      * drain finishes before SIGKILL. Default 75s.
      */
     drain_deadline_ms?: number;
+    /**
+     * Where to mirror this daemon's stdout/stderr as a size-capped, redacted
+     * file. Unset (the default) means no file is written.
+     *
+     * Under systemd - how the hosted fleet runs it, and `jarvis@.service`
+     * carries no `StandardOutput=` - and under Docker there is no log file at
+     * all, so the only record is journald or the container runtime and the
+     * hosting control plane has nothing per instance to read (docs/LOGS.md,
+     * "The brain's side"). Hosted instances get
+     * `/home/u_<id>/.jarvis/logs/jarvis.log` rendered by the control plane; it
+     * has to sit under the instance's home because the unit is
+     * `ProtectSystem=strict` with `ReadWritePaths=/home/%i /run/jarvis`.
+     *
+     * Lives under `daemon:` (rather than a `logging:` section of its own)
+     * because loadConfig DISCARDS every section outside the system-owned set -
+     * see USER_OWNED_SECTIONS below. A new top-level key would be silently
+     * dropped on every load. `~/` is expanded by loadConfig.
+     *
+     * No DEFAULT_CONFIG entry, on the drain_deadline_ms precedent: absent must
+     * stay distinguishable from "set to the default", and the fallback is
+     * applied where the value is consumed (src/util/log-file.ts).
+     */
+    log_file_path?: string;
+    /**
+     * Ring size for `log_file_path`, in bytes. Default 1 MiB, which is also
+     * the control plane's per-read cap. Once the file passes the cap the
+     * oldest lines are dropped from the top, so it settles at roughly this
+     * size and never grows without bound. Values under 4 KiB are raised.
+     */
+    log_file_max_bytes?: number;
   };
   auth?: AuthConfig;
   /**

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -14,7 +14,7 @@ import { flushWindowState } from "./window-state.ts";
 import { ServiceRegistry } from "./services.ts";
 import { HealthMonitor } from "./health.ts";
 import { loadConfig } from "../config/loader.ts";
-import { installLogFileSink } from "../util/log-file.ts";
+import { installLogFileSink, logFileIsProcessStdio } from "../util/log-file.ts";
 import { resolveEngineIdleTtlMs } from "./config-merge.ts";
 import { activeTurns } from "./active-turns.ts";
 import { writeLockedPort } from "./pid.ts";
@@ -383,10 +383,24 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
   // there is no per-instance file for the control plane to read (docs/LOGS.md).
   // Unset log_file_path = no file, which is the self-host default.
   const logFilePath = jarvisConfig.daemon.log_file_path?.trim();
-  if (logFilePath && process.env.JARVIS_NO_LOG_FILE_SINK !== '1') {
-    installLogFileSink({ path: logFilePath, maxBytes: jarvisConfig.daemon.log_file_max_bytes });
-    // Logged AFTER the install so the file's own first line says where it is.
-    console.log(`[Daemon] Log file: ${logFilePath}`);
+  if (logFilePath) {
+    // Skip the sink when the launcher ALREADY has our stdout/stderr open on
+    // that exact file - `jarvis start -d`, `jarvis update`'s restart, the
+    // launchd plist's StandardOutPath, a StandardOutput=append: someone put in
+    // their own unit. Those hand us a descriptor bound to an inode, and the
+    // sink's first compaction renames a new file over the path, leaving fds
+    // 1/2 writing into an unlinked inode that grows without bound and that
+    // `ls` cannot show (measured: 4 KB visible, 226 KB orphaned, nlink=0).
+    // fstat on dev+ino rather than a string compare in each launcher, so this
+    // covers launchers we have not written yet and is immune to symlinks,
+    // bind mounts and $JARVIS_HOME spellings of the same file.
+    if (logFileIsProcessStdio(logFilePath)) {
+      console.log(`[Daemon] Log file: ${logFilePath} (written directly by the launcher; in-process sink not needed)`);
+    } else {
+      installLogFileSink({ path: logFilePath, maxBytes: jarvisConfig.daemon.log_file_max_bytes });
+      // Logged AFTER the install so the file's own first line says where it is.
+      console.log(`[Daemon] Log file: ${logFilePath}`);
+    }
   }
 
   // Drain budget: default 75s; a non-positive value falls back; cap at 85s so a

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -14,6 +14,7 @@ import { flushWindowState } from "./window-state.ts";
 import { ServiceRegistry } from "./services.ts";
 import { HealthMonitor } from "./health.ts";
 import { loadConfig } from "../config/loader.ts";
+import { installLogFileSink } from "../util/log-file.ts";
 import { resolveEngineIdleTtlMs } from "./config-merge.ts";
 import { activeTurns } from "./active-turns.ts";
 import { writeLockedPort } from "./pid.ts";
@@ -374,6 +375,18 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
     console.error(`\n[Daemon] Failed to parse config file: ${message}`);
     console.error('[Daemon] Fix the YAML syntax in ~/.jarvis/config.yaml or delete it to use defaults.\n');
     process.exit(1);
+  }
+
+  // File sink, installed here - the first thing after the config is readable
+  // and before anything else boots - so the log captures startup too. A hosted
+  // brain is a plain systemd process with no `StandardOutput=`, so without this
+  // there is no per-instance file for the control plane to read (docs/LOGS.md).
+  // Unset log_file_path = no file, which is the self-host default.
+  const logFilePath = jarvisConfig.daemon.log_file_path?.trim();
+  if (logFilePath && process.env.JARVIS_NO_LOG_FILE_SINK !== '1') {
+    installLogFileSink({ path: logFilePath, maxBytes: jarvisConfig.daemon.log_file_max_bytes });
+    // Logged AFTER the install so the file's own first line says where it is.
+    console.log(`[Daemon] Log file: ${logFilePath}`);
   }
 
   // Drain budget: default 75s; a non-positive value falls back; cap at 85s so a

--- a/src/util/log-file.test.ts
+++ b/src/util/log-file.test.ts
@@ -1,9 +1,9 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
-import { readFileSync, statSync } from 'node:fs';
+import { chmodSync, closeSync, existsSync, mkdirSync, openSync, readFileSync, readdirSync, statSync, symlinkSync, writeFileSync } from 'node:fs';
 import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
-import { installLogFileSink } from './log-file.ts';
+import { dirname, join } from 'node:path';
+import { installLogFileSink, logFileIsProcessStdio } from './log-file.ts';
 
 let DIR: string;
 let LOG: string;
@@ -19,11 +19,56 @@ afterEach(async () => {
   // would leave every later test in the file writing through a dead sink.
   uninstall?.();
   uninstall = null;
+  try {
+    // A test that chmod'ed the log dir read-only to force a failure would
+    // otherwise make the cleanup fail too.
+    chmodSync(dirname(LOG), 0o755);
+  } catch {
+    // Directory may not exist. Nothing to relax.
+  }
   await rm(DIR, { recursive: true, force: true });
 });
 
 function read(): string {
   return readFileSync(LOG, 'utf8');
+}
+
+/** Lines of the log file that carry `needle`, timestamp prefix stripped. */
+function linesWith(needle: string): string[] {
+  return read()
+    .split('\n')
+    .filter((l) => l.includes(needle));
+}
+
+/**
+ * Run `fn` with stderr captured, returning what the sink wrote to it. The
+ * sink's warnings go to the ORIGINAL stderr write on purpose (console.warn
+ * would recurse through the patched stream), so a plain spy sees them.
+ */
+function withCapturedStderr(fn: () => void): string {
+  const errs: string[] = [];
+  const realErr = process.stderr.write.bind(process.stderr);
+  process.stderr.write = ((chunk: unknown) => {
+    if (typeof chunk === 'string') errs.push(chunk);
+    return true;
+  }) as typeof process.stderr.write;
+  try {
+    fn();
+  } finally {
+    process.stderr.write = realErr;
+  }
+  return errs.join('');
+}
+
+/** Swallow stdout while a burst runs: 4 MB of filler in the test log helps nobody. */
+function quietStdout<T>(fn: () => T): T {
+  const realWrite = process.stdout.write;
+  process.stdout.write = (() => true) as typeof process.stdout.write;
+  try {
+    return fn();
+  } finally {
+    process.stdout.write = realWrite;
+  }
 }
 
 describe('installLogFileSink', () => {
@@ -34,42 +79,80 @@ describe('installLogFileSink', () => {
     uninstall();
     uninstall = null;
 
-    const lines = read().trimEnd().split('\n');
-    expect(lines).toHaveLength(2);
-    expect(lines[0]).toMatch(/^\d{4}-\d{2}-\d{2}T[\d:.]+Z hello from the daemon$/);
-    expect(lines[1]).toMatch(/^\d{4}-\d{2}-\d{2}T[\d:.]+Z and from stderr$/);
+    // Match the lines we wrote rather than counting every line in the file:
+    // bun's own reporter can write to stdout mid-test, and an exact count made
+    // this fail for reasons that had nothing to do with the sink.
+    const out = linesWith('hello from the daemon');
+    const err = linesWith('and from stderr');
+    expect(out).toHaveLength(1);
+    expect(err).toHaveLength(1);
+    expect(out[0]).toMatch(/^\d{4}-\d{2}-\d{2}T[\d:.]+Z hello from the daemon$/);
+    expect(err[0]).toMatch(/^\d{4}-\d{2}-\d{2}T[\d:.]+Z and from stderr$/);
   });
 
   test('strips ANSI escapes (src/cli/helpers.ts colours unconditionally)', () => {
     uninstall = installLogFileSink({ path: LOG });
     process.stdout.write('\x1b[36mJ.A.R.V.I.S.\x1b[0m \x1b[2mv0.13.0\x1b[0m\n');
+    // OSC (a terminal title / hyperlink), an 8-bit CSI and a charset
+    // designation: the tightened, ReDoS-proof pattern has to keep covering
+    // every shape the loose ansi-regex one did.
+    process.stdout.write('\x1b]0;jarvis\x07\x9b1mbold\x9b0m \x1b(Bplain\n');
     uninstall();
     uninstall = null;
 
     const body = read();
     expect(body).toContain('J.A.R.V.I.S. v0.13.0');
+    expect(body).toContain('bold plain');
     expect(body).not.toContain('\x1b');
+    expect(body).not.toContain('\x9b');
     expect(body).not.toContain('[36m');
+  });
+
+  test('a pathological escape run does not stall the sink (CVE-2021-3807 shape)', () => {
+    // The ansi-regex pattern this replaced took 200-400ms on ONE line of
+    // `ESC` + 10-20k semicolons, and log lines carry text jarvis echoes back.
+    const elapsed = quietStdout(() => {
+      uninstall = installLogFileSink({ path: LOG });
+      const started = performance.now();
+      for (let i = 0; i < 20; i++) process.stdout.write(`\x1b${';'.repeat(20_000)} evil\n`);
+      const took = performance.now() - started;
+      uninstall!();
+      uninstall = null;
+      return took;
+    });
+
+    expect(linesWith('evil')).toHaveLength(20);
+    // Generous by 20x against the ~4s the old pattern needed for 20 lines.
+    expect(elapsed).toBeLessThan(2000);
   });
 
   test('redacts credential-shaped material before it reaches disk', () => {
     uninstall = installLogFileSink({ path: LOG });
     console.error('proxy rejected sk-uj-AAAAAAAAAAAAAAAAAAAAAAAA');
     console.error('Authorization: Bearer abcdefghijklmnopqrstuvwxyz012345');
+    // The shapes a log file specifically exposes: every telegram.ts request
+    // URL carries a bot token, and an operator gets handed this file.
+    console.error('GET https://api.telegram.org/bot7123456789:AAHfK3n2xYz-QwErTyUiOpAsDfGhJkLzXcV/getMe');
+    console.error('gh auth ghp_AbCdEfGhIjKlMnOpQrStUvWxYz0123456789AB');
+    console.error('callback ?token=Zk9vQmFyQmF6UXV4MTIzNDU2Nzg5MA&state=x');
     uninstall();
     uninstall = null;
 
     const body = read();
     expect(body).not.toContain('sk-uj-AAAA');
     expect(body).not.toContain('abcdefghijklmnop');
+    expect(body).not.toContain('AAHfK3n2xYz');
+    expect(body).not.toContain('ghp_AbCdEfGh');
+    expect(body).not.toContain('Zk9vQmFyQmF6');
     expect(body).toContain('***redacted***');
   });
 
   test("captures console.* even though bun's console bypasses process.stdout.write", () => {
     // Regression guard for the whole feature: on bun 1.3.8 console.log writes
     // straight to fd 1, so a stream-only patch records none of jarvis's ~1150
-    // console.* call sites. If this ever passes with the console wrapper
-    // removed, the runtime changed and the wrapper can go.
+    // console.* call sites. The stacked spy below is what installLogFileSink
+    // captures as its "original" write, so anything console.* routed through
+    // the stream would land in `seenByStream`.
     const seenByStream: string[] = [];
     const realWrite = process.stdout.write;
     process.stdout.write = ((chunk: unknown, ...rest: unknown[]) => {
@@ -81,6 +164,7 @@ describe('installLogFileSink', () => {
       uninstall = installLogFileSink({ path: LOG });
       console.log('tier %s picked in %dms', 'medium', 12);
       console.log('an object:', { id: 7 });
+      process.stdout.write('RAW-OUT\n');
       uninstall();
       uninstall = null;
     } finally {
@@ -91,7 +175,27 @@ describe('installLogFileSink', () => {
     expect(body).toContain('tier medium picked in 12ms');
     expect(body).toContain('an object: { id: 7 }');
     // Exactly once, not once per capture path.
-    expect(body.split('\n').filter((l) => l.includes('tier medium'))).toHaveLength(1);
+    expect(linesWith('tier medium')).toHaveLength(1);
+
+    // The claim this test is named for: an explicit stream write IS seen by a
+    // stacked stream patch, and console.log is NOT. If the second assertion
+    // ever fails, bun started routing console through the stream and the
+    // console wrapper in log-file.ts can go.
+    expect(seenByStream.join('')).toContain('RAW-OUT');
+    expect(seenByStream.join('')).not.toContain('tier medium');
+  });
+
+  test('console.trace is captured (its native stack frames are not)', () => {
+    // console.trace goes to stderr and is in CONSOLE_METHODS, so the message
+    // lands. Bun renders the stack itself, below the formatted args, so the
+    // frames never reach `format(...)` and are terminal-only. Documented
+    // rather than fixed: the message is what makes the line searchable.
+    uninstall = installLogFileSink({ path: LOG });
+    console.trace('drain took the slow path');
+    uninstall();
+    uninstall = null;
+
+    expect(linesWith('drain took the slow path')).toHaveLength(1);
   });
 
   test('reassembles a line split across writes, and flushes the tail on uninstall', () => {
@@ -104,10 +208,70 @@ describe('installLogFileSink', () => {
     uninstall();
     uninstall = null;
 
-    const lines = read().trimEnd().split('\n');
-    expect(lines).toHaveLength(2);
-    expect(lines[0]).toEndWith('one line in three writes');
-    expect(lines[1]).toEndWith('unterminated tail');
+    expect(linesWith('one line in three writes')).toHaveLength(1);
+    expect(linesWith('unterminated tail')).toHaveLength(1);
+  });
+
+  test('decodes Uint8Array writes, including a multi-byte char split across two', () => {
+    // The Buffer path had no coverage at all. A chunked write can cut a UTF-8
+    // sequence in half, and decoding each chunk on its own would put a U+FFFD
+    // where the accented letter was - StringDecoder holds the tail back.
+    uninstall = installLogFileSink({ path: LOG });
+    const bytes = Buffer.from('caffè latte\n', 'utf8');
+    process.stdout.write(bytes.subarray(0, 5));
+    process.stdout.write(bytes.subarray(5));
+    // A typed array that is a view into a larger buffer must not drag its
+    // neighbours in: the sink slices by byteOffset/byteLength.
+    const backing = Buffer.from('XXXsecond line\nYYY', 'utf8');
+    process.stdout.write(new Uint8Array(backing.buffer, backing.byteOffset + 3, 12));
+    uninstall();
+    uninstall = null;
+
+    const body = read();
+    expect(body).toContain('caffè latte');
+    expect(body).not.toContain('�');
+    expect(linesWith('second line')).toHaveLength(1);
+    expect(body).not.toContain('XXX');
+    expect(body).not.toContain('YYY');
+  });
+
+  test('\\r\\n ends one line, and a bare \\r flushes instead of buffering forever', () => {
+    // A progress renderer redraws with `\r` and may never emit `\n`. Holding
+    // those grew `pending` without bound: 20k frames made one 649 KB string,
+    // +52 MB of heap and seconds of rescanning, with nothing on disk.
+    uninstall = installLogFileSink({ path: LOG });
+    process.stdout.write('crlf line\r\nnext line\n');
+    process.stdout.write('\rframe 1\rframe 2\rframe 3\n');
+    const whileSpinning = statSync(LOG).size;
+    uninstall();
+    uninstall = null;
+
+    expect(linesWith('crlf line')).toHaveLength(1);
+    expect(read()).not.toContain('\r');
+    expect(linesWith('next line')).toHaveLength(1);
+    expect(linesWith('frame 1')).toHaveLength(1);
+    expect(linesWith('frame 2')).toHaveLength(1);
+    expect(linesWith('frame 3')).toHaveLength(1);
+    // The bare `\r` before "frame 1" is a redraw of an empty frame, not a
+    // blank line the process logged.
+    expect(read().split('\n').filter((l) => /Z $/.test(l))).toHaveLength(0);
+    expect(whileSpinning).toBeGreaterThan(0);
+  });
+
+  test('a terminator-free stream is flushed at the pending cap, not buffered forever', () => {
+    const beforeUninstall = quietStdout(() => {
+      uninstall = installLogFileSink({ path: LOG });
+      // 96 KiB with no newline anywhere: past the 64 KiB pending budget.
+      for (let i = 0; i < 96; i++) process.stdout.write('z'.repeat(1024));
+      const size = statSync(LOG).size;
+      uninstall!();
+      uninstall = null;
+      return size;
+    });
+
+    // Flushed while the stream was still running, not only at uninstall.
+    expect(beforeUninstall).toBeGreaterThan(0);
+    expect(read()).toContain('zzzz');
   });
 
   test('stdout and stderr partial lines do not splice into each other', () => {
@@ -118,20 +282,14 @@ describe('installLogFileSink', () => {
     uninstall();
     uninstall = null;
 
-    const lines = read().trimEnd().split('\n');
-    expect(lines[0]).toEndWith('ERR-whole');
-    expect(lines[1]).toEndWith('OUT-head OUT-tail');
+    expect(linesWith('ERR-whole')).toHaveLength(1);
+    expect(linesWith('OUT-head OUT-tail')).toHaveLength(1);
   });
 
   test('the cap holds under a multi-MB burst, dropping the oldest lines first', () => {
     const total = 20_000;
     const maxBytes = 64 * 1024;
-    // Swallow the burst on the way to the terminal: the sink captures whatever
-    // write it finds installed, and 4 MB of filler in the test output helps
-    // nobody.
-    const realWrite = process.stdout.write;
-    process.stdout.write = (() => true) as typeof process.stdout.write;
-    try {
+    quietStdout(() => {
       uninstall = installLogFileSink({ path: LOG, maxBytes });
 
       // ~4 MB of output through a 64 KiB window: ~64 compactions.
@@ -140,9 +298,7 @@ describe('installLogFileSink', () => {
 
       uninstall();
       uninstall = null;
-    } finally {
-      process.stdout.write = realWrite;
-    }
+    });
 
     const size = statSync(LOG).size;
     expect(size).toBeLessThanOrEqual(maxBytes * 1.25);
@@ -157,6 +313,57 @@ describe('installLogFileSink', () => {
     // And the file still starts on a line boundary: the ring only ever holds
     // whole lines, so a rewrite can never begin mid-line.
     expect(body.split('\n')[0]).toMatch(/^\d{4}-\d{2}-\d{2}T[\d:.]+Z line \d+ x+$/);
+  });
+
+  test('one oversized line is truncated instead of evicting the whole window', () => {
+    // The eviction loop stops at `ring.length > 1`, so a single
+    // `console.log(JSON.stringify(big))` used to leave the file holding that
+    // one line and nothing else - and the line after it left the file at 37
+    // bytes. The context around a huge payload is the useful part.
+    quietStdout(() => {
+      uninstall = installLogFileSink({ path: LOG, maxBytes: 4096 });
+      process.stdout.write('small-before\n');
+      process.stdout.write(`${'B'.repeat(20_000)}\n`);
+      process.stdout.write('small-after\n');
+      uninstall();
+      uninstall = null;
+    });
+
+    const body = read();
+    expect(body).toContain('small-before');
+    expect(body).toContain('small-after');
+    expect(body).toContain('truncated by the log sink');
+    // 4096 / 4 is the per-line budget, so nothing close to 20 KB survives.
+    expect(body).not.toContain('B'.repeat(2000));
+    expect(statSync(LOG).size).toBeLessThanOrEqual(4096 * 1.25);
+  });
+
+  test('a restart keeps the previous run\'s tail (the ring is seeded from disk)', () => {
+    // The ring started empty while the byte counter started at the existing
+    // file's size, so the first compaction after a restart replaced the file
+    // with only the new session's lines. A crash loop erased the healthy run
+    // - confirmed gone by restart 4 - which is exactly the log an operator
+    // needs.
+    mkdirSync(dirname(LOG), { recursive: true });
+    const history = Array.from({ length: 100 }, (_, i) => `preexisting ${i} ${'h'.repeat(24)}`).join('\n');
+    writeFileSync(LOG, `${history}\n`);
+    const before = statSync(LOG).size;
+
+    quietStdout(() => {
+      uninstall = installLogFileSink({ path: LOG, maxBytes: 4096 });
+      // Enough to push past compactAt (4096 * 1.25) and force a rewrite.
+      for (let i = 0; i < 20; i++) process.stdout.write(`session2 ${i} ${'n'.repeat(40)}\n`);
+      uninstall();
+      uninstall = null;
+    });
+
+    const body = read();
+    expect(before).toBeGreaterThan(4096 * 0.9);
+    expect(body).toContain('session2 19 ');
+    // The newest history survived the rewrite; only the oldest was evicted.
+    expect(body).toContain('preexisting 99 ');
+    expect(body).not.toContain('preexisting 0 ');
+    expect(statSync(LOG).size).toBeLessThanOrEqual(4096 * 1.25);
   });
 
   test('the original write still receives everything, unmodified', () => {
@@ -208,8 +415,7 @@ describe('installLogFileSink', () => {
 
     expect(process.stdout.write).toBe(before);
     expect(console.log).toBe(beforeLog);
-    const hits = read().split('\n').filter((l) => l.includes('only once please'));
-    expect(hits).toHaveLength(1);
+    expect(linesWith('only once please')).toHaveLength(1);
   });
 
   test('an unopenable path degrades to no sink instead of throwing', async () => {
@@ -217,31 +423,188 @@ describe('installLogFileSink', () => {
     await writeFile(blocker, 'i am a regular file');
     const bad = join(blocker, 'nested', 'jarvis.log');
 
-    const errs: string[] = [];
-    const realErr = process.stderr.write.bind(process.stderr);
-    process.stderr.write = ((chunk: unknown) => {
-      if (typeof chunk === 'string') errs.push(chunk);
-      return true;
-    }) as typeof process.stderr.write;
-    const spyErr = process.stderr.write;
-
     // A holder rather than a `let`: TS narrows a plain local to `null` when the
     // only assignment happens inside a callback.
     const stop: { fn: (() => void) | null } = { fn: null };
-    try {
+    let spyErr: typeof process.stderr.write | null = null;
+    const errs = withCapturedStderr(() => {
+      spyErr = process.stderr.write;
       expect(() => {
         stop.fn = installLogFileSink({ path: bad });
       }).not.toThrow();
       // Bailed out before patching anything, so the daemon keeps logging
       // exactly as it did before.
-      expect(process.stderr.write).toBe(spyErr);
+      expect(process.stderr.write).toBe(spyErr!);
       console.log('still alive');
+    });
+    stop.fn?.();
+
+    expect(errs).toContain('[LogFile]');
+    expect(errs).toContain('continuing without a log file');
+  });
+
+  test('refuses a FIFO at log_file_path instead of hanging the daemon forever', () => {
+    // `openSync(fifo, 'a')` blocks until a reader appears, and the sink is
+    // installed before anything else boots - so startDaemon never returned and
+    // no supervisor restarted it, because nothing had crashed. Jarvis runs
+    // shell commands as its own user, so `mkfifo ~/.jarvis/logs/jarvis.log` is
+    // inside the threat model.
+    mkdirSync(dirname(LOG), { recursive: true });
+    const made = Bun.spawnSync(['mkfifo', LOG]);
+    expect(made.exitCode).toBe(0);
+
+    const before = process.stdout.write;
+    const stop: { fn: (() => void) | null } = { fn: null };
+    const errs = withCapturedStderr(() => {
+      stop.fn = installLogFileSink({ path: LOG });
+    });
+    stop.fn?.();
+
+    expect(process.stdout.write).toBe(before);
+    expect(errs).toContain('is not a regular file');
+    expect(errs).toContain('continuing without a log file');
+  });
+
+  test('refuses a symlink at log_file_path (the hosted reader will not follow one either)', () => {
+    mkdirSync(dirname(LOG), { recursive: true });
+    const target = join(DIR, 'elsewhere.log');
+    writeFileSync(target, '');
+    symlinkSync(target, LOG);
+
+    const before = process.stdout.write;
+    const stop: { fn: (() => void) | null } = { fn: null };
+    const errs = withCapturedStderr(() => {
+      stop.fn = installLogFileSink({ path: LOG });
+    });
+    stop.fn?.();
+
+    expect(process.stdout.write).toBe(before);
+    expect(errs).toContain('is not a regular file');
+  });
+
+  test('the cap is clamped at both ends (it is an in-memory ring, so also an RSS budget)', () => {
+    const tiny = withCapturedStderr(() => {
+      installLogFileSink({ path: LOG, maxBytes: 10 })();
+    });
+    expect(tiny).toContain('out of range');
+    expect(tiny).toContain('using 4096');
+
+    // `log_file_max_bytes: .inf` is legal YAML and gave maxBytes = Infinity:
+    // the ring then never compacted and grew until the daemon was OOM-killed.
+    const infinite = withCapturedStderr(() => {
+      installLogFileSink({ path: LOG, maxBytes: Number.POSITIVE_INFINITY })();
+    });
+    expect(infinite).toContain('out of range');
+    expect(infinite).toContain('using 1048576');
+
+    // 1e12 asks for a 1 TB resident buffer.
+    const huge = withCapturedStderr(() => {
+      installLogFileSink({ path: LOG, maxBytes: 1e12 })();
+    });
+    expect(huge).toContain('out of range');
+    expect(huge).toContain(`using ${64 * 1024 * 1024}`);
+
+    // A value inside the range is used as-is and says nothing.
+    const fine = withCapturedStderr(() => {
+      installLogFileSink({ path: LOG, maxBytes: 65_536 })();
+    });
+    expect(fine).toBe('');
+  });
+
+  test('a compaction failure warns once and recovers when the path works again', () => {
+    // A transient failure used to disable the sink for the life of the
+    // process: one `rm -rf ~/.jarvis/logs` or one ENOSPC meant no log file
+    // until the next restart.
+    const logDir = dirname(LOG);
+    mkdirSync(logDir, { recursive: true });
+    const line = `filler ${'f'.repeat(100)}`;
+
+    const maxBytes = 64 * 1024;
+    const errs = withCapturedStderr(() => {
+      quietStdout(() => {
+        uninstall = installLogFileSink({ path: LOG, maxBytes });
+        // Read-only directory: the compaction temp file cannot be created.
+        chmodSync(logDir, 0o500);
+        for (let i = 0; i < 700; i++) process.stdout.write(`down ${i} ${line}\n`);
+        chmodSync(logDir, 0o755);
+        // More than the retry throttle, so the sink reopens and replays the ring.
+        for (let i = 0; i < 300; i++) process.stdout.write(`back ${i} ${line}\n`);
+        uninstall!();
+        uninstall = null;
+      });
+    });
+
+    expect(errs).toContain('[LogFile]');
+    expect(errs).toContain('could not rewrite');
+    expect(errs).toContain('retrying in the background');
+    // Warned ONCE, not once per failed compaction.
+    expect(errs.split('[LogFile]').length - 1).toBe(1);
+
+    expect(existsSync(LOG)).toBe(true);
+    const body = read();
+    expect(body).toContain('back 299 ');
+    // The ring kept filling while the file was unwritable, so the recovered
+    // file carries lines from the outage - they are not lost with it.
+    expect(body).toContain('down 699 ');
+    expect(statSync(LOG).size).toBeLessThanOrEqual(maxBytes * 1.25);
+  });
+
+  test('cleans stale <path>.<pid>.tmp siblings left by a crash mid-compaction', () => {
+    mkdirSync(dirname(LOG), { recursive: true });
+    const mine = `${LOG}.${process.pid}.tmp`;
+    // pid 1 always exists (init / launchd), so this one belongs to a live
+    // process and must be left alone.
+    const live = `${LOG}.1.tmp`;
+    const unrelated = `${LOG}.keep`;
+    writeFileSync(mine, 'x');
+    writeFileSync(live, 'x');
+    writeFileSync(unrelated, 'x');
+
+    uninstall = installLogFileSink({ path: LOG });
+    uninstall();
+    uninstall = null;
+
+    const left = readdirSync(dirname(LOG));
+    expect(left).not.toContain(`jarvis.log.${process.pid}.tmp`);
+    expect(left).toContain('jarvis.log.1.tmp');
+    expect(left).toContain('jarvis.log.keep');
+  });
+});
+
+describe('logFileIsProcessStdio', () => {
+  test('matches on dev+ino, so a launcher redirect is detected by any spelling', () => {
+    // Without this the sink installs on a file the launcher already has open
+    // as fds 1/2, and the first compaction's rename leaves those descriptors
+    // writing into an unlinked inode that grows forever and that `ls` cannot
+    // show (measured: 4 KB visible, 226 KB orphaned, nlink=0).
+    mkdirSync(dirname(LOG), { recursive: true });
+    writeFileSync(LOG, '');
+    const other = join(DIR, 'other.log');
+    writeFileSync(other, '');
+
+    const onLog = openSync(LOG, 'a');
+    const onOther = openSync(other, 'a');
+    try {
+      expect(logFileIsProcessStdio(LOG, [onLog])).toBe(true);
+      expect(logFileIsProcessStdio(LOG, [onOther])).toBe(false);
+      // Any of the fds matching is enough: launchd redirects stdout and
+      // stderr to two different files.
+      expect(logFileIsProcessStdio(LOG, [onOther, onLog])).toBe(true);
+      // A symlinked spelling of the same file is the same inode, which a
+      // string compare in each launcher would have missed.
+      const alias = join(DIR, 'alias.log');
+      symlinkSync(LOG, alias);
+      expect(logFileIsProcessStdio(alias, [onLog])).toBe(true);
     } finally {
-      stop.fn?.();
-      process.stderr.write = realErr;
+      closeSync(onLog);
+      closeSync(onOther);
     }
 
-    expect(errs.join('')).toContain('[LogFile]');
-    expect(errs.join('')).toContain('continuing without a log file');
+    // Nothing at the path yet: nothing can be open on it.
+    expect(logFileIsProcessStdio(join(DIR, 'never-written.log'))).toBe(false);
+    // A closed descriptor number must not throw or match.
+    expect(logFileIsProcessStdio(LOG, [9999])).toBe(false);
+    // The test runner's real stdout is not this file.
+    expect(logFileIsProcessStdio(LOG)).toBe(false);
   });
 });

--- a/src/util/log-file.test.ts
+++ b/src/util/log-file.test.ts
@@ -1,0 +1,247 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { readFileSync, statSync } from 'node:fs';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { installLogFileSink } from './log-file.ts';
+
+let DIR: string;
+let LOG: string;
+let uninstall: (() => void) | null = null;
+
+beforeEach(async () => {
+  DIR = await mkdtemp(join(tmpdir(), 'jarvis-test-logfile-'));
+  LOG = join(DIR, 'logs', 'jarvis.log');
+});
+
+afterEach(async () => {
+  // Restore the process' writes before anything else, or a failed assertion
+  // would leave every later test in the file writing through a dead sink.
+  uninstall?.();
+  uninstall = null;
+  await rm(DIR, { recursive: true, force: true });
+});
+
+function read(): string {
+  return readFileSync(LOG, 'utf8');
+}
+
+describe('installLogFileSink', () => {
+  test('writes console output as timestamped lines and creates the parent dir', () => {
+    uninstall = installLogFileSink({ path: LOG });
+    console.log('hello from the daemon');
+    console.error('and from stderr');
+    uninstall();
+    uninstall = null;
+
+    const lines = read().trimEnd().split('\n');
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toMatch(/^\d{4}-\d{2}-\d{2}T[\d:.]+Z hello from the daemon$/);
+    expect(lines[1]).toMatch(/^\d{4}-\d{2}-\d{2}T[\d:.]+Z and from stderr$/);
+  });
+
+  test('strips ANSI escapes (src/cli/helpers.ts colours unconditionally)', () => {
+    uninstall = installLogFileSink({ path: LOG });
+    process.stdout.write('\x1b[36mJ.A.R.V.I.S.\x1b[0m \x1b[2mv0.13.0\x1b[0m\n');
+    uninstall();
+    uninstall = null;
+
+    const body = read();
+    expect(body).toContain('J.A.R.V.I.S. v0.13.0');
+    expect(body).not.toContain('\x1b');
+    expect(body).not.toContain('[36m');
+  });
+
+  test('redacts credential-shaped material before it reaches disk', () => {
+    uninstall = installLogFileSink({ path: LOG });
+    console.error('proxy rejected sk-uj-AAAAAAAAAAAAAAAAAAAAAAAA');
+    console.error('Authorization: Bearer abcdefghijklmnopqrstuvwxyz012345');
+    uninstall();
+    uninstall = null;
+
+    const body = read();
+    expect(body).not.toContain('sk-uj-AAAA');
+    expect(body).not.toContain('abcdefghijklmnop');
+    expect(body).toContain('***redacted***');
+  });
+
+  test("captures console.* even though bun's console bypasses process.stdout.write", () => {
+    // Regression guard for the whole feature: on bun 1.3.8 console.log writes
+    // straight to fd 1, so a stream-only patch records none of jarvis's ~1150
+    // console.* call sites. If this ever passes with the console wrapper
+    // removed, the runtime changed and the wrapper can go.
+    const seenByStream: string[] = [];
+    const realWrite = process.stdout.write;
+    process.stdout.write = ((chunk: unknown, ...rest: unknown[]) => {
+      if (typeof chunk === 'string') seenByStream.push(chunk);
+      return (realWrite as (...a: unknown[]) => boolean).apply(process.stdout, [chunk, ...rest]);
+    }) as typeof process.stdout.write;
+
+    try {
+      uninstall = installLogFileSink({ path: LOG });
+      console.log('tier %s picked in %dms', 'medium', 12);
+      console.log('an object:', { id: 7 });
+      uninstall();
+      uninstall = null;
+    } finally {
+      process.stdout.write = realWrite;
+    }
+
+    const body = read();
+    expect(body).toContain('tier medium picked in 12ms');
+    expect(body).toContain('an object: { id: 7 }');
+    // Exactly once, not once per capture path.
+    expect(body.split('\n').filter((l) => l.includes('tier medium'))).toHaveLength(1);
+  });
+
+  test('reassembles a line split across writes, and flushes the tail on uninstall', () => {
+    uninstall = installLogFileSink({ path: LOG });
+    process.stdout.write('one ');
+    process.stdout.write('line ');
+    process.stdout.write('in three writes\n');
+    // No terminator: this must survive as a whole line, not be lost.
+    process.stdout.write('unterminated tail');
+    uninstall();
+    uninstall = null;
+
+    const lines = read().trimEnd().split('\n');
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toEndWith('one line in three writes');
+    expect(lines[1]).toEndWith('unterminated tail');
+  });
+
+  test('stdout and stderr partial lines do not splice into each other', () => {
+    uninstall = installLogFileSink({ path: LOG });
+    process.stdout.write('OUT-head ');
+    process.stderr.write('ERR-whole\n');
+    process.stdout.write('OUT-tail\n');
+    uninstall();
+    uninstall = null;
+
+    const lines = read().trimEnd().split('\n');
+    expect(lines[0]).toEndWith('ERR-whole');
+    expect(lines[1]).toEndWith('OUT-head OUT-tail');
+  });
+
+  test('the cap holds under a multi-MB burst, dropping the oldest lines first', () => {
+    const total = 20_000;
+    const maxBytes = 64 * 1024;
+    // Swallow the burst on the way to the terminal: the sink captures whatever
+    // write it finds installed, and 4 MB of filler in the test output helps
+    // nobody.
+    const realWrite = process.stdout.write;
+    process.stdout.write = (() => true) as typeof process.stdout.write;
+    try {
+      uninstall = installLogFileSink({ path: LOG, maxBytes });
+
+      // ~4 MB of output through a 64 KiB window: ~64 compactions.
+      const filler = 'x'.repeat(200);
+      for (let i = 0; i < total; i++) process.stdout.write(`line ${i} ${filler}\n`);
+
+      uninstall();
+      uninstall = null;
+    } finally {
+      process.stdout.write = realWrite;
+    }
+
+    const size = statSync(LOG).size;
+    expect(size).toBeLessThanOrEqual(maxBytes * 1.25);
+    // Sanity floor: the window should be nearly full, not a handful of lines.
+    expect(size).toBeGreaterThan(maxBytes / 2);
+
+    const body = read();
+    // The newest line is always present; the oldest are long gone.
+    expect(body).toContain(`line ${total - 1} `);
+    expect(body).not.toContain('line 0 ');
+    expect(body).not.toContain('line 100 ');
+    // And the file still starts on a line boundary: the ring only ever holds
+    // whole lines, so a rewrite can never begin mid-line.
+    expect(body.split('\n')[0]).toMatch(/^\d{4}-\d{2}-\d{2}T[\d:.]+Z line \d+ x+$/);
+  });
+
+  test('the original write still receives everything, unmodified', () => {
+    const captured: string[] = [];
+    const realWrite = process.stdout.write.bind(process.stdout);
+    process.stdout.write = ((chunk: unknown, ...rest: unknown[]) => {
+      if (typeof chunk === 'string') captured.push(chunk);
+      return (realWrite as (...a: unknown[]) => boolean)(chunk, ...rest);
+    }) as typeof process.stdout.write;
+    const spy = process.stdout.write;
+
+    try {
+      uninstall = installLogFileSink({ path: LOG });
+      process.stdout.write('\x1b[31msk-uj-AAAAAAAAAAAAAAAAAAAAAAAA\x1b[0m\n');
+      uninstall();
+      uninstall = null;
+    } finally {
+      // installLogFileSink restored the spy; drop it too.
+      expect(process.stdout.write).toBe(spy);
+      process.stdout.write = realWrite;
+    }
+
+    // Terminal / journal output is untouched: escapes intact, no redaction,
+    // no timestamp. Only the FILE is sanitised.
+    expect(captured.join('')).toBe('\x1b[31msk-uj-AAAAAAAAAAAAAAAAAAAAAAAA\x1b[0m\n');
+    expect(read()).toContain('***redacted***');
+  });
+
+  test('uninstall restores the exact write functions it replaced', () => {
+    const beforeOut = process.stdout.write;
+    const beforeErr = process.stderr.write;
+    const stop = installLogFileSink({ path: LOG });
+    expect(process.stdout.write).not.toBe(beforeOut);
+    expect(process.stderr.write).not.toBe(beforeErr);
+    stop();
+    expect(process.stdout.write).toBe(beforeOut);
+    expect(process.stderr.write).toBe(beforeErr);
+  });
+
+  test('installing twice leaves exactly one sink (no double-written lines)', () => {
+    const before = process.stdout.write;
+    const beforeLog = console.log;
+    const first = installLogFileSink({ path: LOG });
+    uninstall = installLogFileSink({ path: LOG });
+    console.log('only once please');
+    uninstall();
+    uninstall = null;
+    first(); // idempotent: the second install already uninstalled this one
+
+    expect(process.stdout.write).toBe(before);
+    expect(console.log).toBe(beforeLog);
+    const hits = read().split('\n').filter((l) => l.includes('only once please'));
+    expect(hits).toHaveLength(1);
+  });
+
+  test('an unopenable path degrades to no sink instead of throwing', async () => {
+    const blocker = join(DIR, 'not-a-dir');
+    await writeFile(blocker, 'i am a regular file');
+    const bad = join(blocker, 'nested', 'jarvis.log');
+
+    const errs: string[] = [];
+    const realErr = process.stderr.write.bind(process.stderr);
+    process.stderr.write = ((chunk: unknown) => {
+      if (typeof chunk === 'string') errs.push(chunk);
+      return true;
+    }) as typeof process.stderr.write;
+    const spyErr = process.stderr.write;
+
+    // A holder rather than a `let`: TS narrows a plain local to `null` when the
+    // only assignment happens inside a callback.
+    const stop: { fn: (() => void) | null } = { fn: null };
+    try {
+      expect(() => {
+        stop.fn = installLogFileSink({ path: bad });
+      }).not.toThrow();
+      // Bailed out before patching anything, so the daemon keeps logging
+      // exactly as it did before.
+      expect(process.stderr.write).toBe(spyErr);
+      console.log('still alive');
+    } finally {
+      stop.fn?.();
+      process.stderr.write = realErr;
+    }
+
+    expect(errs.join('')).toContain('[LogFile]');
+    expect(errs.join('')).toContain('continuing without a log file');
+  });
+});

--- a/src/util/log-file.ts
+++ b/src/util/log-file.ts
@@ -1,0 +1,363 @@
+/**
+ * In-process, size-capped, redacted log-file sink.
+ *
+ * Jarvis only ever had a log file in two launch modes: `jarvis start -d`
+ * (bin/jarvis.ts redirects the detached child's fds at spawn) and launchd.
+ * Under systemd - how the hosted fleet runs it, and `files/jarvis@.service`
+ * carries no `StandardOutput=` - and under Docker there is no file at all, so
+ * the only log is journald or the container runtime and the hosting control
+ * plane has nothing stable per instance to read (docs/LOGS.md, "The brain's
+ * side"). This gives every launch mode the same file, driven by
+ * `daemon.log_file_path`.
+ *
+ * We hook at the STREAM level - `process.stdout.write` / `process.stderr.write`
+ * - so direct write callers and any dependency that writes on its own are
+ * caught, not just our own logging. The original write is always called
+ * through, so the terminal and the journal see everything unchanged.
+ *
+ * The stream hook alone is not enough on Bun. Node's `console.*` is a thin
+ * wrapper over `process.stdout.write`, but Bun's console is native and writes
+ * to the file descriptors directly: with only the stream patch installed,
+ * every one of jarvis's ~1150 `console.*` call sites is invisible to the sink
+ * (verified on bun 1.3.8 - a patched `process.stdout.write` sees `RAW-OUT`
+ * from an explicit write and nothing at all from `console.log`). So `console.*`
+ * is wrapped too. The wrapper calls the REAL console method for the terminal,
+ * then feeds the formatted text to the sink itself, with the stream hook
+ * suppressed for the duration - on a runtime where console DOES route through
+ * the stream (node, and bun's own test reporter) that suppression is what
+ * keeps a line from being recorded twice.
+ *
+ * KNOWN LIMITATION: the ~80 subprocess spawns that use `stdio: 'inherit'` hand
+ * the child our raw file descriptors, and the child then writes to them from
+ * another process. No JS-level patch can observe that, so subprocess output
+ * reaches the terminal and journald but never this file. Deliberately out of
+ * scope: capturing it would mean piping and re-emitting every spawn site.
+ */
+
+import { closeSync, mkdirSync, openSync, renameSync, statSync, unlinkSync, writeFileSync, writeSync } from 'node:fs';
+import { dirname } from 'node:path';
+import { StringDecoder } from 'node:string_decoder';
+import { format } from 'node:util';
+import { redactSecrets } from './redact.ts';
+
+/** Default cap. Matches docs/LOGS.md and the control plane's 1 MiB read cap. */
+export const DEFAULT_LOG_FILE_MAX_BYTES = 1024 * 1024;
+
+/**
+ * Floor for the cap. Below this a compaction rewrite costs more than it saves,
+ * and a single stack trace would blow the whole window away.
+ */
+const MIN_LOG_FILE_MAX_BYTES = 4096;
+
+/**
+ * How far past the cap the file is allowed to grow before it is rewritten.
+ * The slack is what makes appends O(1): without it every line past the cap
+ * would rewrite the whole file. At 1.25 the file settles at ~1 MiB, never
+ * exceeds ~1.25 MiB, and one rewrite buys ~256 KiB of plain appends.
+ */
+const COMPACT_RATIO = 1.25;
+
+/**
+ * ANSI escape sequences: CSI (colours, cursor moves) and OSC (title sets,
+ * hyperlinks). src/cli/helpers.ts exports `c` with hardcoded escapes and no
+ * TTY detection, so anything routed through the CLI helpers carries them even
+ * when stdout is a file - they would otherwise land in the log as mojibake an
+ * operator has to read around.
+ */
+const ANSI_PATTERN =
+  /[\u001B\u009B][[\]()#;?]*(?:(?:[a-zA-Z\d]*(?:;[-a-zA-Z\d/#&.:=?%@~_]*)*)?\u0007|(?:\d{1,4}(?:;\d{0,4})*)?[\dA-PR-TZcf-nq-uy=><~])/g;
+
+export type LogFileSinkOptions = {
+  /** Absolute path of the file to write. Its parent is created if missing. */
+  path: string;
+  /** Ring size in bytes. Defaults to 1 MiB; values under 4 KiB are raised. */
+  maxBytes?: number;
+};
+
+type StreamWrite = typeof process.stdout.write;
+
+/**
+ * Only one sink can be installed at a time: a second patch over the first
+ * would write every line twice and the uninstalls would restore in the wrong
+ * order. Installing again replaces the active sink.
+ */
+let active: (() => void) | null = null;
+
+/**
+ * Install the file sink. Returns an uninstall function that flushes any
+ * buffered partial line, restores the original writes, and closes the file.
+ *
+ * Never throws and never blocks: a path that cannot be opened or written
+ * degrades to "no file sink" with a single warning on the real stderr. The
+ * daemon must not die because its log file is unavailable.
+ */
+export function installLogFileSink(opts: LogFileSinkOptions): () => void {
+  active?.();
+  active = null;
+
+  // Kept UNBOUND on purpose: uninstall must restore the very same function
+  // object it replaced, so a caller that stacked its own wrapper underneath us
+  // (tests do; so does anything that patched stdout before boot) gets it back
+  // by identity rather than as a fresh bound copy.
+  const originalStdoutWrite = process.stdout.write as StreamWrite;
+  const originalStderrWrite = process.stderr.write as StreamWrite;
+
+  let warned = false;
+  const warnOnce = (message: string): void => {
+    if (warned) return;
+    warned = true;
+    // Straight to the original write: console.warn would route through the
+    // patched stderr and recurse back into the code that is already failing.
+    try {
+      originalStderrWrite.call(process.stderr, `[LogFile] ${message}\n`);
+    } catch {
+      // Even stderr is gone. Nothing left to say it with.
+    }
+  };
+
+  const maxBytes = Math.max(
+    MIN_LOG_FILE_MAX_BYTES,
+    Math.floor(opts.maxBytes && opts.maxBytes > 0 ? opts.maxBytes : DEFAULT_LOG_FILE_MAX_BYTES),
+  );
+  const compactAt = Math.floor(maxBytes * COMPACT_RATIO);
+  const filePath = opts.path;
+  const tmpPath = `${filePath}.${process.pid}.tmp`;
+
+  let fd: number;
+  let fileBytes = 0;
+  try {
+    mkdirSync(dirname(filePath), { recursive: true });
+    // 0600: the lines are redacted, but a log still describes what the user
+    // did and nothing else on the box needs to read it.
+    fd = openSync(filePath, 'a', 0o600);
+    try {
+      // Append, so a restart adds to what is there. The size counts toward the
+      // cap from the start: an already-oversized file left by a previous run
+      // is rewritten down to this session's lines on the first compaction,
+      // which is the point of a cap.
+      fileBytes = statSync(filePath).size;
+    } catch {
+      fileBytes = 0;
+    }
+  } catch (err) {
+    warnOnce(`could not open ${filePath}: ${err instanceof Error ? err.message : String(err)}; continuing without a log file`);
+    return () => {};
+  }
+
+  /**
+   * The last `maxBytes` of output, as whole lines. This is what the file is
+   * rewritten from, so dropping the oldest entry IS dropping on a line
+   * boundary - the file can never start mid-line.
+   */
+  let ring: Buffer[] = [];
+  let ringBytes = 0;
+
+  let disabled = false;
+  /**
+   * Re-entrancy guard. Anything this sink writes itself (a warning, a stray
+   * console.* from a dependency reached through our own stack) must pass
+   * straight through to the original write instead of being processed again.
+   */
+  let inSink = false;
+
+  /** Partial trailing line per stream. Writes do not arrive line-aligned, and
+   * splicing stdout's tail onto stderr's head would invent lines that were
+   * never logged - so each stream carries its own. */
+  const pending = { out: '', err: '' };
+
+  /**
+   * Byte chunks are not codepoint-aligned either: a Buffer write can split a
+   * multi-byte character down the middle, and decoding each chunk on its own
+   * would put a U+FFFD in the log where an accented letter was. StringDecoder
+   * holds the incomplete sequence until the rest lands.
+   */
+  const decoders = { out: new StringDecoder('utf8'), err: new StringDecoder('utf8') };
+
+  const closeFd = (): void => {
+    try {
+      closeSync(fd);
+    } catch {
+      // Already closed, or the fd went away with the file. Nothing to do.
+    }
+  };
+
+  const fail = (what: string, err: unknown): void => {
+    disabled = true;
+    closeFd();
+    warnOnce(`${what}: ${err instanceof Error ? err.message : String(err)}; continuing without a log file`);
+  };
+
+  const appendToFile = (buf: Buffer): void => {
+    let offset = 0;
+    // writeSync is allowed to write short. Looping is the only way to know the
+    // line actually landed whole.
+    while (offset < buf.length) {
+      offset += writeSync(fd, buf, offset, buf.length - offset);
+    }
+    fileBytes += buf.length;
+  };
+
+  /**
+   * Rewrite the file from the in-memory ring: write a sibling temp file, then
+   * rename it over the target. rename(2) is atomic, so a reader (the host's
+   * `fetch-logs`, or `tail`) sees either the old file or the new one, never a
+   * half-truncated one. The inode changes, which is why `jarvis logs -f` uses
+   * `tail -F` rather than `tail -f`.
+   */
+  const compact = (): void => {
+    try {
+      writeFileSync(tmpPath, ring.length === 1 ? ring[0]! : Buffer.concat(ring, ringBytes), { mode: 0o600 });
+      renameSync(tmpPath, filePath);
+      closeFd();
+      fd = openSync(filePath, 'a', 0o600);
+      fileBytes = ringBytes;
+    } catch (err) {
+      try {
+        unlinkSync(tmpPath);
+      } catch {
+        // The temp file may never have been created. Either way we are done.
+      }
+      fail(`could not rewrite ${filePath}`, err);
+    }
+  };
+
+  const writeLine = (line: string): void => {
+    const clean = redactSecrets(line.replace(ANSI_PATTERN, ''));
+    const buf = Buffer.from(`${new Date().toISOString()} ${clean}\n`, 'utf8');
+
+    ring.push(buf);
+    ringBytes += buf.length;
+    while (ringBytes > maxBytes && ring.length > 1) {
+      ringBytes -= ring.shift()!.length;
+    }
+
+    appendToFile(buf);
+    if (fileBytes > compactAt) compact();
+  };
+
+  const consume = (stream: 'out' | 'err', text: string): void => {
+    if (!text) return;
+    const buffered = pending[stream] + text;
+    let nl = buffered.indexOf('\n');
+    if (nl === -1) {
+      // No terminator yet. Hold it: the rest of this line is coming in a
+      // later write (process.stdout.write callers chunk mid-line freely).
+      pending[stream] = buffered;
+      return;
+    }
+    let start = 0;
+    while (nl !== -1) {
+      // \r\n and a bare \r-driven progress redraw both leave a stray \r.
+      writeLine(buffered.slice(start, nl).replace(/\r$/, ''));
+      if (disabled) return;
+      start = nl + 1;
+      nl = buffered.indexOf('\n', start);
+    }
+    pending[stream] = buffered.slice(start);
+  };
+
+  const patch = (stream: 'out' | 'err', original: StreamWrite): StreamWrite => {
+    return function patchedWrite(this: unknown, ...args: unknown[]): boolean {
+      // The terminal / journal is served first and unconditionally: whatever
+      // the file sink does or fails to do, the process' own output is intact.
+      const target = stream === 'out' ? process.stdout : process.stderr;
+      const result = (original as (...a: unknown[]) => boolean).apply(target, args);
+      if (disabled || inSink) return result;
+      inSink = true;
+      try {
+        const chunk = args[0];
+        const text =
+          typeof chunk === 'string'
+            ? chunk
+            : chunk instanceof Uint8Array
+              ? decoders[stream].write(Buffer.from(chunk.buffer, chunk.byteOffset, chunk.byteLength))
+              : null;
+        if (text !== null) consume(stream, text);
+      } catch (err) {
+        fail('log sink write failed', err);
+      } finally {
+        inSink = false;
+      }
+      return result;
+    } as StreamWrite;
+  };
+
+  process.stdout.write = patch('out', originalStdoutWrite);
+  process.stderr.write = patch('err', originalStderrWrite);
+
+  /**
+   * Which stream each console method belongs to, matching node/bun: log, info
+   * and debug go to stdout; warn, error and trace to stderr.
+   */
+  const CONSOLE_METHODS = {
+    log: 'out',
+    info: 'out',
+    debug: 'out',
+    warn: 'err',
+    error: 'err',
+    trace: 'err',
+  } as const;
+
+  type ConsoleMethod = keyof typeof CONSOLE_METHODS;
+  const originalConsole = {} as Record<ConsoleMethod, (...args: unknown[]) => void>;
+
+  for (const name of Object.keys(CONSOLE_METHODS) as ConsoleMethod[]) {
+    const original = console[name] as (...args: unknown[]) => void;
+    if (typeof original !== 'function') continue;
+    originalConsole[name] = original;
+    const stream = CONSOLE_METHODS[name];
+    console[name] = (...args: unknown[]): void => {
+      // Terminal first, through the real console: its own formatting and
+      // colouring stay byte-for-byte what they were without the sink.
+      const wasInSink = inSink;
+      inSink = true;
+      try {
+        original.apply(console, args);
+      } finally {
+        inSink = wasInSink;
+      }
+      if (disabled || wasInSink) return;
+      inSink = true;
+      try {
+        // `format` is node's console formatter (%s/%d substitution, object
+        // inspection), so the file records the same text the terminal shows.
+        consume(stream, `${format(...(args as [unknown, ...unknown[]]))}\n`);
+      } catch (err) {
+        fail('log sink write failed', err);
+      } finally {
+        inSink = false;
+      }
+    };
+  }
+
+  const uninstall = (): void => {
+    if (active === uninstall) active = null;
+    process.stdout.write = originalStdoutWrite;
+    process.stderr.write = originalStderrWrite;
+    for (const name of Object.keys(originalConsole) as ConsoleMethod[]) {
+      console[name] = originalConsole[name];
+    }
+    if (disabled) return;
+    inSink = true;
+    try {
+      // Flush whatever never got its newline, so a crash message that was
+      // still mid-line is not the one thing missing from the log.
+      for (const stream of ['out', 'err'] as const) {
+        const rest = pending[stream];
+        pending[stream] = '';
+        if (rest) writeLine(rest);
+      }
+    } catch {
+      // Best effort: we are on the way out.
+    } finally {
+      inSink = false;
+      disabled = true;
+      ring = [];
+      ringBytes = 0;
+      closeFd();
+    }
+  };
+
+  active = uninstall;
+  return uninstall;
+}

--- a/src/util/log-file.ts
+++ b/src/util/log-file.ts
@@ -27,6 +27,10 @@
  * the stream (node, and bun's own test reporter) that suppression is what
  * keeps a line from being recorded twice.
  *
+ * The cap is an IN-MEMORY ring, not a file scan: `log_file_max_bytes` is an
+ * RSS budget as much as a disk budget, which is why it is clamped at both ends
+ * (see MIN/MAX_LOG_FILE_MAX_BYTES).
+ *
  * KNOWN LIMITATION: the ~80 subprocess spawns that use `stdio: 'inherit'` hand
  * the child our raw file descriptors, and the child then writes to them from
  * another process. No JS-level patch can observe that, so subprocess output
@@ -34,8 +38,21 @@
  * scope: capturing it would mean piping and re-emitting every spawn site.
  */
 
-import { closeSync, mkdirSync, openSync, renameSync, statSync, unlinkSync, writeFileSync, writeSync } from 'node:fs';
-import { dirname } from 'node:path';
+import {
+  closeSync,
+  fstatSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  readSync,
+  readdirSync,
+  renameSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+  writeSync,
+} from 'node:fs';
+import { basename, dirname, join } from 'node:path';
 import { StringDecoder } from 'node:string_decoder';
 import { format } from 'node:util';
 import { redactSecrets } from './redact.ts';
@@ -50,6 +67,16 @@ export const DEFAULT_LOG_FILE_MAX_BYTES = 1024 * 1024;
 const MIN_LOG_FILE_MAX_BYTES = 4096;
 
 /**
+ * Ceiling for the cap. The window is held in memory, so the cap is an RSS
+ * budget: `log_file_max_bytes: .inf` (legal YAML, and what a `.inf` typo
+ * produces) gave `maxBytes = Infinity`, which means the ring never compacts
+ * and grows until the daemon is OOM-killed, and `1e12` asks for a 1 TB
+ * resident buffer. 64 MiB is far past any useful debugging window and still
+ * survivable on the 1 GB hosted boxes.
+ */
+const MAX_LOG_FILE_MAX_BYTES = 64 * 1024 * 1024;
+
+/**
  * How far past the cap the file is allowed to grow before it is rewritten.
  * The slack is what makes appends O(1): without it every line past the cap
  * would rewrite the whole file. At 1.25 the file settles at ~1 MiB, never
@@ -58,23 +85,102 @@ const MIN_LOG_FILE_MAX_BYTES = 4096;
 const COMPACT_RATIO = 1.25;
 
 /**
+ * A single line may take at most this fraction of the window. Without it one
+ * `console.log(JSON.stringify(bigObject))` or one long stack trace evicts
+ * EVERY other line (the eviction loop stops at `ring.length > 1`), so the file
+ * ends up holding that one line and nothing else, and the line after it leaves
+ * the file at 37 bytes. Truncating instead keeps the surrounding context,
+ * which is the part an operator actually needs.
+ */
+const MAX_LINE_FRACTION = 4;
+
+/**
+ * How often to retry a file that went away under us. A failed write used to
+ * disable the sink for the life of the process, so an `rm -rf ~/.jarvis/logs`
+ * or a transient ENOSPC meant no log file until the next restart. Retrying on
+ * every line would turn a permanently broken path into a syscall storm, so the
+ * retry is throttled to one attempt per this many lines.
+ */
+const RECOVER_EVERY_LINES = 200;
+
+/**
+ * Force a "line" out at this size even with no terminator in sight. A writer
+ * that only ever emits `\r` (progress redraws) or one that streams a huge
+ * payload with no newline used to grow `pending` without bound: 20k `\r`
+ * frames built a single 649 KB string, +52 MB of heap and 2.1s of repeated
+ * scanning, with nothing written to the file the whole time.
+ */
+const MAX_PENDING_CHARS = 64 * 1024;
+
+/**
  * ANSI escape sequences: CSI (colours, cursor moves) and OSC (title sets,
  * hyperlinks). src/cli/helpers.ts exports `c` with hardcoded escapes and no
  * TTY detection, so anything routed through the CLI helpers carries them even
  * when stdout is a file - they would otherwise land in the log as mojibake an
  * operator has to read around.
+ *
+ * Every quantifier is bounded on purpose. The obvious pattern here is the
+ * `ansi-regex` one, which is CVE-2021-3807: its nested unbounded groups make
+ * `ESC` followed by 10-20k `;` cost 200-400ms per line, and log lines are
+ * attacker-influenced (anything jarvis echoes back). Bounded repetition over
+ * character classes that cannot overlap gives linear scanning instead.
  */
 const ANSI_PATTERN =
-  /[\u001B\u009B][[\]()#;?]*(?:(?:[a-zA-Z\d]*(?:;[-a-zA-Z\d/#&.:=?%@~_]*)*)?\u0007|(?:\d{1,4}(?:;\d{0,4})*)?[\dA-PR-TZcf-nq-uy=><~])/g;
+  /\u001B\][^\u0007\u001B]{0,2048}(?:\u0007|\u001B\\)|[\u001B\u009B]\[[0-9;:<=>?]{0,64}[ -\/]{0,8}[@-~]|\u009B[0-9;:<=>?]{0,64}[ -\/]{0,8}[@-~]|\u001B[ -\/]{1,4}[0-~]|\u001B[0-9A-Za-z=><]/g;
+
+/** Matches the `<pid>.tmp` suffix compaction leaves on its sibling temp file. */
+const TMP_SUFFIX_PATTERN = /^\.(\d+)\.tmp$/;
 
 export type LogFileSinkOptions = {
   /** Absolute path of the file to write. Its parent is created if missing. */
   path: string;
-  /** Ring size in bytes. Defaults to 1 MiB; values under 4 KiB are raised. */
+  /**
+   * Ring size in bytes, held in memory as well as on disk. Defaults to 1 MiB;
+   * values under 4 KiB are raised, values over 64 MiB (and non-finite ones)
+   * are lowered.
+   */
   maxBytes?: number;
 };
 
 type StreamWrite = typeof process.stdout.write;
+
+/**
+ * True when one of `fds` is already open on the very file `path` names.
+ *
+ * This is the guard against the worst failure this sink can cause. A launcher
+ * that redirects the daemon's fds 1/2 into the log file (`jarvis start -d`,
+ * `restartDaemonDetached` in src/cli/update.ts, the launchd plist's
+ * `StandardOutPath`, a `StandardOutput=append:` in someone's unit file) hands
+ * the process a descriptor bound to an INODE. The first compaction renames a
+ * fresh file over that path, so the descriptor keeps pointing at the old,
+ * now-unlinked inode: it grows forever, `ls` cannot see it, and only a reboot
+ * or a restart frees the space. Confirmed - after 2000 lines through a 4 KiB
+ * cap the named file was 4 KB and the orphan behind fd 1 was 226 KB with
+ * nlink=0.
+ *
+ * Checking dev+ino here rather than comparing path strings in each launcher is
+ * what makes it total: it catches every launcher, including ones added later
+ * and ones written by the operator, and it is immune to symlinks, bind mounts
+ * and `$JARVIS_HOME` spellings of the same file.
+ */
+export function logFileIsProcessStdio(path: string, fds: readonly number[] = [1, 2]): boolean {
+  let target: ReturnType<typeof statSync>;
+  try {
+    target = statSync(path);
+  } catch {
+    // Nothing at that path yet, so nothing can already be open on it.
+    return false;
+  }
+  for (const fd of fds) {
+    try {
+      const st = fstatSync(fd);
+      if (st.dev === target.dev && st.ino === target.ino) return true;
+    } catch {
+      // Closed or not a real descriptor. Not our file either way.
+    }
+  }
+  return false;
+}
 
 /**
  * Only one sink can be installed at a time: a second patch over the first
@@ -102,12 +208,9 @@ export function installLogFileSink(opts: LogFileSinkOptions): () => void {
   const originalStdoutWrite = process.stdout.write as StreamWrite;
   const originalStderrWrite = process.stderr.write as StreamWrite;
 
-  let warned = false;
-  const warnOnce = (message: string): void => {
-    if (warned) return;
-    warned = true;
-    // Straight to the original write: console.warn would route through the
-    // patched stderr and recurse back into the code that is already failing.
+  // Straight to the original write: console.warn would route through the
+  // patched stderr and recurse back into the code that is already failing.
+  const say = (message: string): void => {
     try {
       originalStderrWrite.call(process.stderr, `[LogFile] ${message}\n`);
     } catch {
@@ -115,32 +218,91 @@ export function installLogFileSink(opts: LogFileSinkOptions): () => void {
     }
   };
 
-  const maxBytes = Math.max(
-    MIN_LOG_FILE_MAX_BYTES,
-    Math.floor(opts.maxBytes && opts.maxBytes > 0 ? opts.maxBytes : DEFAULT_LOG_FILE_MAX_BYTES),
-  );
+  let warned = false;
+  const warnOnce = (message: string): void => {
+    if (warned) return;
+    warned = true;
+    say(message);
+  };
+
+  // Validate before clamping so the operator is told their value was ignored.
+  // `.inf` and `1e12` are both legal YAML and both used to sail straight
+  // through: `Math.floor(Infinity)` is Infinity, so the ring never compacted.
+  const requested = opts.maxBytes;
+  const usable = typeof requested === 'number' && Number.isFinite(requested) && requested > 0;
+  const maxBytes = usable
+    ? Math.min(MAX_LOG_FILE_MAX_BYTES, Math.max(MIN_LOG_FILE_MAX_BYTES, Math.floor(requested)))
+    : DEFAULT_LOG_FILE_MAX_BYTES;
+  if (requested !== undefined && (!usable || maxBytes !== Math.floor(requested as number))) {
+    say(
+      `log_file_max_bytes=${String(requested)} is out of range (${MIN_LOG_FILE_MAX_BYTES}..${MAX_LOG_FILE_MAX_BYTES} bytes, held in memory); using ${maxBytes}`,
+    );
+  }
   const compactAt = Math.floor(maxBytes * COMPACT_RATIO);
+  const maxLineBytes = Math.max(1024, Math.floor(maxBytes / MAX_LINE_FRACTION));
   const filePath = opts.path;
   const tmpPath = `${filePath}.${process.pid}.tmp`;
 
-  let fd: number;
-  let fileBytes = 0;
+  // A FIFO at this path hangs the whole daemon: `openSync(fifo, 'a')` blocks
+  // until a reader shows up, and it is called before anything else boots, so
+  // startDaemon simply never returns and no supervisor restarts it because
+  // nothing crashed. Jarvis runs shell commands as its own user, so
+  // `mkfifo ~/.jarvis/logs/jarvis.log` is inside the threat model. lstat (not
+  // stat) so a symlink is refused too, matching the hosting side's reader
+  // (infra/vps-scripts/bin/fetch-logs --source instance), which will not
+  // follow one either.
   try {
-    mkdirSync(dirname(filePath), { recursive: true });
-    // 0600: the lines are redacted, but a log still describes what the user
-    // did and nothing else on the box needs to read it.
-    fd = openSync(filePath, 'a', 0o600);
-    try {
-      // Append, so a restart adds to what is there. The size counts toward the
-      // cap from the start: an already-oversized file left by a previous run
-      // is rewritten down to this session's lines on the first compaction,
-      // which is the point of a cap.
-      fileBytes = statSync(filePath).size;
-    } catch {
-      fileBytes = 0;
+    const existing = lstatSync(filePath);
+    if (!existing.isFile()) {
+      warnOnce(`${filePath} is not a regular file; continuing without a log file`);
+      return () => {};
     }
   } catch (err) {
-    warnOnce(`could not open ${filePath}: ${err instanceof Error ? err.message : String(err)}; continuing without a log file`);
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+      warnOnce(`could not stat ${filePath}: ${err instanceof Error ? err.message : String(err)}; continuing without a log file`);
+      return () => {};
+    }
+  }
+
+  /** -1 means "no open descriptor": either not opened yet, or lost mid-run. */
+  let fd = -1;
+  let fileBytes = 0;
+
+  const closeFd = (): void => {
+    if (fd < 0) return;
+    // Clear FIRST. `compact` closes the fd and then may throw on the reopen,
+    // and the error path used to close the same NUMBER a second time - by
+    // which point bun's helper threads can have handed it to something else.
+    const doomed = fd;
+    fd = -1;
+    try {
+      closeSync(doomed);
+    } catch {
+      // Already closed, or the fd went away with the file. Nothing to do.
+    }
+  };
+
+  const openFile = (): Error | null => {
+    try {
+      mkdirSync(dirname(filePath), { recursive: true });
+      // 0600: the lines are redacted, but a log still describes what the user
+      // did and nothing else on the box needs to read it.
+      fd = openSync(filePath, 'a', 0o600);
+      try {
+        fileBytes = statSync(filePath).size;
+      } catch {
+        fileBytes = 0;
+      }
+      return null;
+    } catch (err) {
+      fd = -1;
+      return err instanceof Error ? err : new Error(String(err));
+    }
+  };
+
+  const openErr = openFile();
+  if (openErr) {
+    warnOnce(`could not open ${filePath}: ${openErr.message}; continuing without a log file`);
     return () => {};
   }
 
@@ -152,7 +314,109 @@ export function installLogFileSink(opts: LogFileSinkOptions): () => void {
   let ring: Buffer[] = [];
   let ringBytes = 0;
 
+  /**
+   * Seed the ring from the tail of whatever is already on disk.
+   *
+   * Without this the ring started empty while `fileBytes` started at the
+   * existing file's size, so the FIRST compaction after a restart replaced the
+   * file with only the current session's lines. A crash loop therefore erased
+   * the healthy run's log - the one thing an operator needs - within a few
+   * restarts (confirmed: gone by restart 4).
+   */
+  const seedRing = (): void => {
+    let rfd = -1;
+    try {
+      const size = statSync(filePath).size;
+      if (size <= 0) return;
+      const want = Math.min(size, maxBytes);
+      const buf = Buffer.alloc(want);
+      rfd = openSync(filePath, 'r');
+      let got = 0;
+      while (got < want) {
+        const n = readSync(rfd, buf, got, want - got, size - want + got);
+        if (n <= 0) break;
+        got += n;
+      }
+      let start = 0;
+      if (want < size) {
+        // We cut into the middle of a line. Drop the fragment: the ring holds
+        // whole lines only, and the file is rewritten from it.
+        const nl = buf.indexOf(0x0a, 0);
+        if (nl === -1) return;
+        start = nl + 1;
+      }
+      let from = start;
+      for (let i = start; i < got; i++) {
+        if (buf[i] !== 0x0a) continue;
+        const line = buf.subarray(from, i + 1);
+        ring.push(line);
+        ringBytes += line.length;
+        from = i + 1;
+      }
+      if (from < got) {
+        // Previous run died mid-line. Terminate it so the ring stays line-shaped.
+        const line = Buffer.concat([buf.subarray(from, got), Buffer.from('\n')]);
+        ring.push(line);
+        ringBytes += line.length;
+      }
+      while (ringBytes > maxBytes && ring.length > 1) {
+        ringBytes -= ring.shift()!.length;
+      }
+    } catch {
+      // Unreadable history is not worth failing a boot over. Start empty.
+      ring = [];
+      ringBytes = 0;
+    } finally {
+      if (rfd >= 0) {
+        try {
+          closeSync(rfd);
+        } catch {
+          // Nothing to do.
+        }
+      }
+    }
+  };
+  seedRing();
+
+  /**
+   * Remove `<path>.<pid>.tmp` siblings left by a crash between the temp write
+   * and the rename. Nothing ever cleaned them up, so a box that OOM-killed the
+   * daemon mid-compaction accumulated one near-full-window file per crash. A
+   * tmp file whose pid is still alive belongs to a running process, so leave it.
+   */
+  const cleanStaleTmp = (): void => {
+    try {
+      const dir = dirname(filePath);
+      const base = basename(filePath);
+      for (const name of readdirSync(dir)) {
+        if (!name.startsWith(base) || name.length === base.length) continue;
+        const m = TMP_SUFFIX_PATTERN.exec(name.slice(base.length));
+        if (!m) continue;
+        const pid = Number(m[1]);
+        if (pid !== process.pid) {
+          let alive = true;
+          try {
+            process.kill(pid, 0);
+          } catch (err) {
+            // EPERM means it exists and is someone else's; ESRCH means gone.
+            alive = (err as NodeJS.ErrnoException).code === 'EPERM';
+          }
+          if (alive) continue;
+        }
+        try {
+          unlinkSync(join(dir, name));
+        } catch {
+          // Raced with another cleaner, or not ours to delete.
+        }
+      }
+    } catch {
+      // Directory listing is a nicety; never let it stop the sink.
+    }
+  };
+  cleanStaleTmp();
+
   let disabled = false;
+  let recoverIn = 0;
   /**
    * Re-entrancy guard. Anything this sink writes itself (a warning, a stray
    * console.* from a dependency reached through our own stack) must pass
@@ -173,18 +437,16 @@ export function installLogFileSink(opts: LogFileSinkOptions): () => void {
    */
   const decoders = { out: new StringDecoder('utf8'), err: new StringDecoder('utf8') };
 
-  const closeFd = (): void => {
-    try {
-      closeSync(fd);
-    } catch {
-      // Already closed, or the fd went away with the file. Nothing to do.
-    }
-  };
-
-  const fail = (what: string, err: unknown): void => {
-    disabled = true;
+  /**
+   * Lose the file but keep the sink. This used to set a permanent "disabled"
+   * flag, so one transient failure - `rm -rf ~/.jarvis/logs`, a full disk that
+   * emptied a minute later - meant no log file until the daemon restarted.
+   * The ring keeps filling in memory and `writeLine` retries the open.
+   */
+  const degrade = (what: string, err: unknown): void => {
     closeFd();
-    warnOnce(`${what}: ${err instanceof Error ? err.message : String(err)}; continuing without a log file`);
+    recoverIn = RECOVER_EVERY_LINES;
+    warnOnce(`${what}: ${err instanceof Error ? err.message : String(err)}; retrying in the background`);
   };
 
   const appendToFile = (buf: Buffer): void => {
@@ -202,10 +464,12 @@ export function installLogFileSink(opts: LogFileSinkOptions): () => void {
    * rename it over the target. rename(2) is atomic, so a reader (the host's
    * `fetch-logs`, or `tail`) sees either the old file or the new one, never a
    * half-truncated one. The inode changes, which is why `jarvis logs -f` uses
-   * `tail -F` rather than `tail -f`.
+   * `tail -F` rather than `tail -f` - and why the sink refuses to install when
+   * a launcher already has fds 1/2 open on this file (logFileIsProcessStdio).
    */
   const compact = (): void => {
     try {
+      mkdirSync(dirname(filePath), { recursive: true });
       writeFileSync(tmpPath, ring.length === 1 ? ring[0]! : Buffer.concat(ring, ringBytes), { mode: 0o600 });
       renameSync(tmpPath, filePath);
       closeFd();
@@ -217,12 +481,24 @@ export function installLogFileSink(opts: LogFileSinkOptions): () => void {
       } catch {
         // The temp file may never have been created. Either way we are done.
       }
-      fail(`could not rewrite ${filePath}`, err);
+      degrade(`could not rewrite ${filePath}`, err);
     }
   };
 
+  /**
+   * Cap one line's contribution to the window. Cut on the buffer, not the
+   * string, and decode the head with a StringDecoder so a multi-byte character
+   * straddling the cut is dropped rather than turned into U+FFFD.
+   */
+  const truncateLine = (line: string): string => {
+    if (Buffer.byteLength(line, 'utf8') <= maxLineBytes) return line;
+    const buf = Buffer.from(line, 'utf8');
+    const head = new StringDecoder('utf8').write(buf.subarray(0, maxLineBytes));
+    return `${head}... [truncated by the log sink: ${buf.length - maxLineBytes} more bytes]`;
+  };
+
   const writeLine = (line: string): void => {
-    const clean = redactSecrets(line.replace(ANSI_PATTERN, ''));
+    const clean = truncateLine(redactSecrets(line.replace(ANSI_PATTERN, '')));
     const buf = Buffer.from(`${new Date().toISOString()} ${clean}\n`, 'utf8');
 
     ring.push(buf);
@@ -231,29 +507,57 @@ export function installLogFileSink(opts: LogFileSinkOptions): () => void {
       ringBytes -= ring.shift()!.length;
     }
 
-    appendToFile(buf);
+    if (fd < 0) {
+      // File is gone. Retry occasionally; a successful reopen replays the ring
+      // through `compact`, so the recovered file carries what it missed.
+      if (--recoverIn > 0) return;
+      recoverIn = RECOVER_EVERY_LINES;
+      compact();
+      return;
+    }
+
+    try {
+      appendToFile(buf);
+    } catch (err) {
+      degrade(`could not write to ${filePath}`, err);
+      return;
+    }
     if (fileBytes > compactAt) compact();
   };
 
   const consume = (stream: 'out' | 'err', text: string): void => {
     if (!text) return;
     const buffered = pending[stream] + text;
+    pending[stream] = '';
+
+    // `\r` terminates a line too. Progress renderers redraw with a bare `\r`
+    // and never emit `\n`, and holding those forever meant a growing `pending`
+    // string and nothing on disk. Both indices are tracked and only the
+    // consumed one is re-searched, so the whole scan stays linear.
     let nl = buffered.indexOf('\n');
-    if (nl === -1) {
-      // No terminator yet. Hold it: the rest of this line is coming in a
-      // later write (process.stdout.write callers chunk mid-line freely).
-      pending[stream] = buffered;
-      return;
-    }
+    let cr = buffered.indexOf('\r');
     let start = 0;
-    while (nl !== -1) {
-      // \r\n and a bare \r-driven progress redraw both leave a stray \r.
-      writeLine(buffered.slice(start, nl).replace(/\r$/, ''));
-      if (disabled) return;
-      start = nl + 1;
-      nl = buffered.indexOf('\n', start);
+    while (nl !== -1 || cr !== -1) {
+      const at = nl === -1 ? cr : cr === -1 ? nl : Math.min(nl, cr);
+      const isCr = at === cr;
+      const crlf = isCr && buffered.charCodeAt(at + 1) === 10;
+      const segment = buffered.slice(start, at);
+      // A bare `\r` with nothing before it is a redraw of an empty frame, not
+      // a blank line the process logged. `\r\n` and `\n` keep their blanks.
+      if (segment.length > 0 || !isCr || crlf) writeLine(segment);
+      start = crlf ? at + 2 : at + 1;
+      if (nl !== -1 && nl < start) nl = buffered.indexOf('\n', start);
+      if (cr !== -1 && cr < start) cr = buffered.indexOf('\r', start);
     }
-    pending[stream] = buffered.slice(start);
+
+    let rest = buffered.slice(start);
+    if (rest.length > MAX_PENDING_CHARS) {
+      // No terminator in sight and the buffer is past its budget. Flush it as
+      // a line rather than growing forever.
+      writeLine(rest);
+      rest = '';
+    }
+    pending[stream] = rest;
   };
 
   const patch = (stream: 'out' | 'err', original: StreamWrite): StreamWrite => {
@@ -274,7 +578,7 @@ export function installLogFileSink(opts: LogFileSinkOptions): () => void {
               : null;
         if (text !== null) consume(stream, text);
       } catch (err) {
-        fail('log sink write failed', err);
+        degrade('log sink write failed', err);
       } finally {
         inSink = false;
       }
@@ -323,7 +627,7 @@ export function installLogFileSink(opts: LogFileSinkOptions): () => void {
         // inspection), so the file records the same text the terminal shows.
         consume(stream, `${format(...(args as [unknown, ...unknown[]]))}\n`);
       } catch (err) {
-        fail('log sink write failed', err);
+        degrade('log sink write failed', err);
       } finally {
         inSink = false;
       }

--- a/src/util/redact.test.ts
+++ b/src/util/redact.test.ts
@@ -40,4 +40,73 @@ describe('redactSecrets', () => {
     expect(out).not.toContain(jwt.split('.')[1]);
     expect(out).toContain('***redacted***');
   });
+
+  // The shapes below reached the redactor untouched until this became the
+  // filter in front of the log file (src/util/log-file.ts). A log file is a
+  // durable artifact an operator hands around, so "no call site demonstrably
+  // logs one today" is not good enough for any of them.
+  test('Telegram bot tokens, with and without the `bot` path prefix', () => {
+    // The exact shape src/comms/channels/telegram.ts puts in EVERY request
+    // URL, so anything that logs a failing URL logs the token.
+    const token = '7123456789:AAHfK3n2xYz-QwErTyUiOpAsDfGhJkLzXcV';
+    const url = redactSecrets(`GET https://api.telegram.org/bot${token}/getMe failed`);
+    expect(url).not.toContain('AAHfK3n2xYz');
+    expect(url).toContain('***redacted***');
+    expect(url).toContain('api.telegram.org');
+    expect(redactSecrets(`configured bot ${token}`)).not.toContain('AAHfK3n2xYz');
+  });
+
+  test('GitHub tokens, classic and fine-grained', () => {
+    const classic = 'ghp_AbCdEfGhIjKlMnOpQrStUvWxYz0123456789AB';
+    const pat = 'github_pat_11ABCDEFG0abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJ';
+    expect(redactSecrets(`gh auth ${classic}`)).not.toContain('AbCdEfGh');
+    // `github_pat_` must not be left behind by the short-prefix pattern.
+    const out = redactSecrets(`using ${pat}`);
+    expect(out).not.toContain('abcdefghij');
+    expect(out).not.toContain('github_pat_11');
+  });
+
+  test('labelled key=value / key: value secrets keep the label, lose the value', () => {
+    const cases: ReadonlyArray<readonly [string, string]> = [
+      ['GET /cb?token=Zk9vQmFyQmF6UXV4MTIzNDU2Nzg5MA&state=x', 'Zk9vQmFyQmF6'],
+      ['refresh_token=1//0gAbCdEfGhIjKlMnOpQrStUvWxYz', '0gAbCdEfGh'],
+      ['google client_secret: GOCSPX-AbCdEfGhIjKlMnOpQrStUvWxYz', 'GOCSPX-AbCd'],
+      ['postgres connect password=SuperSecretPassw0rd', 'SuperSecretPassw0rd'],
+    ];
+    for (const [text, secret] of cases) {
+      const out = redactSecrets(text);
+      expect(out).not.toContain(secret);
+      expect(out).toContain('***redacted***');
+    }
+    // The label survives, so the line still says what failed.
+    expect(redactSecrets('client_secret: GOCSPX-AbCdEfGhIjKlMnOpQrStUvWxYz')).toContain('client_secret');
+  });
+
+  test('credentials in a URL userinfo, and a Cookie header end to end', () => {
+    const url = redactSecrets('fetch https://dbuser:hunter2hunter2@db.example.com/health');
+    expect(url).not.toContain('hunter2');
+    expect(url).toContain('db.example.com');
+    const cookie = redactSecrets('Cookie: session=AbCdEfGhIjKlMnOpQrStUvWxYz0123456789; theme=dark');
+    expect(cookie).not.toContain('AbCdEfGh');
+    expect(cookie).toContain('Cookie:');
+  });
+
+  test('webhook signing secrets', () => {
+    const out = redactSecrets('verify against whsec_AbCdEfGhIjKlMnOpQrStUvWxYz0123');
+    expect(out).not.toContain('AbCdEfGh');
+    expect(out).toContain('***redacted***');
+  });
+
+  test('the widened patterns still leave ordinary URLs and prose alone', () => {
+    // A plain https URL with a port looks like `scheme://host:port` - the
+    // userinfo pattern must not read that as user:password.
+    for (const text of [
+      'GET https://api.example.com:8443/v1/models returned 502',
+      'no cookie: found in the response',
+      'bot 7 is not a token',
+      'model uj-chat is not included in your plan (sk is not a prefix here)',
+    ]) {
+      expect(redactSecrets(text)).toBe(text);
+    }
+  });
 });

--- a/src/util/redact.ts
+++ b/src/util/redact.ts
@@ -17,11 +17,34 @@
  * api-key header). Those are caught by shape instead: an `Authorization:
  * Bearer <opaque>` run, or an `api[-_]key`-labelled value. The labelled forms
  * are matched before the bare-token form so the label itself is consumed.
+ *
+ * The labelled set grew when this became the filter in front of the log file
+ * (src/util/log-file.ts): a log file is a durable artifact an operator hands
+ * around, so the shapes jarvis's own dependencies put on a line matter even
+ * where no call site demonstrably leaks one today. A review found these
+ * passing through untouched: Telegram bot tokens (the exact
+ * `bot<digits>:AA...` that src/comms/channels/telegram.ts puts in every request
+ * URL), `ghp_`/`github_pat_`, `?token=`, `refresh_token=`, `client_secret:`,
+ * `password=`, `https://user:pass@host`, `whsec_`, and `Cookie: session=`.
  */
 const CREDENTIAL_PATTERNS: ReadonlyArray<readonly [RegExp, string]> = [
+  // Credentials in a URL's userinfo. Runs first: the `user:pass` run would
+  // otherwise be picked apart by the labelled patterns below.
+  [/\b([a-z][a-z0-9+.-]*:\/\/)[^\s/@:]{1,256}:[^\s/@]{1,256}@/gi, '$1***redacted***@'],
   // Labelled secrets — keep the label so the message still says WHAT failed,
   // drop the value. Runs first so the label is consumed with its value.
   [/\b(api[-_]?key|authorization|x-api-key)(["'\s:=]+)(?:(?:bearer|basic|token)\s+)?[A-Za-z0-9._~+/=-]{12,}/gi, '$1$2***redacted***'],
+  // The `key=value` / `key: value` forms: query strings, OAuth bodies, env
+  // dumps, connection strings, JSON. The value class stops at a quote,
+  // separator or bracket so only the value is eaten, not the rest of the line.
+  [
+    /\b(client[-_]?secret|refresh[-_]?token|access[-_]?token|id[-_]?token|auth[-_]?token|api[-_]?token|session[-_]?token|token|secret|password|passwd|passphrase|pwd)(["'\s]*[:=]["'\s]*)[^\s"'&,;)}\]]{6,}/gi,
+    '$1$2***redacted***',
+  ],
+  // A Cookie / Set-Cookie header is a credential end to end, so the whole
+  // value goes. The `name=` requirement keeps prose ("no cookie: found")
+  // out of it.
+  [/\b((?:set-)?cookie)(["'\s]*:\s*)[A-Za-z0-9_.-]{1,64}=[^\r\n]{1,4096}/gi, '$1$2***redacted***'],
   [/\b(?:bearer|basic|token)\s+[A-Za-z0-9._~+/=-]{12,}/gi, '***redacted***'],
   // Bare JWTs (three base64url segments) with no label at all — Vertex/Azure
   // bodies echo these unlabelled.
@@ -31,6 +54,16 @@ const CREDENTIAL_PATTERNS: ReadonlyArray<readonly [RegExp, string]> = [
   [/\bAIza[A-Za-z0-9_-]{10,}/g, '***redacted***'],
   [/\bAKIA[0-9A-Z]{12,}/g, '***redacted***'],
   [/\bya29\.[A-Za-z0-9._-]{10,}/g, '***redacted***'],
+  // GitHub: the fine-grained PAT form first, since `github_pat_` would
+  // otherwise be left behind by the short-prefix pattern.
+  [/\bgithub_pat_[A-Za-z0-9_]{20,}/g, '***redacted***'],
+  [/\bgh[pousr]_[A-Za-z0-9]{16,}/g, '***redacted***'],
+  // Stripe-style webhook signing secrets.
+  [/\bwhsec_[A-Za-z0-9_-]{8,}/g, '***redacted***'],
+  // Telegram bot tokens: `<bot-id>:AA<base64url>`, optionally with the `bot`
+  // prefix the Bot API wants in the path. Every telegram.ts request URL
+  // carries one, so anything that logs a failing URL logs the token.
+  [/\b(?:bot)?\d{6,16}:AA[A-Za-z0-9_-]{20,}/g, '***redacted***'],
 ];
 
 export function redactSecrets(text: string): string {


### PR DESCRIPTION
Adds an in-process log-file sink so a brain writes a log file in every launch mode, not just `jarvis start -d` and launchd. Under systemd (how the hosted fleet runs it) and under Docker there was no file at all, and there is no logger in the codebase to hook - it is ~1150 raw `console.*` calls with no levels, no file sink and no rotation.

Driven by two new system-owned config keys:

```yaml
daemon:
  log_file_path: /home/u_abc123/.jarvis/logs/jarvis.log
  log_file_max_bytes: 1048576   # optional, defaults to 1 MiB
```

Unset means no file is written. Lines are ANSI-stripped and run through the existing `redactSecrets()` before they are written, so the file on disk is safe to hand an operator. The cap is a ring: the last `maxBytes` are held in memory, the file is appended normally, and past `maxBytes * 1.25` it is rewritten from the ring via write-temp + rename. Drops are on line boundaries, so the file never starts mid-line and appends stay O(1). `log_file_max_bytes` is therefore an RSS cost too, which the docs now say.

Note it patches `console.*` as well as `process.stdout/stderr.write`: on Bun, `console.log` does NOT route through the stream, so a stream-only hook records nothing. There is a regression test pinning that.

The hosting control plane renders `log_file_path` into each managed instance's config and reads the file back for its admin Logs page (usejarvis `docs/LOGS.md`).

## Review fixes in the second commit

An adversarial review found two HIGH defects, both reproduced with probes and both fixed:

- When a launcher redirects fds 1/2 at the same file, the first compaction's `rename` left the process writing to a **deleted inode** that grew forever and was invisible to `ls`. Guarded now by an `fstat` dev+ino identity check in the daemon, which covers all three launchers rather than the one that was originally handled.
- A **FIFO at `log_file_path` hung the daemon at boot** - `openSync` blocks forever with no reader, and systemd never restarts it because nothing crashed. Tenant-reachable. Now refuses anything that is not a regular file.

Also fixed: a restart wiped the previous run's history at the first compaction (worst exactly during a crash loop), one oversized line evicted the whole window, `\r`-only progress output grew `pending` unboundedly (2.1s/+52MB -> 96ms), `log_file_max_bytes: .inf` disabled compaction, and the ANSI pattern was the ansi-regex CVE shape (385ms -> under 20ms). Redaction widened to Telegram, GitHub, `token=`/`secret:`/`password=`, cookies and URL userinfo.

Documented rather than fixed: `tail -F` replays the window after each compaction. That is inherent to any in-place ring - rotation and truncate-in-place restart a tailer too - so `jarvis logs -f` moved to `tail -F` and the behaviour is called out in the docs.

## Tests

`bun test`: 2637 pass, 45 skip, 0 fail. `bunx tsc --noEmit` clean. `src/util/log-file.test.ts` is new (24 tests) covering the cap, line-boundary drops, redaction, the FIFO and symlink refusals, the fd identity skip, degradation and recovery, and the `Uint8Array`/`StringDecoder` path.