### PR TITLE
Harden the sidecar's audio paths against callback stalls and per-clip device churn

### DIFF
--- a/sidecar/client.go
+++ b/sidecar/client.go
@@ -82,6 +82,50 @@ type SidecarClient struct {
 	// threads read it — a plain field is a data race.
 	streamPlayer atomic.Pointer[AudioStreamPlayer]
 	realtime     atomic.Pointer[realtimeVoice]
+
+	// wakeSuppress is the current connection's wake-listener suppression hook,
+	// published here so the playback state hook can find it. The wake listener
+	// is per-connection but the playback service outlives a reconnect (and is
+	// rebuilt by reloadConfig), so the two can't be captured in one closure.
+	wakeSuppress atomic.Pointer[func(playing bool)]
+}
+
+// installPlayStateHook wires a playback service's state callback. Two jobs on
+// each edge:
+//
+//   - Suppress wake captures while TTS is playing, so JARVIS's own voice
+//     through the speakers doesn't trigger a self-wake.
+//   - Hold ambient screen awareness off, so a screenshot + OCR tick can't stall
+//     the cgo audio callback with a GC pause, or make the brain pull a
+//     multi-megabyte capture down the same connection the TTS clips arrive on.
+//     This half is deliberately NOT gated on the wake listener: it matters even
+//     when there is no wake listener to suppress.
+//
+// Called from connectAndServe and from reloadConfig, since either can be the
+// point at which a live playback service first exists.
+func (c *SidecarClient) installPlayStateHook(pb *AudioPlaybackService) {
+	if pb == nil {
+		return
+	}
+	// Sequence number of the hold this hook took when playback started, so the
+	// matching end event can't shorten a hold that a NEWER turn has since
+	// taken. The worker debounces its idle announcement by over a second, which
+	// is easily long enough for the next turn to have started.
+	var holdSeq atomic.Uint64
+	pb.SetPlayStateListener(func(playing bool) {
+		if h := c.wakeSuppress.Load(); h != nil {
+			(*h)(playing)
+		}
+		if playing {
+			holdSeq.Store(ambientHoldFor(voiceTurnAmbientHold))
+			return
+		}
+		// Not a hard release: streaming TTS idles the queue for the 300-800 ms
+		// it takes to synthesize the next sentence, and the next clip
+		// re-extends. The tail keeps the observer out of those gaps while still
+		// recovering promptly at the end of the answer.
+		ambientEndHoldAfter(holdSeq.Load(), voiceTurnAmbientTail)
+	})
 }
 
 func NewSidecarClient(config *SidecarConfig) (*SidecarClient, error) {
@@ -424,6 +468,10 @@ func (c *SidecarClient) reloadConfig() {
 		c.pebble = NewPebbleService()
 		c.pebble.SetEthereal(c.config.Preferences.EtherealPebble, c.config.Preferences.EtherealIdleSeconds)
 		c.playback = NewAudioPlaybackService()
+		// This service was born mid-connection, so connectAndServe's install
+		// already ran against the old (nil) one. Without this, wake suppression
+		// and the ambient hold stay dead until the next reconnect.
+		c.installPlayStateHook(c.playback)
 		c.regions = NewRegionSelectionService()
 	} else if !hasPebble && c.pebble != nil {
 		_ = c.pebble.Close()
@@ -580,14 +628,17 @@ func (c *SidecarClient) connectAndServe(ctx context.Context) error {
 			defer wakeListener.Stop()
 		}
 
-		// Suppress wake captures while TTS is playing so JARVIS's own
-		// voice through the speakers doesn't trigger a self-wake. Hooked
-		// via the playback service's state-change callback.
-		if wakeListener != nil && c.playback != nil {
-			c.playback.SetPlayStateListener(func(playing bool) {
-				wakeListener.Suppress(playing)
-			})
+		// Publish this connection's wake listener so the playback state hook can
+		// suppress it. The hook itself is installed on whichever playback
+		// service is live (see installPlayStateHook), which is not necessarily
+		// the one this connection started with: reloadConfig rebuilds the
+		// service when the pebble capability toggles.
+		if wakeListener != nil {
+			suppress := func(playing bool) { wakeListener.Suppress(playing) }
+			c.wakeSuppress.Store(&suppress)
+			defer c.wakeSuppress.Store(nil)
 		}
+		c.installPlayStateHook(c.playback)
 
 		// runSessionCapture handles one summon→capture→stream cycle. Used
 		// by both the Ctrl+Space hotkey path and the wake-word follow-up
@@ -635,6 +686,14 @@ func (c *SidecarClient) connectAndServe(ctx context.Context) error {
 				return
 			}
 			defer sessionInFlight.Store(false)
+
+			// The turn starts here and ends somewhere in the daemon (STT, then
+			// the LLM, then TTS), so hold ambient screen awareness off on a
+			// deadline rather than a balanced pair: if the response never comes
+			// back, the hold expires on its own instead of stranding the
+			// observer off. Each clip the playback service renders pushes the
+			// deadline back out, so a long answer stays covered.
+			ambientHoldFor(voiceTurnAmbientHold)
 
 			startEvt := SidecarEvent{
 				Type:      "sidecar_event",

--- a/sidecar/observers.go
+++ b/sidecar/observers.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"runtime/debug"
 	"sync"
-	"sync/atomic"
 	"time"
 )
 
@@ -24,13 +23,131 @@ func goSafeObserver(name string, fn func()) {
 	}()
 }
 
-// ambientSuppressed pauses the heavy ambient screen observer (2.4 MB capture +
-// OCR every tick) while the native pebble holds a realtime voice session. During
-// a focused conversation we don't want screen monitoring competing with the
-// audio stream on the sidecar's single WebSocket, nor the reactor it triggers
-// (set_eye flood, proactive narration, autonomous agent actions). The realtime
-// controller toggles this in Start/Stop.
-var ambientSuppressed atomic.Bool
+// Ambient suppression pauses the heavy screen observer while the pebble is in
+// the middle of a voice turn. A tick allocates a full-resolution screenshot
+// (5 MB on a real host), diffs it against the previous one, writes a PNG and
+// shells out to OCR (~1.6 s observed). Two reasons to hold it off:
+//
+//   - The audio device callback is a Go function entered from the C audio
+//     thread through cgo, and it cannot run during a GC stop-the-world. A
+//     missed render deadline is a buffer underrun, audible as a harsh,
+//     high-pitched glitch in the middle of TTS.
+//   - The capture event makes the brain turn around and pull the image with a
+//     fetch_capture RPC, and that multi-megabyte reply shares the sidecar's
+//     control WebSocket with the TTS clips (pebble.play_audio), so the audio
+//     for the next sentence queues behind it.
+//
+// Two kinds of hold, because the two callers know different things:
+//
+//   - ambientHold / ambientRelease: a balanced counter, for a consumer that
+//     owns a well-defined span (the realtime session).
+//   - ambientHoldFor / ambientEndHoldAfter: a deadline, for the one-shot voice
+//     cycle, where the sidecar starts the turn but the daemon owns the middle
+//     of it (STT, then the LLM, then TTS) and may never come back. A deadline
+//     self-heals: a dropped response un-suppresses on its own instead of
+//     stranding screen awareness off forever.
+//
+// Known limit of the deadline: a turn whose silent middle runs longer than
+// voiceTurnAmbientHold (a slow tool call, a very slow first token) expires and
+// lets one tick through before the answer arrives. That is the deliberate
+// price of self-healing, and it is bounded to a single tick because the first
+// TTS clip re-extends the hold.
+//
+// Suppressed iff the counter is up OR the deadline is still in the future.
+// Both live under one mutex rather than in atomics: it keeps the deadline and
+// its sequence number consistent with each other, and it lets the deadline be
+// a time.Time, which carries a monotonic reading. Wall-clock millis would let
+// an NTP correction or a laptop resume, on exactly the two platforms this bug
+// was reported on, either extend a hold indefinitely or end it early.
+var (
+	ambientMu        sync.Mutex
+	ambientDepth     int
+	ambientHoldUntil time.Time
+	ambientHoldSeq   uint64
+)
+
+const (
+	// voiceTurnAmbientHold is the ceiling on one deadline-held voice turn. It
+	// only has to outlast the local capture plus the RPC that follows it: the
+	// daemon re-extends on every pebble state change, and playback re-extends
+	// for as long as JARVIS is actually speaking. So this is really "how long
+	// we stay quiet after the daemon goes silent on us", not the length of a
+	// turn. Short enough that a dropped response costs about one screen tick
+	// (the observer's default interval is 15 s).
+	voiceTurnAmbientHold = 20 * time.Second
+	// voiceTurnAmbientTail keeps the observer out of the gap between two
+	// streamed TTS sentences (synthesizing the next one takes 300-800 ms)
+	// without extending the hold past the end of the answer.
+	voiceTurnAmbientTail = 1500 * time.Millisecond
+	// pebbleStateAmbientTail is the release once the daemon puts the pebble
+	// back to idle: the turn is over, just past the render buffer's tail.
+	pebbleStateAmbientTail = 500 * time.Millisecond
+)
+
+// ambientHoldUnscoped is the sequence number a caller passes to
+// ambientEndHoldAfter when it has no hold of its own to pair with and is
+// simply reporting that the turn is over (the daemon putting the pebble back
+// to idle). Real sequence numbers start at 1.
+const ambientHoldUnscoped uint64 = 0
+
+// ambientSuppressedNow reports whether the ambient screen observer should skip
+// this tick.
+func ambientSuppressedNow() bool {
+	ambientMu.Lock()
+	defer ambientMu.Unlock()
+	return ambientDepth > 0 || time.Now().Before(ambientHoldUntil)
+}
+
+// ambientHold raises the suppression counter. Every call must be paired with
+// exactly one ambientRelease.
+func ambientHold() {
+	ambientMu.Lock()
+	ambientDepth++
+	ambientMu.Unlock()
+}
+
+// ambientRelease lowers the suppression counter, clamped at zero so an
+// unbalanced caller can't drive it negative and wedge suppression on.
+func ambientRelease() {
+	ambientMu.Lock()
+	if ambientDepth <= 0 {
+		ambientMu.Unlock()
+		log.Printf("[observer] ambientRelease with depth already 0, ignoring (unbalanced caller)")
+		return
+	}
+	ambientDepth--
+	ambientMu.Unlock()
+}
+
+// ambientHoldFor pushes the suppression deadline out to now+d and returns a
+// sequence number identifying this hold. The deadline only ever moves forward,
+// so a short hold can't cut a longer one short.
+func ambientHoldFor(d time.Duration) uint64 {
+	ambientMu.Lock()
+	defer ambientMu.Unlock()
+	ambientHoldSeq++
+	if until := time.Now().Add(d); until.After(ambientHoldUntil) {
+		ambientHoldUntil = until
+	}
+	return ambientHoldSeq
+}
+
+// ambientEndHoldAfter pulls the suppression deadline in to now+d, releasing a
+// hold early because the turn finished. It only ever moves the deadline
+// backward, and only when `seq` is still the newest hold: an end event can be
+// seconds late (the playback worker debounces its idle announcement), and by
+// then a NEW turn may have taken a hold that this stale event must not cut
+// short. Pass ambientHoldUnscoped to end whichever hold is current.
+func ambientEndHoldAfter(seq uint64, d time.Duration) {
+	ambientMu.Lock()
+	defer ambientMu.Unlock()
+	if seq != ambientHoldUnscoped && seq != ambientHoldSeq {
+		return // a newer hold owns the deadline now
+	}
+	if until := time.Now().Add(d); until.Before(ambientHoldUntil) {
+		ambientHoldUntil = until
+	}
+}
 
 // EventSender sends sidecar events to the brain.
 // If binaryData is provided and exceeds the ref threshold, the transport
@@ -160,9 +277,15 @@ func (o *ScreenObserver) Run(ctx context.Context, send EventSender) {
 }
 
 func (o *ScreenObserver) capture(ctx context.Context, send EventSender) {
-	// Paused during a realtime voice session (focus mode) — skip the heavy
-	// capture+OCR+send so it doesn't stutter the audio stream.
-	if ambientSuppressed.Load() {
+	// Paused for the duration of a voice turn (realtime session, or a one-shot
+	// summon, STT, LLM, then TTS cycle): skip the heavy capture+OCR+send so it
+	// can't stall the audio callback or queue in front of the TTS clips.
+	// Re-checked at each expensive stage below, not just here: a tick that has
+	// already started is 6-9 seconds of work on Windows (the OCR helper is a
+	// PowerShell subprocess), so a voice turn beginning one tick later would
+	// otherwise land right on top of a screenshot, a pixel diff and an OCR
+	// subprocess. Aborting mid-capture costs one skipped observation.
+	if ambientSuppressedNow() {
 		return
 	}
 	imageData, err := captureScreenBytes()
@@ -172,6 +295,9 @@ func (o *ScreenObserver) capture(ctx context.Context, send EventSender) {
 	}
 	if len(imageData) == 0 {
 		return
+	}
+	if ambientSuppressedNow() {
+		return // a voice turn started while we were grabbing the screen
 	}
 
 	changePct := o.computePixelDiff(imageData)
@@ -199,7 +325,7 @@ func (o *ScreenObserver) capture(ctx context.Context, send EventSender) {
 
 	var ocrText string
 	var ocrDurationMs int64
-	if o.ocrEnabled {
+	if o.ocrEnabled && !ambientSuppressedNow() {
 		ocr, err := platformOCR(imagePath)
 		if err != nil {
 			log.Printf("[screen] OCR failed: %v", err)
@@ -230,6 +356,13 @@ func (o *ScreenObserver) capture(ctx context.Context, send EventSender) {
 		},
 	}
 
+	if ambientSuppressedNow() {
+		// A voice turn started while we were capturing. Dropping the event here
+		// matters as much as skipping the capture: the brain answers one by
+		// pulling the image back with a fetch_capture RPC, and that multi-
+		// megabyte reply would land on the connection mid-conversation.
+		return
+	}
 	if err := send(ctx, event, nil); err != nil {
 		log.Printf("[screen] Failed to send event: %v", err)
 	}

--- a/sidecar/observers_ambient_test.go
+++ b/sidecar/observers_ambient_test.go
@@ -1,0 +1,220 @@
+package main
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+// Timing budgets are deliberately loose: these tests assert ordering around a
+// deadline, not the precision of the sleep. tick is the unit a hold is
+// expressed in, and settle is how long a test waits to be sure a deadline has
+// passed. A loaded -race run can preempt a goroutine for tens of milliseconds,
+// so anything tighter is flaky for no extra coverage.
+const (
+	ambientTestTick   = 300 * time.Millisecond
+	ambientTestSettle = 900 * time.Millisecond
+)
+
+// resetAmbient puts the package-level suppression state back to "not
+// suppressed" so each test starts clean (these are process globals).
+func resetAmbient(t *testing.T) {
+	t.Helper()
+	clear := func() {
+		ambientMu.Lock()
+		ambientDepth = 0
+		ambientHoldUntil = time.Time{}
+		ambientHoldSeq = 0
+		ambientMu.Unlock()
+	}
+	clear()
+	t.Cleanup(clear)
+}
+
+func TestAmbientHoldCounterNests(t *testing.T) {
+	resetAmbient(t)
+
+	if ambientSuppressedNow() {
+		t.Fatal("expected not suppressed at rest")
+	}
+	ambientHold()
+	ambientHold()
+	if !ambientSuppressedNow() {
+		t.Fatal("expected suppressed while two holds are outstanding")
+	}
+	ambientRelease()
+	if !ambientSuppressedNow() {
+		t.Fatal("expected still suppressed, one hold is still outstanding")
+	}
+	ambientRelease()
+	if ambientSuppressedNow() {
+		t.Fatal("expected released once every hold is released")
+	}
+}
+
+// An unbalanced release must not drive the counter negative: a later, correctly
+// paired hold/release would otherwise leave suppression stuck on forever.
+func TestAmbientReleaseClampsAtZero(t *testing.T) {
+	resetAmbient(t)
+
+	ambientRelease()
+	ambientRelease()
+	ambientHold()
+	if !ambientSuppressedNow() {
+		t.Fatal("expected suppressed after a hold following unbalanced releases")
+	}
+	ambientRelease()
+	if ambientSuppressedNow() {
+		t.Fatal("expected released")
+	}
+}
+
+func TestAmbientHoldForSuppressesUntilDeadline(t *testing.T) {
+	resetAmbient(t)
+
+	ambientHoldFor(ambientTestTick)
+	if !ambientSuppressedNow() {
+		t.Fatal("expected suppressed immediately after a deadline hold")
+	}
+	time.Sleep(ambientTestSettle)
+	if ambientSuppressedNow() {
+		t.Fatal("expected the deadline hold to expire on its own")
+	}
+}
+
+// A short hold must never cut a longer one short: this is what keeps a
+// per-clip refresh from shrinking the turn-length hold.
+func TestAmbientHoldForOnlyMovesForward(t *testing.T) {
+	resetAmbient(t)
+
+	ambientHoldFor(10 * time.Second)
+	long := ambientDeadlineForTest()
+	ambientHoldFor(time.Millisecond)
+	if got := ambientDeadlineForTest(); !got.Equal(long) {
+		t.Fatalf("deadline moved backward: got %v, want %v", got, long)
+	}
+	ambientHoldFor(30 * time.Second)
+	if !ambientDeadlineForTest().After(long) {
+		t.Fatal("expected a longer hold to push the deadline forward")
+	}
+}
+
+// ambientEndHoldAfter is the mirror image: it releases early but must never
+// extend a hold that is already shorter than the tail.
+func TestAmbientEndHoldAfterOnlyMovesBackward(t *testing.T) {
+	resetAmbient(t)
+
+	seq := ambientHoldFor(10 * time.Second)
+	ambientEndHoldAfter(seq, ambientTestTick)
+	if !ambientSuppressedNow() {
+		t.Fatal("expected still suppressed during the tail")
+	}
+	time.Sleep(ambientTestSettle)
+	if ambientSuppressedNow() {
+		t.Fatal("expected the shortened hold to have expired")
+	}
+
+	// Already expired: a tail must not resurrect suppression.
+	before := ambientDeadlineForTest()
+	ambientEndHoldAfter(ambientHoldSeqForTest(), 10*time.Second)
+	if got := ambientDeadlineForTest(); !got.Equal(before) {
+		t.Fatalf("tail extended an expired hold: got %v, want %v", got, before)
+	}
+	if ambientSuppressedNow() {
+		t.Fatal("expected still released")
+	}
+}
+
+// The end event for a turn can land seconds late (the playback worker debounces
+// its idle announcement). By then a new turn may have taken a hold, and the
+// stale end must not cut it short. This is the mic-capture-underrun bug: the
+// user dismisses mid-answer and immediately asks something else, and the late
+// "stopped speaking" from the first answer un-suppresses the second turn's
+// listening phase.
+func TestAmbientStaleEndCannotShortenANewerHold(t *testing.T) {
+	resetAmbient(t)
+
+	stale := ambientHoldFor(time.Second) // turn 1: playback started
+	ambientHoldFor(10 * time.Second)     // turn 2: a new summon took a hold
+	fresh := ambientDeadlineForTest()
+
+	ambientEndHoldAfter(stale, time.Millisecond) // turn 1's late "stopped speaking"
+
+	if got := ambientDeadlineForTest(); !got.Equal(fresh) {
+		t.Fatalf("a stale end shortened a newer hold: got %v, want %v", got, fresh)
+	}
+	if !ambientSuppressedNow() {
+		t.Fatal("expected the newer turn to still be suppressed")
+	}
+}
+
+// The unscoped end is for the daemon telling us the turn is over, which is
+// authoritative and has no hold of its own to pair with.
+func TestAmbientUnscopedEndAlwaysApplies(t *testing.T) {
+	resetAmbient(t)
+
+	ambientHoldFor(10 * time.Second)
+	ambientHoldFor(10 * time.Second)
+	ambientEndHoldAfter(ambientHoldUnscoped, ambientTestTick)
+	time.Sleep(ambientTestSettle)
+	if ambientSuppressedNow() {
+		t.Fatal("expected the unscoped end to have released the hold")
+	}
+}
+
+// The realtime session (counter) and the one-shot voice cycle (deadline) can
+// overlap; neither may end the other's suppression.
+func TestAmbientCounterAndDeadlineAreIndependent(t *testing.T) {
+	resetAmbient(t)
+
+	ambientHold() // realtime session
+	seq := ambientHoldFor(ambientTestTick)
+	ambientEndHoldAfter(seq, 0) // voice cycle finished
+	time.Sleep(ambientTestSettle)
+	if !ambientSuppressedNow() {
+		t.Fatal("deadline expiry must not release the realtime session's hold")
+	}
+	ambientRelease()
+	if ambientSuppressedNow() {
+		t.Fatal("expected released once both holds are gone")
+	}
+}
+
+func TestAmbientHoldIsRaceFree(t *testing.T) {
+	resetAmbient(t)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 200; j++ {
+				ambientHold()
+				seq := ambientHoldFor(time.Millisecond)
+				_ = ambientSuppressedNow()
+				ambientEndHoldAfter(seq, time.Millisecond)
+				ambientRelease()
+			}
+		}()
+	}
+	wg.Wait()
+
+	ambientMu.Lock()
+	depth := ambientDepth
+	ambientMu.Unlock()
+	if depth != 0 {
+		t.Fatalf("depth = %d, want 0 after balanced concurrent holds", depth)
+	}
+}
+
+func ambientDeadlineForTest() time.Time {
+	ambientMu.Lock()
+	defer ambientMu.Unlock()
+	return ambientHoldUntil
+}
+
+func ambientHoldSeqForTest() uint64 {
+	ambientMu.Lock()
+	defer ambientMu.Unlock()
+	return ambientHoldSeq
+}

--- a/sidecar/pebble_audio.go
+++ b/sidecar/pebble_audio.go
@@ -35,6 +35,20 @@ const (
 	pebbleAudioSampleRate = 16000
 	pebbleAudioChannels   = 1
 	pebbleAudioBitsPer    = 16
+
+	// pebbleCaptureReserveSeconds is how much audio a one-shot session's PCM
+	// accumulator reserves at Start. Comfortably above the VAD hard cap (15 s)
+	// so the audio thread never has to grow it. See the reservation in Start.
+	pebbleCaptureReserveSeconds = 20
+
+	// pebbleCapturePeriodMs / pebbleCapturePeriods size the capture buffer.
+	// miniaudio's default low-latency profile picked 10 ms x 3 on the host that
+	// reported this bug ("Buffer Size: 160*3"), leaving ~30 ms before a GC pause
+	// costs microphone frames. Doubling the period is a cheap win and still well
+	// inside the VAD's 350 ms silence cutoff and the realtime path's 40 ms
+	// upstream frames, so neither wake latency nor barge-in feel changes.
+	pebbleCapturePeriodMs = 20
+	pebbleCapturePeriods  = 4
 )
 
 // AudioSession represents a single capture session. Spawned on pebble.summon,
@@ -42,8 +56,25 @@ const (
 type AudioSession struct {
 	id        string
 	startedAt time.Time
-	pcm       *bytes.Buffer
-	mu        sync.Mutex
+	// pcm is nil for a session that does not accumulate. See StartStreaming.
+	pcm *bytes.Buffer
+	mu  sync.Mutex
+}
+
+// newAudioSession builds a session, reserving the PCM accumulator up front when
+// the caller wants one.
+//
+// bytes.Buffer grows by doubling, and that realloc-and-copy would run inside the
+// miniaudio data callback, on the audio thread, where stalling past the device
+// period is an underrun. The VAD's hard cap bounds an accumulating session well
+// below the reservation, so in practice the callback never grows the buffer at
+// all; a streaming session allocates nothing to grow.
+func newAudioSession(sessionID string, rate int, accumulate bool) *AudioSession {
+	var pcmBuf *bytes.Buffer
+	if accumulate {
+		pcmBuf = bytes.NewBuffer(make([]byte, 0, rate*pebbleAudioChannels*2*pebbleCaptureReserveSeconds))
+	}
+	return &AudioSession{id: sessionID, startedAt: time.Now(), pcm: pcmBuf}
 }
 
 // AudioCaptureService is the cross-platform mic capture API. The
@@ -83,9 +114,28 @@ func NewStreamingCaptureService(rate int) *AudioCaptureService {
 	return &AudioCaptureService{sampleRate: rate, streamOnly: true}
 }
 
-// Start begins a new capture session. Returns an error if a session is
-// already in progress or if the audio device couldn't be opened.
+// Start begins a new capture session that ACCUMULATES the captured PCM for
+// Stop() to return.
 func (s *AudioCaptureService) Start(sessionID string) error {
+	return s.start(sessionID, !s.streamOnly)
+}
+
+// StartStreaming begins a session that keeps no PCM: chunks reach the chunk
+// listener and nothing else.
+//
+// This is what an open-ended consumer must use. The wake listener holds one
+// session open for as long as it is armed, which is hours, and it discards
+// Stop()'s buffer. Accumulating there grows a bytes.Buffer without bound at
+// ~115 MB an hour, and every doubling is a realloc-and-copy inside the
+// miniaudio data callback, on the audio thread, which is exactly the stall
+// this file is otherwise careful to avoid.
+func (s *AudioCaptureService) StartStreaming(sessionID string) error {
+	return s.start(sessionID, false)
+}
+
+// start opens the device. Returns an error if a session is already in progress
+// or if the audio device couldn't be opened.
+func (s *AudioCaptureService) start(sessionID string, accumulate bool) error {
 	if !s.active.CompareAndSwap(false, true) {
 		return fmt.Errorf("audio capture already in progress")
 	}
@@ -107,25 +157,24 @@ func (s *AudioCaptureService) Start(sessionID string) error {
 		s.ctx = ctx
 	}
 
-	session := &AudioSession{
-		id:        sessionID,
-		startedAt: time.Now(),
-		pcm:       &bytes.Buffer{},
-	}
-	s.session = session
-
 	rate := s.sampleRate
 	if rate <= 0 {
 		rate = pebbleAudioSampleRate
 	}
+
+	session := newAudioSession(sessionID, rate, accumulate)
+	s.session = session
+
 	deviceConfig := malgo.DefaultDeviceConfig(malgo.Capture)
 	deviceConfig.Capture.Format = malgo.FormatS16
 	deviceConfig.Capture.Channels = pebbleAudioChannels
 	deviceConfig.SampleRate = uint32(rate)
+	deviceConfig.PeriodSizeInMilliseconds = pebbleCapturePeriodMs
+	deviceConfig.Periods = pebbleCapturePeriods
 	deviceConfig.Alsa.NoMMap = 1
 
 	onRecv := func(_, input []byte, _ uint32) {
-		if !s.streamOnly {
+		if session.pcm != nil {
 			session.mu.Lock()
 			session.pcm.Write(input)
 			session.mu.Unlock()
@@ -176,9 +225,12 @@ func (s *AudioCaptureService) Stop() ([]byte, time.Duration, error) {
 	// guaranteed to have joined an in-flight onRecv callback on every malgo
 	// backend, and bytes.Buffer is not safe for concurrent Write/Bytes. Copy so
 	// the returned slice is independent of the buffer's backing array too.
-	s.session.mu.Lock()
-	pcm := append([]byte(nil), s.session.pcm.Bytes()...)
-	s.session.mu.Unlock()
+	var pcm []byte
+	if s.session.pcm != nil {
+		s.session.mu.Lock()
+		pcm = append([]byte(nil), s.session.pcm.Bytes()...)
+		s.session.mu.Unlock()
+	}
 	id := s.session.id
 	s.session = nil
 	log.Printf("[audio] capture session %q stopped (%d PCM bytes, %.2fs)", id, len(pcm), dur.Seconds())

--- a/sidecar/pebble_audio_test.go
+++ b/sidecar/pebble_audio_test.go
@@ -1,0 +1,39 @@
+package main
+
+import "testing"
+
+// The wake listener holds one capture session open for as long as it is armed,
+// which is hours, and it discards Stop()'s buffer. Accumulating there grew a
+// bytes.Buffer without bound at ~115 MB an hour, and every doubling was a
+// realloc inside the miniaudio data callback: a stall on the audio thread,
+// which is the failure class this file exists to avoid.
+func TestNewAudioSessionOnlyReservesWhenItAccumulates(t *testing.T) {
+	streaming := newAudioSession("wake-1", pebbleAudioSampleRate, false)
+	if streaming.pcm != nil {
+		t.Fatal("a streaming session must not allocate an accumulator to grow")
+	}
+
+	accumulating := newAudioSession("summon-1", pebbleAudioSampleRate, true)
+	if accumulating.pcm == nil {
+		t.Fatal("an accumulating session has nowhere to put the capture")
+	}
+	// Reserved ahead of the VAD's hard cap so the audio thread never grows it.
+	want := pebbleAudioSampleRate * pebbleAudioChannels * 2 * pebbleCaptureReserveSeconds
+	if got := accumulating.pcm.Cap(); got < want {
+		t.Fatalf("reserved %d bytes, want at least %d", got, want)
+	}
+	hardCapBytes := int(DefaultVADOpts().HardCap.Seconds()) * pebbleAudioSampleRate * pebbleAudioChannels * 2
+	if want <= hardCapBytes {
+		t.Fatalf("reservation %d does not clear the VAD hard cap of %d bytes", want, hardCapBytes)
+	}
+}
+
+// The rate matters: a 24 kHz session reserves more than a 16 kHz one for the
+// same wall-clock duration.
+func TestNewAudioSessionScalesTheReservationWithTheRate(t *testing.T) {
+	low := newAudioSession("a", 16000, true)
+	high := newAudioSession("b", 24000, true)
+	if high.pcm.Cap() <= low.pcm.Cap() {
+		t.Fatalf("24 kHz reserved %d, 16 kHz reserved %d", high.pcm.Cap(), low.pcm.Cap())
+	}
+}

--- a/sidecar/pebble_handlers.go
+++ b/sidecar/pebble_handlers.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"log"
 )
 
 // pebble.spawn — show the native pebble overlay on the desktop.
@@ -62,6 +63,22 @@ func makePebbleSetStateHandler(svc PebbleService) RPCHandler {
 		if err := svc.SetState(PebbleState(s)); err != nil {
 			return nil, err
 		}
+		// The daemon drives this for the whole turn, on every path into the
+		// voice loop, including the single-shot wake ("Jarvis, do X"), which
+		// never runs a local session capture and so has no other early hook.
+		// Hold ambient screen awareness off from the first non-idle state
+		// rather than waiting for the first TTS clip to land, so a capture tick
+		// can't already be mid-OCR when playback opens its device.
+		// Deliberately not PebbleWorking: a backgrounded agent task can sit in
+		// that state for minutes and has no audio to protect.
+		switch PebbleState(s) {
+		case PebbleListening, PebbleThinking, PebbleSpeaking:
+			ambientHoldFor(voiceTurnAmbientHold)
+		case PebbleIdle:
+			// Unscoped: the daemon is the authority on the turn being over, and
+			// this handler has no hold of its own to pair the end against.
+			ambientEndHoldAfter(ambientHoldUnscoped, pebbleStateAmbientTail)
+		}
 		return &RPCResult{Result: map[string]any{"state": s}}, nil
 	}
 }
@@ -74,10 +91,18 @@ func makePebbleSetStateHandler(svc PebbleService) RPCHandler {
 //   "data":      base64-encoded audio bytes (MP3 or WAV — sniffed at decode),
 //   "mime_type": optional hint ("audio/mp3" / "audio/wav"); used as a
 //                fallback when the magic-byte sniff is ambiguous,
-//   "blocking":  optional bool — if true, the RPC waits until playback
-//                finishes; otherwise it returns immediately and playback
-//                runs in the background.
+//   "blocking":  optional bool, accepted for backwards compatibility. It
+//                only changes the shape of the result: this RPC has never
+//                waited for playback to finish, and returns as soon as the
+//                clip is queued either way.
 // }
+//
+// The clip is queued on the calling goroutine, NOT handed to a new one.
+// Queueing is a channel send that cannot block (a full queue is an error), and
+// the daemon dispatches one sentence per RPC and awaits each result before
+// sending the next. Spawning a goroutine here broke that ordering: the two
+// clips raced to the queue, so a long answer could speak its sentences out of
+// sequence.
 func makePebblePlayAudioHandler(svc *AudioPlaybackService) RPCHandler {
 	return func(params map[string]any) (*RPCResult, error) {
 		rawData, ok := params["data"]
@@ -102,23 +127,21 @@ func makePebblePlayAudioHandler(svc *AudioPlaybackService) RPCHandler {
 			blocking = v
 		}
 
-		if blocking {
-			if err := svc.Play(audio, mime); err != nil {
+		if err := svc.Play(audio, mime); err != nil {
+			if blocking {
 				return nil, err
 			}
+			// The daemon's voice cycle fires these and moves on, so a failure
+			// here is logged rather than returned.
+			log.Printf("[playback] enqueue failed: %v", err)
+		}
+
+		if blocking {
 			return &RPCResult{Result: map[string]any{
 				"played": true,
 				"bytes":  len(audio),
 			}}, nil
 		}
-
-		// Fire-and-forget — daemon's voice cycle calls this and continues.
-		// Sidecar logs (not RPC-returns) any decode/playback failure.
-		go func(buf []byte, m string) {
-			if err := svc.Play(buf, m); err != nil {
-				fmt.Printf("[playback] error: %v\n", err)
-			}
-		}(audio, mime)
 
 		return &RPCResult{Result: map[string]any{
 			"queued": true,

--- a/sidecar/pebble_playback.go
+++ b/sidecar/pebble_playback.go
@@ -15,6 +15,26 @@ package main
 //   - WAV PCM s16 (Sarvam, raw daemon-side resampling) — header parsed inline
 // The format is detected from the byte stream's magic header so the daemon
 // can keep using whichever provider the user has configured.
+//
+// Device model: ONE long-lived output device fed from a fixed-size ring
+// buffer, not a fresh device per clip. Streaming TTS enqueues one clip per
+// sentence, and the old model opened/started/stopped/uninit'd a WASAPI or
+// CoreAudio device every one to three seconds, audible as a click at every
+// sentence boundary, and it ended each clip the moment the last bytes were
+// *copied* into miniaudio rather than played, clipping the final phonemes.
+//
+// Real-time safety: the data callback is a Go function entered from the C
+// audio thread through cgo. It cannot run during a GC stop-the-world, and this
+// process allocates hard (screenshots, OCR, base64, MP3 decode). So:
+//   - the render callback allocates nothing, takes one uncontended mutex and
+//     does two memcpys: no decode, no growth, no syscalls;
+//   - the ring is allocated once per device open, so the producer never
+//     reallocates under the lock the audio thread needs;
+//   - the device buffers ~120-160 ms (see playbackPeriodMs) instead of
+//     miniaudio's 10 ms low-latency default, so a GC pause of that order is
+//     absorbed instead of becoming an underrun. TTS playback has no use for
+//     10 ms latency; the cost is that a barge-in leaves one buffer of already
+//     handed-over audio to finish.
 
 import (
 	"bytes"
@@ -23,6 +43,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -30,6 +51,237 @@ import (
 	"github.com/gen2brain/malgo"
 	gomp3 "github.com/hajimehoshi/go-mp3"
 )
+
+// playbackPeriodMs is the device period, and the anti-underrun knob (see the
+// real-time safety note above). It is per-OS because the two backends buffer
+// differently: miniaudio's WASAPI backend gives you Periods x period of slack,
+// but its CoreAudio backend sets the device buffer to ONE period and ignores
+// the count. macOS therefore needs a much larger period to get comparable
+// headroom, and TTS playback can afford it. CoreAudio clamps the request to the
+// device's maximum buffer frame size (commonly 4096 frames), so 120 ms is a
+// ceiling, not a promise: a 44.1 kHz clip lands nearer 93 ms.
+var playbackPeriodMs uint32 = func() uint32 {
+	if runtime.GOOS == "darwin" {
+		return 120
+	}
+	return 40
+}()
+
+const (
+	playbackPeriods = 4
+	// playbackRingSeconds is how much decoded audio the ring holds. Big enough
+	// that a whole sentence usually lands in one go (so the worker rarely waits
+	// on the audio thread), small enough to stay under a megabyte at 44.1 kHz
+	// stereo.
+	playbackRingSeconds = 4
+	// playbackTick paces the worker while there is audio in flight.
+	playbackTick = 50 * time.Millisecond
+	// playbackFeedPoll is how long the worker waits when the ring is full.
+	// Shorter than one period so the ring is topped up promptly.
+	playbackFeedPoll = 10 * time.Millisecond
+	// playbackIdleAnnounce is the quiet time after the ring drains before we
+	// tell the wake listener that JARVIS has stopped speaking. It has to
+	// outlast both the device's own buffered audio and the gap
+	// between two streamed sentences (synthesizing the next one takes
+	// 300-800 ms), or the mic re-opens mid-answer and hears JARVIS.
+	playbackIdleAnnounce = 1200 * time.Millisecond
+	// playbackIdleClose releases the output device after a conversation goes
+	// quiet, so the sidecar isn't holding the endpoint open forever. One
+	// open/close per burst of speech instead of one per sentence.
+	playbackIdleClose = 30 * time.Second
+	// playbackStallTimeout is how long the ring may hold audio that the device
+	// is not taking before we call the device dead. The callback fires once per
+	// period, so any healthy device makes progress many times over within this.
+	playbackStallTimeout = 1500 * time.Millisecond
+	// playbackFeedChunk bounds how much the worker copies into the ring under
+	// the ring's mutex in one go, so the audio thread never waits on a
+	// multi-hundred-kilobyte memcpy.
+	playbackFeedChunk = 32 * 1024
+)
+
+// pcmRing is a fixed-capacity byte ring holding interleaved PCM s16 frames.
+// Reads happen on the audio thread, writes on the playback worker. Every count
+// is aligned to a whole frame so an underrun can never leave the stream
+// half-way through one.
+type pcmRing struct {
+	mu    sync.Mutex
+	buf   []byte
+	r, w  int64 // absolute byte positions; live = w-r, both always frame-aligned
+	frame int   // bytes per frame (channels * 2)
+}
+
+// newPCMRing sizes a ring to hold `seconds` of audio in the given format. The
+// capacity is a whole number of frames so wrapping preserves frame alignment.
+func newPCMRing(sampleRate, channels, seconds int) *pcmRing {
+	frame := channels * 2
+	if frame < 2 {
+		frame = 2 // never zero: read/write take `n % frame` and index `% len(buf)`
+	}
+	frames := sampleRate * seconds
+	if frames < 1 {
+		frames = 1
+	}
+	return &pcmRing{buf: make([]byte, frames*frame), frame: frame}
+}
+
+// read copies up to len(dst) bytes of pending audio into dst and returns the
+// count, truncated to a whole number of frames. Audio-thread hot path: no
+// allocation, no blocking, two memcpys.
+func (rb *pcmRing) read(dst []byte) int {
+	rb.mu.Lock()
+	defer rb.mu.Unlock()
+
+	n := int(rb.w - rb.r)
+	if n > len(dst) {
+		n = len(dst)
+	}
+	n -= n % rb.frame
+	if n <= 0 {
+		return 0
+	}
+	off := int(rb.r % int64(len(rb.buf)))
+	copied := copy(dst[:n], rb.buf[off:])
+	if copied < n {
+		copied += copy(dst[copied:n], rb.buf[:n-copied])
+	}
+	rb.r += int64(copied)
+	return copied
+}
+
+// write copies as much of src as currently fits and returns the count,
+// truncated to a whole number of frames. Never blocks; the caller retries.
+func (rb *pcmRing) write(src []byte) int {
+	rb.mu.Lock()
+	defer rb.mu.Unlock()
+
+	free := len(rb.buf) - int(rb.w-rb.r)
+	n := len(src)
+	if n > free {
+		n = free
+	}
+	n -= n % rb.frame
+	if n <= 0 {
+		return 0
+	}
+	off := int(rb.w % int64(len(rb.buf)))
+	copied := copy(rb.buf[off:], src[:n])
+	if copied < n {
+		copied += copy(rb.buf, src[copied:n])
+	}
+	rb.w += int64(copied)
+	return copied
+}
+
+// writeDropOldest copies src into the ring, dropping the oldest pending audio
+// when there isn't room. Returns how many bytes went in and how many older
+// bytes were dropped to make space. Used by a producer that cannot block (the
+// realtime read loop): a stalled device must cost old audio, not a stalled
+// WebSocket.
+//
+// Both counts are whole frames. An odd-sized drop would byte-shift every
+// following sample, which is precisely the misalignment that turns speech into
+// full-scale high-frequency static.
+func (rb *pcmRing) writeDropOldest(src []byte) (written, dropped int) {
+	rb.mu.Lock()
+	defer rb.mu.Unlock()
+
+	n := len(src) - len(src)%rb.frame
+	// More than the ring can ever hold: keep the newest ring-full of it.
+	if n > len(rb.buf) {
+		skip := n - len(rb.buf)
+		src = src[skip:]
+		n = len(rb.buf)
+		dropped += skip
+	}
+	if n <= 0 {
+		return 0, dropped
+	}
+
+	// Capacity and the live span are both frame-aligned, so the shortfall is
+	// too; the rounding below is belt and braces.
+	if free := len(rb.buf) - int(rb.w-rb.r); n > free {
+		need := n - free
+		if rem := need % rb.frame; rem != 0 {
+			need += rb.frame - rem
+		}
+		if live := int(rb.w - rb.r); need > live {
+			need = live
+		}
+		rb.r += int64(need)
+		dropped += need
+	}
+
+	off := int(rb.w % int64(len(rb.buf)))
+	copied := copy(rb.buf[off:], src[:n])
+	if copied < n {
+		copied += copy(rb.buf, src[copied:n])
+	}
+	rb.w += int64(copied)
+	return copied, dropped
+}
+
+// capacity is the ring's fixed size in bytes. Set at construction and never
+// changed, so this needs no lock.
+func (rb *pcmRing) capacity() int { return len(rb.buf) }
+
+// progress samples, under ONE lock acquisition, how many bytes the reader has
+// taken and whether any are still waiting. Taken together they tell "the device
+// is draining" from "the device has stopped draining", which is the only way to
+// notice a backend-initiated stop: malgo surfaces one only through a Stop
+// callback, and a dead device otherwise looks exactly like a busy one.
+func (rb *pcmRing) progress() (consumed int64, pending bool) {
+	rb.mu.Lock()
+	defer rb.mu.Unlock()
+	return rb.r, rb.w > rb.r
+}
+
+// pending reports how many bytes are still waiting to be rendered.
+func (rb *pcmRing) pending() int {
+	rb.mu.Lock()
+	defer rb.mu.Unlock()
+	return int(rb.w - rb.r)
+}
+
+// flush drops everything not yet rendered (barge-in).
+func (rb *pcmRing) flush() {
+	rb.mu.Lock()
+	rb.r = rb.w
+	rb.mu.Unlock()
+}
+
+// drainWatch decides whether the output device has stopped consuming the ring.
+// Pure state with no clock and no locks of its own, so the decision that
+// releases a device can be tested without one.
+//
+// It exists because a device can die silently: the endpoint goes away (Bluetooth
+// headphones disconnecting mid-answer is the common one) or the backend stops it
+// under us, and malgo reports neither. A dead device looks exactly like a busy
+// one, and left alone it pins the worker's idle timer, so notifyPlayState(false)
+// never fires and the wake listener stays suppressed: JARVIS goes deaf.
+type drainWatch struct {
+	lastConsumed int64
+	lastProgress time.Time
+	armed        bool
+}
+
+// observe folds in one sample and reports whether the device should be
+// considered dead. Nothing pending, or a device that has not been started yet,
+// is not a stall: both disarm the watch.
+func (w *drainWatch) observe(consumed int64, pending, started bool, now time.Time, timeout time.Duration) bool {
+	if !pending || !started {
+		w.armed = false
+		return false
+	}
+	if !w.armed || consumed != w.lastConsumed {
+		w.armed = true
+		w.lastConsumed = consumed
+		w.lastProgress = now
+		return false
+	}
+	return now.Sub(w.lastProgress) >= timeout
+}
+
+func (w *drainWatch) reset() { w.armed = false }
 
 // playbackJob is a single clip waiting in the queue. The generation number
 // lets Stop() invalidate everything queued before the call without needing
@@ -40,31 +292,41 @@ type playbackJob struct {
 	gen   int64
 }
 
-// AudioPlaybackService owns one malgo playback context and a single
-// background worker that drains a queue of clips and plays them
-// back-to-back. Streaming TTS (T17e) enqueues one clip per sentence as
-// the LLM streams; the queue model means clips play seamlessly without
-// the daemon having to wait for each clip's playback to finish before
-// dispatching the next.
+// AudioPlaybackService owns one malgo playback context, one long-lived output
+// device and a single background worker that drains a queue of clips into that
+// device's ring. Streaming TTS (T17e) enqueues one clip per sentence as the LLM
+// streams; the queue model means clips play seamlessly without the daemon
+// having to wait for each clip's playback to finish before dispatching the
+// next, and the shared device means there is no gap or click between them.
 type AudioPlaybackService struct {
-	mu  sync.Mutex
-	ctx *malgo.AllocatedContext
+	ctxMu sync.Mutex
+	ctx   *malgo.AllocatedContext
 
 	queue      chan playbackJob
 	workerOnce sync.Once
 	generation atomic.Int64
 
-	// playing is true whenever the worker is rendering a clip OR has
-	// just finished and not yet idled out (100 ms grace). This is what
-	// the wake-listener suppression hooks observe.
-	playing atomic.Bool
-	// stopReq, when set, makes the data callback feed silence + close
-	// the done channel within ~10 ms. Reset at the start of each new
-	// clip so back-to-back queued clips aren't accidentally aborted.
-	stopReq atomic.Bool
+	// devMu guards the device and the ring it feeds. The audio callback closes
+	// over the ring directly and never takes devMu, so closing the device (which
+	// waits for the audio thread) can't deadlock against a callback waiting for
+	// the lock.
+	devMu       sync.Mutex
+	dev         *malgo.Device
+	ring        *pcmRing
+	devRate     int
+	devChannels int
+	devStarted  bool
 
 	onPlayStateMu     sync.RWMutex
 	onPlayStateChange func(playing bool)
+
+	// onClip fires once per clip actually rendered. onPlayStateChange only
+	// edges (once at the start of a burst, once when it ends), which is the
+	// right shape for a paired suppress/release but useless for a deadline: an
+	// answer longer than the deadline would expire mid-sentence. Anything
+	// time-bounded hangs off this instead.
+	onClipMu sync.RWMutex
+	onClip   func()
 }
 
 func NewAudioPlaybackService() *AudioPlaybackService {
@@ -97,21 +359,32 @@ func (s *AudioPlaybackService) Play(audio []byte, mimeHint string) error {
 	return s.Enqueue(audio, mimeHint)
 }
 
-// worker drains the playback queue, playing each clip via malgo. Idle
-// timeout debounces the play-state notification so back-to-back clips
-// don't toggle the wake listener's suppression flag for every clip
-// boundary — only when the queue genuinely empties for >100 ms.
+// worker drains the playback queue into the output device's ring. It also owns
+// the device's lifecycle: opened on the first clip that needs it, released once
+// the conversation has been quiet for a while.
 func (s *AudioPlaybackService) worker() {
-	const idleTimeout = 100 * time.Millisecond
 	announced := false
+	lastAudio := time.Now()
+	// Catches the stall shape render cannot: a partly-full ring it has already
+	// returned from, i.e. the endpoint dying during the LAST sentence of an
+	// answer. render watches the other shape (a ring too full to accept more).
+	var watch drainWatch
+
 	for {
+		// Nothing playing and no device to release: there is nothing to poll
+		// for, so wait on the queue instead of spinning.
+		tick := playbackTick
+		if !announced && !s.deviceOpen() {
+			tick = time.Hour
+		}
+
 		select {
 		case job, ok := <-s.queue:
 			if !ok {
 				if announced {
 					s.notifyPlayState(false)
-					announced = false
 				}
+				s.closeDevice("queue closed")
 				return
 			}
 			// Skip jobs from a generation older than the current one
@@ -123,120 +396,315 @@ func (s *AudioPlaybackService) worker() {
 				s.notifyPlayState(true)
 				announced = true
 			}
-			s.playing.Store(true)
-			s.stopReq.Store(false)
-			if err := s.playOne(job.audio, job.mime); err != nil {
+			s.notifyClip()
+			if err := s.render(job); err != nil {
 				log.Printf("[playback] error: %v", err)
 			}
-			s.playing.Store(false)
-		case <-time.After(idleTimeout):
-			if announced {
+			lastAudio = time.Now()
+
+		case <-time.After(tick):
+			consumed, pending, started := s.drainProgress()
+			now := time.Now()
+			if watch.observe(consumed, pending, started, now, playbackStallTimeout) {
+				log.Printf("[playback] device stopped draining with %d bytes pending, releasing it", s.pending())
+				s.closeDevice("stalled")
+				watch.reset()
+				continue
+			}
+			if pending {
+				lastAudio = now
+				continue
+			}
+			idle := time.Since(lastAudio)
+			if announced && idle >= playbackIdleAnnounce {
 				s.notifyPlayState(false)
 				announced = false
+			}
+			if !announced && idle >= playbackIdleClose {
+				s.closeDevice("idle")
 			}
 		}
 	}
 }
 
-// playOne renders a single clip through malgo. Blocks until the clip
-// finishes (or stopReq is asserted by Stop()).
-func (s *AudioPlaybackService) playOne(audio []byte, mimeHint string) error {
-	pcm, sampleRate, channels, err := decodeAudio(audio, mimeHint)
+// render decodes one clip and feeds it to the output device, waiting on the
+// audio thread whenever the ring is full. Returns as soon as the last byte is
+// in the ring; the worker's idle accounting, not this function, decides when
+// playback has actually finished.
+func (s *AudioPlaybackService) render(job playbackJob) error {
+	pcm, sampleRate, channels, err := decodeAudio(job.audio, job.mime)
 	if err != nil {
 		return fmt.Errorf("decode: %w", err)
 	}
 	if len(pcm) == 0 {
 		return nil
 	}
+	if sampleRate <= 0 || channels <= 0 {
+		return fmt.Errorf("decode: nonsensical format (%d Hz, %d channels)", sampleRate, channels)
+	}
 
-	s.mu.Lock()
+	ring, err := s.deviceFor(sampleRate, channels)
+	if err != nil {
+		return err
+	}
+
+	// Same stall watch the worker runs, on the other shape: here the ring is too
+	// full to accept more. Watching consumption rather than wall-clock keeps the
+	// two paths to the same 1.5 s verdict; the old byte-based deadline was the
+	// clip's own duration plus three seconds, so a dead device swallowed several
+	// sentences before anyone noticed.
+	var watch drainWatch
+
+	for off := 0; off < len(pcm); {
+		if job.gen != s.generation.Load() {
+			return nil // barge-in: abandon the rest of this clip
+		}
+		end := off + playbackFeedChunk
+		if end > len(pcm) {
+			end = len(pcm)
+		}
+		n := ring.write(pcm[off:end])
+		if n > 0 {
+			off += n
+			// A barge-in can land between the check above and this write, which
+			// would commit a whole chunk of stale audio just after Stop()
+			// flushed the ring. Re-check and undo it: a chunk is a third of a
+			// second of speech, which is very audible after "stop".
+			if job.gen != s.generation.Load() {
+				ring.flush()
+				return nil
+			}
+			// Start on the first bytes in, not at open: the device would
+			// otherwise render its first buffer from an empty ring and put that
+			// much silence in front of every answer.
+			if err := s.startDevice(); err != nil {
+				return err
+			}
+			watch.reset()
+			continue
+		}
+		// Ring full. Either the device is draining and we simply have to wait,
+		// or it has died and we must let it go rather than hand the same dead
+		// device to every later clip.
+		consumed, pending, started := s.drainProgress()
+		if watch.observe(consumed, pending, started, time.Now(), playbackStallTimeout) {
+			log.Printf("[playback] device stopped draining, dropping %d of %d bytes and releasing it",
+				len(pcm)-off, len(pcm))
+			s.closeDevice("stalled")
+			return nil
+		}
+		time.Sleep(playbackFeedPoll)
+	}
+	return nil
+}
+
+// playbackDeviceLatency is roughly how much audio the open device holds beyond
+// the ring. WASAPI buffers Periods x period; CoreAudio buffers one period.
+func playbackDeviceLatency() time.Duration {
+	periods := playbackPeriods
+	if runtime.GOOS == "darwin" {
+		periods = 1
+	}
+	return time.Duration(playbackPeriodMs) * time.Duration(periods) * time.Millisecond
+}
+
+// deviceFor returns the ring feeding an output device in the given format,
+// opening one (or replacing a differently-formatted one) as needed. Only the
+// worker calls this.
+func (s *AudioPlaybackService) deviceFor(sampleRate, channels int) (*pcmRing, error) {
+	s.devMu.Lock()
+	if s.dev != nil && s.devRate == sampleRate && s.devChannels == channels {
+		ring := s.ring
+		s.devMu.Unlock()
+		return ring, nil
+	}
+	reopen := s.dev != nil
+	s.devMu.Unlock()
+
+	// A format change mid-conversation (the user switched TTS provider) has to
+	// let the current clip finish before we pull the device out from under it.
+	if reopen {
+		s.waitDrained(playbackRingSeconds*time.Second + 2*time.Second)
+		// waitDrained only empties the ring; the device still holds a buffer's
+		// worth. miniaudio's WASAPI backend drains that on stop, but its
+		// CoreAudio backend does not, so without this the tail of the last
+		// sentence in the old format is clipped on macOS.
+		time.Sleep(playbackDeviceLatency())
+		s.closeDevice("format change")
+	}
+	return s.openDevice(sampleRate, channels)
+}
+
+func (s *AudioPlaybackService) openDevice(sampleRate, channels int) (*pcmRing, error) {
+	s.ctxMu.Lock()
 	if s.ctx == nil {
 		ctx, err := malgo.InitContext(nil, malgo.ContextConfig{}, func(message string) {
 			log.Printf("[playback] miniaudio: %s", message)
 		})
 		if err != nil {
-			s.mu.Unlock()
-			return fmt.Errorf("malgo.InitContext: %w", err)
+			s.ctxMu.Unlock()
+			return nil, fmt.Errorf("malgo.InitContext: %w", err)
 		}
 		s.ctx = ctx
 	}
 	ctx := s.ctx
-	s.mu.Unlock()
+	s.ctxMu.Unlock()
+
+	ring := newPCMRing(sampleRate, channels, playbackRingSeconds)
+	frameBytes := channels * 2
 
 	deviceConfig := malgo.DefaultDeviceConfig(malgo.Playback)
 	deviceConfig.Playback.Format = malgo.FormatS16
 	deviceConfig.Playback.Channels = uint32(channels)
 	deviceConfig.SampleRate = uint32(sampleRate)
+	deviceConfig.PeriodSizeInMilliseconds = playbackPeriodMs
+	deviceConfig.Periods = playbackPeriods
 	deviceConfig.Alsa.NoMMap = 1
 
-	done := make(chan struct{})
-	var doneOnce sync.Once
-	closeDone := func() { doneOnce.Do(func() { close(done) }) }
-
-	cursor := 0
 	onSend := func(output, _ []byte, frameCount uint32) {
-		bytesPerFrame := int(channels) * 2
-		need := int(frameCount) * bytesPerFrame
-		if s.stopReq.Load() {
-			for i := range output[:need] {
-				output[i] = 0
-			}
-			closeDone()
-			return
+		need := int(frameCount) * frameBytes
+		if need > len(output) {
+			need = len(output)
 		}
-		if cursor >= len(pcm) {
-			for i := range output[:need] {
-				output[i] = 0
-			}
-			closeDone()
-			return
+		n := ring.read(output[:need])
+		for i := n; i < need; i++ {
+			output[i] = 0
 		}
-		end := cursor + need
-		if end > len(pcm) {
-			end = len(pcm)
-		}
-		n := copy(output[:need], pcm[cursor:end])
-		if n < need {
-			for i := n; i < need; i++ {
-				output[i] = 0
-			}
-		}
-		cursor = end
 	}
 
-	device, err := malgo.InitDevice(ctx.Context, deviceConfig, malgo.DeviceCallbacks{
-		Data: onSend,
-	})
+	device, err := malgo.InitDevice(ctx.Context, deviceConfig, malgo.DeviceCallbacks{Data: onSend})
 	if err != nil {
-		return fmt.Errorf("malgo.InitDevice: %w", err)
+		return nil, fmt.Errorf("malgo.InitDevice: %w", err)
 	}
-	defer device.Uninit()
 
-	if err := device.Start(); err != nil {
-		return fmt.Errorf("device.Start: %w", err)
-	}
-	// `done` is closed only from inside the malgo data callback (clip finished
-	// or stopReq seen). If the device opens but then stalls / errors / stops
-	// driving the callback (device disconnect, sample-rate rejected mid-stream),
-	// the callback never reaches the end condition and a bare `<-done` would
-	// hang the singleton worker forever, wedging all future playback. Bound the
-	// wait by the clip's own duration plus a startup/drain grace.
-	timeout := 3 * time.Second
-	if bps := sampleRate * channels * 2; bps > 0 {
-		timeout += time.Duration(float64(len(pcm)) / float64(bps) * float64(time.Second))
-	}
-	select {
-	case <-done:
-	case <-time.After(timeout):
-		log.Printf("[playback] clip wait timed out after %v (device stalled?) — forcing stop", timeout)
-	}
-	device.Stop() //nolint:errcheck
-	return nil
+	s.devMu.Lock()
+	s.dev = device
+	s.ring = ring
+	s.devRate = sampleRate
+	s.devChannels = channels
+	s.devStarted = false
+	s.devMu.Unlock()
+
+	log.Printf("[playback] output device open (PCM s16 %dch %d Hz, %dx%dms buffer)",
+		channels, sampleRate, playbackPeriods, playbackPeriodMs)
+	return ring, nil
 }
 
-// Stop bumps the generation counter (so already-queued clips are skipped
-// by the worker) and asserts stopReq (so the currently-playing clip
-// aborts within ~10 ms). Idempotent.
+// startDevice starts the open device if it isn't running yet. Idempotent and
+// cheap after the first call.
+func (s *AudioPlaybackService) startDevice() error {
+	s.devMu.Lock()
+	if s.dev == nil || s.devStarted {
+		s.devMu.Unlock()
+		return nil
+	}
+	dev := s.dev
+	s.devMu.Unlock()
+
+	// Started outside devMu: ma_device_start blocks until the backend is
+	// actually running and pulls the first callback, and barge-in (Stop) takes
+	// devMu. Safe without the lock because the device's whole lifecycle
+	// (open, start, close) runs on the single worker goroutine; nothing can
+	// swap or free it underneath us here.
+	err := dev.Start()
+	if err == nil {
+		s.devMu.Lock()
+		s.devStarted = true
+		s.devMu.Unlock()
+		return nil
+	}
+
+	// Drop the device rather than leave an open-but-silent one behind: the next
+	// clip would feed a ring nothing is draining, stall out and be discarded.
+	// Releasing it here means the next clip gets a fresh device.
+	s.closeDevice("failed to start")
+	return fmt.Errorf("device.Start: %w", err)
+}
+
+// closeDevice stops and releases the output device. Safe to call when none is
+// open. Never called from the audio thread, and the callback does not take
+// devMu, so the stop can't deadlock against it.
+func (s *AudioPlaybackService) closeDevice(reason string) {
+	s.devMu.Lock()
+	dev, ring := s.dev, s.ring
+	s.dev, s.ring = nil, nil
+	s.devStarted = false
+	s.devRate, s.devChannels = 0, 0
+	s.devMu.Unlock()
+
+	if ring != nil {
+		ring.flush()
+	}
+	if dev != nil {
+		_ = dev.Stop()
+		dev.Uninit()
+		log.Printf("[playback] output device released (%s)", reason)
+	}
+}
+
+// deviceOpen reports whether an output device is currently held.
+func (s *AudioPlaybackService) deviceOpen() bool {
+	s.devMu.Lock()
+	defer s.devMu.Unlock()
+	return s.dev != nil
+}
+
+// pending is how many bytes are still waiting to be rendered.
+func (s *AudioPlaybackService) pending() int {
+	s.devMu.Lock()
+	ring := s.ring
+	s.devMu.Unlock()
+	if ring == nil {
+		return 0
+	}
+	return ring.pending()
+}
+
+// drainProgress samples the device's consumption: how many bytes it has taken so
+// far, whether any are still waiting, and whether it has actually been started
+// (a device that hasn't been started yet isn't stalled, it just hasn't begun).
+// The ring pair comes from a single lock acquisition so the two halves agree;
+// `started` and the ring itself come from one devMu acquisition, for the same
+// reason.
+func (s *AudioPlaybackService) drainProgress() (consumed int64, pending, started bool) {
+	s.devMu.Lock()
+	ring, started := s.ring, s.devStarted
+	s.devMu.Unlock()
+	if ring == nil {
+		return 0, false, started
+	}
+	consumed, pending = ring.progress()
+	return consumed, pending, started
+}
+
+// waitDrained blocks until the ring is empty (or the timeout elapses), so a
+// device swap doesn't cut the clip that is still playing.
+func (s *AudioPlaybackService) waitDrained(timeout time.Duration) {
+	deadline := time.Now().Add(timeout)
+	var watch drainWatch
+	for {
+		consumed, pending, started := s.drainProgress()
+		if !pending {
+			return
+		}
+		now := time.Now()
+		// Don't sit out the full timeout for a device that has died: there is
+		// nothing left to drain.
+		if watch.observe(consumed, pending, started, now, playbackStallTimeout) {
+			return
+		}
+		if now.After(deadline) {
+			return
+		}
+		time.Sleep(playbackFeedPoll)
+	}
+}
+
+// Stop bumps the generation counter (so already-queued clips are skipped by the
+// worker and an in-flight one abandons the rest of its feed) and drops
+// everything already handed to the device. The device's own buffer still has up
+// to one buffer-length of audio committed to the hardware, so a barge-in fades
+// out over ~160 ms rather than instantly. Idempotent.
 func (s *AudioPlaybackService) Stop() {
 	s.generation.Add(1)
 	// Drain queue eagerly so the worker doesn't churn through stale
@@ -249,8 +717,11 @@ drain:
 			break drain
 		}
 	}
-	if s.playing.Load() {
-		s.stopReq.Store(true)
+	s.devMu.Lock()
+	ring := s.ring
+	s.devMu.Unlock()
+	if ring != nil {
+		ring.flush()
 	}
 }
 
@@ -262,6 +733,23 @@ func (s *AudioPlaybackService) SetPlayStateListener(cb func(playing bool)) {
 	s.onPlayStateMu.Lock()
 	s.onPlayStateChange = cb
 	s.onPlayStateMu.Unlock()
+}
+
+// SetClipListener registers a callback that fires once per clip rendered.
+// Pass nil to clear.
+func (s *AudioPlaybackService) SetClipListener(cb func()) {
+	s.onClipMu.Lock()
+	s.onClip = cb
+	s.onClipMu.Unlock()
+}
+
+func (s *AudioPlaybackService) notifyClip() {
+	s.onClipMu.RLock()
+	cb := s.onClip
+	s.onClipMu.RUnlock()
+	if cb != nil {
+		cb()
+	}
 }
 
 func (s *AudioPlaybackService) notifyPlayState(playing bool) {

--- a/sidecar/pebble_playback_test.go
+++ b/sidecar/pebble_playback_test.go
@@ -1,0 +1,594 @@
+package main
+
+import (
+	"bytes"
+	"sync"
+	"testing"
+	"time"
+)
+
+// newTestRing builds a ring with an exact frame capacity, bypassing the
+// seconds-based sizing so tests can force wraps cheaply.
+func newTestRing(frames, channels int) *pcmRing {
+	frame := channels * 2
+	return &pcmRing{buf: make([]byte, frames*frame), frame: frame}
+}
+
+func TestPCMRingSizingIsFrameAligned(t *testing.T) {
+	for _, tc := range []struct{ rate, channels, seconds int }{
+		{24000, 1, 4},
+		{44100, 2, 4},
+		{16000, 2, 1},
+		{0, 0, 0}, // degenerate input must not produce a zero frame or zero buffer
+	} {
+		rb := newPCMRing(tc.rate, tc.channels, tc.seconds)
+		if rb.frame <= 0 {
+			t.Fatalf("%v: frame = %d, want > 0", tc, rb.frame)
+		}
+		if len(rb.buf) == 0 {
+			t.Fatalf("%v: empty ring buffer", tc)
+		}
+		if len(rb.buf)%rb.frame != 0 {
+			t.Fatalf("%v: capacity %d is not a multiple of frame %d", tc, len(rb.buf), rb.frame)
+		}
+	}
+}
+
+func TestPCMRingRoundTrip(t *testing.T) {
+	rb := newTestRing(8, 2) // 32 bytes
+	src := make([]byte, 16)
+	for i := range src {
+		src[i] = byte(i + 1)
+	}
+
+	if n := rb.write(src); n != len(src) {
+		t.Fatalf("write = %d, want %d", n, len(src))
+	}
+	if got := rb.pending(); got != len(src) {
+		t.Fatalf("pending = %d, want %d", got, len(src))
+	}
+
+	dst := make([]byte, 16)
+	if n := rb.read(dst); n != len(src) {
+		t.Fatalf("read = %d, want %d", n, len(src))
+	}
+	if !bytes.Equal(dst, src) {
+		t.Fatalf("round trip mismatch: got %v, want %v", dst, src)
+	}
+	if got := rb.pending(); got != 0 {
+		t.Fatalf("pending = %d after full read, want 0", got)
+	}
+	if n := rb.read(dst); n != 0 {
+		t.Fatalf("read on empty ring = %d, want 0", n)
+	}
+}
+
+// A write bigger than the free space must take what fits and report it, so the
+// caller can retry with the remainder rather than silently losing audio.
+func TestPCMRingWriteIsBoundedByFreeSpace(t *testing.T) {
+	rb := newTestRing(4, 1) // 8 bytes
+	src := make([]byte, 20)
+	for i := range src {
+		src[i] = byte(i + 1)
+	}
+
+	n := rb.write(src)
+	if n != 8 {
+		t.Fatalf("write = %d, want 8 (the whole capacity)", n)
+	}
+	if extra := rb.write(src[n:]); extra != 0 {
+		t.Fatalf("write into a full ring = %d, want 0", extra)
+	}
+
+	dst := make([]byte, 8)
+	rb.read(dst)
+	if !bytes.Equal(dst, src[:8]) {
+		t.Fatalf("got %v, want %v", dst, src[:8])
+	}
+}
+
+// Reads and writes must never split a frame: a partial count would shift every
+// following sample by a byte or two, which is exactly the loud, high-pitched
+// static this whole fix is about.
+func TestPCMRingNeverSplitsAFrame(t *testing.T) {
+	rb := newTestRing(8, 2) // frame = 4 bytes
+	src := make([]byte, 12)
+
+	// A write that is not a whole number of frames moves only whole frames.
+	rb.write(make([]byte, 10)) // 10 bytes offered, 8 accepted (2 frames), 2 refused
+	if got := rb.pending(); got%rb.frame != 0 {
+		t.Fatalf("pending = %d, not frame-aligned", got)
+	}
+
+	// A read into a buffer smaller than one frame must move nothing.
+	if n := rb.read(make([]byte, 3)); n != 0 {
+		t.Fatalf("sub-frame read = %d, want 0", n)
+	}
+	// A read into a non-frame-multiple buffer rounds down.
+	if n := rb.read(make([]byte, 7)); n != 4 {
+		t.Fatalf("7-byte read = %d, want 4", n)
+	}
+
+	rb.flush()
+	if n := rb.write(src); n%rb.frame != 0 {
+		t.Fatalf("write = %d, not frame-aligned", n)
+	}
+}
+
+func TestPCMRingFlushDropsPending(t *testing.T) {
+	rb := newTestRing(8, 1)
+	rb.write(make([]byte, 8))
+	rb.flush()
+	if got := rb.pending(); got != 0 {
+		t.Fatalf("pending = %d after flush, want 0", got)
+	}
+	// The ring stays usable after a flush.
+	src := []byte{9, 8, 7, 6}
+	if n := rb.write(src); n != len(src) {
+		t.Fatalf("write after flush = %d, want %d", n, len(src))
+	}
+	dst := make([]byte, len(src))
+	rb.read(dst)
+	if !bytes.Equal(dst, src) {
+		t.Fatalf("got %v, want %v", dst, src)
+	}
+}
+
+// The real usage: one producer (the playback worker) and one consumer (the
+// audio thread) at different rates, wrapping many times. Every byte must come
+// out exactly once, in order.
+func TestPCMRingStreamsInOrderAcrossWraps(t *testing.T) {
+	const channels = 2
+	rb := newTestRing(16, channels) // 64 bytes, so ~100 wraps below
+	const total = 6400
+
+	src := make([]byte, total)
+	for i := range src {
+		src[i] = byte(i % 251)
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() { // producer
+		defer wg.Done()
+		for off := 0; off < len(src); {
+			end := off + 37 // deliberately not a frame multiple
+			if end > len(src) {
+				end = len(src)
+			}
+			n := rb.write(src[off:end])
+			if n == 0 {
+				time.Sleep(time.Millisecond)
+				continue
+			}
+			off += n
+		}
+	}()
+
+	got := make([]byte, 0, total)
+	dst := make([]byte, 23) // also not a frame multiple
+	deadline := time.Now().Add(10 * time.Second)
+	for len(got) < total {
+		n := rb.read(dst)
+		if n == 0 {
+			if time.Now().After(deadline) {
+				t.Fatalf("timed out after %d of %d bytes", len(got), total)
+			}
+			time.Sleep(time.Millisecond)
+			continue
+		}
+		if n%rb.frame != 0 {
+			t.Fatalf("read %d bytes, not a multiple of frame %d", n, rb.frame)
+		}
+		got = append(got, dst[:n]...)
+	}
+	wg.Wait()
+
+	if !bytes.Equal(got, src) {
+		for i := range got {
+			if got[i] != src[i] {
+				t.Fatalf("stream diverged at byte %d: got %d, want %d", i, got[i], src[i])
+			}
+		}
+		t.Fatal("stream mismatch")
+	}
+}
+
+// decodeAudio has to survive the WAV shapes the daemon's TTS providers emit,
+// including the odd-sized-chunk padding rule.
+func TestDecodeWAVRoundTrip(t *testing.T) {
+	pcm := make([]byte, 320)
+	for i := range pcm {
+		pcm[i] = byte(i)
+	}
+	var buf bytes.Buffer
+	if err := writeWAV(&buf, pcm, 24000, 1, 16); err != nil {
+		t.Fatalf("writeWAV: %v", err)
+	}
+
+	got, rate, channels, err := decodeAudio(buf.Bytes(), "audio/wav")
+	if err != nil {
+		t.Fatalf("decodeAudio: %v", err)
+	}
+	if rate != 24000 || channels != 1 {
+		t.Fatalf("got %d Hz / %d ch, want 24000 / 1", rate, channels)
+	}
+	if !bytes.Equal(got, pcm) {
+		t.Fatal("decoded PCM does not match what was written")
+	}
+}
+
+func TestDecodeAudioRejectsUnknownFormat(t *testing.T) {
+	if _, _, _, err := decodeAudio([]byte{0x00, 0x01, 0x02, 0x03}, ""); err == nil {
+		t.Fatal("expected an error for an unrecognized format")
+	}
+	if _, _, _, err := decodeAudio([]byte{0x00}, "audio/wav"); err == nil {
+		t.Fatal("expected an error for a buffer too small to identify")
+	}
+}
+
+// Enqueue must never block the RPC handler, and must reject a full queue rather
+// than dropping the clip silently.
+func TestPlaybackEnqueueIsNonBlocking(t *testing.T) {
+	s := NewAudioPlaybackService()
+	// Burn the once so Enqueue's `workerOnce.Do(go worker)` is a no-op: the
+	// worker would open a real audio device, which CI has none of. Coupled to
+	// Enqueue starting the worker through workerOnce; if that ever changes,
+	// this and the test below need a different seam.
+	s.workerOnce.Do(func() {})
+
+	clip := []byte{0xFF, 0xFB, 0x00, 0x00}
+	for i := 0; i < cap(s.queue); i++ {
+		if err := s.Enqueue(clip, "audio/mp3"); err != nil {
+			t.Fatalf("enqueue %d: %v", i, err)
+		}
+	}
+	if err := s.Enqueue(clip, "audio/mp3"); err == nil {
+		t.Fatal("expected an error once the queue is full")
+	}
+	if err := s.Enqueue(nil, "audio/mp3"); err == nil {
+		t.Fatal("expected an error for an empty buffer")
+	}
+}
+
+// Stop must invalidate everything already queued, so a barge-in doesn't leave
+// the worker with a backlog of stale sentences to speak.
+func TestPlaybackStopInvalidatesQueuedClips(t *testing.T) {
+	s := NewAudioPlaybackService()
+	s.workerOnce.Do(func() {})
+
+	clip := []byte{0xFF, 0xFB, 0x00, 0x00}
+	for i := 0; i < 4; i++ {
+		if err := s.Enqueue(clip, "audio/mp3"); err != nil {
+			t.Fatalf("enqueue: %v", err)
+		}
+	}
+	before := s.generation.Load()
+	s.Stop()
+
+	if s.generation.Load() <= before {
+		t.Fatal("expected Stop to bump the generation")
+	}
+	if got := len(s.queue); got != 0 {
+		t.Fatalf("queue holds %d jobs after Stop, want 0", got)
+	}
+	// A clip queued after Stop carries the new generation and stays valid.
+	if err := s.Enqueue(clip, "audio/mp3"); err != nil {
+		t.Fatalf("enqueue after stop: %v", err)
+	}
+	job := <-s.queue
+	if job.gen != s.generation.Load() {
+		t.Fatalf("job gen = %d, want the current %d", job.gen, s.generation.Load())
+	}
+}
+
+// writeDropOldest is the realtime path's producer: it cannot block the read
+// loop, so an overflow has to cost the OLDEST audio. Every count must stay
+// frame-aligned; an odd-sized drop byte-shifts every following sample, which is
+// what turns speech into full-scale high-frequency static.
+func TestPCMRingWriteDropOldestKeepsRoomWithoutDropping(t *testing.T) {
+	rb := newTestRing(8, 2) // 32 bytes
+	src := make([]byte, 16)
+	for i := range src {
+		src[i] = byte(i + 1)
+	}
+
+	written, dropped := rb.writeDropOldest(src)
+	if written != len(src) || dropped != 0 {
+		t.Fatalf("written = %d, dropped = %d; want %d, 0", written, dropped, len(src))
+	}
+	dst := make([]byte, 16)
+	rb.read(dst)
+	if !bytes.Equal(dst, src) {
+		t.Fatalf("got %v, want %v", dst, src)
+	}
+}
+
+func TestPCMRingWriteDropOldestEvictsOldestInOrder(t *testing.T) {
+	rb := newTestRing(4, 2) // 16 bytes, frame = 4
+
+	first := []byte{1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4}
+	if n, d := rb.writeDropOldest(first); n != 16 || d != 0 {
+		t.Fatalf("fill: written = %d, dropped = %d", n, d)
+	}
+
+	// Two more frames must evict the two oldest.
+	next := []byte{5, 5, 5, 5, 6, 6, 6, 6}
+	n, dropped := rb.writeDropOldest(next)
+	if n != 8 {
+		t.Fatalf("written = %d, want 8", n)
+	}
+	if dropped != 8 {
+		t.Fatalf("dropped = %d, want 8", dropped)
+	}
+	assertRingFrameAligned(t, rb)
+
+	dst := make([]byte, 16)
+	got := rb.read(dst)
+	want := []byte{3, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 6, 6, 6, 6}
+	if got != len(want) || !bytes.Equal(dst[:got], want) {
+		t.Fatalf("got %v, want %v", dst[:got], want)
+	}
+}
+
+// A write larger than the whole ring keeps the newest ring-full, still aligned.
+func TestPCMRingWriteDropOldestHandlesOversizedWrite(t *testing.T) {
+	rb := newTestRing(4, 2) // 16 bytes
+	src := make([]byte, 40)
+	for i := range src {
+		src[i] = byte(i)
+	}
+
+	written, dropped := rb.writeDropOldest(src)
+	if written != 16 {
+		t.Fatalf("written = %d, want 16 (the whole capacity)", written)
+	}
+	if dropped != len(src)-16 {
+		t.Fatalf("dropped = %d, want %d", dropped, len(src)-16)
+	}
+	assertRingFrameAligned(t, rb)
+
+	dst := make([]byte, 16)
+	rb.read(dst)
+	if !bytes.Equal(dst, src[len(src)-16:]) {
+		t.Fatalf("kept %v, want the newest %v", dst, src[len(src)-16:])
+	}
+}
+
+// The realtime backlog cap used to be applied by advancing the read cursor by an
+// arbitrary byte count. Hammer the eviction path with sizes that are not frame
+// multiples and assert the cursors never leave a frame boundary.
+func TestPCMRingEvictionNeverMisalignsFrames(t *testing.T) {
+	rb := newTestRing(9, 2)  // 36 bytes, frame = 4
+	chunk := make([]byte, 7) // deliberately not a frame multiple
+	for i := range chunk {
+		chunk[i] = byte(i)
+	}
+	scratch := make([]byte, 5) // nor is the read size
+
+	for i := 0; i < 500; i++ {
+		rb.writeDropOldest(chunk)
+		assertRingFrameAligned(t, rb)
+		if i%3 == 0 {
+			if n := rb.read(scratch); n%rb.frame != 0 {
+				t.Fatalf("read %d bytes, not a multiple of frame %d", n, rb.frame)
+			}
+			assertRingFrameAligned(t, rb)
+		}
+	}
+}
+
+func assertRingFrameAligned(t *testing.T, rb *pcmRing) {
+	t.Helper()
+	rb.mu.Lock()
+	r, w, frame := rb.r, rb.w, rb.frame
+	rb.mu.Unlock()
+	if r%int64(frame) != 0 {
+		t.Fatalf("read cursor %d is not frame-aligned (frame %d)", r, frame)
+	}
+	if w%int64(frame) != 0 {
+		t.Fatalf("write cursor %d is not frame-aligned (frame %d)", w, frame)
+	}
+	if w < r {
+		t.Fatalf("write cursor %d fell behind read cursor %d", w, r)
+	}
+}
+
+// The realtime player's ring must be sized to the documented backlog, and its
+// jitter cushion must fit inside it with room to spare.
+func TestStreamRingSizing(t *testing.T) {
+	rb := newPCMRing(streamPlaybackSampleRate, 1, streamBacklogSeconds)
+	want := streamPlaybackSampleRate * 2 * streamBacklogSeconds
+	if rb.capacity() != want {
+		t.Fatalf("capacity = %d, want %d", rb.capacity(), want)
+	}
+	if jitterPrimeBytes >= rb.capacity() {
+		t.Fatalf("jitter cushion %d does not fit in a %d byte ring", jitterPrimeBytes, rb.capacity())
+	}
+	if jitterPrimeBytes%rb.frame != 0 {
+		t.Fatalf("jitter cushion %d is not a whole number of frames", jitterPrimeBytes)
+	}
+}
+
+// An eviction that also wraps the end of the backing array is where an
+// off-by-one in the two-segment copy would show up as scrambled audio.
+func TestPCMRingWriteDropOldestWrapsCorrectly(t *testing.T) {
+	rb := newTestRing(4, 1) // 8 bytes, frame = 2
+
+	// Push the cursors most of the way round so the next write straddles the end.
+	rb.write([]byte{9, 9, 9, 9, 9, 9})
+	rb.read(make([]byte, 6))
+
+	rb.writeDropOldest([]byte{1, 1, 2, 2, 3, 3, 4, 4}) // fills, wrapping
+	written, dropped := rb.writeDropOldest([]byte{5, 5, 6, 6})
+	if written != 4 || dropped != 4 {
+		t.Fatalf("written = %d, dropped = %d; want 4, 4", written, dropped)
+	}
+	assertRingFrameAligned(t, rb)
+
+	dst := make([]byte, 8)
+	n := rb.read(dst)
+	want := []byte{3, 3, 4, 4, 5, 5, 6, 6}
+	if n != len(want) || !bytes.Equal(dst[:n], want) {
+		t.Fatalf("got %v, want %v", dst[:n], want)
+	}
+}
+
+// The realtime shape: a producer that never blocks (the read loop) against the
+// audio thread. Whatever survives must be a contiguous, in-order run of what was
+// produced. Evicting the oldest is allowed; scrambling or interleaving is not.
+func TestPCMRingWriteDropOldestStaysContiguousUnderLoad(t *testing.T) {
+	rb := newTestRing(32, 1) // 64 bytes
+	const total = 4000
+
+	src := make([]byte, total)
+	for i := range src {
+		src[i] = byte(i % 251)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for off := 0; off < len(src); off += 6 {
+			end := off + 6
+			if end > len(src) {
+				end = len(src)
+			}
+			rb.writeDropOldest(src[off:end])
+			// Pace the producer so the consumer actually interleaves. Without
+			// this it finishes before the first read and the test proves
+			// nothing.
+			time.Sleep(50 * time.Microsecond)
+		}
+	}()
+
+	dst := make([]byte, 10)
+	read := 0
+	readAt := 0 // how far into src the previous read reached
+	producing := true
+	deadline := time.Now().Add(30 * time.Second)
+	for producing || rb.pending() > 0 {
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out after reading %d bytes", read)
+		}
+		select {
+		case <-done:
+			producing = false
+		default:
+		}
+		n := rb.read(dst)
+		if n == 0 {
+			continue
+		}
+		// Each read must be a contiguous run of the source occurring at or
+		// after where the previous read ended. Searched forward from readAt,
+		// not from the start: the source repeats every 251 bytes, so a short
+		// window matches in many places and only the ordering constraint makes
+		// the check meaningful. Eviction may skip ahead; it may never go back.
+		rel := bytes.Index(src[readAt:], dst[:n])
+		if rel < 0 {
+			t.Fatalf("read %v at/after offset %d is not a contiguous run of the source", dst[:n], readAt)
+		}
+		readAt += rel + n
+		read += n
+	}
+	<-done
+	assertRingFrameAligned(t, rb)
+	// Without this the test passes vacuously if the consumer never won a read,
+	// which is exactly what it did before this assertion was added.
+	if read < rb.capacity() {
+		t.Fatalf("only read %d bytes; the consumer never really ran", read)
+	}
+}
+
+// drainWatch is what decides to release an output device that has died. It is
+// pure state precisely so this can be pinned without an audio device.
+func TestDrainWatchStallsOnlyWithoutProgress(t *testing.T) {
+	var w drainWatch
+	t0 := time.Now()
+	const timeout = 1500 * time.Millisecond
+
+	// A device that keeps consuming is never a stall, however long it runs.
+	consumed := int64(0)
+	for i := 0; i < 100; i++ {
+		consumed += 960
+		if w.observe(consumed, true, true, t0.Add(time.Duration(i)*time.Second), timeout) {
+			t.Fatalf("healthy device reported stalled at step %d", i)
+		}
+	}
+
+	// Progress stops. The clock runs from the LAST observed progress (t0+99s,
+	// the final healthy sample), not from the first sample that noticed the
+	// lack of it, so keep the steps realistic: the worker samples every 50 ms.
+	frozen := consumed
+	last := t0.Add(99 * time.Second)
+	if w.observe(frozen, true, true, last.Add(50*time.Millisecond), timeout) {
+		t.Fatal("stalled one tick after the last progress")
+	}
+	if w.observe(frozen, true, true, last.Add(timeout-time.Millisecond), timeout) {
+		t.Fatal("stalled just before the timeout")
+	}
+	if !w.observe(frozen, true, true, last.Add(timeout), timeout) {
+		t.Fatal("expected a stall once the timeout elapsed with no progress")
+	}
+}
+
+// Nothing pending, or a device that has not been started, is not a stall: an
+// empty ring is the normal idle state, and a device that has only just been
+// opened has not had a chance to consume anything yet.
+func TestDrainWatchIgnoresIdleAndUnstartedDevices(t *testing.T) {
+	var w drainWatch
+	t0 := time.Now()
+	const timeout = time.Second
+
+	for i := 0; i < 10; i++ {
+		at := t0.Add(time.Duration(i) * time.Hour)
+		if w.observe(0, false, true, at, timeout) {
+			t.Fatal("an empty ring must never read as a stall")
+		}
+		if w.observe(0, true, false, at, timeout) {
+			t.Fatal("an unstarted device must never read as a stall")
+		}
+	}
+}
+
+// A stall must not latch: once the device is replaced and starts consuming
+// again, the watch has to go quiet.
+func TestDrainWatchRecoversAfterReset(t *testing.T) {
+	var w drainWatch
+	t0 := time.Now()
+	const timeout = time.Second
+
+	w.observe(100, true, true, t0, timeout)
+	if !w.observe(100, true, true, t0.Add(2*time.Second), timeout) {
+		t.Fatal("expected a stall")
+	}
+
+	w.reset()
+	if w.observe(100, true, true, t0.Add(3*time.Second), timeout) {
+		t.Fatal("a reset watch must start its clock over, not re-report the stall")
+	}
+	if w.observe(200, true, true, t0.Add(4*time.Second), timeout) {
+		t.Fatal("progress after a reset must clear the stall")
+	}
+}
+
+// An idle gap (ring empties, then a new answer arrives) must not be mistaken
+// for a stall just because `consumed` has not moved since the last sample.
+func TestDrainWatchSurvivesAnIdleGap(t *testing.T) {
+	var w drainWatch
+	t0 := time.Now()
+	const timeout = time.Second
+
+	w.observe(5000, true, true, t0, timeout)
+	// Ring drains; the worker keeps ticking through a long quiet stretch.
+	for i := 0; i < 60; i++ {
+		if w.observe(5000, false, true, t0.Add(time.Duration(i)*time.Second), timeout) {
+			t.Fatal("an idle stretch must not report a stall")
+		}
+	}
+	// New audio arrives; the device has not consumed any of it yet this tick.
+	if w.observe(5000, true, true, t0.Add(60*time.Second), timeout) {
+		t.Fatal("the first sample after an idle gap must only start the clock")
+	}
+}

--- a/sidecar/pebble_realtime.go
+++ b/sidecar/pebble_realtime.go
@@ -130,7 +130,7 @@ func (r *realtimeVoice) Start() {
 	// per tick) so it doesn't contend with the audio stream on the shared WS,
 	// and so its reactor (set_eye flood, proactive narration, autonomous agent
 	// actions) stays quiet during the conversation.
-	ambientSuppressed.Store(true)
+	ambientHold()
 
 	// Open the dedicated audio channel (isolated from the bulk control
 	// connection). Inbound binary plays through this session's stream player;
@@ -180,7 +180,10 @@ func (r *realtimeVoice) Start() {
 	}()
 
 	const frameBytes = realtimeInputSampleRate * 2 * realtimeFrameMs / 1000 // s16 mono
-	var acc []byte
+	// Reserved once, and only ever sliced in place below: this accumulator is
+	// filled from the miniaudio capture callback, i.e. the audio thread, where a
+	// realloc-and-copy costs microphone frames.
+	acc := make([]byte, 0, frameBytes*2)
 	gated := false
 	r.capture.SetChunkListener(func(chunk []byte) {
 		// Half-duplex echo guard: while the assistant is speaking through the
@@ -203,11 +206,17 @@ func (r *realtimeVoice) Start() {
 		}
 		acc = append(acc, chunk...)
 		for len(acc) >= frameBytes {
+			// This one allocation is unavoidable: the frame is handed to the
+			// sender goroutine and outlives the callback. It is a fixed 1920
+			// bytes, unlike the accumulator it used to drag along.
 			out := append([]byte(nil), acc[:frameBytes]...)
-			acc = acc[frameBytes:]
+			// Compact in place rather than re-slicing from the front: acc =
+			// acc[frameBytes:] walks the start pointer forward and shrinks the
+			// capacity, so the next append reallocated on the audio thread.
+			acc = acc[:copy(acc, acc[frameBytes:])]
 			select {
 			case frameCh <- out:
-			default: // network backed up — drop, keep capture real-time
+			default: // network backed up, drop and keep capture real-time
 			}
 		}
 	})
@@ -236,7 +245,7 @@ func (r *realtimeVoice) Start() {
 		r.setStream(nil)
 		player.Stop()
 		r.player = nil
-		ambientSuppressed.Store(false) // Stop() won't run (active already false) — resume screen awareness here
+		ambientRelease() // Stop() won't run (active already false); resume screen awareness here
 		r.resumeWake()
 		r.active.Store(false)
 		return
@@ -279,7 +288,7 @@ func (r *realtimeVoice) Stop(emit bool) {
 		r.player.Stop()
 		r.player = nil
 	}
-	ambientSuppressed.Store(false) // resume ambient screen awareness
+	ambientRelease() // resume ambient screen awareness
 	r.resumeWake()
 	r.setState(PebbleIdle)
 

--- a/sidecar/pebble_stream.go
+++ b/sidecar/pebble_stream.go
@@ -2,18 +2,30 @@ package main
 
 // Low-latency streaming PCM playback for the pebble's realtime voice loop.
 //
-// Unlike AudioPlaybackService (which opens a fresh malgo device per TTS clip and
-// only accepts complete MP3/WAV containers), this opens ONE persistent output
-// device and feeds it raw PCM s16/mono/24 kHz frames as they stream in from the
-// daemon's realtime session. The device's render callback drains a small queue;
-// underruns play silence. Barge-in flushes the queue instantly.
+// Unlike AudioPlaybackService (which accepts complete MP3/WAV containers and
+// decodes them), this feeds one persistent output device raw PCM s16/mono/24 kHz
+// frames as they stream in from the daemon's realtime session. The device's
+// render callback drains a playout buffer; underruns play silence and rebuild
+// the cushion. Barge-in flushes instantly.
 //
 // Frames arrive via the readLoop's `pebble.play_pcm` fast-path (in receive
-// order) and are appended with Write; the audio thread drains them in Render.
+// order) and are appended with Write; the audio thread drains them in the
+// render callback.
+//
+// Real-time safety: the playout buffer is a pcmRing (see pebble_playback.go),
+// allocated once at Start. It used to be a plain slice that `append` grew up to
+// a 2.88 MB backlog while holding the very mutex the render callback needs, so
+// a single realloc could park the audio thread for the length of a multi-
+// megabyte copy. It also trimmed that backlog by an arbitrary byte count, which
+// could leave the read cursor on an odd offset and byte-shift every following
+// sample into full-scale static. The ring fixes both: no growth, and every
+// count is frame-aligned.
 
 import (
 	"log"
+	"runtime"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/gen2brain/malgo"
@@ -21,174 +33,478 @@ import (
 
 const streamPlaybackSampleRate = 24000 // matches the realtime session output rate
 
-// AudioStreamPlayer owns a persistent malgo playback device + a byte queue of
-// pending PCM (s16 mono). Safe for concurrent Write / Flush / Stop.
-type AudioStreamPlayer struct {
-	mu        sync.Mutex
-	ctx       *malgo.AllocatedContext
-	device    *malgo.Device
-	buf       []byte // PCM queue; live (undrained) data is buf[readPos:]
-	readPos   int    // bytes at the front already played (read cursor, not shifted per-callback)
-	started   bool
-	priming   bool      // playout (jitter) buffer: accumulating before (re)starting drain
-	writes    int64     // diagnostic: count of inbound PCM frames
-	lastWrite time.Time // when the most recent output frame arrived (echo gate)
-}
+// streamPeriodMs / streamPeriods size the device buffer. Larger than
+// miniaudio's 10 ms low-latency default so a GC pause doesn't underrun the
+// device, but smaller than the clip player's, because this path is barge-in
+// sensitive: whatever is committed to the hardware still plays after a Flush.
+//
+// Per-OS for the same reason as playbackPeriodMs: miniaudio's WASAPI backend
+// buffers Periods x period, its CoreAudio backend buffers one period and
+// ignores the count. Both land at roughly 60-80 ms, comfortably under the
+// 120 ms jitter cushion sitting above them.
+const streamPeriods = 4
 
-// maxBacklogBytes bounds only a genuinely STALLED device (not draining). It must
-// be far larger than any real answer: OpenAI bursts a long answer's audio faster
-// than real-time, so the queue legitimately holds many seconds of not-yet-played
-// PCM. The old 5 s cap dropped the middle of long answers → chunky playback. ~60 s.
-const maxBacklogBytes = streamPlaybackSampleRate * 2 * 60
+var streamPeriodMs uint32 = func() uint32 {
+	if runtime.GOOS == "darwin" {
+		return 60
+	}
+	return 20
+}()
 
-// jitterPrimeBytes is the playout cushion: the render callback outputs silence
-// until this much PCM is buffered, then drains. Re-primed on underrun. Absorbs
-// delivery jitter (OpenAI bursts, the WSL2 bridge, daemon hiccups) so brief gaps
-// don't drain the device to silence and stutter the voice. ~120 ms.
-const jitterPrimeBytes = streamPlaybackSampleRate * 2 * 120 / 1000
+// streamBacklogSeconds bounds only a genuinely STALLED device (not draining).
+// It must be far larger than any real answer: OpenAI bursts a long answer's
+// audio faster than real-time, so the queue legitimately holds many seconds of
+// not-yet-played PCM. An earlier 5 s cap dropped the middle of long answers,
+// which made playback chunky.
+const streamBacklogSeconds = 60
+
+// The playout cushion: the render callback outputs silence until this much PCM
+// is buffered, then drains. It absorbs delivery jitter so brief gaps don't drain
+// the device to silence and stutter the voice.
+//
+// It is ADAPTIVE because the delivery path is not fixed. A brain running on the
+// same machine delivers audio in bursts far ahead of real time and 120 ms is
+// plenty; a hosted brain sends every frame across the internet, where 120 ms of
+// jitter is ordinary. Too small a cushion there means a continuous cycle of
+// underrun, re-prime, underrun, which is heard as choppy speech with a click at
+// every seam. So: start at the base, widen by a step on every mid-response
+// underrun, cap it, and start each session over at the base.
+const (
+	streamCushionBaseMs = 120
+	streamCushionStepMs = 80
+	streamCushionMaxMs  = 600
+
+	jitterPrimeBytes  = streamPlaybackSampleRate * 2 * streamCushionBaseMs / 1000
+	streamCushionStep = streamPlaybackSampleRate * 2 * streamCushionStepMs / 1000
+	streamCushionMax  = streamPlaybackSampleRate * 2 * streamCushionMaxMs / 1000
+)
+
+// streamInputIdle is how long without a new frame means the response is over
+// rather than merely late. It separates "hold for the cushion" from "this is
+// the tail, play it out": without the distinction the last partial buffer of
+// every answer is stranded in the ring and plays as a stale fragment in front
+// of the NEXT answer.
+//
+// It sits just under the base cushion on purpose. With delivery paced near real
+// time the ring drains about a cushion's worth after the last frame, so a
+// longer window would classify the end of every response as a mid-response
+// underrun and hold the tail back for the difference. Getting it wrong the
+// other way is cheap now that the cushion only widens when audio resumes: a
+// genuine gap this long just plays out what is buffered and re-primes.
+const streamInputIdle = 100 * time.Millisecond
 
 // echoHangover keeps the mic gated briefly after the output buffer drains, so
 // the tail of the assistant's audio (and its acoustic echo) doesn't leak back in.
 const echoHangover = 300 * time.Millisecond
 
-// IsActive reports whether the assistant is currently producing output audio —
+// The realtime controller builds a FRESH AudioStreamPlayer for every session,
+// so a per-player miniaudio context would leak one context (and its backend
+// handles) per conversation. Tearing one down per session is the other obvious
+// answer and is worse: ma_context_uninit calls CoUninitialize on WASAPI, and a
+// goroutine is not pinned to the OS thread that initialized COM. So there is one
+// context for the life of the process, created on first use and never freed.
+var (
+	streamCtxOnce sync.Once
+	streamCtx     *malgo.AllocatedContext
+	streamCtxErr  error
+)
+
+func streamPlaybackContext() (*malgo.AllocatedContext, error) {
+	streamCtxOnce.Do(func() {
+		streamCtx, streamCtxErr = malgo.InitContext(nil, malgo.ContextConfig{}, func(m string) {
+			log.Printf("[stream] miniaudio: %s", m)
+		})
+	})
+	return streamCtx, streamCtxErr
+}
+
+// AudioStreamPlayer owns a persistent malgo playback device plus the ring of
+// pending PCM (s16 mono) that feeds it. Safe for concurrent Write / Flush /
+// Stop / IsActive.
+type AudioStreamPlayer struct {
+	// lifecycleMu serializes Start and Stop. Held across device init/teardown,
+	// which can take tens of milliseconds, so the audio threads must never
+	// touch it.
+	lifecycleMu sync.Mutex
+
+	// mu guards the fields below. Every critical section under it is a handful
+	// of instructions: IsActive runs on the CAPTURE audio thread (it is the
+	// realtime mic gate), so parking there would underrun the microphone.
+	mu          sync.Mutex
+	device      *malgo.Device
+	onSend      malgo.DataProc // built by Start, used when ensureDevice opens
+	ring        *pcmRing
+	started     bool
+	writes      int64     // diagnostic: count of inbound PCM frames
+	lastWrite   time.Time // when the most recent output frame arrived (echo gate)
+	lastDropLog time.Time // rate-limits the backlog-full line
+	carry       [1]byte   // half a sample held back from a previous frame
+	carryLen    int
+
+	// The fields below are read or written by the render callback, so they are
+	// atomics: the callback runs on the audio thread and must not take mu.
+	//
+	// priming is the playout buffer state: while set, the callback outputs
+	// silence and lets the cushion build. cushion is the current target depth in
+	// bytes. lastWriteNanos is when the last frame arrived, which is how the
+	// callback tells a late frame from the end of the response. underruns is a
+	// diagnostic, reported from Write (never logged on the audio thread).
+	priming        atomic.Bool
+	cushion        atomic.Int64
+	lastWriteNanos atomic.Int64
+	underruns      atomic.Int64
+	// deviceFailed latches a failed open so the read loop tries once per
+	// session rather than once per frame. Cleared by Start and by a success.
+	deviceFailed atomic.Bool
+	// underrunPending records that the render callback ran short. The cushion
+	// only widens when audio actually RESUMES afterwards (see Write): a
+	// shortfall with nothing following it is the end of a response, not jitter,
+	// and widening on those ratchets playout latency up over a conversation.
+	underrunPending atomic.Bool
+}
+
+// IsActive reports whether the assistant is currently producing output audio:
 // true while the buffer holds samples, or within the hangover after the last
 // frame. The realtime controller uses this to gate the mic (half-duplex echo
 // suppression when there's no native AEC, e.g. on speakers).
 func (p *AudioStreamPlayer) IsActive() bool {
 	p.mu.Lock()
-	defer p.mu.Unlock()
-	if len(p.buf)-p.readPos > 0 {
+	ring, last := p.ring, p.lastWrite
+	p.mu.Unlock()
+
+	if ring != nil && ring.pending() > 0 {
 		return true
 	}
-	return !p.lastWrite.IsZero() && time.Since(p.lastWrite) < echoHangover
+	return !last.IsZero() && time.Since(last) < echoHangover
 }
 
 func NewAudioStreamPlayer() *AudioStreamPlayer { return &AudioStreamPlayer{} }
 
 // Start opens the persistent output device. Idempotent.
 func (p *AudioStreamPlayer) Start() error {
+	p.lifecycleMu.Lock()
+	defer p.lifecycleMu.Unlock()
+
 	p.mu.Lock()
-	defer p.mu.Unlock()
-	if p.started {
+	started := p.started
+	p.mu.Unlock()
+	if started {
 		return nil
 	}
-	if p.ctx == nil {
-		ctx, err := malgo.InitContext(nil, malgo.ContextConfig{}, func(m string) {
-			log.Printf("[stream] miniaudio: %s", m)
-		})
-		if err != nil {
-			return err
+
+	// Fail fast if audio is unusable at all, but do NOT open the device here:
+	// see ensureDevice.
+	if _, err := streamPlaybackContext(); err != nil {
+		return err
+	}
+
+	// One allocation for the whole session. The callback closes over this ring
+	// directly rather than reading p.ring, so it never needs p.mu and Stop()
+	// can tear the device down without deadlocking against an in-flight
+	// callback waiting for a lock Stop holds.
+	ring := newPCMRing(streamPlaybackSampleRate, 1, streamBacklogSeconds)
+	p.priming.Store(true)
+	p.cushion.Store(jitterPrimeBytes) // each session re-learns the network
+	p.underruns.Store(0)
+	p.lastWriteNanos.Store(0)
+	p.deviceFailed.Store(false)
+	p.underrunPending.Store(false)
+
+	cfg := malgo.DefaultDeviceConfig(malgo.Playback)
+	cfg.Playback.Format = malgo.FormatS16
+	cfg.Playback.Channels = 1
+	cfg.SampleRate = streamPlaybackSampleRate
+	cfg.PeriodSizeInMilliseconds = streamPeriodMs
+	cfg.Periods = streamPeriods
+	cfg.Alsa.NoMMap = 1
+
+	onSend := func(output, _ []byte, frameCount uint32) {
+		need := int(frameCount) * 2 // s16 mono = 2 bytes/frame
+		if need > len(output) {
+			need = len(output)
 		}
-		p.ctx = ctx
+		p.render(output[:need], ring)
+	}
+
+	p.mu.Lock()
+	p.ring = ring
+	p.onSend = onSend
+	p.started = true
+	p.mu.Unlock()
+	return nil
+}
+
+// ensureDevice opens the output device on the first frame that actually needs
+// it, rather than when the session starts.
+//
+// Realtime sessions are opened and closed without ever producing a sample more
+// often than you would think: a mis-fired global hotkey, or a session the daemon
+// declines and closes immediately. A real log showed two such sessions inside
+// three seconds, each cycling a WASAPI render stream on a Realtek endpoint for
+// audio that never came. That churn is pointless at best, and on endpoints that
+// pop when the render stream powers up and down it is audible.
+//
+// Uses TryLock so Write keeps its "never blocks the read loop" property: if a
+// Start or Stop is in flight, the next frame (40 ms later) opens the device.
+func (p *AudioStreamPlayer) ensureDevice() {
+	p.mu.Lock()
+	need := p.started && p.device == nil && p.onSend != nil
+	p.mu.Unlock()
+	if !need {
+		return
+	}
+	if !p.lifecycleMu.TryLock() {
+		return
+	}
+	defer p.lifecycleMu.Unlock()
+
+	p.mu.Lock()
+	need, onSend := p.started && p.device == nil && p.onSend != nil, p.onSend
+	p.mu.Unlock()
+	if !need {
+		return
+	}
+
+	// One attempt per session. Without this a session with no usable output
+	// endpoint retries InitDevice synchronously on the read loop for every
+	// inbound frame, 25 times a second, each with a log line.
+	if !p.deviceFailed.CompareAndSwap(false, true) {
+		return
+	}
+
+	ctx, err := streamPlaybackContext()
+	if err != nil {
+		log.Printf("[stream] playback context unavailable: %v", err)
+		return
 	}
 
 	cfg := malgo.DefaultDeviceConfig(malgo.Playback)
 	cfg.Playback.Format = malgo.FormatS16
 	cfg.Playback.Channels = 1
 	cfg.SampleRate = streamPlaybackSampleRate
+	cfg.PeriodSizeInMilliseconds = streamPeriodMs
+	cfg.Periods = streamPeriods
 	cfg.Alsa.NoMMap = 1
 
-	// Render callback: a playout (jitter) buffer read via a cursor. While priming,
-	// output silence until the cushion (jitterPrimeBytes) is built up, then drain
-	// by advancing readPos (NOT shifting the whole queue — that was O(n) every
-	// callback and choppy for long, deeply-buffered answers). On full drain, reset
-	// the slice and re-prime so the next response rebuilds its cushion.
-	p.priming = true
-	onSend := func(output, _ []byte, frameCount uint32) {
-		need := int(frameCount) * 2 // s16 mono = 2 bytes/frame
-		if need > len(output) {
-			need = len(output)
-		}
-		p.mu.Lock()
-		avail := len(p.buf) - p.readPos
-		if p.priming {
-			if avail >= jitterPrimeBytes {
-				p.priming = false // cushion built — start draining
-			} else {
-				p.mu.Unlock()
-				for i := 0; i < need; i++ {
-					output[i] = 0
-				}
-				return
-			}
-		}
-		n := copy(output[:need], p.buf[p.readPos:])
-		p.readPos += n
-		if p.readPos >= len(p.buf) {
-			// Fully drained — reset to reuse the backing array, re-prime.
-			p.buf = p.buf[:0]
-			p.readPos = 0
-			p.priming = true
-		} else if p.readPos >= 1<<20 {
-			// Reclaim consumed space occasionally (amortized O(1)), never per-callback.
-			rem := len(p.buf) - p.readPos
-			copy(p.buf, p.buf[p.readPos:])
-			p.buf = p.buf[:rem]
-			p.readPos = 0
-		}
-		p.mu.Unlock()
-		for i := n; i < need; i++ {
-			output[i] = 0
-		}
-	}
-
-	device, err := malgo.InitDevice(p.ctx.Context, cfg, malgo.DeviceCallbacks{Data: onSend})
+	device, err := malgo.InitDevice(ctx.Context, cfg, malgo.DeviceCallbacks{Data: onSend})
 	if err != nil {
-		return err
+		log.Printf("[stream] playback device init failed: %v", err)
+		return
 	}
 	if err := device.Start(); err != nil {
 		device.Uninit()
-		return err
+		log.Printf("[stream] playback device start failed: %v", err)
+		return
 	}
+
+	p.mu.Lock()
 	p.device = device
-	p.started = true
-	log.Printf("[stream] playback device open (PCM s16 mono %d Hz)", streamPlaybackSampleRate)
-	return nil
+	p.mu.Unlock()
+	p.deviceFailed.Store(false) // opened; nothing to latch
+
+	log.Printf("[stream] playback device open (PCM s16 mono %d Hz, %dx%dms buffer)",
+		streamPlaybackSampleRate, streamPeriods, streamPeriodMs)
 }
 
-// Write appends a PCM frame to the play queue. Bounded so a stalled device can't
-// grow the queue without limit (drops the oldest audio past ~60 s of backlog).
+// render fills out with the next slice of the response. This is the audio-thread
+// hot path: no allocation, a few atomics and two short ring critical sections
+// (the depth check and the read).
+//
+// While priming, it outputs silence and lets the cushion build; once the
+// cushion is there it drains. An underrun fills the rest with silence and
+// re-primes, so the next burst rebuilds the cushion rather than stuttering
+// through it. Split out of the device callback so the cushion, the underrun
+// re-prime and Flush can be tested without an audio device.
+func (p *AudioStreamPlayer) render(out []byte, ring *pcmRing) {
+	pending := ring.pending()
+	ended := p.inputIdle()
+
+	if p.priming.Load() {
+		if pending < int(p.cushion.Load()) && !ended {
+			zeroPCM(out)
+			return
+		}
+		p.priming.Store(false)
+	}
+
+	// The healthy path: a whole buffer, rendered with no seam.
+	if pending >= len(out) {
+		ring.read(out)
+		return
+	}
+
+	if ended {
+		// The tail of the response. Play out what is left, then silence.
+		n := ring.read(out)
+		zeroPCM(out[n:])
+		p.priming.Store(true)
+		return
+	}
+
+	// Mid-response underrun. Deliberately leave the remainder IN the ring rather
+	// than emitting it followed by zeros: a partial buffer padded with silence
+	// is a hard edge in the middle of a waveform, and a hard edge is a click,
+	// which is what a listener describes as a sharp high-pitched glitch. Holding
+	// it means the audio resumes contiguously once the cushion rebuilds.
+	zeroPCM(out)
+	p.priming.Store(true)
+	// Recorded, not acted on: only Write knows whether this was jitter (audio
+	// resumed) or simply the end of the response.
+	p.underrunPending.Store(true)
+}
+
+// noteAudioResumed is called from Write when a frame arrives after the render
+// callback ran short. That ordering is what makes it jitter rather than the end
+// of a response, and only jitter justifies a wider cushion.
+func (p *AudioStreamPlayer) noteAudioResumed() {
+	if !p.underrunPending.CompareAndSwap(true, false) {
+		return
+	}
+	p.underruns.Add(1)
+	for {
+		c := p.cushion.Load()
+		if c >= streamCushionMax {
+			return
+		}
+		next := c + streamCushionStep
+		if next > streamCushionMax {
+			next = streamCushionMax
+		}
+		if p.cushion.CompareAndSwap(c, next) {
+			return
+		}
+	}
+}
+
+func zeroPCM(b []byte) {
+	for i := range b {
+		b[i] = 0
+	}
+}
+
+// inputIdle reports whether the daemon has stopped sending, i.e. the response
+// has ended rather than merely fallen behind.
+func (p *AudioStreamPlayer) inputIdle() bool {
+	last := p.lastWriteNanos.Load()
+	if last == 0 {
+		return false // nothing has ever arrived; there is no tail to drain
+	}
+	return time.Since(time.Unix(0, last)) > streamInputIdle
+}
+
+// Write appends a PCM frame to the play queue. Never blocks: this runs on the
+// readLoop, and a stalled output device must cost old audio rather than stall
+// the connection. Past ~60 s of backlog the oldest un-played audio is dropped.
 func (p *AudioStreamPlayer) Write(pcm []byte) {
 	if len(pcm) == 0 {
 		return
 	}
+	now := time.Now()
+	p.lastWriteNanos.Store(now.UnixNano())
 	p.mu.Lock()
-	p.buf = append(p.buf, pcm...)
-	// Only a stalled device (not draining) can exceed the cap; drop the oldest
-	// un-played audio by advancing the cursor. Real answers never reach this.
-	if avail := len(p.buf) - p.readPos; avail > maxBacklogBytes {
-		p.readPos += avail - maxBacklogBytes
-	}
+	ring := p.ring
 	p.writes++
-	p.lastWrite = time.Now()
 	w := p.writes
+	p.lastWrite = now
 	p.mu.Unlock()
+
+	if ring == nil {
+		return // stopped between the daemon's send and our write
+	}
+	pcm = p.alignToFrames(pcm)
+	if len(pcm) == 0 {
+		return
+	}
+	p.noteAudioResumed()
+	p.ensureDevice()
+	if _, dropped := ring.writeDropOldest(pcm); dropped > 0 {
+		// Once a stalled device fills the backlog, EVERY inbound frame drops.
+		// At 25 frames/s that is a log line every 40 ms for as long as the stall
+		// lasts, so rate-limit it to one line per stall-ish window.
+		p.mu.Lock()
+		say := time.Since(p.lastDropLog) > time.Second
+		if say {
+			p.lastDropLog = time.Now()
+		}
+		p.mu.Unlock()
+		if say {
+			log.Printf("[stream] output backlog full (%d bytes); dropping the oldest audio",
+				ring.capacity())
+		}
+	}
 	if w == 1 || w%125 == 0 { // first inbound frame, then every ~5 s
-		log.Printf("[stream] pcm frames received from daemon: %d", w)
+		// Reported here rather than from the render callback: this runs on the
+		// read loop, where logging is allowed. Underruns and a cushion above the
+		// base are the signature of a delivery path slower or jitterier than the
+		// playout buffer, which sounds like chopped speech with a click at every
+		// seam.
+		log.Printf("[stream] pcm frames received from daemon: %d (buffered %dms, cushion %dms, underruns %d)",
+			w, msOfPCM(ring.pending()), msOfPCM(int(p.cushion.Load())), p.underruns.Load())
 	}
 }
 
+// alignToFrames trims a trailing half-sample and carries it into the next
+// frame. Frames from the daemon are whole samples, but nothing on the wire
+// enforces it, and a dropped odd byte byte-shifts every sample after it into
+// full-scale static: the exact failure this player was rewritten to make
+// impossible. Runs on the read loop under p.mu, never on the audio thread.
+func (p *AudioStreamPlayer) alignToFrames(pcm []byte) []byte {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.carryLen > 0 {
+		joined := make([]byte, 0, p.carryLen+len(pcm))
+		joined = append(joined, p.carry[:p.carryLen]...)
+		pcm = append(joined, pcm...)
+		p.carryLen = 0
+	}
+	if odd := len(pcm) % 2; odd != 0 {
+		p.carry[0] = pcm[len(pcm)-1]
+		p.carryLen = 1
+		pcm = pcm[:len(pcm)-1]
+	}
+	return pcm
+}
+
+// msOfPCM converts a byte count at the stream format to milliseconds.
+func msOfPCM(b int) int { return b * 1000 / (streamPlaybackSampleRate * 2) }
+
 // Flush drops all queued audio immediately (barge-in / interruption) and
-// re-arms priming so the next response rebuilds its playout cushion.
+// re-arms priming so the next response rebuilds its playout cushion. Audio
+// already committed to the device (up to one buffer) still plays out.
 func (p *AudioStreamPlayer) Flush() {
 	p.mu.Lock()
-	p.buf = p.buf[:0]
-	p.readPos = 0
-	p.priming = true
+	ring := p.ring
 	p.mu.Unlock()
+
+	if ring != nil {
+		ring.flush()
+	}
+	p.priming.Store(true)
 }
 
 // Stop closes the device and releases the queue. Idempotent.
+//
+// The device is stopped OUTSIDE p.mu on purpose. ma_device_stop waits for the
+// audio thread to finish its current callback; holding the callback's lock
+// across that wait is a deadlock. (The callback doesn't take p.mu today, but
+// the ordering is the invariant worth keeping, not the current callback body.)
 func (p *AudioStreamPlayer) Stop() {
+	p.lifecycleMu.Lock()
+	defer p.lifecycleMu.Unlock()
+
 	p.mu.Lock()
-	defer p.mu.Unlock()
-	if p.device != nil {
-		_ = p.device.Stop()
-		p.device.Uninit()
-		p.device = nil
-	}
-	p.buf = nil
-	p.readPos = 0
+	device, ring := p.device, p.ring
+	p.device, p.ring, p.onSend = nil, nil, nil
 	p.started = false
+	p.mu.Unlock()
+
+	if ring != nil {
+		ring.flush()
+	}
+	if device != nil {
+		_ = device.Stop()
+		device.Uninit()
+	}
+	p.priming.Store(true)
 }

--- a/sidecar/pebble_stream_test.go
+++ b/sidecar/pebble_stream_test.go
@@ -1,0 +1,323 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+	"time"
+)
+
+// The stream player's render body is split out of the malgo callback precisely
+// so the jitter cushion can be tested without an audio device.
+
+func silence(n int) []byte { return make([]byte, n) }
+
+func loudPCM(n int) []byte {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = 0x7F
+	}
+	return b
+}
+
+// While priming, the callback must output silence even though audio is
+// available: that is the whole point of the playout cushion. It starts draining
+// only once the cushion is built.
+func TestStreamRenderHoldsSilenceUntilCushionIsBuilt(t *testing.T) {
+	p := NewAudioStreamPlayer()
+	ring := newPCMRing(streamPlaybackSampleRate, 1, streamBacklogSeconds)
+	p.priming.Store(true)
+	p.cushion.Store(jitterPrimeBytes)
+
+	// Just under the cushion: still silence, still priming.
+	ring.write(loudPCM(jitterPrimeBytes - 2))
+	out := make([]byte, 480)
+	p.render(out, ring)
+	if !bytes.Equal(out, silence(len(out))) {
+		t.Fatal("expected silence while the cushion is still building")
+	}
+	if !p.priming.Load() {
+		t.Fatal("expected to still be priming below the cushion")
+	}
+	if ring.pending() != jitterPrimeBytes-2 {
+		t.Fatal("priming must not consume the buffer it is accumulating")
+	}
+
+	// Over the cushion: drains.
+	ring.write(loudPCM(480))
+	p.render(out, ring)
+	if bytes.Equal(out, silence(len(out))) {
+		t.Fatal("expected audio once the cushion is built")
+	}
+	if p.priming.Load() {
+		t.Fatal("expected priming to have cleared")
+	}
+}
+
+// A mid-response underrun must NOT emit the partial audio it has. A partial
+// buffer padded with zeros puts a hard edge in the middle of a waveform, and a
+// hard edge is a click: the sharp high-pitched glitch users reported. The
+// remainder stays in the ring so playback resumes contiguously once the cushion
+// rebuilds, and the cushion widens so the next gap of that size is absorbed.
+func TestStreamRenderHoldsAudioBackOnMidResponseUnderrun(t *testing.T) {
+	p := NewAudioStreamPlayer()
+	ring := newPCMRing(streamPlaybackSampleRate, 1, streamBacklogSeconds)
+	p.priming.Store(false)
+	p.cushion.Store(jitterPrimeBytes)
+	p.lastWriteNanos.Store(time.Now().UnixNano()) // the daemon is still sending
+
+	ring.write(loudPCM(100))
+	out := make([]byte, 480)
+	p.render(out, ring)
+
+	if !bytes.Equal(out, silence(len(out))) {
+		t.Fatal("expected a clean silent buffer, not a partial one with a seam")
+	}
+	if ring.pending() != 100 {
+		t.Fatalf("pending = %d, want the 100 bytes held back for contiguous playback", ring.pending())
+	}
+	if !p.priming.Load() {
+		t.Fatal("expected an underrun to re-arm priming")
+	}
+	// The widen is deferred: only audio ARRIVING after the shortfall proves it
+	// was jitter rather than the end of the response.
+	if got := p.cushion.Load(); got != jitterPrimeBytes {
+		t.Fatalf("cushion = %d, want it unchanged until audio resumes", got)
+	}
+	p.noteAudioResumed()
+	if p.underruns.Load() != 1 {
+		t.Fatalf("underruns = %d, want 1", p.underruns.Load())
+	}
+	if got := p.cushion.Load(); got != jitterPrimeBytes+streamCushionStep {
+		t.Fatalf("cushion = %d, want it widened to %d", got, jitterPrimeBytes+streamCushionStep)
+	}
+}
+
+// The ratchet this guards against: with delivery paced near real time, the ring
+// runs dry at the end of EVERY response. Widening on those would push playout
+// latency to the cap over a conversation and add most of a second before the
+// assistant starts speaking.
+func TestStreamCushionDoesNotWidenAtTheEndOfAResponse(t *testing.T) {
+	p := NewAudioStreamPlayer()
+	ring := newPCMRing(streamPlaybackSampleRate, 1, streamBacklogSeconds)
+	p.cushion.Store(jitterPrimeBytes)
+	out := make([]byte, 480)
+
+	for turn := 0; turn < 20; turn++ {
+		// A response: audio arrives, plays, then the ring runs dry and nothing
+		// follows before the next turn begins.
+		p.priming.Store(false)
+		p.lastWriteNanos.Store(time.Now().UnixNano())
+		ring.write(loudPCM(100))
+		p.render(out, ring) // short: holds back, marks pending
+		ring.flush()
+	}
+	if got := p.cushion.Load(); got != jitterPrimeBytes {
+		t.Fatalf("cushion = %d after 20 quiet turn endings, want the base %d", got, jitterPrimeBytes)
+	}
+	if got := p.underruns.Load(); got != 0 {
+		t.Fatalf("underruns = %d, want 0: a response ending is not an underrun", got)
+	}
+}
+
+// Write is where a resumed stream is noticed, so the wiring has to hold.
+func TestStreamWriteWidensTheCushionAfterAShortfall(t *testing.T) {
+	p := NewAudioStreamPlayer()
+	ring := newPCMRing(streamPlaybackSampleRate, 1, streamBacklogSeconds)
+	p.mu.Lock()
+	p.ring = ring
+	p.started = true
+	p.mu.Unlock()
+	p.cushion.Store(jitterPrimeBytes)
+	p.priming.Store(false)
+	p.lastWriteNanos.Store(time.Now().UnixNano())
+
+	ring.write(loudPCM(100))
+	p.render(make([]byte, 480), ring) // shortfall mid-response
+	p.Write(loudPCM(960))             // ... and the stream resumes
+
+	if got := p.cushion.Load(); got != jitterPrimeBytes+streamCushionStep {
+		t.Fatalf("cushion = %d, want %d", got, jitterPrimeBytes+streamCushionStep)
+	}
+}
+
+// Half a sample must never be dropped: the next frame would be byte-shifted,
+// and byte-shifted s16 is full-scale static.
+func TestStreamWriteCarriesAnOddTrailingByte(t *testing.T) {
+	p := NewAudioStreamPlayer()
+	ring := newPCMRing(streamPlaybackSampleRate, 1, streamBacklogSeconds)
+	p.mu.Lock()
+	p.ring = ring
+	p.started = true
+	p.mu.Unlock()
+
+	p.Write([]byte{1, 2, 3})    // one whole sample, one orphaned byte
+	p.Write([]byte{4, 5, 6, 7}) // the orphan pairs with the first byte here
+
+	got := make([]byte, 8)
+	n := ring.read(got)
+	want := []byte{1, 2, 3, 4, 5, 6}
+	if n != len(want) || !bytes.Equal(got[:n], want) {
+		t.Fatalf("got %v, want %v (nothing dropped, nothing reordered)", got[:n], want)
+	}
+	if rem := ring.pending(); rem != 0 {
+		t.Fatalf("pending = %d, want 0 with one byte still carried", rem)
+	}
+}
+
+// The cushion must widen on repeated underruns but stop at the cap, or a bad
+// network would push playout latency up without bound.
+func TestStreamCushionWidensToACap(t *testing.T) {
+	p := NewAudioStreamPlayer()
+	ring := newPCMRing(streamPlaybackSampleRate, 1, streamBacklogSeconds)
+	p.cushion.Store(jitterPrimeBytes)
+	out := make([]byte, 480)
+
+	for i := 0; i < 100; i++ {
+		p.priming.Store(false)
+		p.lastWriteNanos.Store(time.Now().UnixNano())
+		p.render(out, ring)
+		p.noteAudioResumed() // the stream keeps flowing: genuine jitter
+	}
+	if got := p.cushion.Load(); got != streamCushionMax {
+		t.Fatalf("cushion = %d, want the cap %d", got, streamCushionMax)
+	}
+}
+
+// The end of a response is not an underrun: once the daemon stops sending, the
+// last partial buffer has to be played out. Otherwise it is stranded in the ring
+// and surfaces as a stale fragment in front of the NEXT answer.
+func TestStreamRenderDrainsTheTailWhenInputStops(t *testing.T) {
+	p := NewAudioStreamPlayer()
+	ring := newPCMRing(streamPlaybackSampleRate, 1, streamBacklogSeconds)
+	p.priming.Store(false)
+	p.cushion.Store(jitterPrimeBytes)
+	// The daemon stopped sending a while ago: the response is over.
+	p.lastWriteNanos.Store(time.Now().Add(-2 * streamInputIdle).UnixNano())
+
+	ring.write(loudPCM(100))
+	out := make([]byte, 480)
+	p.render(out, ring)
+
+	if !bytes.Equal(out[:100], loudPCM(100)) {
+		t.Fatal("expected the tail to be played out")
+	}
+	if !bytes.Equal(out[100:], silence(len(out)-100)) {
+		t.Fatal("expected silence after the tail")
+	}
+	if ring.pending() != 0 {
+		t.Fatalf("pending = %d, want the tail consumed", ring.pending())
+	}
+	if p.underruns.Load() != 0 {
+		t.Fatal("the end of a response must not count as an underrun")
+	}
+	if got := p.cushion.Load(); got != jitterPrimeBytes {
+		t.Fatal("the end of a response must not widen the cushion")
+	}
+}
+
+// A response that ends while still priming must still release its tail, or a
+// very short answer (less than one cushion) would never play at all.
+func TestStreamRenderReleasesAShortAnswerStuckBelowTheCushion(t *testing.T) {
+	p := NewAudioStreamPlayer()
+	ring := newPCMRing(streamPlaybackSampleRate, 1, streamBacklogSeconds)
+	p.priming.Store(true)
+	p.cushion.Store(jitterPrimeBytes)
+	p.lastWriteNanos.Store(time.Now().Add(-2 * streamInputIdle).UnixNano())
+
+	ring.write(loudPCM(480)) // well under the cushion
+	out := make([]byte, 480)
+	p.render(out, ring)
+
+	if bytes.Equal(out, silence(len(out))) {
+		t.Fatal("a finished short answer must play, not wait for a cushion that will never arrive")
+	}
+}
+
+// A full buffer must render without touching priming: no cushion rebuild in the
+// middle of a healthy response.
+func TestStreamRenderLeavesPrimingAloneWhenFed(t *testing.T) {
+	p := NewAudioStreamPlayer()
+	ring := newPCMRing(streamPlaybackSampleRate, 1, streamBacklogSeconds)
+	p.priming.Store(false)
+	p.cushion.Store(jitterPrimeBytes)
+
+	ring.write(loudPCM(4800))
+	out := make([]byte, 480)
+	for i := 0; i < 10; i++ {
+		p.render(out, ring)
+		if bytes.Equal(out, silence(len(out))) {
+			t.Fatalf("render %d produced silence with a full buffer", i)
+		}
+		if p.priming.Load() {
+			t.Fatalf("render %d re-primed with a full buffer", i)
+		}
+	}
+}
+
+// Flush is barge-in: the queue empties and the next response has to rebuild its
+// cushion rather than playing the tail of the interrupted one.
+func TestStreamFlushDropsQueuedAudioAndRePrimes(t *testing.T) {
+	p := NewAudioStreamPlayer()
+	ring := newPCMRing(streamPlaybackSampleRate, 1, streamBacklogSeconds)
+	p.mu.Lock()
+	p.ring = ring
+	p.mu.Unlock()
+	p.priming.Store(false)
+
+	ring.write(loudPCM(jitterPrimeBytes * 2))
+	p.Flush()
+
+	if ring.pending() != 0 {
+		t.Fatalf("pending = %d after Flush, want 0", ring.pending())
+	}
+	if !p.priming.Load() {
+		t.Fatal("expected Flush to re-arm priming")
+	}
+
+	out := make([]byte, 480)
+	p.render(out, ring)
+	if !bytes.Equal(out, silence(len(out))) {
+		t.Fatal("expected silence immediately after a flush")
+	}
+}
+
+// IsActive is the realtime half-duplex mic gate. It must report true while
+// audio is queued, and it must not panic or block when no device is open.
+func TestStreamIsActiveTracksQueuedAudio(t *testing.T) {
+	p := NewAudioStreamPlayer()
+	if p.IsActive() {
+		t.Fatal("expected inactive before anything is written")
+	}
+
+	ring := newPCMRing(streamPlaybackSampleRate, 1, streamBacklogSeconds)
+	p.mu.Lock()
+	p.ring = ring
+	p.mu.Unlock()
+
+	ring.write(loudPCM(480))
+	if !p.IsActive() {
+		t.Fatal("expected active while audio is queued")
+	}
+
+	ring.read(make([]byte, 480))
+	// Drained, but no frame has ever arrived, so the echo hangover has nothing
+	// to hold open.
+	if p.IsActive() {
+		t.Fatal("expected inactive once drained with no recent write")
+	}
+}
+
+// Write must be safe (and a no-op) when the player has been stopped, since a
+// play_pcm frame can arrive between the daemon's send and our teardown.
+func TestStreamWriteAfterStopIsHarmless(t *testing.T) {
+	p := NewAudioStreamPlayer()
+	p.Stop() // never started; must not panic
+	p.Write(loudPCM(480))
+
+	p.mu.Lock()
+	writes := p.writes
+	p.mu.Unlock()
+	if writes != 1 {
+		t.Fatalf("writes = %d, want 1 (the frame is still counted)", writes)
+	}
+}

--- a/sidecar/pebble_wake.go
+++ b/sidecar/pebble_wake.go
@@ -46,7 +46,7 @@ import (
 type WakeListenerOpts struct {
 	RMSThreshold      float64       // chunk RMS above this counts as speech (default 500)
 	SilenceCutoff     time.Duration // silence after speech that ends a segment (default 900 ms)
-	MinSegmentDur     time.Duration // DEPRECATED: superseded by minWakeSpeechChunks; no longer gates emission
+	MinSegmentDur     time.Duration // DEPRECATED: superseded by minWakeSpeechMs; no longer gates emission
 	MaxSegmentDur     time.Duration // hard cap on segment length (default 12 s)
 	PreSpeechIdleScan time.Duration // poll interval while waiting for speech (default 50 ms)
 }
@@ -94,8 +94,10 @@ type WakeListenerService struct {
 	// read by the coordinator goroutine. Mutex-protected.
 	mu              sync.Mutex
 	segBuf          []byte
+	segFullLogged   bool // one "segment full" line per segment, not per chunk
 	speechSeen      bool
-	speechChunks    int // count of speech-energy chunks this segment (gap-tolerant)
+	speechChunks    int // count of speech-energy chunks this segment (diagnostic only)
+	speechBytes     int // voiced PCM in this segment; what the emit gate measures
 	speechStartedAt time.Time
 	lastSpeechAt    time.Time
 	segStartedAt    time.Time
@@ -106,11 +108,15 @@ type WakeListenerService struct {
 // listener does NOT start automatically — call Start() once the websocket
 // connection is up so the segments have somewhere to go.
 func NewWakeListenerService(audioSvc *AudioCaptureService, sender EventSender, opts WakeListenerOpts) *WakeListenerService {
-	return &WakeListenerService{
+	w := &WakeListenerService{
 		audioSvc: audioSvc,
 		sender:   sender,
 		opts:     opts,
 	}
+	// Reserve the segment buffer here, not on first use: the first use is on
+	// the audio thread. See appendSegment.
+	w.segBuf = make([]byte, 0, w.segmentCapBytes())
+	return w
 }
 
 // Start kicks off the continuous capture + segmentation loop. Idempotent.
@@ -136,7 +142,7 @@ func (w *WakeListenerService) Start(ctx context.Context) error {
 
 	// Hook the chunk listener BEFORE Start so we don't miss any audio.
 	w.audioSvc.SetChunkListener(w.onChunk)
-	if err := w.audioSvc.Start(fmt.Sprintf("wake-%d", time.Now().UnixMilli())); err != nil {
+	if err := w.audioSvc.StartStreaming(fmt.Sprintf("wake-%d", time.Now().UnixMilli())); err != nil {
 		w.audioSvc.SetChunkListener(nil)
 		w.running.Store(false)
 		close(w.doneCh)
@@ -197,7 +203,7 @@ func (w *WakeListenerService) Resume(ctx context.Context) {
 			w.paused.Store(true)
 			return
 		}
-		if err = w.audioSvc.Start(fmt.Sprintf("wake-%d", time.Now().UnixMilli())); err == nil {
+		if err = w.audioSvc.StartStreaming(fmt.Sprintf("wake-%d", time.Now().UnixMilli())); err == nil {
 			log.Printf("[wake] resumed")
 			return
 		}
@@ -254,9 +260,10 @@ func (w *WakeListenerService) Suppress(yes bool) {
 }
 
 // onChunk runs on the malgo callback goroutine for every PCM buffer.
-// Updates the segmentation state under the mutex. Cheap — RMS over a
-// 30 ms buffer is ~480 multiplies. Keep work here minimal so we don't
-// stall the audio thread.
+// Updates the segmentation state under the mutex. Cheap: RMS over one
+// capture period (320 samples at the 20 ms the sidecar now requests) is a
+// few hundred multiplies. Keep work here minimal so we don't stall the
+// audio thread.
 func (w *WakeListenerService) onChunk(buf []byte) {
 	if w.paused.Load() || w.suppressDepth.Load() > 0 {
 		return
@@ -277,16 +284,41 @@ func (w *WakeListenerService) onChunk(buf []byte) {
 			w.segStartedAt = now
 		}
 		w.speechChunks++
+		w.speechBytes += len(buf)
 		w.lastSpeechAt = now
-		w.segBuf = append(w.segBuf, buf...)
+		w.appendSegment(buf)
 		return
 	}
-	// Silent chunk — append only if we're already mid-segment, so the
+	// Silent chunk: append only if we're already mid-segment, so the
 	// trailing silence becomes part of the emitted PCM (helps STT not
 	// chop final phonemes).
 	if w.speechSeen {
-		w.segBuf = append(w.segBuf, buf...)
+		w.appendSegment(buf)
 	}
+}
+
+// appendSegment adds a chunk to the in-flight segment without ever growing the
+// backing array. This runs on the miniaudio callback goroutine, i.e. the audio
+// thread: a realloc-and-copy of a few hundred kilobytes there stalls the device
+// past its period and underruns, which is audible as a glitch. resetSegment
+// reserves the whole cap up front, and the coordinator's MaxSegmentDur is the
+// real bound; this ceiling only catches the case where the coordinator's 25 ms
+// poll hasn't come round yet. Caller holds w.mu.
+func (w *WakeListenerService) appendSegment(buf []byte) {
+	if cap(w.segBuf) == 0 {
+		// Belt and braces: the constructor reserves this, so reaching here means
+		// a listener built some other way. Pay the one allocation rather than
+		// going deaf.
+		w.segBuf = make([]byte, 0, w.segmentCapBytes())
+	}
+	if len(w.segBuf)+len(buf) > cap(w.segBuf) {
+		if !w.segFullLogged {
+			w.segFullLogged = true
+			log.Printf("[wake] segment hit its %d byte ceiling; dropping the tail until it is emitted", cap(w.segBuf))
+		}
+		return // the coordinator's MaxSegmentDur will emit it shortly
+	}
+	w.segBuf = append(w.segBuf, buf...)
 }
 
 // coordinate runs the segment-emission timer. Polls the segmentation
@@ -315,12 +347,33 @@ func (w *WakeListenerService) coordinate(ctx context.Context) {
 // maybeEmitSegment checks whether the current segment is ready to emit
 // (silence cutoff reached, or hard cap exceeded). When ready, snapshots
 // the buffer, resets state, and ships the segment to the daemon.
-// minWakeSpeechChunks is the floor on speech-energy chunks for a segment to be
-// shipped for STT. At the ~30 ms capture buffer this is ~90 ms of voiced audio
-// — enough to reject stray clicks/blips while still catching a single short
-// "Jarvis". (Replaces the old first-to-last speech-timestamp span, which
-// under-measured clipped words and silently dropped the core wake utterance.)
-const minWakeSpeechChunks = 3
+// minWakeSpeechMs is the floor on VOICED audio for a segment to be shipped for
+// STT: enough to reject stray clicks and keystrokes while still catching a
+// single short "Jarvis". (It replaced a first-to-last speech-timestamp span,
+// which under-measured clipped words and silently dropped the core wake
+// utterance.)
+//
+// Measured in milliseconds of audio, not in callback buffers. It used to be a
+// count of 3 buffers, documented as "~90 ms at the ~30 ms capture buffer", but
+// the buffer size is the device's choice, not ours: the host that reported the
+// voice bugs ran 160 frames at 16 kHz, i.e. 10 ms, which made the real floor
+// 30 ms. That shipped a segment for every noise blip, roughly one STT round
+// trip every two seconds while the user was simply talking near the machine.
+//
+// The effective floor is quantized upward by the capture period: at the 20 ms
+// the sidecar requests, four chunks are 80 ms and five are 100 ms, so 100 ms is
+// what actually ships. Well under a spoken "Jarvis" (350-500 ms voiced).
+const minWakeSpeechMs = 90
+
+// wakeSpeechMs converts a count of captured s16 mono bytes to milliseconds at
+// the wake listener's capture format.
+func wakeSpeechMs(b int) int {
+	bytesPerMs := pebbleAudioSampleRate * pebbleAudioChannels * 2 / 1000
+	if bytesPerMs <= 0 {
+		return 0
+	}
+	return b / bytesPerMs
+}
 
 func (w *WakeListenerService) maybeEmitSegment(ctx context.Context) {
 	now := time.Now()
@@ -335,23 +388,31 @@ func (w *WakeListenerService) maybeEmitSegment(ctx context.Context) {
 		w.mu.Unlock()
 		return
 	}
-	pcm := w.segBuf
+	// Copy rather than hand the array over: segBuf is reserved once and reused
+	// so the audio thread never allocates (see appendSegment). The copy runs
+	// here, on the coordinator goroutine, not in the callback.
+	pcm := append([]byte(nil), w.segBuf...)
 	speechDur := w.lastSpeechAt.Sub(w.speechStartedAt)
 	speechChunks := w.speechChunks
-	w.segBuf = nil
+	speechMs := wakeSpeechMs(w.speechBytes)
+	w.segBuf = w.segBuf[:0]
+	w.segFullLogged = false
 	w.speechSeen = false
 	w.speechChunks = 0
+	w.speechBytes = 0
 	w.mu.Unlock()
 
-	// Discard tiny blips — most likely background noise, not a real utterance.
-	// Gate on the COUNT of speech-energy chunks, not the first-to-last speech
-	// timestamp span: a single clipped/quiet word ("Jarvis") whose energy only
-	// crosses the threshold in a few non-contiguous chunks has a tiny span yet
-	// is exactly what we must catch. The chunk count is gap-tolerant. The
+	// Discard tiny blips: most likely background noise, not a real utterance.
+	// Gate on the TOTAL voiced audio, not the first-to-last speech timestamp
+	// span: a single clipped or quiet word ("Jarvis") whose energy only crosses
+	// the threshold in a few non-contiguous chunks has a tiny span yet is
+	// exactly what we must catch. Summing voiced audio is gap-tolerant in the
+	// same way while staying independent of the device's buffer size. The
 	// daemon's STT + "jarvis" regex is the real noise filter, so we err toward
 	// keeping borderline segments.
-	if speechChunks < minWakeSpeechChunks {
-		log.Printf("[wake] discard short segment (%d speech chunks, %dms span)", speechChunks, speechDur.Milliseconds())
+	if speechMs < minWakeSpeechMs {
+		log.Printf("[wake] discard short segment (%dms speech in %d chunks, %dms span)",
+			speechMs, speechChunks, speechDur.Milliseconds())
 		return
 	}
 	if len(pcm) == 0 {
@@ -361,8 +422,8 @@ func (w *WakeListenerService) maybeEmitSegment(ctx context.Context) {
 	segmentID := fmt.Sprintf("wake-%d", now.UnixMilli())
 	durMs := int64(speechDur / time.Millisecond)
 	totalMs := int64(totalDur / time.Millisecond)
-	log.Printf("[wake] emit segment %s (%d PCM bytes, %dms speech, %dms total)",
-		segmentID, len(pcm), durMs, totalMs)
+	log.Printf("[wake] emit segment %s (%d PCM bytes, %dms voiced, %dms span, %dms total)",
+		segmentID, len(pcm), speechMs, durMs, totalMs)
 
 	evt := SidecarEvent{
 		Type:      "sidecar_event",
@@ -392,7 +453,24 @@ func (w *WakeListenerService) maybeEmitSegment(ctx context.Context) {
 func (w *WakeListenerService) resetSegment() {
 	w.mu.Lock()
 	defer w.mu.Unlock()
-	w.segBuf = nil
+	if w.segBuf == nil {
+		w.segBuf = make([]byte, 0, w.segmentCapBytes())
+	} else {
+		w.segBuf = w.segBuf[:0]
+	}
+	w.segFullLogged = false
 	w.speechSeen = false
 	w.speechChunks = 0
+	w.speechBytes = 0
+}
+
+// segmentCapBytes reserves one segment's worth of PCM: the hard cap on segment
+// length plus a second of slack for the coordinator's poll interval, at the
+// capture format (s16 mono, 16 kHz).
+func (w *WakeListenerService) segmentCapBytes() int {
+	d := w.opts.MaxSegmentDur
+	if d <= 0 {
+		d = 12 * time.Second
+	}
+	return int((d+time.Second)/time.Second) * pebbleAudioSampleRate * pebbleAudioChannels * 2
 }

--- a/sidecar/pebble_wake_test.go
+++ b/sidecar/pebble_wake_test.go
@@ -17,19 +17,24 @@ func pcmChunk(n int, amp int16) []byte {
 }
 
 // TestWakeOnChunkCountsSpeech verifies onChunk counts speech-energy chunks and
-// buffers audio, and that resetSegment clears the counter — the signal the
-// emit gate now relies on instead of the fragile first-to-last speech span.
+// buffers audio, and that resetSegment clears it. Voiced BYTES are what the
+// emit gate measures; the chunk count is kept only for the log line.
 func TestWakeOnChunkCountsSpeech(t *testing.T) {
 	w := NewWakeListenerService(nil, nil, DefaultWakeListenerOpts())
 
-	loud := pcmChunk(160, 8000)  // RMS 8000 >> 500 threshold -> speech
-	quiet := pcmChunk(160, 5)    // RMS ~5 << threshold -> silence
+	loud := pcmChunk(160, 8000) // RMS 8000 >> 500 threshold -> speech
+	quiet := pcmChunk(160, 5)   // RMS ~5 << threshold -> silence
 
 	w.onChunk(loud)
 	w.onChunk(loud)
 	w.onChunk(quiet) // trailing silence is buffered but not counted as speech
 	if w.speechChunks != 2 {
 		t.Fatalf("speechChunks = %d, want 2", w.speechChunks)
+	}
+	// Two 160-sample chunks of voiced audio, and only those: the silent one is
+	// buffered for STT but must not count toward the gate.
+	if want := 2 * 160 * 2; w.speechBytes != want {
+		t.Fatalf("speechBytes = %d, want %d", w.speechBytes, want)
 	}
 	if !w.speechSeen {
 		t.Fatalf("speechSeen = false, want true after speech")
@@ -38,18 +43,24 @@ func TestWakeOnChunkCountsSpeech(t *testing.T) {
 		t.Fatalf("segBuf empty, want buffered audio")
 	}
 
+	// resetSegment empties the buffer but keeps its reservation: the array is
+	// reused so the audio thread never has to allocate (see appendSegment).
 	w.resetSegment()
-	if w.speechChunks != 0 || w.speechSeen || w.segBuf != nil {
-		t.Fatalf("resetSegment left state: chunks=%d seen=%v buf=%d", w.speechChunks, w.speechSeen, len(w.segBuf))
+	if w.speechChunks != 0 || w.speechBytes != 0 || w.speechSeen || len(w.segBuf) != 0 {
+		t.Fatalf("resetSegment left state: chunks=%d bytes=%d seen=%v buf=%d",
+			w.speechChunks, w.speechBytes, w.speechSeen, len(w.segBuf))
+	}
+	if cap(w.segBuf) == 0 {
+		t.Fatal("resetSegment dropped the segment buffer's reservation")
 	}
 }
 
 // TestWakeEmitGate verifies maybeEmitSegment discards a too-short segment but
-// ships one with enough speech chunks — catching a clipped "Jarvis" that the
-// old span-based gate would have dropped. State is set directly and lastSpeechAt
-// is backdated so silence exceeds the cutoff without needing a clock.
+// ships one with enough voiced audio: a clipped "Jarvis" that the old
+// span-based gate would have dropped. State is set directly and lastSpeechAt is
+// backdated so silence exceeds the cutoff without needing a clock.
 func TestWakeEmitGate(t *testing.T) {
-	emit := func(chunks int) bool {
+	emitMs := func(ms int) bool {
 		sent := false
 		var sender EventSender = func(context.Context, SidecarEvent, []byte) error {
 			sent = true
@@ -57,20 +68,106 @@ func TestWakeEmitGate(t *testing.T) {
 		}
 		w := NewWakeListenerService(nil, sender, DefaultWakeListenerOpts())
 		past := time.Now().Add(-10 * time.Second) // silence >> SilenceCutoff
+		samples := pebbleAudioSampleRate * ms / 1000
 		w.speechSeen = true
-		w.speechChunks = chunks
+		w.speechChunks = 3
+		w.speechBytes = samples * 2
 		w.speechStartedAt = past
 		w.lastSpeechAt = past
 		w.segStartedAt = past
-		w.segBuf = pcmChunk(160*chunks, 8000)
+		w.segBuf = pcmChunk(samples, 8000)
 		w.maybeEmitSegment(context.Background())
 		return sent
 	}
 
-	if emit(minWakeSpeechChunks - 1) {
-		t.Errorf("segment with %d chunks should be discarded", minWakeSpeechChunks-1)
+	if emitMs(minWakeSpeechMs - 10) {
+		t.Errorf("segment with %dms of voiced audio should be discarded", minWakeSpeechMs-10)
 	}
-	if !emit(minWakeSpeechChunks) {
-		t.Errorf("segment with %d chunks should be emitted (clipped wake word)", minWakeSpeechChunks)
+	if !emitMs(minWakeSpeechMs) {
+		t.Errorf("segment with %dms of voiced audio should be emitted (clipped wake word)", minWakeSpeechMs)
+	}
+}
+
+// The gate must measure AUDIO, not callback buffers. The host that reported the
+// voice bugs delivered 10 ms buffers, where the old count-of-3 gate let 30 ms
+// noise blips through. The same three buffers must now be rejected, while the
+// same 90 ms of speech is accepted however the device chooses to chop it up.
+func TestWakeEmitGateIsIndependentOfDeviceBufferSize(t *testing.T) {
+	segmentFrom := func(chunkSamples, chunks int) bool {
+		sent := false
+		var sender EventSender = func(context.Context, SidecarEvent, []byte) error {
+			sent = true
+			return nil
+		}
+		w := NewWakeListenerService(nil, sender, DefaultWakeListenerOpts())
+		loud := pcmChunk(chunkSamples, 8000)
+		for i := 0; i < chunks; i++ {
+			w.onChunk(loud)
+		}
+		past := time.Now().Add(-10 * time.Second)
+		w.mu.Lock()
+		w.speechStartedAt, w.lastSpeechAt, w.segStartedAt = past, past, past
+		w.mu.Unlock()
+		w.maybeEmitSegment(context.Background())
+		return sent
+	}
+
+	// 10 ms buffers (160 samples at 16 kHz), the shape from the bug report.
+	if segmentFrom(160, 3) {
+		t.Error("three 10ms buffers (30ms of speech) should be discarded")
+	}
+	if !segmentFrom(160, 9) {
+		t.Error("nine 10ms buffers (90ms of speech) should be emitted")
+	}
+	// 30 ms buffers: the same 90 ms of speech, three callbacks instead of nine.
+	if !segmentFrom(480, 3) {
+		t.Error("three 30ms buffers (90ms of speech) should be emitted")
+	}
+	// 20 ms buffers, the period the sidecar actually requests. The floor is
+	// quantized up to 100 ms here; pin both sides of that so a future change to
+	// the capture period has to look at this gate.
+	twentyMs := pebbleAudioSampleRate * int(pebbleCapturePeriodMs) / 1000
+	if segmentFrom(twentyMs, 4) {
+		t.Error("four 20ms buffers (80ms of speech) should be discarded")
+	}
+	if !segmentFrom(twentyMs, 5) {
+		t.Error("five 20ms buffers (100ms of speech) should be emitted")
+	}
+}
+
+// The segment buffer is reserved once and reused so the audio thread never
+// allocates. That only holds if appendSegment refuses to grow past the
+// reservation, and if it says so once per segment rather than once per chunk.
+func TestWakeAppendSegmentRespectsItsCeiling(t *testing.T) {
+	w := NewWakeListenerService(nil, nil, DefaultWakeListenerOpts())
+
+	reserved := cap(w.segBuf)
+	if want := w.segmentCapBytes(); reserved != want {
+		t.Fatalf("reserved %d bytes, want %d", reserved, want)
+	}
+	// The ceiling has to sit above the coordinator's own hard cap, or it would
+	// start truncating normal segments instead of only pathological ones.
+	maxNormal := int(w.opts.MaxSegmentDur/time.Second) * pebbleAudioSampleRate * pebbleAudioChannels * 2
+	if reserved <= maxNormal {
+		t.Fatalf("reservation %d does not clear MaxSegmentDur's %d bytes", reserved, maxNormal)
+	}
+
+	loud := pcmChunk(1600, 8000) // 100 ms
+	w.mu.Lock()
+	for i := 0; i < (reserved/len(loud))+10; i++ {
+		w.appendSegment(loud)
+	}
+	held, ceilingHit := len(w.segBuf), w.segFullLogged
+	grown := cap(w.segBuf)
+	w.mu.Unlock()
+
+	if grown != reserved {
+		t.Fatalf("segment buffer grew from %d to %d: the audio thread allocated", reserved, grown)
+	}
+	if held > reserved {
+		t.Fatalf("held %d bytes in a %d byte reservation", held, reserved)
+	}
+	if !ceilingHit {
+		t.Fatal("expected the ceiling to be noted once")
 	}
 }


### PR DESCRIPTION
Found while chasing a reported audio glitch on Windows and macOS. It does **not** fix that glitch -- the cause turned out to be the dashboard holding the microphone open, which is a separate PR. These are real defects in the sidecar's audio paths that the hunt turned up, and they stand on their own.

## The audio thread was doing work it must not do

The miniaudio data callbacks are Go functions entered from a C audio thread through cgo. They cannot run during a GC stop-the-world, and this process allocates hard (screenshots, OCR, base64, MP3 decode). Missing the render deadline is a buffer underrun.

- The realtime player's playout buffer was a slice that `append` grew up to a 2.88 MB backlog **while holding the mutex the render callback needs**. One realloc could park the audio thread for a multi-megabyte copy.
- Its backlog trim advanced the read cursor by an arbitrary byte count. An odd offset there byte-shifts every following s16 sample into full-scale static.
- The capture accumulator and the wake listener's segment buffer both grew by doubling inside the data callback.
- The wake listener accumulated captured PCM for a session it holds open for hours and then discards -- unbounded growth at roughly 115 MB an hour.
- Every device ran on miniaudio's 10 ms low-latency default, about 30 ms of slack.

All of these now use a fixed-capacity ring allocated once, or reserve up front, or (for the wake listener) accumulate nothing at all. Device periods are set explicitly and sized per backend, since WASAPI buffers `periods x period` while CoreAudio buffers a single period and ignores the count.

## The clip player opened a device per sentence

Streaming TTS sends one clip per sentence, and the player opened, started, stopped and destroyed a fresh device for each one. It also considered a clip finished the moment its last bytes were *copied* into miniaudio rather than played, so the tail of every sentence could be cut.

Now: one long-lived device per format, fed from the ring, released after 30 s of quiet. A device that stops draining (an endpoint disappearing mid-answer) is detected and released -- previously that left a full ring, which pinned the idle timer, never announced that playback had stopped, and left the wake listener suppressed, so voice went deaf until the next hotkey press.

## Ambient screen captures ran through the whole voice turn

The suppression existed but was wired only to the realtime path, so the one-shot summon cycle never used it. A capture tick is a multi-megabyte screenshot plus an OCR subprocess -- around 7 seconds on Windows -- and it could not be interrupted once started. It is now held off for the whole turn and re-checked at each expensive stage.

## Smaller fixes

- `AudioStreamPlayer.Stop()` held the render callback's lock across `device.Stop()`, which waits for the audio thread. A deadlock.
- `pebble.play_audio` spawned a goroutine inside a handler that already ran in one, so two clips could reach the queue in either order and a long answer could speak its sentences out of sequence.
- The wake gate counted callback buffers while its own comment assumed they were 30 ms. Real hardware reports 10 ms, making the floor a third of what was intended -- 19 segments shipped for STT in 45 seconds on one machine. It now measures milliseconds of voiced audio, so it behaves the same whatever buffer size the device picks.
- A mid-response underrun no longer emits a partial buffer padded with zeros. That seam is a click. The audio is held back and plays contiguously once the buffer recovers.
- The realtime playout cushion adapts to the delivery path, which matters for a hosted brain where every frame crosses the internet. It widens only when audio actually resumes after a shortfall, so the end of a response cannot ratchet it up.

## Testing

New tests for the ring buffer, the stall detector, the jitter cushion and playout, the session reservation, and the wake gate. `go build`, `go vet` and the full suite pass.

Two caveats worth stating: `go test -race` fails on `TestMutedNudgeExpirySparesOtherText`, which fails identically at HEAD and is unrelated. And all of this is verified on Linux only -- it cross-compiles for Windows and vets clean there, but has not been exercised on macOS at all.

## Behaviour changes worth knowing

- Barge-in on TTS clips now trails by one device buffer (~160 ms on Windows, ~120 ms on macOS) instead of ~10-30 ms.
- The wake listener stays suppressed about 1.1 s longer after speech ends, so it stops re-opening between streamed sentences.
- Ambient screen awareness pauses for the duration of a voice turn.
