### PR TITLE
Panel sessions: stop the sidecar's panels dying 10 minutes in

### DIFF
--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -31,11 +31,18 @@ jarvis enroll "my-desktop"
 This mints a long-lived enrollment token (ES256 JWT) and prints it. The
 enrollment token is accepted on exactly two endpoints: `/sidecar/connect`
 (the sidecar WebSocket) and `POST /sidecar/token`, which exchanges it for a
-short-lived access token (10 minutes). Everything else - dashboard, API,
-`/ws` - requires an access token. The desktop sidecar app handles this
-automatically: paste the enrollment token into it once, and it connects,
-re-mints access tokens as needed, and opens dashboard panels that are already
-authenticated.
+short-lived access token (10 minutes). That access token is a bootstrap, not
+the thing the dashboard runs on: a panel opens with it in the URL, the brain
+trades it for a panel session, and everything else - dashboard, API, `/ws` -
+is authorized by that session's cookie. The desktop sidecar app handles all of
+it: paste the enrollment token into it once, and it connects, mints as needed,
+and opens dashboard panels that are already authenticated.
+
+A panel session lasts until whichever comes first: the device is revoked, the
+panel has been closed for 4 hours while that device's sidecar is connected, or
+an absolute 12-hour cap. A sleeping or offline machine accrues no idle time at
+all, so closing the lid over lunch does not cost you your open windows, and
+neither does a brain restart - sessions are persisted.
 
 The only public (unauthenticated) routes are `/health`, `/sidecar/connect`,
 the JWKS endpoint (`/api/sidecars/.well-known/jwks.json`), and
@@ -160,10 +167,10 @@ secure and the sidecar will try `wss://` and fail to connect.
 
 ### What works over plain HTTP on a LAN
 
-Auth works: the login cookie is intentionally not marked `Secure` on plain
-HTTP, so the token flow functions. Chat, tools, workflows - all fine.
-Sending tokens in cleartext across your own LAN is the accepted tradeoff
-here; don't do it on a network you don't trust.
+Auth works: the session cookie is intentionally not marked `Secure` on plain
+HTTP, so the flow functions. Chat, tools, workflows - all fine. Sending a
+credential in cleartext across your own LAN is the accepted tradeoff here;
+don't do it on a network you don't trust.
 
 What does NOT work from a `http://192.168.x.x` dashboard is anything the
 browser gates behind secure contexts. That is browser policy and cannot be

--- a/src/comms/websocket.test.ts
+++ b/src/comms/websocket.test.ts
@@ -1,4 +1,5 @@
 import { test, expect, beforeEach, afterEach } from 'bun:test';
