### PR TITLE
Fix the macOS first run that captured the enrollment token and then hung

### DIFF
--- a/scripts/vendor-webview.sh
+++ b/scripts/vendor-webview.sh
@@ -96,7 +96,10 @@ grep -q "w->browser_controller()" "$HEADER"                 # reject half-built 
 # onboarding windows hand control back to main(). Losing either silently is a
 # hang, not a build failure, so assert both.
 grep -q "webview_set_host_owns_run_loop" "$HEADER"          # cocoa: host-owned loop flag
-grep -q "jarvis_host_owns_run_loop()) {" "$HEADER"          # cocoa: terminate still stops a window-owned loop
+# The whole guard, not just its condition: an inverted `if (` or an emptied body
+# both leave the string "jarvis_host_owns_run_loop()) {" in place while breaking
+# it in the direction where first run hangs.
+grep -A1 'if (!jarvis_host_owns_run_loop()) {' "$HEADER" | grep -q 'stop_run_loop();'
 grep -q "PATCHED (jarvis)" "$VENDOR_DIR/webview.go"         # nil WebView on NULL handle
 grep -q "PATCHED (jarvis)" "$VENDOR_DIR/jarvis_native.go"   # browser controller accessor
 grep -q "SetHostOwnsRunLoop" "$VENDOR_DIR/jarvis_native.go" # cocoa: the flag's Go binding

--- a/scripts/vendor-webview.sh
+++ b/scripts/vendor-webview.sh
@@ -90,8 +90,16 @@ grep -q "PATCHED (jarvis)" "$HEADER"
 grep -q "ShowWindow(m_window, SW_HIDE)" "$HEADER"           # win32: no open flash
 grep -q "isMainThread" "$HEADER"                            # cocoa: main-thread window
 grep -q "w->browser_controller()" "$HEADER"                 # reject half-built engines
+# The cocoa terminate guard, in BOTH directions. It had no marker until a lost
+# first run made the case for one: the no-op half protects the tray's shared
+# loop, and the stop_run_loop half is what lets the pre-tray connect and
+# onboarding windows hand control back to main(). Losing either silently is a
+# hang, not a build failure, so assert both.
+grep -q "webview_set_host_owns_run_loop" "$HEADER"          # cocoa: host-owned loop flag
+grep -q "jarvis_host_owns_run_loop()) {" "$HEADER"          # cocoa: terminate still stops a window-owned loop
 grep -q "PATCHED (jarvis)" "$VENDOR_DIR/webview.go"         # nil WebView on NULL handle
 grep -q "PATCHED (jarvis)" "$VENDOR_DIR/jarvis_native.go"   # browser controller accessor
+grep -q "SetHostOwnsRunLoop" "$VENDOR_DIR/jarvis_native.go" # cocoa: the flag's Go binding
 
 # Record the pinned version (single source of truth for the update workflow).
 printf '%s\n' "$VERSION" > "$VENDOR_DIR/UPSTREAM_VERSION"

