### PR TITLE
Don't run a wake word's trailing punctuation as a command

### DIFF
--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -43,6 +43,7 @@ import { ApprovalManager } from "../authority/approval.ts";
 import { AuditTrail } from "../authority/audit.ts";
 import { impactFromCategory } from "../roles/authority.ts";
 import { SIDECAR_RECOMMENDED_VERSION } from "../sidecar/compat.ts";
+import { containsWakePhrase, hasSpokenContent, wakeCommandFrom } from "../voice/wake-phrase.ts";
 import { AuthorityLearner } from "../authority/learning.ts";
 import { EmergencyController } from "../authority/emergency.ts";
 import { ApprovalDelivery } from "../authority/approval-delivery.ts";
@@ -3499,8 +3500,14 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
           }
           if (ctrl.cancelled) return;
 
-          if (!transcript) {
-            console.log('[ambient-ui] empty transcript — returning to idle');
+          // `hasSpokenContent`, not a bare truthiness check: STT renders a
+          // captured silence as "." or "?!" often enough, and those used to
+          // run as the user's whole turn.
+          if (!hasSpokenContent(transcript)) {
+            console.log(
+              `[ambient-ui] no speech in transcript${transcript ? ` (${JSON.stringify(transcript)})` : ''}` +
+              ` — returning to idle`,
+            );
             await setState(session.sidecarId, 'idle', '');
             clearSummon(session.sidecarId, ctrl);
             return;
@@ -3521,25 +3528,11 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
       // transcribe and word-search for "jarvis"; on a hit, we either
       //   - run the LLM directly with the trailing command (single-shot,
       //     "Jarvis play music" works without saying it twice), or
-      //   - if only "jarvis" alone, fire a normal listening summon so the
-      //     user can speak the command after the bubble pops up.
+      //   - if only "jarvis" alone (bare, or trailed by nothing but
+      //     punctuation), fire a normal listening summon so the user can
+      //     speak the command after the bubble pops up.
       // Suppressed when a summon cycle is already running so the
       // continuous wake stream doesn't fight with the active turn.
-      const wakePhrase = /\bjarvis\b/i;
-      const stripWakePrefix = (text: string): string => {
-        // Pull out the segment after the LAST occurrence of "jarvis" so
-        // "I'm at home, Jarvis play music" → "play music". Trailing
-        // punctuation/whitespace removed; if nothing follows, returns "".
-        const re = /\bjarvis\b[\s,.\-—:]*/gi;
-        let last: RegExpExecArray | null = null;
-        let m: RegExpExecArray | null;
-        while ((m = re.exec(text)) !== null) {
-          last = m;
-        }
-        if (!last) return '';
-        return text.slice(last.index + last[0].length).trim();
-      };
-
       sidecarManager.onEvent(async (sidecarId, event) => {
         if (event.event_type !== 'audio.wake_segment') return;
         // Suppress while an active summon is in flight — the user already
@@ -3576,13 +3569,13 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
         }
         const sttMs = Date.now() - sttStart;
         if (!transcript) return;
-        if (!wakePhrase.test(transcript)) {
+        if (!containsWakePhrase(transcript)) {
           // Most segments — user talking about other things. Quietly drop.
           return;
         }
         console.log(`[ambient-ui] wake-segment matched (${sttMs}ms STT, ${transcript.length} chars)`);
 
-        const command = stripWakePrefix(transcript);
+        const command = wakeCommandFrom(transcript);
         // Re-check: a manual summon (Ctrl+Space) may have claimed the slot while
         // we were transcribing (the entry guard at the top ran before the STT
         // await). The deliberate press wins, so bail rather than clobber its ctrl
@@ -3593,7 +3586,8 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
         pendingSummons.set(sidecarId, ctrl);
 
         if (!command) {
-          // Just "Jarvis" alone — flip to listening and trigger a fresh
+          // Just "Jarvis" alone, "Hey Jarvis!" included (`wakeCommandFrom`
+          // won't hand back bare punctuation): flip to listening and trigger a fresh
           // session capture on the sidecar so the user's next utterance
           // gets transcribed + run through the LLM. The session_end
           // event will land in `audioSessions.onComplete` above, which

--- a/src/voice/wake-phrase.test.ts
+++ b/src/voice/wake-phrase.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { containsStopPhrase, containsWakePhrase } from './wake-phrase.ts';
+import { containsStopPhrase, containsWakePhrase, hasSpokenContent, wakeCommandFrom } from './wake-phrase.ts';
 
 describe('containsWakePhrase', () => {
   test('matches the bare wake phrase', () => {
@@ -63,5 +63,74 @@ describe('containsStopPhrase', () => {
     expect(containsStopPhrase('Ask Jarvis about the bus stop')).toBe(false);
     expect(containsStopPhrase('Please stop by tomorrow')).toBe(false);
     expect(containsStopPhrase('')).toBe(false);
+  });
+});
+
+describe('wakeCommandFrom', () => {
+  test('returns the command that follows the wake word', () => {
+    expect(wakeCommandFrom('Jarvis play music')).toBe('play music');
+    expect(wakeCommandFrom('Hey Jarvis, what are you working on?')).toBe('what are you working on?');
+    expect(wakeCommandFrom('jarvis: open the dashboard')).toBe('open the dashboard');
+  });
+
+  test('uses the LAST wake word so lead-in chatter is dropped', () => {
+    expect(wakeCommandFrom("I'm at home, Jarvis play music")).toBe('play music');
+    expect(wakeCommandFrom('I told Jarvis already. Jarvis, mute yourself')).toBe('mute yourself');
+  });
+
+  test('returns "" for a bare summon, whatever punctuation STT tacks on', () => {
+    // The bug: "Hey Jarvis!" left a "!" behind, which was run as the whole
+    // user turn and answered with three hundred lines of counting.
+    expect(wakeCommandFrom('Hey Jarvis!')).toBe('');
+    expect(wakeCommandFrom('Hey Jarvis?')).toBe('');
+    expect(wakeCommandFrom('Hey Jarvis.')).toBe('');
+    expect(wakeCommandFrom('Jarvis!!')).toBe('');
+    expect(wakeCommandFrom('Jarvis...')).toBe('');
+    expect(wakeCommandFrom('jarvis')).toBe('');
+    expect(wakeCommandFrom('Jarvis —')).toBe('');
+    expect(wakeCommandFrom('"Jarvis?!"')).toBe('');
+  });
+
+  test('keeps a command that merely opens with punctuation', () => {
+    expect(wakeCommandFrom('Jarvis, "play music"')).toBe('play music"');
+    expect(wakeCommandFrom('Jarvis \u2014 5 minute timer')).toBe('5 minute timer');
+  });
+
+  test('keeps punctuation that belongs to the command, not to the gap', () => {
+    // The mirror of the bug: stripping every leading symbol would quietly
+    // rewrite these. Only separators come off.
+    expect(wakeCommandFrom('Jarvis, $100 budget for the trip')).toBe('$100 budget for the trip');
+    expect(wakeCommandFrom('Jarvis, #general is muted')).toBe('#general is muted');
+    expect(wakeCommandFrom('Jarvis +5 minutes on the timer')).toBe('+5 minutes on the timer');
+    expect(wakeCommandFrom('Jarvis, @dad called')).toBe('@dad called');
+  });
+
+  test('accepts non-Latin commands', () => {
+    expect(wakeCommandFrom('Jarvis, che ore sono?')).toBe('che ore sono?');
+    expect(wakeCommandFrom('Jarvis, 天気は?')).toBe('天気は?');
+  });
+
+  test('returns "" when there is no wake word at all', () => {
+    expect(wakeCommandFrom('play music')).toBe('');
+    expect(wakeCommandFrom('jarvisson play music')).toBe('');
+    expect(wakeCommandFrom('')).toBe('');
+  });
+});
+
+describe('hasSpokenContent', () => {
+  test('accepts anything with a letter or a digit', () => {
+    expect(hasSpokenContent('what are you working on?')).toBe(true);
+    expect(hasSpokenContent('5')).toBe(true);
+    expect(hasSpokenContent('...ok')).toBe(true);
+    expect(hasSpokenContent('\u5929\u6c17\u306f?')).toBe(true);
+  });
+
+  test('rejects the punctuation STT invents out of silence', () => {
+    expect(hasSpokenContent('.')).toBe(false);
+    expect(hasSpokenContent('!')).toBe(false);
+    expect(hasSpokenContent('?!')).toBe(false);
+    expect(hasSpokenContent('...')).toBe(false);
+    expect(hasSpokenContent('  ')).toBe(false);
+    expect(hasSpokenContent('')).toBe(false);
   });
 });

--- a/src/voice/wake-phrase.ts
+++ b/src/voice/wake-phrase.ts
@@ -31,3 +31,52 @@ export function containsStopPhrase(text: string): boolean {
   if (!text) return false;
   return /\bjarvis\b\W+(?:stop|(?:be\s+)?quiet)\b/i.test(text);
 }
+
+/**
+ * True when a transcript carries something a person actually said, as
+ * opposed to punctuation an STT engine tacked onto silence. Whisper and
+ * friends will happily render a door slam as "." or "?!", and every such
+ * string is truthy, so a bare `if (!transcript)` guard lets it through to
+ * the LLM as a whole user turn. A promptless "!" is a known trigger for a
+ * degenerate completion: one answered by counting upwards for three
+ * hundred lines and queued five minutes of speech behind it.
+ */
+export function hasSpokenContent(text: string): boolean {
+  if (!text) return false;
+  return /[\p{L}\p{N}]/u.test(text);
+}
+
+/**
+ * Separators an STT engine puts between the wake word and the command:
+ * whitespace, sentence punctuation, dashes and quotes. Deliberately NOT
+ * every punctuation mark -- "Jarvis, $100 budget" and "Jarvis, #general"
+ * must keep the leading character, since it belongs to the command
+ * rather than to the gap in front of it.
+ */
+const WAKE_SEPARATORS = /^[\s,.;:!?\u00a1\u00bf\u2026'"\u2018\u2019\u201c\u201d\u00ab\u00bb\-\u2013\u2014]+/;
+
+/**
+ * Pull the command out of a wake segment: everything after the LAST
+ * "jarvis" in the transcript, so "I'm at home, Jarvis play music" =>
+ * "play music". Returns "" when the user only said the wake word, which
+ * is the caller's signal to open the mic and listen for the command
+ * instead of running one.
+ *
+ * The separator strip has to cover sentence-final punctuation, because
+ * STT renders a bare summon as "Hey Jarvis." or "Hey Jarvis!" more or
+ * less at random. A leftover "!" is not a command, and it used to run as
+ * one. `hasSpokenContent` is the backstop that makes that structural:
+ * whatever survives the strip must contain a letter or a digit.
+ */
+export function wakeCommandFrom(text: string): string {
+  if (!text) return '';
+  const re = /\bjarvis\b/gi;
+  let last: RegExpExecArray | null = null;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(text)) !== null) {
+    last = m;
+  }
+  if (!last) return '';
+  const rest = text.slice(last.index + last[0].length).replace(WAKE_SEPARATORS, '').trim();
+  return hasSpokenContent(rest) ? rest : '';
+}


### PR DESCRIPTION
Asking JARVIS a question got back a list of numbers: he counted from 1 to roughly 300 and queued about 5.7 minutes of speech to read it out.

## What happened

The wake path splits a segment into "wake word alone" (open the mic and listen) vs "wake word + command" (run the LLM now). The separator class it stripped between the two was `[\s,.\-—:]*`, which has no `!` and no `?`.

The brain log has the control and the experiment two minutes apart, both 11 characters:

```
17:43:45  wake-segment matched (11 chars)  ->  wake to listening     # STT wrote "Hey Jarvis."  -> remainder ""
17:45:02  wake-segment matched (11 chars)  ->  wake to command: "!"  # STT wrote "Hey Jarvis!"  -> remainder "!"
```

So the mic never opened, my actual question was never captured, and `"!"` went to the LLM as the entire user turn. A promptless `"!"` is a reliable trigger for a degenerate completion, and it counted: 18.8s of LLM, 1891 chars, then `total_audio~=342384ms` of TTS behind it.

## The fix

Moved the helper out of the daemon into `src/voice/wake-phrase.ts` as `wakeCommandFrom()`, next to the wake-word predicates that already have tests, and made the guard structural rather than a longer punctuation list:

- separators come off via an explicit set (whitespace, sentence punctuation, dashes, quotes), deliberately not every punctuation mark, so `Jarvis, $100 budget` and `Jarvis, #general` keep the character that belongs to the command
- whatever survives must contain a letter or a digit (`hasSpokenContent`) to count as a command at all

`hasSpokenContent` also fixes the same defect on the sibling path: the listening path guarded with a bare `if (!transcript)`, and `"."` is truthy. STT renders a captured door slam that way often enough, so that path could hand the LLM a promptless punctuation turn by a different route.

Also in here, both fallout from the above:

- the daemon kept its own `const wakePhrase = /\bjarvis\b/i` four lines from the import of the module that exports exactly that. Two copies that have to agree; now it calls `containsWakePhrase`
- `[ambient-ui] empty transcript` now fires on `"."` too, so it logs the discarded text instead of claiming it was empty. This whole diagnosis hung on log lines

## Testing

9 new tests in `src/voice/wake-phrase.test.ts` covering the exact regression, multi-`jarvis` transcripts, commands that legitimately open with `$ # + @`, and non-Latin commands. Full suite 2612 pass / 0 fail, `tsc --noEmit` clean.

## Not in scope

The runaway reply still got 5.7 minutes of TTS queued behind it. The long-answer path registered it to a panel but handed the whole thing to the speaker anyway. This PR stops the trigger, not the general case of a reply monopolizing audio; a spoken-length cap is a separate change.
