### PR TITLE
Fix Ctrl+Space flashing the pebble and dying when the realtime voice dial is refused

### DIFF
--- a/sidecar/client.go
+++ b/sidecar/client.go
@@ -1077,10 +1077,30 @@ func (c *SidecarClient) connectAndServe(ctx context.Context) error {
 		})
 		c.handlers["pebble.realtime_status"] = func(params map[string]any) (*RPCResult, error) {
 			state, _ := params["state"].(string)
+			detail, _ := params["detail"].(string)
+			// Logged, not swallowed: the daemon owns the realtime session, so
+			// this line is the ONLY place its outcome reaches the machine the
+			// user is sitting at. Dropping the detail is what made a refused
+			// session look like a dead hotkey: a pebble that flashed and went
+			// back to idle, with the reason on the other end of the wire.
+			if detail != "" {
+				log.Printf("[realtime] daemon says %s: %s", state, detail)
+			} else {
+				log.Printf("[realtime] daemon says %s", state)
+			}
 			// Daemon-initiated teardown (budget / timeout / error): stop the
 			// local audio without re-emitting realtime_stop (its side is gone).
 			if rt := c.realtime.Load(); rt != nil && (state == "closed" || state == "error") {
+				wasActive := rt.active.Load()
 				rt.Stop(false)
+				// Say it on the pebble too, but only when a press actually went
+				// nowhere: a `closed` for a conversation that ran its course
+				// needs no explanation, and Stop() has already put the pebble
+				// back to idle. AFTER Stop, whose setState would otherwise
+				// paint over the nudge.
+				if state == "error" && wasActive {
+					flashPebbleNudge(c.pebble, PebbleIdle, "Live voice unavailable - press Ctrl+Space to talk")
+				}
 			}
 			return &RPCResult{Result: map[string]any{"ok": true}}, nil
 		}