--- a/sidecar/run_loop_ownership_test.go
+++ b/sidecar/run_loop_ownership_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -25,26 +26,40 @@ import (
 // once. These are cheap and they run on every platform, unlike the Cocoa code
 // they protect.
 func TestHostOwnsRunLoopIsDeclaredOnlyByTheTray(t *testing.T) {
-	entries, err := filepath.Glob("*.go")
-	if err != nil {
-		t.Fatalf("glob: %v", err)
-	}
-	for _, path := range entries {
-		if strings.HasSuffix(path, "_test.go") {
-			continue
-		}
-		src, err := os.ReadFile(path)
+	// Walked, not globbed: a glob of the package directory would miss a call
+	// added under internal/, which is a real place for one to appear.
+	// third_party is upstream's tree and defines the binding itself.
+	err := filepath.WalkDir(".", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
-			t.Fatalf("read %s: %v", path, err)
+			return err
 		}
-		if !strings.Contains(string(src), "SetHostOwnsRunLoop") {
-			continue
+		if d.IsDir() {
+			if d.Name() == "third_party" || d.Name() == "node_modules" || d.Name() == "dist" {
+				return filepath.SkipDir
+			}
+			return nil
 		}
-		if path != "tray_darwin.go" {
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		src, rerr := os.ReadFile(path)
+		if rerr != nil {
+			return rerr
+		}
+		// A CALL, not a mention: the identifier appears in prose in more than
+		// one comment, and flagging those would train people to ignore this.
+		if !strings.Contains(string(src), "SetHostOwnsRunLoop(") {
+			return nil
+		}
+		if filepath.ToSlash(path) != "tray_darwin.go" {
 			t.Errorf("%s calls SetHostOwnsRunLoop; only the tray may, and only as it "+
 				"enters the shared run loop. Anything earlier makes Terminate a no-op "+
 				"for the pre-tray first-run windows, which then never return from Run().", path)
 		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk: %v", err)
 	}
 }
 
@@ -110,8 +125,12 @@ func TestRunLoopBindingSurvivesReVendoring(t *testing.T) {
 			"without the jarvis patch?)")
 	}
 	// The half that a silent revert would take: without this, terminate is an
-	// unconditional no-op again and first run hangs.
-	if !strings.Contains(text, "jarvis_host_owns_run_loop()) {") {
+	// unconditional no-op again and first run hangs. Assert the whole guard,
+	// not just its condition -- `if (jarvis_host_owns_run_loop()) {` (inverted)
+	// and an empty body both read as "present" to a looser check, and both
+	// break it in the direction that hangs.
+	guard := "if (!jarvis_host_owns_run_loop()) {\n      stop_run_loop();\n    }"
+	if !strings.Contains(text, guard) {
 		t.Fatal("webview.h's Cocoa terminate_impl no longer stops a window-owned " +
 			"run loop; the pre-tray first-run windows will hang in Run()")
 	}

--- a/sidecar/run_loop_ownership_test.go
+++ b/sidecar/run_loop_ownership_test.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Who is allowed to say "something other than a webview window owns the Cocoa
+// run loop", and when.
+//
+// The flag exists because `terminate_impl` on Cocoa has to do two opposite
+// things (see third_party/webview_go/JARVIS_PATCH.md). Under the tray's single
+// shared [NSApp run] loop, a window closing must NOT stop it. Before the tray
+// exists, the first-run connect window and the onboarding wizard own the loop
+// themselves and end by calling Terminate() to hand control back to main() --
+// for those, terminate must actually terminate.
+//
+// Setting the flag too early collapses the second case into the first, and the
+// failure is silent on both sides: Run() never returns, the window sits open on
+// its "connected" screen, the enrollment token it already captured is never
+// saved, and the sidecar never dials the brain a user has just paid for. No
+// crash, no error, nothing in the log after the token arrives. That shipped
+// once. These are cheap and they run on every platform, unlike the Cocoa code
+// they protect.
+func TestHostOwnsRunLoopIsDeclaredOnlyByTheTray(t *testing.T) {
+	entries, err := filepath.Glob("*.go")
+	if err != nil {
+		t.Fatalf("glob: %v", err)
+	}
+	for _, path := range entries {
+		if strings.HasSuffix(path, "_test.go") {
+			continue
+		}
+		src, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		if !strings.Contains(string(src), "SetHostOwnsRunLoop") {
+			continue
+		}
+		if path != "tray_darwin.go" {
+			t.Errorf("%s calls SetHostOwnsRunLoop; only the tray may, and only as it "+
+				"enters the shared run loop. Anything earlier makes Terminate a no-op "+
+				"for the pre-tray first-run windows, which then never return from Run().", path)
+		}
+	}
+}
+
+func TestTrayClaimsTheRunLoopOnlyAsItEntersIt(t *testing.T) {
+	src, err := os.ReadFile("tray_darwin.go")
+	if err != nil {
+		t.Fatalf("read tray_darwin.go: %v", err)
+	}
+	text := string(src)
+
+	const claim = "webview.SetHostOwnsRunLoop(true)"
+	const enter = "C.jarvisTrayRun()"
+
+	if n := strings.Count(text, claim); n != 1 {
+		t.Fatalf("found %d calls to %s in tray_darwin.go, want exactly 1", n, claim)
+	}
+	if n := strings.Count(text, enter); n != 1 {
+		t.Fatalf("found %d calls to %s in tray_darwin.go, want exactly 1", n, enter)
+	}
+
+	claimAt := strings.Index(text, claim)
+	enterAt := strings.Index(text, enter)
+	if claimAt > enterAt {
+		t.Fatalf("%s is claimed AFTER entering the run loop; a window closing in "+
+			"between would stop the tray's loop", claim)
+	}
+
+	// Adjacent, not merely earlier: the guarantee is "everything before this
+	// line owns its own loop". A claim hoisted to the top of runWithTray would
+	// still pass an ordering-only check while covering setup paths it must not.
+	between := strings.TrimSpace(text[claimAt+len(claim) : enterAt])
+	for _, line := range strings.Split(between, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "//") {
+			continue
+		}
+		t.Fatalf("statement between claiming the run loop and entering it: %q. "+
+			"The claim must be the last thing before [NSApp run].", line)
+	}
+}
+
+// The Go binding is what the tray calls; losing it is a compile error there but
+// this names the reason so a re-vendor that drops jarvis_native.go fails here
+// with an explanation rather than only in the Cocoa build nobody runs locally.
+func TestRunLoopBindingSurvivesReVendoring(t *testing.T) {
+	src, err := os.ReadFile(filepath.Join("third_party", "webview_go", "jarvis_native.go"))
+	if err != nil {
+		t.Fatalf("read jarvis_native.go: %v", err)
+	}
+	if !strings.Contains(string(src), "func SetHostOwnsRunLoop(") {
+		t.Fatal("jarvis_native.go no longer exports SetHostOwnsRunLoop. A re-vendor " +
+			"drops anything jarvis.patch stops carrying; see JARVIS_PATCH.md.")
+	}
+
+	header, err := os.ReadFile(filepath.Join(
+		"third_party", "webview_go", "libs", "webview", "include", "webview.h"))
+	if err != nil {
+		t.Fatalf("read webview.h: %v", err)
+	}
+	text := string(header)
+	if !strings.Contains(text, "webview_set_host_owns_run_loop") {
+		t.Fatal("webview.h lost the host-owns-run-loop entry point (re-vendored " +
+			"without the jarvis patch?)")
+	}
+	// The half that a silent revert would take: without this, terminate is an
+	// unconditional no-op again and first run hangs.
+	if !strings.Contains(text, "jarvis_host_owns_run_loop()) {") {
+		t.Fatal("webview.h's Cocoa terminate_impl no longer stops a window-owned " +
+			"run loop; the pre-tray first-run windows will hang in Run()")
+	}
+}

--- a/sidecar/third_party/webview_go/JARVIS_PATCH.md
+++ b/sidecar/third_party/webview_go/JARVIS_PATCH.md
@@ -163,7 +163,7 @@ Two shape decisions worth keeping:
 
 - **A new file, not a hunk in `webview.go` or `webview.h`.** It touches no
   upstream source, so it has nothing to conflict with when the monthly bot
-  re-vendors — unlike `webview.h`, which already carries five hunks and whose
+  re-vendors — unlike `webview.h`, which already carries several hunks and whose
   win32 constructor context this file explicitly warns about above. `patch`
   creates it from a `--- /dev/null` hunk, and it must NOT go in `KEEP_FILES`:
   the whole point is that the patch carries it.
@@ -172,7 +172,7 @@ Two shape decisions worth keeping:
   `NativeHandle` with a different signature, and a package-level function has
   a far smaller collision surface.
 
-Unlike the other four, this patch cannot be silently reverted: `internal/winchrome`
+Unlike the others, this patch cannot be silently reverted: `internal/winchrome`
 *calls* `webview.BrowserController`, so losing it is a **build failure** on the
 Windows cross-build in `test.yml` and `update-webview.yml`, not a green PR that
 quietly dropped a behavior. The sanity grep in `vendor-webview.sh` is kept

--- a/sidecar/third_party/webview_go/JARVIS_PATCH.md
+++ b/sidecar/third_party/webview_go/JARVIS_PATCH.md
@@ -2,10 +2,11 @@
 
 This is a local copy of `github.com/webview/webview_go` (the pinned version is
 in `UPSTREAM_VERSION`), wired in via a `replace` directive in `sidecar/go.mod`,
-with **five patches**, all carried by `jarvis.patch`: a Win32 one for the open
+with **six patches**, all carried by `jarvis.patch`: a Win32 one for the open
 flash, a Cocoa one to create the window on the main thread, a `webview_create`
 check that rejects a half-built engine, a NULL-handle guard in `webview.go`,
-and a browser-controller accessor in a file of our own, `jarvis_native.go`.
+a browser-controller accessor in a file of our own, `jarvis_native.go`, and a
+Cocoa `terminate` that stops the run loop only when a window actually owns it.
 
 `jarvis.patch` must carry EVERY vendored edit. `vendor-webview.sh` deletes the
 vendor directory and copies pristine upstream over it, keeping only
@@ -176,3 +177,45 @@ Unlike the other four, this patch cannot be silently reverted: `internal/winchro
 Windows cross-build in `test.yml` and `update-webview.yml`, not a green PR that
 quietly dropped a behavior. The sanity grep in `vendor-webview.sh` is kept
 anyway, both for consistency and because it names the intent.
+
+## The Cocoa terminate guard
+
+The sidecar's tray runs ONE shared `[NSApp run]` loop, and every window opened
+afterwards (panels, settings, logs) lives under it. Upstream's
+`on_window_destroyed()` calls `terminate()` when the last webview window closes,
+whose Cocoa implementation is `stop_run_loop()` -> `[NSApp stop]` -- which would
+stop the tray's loop. Re-entering `[NSApp run]` afterwards leaves the main
+dispatch queue unserviced, so the next `webview.New()`'s `dispatch_sync` to the
+main thread hangs forever, the pebble's main-queue paint stalls, and the tray
+can't post its own quit. So `terminate_impl` must not stop that loop.
+
+It was first patched to be an unconditional no-op, and that broke the other
+half of the story. The first-run windows -- the hosted connect window
+(`hosted_window.go`) and the onboarding wizard (`setup_onboarding.go`) -- open
+BEFORE the tray exists and own the run loop themselves. They end by calling
+`Terminate()` to return from `Run()` and hand control back to `main()`. Made a
+no-op, that call did nothing: `Run()` never returned, the window sat open on its
+"connected" screen, and the enrollment token it had already captured was never
+saved. The user had paid, the brain was provisioned, and the sidecar never
+dialled it -- so the hosted setup page waited forever on a device that would
+never phone home. There was no crash and no error, on either side.
+
+The fix is a flag rather than a no-op:
+
+```cpp
+  void terminate_impl() override {
+    if (!jarvis_host_owns_run_loop()) {
+      stop_run_loop();
+    }
+  }
+```
+
+`webview_set_host_owns_run_loop(1)` (Go: `webview.SetHostOwnsRunLoop(true)`) is
+called once, from `tray_darwin.go`, immediately before entering
+`jarvisTrayRun()`. Everything before that point owns the loop and terminates
+normally; everything after is under the tray's loop and cannot stop it. The C
+entry point exists on every platform and is a no-op off Cocoa, so the Go caller
+needs no build tag.
+
+Both halves have their own sanity grep in `vendor-webview.sh`. Neither is
+detectable by the build: losing either one is a hang, not a compile error.

--- a/sidecar/third_party/webview_go/jarvis.patch
+++ b/sidecar/third_party/webview_go/jarvis.patch
@@ -29,7 +29,7 @@
  
  namespace webview {
  namespace detail {
-@@ -1551,6 +1566,19 @@
+@@ -1551,6 +1566,26 @@
    return objc::msg_send<id>("NSString"_cls, "stringWithUTF8String:"_sel, s);
  }
  
@@ -37,19 +37,26 @@
 + * PATCHED (jarvis): does something OTHER than a webview window own the Cocoa
 + * run loop right now? See webview_set_host_owns_run_loop.
 + *
-+ * Function-local static rather than a namespace-scope global: this header is
-+ * included by more than one translation unit (the cgo preamble includes it too)
-+ * and a plain global would be a duplicate symbol at link time.
++ * Function-local static in an inline function, not a namespace-scope global:
++ * this is a header-only library, so a plain definition here would be a
++ * duplicate symbol the moment a second C++ translation unit included the
++ * implementation section. The ODR merges this one.
++ *
++ * Atomic because `terminate()` is documented as callable from any thread. Every
++ * caller in this codebase reaches it on the main thread (window close is
++ * dispatched there, and the Go binding wraps Terminate in Dispatch), so there is
++ * no live race today -- but the guarantee costs nothing and the class already
++ * uses the same pattern for `first` below.
 + */
-+inline bool &jarvis_host_owns_run_loop() {
-+  static bool owns = false;
++inline std::atomic<bool> &jarvis_host_owns_run_loop() {
++  static std::atomic<bool> owns{false};
 +  return owns;
 +}
 +
  class cocoa_wkwebview_engine : public engine_base {
  public:
    cocoa_wkwebview_engine(bool debug, void *window)
-@@ -1634,7 +1662,31 @@
+@@ -1634,7 +1669,31 @@
    void *window_impl() override { return (void *)m_window; }
    void *widget_impl() override { return (void *)m_webview; }
    void *browser_controller_impl() override { return (void *)m_webview; };
@@ -82,7 +89,7 @@
    void run_impl() override {
      auto app = get_shared_application();
      objc::msg_send<void>(app, "run"_sel);
-@@ -1895,6 +1947,19 @@
+@@ -1895,6 +1954,19 @@
      dispatch([this] { on_window_destroyed(); });
    }
    void set_up_window() {
@@ -102,7 +109,7 @@
      objc::autoreleasepool arp;
  
      // Main window
-@@ -2022,23 +2087,14 @@
+@@ -2022,23 +2094,14 @@
  
    // Blocks while depleting the run loop of events.
    void deplete_run_loop_event_queue() {
@@ -134,7 +141,7 @@
    }
  
    bool m_debug{};
-@@ -3179,9 +3235,10 @@
+@@ -3179,9 +3242,10 @@
                      nullptr, hInstance, this);
  
      if (m_owns_window) {
@@ -148,7 +155,7 @@
      }
  
      auto cb =
-@@ -3500,7 +3557,16 @@
+@@ -3500,7 +3564,16 @@
  
  WEBVIEW_API webview_t webview_create(int debug, void *wnd) {
    auto w = new webview::webview(debug, wnd);
@@ -166,7 +173,7 @@
      delete w;
      return nullptr;
    }
-@@ -3519,6 +3585,17 @@
+@@ -3519,6 +3592,17 @@
    static_cast<webview::webview *>(w)->terminate();
  }
  

--- a/sidecar/third_party/webview_go/jarvis.patch
+++ b/sidecar/third_party/webview_go/jarvis.patch
@@ -1,6 +1,27 @@
 --- a/libs/webview/include/webview.h
 +++ b/libs/webview/include/webview.h
-@@ -1471,6 +1471,7 @@
+@@ -215,6 +215,20 @@
+ WEBVIEW_API void webview_terminate(webview_t w);
+ 
+ /**
++ * PATCHED (jarvis): declare that a HOST-OWNED run loop is running, so a
++ * window's terminate must not stop it.
++ *
++ * Cocoa only; a no-op elsewhere. The sidecar's tray runs one shared [NSApp run]
++ * loop that every later window (panels, settings, logs) lives under, and a
++ * window closing must not take the app down with it. But the FIRST-RUN windows
++ * open before the tray exists and own the loop themselves, so for those
++ * terminate has to work exactly as upstream intends.
++ *
++ * Set it to 1 immediately before entering the shared loop and leave it there.
++ */
++WEBVIEW_API void webview_set_host_owns_run_loop(int owns);
++
++/**
+  * Schedules a function to be invoked on the thread with the run/event loop.
+  * Use this function e.g. to interact with the library or native handles.
+  *
+@@ -1471,6 +1485,7 @@
  #include <CoreGraphics/CoreGraphics.h>
  #include <objc/NSObjCRuntime.h>
  #include <objc/objc-runtime.h>
@@ -8,26 +29,60 @@
  
  namespace webview {
  namespace detail {
-@@ -1634,7 +1635,17 @@
+@@ -1551,6 +1566,19 @@
+   return objc::msg_send<id>("NSString"_cls, "stringWithUTF8String:"_sel, s);
+ }
+ 
++/**
++ * PATCHED (jarvis): does something OTHER than a webview window own the Cocoa
++ * run loop right now? See webview_set_host_owns_run_loop.
++ *
++ * Function-local static rather than a namespace-scope global: this header is
++ * included by more than one translation unit (the cgo preamble includes it too)
++ * and a plain global would be a duplicate symbol at link time.
++ */
++inline bool &jarvis_host_owns_run_loop() {
++  static bool owns = false;
++  return owns;
++}
++
+ class cocoa_wkwebview_engine : public engine_base {
+ public:
+   cocoa_wkwebview_engine(bool debug, void *window)
+@@ -1634,7 +1662,31 @@
    void *window_impl() override { return (void *)m_window; }
    void *widget_impl() override { return (void *)m_webview; }
    void *browser_controller_impl() override { return (void *)m_webview; };
 -  void terminate_impl() override { stop_run_loop(); }
 +  void terminate_impl() override {
-+    // PATCHED (jarvis): no-op on Cocoa. The sidecar runs every webview window
-+    // (panels, settings, logs) under the tray's single shared [NSApp run] loop.
-+    // on_window_destroyed() calls terminate() when the LAST webview window
-+    // closes; the upstream behavior here is stop_run_loop() -> [NSApp stop],
-+    // which stops the tray's loop. Re-entering [NSApp run] afterwards leaves the
-+    // main dispatch queue unserviced, so the next webview.New()'s dispatch_sync
-+    // to the main thread hangs forever (and the pebble's main-queue paint stalls
-+    // + tray quit can't post). The app must only ever quit via the tray's own
-+    // jarvisTrayQuit ([NSApp stop] + gTrayShouldQuit), never on a window close.
++    // PATCHED (jarvis): no-op on Cocoa ONCE THE TRAY OWNS THE LOOP. The sidecar
++    // runs every webview window (panels, settings, logs) under the tray's
++    // single shared [NSApp run] loop. on_window_destroyed() calls terminate()
++    // when the LAST webview window closes; the upstream behavior here is
++    // stop_run_loop() -> [NSApp stop], which stops the tray's loop. Re-entering
++    // [NSApp run] afterwards leaves the main dispatch queue unserviced, so the
++    // next webview.New()'s dispatch_sync to the main thread hangs forever (and
++    // the pebble's main-queue paint stalls + tray quit can't post). The app must
++    // only ever quit via the tray's own jarvisTrayQuit ([NSApp stop] +
++    // gTrayShouldQuit), never on a window close.
++    //
++    // The GUARD is the whole point, and skipping it cost a paid user their
++    // first run: the connect and onboarding windows open BEFORE the tray, own
++    // this loop themselves, and end by calling terminate() to hand control back
++    // to main(). Made unconditionally no-op, that call did nothing, run()
++    // never returned, and the window sat open on its "connected" screen with
++    // the enrollment token captured but never saved -- so the sidecar never
++    // dialled the brain and the hosted setup page waited for a device that
++    // would never phone home. Before the tray there is no shared loop to
++    // protect, and terminate must mean terminate.
++    if (!jarvis_host_owns_run_loop()) {
++      stop_run_loop();
++    }
 +  }
    void run_impl() override {
      auto app = get_shared_application();
      objc::msg_send<void>(app, "run"_sel);
-@@ -1895,6 +1906,19 @@
+@@ -1895,6 +1947,19 @@
      dispatch([this] { on_window_destroyed(); });
    }
    void set_up_window() {
@@ -47,7 +102,7 @@
      objc::autoreleasepool arp;
  
      // Main window
-@@ -2022,23 +2046,14 @@
+@@ -2022,23 +2087,14 @@
  
    // Blocks while depleting the run loop of events.
    void deplete_run_loop_event_queue() {
@@ -79,7 +134,7 @@
    }
  
    bool m_debug{};
-@@ -3179,9 +3194,10 @@
+@@ -3179,9 +3235,10 @@
                      nullptr, hInstance, this);
  
      if (m_owns_window) {
@@ -93,7 +148,7 @@
      }
  
      auto cb =
-@@ -3500,7 +3516,16 @@
+@@ -3500,7 +3557,16 @@
  
  WEBVIEW_API webview_t webview_create(int debug, void *wnd) {
    auto w = new webview::webview(debug, wnd);
@@ -111,6 +166,24 @@
      delete w;
      return nullptr;
    }
+@@ -3519,6 +3585,17 @@
+   static_cast<webview::webview *>(w)->terminate();
+ }
+ 
++WEBVIEW_API void webview_set_host_owns_run_loop(int owns) {
++#if defined(WEBVIEW_COCOA)
++  webview::detail::jarvis_host_owns_run_loop() = owns != 0;
++#else
++  // Windows and GTK stop their loops per window and have no shared host loop
++  // to protect, so there is nothing to declare. Present on every platform
++  // anyway, so the Go caller needs no build tag of its own.
++  (void)owns;
++#endif
++}
++
+ WEBVIEW_API void webview_dispatch(webview_t w, void (*fn)(webview_t, void *),
+                                   void *arg) {
+   static_cast<webview::webview *>(w)->dispatch([=]() { fn(w, arg); });
 --- a/webview.go
 +++ b/webview.go
 @@ -155,6 +155,16 @@
@@ -132,7 +205,7 @@
  
 --- /dev/null
 +++ b/jarvis_native.go
-@@ -0,0 +1,44 @@
+@@ -0,0 +1,65 @@
 +package webview
 +
 +/*
@@ -176,4 +249,25 @@
 +		return nil
 +	}
 +	return unsafe.Pointer(C.webview_get_native_handle(iw.w, C.WEBVIEW_NATIVE_HANDLE_KIND_BROWSER_CONTROLLER))
++}
++
++// PATCHED (jarvis): declare that a host-owned run loop is running.
++//
++// Cocoa only; a no-op on Windows and GTK, which stop their loops per window.
++//
++// The sidecar's tray runs ONE shared [NSApp run] loop that every window opened
++// afterwards (panels, settings, logs) lives under, so a window closing must not
++// stop it -- see terminate_impl in webview.h for what breaks if it does. The
++// first-run windows are the exception that makes this a flag rather than an
++// unconditional no-op: they open before the tray, own the loop themselves, and
++// call Terminate to hand control back to main().
++//
++// Call with true once, immediately before entering the shared loop. There is no
++// matching false: the tray owns the loop until the process exits.
++func SetHostOwnsRunLoop(owns bool) {
++	v := C.int(0)
++	if owns {
++		v = C.int(1)
++	}
++	C.webview_set_host_owns_run_loop(v)
 +}

--- a/sidecar/third_party/webview_go/jarvis_native.go
+++ b/sidecar/third_party/webview_go/jarvis_native.go
@@ -42,3 +42,24 @@ func BrowserController(w WebView) unsafe.Pointer {
 	}
 	return unsafe.Pointer(C.webview_get_native_handle(iw.w, C.WEBVIEW_NATIVE_HANDLE_KIND_BROWSER_CONTROLLER))
 }
+
+// PATCHED (jarvis): declare that a host-owned run loop is running.
+//
+// Cocoa only; a no-op on Windows and GTK, which stop their loops per window.
+//
+// The sidecar's tray runs ONE shared [NSApp run] loop that every window opened
+// afterwards (panels, settings, logs) lives under, so a window closing must not
+// stop it -- see terminate_impl in webview.h for what breaks if it does. The
+// first-run windows are the exception that makes this a flag rather than an
+// unconditional no-op: they open before the tray, own the loop themselves, and
+// call Terminate to hand control back to main().
+//
+// Call with true once, immediately before entering the shared loop. There is no
+// matching false: the tray owns the loop until the process exits.
+func SetHostOwnsRunLoop(owns bool) {
+	v := C.int(0)
+	if owns {
+		v = C.int(1)
+	}
+	C.webview_set_host_owns_run_loop(v)
+}

--- a/sidecar/third_party/webview_go/libs/webview/include/webview.h
+++ b/sidecar/third_party/webview_go/libs/webview/include/webview.h
@@ -1570,12 +1570,19 @@ inline id operator"" _str(const char *s, std::size_t) {
  * PATCHED (jarvis): does something OTHER than a webview window own the Cocoa
  * run loop right now? See webview_set_host_owns_run_loop.
  *
- * Function-local static rather than a namespace-scope global: this header is
- * included by more than one translation unit (the cgo preamble includes it too)
- * and a plain global would be a duplicate symbol at link time.
+ * Function-local static in an inline function, not a namespace-scope global:
+ * this is a header-only library, so a plain definition here would be a
+ * duplicate symbol the moment a second C++ translation unit included the
+ * implementation section. The ODR merges this one.
+ *
+ * Atomic because `terminate()` is documented as callable from any thread. Every
+ * caller in this codebase reaches it on the main thread (window close is
+ * dispatched there, and the Go binding wraps Terminate in Dispatch), so there is
+ * no live race today -- but the guarantee costs nothing and the class already
+ * uses the same pattern for `first` below.
  */
-inline bool &jarvis_host_owns_run_loop() {
-  static bool owns = false;
+inline std::atomic<bool> &jarvis_host_owns_run_loop() {
+  static std::atomic<bool> owns{false};
   return owns;
 }
 

--- a/sidecar/third_party/webview_go/libs/webview/include/webview.h
+++ b/sidecar/third_party/webview_go/libs/webview/include/webview.h
@@ -215,6 +215,20 @@ WEBVIEW_API void webview_run(webview_t w);
 WEBVIEW_API void webview_terminate(webview_t w);
 
 /**
+ * PATCHED (jarvis): declare that a HOST-OWNED run loop is running, so a
+ * window's terminate must not stop it.
+ *
+ * Cocoa only; a no-op elsewhere. The sidecar's tray runs one shared [NSApp run]
+ * loop that every later window (panels, settings, logs) lives under, and a
+ * window closing must not take the app down with it. But the FIRST-RUN windows
+ * open before the tray exists and own the loop themselves, so for those
+ * terminate has to work exactly as upstream intends.
+ *
+ * Set it to 1 immediately before entering the shared loop and leave it there.
+ */
+WEBVIEW_API void webview_set_host_owns_run_loop(int owns);
+
+/**
  * Schedules a function to be invoked on the thread with the run/event loop.
  * Use this function e.g. to interact with the library or native handles.
  *
@@ -1552,6 +1566,19 @@ inline id operator"" _str(const char *s, std::size_t) {
   return objc::msg_send<id>("NSString"_cls, "stringWithUTF8String:"_sel, s);
 }
 
+/**
+ * PATCHED (jarvis): does something OTHER than a webview window own the Cocoa
+ * run loop right now? See webview_set_host_owns_run_loop.
+ *
+ * Function-local static rather than a namespace-scope global: this header is
+ * included by more than one translation unit (the cgo preamble includes it too)
+ * and a plain global would be a duplicate symbol at link time.
+ */
+inline bool &jarvis_host_owns_run_loop() {
+  static bool owns = false;
+  return owns;
+}
+
 class cocoa_wkwebview_engine : public engine_base {
 public:
   cocoa_wkwebview_engine(bool debug, void *window)
@@ -1636,15 +1663,29 @@ public:
   void *widget_impl() override { return (void *)m_webview; }
   void *browser_controller_impl() override { return (void *)m_webview; };
   void terminate_impl() override {
-    // PATCHED (jarvis): no-op on Cocoa. The sidecar runs every webview window
-    // (panels, settings, logs) under the tray's single shared [NSApp run] loop.
-    // on_window_destroyed() calls terminate() when the LAST webview window
-    // closes; the upstream behavior here is stop_run_loop() -> [NSApp stop],
-    // which stops the tray's loop. Re-entering [NSApp run] afterwards leaves the
-    // main dispatch queue unserviced, so the next webview.New()'s dispatch_sync
-    // to the main thread hangs forever (and the pebble's main-queue paint stalls
-    // + tray quit can't post). The app must only ever quit via the tray's own
-    // jarvisTrayQuit ([NSApp stop] + gTrayShouldQuit), never on a window close.
+    // PATCHED (jarvis): no-op on Cocoa ONCE THE TRAY OWNS THE LOOP. The sidecar
+    // runs every webview window (panels, settings, logs) under the tray's
+    // single shared [NSApp run] loop. on_window_destroyed() calls terminate()
+    // when the LAST webview window closes; the upstream behavior here is
+    // stop_run_loop() -> [NSApp stop], which stops the tray's loop. Re-entering
+    // [NSApp run] afterwards leaves the main dispatch queue unserviced, so the
+    // next webview.New()'s dispatch_sync to the main thread hangs forever (and
+    // the pebble's main-queue paint stalls + tray quit can't post). The app must
+    // only ever quit via the tray's own jarvisTrayQuit ([NSApp stop] +
+    // gTrayShouldQuit), never on a window close.
+    //
+    // The GUARD is the whole point, and skipping it cost a paid user their
+    // first run: the connect and onboarding windows open BEFORE the tray, own
+    // this loop themselves, and end by calling terminate() to hand control back
+    // to main(). Made unconditionally no-op, that call did nothing, run()
+    // never returned, and the window sat open on its "connected" screen with
+    // the enrollment token captured but never saved -- so the sidecar never
+    // dialled the brain and the hosted setup page waited for a device that
+    // would never phone home. Before the tray there is no shared loop to
+    // protect, and terminate must mean terminate.
+    if (!jarvis_host_owns_run_loop()) {
+      stop_run_loop();
+    }
   }
   void run_impl() override {
     auto app = get_shared_application();
@@ -3542,6 +3583,17 @@ WEBVIEW_API void webview_run(webview_t w) {
 
 WEBVIEW_API void webview_terminate(webview_t w) {
   static_cast<webview::webview *>(w)->terminate();
+}
+
+WEBVIEW_API void webview_set_host_owns_run_loop(int owns) {
+#if defined(WEBVIEW_COCOA)
+  webview::detail::jarvis_host_owns_run_loop() = owns != 0;
+#else
+  // Windows and GTK stop their loops per window and have no shared host loop
+  // to protect, so there is nothing to declare. Present on every platform
+  // anyway, so the Go caller needs no build tag of its own.
+  (void)owns;
+#endif
 }
 
 WEBVIEW_API void webview_dispatch(webview_t w, void (*fn)(webview_t, void *),

--- a/sidecar/tray_darwin.go
+++ b/sidecar/tray_darwin.go
@@ -270,10 +270,12 @@ static void jarvisTrayRebuild(const char* header, int waiting, int paused, int m
     });
 }
 
-// gTrayShouldQuit is set true only by jarvisTrayQuit. webview_go stops the app
-// run loop when a panel window closes (on_window_destroyed -> terminate ->
-// [NSApp stop]); that must NOT end the sidecar. So jarvisTrayRun re-enters the
-// run loop after any stop and only returns when we actually want to quit.
+// gTrayShouldQuit is set true only by jarvisTrayQuit. A webview window closing
+// must NOT end the sidecar, and the patched Cocoa terminate_impl is what stops
+// it trying: once webview_set_host_owns_run_loop(1) is raised below, a window
+// close no longer calls [NSApp stop] at all (see JARVIS_PATCH.md). This
+// re-enter loop is the BACKSTOP for anything that stops the loop anyway, not
+// the mechanism -- it only returns when we actually want to quit.
 static volatile int gTrayShouldQuit = 0;
 
 // jarvisTrayRun runs the Cocoa main loop (blocks until jarvisTrayQuit).

--- a/sidecar/tray_darwin.go
+++ b/sidecar/tray_darwin.go
@@ -315,6 +315,8 @@ import (
 	"strings"
 	"time"
 	"unsafe"
+
+	webview "github.com/webview/webview_go"
 )
 
 // Pin the main goroutine to the process's main OS thread (thread 0) for the
@@ -468,5 +470,11 @@ func runWithTray(ctx context.Context, cancel context.CancelFunc, client *Sidecar
 		<-ctx.Done()
 		C.jarvisTrayQuit()
 	}()
+	// From here the tray owns the Cocoa run loop, so a window closing must not
+	// stop it (webview.h terminate_impl explains what breaks if it does). Set
+	// LAST, immediately before entering the loop: everything before this point
+	// -- the first-run connect window, the onboarding wizard -- owns the loop
+	// itself and needs Terminate to actually terminate.
+	webview.SetHostOwnsRunLoop(true)
 	C.jarvisTrayRun() // blocks on [NSApp run]
 }


### PR DESCRIPTION
A test user on macOS paid, the brain provisioned fine, and then nothing happened: the hosted setup page sat on "Setting up your instance…" with "account linked" ticked and "starting your brain" spinning forever, while the sidecar showed a green pebble reading "connected".

The green pebble was the connect window's own success screen (`window.__setConnected()`), not a live brain connection. The sidecar never dialled the brain at all.

## Cause

`terminate_impl()` for Cocoa is patched to an unconditional no-op, so on macOS `w.Terminate()` does nothing.

`runFirstRunWindow` ends in `w.Run()`, and the only thing that makes that return is `Terminate()`. So after the handshake delivered the token, `connectedThenClose()` painted the success screen, waited its 3.5s dwell, called `Terminate()` into the void, and the window sat there. `Run()` never returned, the captured token was never saved, `restartAfterSetup()` never ran, and the sidecar never connected. The brain therefore never recorded a device, `last_seen_at` stayed null, and the page's `confirmConnected` had nothing to confirm.

The user's log shows it directly, in two separate sessions: after `enrollment token received via handshake` there is never a `Token saved to config`, and never the `Connecting to…` / `Connected` pair the client logs on every dial. All three are unconditional.

`hosted_window.go` already carries a comment describing this exact symptom ("Seen live on macOS: the token arrived, the closure never drained, and the window sat open forever while runFirstRunWindow stayed blocked in Run()"). That fix addressed the token being lost, not the hang.

## Fix

The no-op exists for a real reason: the tray runs one shared `[NSApp run]` loop that every later window (panels, settings, logs) lives under, and a window closing must not stop it. But the first-run windows open *before* the tray and own the loop themselves.

So it becomes a flag instead of a no-op. `webview_set_host_owns_run_loop(1)` is raised once, from `tray_darwin.go`, as the last statement before entering the tray loop. Everything before that terminates normally; everything after is protected exactly as it is today. The C entry point exists on every platform and is a no-op off Cocoa, so nothing leaks into the Go callers.

This also fixes a quieter case: with terminate inert, closing the connect window by hand could not exit either, so `main`'s "Setup cancelled" path was unreachable.

## Keeping it fixed

`vendor-webview.sh` wipes the vendored tree monthly and re-applies `jarvis.patch`, asserting one grep per patched behaviour. **The Cocoa terminate patch had no grep**, so it was already one re-vendor away from silently reverting.

- `jarvis.patch` regenerated from pristine upstream. Verified: it applies cleanly to the pinned upstream and reproduces the vendored tree byte-for-byte.
- Greps added for both halves of the guard, plus the Go binding.
- Documented as the sixth patch in `JARVIS_PATCH.md`.
- `run_loop_ownership_test.go` guards the ordering invariant on every platform: the flag may only be raised by the tray, exactly once, with nothing between it and `[NSApp run]`. An adjacency check, not just an ordering one, because a claim hoisted to the top of `runWithTray` would still be "before" the loop while covering setup paths it must not.

I checked both tests fail when the bug is reintroduced: reverting the guard fails one, hoisting the flag fails the other.

## Verified

Confirmed working end to end on macOS. The three lines that were missing before now all appear, in order:

```
[hosted] enrollment token received via handshake
[sidecar] Token saved to config
[sidecar] Connecting to wss://<brain>/sidecar/connect...
[sidecar] Connected
```

The window terminated, `Run()` returned, the token was written, the re-exec happened and the sidecar dialled the brain. The four seconds between the token arriving and it being saved are the deliberate 3.5s `connectedDwell`; the minute before that is the sidecar blocked in `awaitHandshakeToken` while the user completes login and checkout in the browser.

The darwin CI job also compiles this change for arm64 and amd64 at the release deployment target, which is the only build of the Cocoa branch that exists (it cannot be compiled on Linux).

A later commit on this branch hardens the guard after review: the flag is `std::atomic<bool>`, the vendor greps and the test assert the whole guard rather than just its condition (an inverted `if` or an emptied body now fail both), and the source scan walks subpackages instead of globbing one directory. Both evasions were verified to fail.

## Related, not fixed here

Even with this fixed, `ConnectPage.tsx` in the hosting repo gives up confirming after ~12 tries and leaves the page on "provisioning" with no error and no retry, which is how a transient SSH failure becomes an identical-looking permanent hang. It is also why this bug surfaced as a user report rather than a log. Separate repo, separate change.

