### PR TITLE
Stop the dashboard holding the microphone open and defer the wake word to the sidecar

### DIFF
--- a/ui/src/hooks/useVoice.test.ts
+++ b/ui/src/hooks/useVoice.test.ts
@@ -86,6 +86,7 @@ describe("shouldSpeechWakeBeRunning", () => {
   const base = {
     isMicAvailable: true,
     wakeWordEnabled: true,
+    nativeWakeActive: false,
     voiceState: "idle" as const,
     wakeEngine: "webspeech" as const,
     speechRecognitionAvailable: true,
@@ -133,6 +134,7 @@ describe("selectActiveWakeEngine", () => {
   const base = {
     isMicAvailable: true,
     wakeWordEnabled: true,
+    nativeWakeActive: false,
     wakeEngine: "openwakeword" as const,
     speechRecognitionAvailable: true,
     speechWakeFatal: false,
@@ -256,5 +258,54 @@ describe("planContainsWakeFlip — regression boundary for the mid-turn cooldown
       const allEqual = flags.every((f) => f === flags[0]);
       expect(allEqual).toBe(true);
     }
+  });
+});
+
+// The dashboard defers wake detection to the sidecar. Every dashboard session
+// has one behind it (the only credential the app is served with is a token an
+// enrolled sidecar minted), and the sidecar's listener coordinates with
+// playback in a way the browser one cannot: it releases the microphone for a
+// capture session and suppresses itself while the assistant speaks.
+//
+// Holding the microphone here regardless degraded audio played by every process
+// on the output device, because Chromium's default constraints turn on echo
+// cancellation, which attaches the page to that device.
+describe("deferring the wake word to the sidecar", () => {
+  const base = {
+    isMicAvailable: true,
+    wakeWordEnabled: true,
+    nativeWakeActive: true,
+    wakeEngine: "openwakeword" as const,
+    speechRecognitionAvailable: true,
+    speechWakeFatal: false,
+  };
+
+  test("runs no browser engine when the sidecar is listening", () => {
+    expect(selectActiveWakeEngine(base)).toBe("none");
+    expect(selectActiveWakeEngine({ ...base, wakeEngine: "webspeech" })).toBe("none");
+    expect(selectActiveWakeEngine({ ...base, wakeEngine: "auto" })).toBe("none");
+  });
+
+  test("keeps the speech recognizer off too, in every voice state", () => {
+    for (const voiceState of ["idle", "speaking", "processing", "wake_detected"] as const) {
+      expect(
+        shouldSpeechWakeBeRunning({ ...base, wakeEngine: "webspeech", voiceState }),
+      ).toBe(false);
+    }
+  });
+
+  // The flag is the only thing turning it off, so it has to be load-bearing:
+  // if the access model ever allows a dashboard with no sidecar, flipping this
+  // must bring the browser engine back rather than leaving it silently dead.
+  test("restores the browser engine when no sidecar is listening", () => {
+    expect(selectActiveWakeEngine({ ...base, nativeWakeActive: false })).toBe("openwakeword");
+    expect(
+      shouldSpeechWakeBeRunning({
+        ...base,
+        nativeWakeActive: false,
+        wakeEngine: "webspeech",
+        voiceState: "idle",
+      }),
+    ).toBe(true);
   });
 });

--- a/ui/src/hooks/useVoice.ts
+++ b/ui/src/hooks/useVoice.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { RealtimeVoiceController } from "../lib/RealtimeVoiceController";
 import { uuid } from "../lib/uuid";
+import { withWakeMicConstraints } from "../lib/wakeMic";
 
 const SPEECH_WAKE_INTERRUPT_COMMANDS = new Set([
   "stop",
@@ -141,12 +142,23 @@ export function classifySpeechWakeError(code: SpeechRecognitionErrorCode): "expe
 export function selectActiveWakeEngine(inputs: {
   isMicAvailable: boolean;
   wakeWordEnabled: boolean;
+  /**
+   * True when the machine's sidecar is already listening for the wake word
+   * natively, which makes a second detector in the browser pure duplication.
+   * See the note in AppShell for why this is currently always true.
+   */
+  nativeWakeActive: boolean;
   wakeEngine: WakeEngineChoice;
   speechRecognitionAvailable: boolean;
   speechWakeFatal: boolean;
 }): ActiveWakeEngine {
-  const { isMicAvailable, wakeWordEnabled, wakeEngine, speechRecognitionAvailable, speechWakeFatal } = inputs;
+  const { isMicAvailable, wakeWordEnabled, nativeWakeActive, wakeEngine, speechRecognitionAvailable, speechWakeFatal } = inputs;
   if (!isMicAvailable || !wakeWordEnabled) return "none";
+  // Defer to the sidecar. Its listener releases the microphone for a capture
+  // session and suppresses itself while the assistant speaks; this one holds
+  // the microphone open regardless, and holding it with Chromium's default
+  // constraints degraded playback for every process on the output device.
+  if (nativeWakeActive) return "none";
   if (wakeEngine === "openwakeword") return "openwakeword";
   const speechUsable = speechRecognitionAvailable && !speechWakeFatal;
   if (wakeEngine === "webspeech") return speechUsable ? "webspeech" : "none";
@@ -161,14 +173,17 @@ export function selectActiveWakeEngine(inputs: {
 export function shouldSpeechWakeBeRunning(inputs: {
   isMicAvailable: boolean;
   wakeWordEnabled: boolean;
+  /** See selectActiveWakeEngine: the sidecar already does this. */
+  nativeWakeActive: boolean;
   voiceState: VoiceState;
   wakeEngine: WakeEngineChoice;
   speechRecognitionAvailable: boolean;
   /** True once the recognizer has hit a non-recoverable error. */
   speechWakeFatal?: boolean;
 }): boolean {
-  const { isMicAvailable, wakeWordEnabled, voiceState, wakeEngine, speechRecognitionAvailable, speechWakeFatal } = inputs;
+  const { isMicAvailable, wakeWordEnabled, nativeWakeActive, voiceState, wakeEngine, speechRecognitionAvailable, speechWakeFatal } = inputs;
   if (speechWakeFatal) return false;
+  if (nativeWakeActive) return false;
   if (!isMicAvailable || !wakeWordEnabled || !speechRecognitionAvailable) return false;
   // Run in every state except active recording (which owns the mic for the
   // live transcript recognizer). Includes processing/wake_detected/speaking
@@ -230,6 +245,8 @@ export type UseVoiceOptions = {
   wakeWordEnabled?: boolean;
   /** Default "openwakeword" (local). "webspeech" uses Chromium's cloud STT. */
   wakeEngine?: WakeEngineChoice;
+  /** The sidecar on this machine already listens for the wake word. */
+  nativeWakeActive?: boolean;
   /**
    * Phase 6.7.C — Optional getter for the current Room key (or null when
    * on the home thread). Included in every voice_start/voice_text payload
@@ -280,7 +297,7 @@ export type UseVoiceReturn = {
   forceIdle: () => void;
 };
 
-export function useVoice({ wsRef, wakeWordEnabled = true, wakeEngine = "openwakeword", getCurrentRoom, speakingTailCooldownMs = 700 }: UseVoiceOptions): UseVoiceReturn {
+export function useVoice({ wsRef, wakeWordEnabled = true, nativeWakeActive = false, wakeEngine = "openwakeword", getCurrentRoom, speakingTailCooldownMs = 700 }: UseVoiceOptions): UseVoiceReturn {
   const [voiceState, setVoiceState] = useState<VoiceState>("idle");
   const [isMicAvailable, setIsMicAvailable] = useState(false);
   const [isWakeWordReady, setIsWakeWordReady] = useState(false);
@@ -323,6 +340,9 @@ export function useVoice({ wsRef, wakeWordEnabled = true, wakeEngine = "openwake
   const lastWakeAtRef = useRef(0);
   const isMicAvailableRef = useRef(false);
   const configuredWakeEngineRef = useRef<WakeEngineChoice>(wakeEngine);
+  // Read through a ref: shouldSpeechWakeRun is memoized on an identity that
+  // does not include this prop, so a direct closure would go stale.
+  const nativeWakeActiveRef = useRef(nativeWakeActive);
   // Timestamp of the most recent transition OUT of the "speaking" state.
   // Used to apply a short cooldown before re-arming the speech wake
   // recognizer so trailing TTS audio (and any speaker reverb) doesn't
@@ -361,6 +381,7 @@ export function useVoice({ wsRef, wakeWordEnabled = true, wakeEngine = "openwake
   useEffect(() => { wakeWordEnabledRef.current = wakeWordEnabled; }, [wakeWordEnabled]);
   useEffect(() => { isMicAvailableRef.current = isMicAvailable; }, [isMicAvailable]);
   useEffect(() => { configuredWakeEngineRef.current = wakeEngine; }, [wakeEngine]);
+  useEffect(() => { nativeWakeActiveRef.current = nativeWakeActive; }, [nativeWakeActive]);
   useEffect(() => { speechWakeFatalRef.current = speechWakeFatal; }, [speechWakeFatal]);
   useEffect(() => { mutedRef.current = muted; }, [muted]);
 
@@ -534,7 +555,7 @@ export function useVoice({ wsRef, wakeWordEnabled = true, wakeEngine = "openwake
   // --- Wake word engine ---
   const startWakeWordEngine = useCallback(async () => {
     if (wakeEngineRef.current) {
-      try { await wakeEngineRef.current.start(); } catch {}
+      try { await withWakeMicConstraints(() => wakeEngineRef.current.start()); } catch {}
       return;
     }
 
@@ -577,7 +598,11 @@ export function useVoice({ wsRef, wakeWordEnabled = true, wakeEngine = "openwake
 
       await engine.load();
       wakeEngineRef.current = engine;
-      await engine.start();
+      // Opened without echo cancellation and friends: see browserWakeWord.ts.
+      // Chromium's defaults attach the page to the OUTPUT endpoint, which
+      // degraded playback for every process on that device, the sidecar's own
+      // speech included.
+      await withWakeMicConstraints(() => engine.start());
       setIsWakeWordReady(true);
       console.log("[Voice] Wake word engine ready — say 'Hey JARVIS'");
     } catch (err) {
@@ -620,6 +645,7 @@ export function useVoice({ wsRef, wakeWordEnabled = true, wakeEngine = "openwake
     return shouldSpeechWakeBeRunning({
       isMicAvailable: isMicAvailableRef.current,
       wakeWordEnabled: wakeWordEnabledRef.current,
+      nativeWakeActive: nativeWakeActiveRef.current,
       voiceState: voiceStateRef.current,
       wakeEngine: configuredWakeEngineRef.current,
       speechRecognitionAvailable: isSpeechRecognitionAvailable(),
@@ -834,6 +860,7 @@ export function useVoice({ wsRef, wakeWordEnabled = true, wakeEngine = "openwake
     const active = (muted || blockedBySpeaking) ? "none" : selectActiveWakeEngine({
       isMicAvailable,
       wakeWordEnabled,
+      nativeWakeActive,
       wakeEngine,
       speechRecognitionAvailable: isSpeechRecognitionAvailable(),
       speechWakeFatal,
@@ -841,7 +868,7 @@ export function useVoice({ wsRef, wakeWordEnabled = true, wakeEngine = "openwake
     setActiveWakeEngine(active);
     if (active === "openwakeword") startWakeWordEngine();
     else stopWakeWordEngine();
-  }, [muted, isMicAvailable, wakeWordEnabled, wakeEngine, voiceState, speechWakeFatal, startWakeWordEngine, stopWakeWordEngine, isSpeechRecognitionAvailable]);
+  }, [muted, isMicAvailable, wakeWordEnabled, nativeWakeActive, wakeEngine, voiceState, speechWakeFatal, startWakeWordEngine, stopWakeWordEngine, isSpeechRecognitionAvailable]);
 
   // Single reconcile effect for the Web Speech recognizer. Computes desired
   // running state from inputs and nudges the state machine toward it. Has no
@@ -858,6 +885,7 @@ export function useVoice({ wsRef, wakeWordEnabled = true, wakeEngine = "openwake
     const shouldRun = !muted && !blockedBySpeaking && shouldSpeechWakeBeRunning({
       isMicAvailable,
       wakeWordEnabled,
+      nativeWakeActive,
       voiceState,
       wakeEngine,
       speechRecognitionAvailable: isSpeechRecognitionAvailable(),
@@ -865,21 +893,21 @@ export function useVoice({ wsRef, wakeWordEnabled = true, wakeEngine = "openwake
     });
     if (shouldRun) startSpeechWakeIfNeeded();
     else stopSpeechWakeIfNeeded();
-  }, [muted, isMicAvailable, wakeWordEnabled, voiceState, wakeEngine, speechWakeFatal, startSpeechWakeIfNeeded, stopSpeechWakeIfNeeded, isSpeechRecognitionAvailable]);
+  }, [muted, isMicAvailable, wakeWordEnabled, nativeWakeActive, voiceState, wakeEngine, speechWakeFatal, startSpeechWakeIfNeeded, stopSpeechWakeIfNeeded, isSpeechRecognitionAvailable]);
 
   // Restart wake word listening when returning to idle (with delay for mic release)
   useEffect(() => {
     if (voiceState === "idle" && wakeWordEnabledRef.current && wakeEngineRef.current) {
       const timer = setTimeout(() => {
         if (voiceStateRef.current !== "idle") return;
-        wakeEngineRef.current?.start()
+        withWakeMicConstraints(() => wakeEngineRef.current!.start())
           .then(() => console.log("[Voice] Wake word engine restarted"))
           .catch((err: Error) => {
             console.error("[Voice] Wake word engine restart failed:", err);
             // Retry once after a longer delay
             setTimeout(() => {
               if (voiceStateRef.current === "idle" && wakeEngineRef.current) {
-                wakeEngineRef.current.start()
+                withWakeMicConstraints(() => wakeEngineRef.current!.start())
                   .then(() => console.log("[Voice] Wake word engine restarted (retry)"))
                   .catch((e: Error) => console.error("[Voice] Wake word restart retry failed:", e));
               }

--- a/ui/src/lib/wakeMic.test.ts
+++ b/ui/src/lib/wakeMic.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  WAKE_MIC_CONSTRAINTS,
+  mergeWakeMicConstraints,
+  withWakeMicConstraints,
+} from "./wakeMic.ts";
+
+afterEach(() => {
+  delete (globalThis as Record<string, unknown>).navigator;
+});
+
+describe("mergeWakeMicConstraints", () => {
+  // Echo cancellation is the one that matters: it is what attaches the page to
+  // the OUTPUT device and degrades playback for everything else on it.
+  test("turns off Chromium's audio processing for `audio: true`", () => {
+    const got = mergeWakeMicConstraints({ audio: true });
+    expect(got.audio).toEqual({ ...WAKE_MIC_CONSTRAINTS });
+    expect((got.audio as MediaTrackConstraints).echoCancellation).toBe(false);
+  });
+
+  test("turns it off when no constraints were given at all", () => {
+    expect(mergeWakeMicConstraints(undefined).audio).toEqual({ ...WAKE_MIC_CONSTRAINTS });
+  });
+
+  // The engine passes a deviceId when the user picked a specific microphone.
+  // Losing that would silently move wake detection to the wrong input.
+  test("preserves a device selection", () => {
+    const got = mergeWakeMicConstraints({ audio: { deviceId: { exact: "mic-7" } } });
+    expect(got.audio).toEqual({ deviceId: { exact: "mic-7" }, ...WAKE_MIC_CONSTRAINTS });
+  });
+
+  test("overrides processing the caller asked for", () => {
+    const got = mergeWakeMicConstraints({ audio: { echoCancellation: true, noiseSuppression: true } });
+    expect((got.audio as MediaTrackConstraints).echoCancellation).toBe(false);
+    expect((got.audio as MediaTrackConstraints).noiseSuppression).toBe(false);
+  });
+
+  test("leaves an explicit audio:false alone", () => {
+    expect(mergeWakeMicConstraints({ audio: false, video: true }).audio).toBe(false);
+  });
+});
+
+describe("withWakeMicConstraints", () => {
+  function installMediaDevices() {
+    const calls: MediaStreamConstraints[] = [];
+    const original = (c?: MediaStreamConstraints) => {
+      calls.push(c!);
+      return Promise.resolve({} as MediaStream);
+    };
+    (globalThis as Record<string, unknown>).navigator = { mediaDevices: { getUserMedia: original } };
+    return { calls, original };
+  }
+
+  test("applies the constraints to whatever the callee opens", async () => {
+    const { calls } = installMediaDevices();
+    await withWakeMicConstraints(async () => {
+      await globalThis.navigator.mediaDevices.getUserMedia({ audio: true });
+    });
+    expect(calls).toHaveLength(1);
+    expect((calls[0]!.audio as MediaTrackConstraints).echoCancellation).toBe(false);
+  });
+
+  // A leaked override would silently strip echo cancellation from the RECORDER
+  // too, which does want it. Identity, not just behaviour: restoring a bound
+  // copy would leave the native method permanently replaced.
+  test("restores the original afterwards", async () => {
+    const { original } = installMediaDevices();
+    await withWakeMicConstraints(async () => {});
+    expect(globalThis.navigator.mediaDevices.getUserMedia).toBe(original as never);
+  });
+
+  test("restores the original even when the callee throws", async () => {
+    const { original } = installMediaDevices();
+    await expect(
+      withWakeMicConstraints(async () => {
+        throw new Error("mic busy");
+      }),
+    ).rejects.toThrow("mic busy");
+    expect(globalThis.navigator.mediaDevices.getUserMedia).toBe(original as never);
+  });
+
+  test("still runs the callee when there is no mediaDevices at all", async () => {
+    (globalThis as Record<string, unknown>).navigator = {};
+    let ran = false;
+    await withWakeMicConstraints(async () => {
+      ran = true;
+    });
+    expect(ran).toBe(true);
+  });
+});

--- a/ui/src/lib/wakeMic.ts
+++ b/ui/src/lib/wakeMic.ts
@@ -1,0 +1,83 @@
+/**
+ * Microphone constraints for a browser-side wake-word listener.
+ *
+ * Kept even though the dashboard does not currently run one (see
+ * selectActiveWakeEngine): if the engine is ever re-enabled it must not take
+ * the output device with it.
+ *
+ * The engine opens the microphone with `getUserMedia({ audio: true })`, i.e.
+ * Chromium's defaults, which turn on echo cancellation, noise suppression and
+ * automatic gain control. Echo cancellation is the expensive one: to cancel
+ * echo the browser has to know what is being played, so it attaches itself to
+ * the output endpoint and Windows treats the capture stream as communications
+ * activity. The observable result was that audio played by ANY process on that
+ * endpoint degraded while a dashboard was open, including the sidecar's own
+ * speech, which the dashboard is not otherwise involved in.
+ *
+ * A wake-word detector wants none of the three anyway: they all reshape the
+ * audio the model was trained on.
+ */
+
+/**
+ * Microphone constraints for the wake-word listener.
+ *
+ * A wake-word detector wants the rawest signal it can get: echo cancellation,
+ * noise suppression and gain control all reshape the audio the model was
+ * trained on, and echo cancellation is what pulls the browser onto the output
+ * device. None of the three earns its place here.
+ */
+export const WAKE_MIC_CONSTRAINTS: MediaTrackConstraints = {
+  echoCancellation: false,
+  noiseSuppression: false,
+  autoGainControl: false,
+};
+
+
+
+/**
+ * Applies WAKE_MIC_CONSTRAINTS to whatever `fn` opens, then restores the
+ * original getUserMedia.
+ *
+ * This is a wrapper rather than a parameter because the upstream engine
+ * hardcodes `audio: true` and its `start()` accepts only `deviceId` and `gain`,
+ * so there is no seam to pass constraints through. The override is installed
+ * for the duration of one `start()` call and removed in a finally.
+ *
+ * Caveat, deliberately accepted: a getUserMedia call made by something else
+ * during that window would also get these constraints. The window is one
+ * engine start, and the only other caller in the app is the recorder, which
+ * cannot run while the wake engine is starting.
+ */
+export async function withWakeMicConstraints<T>(fn: () => Promise<T>): Promise<T> {
+  const md = globalThis.navigator?.mediaDevices;
+  if (!md?.getUserMedia) return fn();
+
+  // Capture the property as-is and restore exactly that. Binding it first and
+  // restoring the bound copy would leave the native method permanently replaced
+  // and stack a new binding on every call.
+  const original = md.getUserMedia;
+  md.getUserMedia = function (constraints?: MediaStreamConstraints) {
+    return original.call(md, mergeWakeMicConstraints(constraints));
+  };
+  try {
+    return await fn();
+  } finally {
+    md.getUserMedia = original;
+  }
+}
+
+/**
+ * Folds WAKE_MIC_CONSTRAINTS into whatever the caller asked for, preserving any
+ * device selection it made. Exported for testing.
+ */
+export function mergeWakeMicConstraints(
+  constraints: MediaStreamConstraints | undefined,
+): MediaStreamConstraints {
+  const audio = constraints?.audio;
+  if (audio === false) return { ...constraints, audio: false };
+  if (audio && typeof audio === "object") {
+    return { ...constraints, audio: { ...audio, ...WAKE_MIC_CONSTRAINTS } };
+  }
+  // `true`, or absent: the engine's own default.
+  return { ...constraints, audio: { ...WAKE_MIC_CONSTRAINTS } };
+}

--- a/ui/src/v2/shell/AppShell.tsx
+++ b/ui/src/v2/shell/AppShell.tsx
@@ -141,6 +141,18 @@ function AppShellLive() {
   const voice = useVoice({
     wsRef: live.wsRef,
     wakeWordEnabled: true,
+    // Always true, because a dashboard session always has a sidecar behind it:
+    // the only credential this app is served with is a short-lived access token
+    // minted by an enrolled sidecar, so there is no way to reach the brain
+    // without one. Its native listener already handles the wake word, and it
+    // does so properly, releasing the microphone for a capture session and
+    // suppressing itself while the assistant speaks.
+    //
+    // A second detector here bought nothing and cost real damage: it held the
+    // microphone open for as long as the page was, with Chromium's default
+    // constraints, which degraded audio played by every process on the output
+    // device, the sidecar's own speech included.
+    nativeWakeActive: true,
     getCurrentRoom,
   });
 


### PR DESCRIPTION
Fixes the reported audio glitch: a loud, high-pitched, glitchy artifact from the speakers whenever JARVIS spoke, on both Windows and macOS.

## What was happening

The dashboard ran its own always-on wake-word engine. `AppShell` passed `wakeWordEnabled: true` as a hardcoded literal, so for as long as a dashboard was open the page held the microphone via `getUserMedia({ audio: true })` -- Chromium's default constraints, which turn on echo cancellation, noise suppression and automatic gain control.

Echo cancellation is the one that does the damage. To cancel echo the browser has to know what is being played, so it attaches itself to the output endpoint, and Windows treats the capture stream as communications activity. The result was that audio played by **any** process on that device degraded while a dashboard was open -- including the sidecar's own speech, which the dashboard is not otherwise involved in.

That is why closing the dashboard fixed the audio, and why the artifact showed up both when talking to the pebble (the sidecar plays) and when typing in chat (the dashboard plays).

## What changed

The dashboard now defers wake detection to the sidecar. That is not a compromise: a dashboard session always has a sidecar behind it, since the only credential this app is served with is a short-lived access token minted by an enrolled sidecar. And the sidecar's listener is the better one -- it releases the microphone for a capture session and suppresses itself while the assistant is speaking, neither of which the browser engine does.

Two detectors on one microphone bought nothing and cost this.

The decision lives in the existing pure selectors (`selectActiveWakeEngine`, `shouldSpeechWakeBeRunning`) as a `nativeWakeActive` input rather than a deleted feature, so if the access model ever allows a dashboard with no sidecar it is one line to bring back. There is a test asserting exactly that.

`wakeMic.ts` keeps the microphone constraints the engine should have been using -- echo cancellation, noise suppression and gain control all off, none of which a wake-word detector wants -- wired into the engine's start paths. Inert while the engine does not run, but it means re-enabling it cannot reintroduce this.

## Testing

9 new tests covering the constraint merge, the getUserMedia wrapper's restore behaviour, and the deferral decision in both selectors. Typecheck clean; 268 UI tests pass.

## Note

This is client-side code, so it reaches a machine only on a UI deploy -- a sidecar build does not carry it.

The mechanism is evidenced rather than proven: closing the dashboard demonstrably fixes the audio, and the microphone hold with echo cancellation is the only relevant difference between the two states. The cheap confirmation, if wanted before merging, is to open the dashboard in a browser with microphone permission denied and check that the artifact is gone.