+import { PanelSessionStore, PANEL_SESSION_CLOSED_CODE } from '../sidecar/panel-sessions.ts';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
@@ -280,11 +281,53 @@ test('WebSocketServer - sendBinary reaches client', async () => {
 // JWT-only by default: non-public routes require a valid short-lived sidecar
 // access token; auth.insecure_open_access is the sole (loud) escape hatch.
 
-/** Minimal stand-in for the SidecarManager's access-token verification. */
+/**
+ * Backed by the REAL PanelSessionStore, so these exercise the actual bootstrap
+ * -> session -> cookie path rather than a stub of it. `revoke()` drops the
+ * bootstrap credential WITHOUT touching the store, which is how a test
+ * reproduces the thing this design fixes: the access token going invalid
+ * (expiry, in production) while the panel is mid-use.
+ */
 function fakeSidecarManager(validToken: string) {
-  return {
-    verifyAccessToken: async (tok: string) => (tok === validToken ? { sid: 's1' } : null),
-  } as unknown as import('../sidecar/manager.ts').SidecarManager;
+  const sessions = new PanelSessionStore();
+  let accepted: string | null = validToken;
+  // Typed as a Pick of the REAL class, with no `unknown` hop, so a SHAPE change
+  // to any of these five stops compiling instead of silently passing while the
+  // real code takes a different branch. A sync `resolvePanelSession` that
+  // became async would otherwise return a Promise, which `if (!session)` treats
+  // as authorized -- an auth bypass no test here could see.
+  //
+  // It does not catch the server calling a SIXTH method: the final assertion
+  // widens this to the full class, so that surfaces as a TypeError at test
+  // time rather than a compile error. Still a failing test, just later.
+  const impl: Pick<
+    import('../sidecar/manager.ts').SidecarManager,
+    'verifyAccessToken' | 'openPanelSession' | 'resolvePanelSession' | 'panelSocketOpened' | 'panelSocketClosed'
+  > = {
+    verifyAccessToken: async (tok: string) => (tok === accepted ? { sid: 's1' } : null),
+    openPanelSession: async (tok: string) => (tok === accepted ? sessions.create('s1') : null),
+    resolvePanelSession: (id: string) => sessions.get(id),
+    panelSocketOpened: (id: string, socket: { close(code?: number, reason?: string): void }) =>
+      sessions.socketOpened(id, socket),
+    panelSocketClosed: (id: string, socket: { close(code?: number, reason?: string): void }) =>
+      sessions.socketClosed(id, socket),
+  };
+  return Object.assign(impl as import('../sidecar/manager.ts').SidecarManager, {
+    /** Make the BOOTSTRAP credential stop verifying, which is what expiry does
+     *  in production. Not revocation: that also kills live sessions, and is
+     *  covered against the real manager in src/sidecar/manager.test.ts. */
+    expireToken: () => {
+      accepted = null;
+    },
+    sessions,
+  });
+}
+
+/** Pull the session id out of a Set-Cookie header. */
+function sessionCookie(setCookie: string | null): string {
+  const m = /panel_session=([^;]+)/.exec(setCookie ?? '');
+  if (!m) throw new Error(`no panel_session in Set-Cookie: ${setCookie}`);
+  return `panel_session=${m[1]}`;
 }
 
 test('WebSocketServer - JWT-only by DEFAULT: unauthenticated requests are blocked', async () => {
@@ -317,7 +360,7 @@ test('WebSocketServer - JWT-only by DEFAULT: unauthenticated requests are blocke
   }
 });
 
-test('WebSocketServer - a valid sidecar access token authorizes via ?token= then cookie', async () => {
+test('WebSocketServer - ?token= is exchanged for a panel session, and the session is what the cookie carries', async () => {
   const authServer = new WebSocketServer(3151);
   authServer.setSidecarManager(fakeSidecarManager('valid-access-token'));
   authServer.setApiRoutes({
@@ -328,23 +371,58 @@ test('WebSocketServer - a valid sidecar access token authorizes via ?token= then
   authServer.start();
 
   try {
-    // Query param with a valid access token → 302 + Set-Cookie
+    // Query param with a valid access token -> 302 + a session cookie.
     const withToken = await fetch('http://localhost:3151/?token=valid-access-token', { redirect: 'manual' });
     expect(withToken.status).toBe(302);
-    expect(withToken.headers.get('Set-Cookie')).toContain('token=valid-access-token');
     expect(withToken.headers.get('Location')).toBe('/');
+    const setCookie = withToken.headers.get('Set-Cookie');
+    expect(setCookie).toContain('panel_session=');
+    expect(setCookie).toContain('HttpOnly');
+    // The whole point: the credential is NOT what ends up in the cookie.
+    expect(setCookie).not.toContain('valid-access-token');
 
-    // Cookie authorizes API requests
+    // The session authorizes API requests.
     const res = await fetch('http://localhost:3151/api/health', {
-      headers: { Cookie: 'token=valid-access-token' },
+      headers: { Cookie: sessionCookie(setCookie) },
     });
     expect(res.ok).toBe(true);
     const data = await res.json() as any;
     expect(data.status).toBe('ok');
 
-    // Wrong tokens stay out
+    // A bad bootstrap token opens nothing, and the old scheme's cookie (the
+    // access token itself) is not a session id and buys nothing either.
     expect((await fetch('http://localhost:3151/?token=wrong', { redirect: 'manual' })).status).toBe(401);
-    expect((await fetch('http://localhost:3151/api/health', { headers: { Cookie: 'token=wrong' } })).status).toBe(401);
+    expect((await fetch('http://localhost:3151/api/health', { headers: { Cookie: 'panel_session=wrong' } })).status).toBe(401);
+    expect((await fetch('http://localhost:3151/api/health', { headers: { Cookie: 'token=valid-access-token' } })).status).toBe(401);
+  } finally {
+    authServer.stop();
+  }
+});
+
+test('WebSocketServer - a panel session outlives the expiry of the bootstrap token that opened it', async () => {
+  // THE REGRESSION THIS PHASE EXISTS FOR. The access token used to BE the
+  // cookie, so when it expired (10 minutes) the panel was dead mid-use with no
+  // way back. Here the token goes invalid right after bootstrap and the panel
+  // carries on, which is exactly the production sequence.
+  const authServer = new WebSocketServer(3157);
+  const mgr = fakeSidecarManager('valid-access-token');
+  authServer.setSidecarManager(mgr);
+  authServer.setApiRoutes({
+    '/api/health': { GET: () => Response.json({ status: 'ok' }) },
+  });
+  authServer.start();
+
+  try {
+    const boot = await fetch('http://localhost:3157/?token=valid-access-token', { redirect: 'manual' });
+    const cookie = sessionCookie(boot.headers.get('Set-Cookie'));
+
+    mgr.expireToken();
+
+    // The bootstrap credential is gone, so no NEW panel can open...
+    expect((await fetch('http://localhost:3157/?token=valid-access-token', { redirect: 'manual' })).status).toBe(401);
+    // ...but the one already open keeps working.
+    const res = await fetch('http://localhost:3157/api/health', { headers: { Cookie: cookie } });
+    expect(res.ok).toBe(true);
   } finally {
     authServer.stop();
   }
@@ -357,6 +435,9 @@ test('WebSocketServer - there is NO shared-token backdoor without a sidecar mana
   authServer.start();
 
   try {
+    expect((await fetch('http://localhost:3152/api/health', { headers: { Cookie: 'panel_session=anything' } })).status).toBe(401);
+    // ...and with the cookie the previous scheme used, which is now just a
+    // string that names no session.
     expect((await fetch('http://localhost:3152/api/health', { headers: { Cookie: 'token=anything' } })).status).toBe(401);
     expect((await fetch('http://localhost:3152/?token=anything', { redirect: 'manual' })).status).toBe(401);
   } finally {
@@ -399,14 +480,18 @@ test('WebSocketServer - auth.insecure_open_access opens the dashboard (setup esc
   }
 });
 
-test('WebSocketServer - WebSocket upgrade allowed with a valid access-token cookie', async () => {
+test('WebSocketServer - WebSocket upgrade allowed with a valid panel-session cookie', async () => {
   const authServer = new WebSocketServer(3155);
-  authServer.setSidecarManager(fakeSidecarManager('valid-access-token'));
+  const mgr = fakeSidecarManager('valid-access-token');
+  authServer.setSidecarManager(mgr);
   authServer.start();
+
+  const sessionId = mgr.sessions.create('s1').id;
+  const cookie = `panel_session=${sessionId}`;
 
   try {
     const ws = new WebSocket('ws://localhost:3155/ws', {
-      headers: { Cookie: 'token=valid-access-token' },
+      headers: { Cookie: cookie },
     } as any);
 
     const connected = await new Promise<boolean>((resolve) => {
@@ -416,8 +501,57 @@ test('WebSocketServer - WebSocket upgrade allowed with a valid access-token cook
     });
 
     expect(connected).toBe(true);
+    // The plumbing this phase IS: upgrade stamps the session onto ws.data, and
+    // open/close move the store's socket count. Without this assertion the
+    // whole liveness mechanism could be unwired and every store-level test
+    // would still pass.
+    expect(mgr.sessions.socketsOpen(sessionId)).toBe(1);
+
     ws.close();
     await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(mgr.sessions.socketsOpen(sessionId)).toBe(0);
+  } finally {
+    authServer.stop();
+  }
+});
+
+test('WebSocketServer - tearing down a session hangs up on its live socket and refuses the reconnect', async () => {
+  // The end-to-end shape of `jarvis revoke` against an open panel: not just
+  // "the map entry is gone" but "the socket the attacker already had is
+  // closed, and the reconnect it will immediately attempt is refused". A
+  // socket is authorized ONCE, at the upgrade, and never re-checked.
+  const authServer = new WebSocketServer(3158);
+  const mgr = fakeSidecarManager('valid-access-token');
+  authServer.setSidecarManager(mgr);
+  authServer.start();
+
+  const sessionId = mgr.sessions.create('s1').id;
+  const cookie = `panel_session=${sessionId}`;
+
+  try {
+    const ws = new WebSocket('ws://localhost:3158/ws', { headers: { Cookie: cookie } } as any);
+    const closed = new Promise<number>((resolve) => {
+      ws.onclose = (e) => resolve(e.code);
+    });
+    await new Promise<void>((resolve, reject) => {
+      ws.onopen = () => resolve();
+      ws.onerror = () => reject(new Error('did not connect'));
+      setTimeout(() => reject(new Error('connect timed out')), 2000);
+    });
+    expect(mgr.sessions.socketsOpen(sessionId)).toBe(1);
+
+    mgr.sessions.deleteBySid('s1');
+
+    expect(await closed).toBe(PANEL_SESSION_CLOSED_CODE);
+
+    // And the cookie it still holds buys nothing on the way back in.
+    const retry = new WebSocket('ws://localhost:3158/ws', { headers: { Cookie: cookie } } as any);
+    const reconnected = await new Promise<boolean>((resolve) => {
+      retry.onopen = () => resolve(true);
+      retry.onerror = () => resolve(false);
+      setTimeout(() => resolve(false), 1500);
+    });
+    expect(reconnected).toBe(false);
   } finally {
     authServer.stop();
   }

--- a/src/comms/websocket.ts
+++ b/src/comms/websocket.ts
@@ -3,6 +3,7 @@ import { timingSafeEqual } from 'node:crypto';
 import path from 'node:path';
 import { isWithin } from '../util/path.ts';
 import type { SidecarManager } from '../sidecar/manager.ts';
+import { PANEL_SESSION_COOKIE } from '../sidecar/panel-sessions.ts';
 
 /** Constant-time string comparison to prevent timing attacks */
 export type WSMessage = {
@@ -88,7 +89,16 @@ function getCookie(req: Request, name: string): string | null {
   const cookies = req.headers.get('Cookie');
   if (!cookies) return null;
   const match = cookies.match(new RegExp(`(?:^|;\\s*)${name}=([^;]*)`));
-  return match ? decodeURIComponent(match[1]!) : null;
+  if (!match) return null;
+  try {
+    return decodeURIComponent(match[1]!);
+  } catch {
+    // A malformed escape (`%E0%A4%A`) makes decodeURIComponent throw, which
+    // would unwind out of fetch() as a 500. This value is attacker-controlled
+    // and read on the authentication path, so an unusable cookie has to read
+    // as "no cookie" (401) rather than as a server fault.
+    return null;
+  }
 }
 
 function isPublicRoute(pathname: string, method: string): boolean {
@@ -147,9 +157,10 @@ export class WebSocketServer {
   private publicDir: string | null = null;
   private sidecarManager: SidecarManager | null = null;
   /**
-   * JWT-only by default: every non-public route requires a valid short-lived
-   * sidecar access token (minted from an enrollment JWT). The ONLY way to
-   * open the dashboard without one is the explicit config escape hatch
+   * Authenticated by default: every non-public route requires a live PANEL
+   * SESSION (src/sidecar/panel-sessions.ts), which is opened by exchanging an
+   * access token that was itself minted from an enrollment JWT. The ONLY way
+   * to open the dashboard without one is the explicit config escape hatch
    * `auth.insecure_open_access: true` (pre-enrollment setup; see docs).
    */
   private insecureOpenAccess = false;
@@ -234,13 +245,16 @@ export class WebSocketServer {
     // one variant, so the pair is cast to the port variant; at runtime Bun
     // receives exactly one of the two keys.
     const listenOpts = (this.unixPath ? { unix: this.unixPath } : { port: this.port }) as { port: number };
-    this.server = Bun.serve<{ sidecar_id?: string; channel?: string; proxy_target?: string; _proxyUpstream?: WebSocket }>({
+    this.server = Bun.serve<{ sidecar_id?: string; channel?: string; proxy_target?: string; panel_session?: string; _proxyUpstream?: WebSocket }>({
       ...listenOpts,
       idleTimeout: 30, // seconds — prevent timeout during heavy processing (OCR, PowerShell)
 
       async fetch(req, server) {
         const url = new URL(req.url);
         const pathname = url.pathname;
+        /** Set by the auth block when this request carried a live panel
+         *  session; read by the /ws upgrade to bind the socket to it. */
+        let panelSessionId: string | null = null;
 
         // 0. Sidecar WebSocket upgrade (has its own JWT auth)
         if (pathname === '/sidecar/connect' && self.sidecarManager) {
@@ -270,9 +284,10 @@ export class WebSocketServer {
         // 0b. Sidecar access-token mint. Authenticated by the long-lived
         //     enrollment JWT (Authorization: Bearer) — this and /sidecar/connect
         //     are the ONLY places that credential is accepted. Returns a
-        //     short-lived access token the sidecar injects into its panel
-        //     webviews; everything on the data plane (/api, /ws) authenticates
-        //     with that access token, never the enrollment JWT.
+        //     short-lived access token the sidecar puts in a panel's spawn
+        //     URL, where it is exchanged for a panel session; the data plane
+        //     (/api, /ws) then authenticates with that SESSION, never with
+        //     this token and never with the enrollment JWT.
         if (pathname === '/sidecar/token' && req.method === 'POST' && self.sidecarManager) {
           const authHeader = req.headers.get('Authorization');
           const enrollTok = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : null;
@@ -287,35 +302,53 @@ export class WebSocketServer {
           return Response.json({ access_token: minted.token, expires_in: minted.expiresIn });
         }
 
-        // 1. Auth check. JWT-only by default: a request is authorized by a
-        // valid short-lived sidecar ACCESS token (minted from the enrollment
-        // JWT via /sidecar/token) - the sidecar's panel webviews carry one.
-        // The long-lived enrollment JWT is deliberately NOT accepted here —
-        // only on /sidecar/connect and the mint endpoint — so a leaked panel
-        // credential is bounded to the access-token TTL instead of forever.
-        // There is NO shared dashboard token: enroll a device or (setup only)
-        // set auth.insecure_open_access.
+        // 1. Auth check. A request is authorized by a PANEL SESSION cookie
+        // (panel-sessions.ts). The access token minted from the enrollment JWT
+        // is now a bootstrap credential only: it arrives as ?token= on a freshly
+        // spawned panel, is exchanged here for a session, and is never the thing
+        // the cookie carries. The exchange is not single-use and cannot cheaply
+        // be made so; panel-sessions.ts records what that costs.
+        //
+        // It used to BE the cookie, which made the token's 10-minute TTL the
+        // session's lifetime: the panel died mid-use and no amount of retrying
+        // could revive it, because only the sidecar may mint and the cookie is
+        // HttpOnly. A session is refreshed by nothing and outlives no
+        // revocation -- see the resolver, which re-checks enrollment.
+        //
+        // The long-lived enrollment JWT is still NOT accepted here, only on
+        // /sidecar/connect and the mint endpoint. There is NO shared dashboard
+        // token: enroll a device or (setup only) set auth.insecure_open_access.
         if (!self.insecureOpenAccess && !isPublicRoute(pathname, req.method)) {
-          const accepts = async (tok: string | null): Promise<boolean> => {
-            if (!tok) return false;
-            if (self.sidecarManager && (await self.sidecarManager.verifyAccessToken(tok))) return true;
-            return false;
-          };
-          const cookieToken = getCookie(req, 'token');
-          if (!(await accepts(cookieToken))) {
-            // Check ?token= query param — set cookie via Set-Cookie and redirect
+          const cookie = getCookie(req, PANEL_SESSION_COOKIE);
+          const session = cookie && self.sidecarManager
+            ? self.sidecarManager.resolvePanelSession(cookie)
+            : null;
+          if (session) {
+            // Remembered for the /ws upgrade below, which binds the socket to
+            // the session so an open panel counts as live (panel-sessions.ts).
+            panelSessionId = session.id;
+          }
+          if (!session) {
+            // No session yet (a freshly spawned panel) or a dead one. Bootstrap
+            // from ?token=, then redirect to the same URL WITHOUT it so the
+            // credential does not survive in the address bar or history.
             const queryToken = url.searchParams.get('token');
-            if (await accepts(queryToken)) {
+            const opened = queryToken && self.sidecarManager
+              ? await self.sidecarManager.openPanelSession(queryToken)
+              : null;
+            if (opened) {
               const cleanParams = new URLSearchParams(url.searchParams);
               cleanParams.delete('token');
               const qs = cleanParams.toString();
               const redirectTo = pathname + (qs ? '?' + qs : '');
               // Mark the cookie Secure whenever the connection is TLS (directly,
-              // or terminated upstream and forwarded) so the token can't leak
-              // over a downgraded http request to the same host.
+              // or terminated upstream and forwarded) so the session id can't
+              // leak over a downgraded http request to the same host.
               const xfProto = (req.headers.get('x-forwarded-proto') ?? '').split(',')[0]?.trim();
               const isHttps = url.protocol === 'https:' || xfProto === 'https';
-              const cookie = `token=${queryToken}; Path=/; SameSite=Lax; HttpOnly` +
+              // No Max-Age on purpose: the cookie dies with the webview, and
+              // the store's absolute cap is what bounds it server-side.
+              const cookie = `${PANEL_SESSION_COOKIE}=${opened.id}; Path=/; SameSite=Lax; HttpOnly` +
                 (isHttps ? '; Secure' : '');
               return new Response(null, {
                 status: 302,
@@ -356,7 +389,7 @@ export class WebSocketServer {
               return new Response('Forbidden: origin mismatch', { status: 403 });
             }
           }
-          const success = server.upgrade(req, { data: {} });
+          const success = server.upgrade(req, { data: { panel_session: panelSessionId ?? undefined } });
           if (success) return undefined;
           return new Response('WebSocket upgrade failed', { status: 500 });
         }
@@ -394,7 +427,10 @@ export class WebSocketServer {
                 return new Response('Dev server not running', { status: 502 });
               }
               const success = server.upgrade(req, {
-                data: { proxy_target: targetUrl },
+                // panel_session so a revoked device's dev-server bridge is hung
+                // up on like any other panel socket; it passed the same auth
+                // block to get here.
+                data: { proxy_target: targetUrl, panel_session: panelSessionId ?? undefined },
               });
               if (success) return undefined;
               return new Response('WebSocket upgrade failed', { status: 500 });
@@ -517,7 +553,11 @@ export class WebSocketServer {
           if (req.headers.get('upgrade')?.toLowerCase() === 'websocket') {
             const targetUrl = self.siteProxy.getWebSocketTargetFromCookie(req, pathname);
             if (targetUrl) {
-              const success = server.upgrade(req, { data: { proxy_target: targetUrl } });
+              const success = server.upgrade(req, {
+                // panel_session so a revoked device's dev-server bridge is hung up on
+                // like any other panel socket; it passed the same auth block.
+                data: { proxy_target: targetUrl, panel_session: panelSessionId ?? undefined },
+              });
               if (success) return undefined;
             }
           }
@@ -534,6 +574,13 @@ export class WebSocketServer {
         maxPayloadLength: 16 * 1024 * 1024,
 
         open(ws) {
+          // Before any branch: every socket that carried a panel session is
+          // tracked, including the HMR bridge below, which returns early. An
+          // untracked socket is one no teardown can hang up on.
+          if (ws.data?.panel_session) {
+            self.sidecarManager?.panelSocketOpened(ws.data.panel_session, ws);
+          }
+
           // HMR proxy WebSocket — bridge to dev server
           const proxyTarget = (ws.data as any)?.proxy_target as string | undefined;
           if (proxyTarget) {
@@ -636,6 +683,14 @@ export class WebSocketServer {
         },
 
         close(ws) {
+          // Mirrors open(): before any early return. A panel's window going
+          // away takes its sockets with it, on every platform and every spawn
+          // path, and that is what marks the session collectable
+          // (PANEL_SESSION_IDLE_MS).
+          if (ws.data?.panel_session) {
+            self.sidecarManager?.panelSocketClosed(ws.data.panel_session, ws);
+          }
+
           // HMR proxy cleanup
           const proxyUpstream = (ws.data as any)?._proxyUpstream as WebSocket | undefined;
           if (proxyUpstream) {

--- a/src/sidecar/manager.test.ts
+++ b/src/sidecar/manager.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { decodeJwt } from 'jose';
 import { buildEnrollmentUrls, isLocalhostBrainUrl, SidecarManager } from './manager.ts';
-import { initDatabase, closeDb } from '../vault/schema.ts';
+import { initDatabase, closeDb, getDb } from '../vault/schema.ts';
 import { computeAnonId } from '../telemetry/anon-id.ts';
 
 function keyPaths(dataDir: string): { keyDir: string; privateKeyPath: string; publicKeyPath: string } {
@@ -267,6 +267,200 @@ describe('SidecarManager access tokens', () => {
       expect(await manager.verifyAccessToken(tampered)).toBeNull();
 
       await manager.stop();
+    } finally {
+      closeDb();
+      await rm(dataDir, { recursive: true, force: true });
+    }
+  });
+});
+
+/**
+ * Panel sessions are what a panel webview authenticates with once its
+ * bootstrap access token has been exchanged. The access token's 10-minute TTL
+ * used to be BOTH the session lifetime (which broke panels mid-use) and the
+ * revocation mechanism (`verifyAccessToken` is stateless on purpose). Removing
+ * the first meant taking on the second explicitly, so these pin revocation.
+ */
+describe('SidecarManager panel sessions', () => {
+  const withManager = async (
+    body: (manager: SidecarManager, dataDir: string) => Promise<void>,
+  ) => {
+    const dataDir = await mkdtemp(join(tmpdir(), 'jarvis-sidecar-manager-'));
+    initDatabase(':memory:');
+    try {
+      const manager = new SidecarManager(dataDir);
+      await manager.start();
+      manager.setBrainUrl('https://brain.example.com');
+      await body(manager, dataDir);
+      await manager.stop();
+    } finally {
+      closeDb();
+      await rm(dataDir, { recursive: true, force: true });
+    }
+  };
+
+  test('opens a session only for a token that verifies, and only while enrolled', async () => {
+    await withManager(async (manager) => {
+      const { sidecar } = await manager.enrollSidecar('panel-open');
+      const minted = await manager.issueAccessToken(sidecar.id);
+
+      const session = await manager.openPanelSession(minted!.token);
+      expect(session).not.toBeNull();
+      expect(session!.sid).toBe(sidecar.id);
+
+      // Garbage, and the enrollment JWT itself, open nothing.
+      expect(await manager.openPanelSession('not-a-token')).toBeNull();
+      expect(await manager.openPanelSession('')).toBeNull();
+    });
+  });
+
+  test('revoking a device closes its panels and leaves other devices alone', async () => {
+    await withManager(async (manager) => {
+      const a = (await manager.enrollSidecar('device-a')).sidecar;
+      const b = (await manager.enrollSidecar('device-b')).sidecar;
+      const aSession = (await manager.openPanelSession((await manager.issueAccessToken(a.id))!.token))!;
+      const bSession = (await manager.openPanelSession((await manager.issueAccessToken(b.id))!.token))!;
+
+      expect(manager.revokeSidecar(a.id)).toBe(true);
+
+      expect(manager.resolvePanelSession(aSession.id)).toBeNull();
+      expect(manager.resolvePanelSession(bSession.id)?.sid).toBe(b.id);
+      expect(manager.listPanelSessions()).toHaveLength(1);
+    });
+  });
+
+  test('a revoked device is refused on the next request, not at the next sweep', async () => {
+    await withManager(async (manager) => {
+      const { sidecar } = await manager.enrollSidecar('cli-revoke');
+      const session = (await manager.openPanelSession((await manager.issueAccessToken(sidecar.id))!.token))!;
+      expect(manager.resolvePanelSession(session.id)).not.toBeNull();
+
+      // What `jarvis revoke` does from ANOTHER process: the row goes, and this
+      // daemon is not told. The resolver must not need to have been told.
+      const db = getDb();
+      db.run('DELETE FROM sidecars WHERE id = ?', [sidecar.id]);
+
+      expect(manager.resolvePanelSession(session.id)).toBeNull();
+      // ...and it is forgotten, not merely refused each time.
+      expect(manager.listPanelSessions()).toHaveLength(0);
+    });
+  });
+
+  test('the sweep closes panels of a device revoked while it was offline', async () => {
+    await withManager(async (manager) => {
+      const { sidecar } = await manager.enrollSidecar('offline-revoke');
+      await manager.openPanelSession((await manager.issueAccessToken(sidecar.id))!.token);
+      expect(manager.listPanelSessions()).toHaveLength(1);
+
+      // No live connection to sever, so sweepRevokedConnections sees nothing.
+      getDb().run('DELETE FROM sidecars WHERE id = ?', [sidecar.id]);
+      expect(manager.sweepRevokedConnections()).toBe(0);
+
+      expect(manager.sweepPanelSessions()).toBe(1);
+      expect(manager.listPanelSessions()).toHaveLength(0);
+    });
+  });
+
+  test('closing a session removes its row, not just its map entry', async () => {
+    // Every write-through assertion elsewhere runs against a fake sink. This
+    // one runs against the real table, so a typo in the SQL is caught rather
+    // than passing every in-memory check.
+    await withManager(async (manager) => {
+      const { sidecar } = await manager.enrollSidecar('rows-test');
+      await manager.openPanelSession((await manager.issueAccessToken(sidecar.id))!.token);
+      const rows = () =>
+        (getDb().query('SELECT count(*) AS n FROM panel_sessions').get() as { n: number }).n;
+      expect(rows()).toBe(1);
+
+      expect(manager.revokeSidecar(sidecar.id)).toBe(true);
+      expect(rows()).toBe(0);
+    });
+  });
+
+  test('a CLI revoke takes the rows with it, in that process, via the cascade', async () => {
+    await withManager(async (manager) => {
+      const { sidecar } = await manager.enrollSidecar('cascade-test');
+      await manager.openPanelSession((await manager.issueAccessToken(sidecar.id))!.token);
+
+      // What `jarvis revoke` does, from a process that knows nothing about
+      // panel sessions. The FK is what cleans up on its behalf.
+      getDb().run('DELETE FROM sidecars WHERE id = ?', [sidecar.id]);
+
+      const n = (getDb().query('SELECT count(*) AS n FROM panel_sessions').get() as { n: number }).n;
+      expect(n).toBe(0);
+    });
+  });
+
+  test('a device revoked while the brain was down does not come back with it', async () => {
+    // The dangerous shape of the restart feature: sessions persist, so a
+    // revocation performed during the downtime must still be honoured on the
+    // way back up rather than restored as a live panel.
+    const dataDir = await mkdtemp(join(tmpdir(), 'jarvis-sidecar-manager-'));
+    initDatabase(':memory:');
+    try {
+      const first = new SidecarManager(dataDir);
+      await first.start();
+      first.setBrainUrl('https://brain.example.com');
+      const { sidecar } = await first.enrollSidecar('revoked-while-down');
+      const session = (await first.openPanelSession((await first.issueAccessToken(sidecar.id))!.token))!;
+      await first.stop();
+
+      getDb().run('DELETE FROM sidecars WHERE id = ?', [sidecar.id]);
+
+      const second = new SidecarManager(dataDir);
+      await second.start();
+      // Assert BEFORE resolving: `resolvePanelSession` deletes on a failed
+      // enrollment check, so checking after it would pass whether the cascade
+      // worked or not. Nothing should have been restored at all.
+      expect(second.listPanelSessions()).toHaveLength(0);
+      expect(second.resolvePanelSession(session.id)).toBeNull();
+      await second.stop();
+    } finally {
+      closeDb();
+      await rm(dataDir, { recursive: true, force: true });
+    }
+  });
+
+  test('revoking a device with more sessions than SQLite has variables still clears the table', async () => {
+    // The bootstrap token is reusable inside its TTL, so the number of sessions
+    // for one sid is not bounded by anything the code controls. An unchunked
+    // `DELETE ... IN (?,...)` throws past ~32k variables, and persist() swallows
+    // it -- leaving rows on disk that every later sweep and every start would
+    // re-throw on. 600 is enough to catch an unchunked delete against the real
+    // driver without minting 33k JWTs.
+    await withManager(async (manager) => {
+      const { sidecar } = await manager.enrollSidecar('chunk-test');
+      const token = (await manager.issueAccessToken(sidecar.id))!.token;
+      for (let i = 0; i < 600; i++) await manager.openPanelSession(token);
+
+      const rows = () =>
+        (getDb().query('SELECT count(*) AS n FROM panel_sessions').get() as { n: number }).n;
+      expect(rows()).toBe(600);
+
+      expect(manager.revokeSidecar(sidecar.id)).toBe(true);
+      expect(rows()).toBe(0);
+      expect(manager.listPanelSessions()).toHaveLength(0);
+    });
+  });
+
+  test('an open panel survives a brain restart', async () => {
+    // THE REASON SESSIONS ARE PERSISTED. Every hosted update restarts the
+    // instance unit; an in-memory-only session would put every open panel on a
+    // 401 it could never recover from.
+    const dataDir = await mkdtemp(join(tmpdir(), 'jarvis-sidecar-manager-'));
+    initDatabase(':memory:');
+    try {
+      const first = new SidecarManager(dataDir);
+      await first.start();
+      first.setBrainUrl('https://brain.example.com');
+      const { sidecar } = await first.enrollSidecar('restart-test');
+      const session = (await first.openPanelSession((await first.issueAccessToken(sidecar.id))!.token))!;
+      await first.stop();
+
+      const second = new SidecarManager(dataDir);
+      await second.start();
+      expect(second.resolvePanelSession(session.id)?.sid).toBe(sidecar.id);
+      await second.stop();
     } finally {
       closeDb();
       await rm(dataDir, { recursive: true, force: true });

--- a/src/sidecar/manager.ts
+++ b/src/sidecar/manager.ts
@@ -25,6 +25,7 @@ import { EventScheduler, type DroppedEventsStats } from './scheduler.ts';
 import { RPCTracker } from './rpc.ts';
 import { BinarySpool, type BinarySpoolStats } from './binary-spool.ts';
 import { SidecarConnection } from './connection.ts';
+import { PanelSessionStore, vaultPanelSessionSink, type PanelSession, type PanelSocket } from './panel-sessions.ts';
 import { classifySidecarVersion, SIDECAR_MIN_VERSION, SIDECAR_RECOMMENDED_VERSION } from './compat.ts';
 import { chmodWithWarning, secureDirectory, secureWriteFile } from '../util/fs-secure.ts';
 import { computeAnonId } from '../telemetry/anon-id.ts';
@@ -39,11 +40,15 @@ const PUBLIC_KEY_FILE = 'public.pem';
 
 // Short-lived access tokens. The enrollment JWT is a long-lived REFRESH-style
 // credential that never leaves the sidecar except as an Authorization: Bearer
-// header to /sidecar/connect and the token-mint endpoint. Everything on the
-// data plane (panel /api fetches, the /ws control socket) authenticates with
-// one of these instead: minted on demand from the enrollment JWT, signed with
-// the same ES256 key, scoped by audience, and verified statelessly (signature +
-// exp + aud, no DB hit) so a leak is bounded to the TTL rather than forever.
+// header to /sidecar/connect and the token-mint endpoint.
+//
+// An access token is the BOOTSTRAP for a panel webview: minted on demand from
+// the enrollment JWT, signed with the same ES256 key, scoped by audience, and
+// verified statelessly (signature + exp + aud, no DB hit). It is presented
+// once, as ?token= on a panel's spawn URL, and exchanged for a panel session
+// (panel-sessions.ts) -- the session, not this token, is what authenticates
+// the data plane afterwards, and the TTL below therefore bounds the bootstrap
+// and nothing else.
 const ACCESS_TOKEN_AUDIENCE = 'brain-api';
 const ACCESS_TOKEN_TTL_SECONDS = 600; // 10 minutes
 
@@ -88,6 +93,9 @@ export class SidecarManager implements Service {
   private binarySpool: BinarySpool;
   private sidecarConnections = new Map<string, SidecarConnection>();
   private revocationSweepTimer: ReturnType<typeof setInterval> | null = null;
+  /** Panel webview sessions (panel-sessions.ts). Owned here because this is
+   *  what knows about enrollment and revocation, which is what bounds them. */
+  private panelSessions = new PanelSessionStore({ sink: vaultPanelSessionSink(getDb) });
   private progressListeners = new Set<(sidecarId: string, rpcId: string, progress: number, message?: string) => void>();
   private eventListeners = new Set<(sidecarId: string, event: SidecarEvent) => void>();
   // Two parallel notify APIs:
@@ -157,6 +165,15 @@ export class SidecarManager implements Service {
     try {
       await this.loadOrGenerateKeys();
 
+      // Panels open across a restart present their cookie immediately, so this
+      // has to happen before the server takes a request. Without it a hosted
+      // update (`systemctl restart` on the instance unit) would stand every
+      // open panel down onto a permanent 401.
+      const restored = this.panelSessions.hydrate();
+      if (restored > 0) {
+        console.log(`[SidecarManager] Restored ${restored} panel session(s)`);
+      }
+
       // CLI revocations happen in another process; sweep so they take
       // effect on live sessions within ~30s, not only at the next connect.
       this.revocationSweepTimer = setInterval(() => {
@@ -164,6 +181,17 @@ export class SidecarManager implements Service {
           this.sweepRevokedConnections();
         } catch (err) {
           console.error('[SidecarManager] Revocation sweep failed:', err);
+        }
+        // Panel windows are revoked on the same beat as connections, in a
+        // SEPARATE pass with its own try: a panel session can outlive the
+        // connection that spawned it (a sidecar that reconnects after a blip
+        // leaves its windows open on purpose), so sweeping connections alone
+        // would miss the panels of a device revoked while briefly offline --
+        // and a throw in that sweep must not be what skips this one.
+        try {
+          this.sweepPanelSessions();
+        } catch (err) {
+          console.error('[SidecarManager] Panel session sweep failed:', err);
         }
       }, 30_000);
 
@@ -231,6 +259,11 @@ export class SidecarManager implements Service {
       clearInterval(this.revocationSweepTimer);
       this.revocationSweepTimer = null;
     }
+
+    // Forget panel sessions in memory. They stay on disk, which is what lets a
+    // panel survive the restart this stop is usually half of; what must not
+    // survive is a stopped manager still resolving cookies.
+    this.panelSessions.clear();
 
     // Stop scheduler
     this.scheduler.stop();
@@ -353,6 +386,16 @@ export class SidecarManager implements Service {
       // RPCs indefinitely (stolen-device scenario).
       this.handleSidecarDisconnect(id);
       this.connected.delete(id);
+      // And the device's open PANEL windows, which authenticate with a session
+      // of their own (panel-sessions.ts). Both halves of the data plane have to
+      // go: an HTTP request is refused by `resolvePanelSession` on its own, but
+      // a panel's WebSocket is authorized once at the upgrade and never
+      // re-checked, so deleting the session alone would leave a revoked laptop
+      // chatting over the socket it already had. deleteBySid hangs up.
+      const panels = this.panelSessions.deleteBySid(id);
+      if (panels > 0) {
+        console.log(`[SidecarManager] Closed ${panels} panel session(s) for revoked sidecar ${id}`);
+      }
       console.log(`[SidecarManager] Revoked and removed sidecar ${id}`);
       return true;
     }
@@ -377,6 +420,49 @@ export class SidecarManager implements Service {
       }
     }
     return severed;
+  }
+
+  /**
+   * Hygiene pass over panel sessions: drop what has aged past the store's cap,
+   * what has been idle long enough to have no window left (gated on the
+   * sidecar being connected, see below), and what belongs to a sidecar that is
+   * no longer enrolled.
+   *
+   * NOT the correctness boundary. `resolvePanelSession` re-checks enrollment
+   * and age on every single request, so a session that should be dead is
+   * already refused before this ever runs. This is what stops an abandoned
+   * panel's entry from sitting in the map until the process restarts, and what
+   * closes a revoked device's panels when the revocation happened in the CLI
+   * process (which the daemon only learns about by looking).
+   *
+   * Enrollment is queried once per DISTINCT sidecar rather than once per
+   * session, so a device with six panels open costs one lookup.
+   */
+  sweepPanelSessions(): number {
+    // Only a CONNECTED sidecar's sessions may be idle-collected. A machine that
+    // is asleep or partitioned still has its panel windows on screen and its
+    // sockets died with the connection, so without this gate the sweep would
+    // collect a live user's session and strand them on a 401 they cannot
+    // recover from.
+    //
+    // The gate alone is not enough, because it only says "connected NOW" while
+    // lastSeenAt may be hours stale: handleSidecarConnect refreshes this
+    // device's sessions on the way in, so the idle clock genuinely measures
+    // time spent connected-with-no-panel rather than time since the last
+    // fetch. Even then a socketless page (the onboarding wizard, the
+    // task/answer/palette rooms) is a real open window with no socket at all,
+    // which is why the window is hours rather than minutes.
+    let closed = this.panelSessions.sweep((sid) => this.sidecarConnections.has(sid));
+    const enrolled = new Map<string, boolean>();
+    for (const session of this.panelSessions.list()) {
+      let ok = enrolled.get(session.sid);
+      if (ok === undefined) {
+        ok = this.isEnrolled(session.sid);
+        enrolled.set(session.sid, ok);
+      }
+      if (!ok && this.panelSessions.delete(session.id)) closed++;
+    }
+    return closed;
   }
 
   /** Check if a sidecar ID is enrolled (not revoked) */
@@ -519,12 +605,19 @@ export class SidecarManager implements Service {
   }
 
   /**
-   * Mint a short-lived access token for an enrolled sidecar. This is the only
-   * credential that authenticates the data plane (panel /api fetches + /ws); the
-   * enrollment JWT is never accepted there. Enrollment is checked here at mint
-   * time, so a revoked sidecar can't obtain new tokens (and existing ones expire
-   * within the TTL). Returns null if the sidecar isn't enrolled or keys aren't
-   * loaded.
+   * Mint a short-lived access token for an enrolled sidecar.
+   *
+   * This is the BOOTSTRAP credential for a panel webview, not what
+   * authenticates it: the page presents this once as ?token=, the brain
+   * exchanges it for a panel session, and the session is what authenticates
+   * the data plane from then on (see openPanelSession and panel-sessions.ts).
+   * The enrollment JWT is never accepted on the data plane at all.
+   *
+   * Enrollment is checked here at mint time, so a revoked sidecar can't obtain
+   * new tokens. Note this no longer bounds much on its own: a session opened
+   * with a token outlives that token, and it is the session's own cap and
+   * enrollment re-check that bound it. Returns null if the sidecar isn't
+   * enrolled or keys aren't loaded.
    */
   async issueAccessToken(sid: string): Promise<{ token: string; expiresIn: number } | null> {
     if (!this.privateKey) return null;
@@ -541,9 +634,16 @@ export class SidecarManager implements Service {
 
   /**
    * Verify a short-lived access token. Returns { sid } if the signature,
-   * audience, and expiry all check out, else null. Deliberately stateless (no
-   * DB / isEnrolled lookup): the short TTL is the revocation mechanism, which
-   * also keeps this cheap on every authenticated request.
+   * audience, and expiry all check out, else null.
+   *
+   * Deliberately stateless (no DB / isEnrolled lookup). That USED to be safe
+   * because this gated every authenticated request and the short TTL was
+   * therefore the revocation mechanism. It no longer gates them: it runs once,
+   * at bootstrap, and the callers that took over the data plane
+   * (openPanelSession, resolvePanelSession) do their own isEnrolled check
+   * precisely because a session outlives one TTL. Keep this stateless, but do
+   * not reintroduce it as a per-request gate on the strength of the old
+   * comment.
    */
   async verifyAccessToken(token: string): Promise<{ sid: string } | null> {
     if (!this.publicKey) return null;
@@ -560,10 +660,83 @@ export class SidecarManager implements Service {
     }
   }
 
+  // --------------- Panel sessions ---------------
+
+  /**
+   * Exchange a bootstrap access token for a panel session (panel-sessions.ts).
+   *
+   * This is the ONLY way a session is created, and it is what keeps the new
+   * scheme's trust anchored where the old one had it: the token can only have
+   * come from `issueAccessToken`, which mints solely for the /sidecar/token
+   * endpoint, which accepts solely the enrollment JWT. So a session still
+   * traces back to a device that proved possession of that credential -- the
+   * cookie simply stops BEING the credential.
+   *
+   * One token can open MORE than one session, by design (the sidecar reuses a
+   * cached token across spawns). See panel-sessions.ts for what that means for
+   * a leaked spawn URL.
+   *
+   * Returns null for anything unverifiable, expired, or belonging to a sidecar
+   * that has since been revoked. The enrollment re-check is not redundant with
+   * `verifyAccessToken`, which is deliberately stateless.
+   */
+  async openPanelSession(accessToken: string): Promise<PanelSession | null> {
+    const verified = await this.verifyAccessToken(accessToken);
+    if (!verified) return null;
+    if (!this.isEnrolled(verified.sid)) return null;
+    return this.panelSessions.create(verified.sid);
+  }
+
+  /**
+   * Resolve a panel-session cookie to its sidecar, or null.
+   *
+   * The enrollment lookup runs on EVERY authenticated request. That is the
+   * trade this design makes knowingly: `verifyAccessToken` skipped it because
+   * a 10-minute TTL was the revocation mechanism, and a session that outlives
+   * one TTL has to pay for what that bought. On a single-user brain it is a
+   * local prepared query, not a per-tenant round trip.
+   */
+  resolvePanelSession(sessionId: string): PanelSession | null {
+    const session = this.panelSessions.get(sessionId);
+    if (!session) return null;
+    if (!this.isEnrolled(session.sid)) {
+      // Revoked out from under a live panel. Drop it here rather than waiting
+      // for a sweep, so the very request that noticed is also the one refused.
+      this.panelSessions.delete(session.id);
+      return null;
+    }
+    return session;
+  }
+
+  /** A panel's WebSocket opened on this session. An open socket is liveness:
+   *  a healthy panel makes no HTTP requests, so without this an idle-but-open
+   *  window would look abandoned. */
+  panelSocketOpened(sessionId: string, socket: PanelSocket): void {
+    this.panelSessions.socketOpened(sessionId, socket);
+  }
+
+  /** A panel's WebSocket closed. When the last one goes the session becomes
+   *  idle-collectable, which is how a closed window is cleaned up without
+   *  threading panel ids through every spawn path. */
+  panelSocketClosed(sessionId: string, socket: PanelSocket): void {
+    this.panelSessions.socketClosed(sessionId, socket);
+  }
+
+  /** Live panel sessions. For tests and ops surfaces. */
+  listPanelSessions(): PanelSession[] {
+    return this.panelSessions.list();
+  }
+
   // --------------- Protocol: WebSocket Handlers ---------------
 
   /** Called when a sidecar WebSocket connects (after JWT validation) */
   handleSidecarConnect(ws: ServerWebSocket<unknown>, sidecarId: string): void {
+    // This device's panels get a fresh idle window. Its own socket comes back
+    // a second or two before theirs do (their reconnect loop retries every
+    // ~2s), and without this a sweep landing in that gap would collect a panel
+    // that is still on the user's screen -- see touchBySid.
+    this.panelSessions.touchBySid(sidecarId);
+
     const connection = new SidecarConnection(
       sidecarId,
       ws,
@@ -663,7 +836,21 @@ export class SidecarManager implements Service {
     }
   }
 
-  /** Called when a sidecar WebSocket disconnects */
+  /**
+   * Called when a sidecar WebSocket disconnects.
+   *
+   * Deliberately does NOT close the device's panel sessions, and that omission
+   * is the design, not an oversight. A disconnect is not a security event: it
+   * is a network blip, a brain restart, a laptop lid. The panels are native
+   * windows owned by the sidecar PROCESS, so if that process is gone its
+   * windows went with it and there is nothing to protect; if it is merely
+   * offline for eight seconds, the windows are still on screen in front of a
+   * working user, and standing them down onto a 401 they cannot recover from
+   * would recreate the exact failure panel sessions were introduced to remove.
+   *
+   * Revocation is the event that closes panels -- see revokeSidecar and
+   * sweepPanelSessions.
+   */
   handleSidecarDisconnect(sidecarId: string): void {
     const conn = this.sidecarConnections.get(sidecarId);
     if (conn) {

--- a/src/sidecar/panel-sessions.test.ts
+++ b/src/sidecar/panel-sessions.test.ts
@@ -1,0 +1,568 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  PanelSessionStore,
+  PANEL_SESSION_MAX_AGE_MS,
+  PANEL_SESSION_CLOSED_CODE,
+  type PanelSession,
+  type PanelSessionSink,
+} from './panel-sessions.ts';
+
+/**
+ * The store exists because the panel's auth used to expire at 10 minutes with
+ * no way to renew. So the cases that matter are the two ends of that: a
+ * session must survive ordinary use indefinitely, and it must still have a
+ * hard end -- the cap is the only thing left bounding a leaked cookie once
+ * the JWT's TTL is gone.
+ */
+describe('PanelSessionStore', () => {
+  const at = (start = 0) => {
+    let clock = start;
+    return {
+      now: () => clock,
+      advance: (ms: number) => {
+        clock += ms;
+      },
+    };
+  };
+
+  test('ids are opaque and unique', () => {
+    const store = new PanelSessionStore();
+    const a = store.create('sid-1');
+    const b = store.create('sid-1');
+    expect(a.id).not.toBe(b.id);
+    // No claims, no structure to parse: base64url of 32 bytes.
+    expect(a.id).toMatch(/^[A-Za-z0-9_-]{43}$/);
+    expect(a.id).not.toContain('.');
+  });
+
+  test('survives well past the old 10-minute TTL', () => {
+    const clock = at();
+    const store = new PanelSessionStore({ now: clock.now });
+    const session = store.create('sid-1');
+
+    clock.advance(10 * 60 * 1000);
+    expect(store.get(session.id)?.sid).toBe('sid-1');
+    clock.advance(60 * 60 * 1000);
+    expect(store.get(session.id)?.sid).toBe('sid-1');
+  });
+
+  test('use does not extend it: the cap is absolute', () => {
+    const clock = at();
+    const store = new PanelSessionStore({ now: clock.now, maxAgeMs: 1000 });
+    const session = store.create('sid-1');
+
+    // Busy right up to the deadline.
+    for (let i = 0; i < 9; i++) {
+      clock.advance(100);
+      expect(store.get(session.id)).not.toBeNull();
+    }
+    clock.advance(100);
+    expect(store.get(session.id)).toBeNull();
+  });
+
+  test('an aged-out session is refused on the request that notices, not at the next sweep', () => {
+    const clock = at();
+    const store = new PanelSessionStore({ now: clock.now, maxAgeMs: 1000 });
+    const session = store.create('sid-1');
+    clock.advance(1000);
+
+    expect(store.get(session.id)).toBeNull();
+    // ...and dropped on the way past, so an abandoned panel does not leak an entry.
+    expect(store.size).toBe(0);
+  });
+
+  test('lastSeenAt tracks use, createdAt does not move', () => {
+    const clock = at(5_000);
+    const store = new PanelSessionStore({ now: clock.now });
+    const session = store.create('sid-1');
+    expect(session.createdAt).toBe(5_000);
+
+    clock.advance(2_000);
+    const seen = store.get(session.id);
+    expect(seen?.createdAt).toBe(5_000);
+    expect(seen?.lastSeenAt).toBe(7_000);
+  });
+
+  test('an unknown id resolves to nothing', () => {
+    const store = new PanelSessionStore();
+    expect(store.get('not-a-session')).toBeNull();
+    expect(store.get('')).toBeNull();
+  });
+
+  test('deleteBySid closes every panel of one device and leaves the others', () => {
+    const store = new PanelSessionStore();
+    const a1 = store.create('sid-a');
+    const a2 = store.create('sid-a');
+    const b1 = store.create('sid-b');
+
+    expect(store.deleteBySid('sid-a')).toBe(2);
+    expect(store.get(a1.id)).toBeNull();
+    expect(store.get(a2.id)).toBeNull();
+    expect(store.get(b1.id)?.sid).toBe('sid-b');
+  });
+
+  test('deleteBySid on a device with no panels is a no-op', () => {
+    const store = new PanelSessionStore();
+    store.create('sid-a');
+    expect(store.deleteBySid('sid-b')).toBe(0);
+    expect(store.size).toBe(1);
+  });
+
+  test('delete closes exactly one session', () => {
+    const store = new PanelSessionStore();
+    const a = store.create('sid-1');
+    const b = store.create('sid-1');
+
+    expect(store.delete(a.id)).toBe(true);
+    expect(store.delete(a.id)).toBe(false);
+    expect(store.get(b.id)).not.toBeNull();
+  });
+
+  test('sweep drops only what is past the cap', () => {
+    const clock = at();
+    const store = new PanelSessionStore({ now: clock.now, maxAgeMs: 1000 });
+    const old = store.create('sid-1');
+    clock.advance(600);
+    const fresh = store.create('sid-1');
+    clock.advance(400);
+
+    expect(store.sweep()).toBe(1);
+    expect(store.get(old.id)).toBeNull();
+    expect(store.get(fresh.id)).not.toBeNull();
+  });
+
+  test('the default cap is the documented 12 hours', () => {
+    expect(PANEL_SESSION_MAX_AGE_MS).toBe(12 * 60 * 60 * 1000);
+    const clock = at();
+    const store = new PanelSessionStore({ now: clock.now });
+    const session = store.create('sid-1');
+    clock.advance(PANEL_SESSION_MAX_AGE_MS - 1);
+    expect(store.get(session.id)).not.toBeNull();
+    clock.advance(1);
+    expect(store.get(session.id)).toBeNull();
+  });
+});
+
+/**
+ * Persistence exists for one reason: the brain is restarted routinely (every
+ * hosted update runs `systemctl restart` on the instance unit), and a session
+ * that did not survive that would strand open panels on a permanent 401 -- the
+ * same failure the sessions were introduced to remove, from a different cause.
+ */
+describe('PanelSessionStore persistence', () => {
+  const fakeSink = () => {
+    const rows = new Map<string, PanelSession>();
+    return {
+      rows,
+      sink: {
+        insert: (s: PanelSession) => {
+          rows.set(s.id, { ...s });
+        },
+        remove: (ids: readonly string[]) => {
+          for (const id of ids) rows.delete(id);
+        },
+        load: () => [...rows.values()],
+      } satisfies PanelSessionSink,
+    };
+  };
+
+  test('a session opened before a restart still authorizes after one', () => {
+    const { sink } = fakeSink();
+    const before = new PanelSessionStore({ sink });
+    const session = before.create('sid-1');
+
+    // A new process, same disk.
+    const after = new PanelSessionStore({ sink });
+    expect(after.hydrate()).toBe(1);
+    expect(after.get(session.id)?.sid).toBe('sid-1');
+  });
+
+  test('hydrate drops what aged out while the brain was down, and forgets it', () => {
+    const clock = { t: 0 };
+    const { rows, sink } = fakeSink();
+    const before = new PanelSessionStore({ sink, now: () => clock.t, maxAgeMs: 1000 });
+    const stale = before.create('sid-1');
+    clock.t += 600;
+    const live = before.create('sid-1');
+
+    clock.t += 400; // stale is exactly at the cap, live is not
+    const after = new PanelSessionStore({ sink, now: () => clock.t, maxAgeMs: 1000 });
+    expect(after.hydrate()).toBe(1);
+    expect(after.get(stale.id)).toBeNull();
+    expect(after.get(live.id)).not.toBeNull();
+    expect(rows.has(stale.id)).toBe(false);
+  });
+
+  test('every close is written through, so nothing resurrects on the next start', () => {
+    const { rows, sink } = fakeSink();
+    const store = new PanelSessionStore({ sink });
+    const a = store.create('sid-a');
+    const b = store.create('sid-a');
+    const c = store.create('sid-b');
+    expect(rows.size).toBe(3);
+
+    store.delete(a.id);
+    expect(rows.has(a.id)).toBe(false);
+
+    store.deleteBySid('sid-a');
+    expect(rows.has(b.id)).toBe(false);
+    expect(rows.has(c.id)).toBe(true);
+
+    const revived = new PanelSessionStore({ sink });
+    revived.hydrate();
+    expect(revived.size).toBe(1);
+  });
+
+  test('an aged-out session is forgotten by the sweep and by the request that finds it', () => {
+    const clock = { t: 0 };
+    const { rows, sink } = fakeSink();
+    const store = new PanelSessionStore({ sink, now: () => clock.t, maxAgeMs: 1000 });
+    const viaGet = store.create('sid-1');
+    const viaSweep = store.create('sid-1');
+    clock.t += 1000;
+
+    expect(store.get(viaGet.id)).toBeNull();
+    expect(rows.has(viaGet.id)).toBe(false);
+    expect(store.sweep()).toBe(1);
+    expect(rows.has(viaSweep.id)).toBe(false);
+  });
+
+  test('a failing disk never takes out a live session', () => {
+    const angry: PanelSessionSink = {
+      insert: () => {
+        throw new Error('disk full');
+      },
+      remove: () => {
+        throw new Error('disk full');
+      },
+      load: () => {
+        throw new Error('disk gone');
+      },
+    };
+    const store = new PanelSessionStore({ sink: angry });
+
+    // Hydration failure is an empty store, not a brain that will not boot.
+    expect(store.hydrate()).toBe(0);
+
+    // And a session that cannot be persisted is still a working session: the
+    // user keeps their panel, they just lose it across the next restart.
+    const session = store.create('sid-1');
+    expect(store.get(session.id)?.sid).toBe('sid-1');
+    expect(store.delete(session.id)).toBe(true);
+  });
+
+  test('with no sink at all it is a plain in-memory store', () => {
+    const store = new PanelSessionStore();
+    const session = store.create('sid-1');
+    expect(store.hydrate()).toBe(0);
+    expect(store.get(session.id)).not.toBeNull();
+  });
+});
+
+/**
+ * How a CLOSED panel's session gets cleaned up. Not by panel id: all of a
+ * sidecar's webviews share a cookie jar, so a second panel opened while the
+ * first's cookie is valid never exchanges a token and rides the same session.
+ * A session therefore has no single panel identity, and "close it when panel P
+ * closes" would kill P's siblings. Sockets give the right semantics for free:
+ * the session goes when the LAST window holding it goes.
+ */
+describe('PanelSessionStore liveness', () => {
+  const at = (start = 0) => {
+    let clock = start;
+    return { now: () => clock, advance: (ms: number) => { clock += ms; } };
+  };
+
+  /** A socket that records being hung up on. */
+  const sock = () => {
+    const closed: Array<{ code?: number; reason?: string }> = [];
+    return { closed, close: (code?: number, reason?: string) => closed.push({ code, reason }) };
+  };
+
+  test('an open socket keeps an otherwise silent panel alive', () => {
+    const clock = at();
+    const store = new PanelSessionStore({ now: clock.now, idleMs: 1000 });
+    const session = store.create('sid-1');
+    store.socketOpened(session.id, sock());
+
+    // A healthy /ws makes no HTTP requests at all, so lastSeenAt never moves.
+    // Collecting here would be the original bug with a new trigger.
+    clock.advance(100_000);
+    expect(store.sweep()).toBe(0);
+    expect(store.get(session.id)).not.toBeNull();
+  });
+
+  test('the session goes once the window closes and stays shut', () => {
+    const clock = at();
+    const store = new PanelSessionStore({ now: clock.now, idleMs: 1000 });
+    const session = store.create('sid-1');
+    const ws = sock();
+    store.socketOpened(session.id, ws);
+
+    store.socketClosed(session.id, ws);
+    // Not immediately: a reconnect (brain restart, network blip) reopens within
+    // seconds, and the panel is still on screen.
+    clock.advance(999);
+    expect(store.sweep()).toBe(0);
+
+    clock.advance(1);
+    expect(store.sweep()).toBe(1);
+    expect(store.get(session.id)).toBeNull();
+  });
+
+  test('sibling panels sharing one session: collected only when the last closes', () => {
+    const clock = at();
+    const store = new PanelSessionStore({ now: clock.now, idleMs: 1000 });
+    const session = store.create('sid-1');
+    const first = sock();
+    const second = sock();
+    store.socketOpened(session.id, first);
+    store.socketOpened(session.id, second);
+    expect(store.socketsOpen(session.id)).toBe(2);
+
+    store.socketClosed(session.id, first);
+    clock.advance(5000);
+    expect(store.sweep()).toBe(0);
+    expect(store.get(session.id)).not.toBeNull();
+
+    store.socketClosed(session.id, second);
+    clock.advance(5000);
+    expect(store.sweep()).toBe(1);
+  });
+
+  test('a reconnecting panel is not collected', () => {
+    const clock = at();
+    const store = new PanelSessionStore({ now: clock.now, idleMs: 1000 });
+    const session = store.create('sid-1');
+    const dropped = sock();
+    store.socketOpened(session.id, dropped);
+    store.socketClosed(session.id, dropped);
+
+    clock.advance(500);
+    store.socketOpened(session.id, sock()); // the 2s reconnect loop got through
+    clock.advance(100_000);
+    expect(store.sweep()).toBe(0);
+  });
+
+  test('socket bookkeeping ignores ids it does not know', () => {
+    const store = new PanelSessionStore();
+    expect(() => store.socketOpened('nope', sock())).not.toThrow();
+    expect(() => store.socketClosed('nope', sock())).not.toThrow();
+    expect(store.socketsOpen('nope')).toBe(0);
+    // An unbalanced close, or a close naming a socket that was never opened,
+    // cannot drive the count negative or strand it above zero.
+    const session = store.create('sid-1');
+    store.socketClosed(session.id, sock());
+    expect(store.socketsOpen(session.id)).toBe(0);
+    const ws = sock();
+    store.socketOpened(session.id, ws);
+    store.socketClosed(session.id, sock());
+    expect(store.socketsOpen(session.id)).toBe(1);
+    store.socketClosed(session.id, ws);
+    expect(store.socketsOpen(session.id)).toBe(0);
+  });
+
+  test('a session restored from disk gets a full window to reconnect in', () => {
+    const rows = new Map<string, PanelSession>();
+    const sink: PanelSessionSink = {
+      insert: (s) => { rows.set(s.id, { ...s }); },
+      remove: (ids) => { for (const id of ids) rows.delete(id); },
+      load: () => [...rows.values()],
+    };
+    const clock = at();
+    const before = new PanelSessionStore({ now: clock.now, idleMs: 1000, sink });
+    const session = before.create('sid-1');
+
+    // The brain was down for a long time. lastSeenAt on disk is ancient, but
+    // the panel is still open and its /ws is retrying every 2s.
+    clock.advance(60_000);
+    const after = new PanelSessionStore({ now: clock.now, idleMs: 1000, sink });
+    expect(after.hydrate()).toBe(1);
+    expect(after.sweep()).toBe(0);
+    expect(after.get(session.id)).not.toBeNull();
+  });
+
+  test('the cap still wins over an open socket', () => {
+    const clock = at();
+    const store = new PanelSessionStore({ now: clock.now, maxAgeMs: 1000, idleMs: 100_000 });
+    const session = store.create('sid-1');
+    store.socketOpened(session.id, sock());
+
+    clock.advance(1000);
+    expect(store.sweep()).toBe(1);
+    expect(store.get(session.id)).toBeNull();
+  });
+
+  test('teardown hangs up on the open sockets, it does not just forget them', () => {
+    // A socket is authorized ONCE, at the upgrade, and never re-checked. So a
+    // revoked laptop with a chat panel open keeps chatting unless the session
+    // closes the socket itself. Deleting the map entry is not enough.
+    const store = new PanelSessionStore();
+    const session = store.create('sid-1');
+    const ws = sock();
+    store.socketOpened(session.id, ws);
+
+    store.delete(session.id);
+
+    expect(ws.closed).toHaveLength(1);
+    expect(ws.closed[0]!.code).toBe(PANEL_SESSION_CLOSED_CODE);
+    expect(store.socketsOpen(session.id)).toBe(0);
+  });
+
+  test('revoking a device hangs up on every one of its panels', () => {
+    const store = new PanelSessionStore();
+    const mine = store.create('sid-a');
+    const alsoMine = store.create('sid-a');
+    const theirs = store.create('sid-b');
+    const a1 = sock();
+    const a2 = sock();
+    const b1 = sock();
+    store.socketOpened(mine.id, a1);
+    store.socketOpened(alsoMine.id, a2);
+    store.socketOpened(theirs.id, b1);
+
+    store.deleteBySid('sid-a');
+
+    expect(a1.closed).toHaveLength(1);
+    expect(a2.closed).toHaveLength(1);
+    expect(b1.closed).toHaveLength(0);
+  });
+
+  test('the cap and the sweep hang up too', () => {
+    const clock = at();
+    const store = new PanelSessionStore({ now: clock.now, maxAgeMs: 1000, idleMs: 100_000 });
+    const viaGet = store.create('sid-1');
+    const viaSweep = store.create('sid-1');
+    const g = sock();
+    const w = sock();
+    store.socketOpened(viaGet.id, g);
+    store.socketOpened(viaSweep.id, w);
+
+    clock.advance(1000);
+    expect(store.get(viaGet.id)).toBeNull();
+    expect(g.closed).toHaveLength(1);
+    store.sweep();
+    expect(w.closed).toHaveLength(1);
+  });
+
+  test('a socket that throws on close does not block the others', () => {
+    const store = new PanelSessionStore();
+    const session = store.create('sid-1');
+    const angry = { close: () => { throw new Error('already gone'); } };
+    const ok = sock();
+    store.socketOpened(session.id, angry);
+    store.socketOpened(session.id, ok);
+
+    expect(() => store.delete(session.id)).not.toThrow();
+    expect(ok.closed).toHaveLength(1);
+  });
+
+  test('a sleeping machine accrues no idle time: its windows are still on screen', () => {
+    // The lid-closed case. The socket dies within a couple of minutes, no
+    // requests arrive, and the panel is still there when the user comes back.
+    // Collecting it would strand them on a 401 nothing in the page can fix --
+    // the exact failure this work removes, on a commoner trigger than the
+    // 10-minute expiry ever was.
+    const clock = at();
+    const store = new PanelSessionStore({ now: clock.now, idleMs: 1000 });
+    const session = store.create('sid-1');
+    const ws = sock();
+    store.socketOpened(session.id, ws);
+    store.socketClosed(session.id, ws);
+
+    const offline = () => false;
+    const online = () => true;
+    clock.advance(100_000);
+    expect(store.sweep(offline)).toBe(0);
+    // `list`, not `get`: a get IS a request, so it would refresh lastSeenAt and
+    // quietly make the session fresh again before the next assertion.
+    expect(store.list().map((x) => x.id)).toContain(session.id);
+
+    // WAKE, in the order it actually happens: the sidecar's own socket returns
+    // first and the panel's reconnect loop follows a second or two later. A
+    // sweep in that gap sees no panel socket, a lastSeenAt hours old, and a
+    // connected sidecar. The gate alone would collect a window still on screen.
+    store.touchBySid('sid-1');
+    expect(store.sweep(online)).toBe(0);
+    expect(store.list().map((x) => x.id)).toContain(session.id);
+
+    // The panel reconnects and life goes on.
+    store.socketOpened(session.id, sock());
+    clock.advance(100_000);
+    expect(store.sweep(online)).toBe(0);
+  });
+
+  test('a connected sidecar with no window really does get collected', () => {
+    // The other side of the wake test: touchBySid grants a window, it is not a
+    // reprieve. A device that is online and opens no panel socket for the whole
+    // window has genuinely closed its windows.
+    const clock = at();
+    const store = new PanelSessionStore({ now: clock.now, idleMs: 1000 });
+    const session = store.create('sid-1');
+    store.touchBySid('sid-1');
+
+    clock.advance(1000);
+    expect(store.sweep(() => true)).toBe(1);
+    expect(store.list()).toHaveLength(0);
+  });
+
+  test('touchBySid refreshes only the named device', () => {
+    const clock = at();
+    const store = new PanelSessionStore({ now: clock.now, idleMs: 1000 });
+    const mine = store.create('sid-a');
+    const theirs = store.create('sid-b');
+    clock.advance(999);
+
+    expect(store.touchBySid('sid-a')).toBe(1);
+    clock.advance(1);
+    expect(store.sweep(() => true)).toBe(1);
+    expect(store.list().map((x) => x.id)).toEqual([mine.id]);
+    expect(store.list().map((x) => x.id)).not.toContain(theirs.id);
+  });
+
+  test('a socket that arrives after its session was collected is hung up on', () => {
+    // Upgrade succeeded, then the sweep ran before open() did. Returning early
+    // would leave it connected, authorized, and in no session's set -- so no
+    // teardown could ever reach it.
+    const store = new PanelSessionStore();
+    const late = sock();
+    store.socketOpened('already-collected', late);
+
+    expect(late.closed).toHaveLength(1);
+    expect(late.closed[0]!.code).toBe(PANEL_SESSION_CLOSED_CODE);
+  });
+
+  test('the cap ignores the gate: it is a bound, not hygiene', () => {
+    const clock = at();
+    const store = new PanelSessionStore({ now: clock.now, maxAgeMs: 1000, idleMs: 100_000 });
+    const session = store.create('sid-1');
+
+    clock.advance(1000);
+    expect(store.sweep(() => false)).toBe(1);
+    expect(store.get(session.id)).toBeNull();
+  });
+
+  test('the gate is asked about the right device', () => {
+    const clock = at();
+    const store = new PanelSessionStore({ now: clock.now, idleMs: 1000 });
+    const online = store.create('sid-online');
+    const offline = store.create('sid-offline');
+    clock.advance(5000);
+
+    expect(store.sweep((sid) => sid === 'sid-online')).toBe(1);
+    expect(store.get(online.id)).toBeNull();
+    expect(store.get(offline.id)).not.toBeNull();
+  });
+
+  test('stopping is not revocation: clear() does not hang up', () => {
+    // A 4401 would tell a panel it was revoked when the brain is merely
+    // restarting around it, and its session is on disk waiting for it.
+    const store = new PanelSessionStore();
+    const session = store.create('sid-1');
+    const ws = sock();
+    store.socketOpened(session.id, ws);
+
+    store.clear();
+    expect(ws.closed).toHaveLength(0);
+  });
+});

--- a/src/sidecar/panel-sessions.ts
+++ b/src/sidecar/panel-sessions.ts
@@ -1,0 +1,515 @@
+/**
+ * Panel sessions: what authenticates a panel webview's data-plane traffic.
+ *
+ * REPLACES putting a short-lived access JWT in the cookie. That design made
+ * the cookie's lifetime the session's lifetime: at 10 minutes the JWT expired,
+ * every /api call started 401ing and the panel's /ws could never reconnect,
+ * and nothing in the page could fix it (the cookie is HttpOnly and only the
+ * sidecar, which holds the enrollment JWT, may mint). The window had to be
+ * closed and reopened. See the TTL note on issueAccessToken.
+ *
+ * The access token is now a BOOTSTRAP credential only: the sidecar mints one,
+ * puts it in the spawn URL, and the brain exchanges it for a session. The
+ * session id -- an opaque random string that grants nothing on its own and
+ * carries no claims -- is what lives in the cookie afterwards.
+ *
+ * That exchange is NOT single-use, and saying so matters. There is no `jti` on
+ * an access token to record, and the sidecar deliberately caches one token and
+ * reuses it for every panel spawned in the following ~9 minutes (see
+ * accessTokenProvider in sidecar/access_token.go), so enforcing single-use
+ * would break the second window a user opens. A spawn URL that leaks inside
+ * the token's TTL therefore opens sessions, and what bounds those is the list
+ * below rather than the token's expiry.
+ *
+ * WHAT BOUNDS A LEAKED COOKIE, now that it is not a 10-minute JWT:
+ *
+ *  1. The absolute cap here. A session cannot outlive it under any traffic
+ *     pattern, so a stolen cookie has a hard deadline like the JWT did -- a
+ *     much longer one, which is the cost of this change and is only worth
+ *     paying because of 2 and 3.
+ *  2. Enrollment, re-checked on every request by the resolver (the store holds
+ *     `sid` for exactly this). `verifyAccessToken` skipped that lookup on the
+ *     grounds that the short TTL was the revocation mechanism; a session that
+ *     can outlive one TTL has to do the check it was trading away.
+ *  3. Teardown on revocation: immediately, and within 30s for a revocation
+ *     performed by the separate `jarvis revoke` process. Both hang up on the
+ *     session's open sockets, which are authorized once at the upgrade and
+ *     never re-checked.
+ *
+ * Idle collection (PANEL_SESSION_IDLE_MS) is deliberately NOT on that list. It
+ * reclaims sessions whose windows are gone; it bounds no adversary, because
+ * one holding the cookie holds a socket open and never goes idle.
+ *
+ * And one more that is the same product decision as the enroll note above:
+ * DELETE /api/sidecars/:id is authorized by the same cookie, so a stolen one
+ * can also revoke the owner's OTHER devices -- denial of service on top of the
+ * laundering.
+ *
+ * WHAT IS NOT BOUNDED, recorded so the trade is made knowingly: POST
+ * /api/sidecars/enroll (src/daemon/api-routes.ts) is authorized by nothing but
+ * a data-plane cookie and returns a fresh long-lived enrollment JWT under a
+ * NEW sid. A stolen cookie can therefore be laundered into a credential that
+ * outlives every bound above, and revoking the original device does not touch
+ * it. That path predates this change -- it was reachable with the access-token
+ * cookie too -- but the window to use it grows from 10 minutes to the cap, so
+ * it wants a real fix: enrollment is a control-plane act and should not be
+ * authorized by a panel session.
+ *
+ * Held in memory for the read path and written through to `panel_sessions` for
+ * durability. A brain serves ONE user, so a lookup is a Map hit and not a
+ * per-tenant round trip; the table exists because the brain is restarted
+ * routinely (every hosted update runs `systemctl restart` on the instance
+ * unit) and an in-memory-only session would strand every open panel on a 401
+ * no page could recover from.
+ */
+
+/**
+ * Cookie name. Deliberately NOT the old `token`: a stale cookie from the
+ * previous scheme holds a JWT, and a resolver that read it as a session id
+ * would simply miss, which is the behaviour we want (fall through to the
+ * bootstrap exchange) rather than anything ambiguous.
+ */
+export const PANEL_SESSION_COOKIE = 'panel_session';
+
+/**
+ * The hard ceiling on one session. Long enough that a working day never hits
+ * it, short enough to bound a leaked cookie on a machine that never revokes
+ * anything.
+ *
+ * Be honest about what reaching it looks like: nothing renews, so the panel
+ * gets the ORIGINAL failure back -- 401s and a /ws reconnect loop -- and has
+ * to be closed and reopened. That is a deliberately accepted edge at 12 hours
+ * where it was intolerable at 10 minutes, not a case that is handled. Handling
+ * it properly means the sidecar re-navigating a stranded panel, which it
+ * cannot do today (sidecar/access_token.go calls live re-injection a
+ * follow-up).
+ */
+export const PANEL_SESSION_MAX_AGE_MS = 12 * 60 * 60 * 1000;
+
+/**
+ * How long a session with NO open panel socket and no requests survives before
+ * it is collected.
+ *
+ * This is what reclaims a session when the window closes, and it is
+ * deliberately not built on panel ids. The sidecar does emit `panel.closed`
+ * with one, but binding it to a session would mean threading an identifier
+ * through every spawn path -- the brain's panel.spawn RPC, the tray's own
+ * OpenChat, and whatever spawns next -- in Go, per platform, where the cost of
+ * missing one is a session that is silently never collected. Worse, panels
+ * SHARE a session: every webview in the sidecar process shares a cookie jar,
+ * so a second window opened while the first's cookie is live never exchanges a
+ * token at all, and closing on one panel's id would kill its siblings. A
+ * window going away takes its WebSocket with it, on every platform and every
+ * spawn path, and the last socket going is exactly "the last window closed".
+ *
+ * HYGIENE, NOT A BOUND. It reclaims sessions whose panels are gone; it defends
+ * against nobody, because an adversary holding the cookie also holds a socket
+ * open and never goes idle. The bounds are the cap and revocation.
+ *
+ * Which is why this is generous, and why `sweep` will not apply it to a
+ * session whose sidecar is OFFLINE. Two ways a live panel looks idle:
+ *
+ *  1. The machine sleeps. The socket dies within a couple of minutes, no
+ *     requests arrive, and the window is still on screen when the user
+ *     returns. Two things cover this: the sweep will not idle-collect while
+ *     the sidecar is disconnected, and `touchBySid` grants a fresh window when
+ *     it reconnects -- because the sidecar's socket comes back a second or two
+ *     before the panel's, and the gate alone would leave that gap open.
+ *  2. The page never opens a socket at all. The onboarding wizard renders
+ *     instead of the app shell, and the task/answer/palette rooms only fetch.
+ *     A user who leaves the wizard to go and find an API key is idle at the
+ *     highest-friction moment in the product, with the sidecar online -- so
+ *     the gate does not cover this one and only the length of the window does.
+ *
+ * Collecting either would strand the panel on a permanent 401 it cannot
+ * recover from: the failure this whole change exists to remove, arriving on a
+ * more common trigger than the 10-minute expiry ever was. Hours, therefore,
+ * and short enough only to still beat the 12-hour cap to the work.
+ */
+export const PANEL_SESSION_IDLE_MS = 4 * 60 * 60 * 1000;
+
+/**
+ * Just enough of a WebSocket to hold and hang up on. Structural so this module
+ * never imports Bun's ServerWebSocket, and so a test can pass a recorder.
+ */
+export interface PanelSocket {
+  close(code?: number, reason?: string): void;
+}
+
+/** Close code sent to a panel whose session was torn down under it. In the
+ *  4000-4999 application range; the page sees a clean close, not a network
+ *  error, and its reconnect will be refused at the upgrade. */
+export const PANEL_SESSION_CLOSED_CODE = 4401;
+
+/**
+ * Durable backing for the store. Kept as a seam rather than reaching for the
+ * vault DB directly so the store stays a plain data structure with an
+ * injectable clock, and so a caller that genuinely wants a throwaway store
+ * (tests, the setup-only open-access mode) can have one by passing nothing.
+ *
+ * Every method is best-effort from the store's point of view: a persistence
+ * failure must never take out the in-memory session, because that would turn
+ * a disk hiccup into the exact permanent-401 the sessions exist to prevent.
+ */
+export interface PanelSessionSink {
+  insert(session: PanelSession): void;
+  remove(ids: readonly string[]): void;
+  load(): PanelSession[];
+}
+
+export interface PanelSession {
+  /** Opaque, 256 bits of randomness. The cookie value. */
+  readonly id: string;
+  /** The enrolled sidecar this session belongs to. Drives the enrollment
+   *  re-check and every teardown path. */
+  readonly sid: string;
+  readonly createdAt: number;
+  /** Last time this session authenticated a request. Read by the idle rule in
+   *  `sweep`, together with whether any socket is open. */
+  lastSeenAt: number;
+}
+
+/** 32 bytes of CSPRNG as base64url. Unguessable, so a Map lookup is a safe
+ *  index -- there is no secret being compared here, only one being found. */
+function newSessionId(): string {
+  const bytes = new Uint8Array(32);
+  crypto.getRandomValues(bytes);
+  return Buffer.from(bytes).toString('base64url');
+}
+
+export class PanelSessionStore {
+  private sessions = new Map<string, PanelSession>();
+  private readonly now: () => number;
+  private readonly maxAgeMs: number;
+  private readonly sink: PanelSessionSink | null;
+  private readonly idleMs: number;
+  /**
+   * Open panel sockets per session. Holds the sockets themselves rather than a
+   * count for two jobs at once: an open socket is liveness (so an idle-but-open
+   * window is never collected), AND a torn-down session has to HANG UP on them.
+   *
+   * That second job is not optional. A socket is authorized once, at the
+   * upgrade, and never re-checked; deleting the session only stops the next
+   * HTTP request and the next reconnect. Without this, revoking a stolen
+   * laptop left its already-open chat panel streaming.
+   */
+  private live = new Map<string, Set<PanelSocket>>();
+
+  constructor(
+    opts: { now?: () => number; maxAgeMs?: number; idleMs?: number; sink?: PanelSessionSink } = {},
+  ) {
+    this.now = opts.now ?? Date.now;
+    this.maxAgeMs = opts.maxAgeMs ?? PANEL_SESSION_MAX_AGE_MS;
+    this.idleMs = opts.idleMs ?? PANEL_SESSION_IDLE_MS;
+    this.sink = opts.sink ?? null;
+  }
+
+  /** A panel socket opened on this session. Unknown ids are ignored: the
+   *  session may have been collected between the upgrade and this call. */
+  socketOpened(id: string, socket: PanelSocket): void {
+    if (!this.sessions.has(id)) {
+      // Collected between the upgrade and this call. The socket is already
+      // connected and authorized, and nothing would ever be able to reach it
+      // again (it is in no session's set), so close it here or it outlives the
+      // session that justified it.
+      try {
+        socket.close(PANEL_SESSION_CLOSED_CODE, 'panel session closed');
+      } catch {
+        /* already gone */
+      }
+      return;
+    }
+    const open = this.live.get(id);
+    if (open) open.add(socket);
+    else this.live.set(id, new Set([socket]));
+  }
+
+  /** A panel socket closed. The session becomes idle-collectable once the last
+   *  one goes, which is what happens when the window is closed. */
+  socketClosed(id: string, socket: PanelSocket): void {
+    const open = this.live.get(id);
+    if (!open) return;
+    open.delete(socket);
+    if (open.size === 0) this.live.delete(id);
+  }
+
+  /** Open panel sockets on a session. For tests and ops surfaces. */
+  socketsOpen(id: string): number {
+    return this.live.get(id)?.size ?? 0;
+  }
+
+  /**
+   * Drop a session's sockets and hang up on them. Called from every path that
+   * ends a session, because none of them are complete without it.
+   *
+   * Best-effort per socket: one that throws on close (already gone) must not
+   * stop the rest from being closed.
+   */
+  private hangUp(id: string): void {
+    const open = this.live.get(id);
+    if (!open) return;
+    this.live.delete(id);
+    for (const socket of open) {
+      try {
+        socket.close(PANEL_SESSION_CLOSED_CODE, 'panel session closed');
+      } catch {
+        /* already gone */
+      }
+    }
+  }
+
+  /**
+   * Read persisted sessions back in, dropping anything already past the cap.
+   * Call once at startup, before the server accepts a request: a panel that
+   * was open across a brain restart presents its cookie immediately.
+   *
+   * Returns how many were restored. Never throws -- a store that cannot read
+   * its backing is an empty store, which costs the user a reopened window,
+   * whereas a throw here would cost them a brain that will not start.
+   */
+  hydrate(): number {
+    if (!this.sink) return 0;
+    let restored = 0;
+    try {
+      const at = this.now();
+      const stale: string[] = [];
+      for (const session of this.sink.load()) {
+        if (at - session.createdAt >= this.maxAgeMs) {
+          stale.push(session.id);
+          continue;
+        }
+        // lastSeenAt is restored as of the last write, which for a session
+        // that sat through a long downtime would read as instantly idle. The
+        // panel is about to reconnect (its /ws retries every 2s), so give it a
+        // full window to do so rather than collecting it before it can.
+        this.sessions.set(session.id, { ...session, lastSeenAt: at });
+        restored++;
+      }
+      if (stale.length > 0) this.sink.remove(stale);
+    } catch (err) {
+      console.error('[PanelSessions] Could not restore sessions:', err);
+    }
+    return restored;
+  }
+
+  /** Persistence is best-effort by construction: see PanelSessionSink. */
+  private persist(fn: (sink: PanelSessionSink) => void): void {
+    if (!this.sink) return;
+    try {
+      fn(this.sink);
+    } catch (err) {
+      console.error('[PanelSessions] Persistence failed (session still live):', err);
+    }
+  }
+
+  /** Open a session for an enrolled sidecar. The caller is responsible for
+   *  having established that `sid` is enrolled (the bootstrap exchange does
+   *  it by verifying a brain-minted access token). */
+  create(sid: string): PanelSession {
+    const at = this.now();
+    const session: PanelSession = { id: newSessionId(), sid, createdAt: at, lastSeenAt: at };
+    this.sessions.set(session.id, session);
+    this.persist((sink) => sink.insert(session));
+    return session;
+  }
+
+  /**
+   * Resolve a cookie value, or null when it names nothing / has aged out.
+   *
+   * Expiry is enforced HERE rather than only in the periodic sweep, so a
+   * session is dead the moment it is too old even if no sweep has run since.
+   * Aged-out entries are dropped on the way past, which is what keeps an
+   * abandoned panel's session from sitting in the map forever.
+   */
+  get(id: string): PanelSession | null {
+    const session = this.sessions.get(id);
+    if (!session) return null;
+    const at = this.now();
+    if (at - session.createdAt >= this.maxAgeMs) {
+      this.sessions.delete(id);
+      this.hangUp(id);
+      this.persist((sink) => sink.remove([id]));
+      return null;
+    }
+    // Deliberately NOT written through. lastSeenAt moves on every authenticated
+    // request; a write per request would put a disk round trip on the hot path
+    // to keep a field nothing AUTHORIZES on (the cap is measured from
+    // createdAt, and authorization never reads this). The idle rule in `sweep`
+    // does read it, which is the reason hydrate() resets it to the restore
+    // time rather than trusting the on-disk value -- that value is always the
+    // one written at INSERT, and would read as instantly idle.
+    session.lastSeenAt = at;
+    return session;
+  }
+
+  /**
+   * Give every session of one sidecar a fresh idle window.
+   *
+   * Called when that sidecar (re)connects, and it is what makes the idle rule
+   * safe. `lastSeenAt` only advances on an authenticated HTTP REQUEST -- an
+   * open socket protects a session but never touches it -- so a panel that has
+   * been open and quiet for longer than the idle window carries an ancient
+   * `lastSeenAt` while being perfectly alive. On wake the sidecar's own socket
+   * comes back a second or two before the panel's does, and a sweep landing in
+   * that gap would see no sockets, a stale `lastSeenAt` and a connected
+   * sidecar, and collect a window that is still on the user's screen.
+   *
+   * Same treatment `hydrate` gives a restored session, for the same reason:
+   * something just came back and its panels are about to.
+   */
+  touchBySid(sid: string): number {
+    const at = this.now();
+    let touched = 0;
+    for (const session of this.sessions.values()) {
+      if (session.sid === sid) {
+        session.lastSeenAt = at;
+        touched++;
+      }
+    }
+    return touched;
+  }
+
+  /** Close one session. Returns whether it existed. */
+  delete(id: string): boolean {
+    const existed = this.sessions.delete(id);
+    this.hangUp(id);
+    if (existed) this.persist((sink) => sink.remove([id]));
+    return existed;
+  }
+
+  /** Close EVERY session belonging to one sidecar, hanging up on their sockets.
+   *  Called on REVOCATION only -- a mere disconnect deliberately leaves panels
+   *  alone (see handleSidecarDisconnect). Returns how many were closed. */
+  deleteBySid(sid: string): number {
+    const gone: string[] = [];
+    for (const [id, session] of this.sessions) {
+      if (session.sid === sid) {
+        this.sessions.delete(id);
+        this.hangUp(id);
+        gone.push(id);
+      }
+    }
+    if (gone.length > 0) this.persist((sink) => sink.remove(gone));
+    return gone.length;
+  }
+
+  /**
+   * Drop everything past the cap, and everything idle enough to be gone.
+   * Returns how many went.
+   *
+   * `canIdle` decides whether a session is even eligible for the idle rule.
+   * The manager passes "is this session's sidecar connected right now", so a
+   * sleeping or partitioned machine accrues no idle time at all -- its panels
+   * are still on screen, and collecting them would strand a working user. The
+   * cap ignores it: that one is a bound and applies unconditionally.
+   */
+  sweep(canIdle: (sid: string) => boolean = () => true): number {
+    const at = this.now();
+    const gone: string[] = [];
+    for (const [id, session] of this.sessions) {
+      const expired = at - session.createdAt >= this.maxAgeMs;
+      // An open socket is liveness on its own; only a session with none can be
+      // idle. See PANEL_SESSION_IDLE_MS.
+      const idle =
+        (this.live.get(id)?.size ?? 0) === 0 &&
+        at - session.lastSeenAt >= this.idleMs &&
+        canIdle(session.sid);
+      if (expired || idle) {
+        this.sessions.delete(id);
+        this.hangUp(id);
+        gone.push(id);
+      }
+    }
+    if (gone.length > 0) this.persist((sink) => sink.remove(gone));
+    return gone.length;
+  }
+
+  /** Live sessions. For tests and ops surfaces. */
+  get size(): number {
+    return this.sessions.size;
+  }
+
+  /**
+   * Forget everything in memory WITHOUT touching the backing store, so a
+   * stopped manager resolves no cookies while a restart can still restore the
+   * panels that were open. Anything that should not come back must be closed
+   * through `delete`/`deleteBySid`, which do write through.
+   */
+  clear(): void {
+    this.sessions.clear();
+    // No hangUp: this is a stop, not a teardown, and a 4401 would tell a panel
+    // it was revoked when its session is on disk waiting for the restart.
+    // (Bun's server.stop() without closeActiveConnections does not close them
+    // either; process exit does. That is fine -- the panel sees a dropped
+    // connection and reconnects, which is what should happen.)
+    this.live.clear();
+  }
+
+  /**
+   * Snapshot, newest first. For an ops surface that lists open panels.
+   *
+   * Filters what `get` would already refuse: an aged-out session that nothing
+   * has looked up yet is still in the map, and reporting it as an open panel
+   * would be a lie told to whoever is reading the list to decide something.
+   */
+  list(): PanelSession[] {
+    const at = this.now();
+    return [...this.sessions.values()]
+      .filter((s) => at - s.createdAt < this.maxAgeMs)
+      .sort((a, b) => b.createdAt - a.createdAt);
+  }
+}
+
+/**
+ * The vault-backed sink. Lives here rather than in the store so the store
+ * itself never imports the DB, and so the SQL for one table sits next to the
+ * shape it persists.
+ *
+ * `getDb` is injected because the vault opens lazily and a module-level handle
+ * would bind this to whichever database existed at import time -- which in the
+ * test suite is a different one per file.
+ */
+export function vaultPanelSessionSink(getDb: () => {
+  run(sql: string, params?: unknown[]): unknown;
+  query(sql: string): { all(...params: unknown[]): unknown[] };
+}): PanelSessionSink {
+  return {
+    insert(session) {
+      // Plain INSERT: a collision on a 256-bit random id is a bug in the id
+      // generator, and OR REPLACE would hide it.
+      getDb().run(
+        'INSERT INTO panel_sessions (id, sidecar_id, created_at, last_seen_at) VALUES (?, ?, ?, ?)',
+        [session.id, session.sid, session.createdAt, session.lastSeenAt],
+      );
+    },
+    remove(ids) {
+      if (ids.length === 0) return;
+      const db = getDb();
+      // Chunked because SQLite caps bound variables (32766 on the bundled
+      // build) and this list is not bounded by anything the code controls: the
+      // bootstrap token is reusable inside its TTL, so a leaked spawn URL can
+      // open an unlimited number of sessions for one sid, and the deleteBySid
+      // that eventually cleans them up would throw "too many SQL variables"
+      // forever -- swallowed by persist(), leaving the rows on disk for good.
+      for (let i = 0; i < ids.length; i += 500) {
+        const chunk = ids.slice(i, i + 500);
+        // Parameterised placeholders, not interpolation: these ids are ours,
+        // but this table is one revoked-device teardown away from being fed a
+        // value that came off a cookie.
+        const holes = chunk.map(() => '?').join(',');
+        db.run(`DELETE FROM panel_sessions WHERE id IN (${holes})`, [...chunk]);
+      }
+    },
+    load() {
+      const rows = getDb()
+        .query('SELECT id, sidecar_id, created_at, last_seen_at FROM panel_sessions')
+        .all() as Array<{ id: string; sidecar_id: string; created_at: number; last_seen_at: number }>;
+      return rows.map((r) => ({
+        id: r.id,
+        sid: r.sidecar_id,
+        createdAt: r.created_at,
+        lastSeenAt: r.last_seen_at,
+      }));
+    },
+  };
+}

--- a/src/vault/schema.ts
+++ b/src/vault/schema.ts
@@ -54,6 +54,14 @@ export function initDatabase(dbPath: string = ":memory:", opts?: { quiet?: boole
     // Enable foreign key constraints
     dbInstance.exec("PRAGMA foreign_keys=ON");
 
+    // Wait rather than fail on a locked write. This file is written by MORE
+    // than the daemon: `jarvis enroll` and `jarvis revoke` run in their own
+    // processes against the same WAL database. Without a busy timeout a
+    // collision surfaces as an immediate SQLITE_BUSY throw, and a write that
+    // is swallowed by a best-effort path (panel_sessions teardown) would leave
+    // a row on disk that a later start reads back as a live session.
+    dbInstance.exec("PRAGMA busy_timeout=5000");
+
     // Create all tables
     createTables(dbInstance);
 
@@ -673,6 +681,39 @@ function createTables(db: Database): void {
   `);
   db.run(`CREATE INDEX IF NOT EXISTS idx_sidecars_name ON sidecars(name)`);
   db.run(`CREATE INDEX IF NOT EXISTS idx_sidecars_token_id ON sidecars(token_id)`);
+
+  // Panel webview sessions (src/sidecar/panel-sessions.ts). Persisted rather
+  // than held only in memory because the brain is RESTARTED routinely -- every
+  // hosted update does `systemctl restart` on the instance unit -- and an
+  // in-memory-only session would strand every open panel on a permanent 401
+  // that nothing in the page could recover from. That is the same failure this
+  // whole change exists to remove, arriving from a different direction: the
+  // access-token cookie it replaces survived a restart, because the key that
+  // signs it is loaded from disk.
+  //
+  // Times are epoch ms (not the datetime('now') text the older tables use), so
+  // an age check is integer arithmetic instead of string parsing on the
+  // authentication path.
+  //
+  // ON DELETE CASCADE (foreign_keys is ON above) is what makes this table
+  // self-cleaning across PROCESSES: `jarvis revoke` deletes the sidecars row
+  // from its own process, which the daemon only learns about by looking, and
+  // the cascade closes that device's panel rows in the same transaction rather
+  // than leaving them to be read back as live sessions on the next start.
+  // Nothing legitimate inserts without an enrolled row -- openPanelSession
+  // checks enrollment first -- so the constraint refuses no real create except
+  // in one harmless race: a CLI revoke landing between that check and the
+  // INSERT fails the FK, which the store's best-effort persist swallows,
+  // leaving an in-memory session that the next request refuses anyway.
+  db.run(`
+    CREATE TABLE IF NOT EXISTS panel_sessions (
+      id TEXT PRIMARY KEY,
+      sidecar_id TEXT NOT NULL REFERENCES sidecars(id) ON DELETE CASCADE,
+      created_at INTEGER NOT NULL,
+      last_seen_at INTEGER NOT NULL
+    )
+  `);
+  db.run(`CREATE INDEX IF NOT EXISTS idx_panel_sessions_sidecar ON panel_sessions(sidecar_id)`);
   // Sidecar's own (brain-decoupled) version, reported on register. Added later;
   // ALTER in try/catch is the migration pattern used throughout this file.
   try { db.run('ALTER TABLE sidecars ADD COLUMN version TEXT'); } catch { /* already present */ }


### PR DESCRIPTION
Test users reported the sidecar disconnecting after ~10 minutes. It is the panel webviews, and the number is not a coincidence.

## The bug

The panel's cookie held a 10-minute access JWT, so the token's TTL *was* the session's lifetime. At 10 minutes every `/api` call 401s and the panel's `/ws` can never reconnect (it retries every 2s, forever). Nothing in the page can fix it: the cookie is HttpOnly, and only the sidecar, which holds the enrollment JWT, may mint. The window has to be closed and reopened. `sidecar/access_token.go` already called live re-injection a follow-up.

## The fix

The access token becomes a bootstrap credential, exchanged once per spawn for an opaque server-side session. The session id is what the cookie carries.

That TTL was doing a second job, though: `verifyAccessToken` is stateless *on the explicit grounds that* "the short TTL is the revocation mechanism". Removing it means taking that on directly, so a session now:

- re-checks enrollment on every request, and is refused and dropped the moment the device is revoked, including by the separate `jarvis revoke` process
- hangs up on its open WebSockets when torn down (close 4401). A socket is authorized once, at the upgrade, and never re-checked, so deleting the session alone left a revoked laptop chatting over the socket it already had
- is persisted, so a panel survives a brain restart. Without this the fix would have made things worse: the old cookie survived restarts because the signing key loads from disk, and every hosted update runs `systemctl restart` on the unit
- is idle-collected when its windows are gone, and capped at 12 hours

`panel_sessions.sidecar_id` is `ON DELETE CASCADE`, so a CLI revoke cleans up inside its own process rather than waiting for the daemon to notice.

## Why liveness comes from the socket, not `panel.closed`

The sidecar already emits `panel.closed` with a panel id, but binding sessions to it does not work: every webview in the sidecar process shares a cookie jar, so a second window opened while the first's cookie is live never exchanges a token and rides the first's session. Closing on one panel's id would kill its siblings. Counting open sockets gives "collect when the last window closes" for free, on every platform and every spawn path, with no id threading through Go.

Idle collection is gated hard, because collecting a live panel would recreate the original bug on a commoner trigger:

- it never runs while the device's sidecar is disconnected (a sleeping laptop still has its windows on screen)
- a sidecar reconnect grants a fresh window, because its own socket returns a second or two before the panels' do and a sweep in that gap would strand them
- the window is 4 hours, not minutes, because some panels never open a socket at all (the onboarding wizard, the task/answer/palette rooms)

## Two decisions I did not make

**`POST /api/sidecars/enroll` is authorized by a panel cookie** and returns a permanent enrollment JWT under a new sid, which revoking the original device does not touch. `DELETE /api/sidecars/:id` is the same, so a stolen cookie can also revoke your other devices. This predates the PR and the dashboard genuinely uses it (`ui/src/v2/rooms/settings/useSettingsData.ts:1030`), so it is a product question: should the dashboard enroll devices at all? What this PR does is widen the window from 10 minutes to 12 hours. Recorded in the threat notes in `panel-sessions.ts`, not fixed here.

**At the 12-hour cap the original failure returns** and the panel must be reopened. Accepted at 12h where it was intolerable at 10min. Fixing it properly means the sidecar re-navigating a stranded panel, which it cannot do today.

## Testing

2683 pass, 0 fail; typecheck clean. New coverage includes the store's semantics against a fake clock and recorder sockets, revocation/restart/cascade against the real manager and schema, a real `/ws` proving the 4401 close and the refused reconnect, and a chunked delete of 600 sessions against the real driver.

Four review rounds went over this, each finding real defects in the last round's work, including three regressions of mine: in-memory-only sessions that would have stranded panels on every update, an idle sweep that collected sleeping laptops, and a revocation that left sockets open. Known gap: the idle gate's wiring is covered only at the store level, since a 4-hour window cannot be exercised end to end without a test seam in production code.