--- a/sidecar/pebble_overlay.go
+++ b/sidecar/pebble_overlay.go
@@ -148,12 +148,22 @@ var mutedNudgeDur = 2500 * time.Millisecond
 func invalidateMutedNudge() { mutedNudgeGen.Add(1) }
 
 func flashMutedPebble(p PebbleService) {
+	flashPebbleNudge(p, PebbleMuted, "Microphone muted — unmute from the tray menu")
+}
+
+// flashPebbleNudge is the general form: assert `state` and hold `text` in the
+// bubble for mutedNudgeDur, then hand the bubble back to the state's default
+// copy. Used for every "your key press went nowhere, and here is why" moment:
+// mute, and a live-voice session the server would not open. Silence there is
+// indistinguishable from a broken hotkey, which is precisely how a refused
+// realtime dial used to read.
+func flashPebbleNudge(p PebbleService, state PebbleState, text string) {
 	if p == nil {
 		return
 	}
 	gen := mutedNudgeGen.Add(1)
-	_ = p.SetText("Microphone muted — unmute from the tray menu")
-	_ = p.SetState(PebbleMuted)
+	_ = p.SetText(text)
+	_ = p.SetState(state)
 	go func() {
 		time.Sleep(mutedNudgeDur)
 		// Only the most recent claim clears the text; if anything else has

--- a/src/comms/realtime.test.ts
+++ b/src/comms/realtime.test.ts
@@ -76,8 +76,11 @@ class FakeSocket implements RealtimeSocket {
 function makeSession() {
   const socket = new FakeSocket();
   const dialed: string[] = [];
+  // connect() resolves on OPEN now, so a dial that never opens is a dial that
+  // failed. Fire onopen a microtask later, the way a real socket would.
   const factory: RealtimeSocketFactory = (url) => {
     dialed.push(String(url));
+    queueMicrotask(() => socket.onopen?.());
     return socket;
   };
   const sentAudio: Buffer[] = [];
@@ -105,14 +108,58 @@ describe('RealtimeSession lifecycle', () => {
   test('sends session.update on open', async () => {
     const { socket, session } = makeSession();
     await session.connect();
-    socket.onopen!();
     expect(socket.sentTypes()).toContain('session.update');
+  });
+
+  // The pebble bug: a proxy that refuses the upgrade (revoked key, a plan that
+  // does not serve realtime, wrong endpoint) closes the socket without ever
+  // sending an `error` event. connect() used to resolve regardless, so callers
+  // announced the session `live`, flipped the pebble to listening, and dropped
+  // back to idle when the close landed -- with the reason nowhere in sight.
+  test('connect() rejects when the socket closes before it opens', async () => {
+    const socket = new FakeSocket();
+    const session = new RealtimeSession({
+      resolved: RESOLVED,
+      tools: [],
+      instructions: 'x',
+      transport: new BrowserAudioTransport({ sendAudio: () => {}, inputSampleRate: 24000 }),
+      socketFactory: () => {
+        queueMicrotask(() => socket.onclose?.({ code: 1008, reason: 'model not in plan' }));
+        return socket;
+      },
+    });
+    // The close code and reason are the server's only explanation, so they have
+    // to survive into the error the caller logs.
+    await expect(session.connect()).rejects.toThrow(/closed before it opened.*1008.*model not in plan/);
+  });
+
+  test('connect() rejects when the socket errors before it opens', async () => {
+    const socket = new FakeSocket();
+    const session = new RealtimeSession({
+      resolved: RESOLVED,
+      tools: [],
+      instructions: 'x',
+      transport: new BrowserAudioTransport({ sendAudio: () => {}, inputSampleRate: 24000 }),
+      socketFactory: () => {
+        queueMicrotask(() => socket.onerror?.({}));
+        return socket;
+      },
+    });
+    await expect(session.connect()).rejects.toThrow(/while connecting/);
+  });
+
+  test('a close AFTER open reports the code/reason to onClose, not to connect()', async () => {
+    const { socket, session } = makeSession();
+    const closes: Array<string | undefined> = [];
+    session.onClose((detail) => closes.push(detail));
+    await session.connect();
+    socket.onclose!({ code: 1011, reason: 'upstream error' });
+    expect(closes).toEqual(['code 1011: upstream error']);
   });
 
   test('mic chunks become input_audio_buffer.append', async () => {
     const { socket, session, transport } = makeSession();
     await session.connect();
-    socket.onopen!();
     (transport as BrowserAudioTransport).pushMicChunk(Buffer.from([1, 2, 3, 4]));
     const appendMsg = socket.sent.map((s) => JSON.parse(s)).find((m) => m.type === 'input_audio_buffer.append');
     expect(appendMsg).toBeTruthy();
@@ -122,7 +169,6 @@ describe('RealtimeSession lifecycle', () => {
   test('output audio delta is decoded and routed to transport playback', async () => {
     const { socket, session, sentAudio } = makeSession();
     await session.connect();
-    socket.onopen!();
     const pcm = Buffer.from([9, 8, 7, 6]);
     socket.emit({ type: 'response.output_audio.delta', delta: pcm.toString('base64') });
     expect(sentAudio).toHaveLength(1);
@@ -134,7 +180,6 @@ describe('RealtimeSession lifecycle', () => {
     const got: Array<{ role: string; text: string; final: boolean }> = [];
     session.onTranscript((t) => got.push(t));
     await session.connect();
-    socket.onopen!();
     socket.emit({ type: 'conversation.item.input_audio_transcription.completed', transcript: 'hello' });
     socket.emit({ type: 'response.output_audio_transcript.done', transcript: 'hi there' });
     expect(got).toEqual([
@@ -148,7 +193,6 @@ describe('RealtimeSession lifecycle', () => {
     const calls: any[] = [];
     session.onFunctionCall((c) => calls.push(c));
     await session.connect();
-    socket.onopen!();
     socket.emit({ type: 'response.output_item.added', item: { type: 'function_call', call_id: 'c1', name: 'read_file' } });
     socket.emit({ type: 'response.function_call_arguments.done', call_id: 'c1', arguments: '{"path":"/etc/hosts"}' });
     expect(calls).toEqual([{ callId: 'c1', name: 'read_file', args: { path: '/etc/hosts' } }]);
@@ -157,7 +201,6 @@ describe('RealtimeSession lifecycle', () => {
   test('sendFunctionResult emits function_call_output + response.create', async () => {
     const { socket, session } = makeSession();
     await session.connect();
-    socket.onopen!();
     socket.sent = [];
     session.sendFunctionResult('c1', { ok: true });
     expect(socket.sentTypes()).toEqual(['conversation.item.create', 'response.create']);
@@ -171,7 +214,6 @@ describe('RealtimeSession lifecycle', () => {
     const orig = transport.stopPlayback.bind(transport);
     transport.stopPlayback = () => { stopped++; orig(); };
     await session.connect();
-    socket.onopen!();
     socket.emit({ type: 'input_audio_buffer.speech_started' });
     expect(stopped).toBe(1);
   });
@@ -179,7 +221,6 @@ describe('RealtimeSession lifecycle', () => {
   test('barge-in cancels the active response and suppresses its trailing audio', async () => {
     const { socket, session, sentAudio } = makeSession();
     await session.connect();
-    socket.onopen!();
     // A response is in flight and producing audio.
     socket.emit({ type: 'response.created' });
     socket.emit({ type: 'response.output_audio.delta', delta: Buffer.from([1, 2]).toString('base64') });
@@ -202,7 +243,6 @@ describe('RealtimeSession lifecycle', () => {
     const events: Array<{ input_tokens: number; output_tokens: number; latency_ms: number }> = [];
     session.onUsage((u) => events.push(u));
     await session.connect();
-    socket.onopen!();
     socket.emit({ type: 'response.created' });
     socket.emit({
       type: 'response.done',
@@ -219,7 +259,6 @@ describe('RealtimeSession lifecycle', () => {
     const events: unknown[] = [];
     session.onUsage((u) => events.push(u));
     await session.connect();
-    socket.onopen!();
     socket.emit({ type: 'response.created' });
     socket.emit({ type: 'response.done', response: {} });
     expect(events).toHaveLength(0);
@@ -228,7 +267,6 @@ describe('RealtimeSession lifecycle', () => {
   test('barge-in with no active response does not send response.cancel', async () => {
     const { socket, session } = makeSession();
     await session.connect();
-    socket.onopen!();
     socket.sent = [];
     socket.emit({ type: 'input_audio_buffer.speech_started' });
     expect(socket.sentTypes()).not.toContain('response.cancel');
@@ -239,7 +277,6 @@ describe('RealtimeSession lifecycle', () => {
     const errs: string[] = [];
     session.onError((e) => errs.push(e));
     await session.connect();
-    socket.onopen!();
     socket.emit({ type: 'error', error: { message: 'boom' } });
     expect(errs).toEqual(['boom']);
   });
@@ -249,7 +286,6 @@ describe('RealtimeSession lifecycle', () => {
     const errs: string[] = [];
     session.onError((e) => errs.push(e));
     await session.connect();
-    socket.onopen!();
     // Both the message form and the code form must be swallowed.
     socket.emit({ type: 'error', error: { message: 'Cancellation failed: no active response found' } });
     socket.emit({ type: 'error', error: { code: 'response_cancel_not_active', message: 'x' } });
@@ -267,7 +303,10 @@ describe('RealtimeSession lifecycle', () => {
       tools: [],
       instructions: 'x',
       transport,
-      socketFactory: () => socket,
+      socketFactory: () => {
+        queueMicrotask(() => socket.onopen?.());
+        return socket;
+      },
     });
     const errs: string[] = [];
     session.onError((e) => errs.push(e));

--- a/src/comms/realtime.ts
+++ b/src/comms/realtime.ts
@@ -133,6 +133,25 @@ export function buildSessionUpdate(
   return { type: 'session.update', session };
 }
 
+/**
+ * How long to wait for the realtime socket to open before calling the dial
+ * failed. Generous (a cold proxy can take seconds) but bounded, because the
+ * caller is holding the user's microphone open while it waits.
+ */
+const CONNECT_TIMEOUT_MS = 15_000;
+
+/**
+ * Render a close event as `code 1008: reason` for logs. A refused realtime
+ * upgrade says everything it is going to say here, so this is usually the only
+ * evidence of WHY a session would not open.
+ */
+function describeSocketClose(ev: unknown): string {
+  const e = ev as { code?: unknown; reason?: unknown } | undefined;
+  const code = typeof e?.code === 'number' ? e.code : undefined;
+  const reason = typeof e?.reason === 'string' ? e.reason.trim() : '';
+  return [code !== undefined ? `code ${code}` : '', reason].filter(Boolean).join(': ');
+}
+
 function defaultSocketFactory(url: string, opts: { headers: Record<string, string> }): RealtimeSocket {
   // Bun's WebSocket accepts a headers option (non-standard but supported).
   return new WebSocket(url, opts as unknown as string[]) as unknown as RealtimeSocket;
@@ -153,7 +172,7 @@ export class RealtimeSession {
   private usageCb: ((u: RealtimeUsage) => void) | null = null;
   private errorCb: ((err: string) => void) | null = null;
   private openCb: (() => void) | null = null;
-  private closeCb: (() => void) | null = null;
+  private closeCb: ((detail?: string) => void) | null = null;
   private speechStartedCb: (() => void) | null = null;
   // Response-latency instrumentation (user-stopped → first audio).
   private turnEndedAt = 0;
@@ -180,12 +199,27 @@ export class RealtimeSession {
   onUsage(cb: (u: RealtimeUsage) => void): void { this.usageCb = cb; }
   onError(cb: (err: string) => void): void { this.errorCb = cb; }
   onOpen(cb: () => void): void { this.openCb = cb; }
-  onClose(cb: () => void): void { this.closeCb = cb; }
+  /** Fired when the socket closes. `detail` carries the close code/reason
+   *  when the server gave one: the only explanation a refused session ever
+   *  produces, since a rejected upgrade sends no `error` event. */
+  onClose(cb: (detail?: string) => void): void { this.closeCb = cb; }
   /** Fired when the model detects the user started speaking (barge-in). */
   onSpeechStarted(cb: () => void): void { this.speechStartedCb = cb; }
 
-  /** Connect, send session.update, and wire the transport's mic + playback. */
-  async connect(): Promise<void> {
+  /**
+   * Connect, send session.update, and wire the transport's mic + playback.
+   *
+   * Resolves only once the socket is OPEN, and rejects when the dial fails.
+   * That matters more than it looks: this used to resolve the moment the socket
+   * object existed, so every caller announced a session as `live` before the
+   * server had accepted it. A refused upgrade (revoked key, a plan that does
+   * not serve realtime, a wrong endpoint) arrives as a bare `close` with no
+   * `error` event, so the pebble went to `listening` on a socket that was
+   * already gone and dropped back to idle half a second later with the reason
+   * nowhere in either log. Any close or socket error BEFORE open is the dial
+   * failing, and it is reported as such.
+   */
+  connect(): Promise<void> {
     const { resolved, safetyIdentifier, socketFactory, transport } = this.opts;
     const url = `${resolved.url}?model=${encodeURIComponent(resolved.model)}`;
     const headers: Record<string, string> = {
@@ -205,26 +239,64 @@ export class RealtimeSession {
     const ws = factory(url, { headers });
     this.ws = ws;
 
-    ws.onopen = () => {
-      this.send(buildSessionUpdate(resolved, this.opts.tools, this.opts.instructions, transport.inputSampleRate, transport.outputSampleRate));
-      // Route mic audio straight into the realtime input buffer.
-      transport.onMicChunk((pcm) => this.pushAudio(pcm));
-      // Route realtime output audio to the speaker.
-      this.onAudio((chunk) => transport.playback(chunk));
-      // Barge-in: stop playback the moment the user starts talking.
-      this.onSpeechStarted(() => transport.stopPlayback());
-      this.openCb?.();
-    };
-    ws.onmessage = (ev) => {
-      try {
-        const data = typeof ev.data === 'string' ? ev.data : String(ev.data);
-        this.handleServerEvent(JSON.parse(data));
-      } catch (err) {
-        this.errorCb?.(`Failed to parse realtime event: ${err}`);
-      }
-    };
-    ws.onerror = () => this.errorCb?.('Realtime WebSocket error');
-    ws.onclose = () => { this.closed = true; this.closeCb?.(); };
+    return new Promise<void>((resolve, reject) => {
+      let settled = false;
+      const timer = setTimeout(() => {
+        if (settled) return;
+        settled = true;
+        // Close the half-open socket ourselves: without this a proxy that
+        // accepts the TCP connection and then never completes the upgrade
+        // leaves a dangling socket per press.
+        this.close();
+        reject(new Error(`realtime socket did not open within ${CONNECT_TIMEOUT_MS}ms`));
+      }, CONNECT_TIMEOUT_MS);
+      const settle = (err?: Error) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        if (err) reject(err);
+        else resolve();
+      };
+
+      ws.onopen = () => {
+        this.send(buildSessionUpdate(resolved, this.opts.tools, this.opts.instructions, transport.inputSampleRate, transport.outputSampleRate));
+        // Route mic audio straight into the realtime input buffer.
+        transport.onMicChunk((pcm) => this.pushAudio(pcm));
+        // Route realtime output audio to the speaker.
+        this.onAudio((chunk) => transport.playback(chunk));
+        // Barge-in: stop playback the moment the user starts talking.
+        this.onSpeechStarted(() => transport.stopPlayback());
+        this.openCb?.();
+        settle();
+      };
+      ws.onmessage = (ev) => {
+        try {
+          const data = typeof ev.data === 'string' ? ev.data : String(ev.data);
+          this.handleServerEvent(JSON.parse(data));
+        } catch (err) {
+          this.errorCb?.(`Failed to parse realtime event: ${err}`);
+        }
+      };
+      ws.onerror = () => {
+        // Before open this IS the dial failing, so reject rather than fire the
+        // live-session error sink, which the caller reads as "a live session
+        // hit a problem" and answers by tearing down a session that never was.
+        if (!settled) {
+          settle(new Error('realtime WebSocket error while connecting'));
+          return;
+        }
+        this.errorCb?.('Realtime WebSocket error');
+      };
+      ws.onclose = (ev) => {
+        this.closed = true;
+        const detail = describeSocketClose(ev);
+        if (!settled) {
+          settle(new Error(`realtime socket closed before it opened${detail ? ` (${detail})` : ''}`));
+          return;
+        }
+        this.closeCb?.(detail || undefined);
+      };
+    });
   }
 
   /** Append a PCM s16/mono frame to the realtime input buffer. */

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -873,6 +873,23 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
             console.warn('[pebble-realtime] post-refusal re-advertisement failed:', err),
           );
         },
+        // The session never became usable. Re-advertising would not help here:
+        // the advertisement is computed from the plan gate, and the plan gate is
+        // exactly what said yes. Switch this sidecar off realtime directly and
+        // let the summon hotkey do a one-shot capture instead. Without it every
+        // press opened a session the server dropped a moment later: the pebble
+        // flashed listening, went back to idle with nothing captured, and the
+        // reason lived only in the daemon log. Scoped to the connection, since
+        // a reconnect and a settings reload both re-advertise -- so a transient
+        // outage heals itself.
+        onUnusableSession: (sidecarId, detail) => {
+          console.warn(
+            `[pebble-realtime] ${sidecarId} got no usable live session (${detail}) - ` +
+            'falling back to one-shot voice capture for this connection',
+          );
+          void sidecarManager.dispatchRPC(sidecarId, 'pebble.configure_realtime', { enabled: false })
+            .catch((err) => console.warn('[pebble-realtime] fallback downgrade failed:', err));
+        },
       });
 
       // Tell each pebble-capable sidecar whether realtime is available so its

--- a/src/daemon/pebble-realtime.test.ts
+++ b/src/daemon/pebble-realtime.test.ts
@@ -2,6 +2,7 @@ import { test, expect, describe, afterEach } from 'bun:test';
 import { PebbleRealtimeManager, foldTranscript, newTranscriptAccumulator } from './pebble-realtime.ts';
 import { clearRealtimeGateCache } from './realtime-gate.ts';
 import type { ResolvedRealtimeVoice } from '../config/realtime.ts';
+import type { RealtimeVoiceSession, RealtimeVoiceDeps } from './realtime-voice.ts';
 
 const originalFetch = globalThis.fetch;
 afterEach(() => {
@@ -101,6 +102,74 @@ describe('start/stop race across the plan gate', () => {
     // Surfaced as a lifecycle close (informative), not an error flash.
     expect(statuses.some((s) => s.status === 'closed')).toBe(true);
     expect(statuses.some((s) => s.status === 'error')).toBe(false);
+  });
+});
+
+// The Windows report behind this: realtime was advertised as available (the
+// plan gate says the alias is included), the summon hotkey opened a session,
+// and the server dropped it half a second later. Every press did the same thing
+// -- the pebble flashed listening and fell back to idle -- so Ctrl+Space looked
+// dead while the wake word kept working. A press has to fall back to one-shot
+// capture instead of re-opening a session the server will not serve.
+describe('a session that never becomes usable downgrades the summon hotkey', () => {
+  /** The plan gate says the alias IS included, so start() reaches the dial. */
+  const planAllows = () => {
+    globalThis.fetch = (async () => new Response(JSON.stringify({ data: [{ id: 'uj-realtime' }] }), {
+      status: 200, headers: { 'Content-Type': 'application/json' },
+    })) as unknown as typeof fetch;
+  };
+
+  /** Stand-in for the websocket session, so no test ever dials for real. */
+  const fakeSession = (connect: () => Promise<void>) => {
+    let voiceDeps: RealtimeVoiceDeps | null = null;
+    const createSession = ((_r: unknown, _t: unknown, deps: RealtimeVoiceDeps) => {
+      voiceDeps = deps;
+      return { connect, close: () => {}, interrupt: () => {} } as unknown as RealtimeVoiceSession;
+    }) as NonNullable<ConstructorParameters<typeof PebbleRealtimeManager>[0]['createSession']>;
+    return { createSession, deps: () => voiceDeps! };
+  };
+
+  test('a refused dial downgrades the sidecar to one-shot capture', async () => {
+    planAllows();
+    const unusable: Array<{ id: string; detail: string }> = [];
+    const fake = fakeSession(async () => {
+      throw new Error('realtime socket closed before it opened (code 1008: not in plan)');
+    });
+    const mgr = makeManager({
+      createSession: fake.createSession,
+      onUnusableSession: (id, detail) => { unusable.push({ id, detail }); },
+    });
+    await mgr.start('sidecar-1');
+    expect(mgr.isActive('sidecar-1')).toBe(false);
+    expect(unusable).toHaveLength(1);
+    // The close code is the server's only explanation; it has to reach the log.
+    expect(unusable[0]!.detail).toContain('1008');
+  });
+
+  test('a session that opens and dies before a single word also downgrades', async () => {
+    planAllows();
+    const unusable: string[] = [];
+    const fake = fakeSession(async () => {});
+    const mgr = makeManager({ createSession: fake.createSession, onUnusableSession: (id) => { unusable.push(id); } });
+    await mgr.start('sidecar-1');
+    expect(mgr.isActive('sidecar-1')).toBe(true);
+    fake.deps().onClose?.('code 1011: upstream closed');
+    expect(unusable).toEqual(['sidecar-1']);
+    expect(mgr.isActive('sidecar-1')).toBe(false);
+  });
+
+  test('a conversation that ran does NOT downgrade when it ends', async () => {
+    planAllows();
+    const unusable: string[] = [];
+    const fake = fakeSession(async () => {});
+    const mgr = makeManager({ createSession: fake.createSession, onUnusableSession: (id) => { unusable.push(id); } });
+    await mgr.start('sidecar-1');
+    // One real turn is the whole difference: the server served this session, so
+    // its ending says nothing about whether the next one can open.
+    fake.deps().onTranscript?.({ role: 'user', text: 'what time is it', final: true });
+    fake.deps().onClose?.('code 1000');
+    expect(unusable).toEqual([]);
+    expect(mgr.isActive('sidecar-1')).toBe(false);
   });
 });
 

--- a/src/daemon/pebble-realtime.ts
+++ b/src/daemon/pebble-realtime.ts
@@ -17,7 +17,7 @@
  */
 
 import { PebbleAudioTransport } from '../comms/pebble-audio-transport.ts';
-import { RealtimeVoiceSession } from './realtime-voice.ts';
+import { RealtimeVoiceSession, type RealtimeVoiceDeps } from './realtime-voice.ts';
 import type { ResolvedRealtimeVoice } from '../config/realtime.ts';
 import { hostedRealtimeIncluded } from './realtime-gate.ts';
 import type { LLMTool } from '../llm/provider.ts';
@@ -54,6 +54,21 @@ export type PebbleRealtimeDeps = {
    *  and re-advertising with the now-cached definitive verdict flips the
    *  hotkey back to one-shot capture instead of an error dead-end. */
   readvertise?: (sidecarId: string) => void;
+  /** The session was never usable: the dial was refused (dead key, wrong
+   *  endpoint, a plan that does not serve realtime), or it opened and died
+   *  before the user got a word in. The advertisement that routed the summon
+   *  key here was a guess (the plan gate advisory-allows when the catalog is
+   *  unreachable), so the caller downgrades this sidecar to the one-shot
+   *  capture path rather than letting every press open a session that dies
+   *  half a second later. `detail` is for the log, not the user. */
+  onUnusableSession?: (sidecarId: string, detail: string) => void;
+  /** Injectable voice-session factory (tests), mirroring the seam
+   *  RealtimeVoiceSession itself offers. Defaults to the real session. */
+  createSession?: (
+    resolved: ResolvedRealtimeVoice,
+    transport: PebbleAudioTransport,
+    deps: RealtimeVoiceDeps,
+  ) => RealtimeVoiceSession;
 };
 
 type Entry = {
@@ -63,6 +78,10 @@ type Entry = {
   startedAt: number;
   lastState?: PebbleRealtimeState; // dedupe textless set_state so repeats don't flood RPCs
   transcript: TranscriptAccumulator;
+  /** Set on the first transcript from either side. A session that closes
+   *  without one carried no conversation, which is what separates "the server
+   *  would not serve this" from "the conversation ended". */
+  used?: boolean;
 };
 
 /** Accumulator for assistant transcript deltas (incremental fragments). */
@@ -103,6 +122,13 @@ export function foldTranscript(
   acc.lastEmitAt = 0;
   return { state: 'listening' };
 }
+
+/**
+ * A session that closes within this window without a single transcript never
+ * became a conversation. Generous enough to cover a slow first turn on a cold
+ * proxy, short enough that a real conversation's ending never trips it.
+ */
+const UNUSABLE_SESSION_MS = 8_000;
 
 export class PebbleRealtimeManager {
   private sessions = new Map<string, Entry>(); // sidecarId -> entry
@@ -188,7 +214,7 @@ export class PebbleRealtimeManager {
       outputSampleRate: 24000,
     });
 
-    const session = new RealtimeVoiceSession(resolved, transport, {
+    const voiceDeps: RealtimeVoiceDeps = {
       tools: this.deps.tools(),
       instructions: this.deps.instructions(),
       executeToolCall: (name, args) => this.deps.executeToolCall(sidecarId, name, args, resolved.blockedCategories),
@@ -198,6 +224,7 @@ export class PebbleRealtimeManager {
         // fragments and throttles the pushes so RPCs stay bounded.
         const entry = this.sessions.get(sidecarId);
         if (!entry) return;
+        entry.used = true; // a real turn happened; this session was serviceable
         const out = foldTranscript(entry.transcript, t, Date.now());
         if (!out) return;
         // Textless pushes are only worth an RPC when the state actually flips.
@@ -207,10 +234,19 @@ export class PebbleRealtimeManager {
       },
       onError: (err) => {
         this.deps.onStatus?.(sidecarId, 'error', err);
+        this.reportIfUnusable(sidecarId, err);
         this.stop(sidecarId);
       },
-      onClose: () => this.stop(sidecarId),
-    });
+      onClose: (detail) => {
+        // A socket that drops this early carried no conversation. Checked
+        // before stop() deletes the entry it reads.
+        this.reportIfUnusable(sidecarId, detail ?? 'the session closed');
+        this.stop(sidecarId, detail);
+      },
+    };
+    const session = this.deps.createSession
+      ? this.deps.createSession(resolved, transport, voiceDeps)
+      : new RealtimeVoiceSession(resolved, transport, voiceDeps);
 
     // Cost guard: the session is otherwise perpetual, so cap wall-clock.
     const timeout = setTimeout(() => {
@@ -221,13 +257,36 @@ export class PebbleRealtimeManager {
     this.sessions.set(sidecarId, { session, transport, timeout, startedAt: Date.now(), transcript: newTranscriptAccumulator() });
 
     try {
+      // Resolves only once the socket is OPEN (comms/realtime.ts connect), so
+      // `live` and the listening pebble now mean the session really is up.
       await session.connect();
       this.deps.onStatus?.(sidecarId, 'live', resolved.model);
       this.deps.onState?.(sidecarId, 'listening'); // mic hot, awaiting the user
     } catch (err) {
-      this.deps.onStatus?.(sidecarId, 'error', `Realtime connect failed: ${String(err)}`);
+      const detail = err instanceof Error ? err.message : String(err);
+      this.deps.onStatus?.(sidecarId, 'error', `Realtime connect failed: ${detail}`);
       this.stop(sidecarId);
+      // Stop the summon key opening a session the server will not serve.
+      this.deps.onUnusableSession?.(sidecarId, detail);
     }
+  }
+
+  /**
+   * Report a session that ended without ever being usable, so the caller can
+   * stop routing the summon hotkey into it.
+   *
+   * The window matters: a conversation that ran and then dropped says nothing
+   * about whether the next one can open, and downgrading on that would cost the
+   * user live voice for the rest of the connection over a normal ending. A
+   * socket that dies within seconds having carried no transcript is a different
+   * animal -- that is a server refusing the session, and repeating it on every
+   * press is what makes the hotkey look broken.
+   */
+  private reportIfUnusable(sidecarId: string, detail: string): void {
+    const entry = this.sessions.get(sidecarId);
+    if (!entry || entry.used) return;
+    if (Date.now() - entry.startedAt > UNUSABLE_SESSION_MS) return;
+    this.deps.onUnusableSession?.(sidecarId, detail);
   }
 
   /** Feed one mic PCM frame (s16/mono/24 kHz) from the sidecar into the session. */
@@ -235,8 +294,10 @@ export class PebbleRealtimeManager {
     this.sessions.get(sidecarId)?.transport.pushMicChunk(pcm);
   }
 
-  /** Close the session and return the pebble to idle (idempotent). */
-  stop(sidecarId: string): void {
+  /** Close the session and return the pebble to idle (idempotent).
+   *  `detail` explains an involuntary close (the socket's code/reason) so the
+   *  sidecar log and the pebble can say why the conversation ended. */
+  stop(sidecarId: string, detail?: string): void {
     // A start parked on the gate await has no session entry yet — cancel the
     // token so it aborts instead of opening a session for a peer that's gone.
     const pending = this.pendingStarts.get(sidecarId);
@@ -248,7 +309,7 @@ export class PebbleRealtimeManager {
     try { entry.session.close(); } catch {/* ignore */}
     try { entry.transport.stop(); } catch {/* ignore */}
     this.deps.onState?.(sidecarId, 'idle');
-    this.deps.onStatus?.(sidecarId, 'closed');
+    this.deps.onStatus?.(sidecarId, 'closed', detail);
   }
 
   stopAll(): void {

--- a/src/daemon/realtime-voice.ts
+++ b/src/daemon/realtime-voice.ts
@@ -32,8 +32,9 @@ export type RealtimeVoiceDeps = {
   onTranscript?: (t: RealtimeTranscript) => void;
   /** Error sink. */
   onError?: (err: string) => void;
-  /** Fired when the underlying session closes (for ws-service cleanup). */
-  onClose?: () => void;
+  /** Fired when the underlying session closes (for ws-service cleanup).
+   *  `detail` is the socket's close code/reason when the server gave one. */
+  onClose?: (detail?: string) => void;
   /** Hashed user id for OpenAI abuse monitoring. */
   safetyIdentifier?: string;
   /** Injectable session factory (tests). Defaults to a real `RealtimeSession`. */
@@ -63,9 +64,9 @@ export class RealtimeVoiceSession {
 
     this.session.onTranscript((t) => this.deps.onTranscript?.(t));
     this.session.onError((e) => this.deps.onError?.(e));
-    this.session.onClose(() => {
+    this.session.onClose((detail) => {
       this.closed = true;
-      this.deps.onClose?.();
+      this.deps.onClose?.(detail);
     });
 
     // Fold realtime token usage into the shared llm_usage table so the Usage


### PR DESCRIPTION
Ctrl+Space did nothing on Windows: the pebble flashed red for an instant and dropped back to idle, while the wake word kept working. From the sidecar log, the press takes the realtime voice path (hosted install, `realtime_enabled=true`), the daemon reported the session `live`, and the server dropped it half a second later.

The defect: `RealtimeSession.connect()` wired the socket handlers and returned without ever waiting for the socket to open. So `await session.connect()` always "succeeded" -- the daemon announced the session `live` and flipped the pebble to listening on a socket the server may already have refused. A refused WebSocket upgrade (dead key, a plan that does not serve the alias, wrong endpoint) arrives as a bare `close` with no `error` event, so the failure was invisible on both ends, and every press repeated it with no fallback. The wake word kept working because it never touches the realtime session.

## Changes

- `src/comms/realtime.ts` -- `connect()` resolves on OPEN and rejects when the dial fails, with a 15s timeout. Any close or socket error before open is reported as a failed dial and carries the close code/reason, which is the server's only explanation. A close after open passes that same detail to `onClose`.
- `src/daemon/pebble-realtime.ts` -- a session that is never usable (refused dial, or opened and died within 8s without a single transcript) reports through a new `onUnusableSession` hook. A session that carried a real turn does not, so a normal ending never trips it.
- `src/daemon/index.ts` -- on that signal the daemon pushes `configure_realtime {enabled:false}` to the sidecar, so the summon hotkey falls back to one-shot capture instead of reopening a session the server will not serve. Connection-scoped: a reconnect or settings reload re-advertises, so a transient outage heals itself.
- `sidecar/client.go` -- `pebble.realtime_status` logs the `detail` it used to throw away, and puts "Live voice unavailable - press Ctrl+Space to talk" on the pebble instead of silently going back to idle.
- `sidecar/pebble_overlay.go` -- generalized `flashMutedPebble` into `flashPebbleNudge`.

## Behaviour after this

The first press after a connect can still fail, but it now says so on the pebble and names the close code in the sidecar log. From there on Ctrl+Space does the one-shot capture and works.

That log line also answers the part I cannot see from the client: whether the proxy refuses the upgrade outright or accepts and then drops. Look for `[realtime] daemon says error: Realtime connect failed: realtime socket closed before it opened (code NNNN: ...)`.

## Tests

- `src/comms/realtime.test.ts`: dial refused (close before open, code/reason preserved), dial errored, close after open reported to `onClose` rather than `connect()`.
- `src/daemon/pebble-realtime.test.ts`: downgrade on a refused dial, downgrade on a session that dies before a word, and no downgrade after a conversation that actually ran.

Full suite passes (2709 pass, 0 fail); `tsc --noEmit` and `go build ./...` clean.

## Not in this PR

`startHotkeyListener` on Windows (`sidecar/hotkeys_windows.go`) logs a failed `RegisterHotKey` inside its goroutine but still returns a nil error, so the caller prints "summon hotkey 'ctrl+space' registered" even when it is not. Not the cause here, but it would mislead the next person debugging a dead hotkey.
