### PR TITLE
Make the Windows hotkey backend report its failures and accept the same specs as macOS and Linux

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -238,12 +238,14 @@ jobs:
           # separate decision, not a side effect of the chrome work.
           go vet ./internal/winchrome/
 
-  # The windows-tagged tests (pebble draw-bounds crop invariant) are pure Go
-  # but can only RUN on a Windows runner — the mingw cross-build above only
-  # proves the package compiles. `go test` also compiles every _test.go under
-  # GOOS=windows, which the cross-build (build-only) never checks. Scoped to
-  # the draw-bounds test to keep runtime bounded; the full logic suite is
-  # covered on linux.
+  # The windows-tagged tests (pebble draw-bounds crop invariant, global hotkey
+  # registration) are pure Go but can only RUN on a Windows runner — the mingw
+  # cross-build above only proves the package compiles. `go test` also compiles
+  # every _test.go under GOOS=windows, which the cross-build (build-only) never
+  # checks. Scoped to a named few to keep runtime bounded; the full logic suite
+  # is covered on linux. The hotkey tests need the real RegisterHotKey — a
+  # refused registration is exactly what has to surface as an error, and no
+  # other platform can produce one.
   sidecar-test-windows:
     runs-on: windows-latest
     steps:
@@ -260,7 +262,7 @@ jobs:
         run: |
           set -euo pipefail
           export CGO_CFLAGS="-I$(pwd)/include" CGO_CXXFLAGS="-I$(pwd)/include"
-          go test -run '^TestMainPebbleDrawStaysInsideCrop$' -v .
+          go test -run '^(TestMainPebbleDrawStaysInsideCrop|TestStartHotkeyListenerReportsARefusedRegistration|TestRegisterHotKeyErrorIsActionable)$' -v .
 
   # Compile gate for the darwin cgo files (deeplink_darwin.go, the *_darwin
   # bridges): build tags hide them from the linux job, so without this their

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -243,9 +243,11 @@ jobs:
   # cross-build above only proves the package compiles. `go test` also compiles
   # every _test.go under GOOS=windows, which the cross-build (build-only) never
   # checks. Scoped to a named few to keep runtime bounded; the full logic suite
-  # is covered on linux. The hotkey tests need the real RegisterHotKey — a
-  # refused registration is exactly what has to surface as an error, and no
-  # other platform can produce one.
+  # is covered on linux. The TestHotkeys* prefix is matched as a group so a new
+  # hotkey test runs without editing this file; they live here rather than on
+  # linux because the file is windows-tagged and one of them needs the real
+  # RegisterHotKey — a refused registration is exactly what has to surface as an
+  # error, and no other platform can produce one.
   sidecar-test-windows:
     runs-on: windows-latest
     steps:
@@ -262,7 +264,18 @@ jobs:
         run: |
           set -euo pipefail
           export CGO_CFLAGS="-I$(pwd)/include" CGO_CXXFLAGS="-I$(pwd)/include"
-          go test -run '^(TestMainPebbleDrawStaysInsideCrop|TestStartHotkeyListenerReportsARefusedRegistration|TestRegisterHotKeyErrorIsActionable)$' -v .
+          pattern='^(TestMainPebbleDrawStaysInsideCrop|TestHotkeys.*)$'
+          # Same reason as the parity test above: `go test -run` with no match
+          # prints "no tests to run" and exits 0. A floor rather than an exact
+          # count, so the TestHotkeys.* group can grow without editing this, but
+          # a rename that empties it still fails here instead of quietly
+          # skipping every windows-only test we have.
+          listed=$(go test -list "$pattern" . | grep -c '^Test' || true)
+          if [ "$listed" -lt 5 ]; then
+            echo "::error::windows test pattern matched $listed tests, expected at least 5"
+            exit 1
+          fi
+          go test -count=1 -run "$pattern" -v .
 
   # Compile gate for the darwin cgo files (deeplink_darwin.go, the *_darwin
   # bridges): build tags hide them from the linux job, so without this their

--- a/sidecar/hotkeys_windows.go
+++ b/sidecar/hotkeys_windows.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"runtime"
 	"syscall"
@@ -11,10 +12,10 @@ import (
 
 // Win32 hotkey modifiers + virtual-key codes.
 const (
-	modAlt     = 0x0001
-	modControl = 0x0002
-	modShift   = 0x0004
-	modWin     = 0x0008
+	modAlt      = 0x0001
+	modControl  = 0x0002
+	modShift    = 0x0004
+	modWin      = 0x0008
 	modNoRepeat = 0x4000
 )
 
@@ -28,6 +29,10 @@ const (
 	wmHotkey = 0x0312
 	wmQuit   = 0x0012
 )
+
+// ERROR_HOTKEY_ALREADY_REGISTERED — another process (an IME, a launcher, a
+// window manager) owns this combination, so ours will never fire.
+const errHotkeyAlreadyRegistered = syscall.Errno(1409)
 
 // Win32 message struct layout.
 type w32Msg struct {
@@ -52,6 +57,15 @@ var (
 // thread and runs a Win32 message loop, invoking onFire on every press.
 // Returns a stop function that unregisters the hotkey and breaks the loop.
 //
+// A registration that FAILS comes back as an error. It used to be logged from
+// inside the goroutine while this function still returned (stop, nil), so every
+// caller went on to announce the hotkey as registered -- the sidecar log said
+// "summon hotkey 'ctrl+space' registered" for a key that did nothing, which is
+// the worst possible thing for it to say when someone is trying to work out why
+// their hotkey is dead. Ctrl+Space in particular is contended on Windows (IMEs
+// and other launchers take it), and RegisterHotKey refuses a combination that
+// another process already holds.
+//
 // keyspec is parsed by parseHotkey; only "ctrl+space" is supported in W2-T2.
 // Mac/Linux will plug in here when their hotkey backends land.
 func startHotkeyListener(keyspec string, onFire func()) (stop func(), err error) {
@@ -60,7 +74,14 @@ func startHotkeyListener(keyspec string, onFire func()) (stop func(), err error)
 		return nil, err
 	}
 
-	threadIDCh := make(chan uint32, 1)
+	// The thread id is only useful once the hotkey is actually registered (it
+	// exists to unblock GetMessage in stop()), so it rides along with the
+	// verdict rather than being published ahead of it.
+	type registration struct {
+		tid uint32
+		err error
+	}
+	regCh := make(chan registration, 1)
 	stopCh := make(chan struct{})
 
 	go func() {
@@ -68,15 +89,15 @@ func startHotkeyListener(keyspec string, onFire func()) (stop func(), err error)
 		defer runtime.UnlockOSThread()
 
 		tid, _, _ := procGetCurrentThread.Call()
-		threadIDCh <- uint32(tid)
 
 		const hotkeyID = 1
 		r, _, e := procRegisterHotKey.Call(0, hotkeyID, uintptr(mods|modNoRepeat), uintptr(vk))
 		if r == 0 {
-			log.Printf("[hotkeys] RegisterHotKey(%s) failed: %v", keyspec, e)
+			regCh <- registration{err: registerHotKeyError(keyspec, e)}
 			return
 		}
 		defer procUnregisterHotKey.Call(0, hotkeyID)
+		regCh <- registration{tid: uint32(tid)}
 		log.Printf("[hotkeys] registered %s (mods=0x%x, vk=0x%x)", keyspec, mods, vk)
 
 		for {
@@ -91,7 +112,12 @@ func startHotkeyListener(keyspec string, onFire func()) (stop func(), err error)
 				uintptr(unsafe.Pointer(&msg)),
 				0, 0, 0,
 			)
-			if r == 0 || r == ^uintptr(0) {
+			// GetMessage returns a 32-bit BOOL, and -1 is its error return. The
+			// upper half of the register is not part of that value, so compare
+			// as int32: `r == ^uintptr(0)` only ever matched a sign-extended
+			// -1, and on the error path that never matches the loop would spin
+			// on a failing call forever.
+			if r == 0 || int32(r) == -1 {
 				return
 			}
 			if msg.Message == wmHotkey && msg.WParam == hotkeyID {
@@ -101,14 +127,33 @@ func startHotkeyListener(keyspec string, onFire func()) (stop func(), err error)
 		}
 	}()
 
-	tid := <-threadIDCh
+	reg := <-regCh
+	if reg.err != nil {
+		return nil, reg.err
+	}
 
+	tid := reg.tid
 	stop = func() {
 		close(stopCh)
 		// Unblock GetMessage by posting WM_QUIT to the listener thread.
 		procPostThreadMsg.Call(uintptr(tid), wmQuit, 0, 0)
 	}
 	return stop, nil
+}
+
+// registerHotKeyError turns RegisterHotKey's failure into something a user can
+// act on. The common case by far is another process already owning the
+// combination, and "the operation completed successfully" -- which is what a
+// zero errno formats as -- is not an error message.
+func registerHotKeyError(keyspec string, e error) error {
+	errno, ok := e.(syscall.Errno)
+	switch {
+	case ok && errno == errHotkeyAlreadyRegistered:
+		return fmt.Errorf("RegisterHotKey(%s): already registered by another application", keyspec)
+	case ok && errno == 0:
+		return fmt.Errorf("RegisterHotKey(%s): refused with no error code", keyspec)
+	}
+	return fmt.Errorf("RegisterHotKey(%s): %w", keyspec, e)
 }
 
 // parseHotkey converts a string like "ctrl+space" or "alt+j" into Win32

--- a/sidecar/hotkeys_windows.go
+++ b/sidecar/hotkeys_windows.go
@@ -30,8 +30,11 @@ const (
 	wmQuit   = 0x0012
 )
 
-// ERROR_HOTKEY_ALREADY_REGISTERED — another process (an IME, a launcher, a
-// window manager) owns this combination, so ours will never fire.
+// ERROR_HOTKEY_ALREADY_REGISTERED — some other hot key already owns this
+// combination, so ours will never fire. Usually another app (an IME, a
+// launcher, a window manager), but not always ours to blame elsewhere: a
+// previous sidecar instance that has not finished exiting still holds its
+// hotkeys, which is exactly the window relaunch.go waits out.
 const errHotkeyAlreadyRegistered = syscall.Errno(1409)
 
 // Win32 message struct layout.
@@ -63,8 +66,9 @@ var (
 // "summon hotkey 'ctrl+space' registered" for a key that did nothing, which is
 // the worst possible thing for it to say when someone is trying to work out why
 // their hotkey is dead. Ctrl+Space in particular is contended on Windows (IMEs
-// and other launchers take it), and RegisterHotKey refuses a combination that
-// another process already holds.
+// and other launchers take it), and RegisterHotKey refuses any combination that
+// another hot key already holds -- including one held by a previous instance of
+// this sidecar that has not finished exiting.
 //
 // keyspec is parsed by parseHotkey; only "ctrl+space" is supported in W2-T2.
 // Mac/Linux will plug in here when their hotkey backends land.
@@ -112,12 +116,21 @@ func startHotkeyListener(keyspec string, onFire func()) (stop func(), err error)
 				uintptr(unsafe.Pointer(&msg)),
 				0, 0, 0,
 			)
+			if r == 0 {
+				return // WM_QUIT: stop() asked for it
+			}
 			// GetMessage returns a 32-bit BOOL, and -1 is its error return. The
 			// upper half of the register is not part of that value, so compare
 			// as int32: `r == ^uintptr(0)` only ever matched a sign-extended
 			// -1, and on the error path that never matches the loop would spin
 			// on a failing call forever.
-			if r == 0 || int32(r) == -1 {
+			//
+			// Said out loud, because this is the listener going deaf for the
+			// rest of the process's life. A silent return here would put us
+			// straight back to the thing this file exists to stop: a hotkey
+			// that does nothing and a log with no trace of why.
+			if int32(r) == -1 {
+				log.Printf("[hotkeys] GetMessage failed for %s; listener stopping (hotkey is now dead)", keyspec)
 				return
 			}
 			if msg.Message == wmHotkey && msg.WParam == hotkeyID {
@@ -142,16 +155,21 @@ func startHotkeyListener(keyspec string, onFire func()) (stop func(), err error)
 }
 
 // registerHotKeyError turns RegisterHotKey's failure into something a user can
-// act on. The common case by far is another process already owning the
-// combination, and "the operation completed successfully" -- which is what a
-// zero errno formats as -- is not an error message.
+// act on. The common case by far is the combination already being taken, and
+// "the operation completed successfully" -- which is what a zero errno formats
+// as -- is not an error message.
+//
+// Deliberately does NOT name a culprit: the holder can be another app or a
+// previous instance of this sidecar, and we cannot tell which from here.
 func registerHotKeyError(keyspec string, e error) error {
 	errno, ok := e.(syscall.Errno)
 	switch {
 	case ok && errno == errHotkeyAlreadyRegistered:
-		return fmt.Errorf("RegisterHotKey(%s): already registered by another application", keyspec)
+		return fmt.Errorf("RegisterHotKey(%s): already held by another hot key (another app, or a sidecar that has not exited)", keyspec)
 	case ok && errno == 0:
 		return fmt.Errorf("RegisterHotKey(%s): refused with no error code", keyspec)
+	case e == nil:
+		return fmt.Errorf("RegisterHotKey(%s): refused", keyspec)
 	}
 	return fmt.Errorf("RegisterHotKey(%s): %w", keyspec, e)
 }

--- a/sidecar/hotkeys_windows.go
+++ b/sidecar/hotkeys_windows.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"log"
 	"runtime"
+	"strconv"
+	"strings"
 	"syscall"
 	"unsafe"
 )
@@ -21,8 +23,38 @@ const (
 
 const (
 	vkSpace = 0x20
-	vkK     = 0x4B
+	vkF1    = 0x70 // VK_F1; F2..F24 follow contiguously
 )
+
+// namedVKCodes covers the keys that have a name rather than a character.
+// Letters, digits and the function keys are computed in windowsVK.
+//
+// The names are the ones hotkeys_linux.go and hotkeys_darwin.go already accept,
+// so one keyspec in config means the same thing on all three platforms.
+var namedVKCodes = map[string]uint32{
+	"space":     vkSpace,
+	"spacebar":  vkSpace,
+	"enter":     0x0D, // VK_RETURN
+	"return":    0x0D,
+	"tab":       0x09,
+	"esc":       0x1B, // VK_ESCAPE
+	"escape":    0x1B,
+	"backspace": 0x08,
+	"del":       0x2E, // VK_DELETE
+	"delete":    0x2E,
+	"ins":       0x2D, // VK_INSERT
+	"insert":    0x2D,
+	"home":      0x24,
+	"end":       0x23,
+	"pageup":    0x21, // VK_PRIOR
+	"pgup":      0x21,
+	"pagedown":  0x22, // VK_NEXT
+	"pgdn":      0x22,
+	"left":      0x25,
+	"up":        0x26,
+	"right":     0x27,
+	"down":      0x28,
+}
 
 // Win32 message identifiers.
 const (
@@ -70,8 +102,8 @@ var (
 // another hot key already holds -- including one held by a previous instance of
 // this sidecar that has not finished exiting.
 //
-// keyspec is parsed by parseHotkey; only "ctrl+space" is supported in W2-T2.
-// Mac/Linux will plug in here when their hotkey backends land.
+// keyspec is parsed by parseHotkey, which takes the same grammar as the macOS
+// and Linux backends.
 func startHotkeyListener(keyspec string, onFire func()) (stop func(), err error) {
 	mods, vk, err := parseHotkey(keyspec)
 	if err != nil {
@@ -174,21 +206,65 @@ func registerHotKeyError(keyspec string, e error) error {
 	return fmt.Errorf("RegisterHotKey(%s): %w", keyspec, e)
 }
 
-// parseHotkey converts a string like "ctrl+space" or "alt+j" into Win32
-// modifier flags and a virtual-key code. Only the keys we actually use are
-// supported in W2-T2 (extending here is trivial).
+// parseHotkey converts a spec like "ctrl+space", "Ctrl+Shift+K" or "alt+f4"
+// into Win32 modifier flags and a virtual-key code: the last "+"-separated
+// token is the key, everything before it is a modifier, and case does not
+// matter.
+//
+// Deliberately the same grammar as parseLinuxKeyspec and parseDarwinKeyspec.
+// This used to be a switch over six literal spellings of the two hotkeys the
+// daemon happens to send, which held only while the hotkey was hardcoded:
+// anything else -- "Ctrl+space" included, a spelling both other platforms
+// accept -- failed on Windows alone, and failed at the one call site whose
+// error the user experiences as a dead key.
 func parseHotkey(spec string) (mods, vk uint32, err error) {
-	switch spec {
-	case "ctrl+space", "Ctrl+Space", "CTRL+SPACE":
-		return modControl, vkSpace, nil
-	case "ctrl+k", "Ctrl+K", "CTRL+K":
-		return modControl, vkK, nil
+	parts := strings.Split(strings.ToLower(strings.TrimSpace(spec)), "+")
+	for i := range parts {
+		parts[i] = strings.TrimSpace(parts[i])
 	}
-	return 0, 0, &hotkeyParseError{spec: spec}
+	keyTok := parts[len(parts)-1]
+	if keyTok == "" {
+		return 0, 0, fmt.Errorf("hotkey %q names no key", spec)
+	}
+	for _, m := range parts[:len(parts)-1] {
+		switch m {
+		case "ctrl", "control":
+			mods |= modControl
+		case "shift":
+			mods |= modShift
+		case "alt", "option":
+			mods |= modAlt
+		case "super", "cmd", "command", "win", "meta":
+			mods |= modWin
+		default:
+			return 0, 0, fmt.Errorf("unknown modifier %q in hotkey %q", m, spec)
+		}
+	}
+	vk, ok := windowsVK(keyTok)
+	if !ok {
+		return 0, 0, fmt.Errorf("unsupported key %q in hotkey %q", keyTok, spec)
+	}
+	return mods, vk, nil
 }
 
-type hotkeyParseError struct{ spec string }
-
-func (e *hotkeyParseError) Error() string {
-	return "unsupported hotkey: " + e.spec
+// windowsVK resolves one key name to a Win32 virtual-key code. Letters, digits
+// and F1-F24 are computed (the VK ranges are contiguous and match ASCII for the
+// first two); everything else comes from namedVKCodes.
+func windowsVK(name string) (uint32, bool) {
+	if len(name) == 1 {
+		switch c := name[0]; {
+		case c >= 'a' && c <= 'z':
+			return uint32(c-'a') + 0x41, true // VK_A..VK_Z are 'A'..'Z'
+		case c >= '0' && c <= '9':
+			return uint32(c-'0') + 0x30, true // VK_0..VK_9 are '0'..'9'
+		}
+	}
+	// Guarded by the single-character case above, so a bare "f" is the letter.
+	if len(name) > 1 && name[0] == 'f' {
+		if n, err := strconv.Atoi(name[1:]); err == nil && n >= 1 && n <= 24 {
+			return vkF1 + uint32(n) - 1, true
+		}
+	}
+	vk, ok := namedVKCodes[name]
+	return vk, ok
 }

--- a/sidecar/hotkeys_windows_test.go
+++ b/sidecar/hotkeys_windows_test.go
@@ -46,8 +46,14 @@ func TestStartHotkeyListenerReportsARefusedRegistration(t *testing.T) {
 // translating before they reach a log a person has to act on.
 func TestRegisterHotKeyErrorIsActionable(t *testing.T) {
 	contended := registerHotKeyError("ctrl+space", errHotkeyAlreadyRegistered)
-	if !strings.Contains(contended.Error(), "another application") {
-		t.Fatalf("a contended combination should say who is holding it, got: %v", contended)
+	if !strings.Contains(contended.Error(), "already held") {
+		t.Fatalf("a contended combination should say the key is taken, got: %v", contended)
+	}
+
+	// A nil error is not reachable through LazyProc.Call (it always hands back
+	// an Errno), but the formatting verb must not be the thing that finds out.
+	if got := registerHotKeyError("ctrl+space", nil).Error(); strings.Contains(got, "%!w") {
+		t.Fatalf("a nil errno should still format cleanly, got: %v", got)
 	}
 
 	// A zero errno formats as "The operation completed successfully.", which as

--- a/sidecar/hotkeys_windows_test.go
+++ b/sidecar/hotkeys_windows_test.go
@@ -18,7 +18,7 @@ import (
 // Ctrl+Space is genuinely contended on Windows (IMEs, launchers), and
 // RegisterHotKey refuses a combination another hot key already holds, which is
 // what this reproduces: hold one, then ask for it again.
-func TestStartHotkeyListenerReportsARefusedRegistration(t *testing.T) {
+func TestHotkeysRefusedRegistrationIsReported(t *testing.T) {
 	held, err := startHotkeyListener("ctrl+k", func() {})
 	if err != nil {
 		t.Skipf("this environment cannot register global hotkeys at all: %v", err)
@@ -44,7 +44,7 @@ func TestStartHotkeyListenerReportsARefusedRegistration(t *testing.T) {
 
 // The errno is the only thing the OS tells us, and two of its values need
 // translating before they reach a log a person has to act on.
-func TestRegisterHotKeyErrorIsActionable(t *testing.T) {
+func TestHotkeysRegisterErrorIsActionable(t *testing.T) {
 	contended := registerHotKeyError("ctrl+space", errHotkeyAlreadyRegistered)
 	if !strings.Contains(contended.Error(), "already held") {
 		t.Fatalf("a contended combination should say the key is taken, got: %v", contended)
@@ -66,5 +66,64 @@ func TestRegisterHotKeyErrorIsActionable(t *testing.T) {
 	other := registerHotKeyError("ctrl+space", syscall.Errno(87)) // ERROR_INVALID_PARAMETER
 	if !strings.Contains(other.Error(), "ctrl+space") {
 		t.Fatalf("the error should name the hotkey that failed, got: %v", other)
+	}
+}
+
+// Every spelling below works on macOS and Linux, so it has to work here. The
+// mixed-case one is the regression: "Ctrl+space" was rejected on Windows alone
+// while the other two backends took it, and a rejected spec reaches the user as
+// a hotkey that does nothing.
+func TestHotkeysParseSpecMatchesTheOtherPlatforms(t *testing.T) {
+	for _, c := range []struct {
+		spec string
+		mods uint32
+		vk   uint32
+	}{
+		{"ctrl+space", modControl, 0x20},
+		{"Ctrl+Space", modControl, 0x20},
+		{"CTRL+SPACE", modControl, 0x20},
+		{"Ctrl+space", modControl, 0x20}, // the spelling that used to fail
+		{"  ctrl + space  ", modControl, 0x20},
+		{"ctrl+spacebar", modControl, 0x20},
+		{"ctrl+k", modControl, 0x4B},
+		{"CTRL+K", modControl, 0x4B},
+		{"ctrl+shift+k", modControl | modShift, 0x4B},
+		{"control+alt+delete", modControl | modAlt, 0x2E},
+		{"alt+f4", modAlt, 0x73},
+		{"ctrl+f12", modControl, 0x7B},
+		{"win+d", modWin, 0x44},
+		{"super+1", modWin, 0x31},
+		{"ctrl+option+up", modControl | modAlt, 0x26},
+		{"f", 0, 0x46}, // a bare "f" is the letter, not a broken F-key
+		{"f1", 0, 0x70},
+		{"ctrl+enter", modControl, 0x0D},
+		{"ctrl+esc", modControl, 0x1B},
+	} {
+		mods, vk, err := parseHotkey(c.spec)
+		if err != nil {
+			t.Errorf("parseHotkey(%q): unexpected error %v", c.spec, err)
+			continue
+		}
+		if mods != c.mods || vk != c.vk {
+			t.Errorf("parseHotkey(%q) = (0x%x, 0x%x), want (0x%x, 0x%x)", c.spec, mods, vk, c.mods, c.vk)
+		}
+	}
+}
+
+func TestHotkeysParseSpecRejectsWhatItCannotRegister(t *testing.T) {
+	// Silently registering the wrong key would be worse than refusing: the
+	// caller logs the refusal, and a wrong key looks like a broken one.
+	for _, spec := range []string{
+		"",
+		"ctrl+",
+		"hyper+k",       // modifier Win32 has no flag for
+		"ctrl+capslock", // key we have no VK for
+		"ctrl+f25",      // past VK_F24
+		"ctrl+f0",
+		"ctrl+space+k", // "space" read as a modifier
+	} {
+		if _, _, err := parseHotkey(spec); err == nil {
+			t.Errorf("parseHotkey(%q) should have failed", spec)
+		}
 	}
 }

--- a/sidecar/hotkeys_windows_test.go
+++ b/sidecar/hotkeys_windows_test.go
@@ -1,0 +1,64 @@
+//go:build windows
+
+package main
+
+import (
+	"strings"
+	"syscall"
+	"testing"
+)
+
+// A registration the OS refuses has to come back as an ERROR.
+//
+// It used to be logged from inside the listener goroutine while
+// startHotkeyListener returned (stop, nil), so the caller logged "summon hotkey
+// 'ctrl+space' registered" for a key that could never fire -- the one message
+// guaranteed to send whoever is debugging a dead hotkey looking somewhere else.
+//
+// Ctrl+Space is genuinely contended on Windows (IMEs, launchers), and
+// RegisterHotKey refuses a combination another hot key already holds, which is
+// what this reproduces: hold one, then ask for it again.
+func TestStartHotkeyListenerReportsARefusedRegistration(t *testing.T) {
+	held, err := startHotkeyListener("ctrl+k", func() {})
+	if err != nil {
+		t.Skipf("this environment cannot register global hotkeys at all: %v", err)
+	}
+	defer held()
+
+	second, err := startHotkeyListener("ctrl+k", func() {})
+	if err == nil {
+		// The OS allowed the duplicate, so there is no refusal to observe here.
+		// Not a failure of the code under test -- release it and move on.
+		if second != nil {
+			second()
+		}
+		t.Skip("this Windows build allows a duplicate hot-key registration")
+	}
+	if second != nil {
+		t.Fatal("a refused registration handed back a stop function; callers read a non-nil stop as a live hotkey")
+	}
+	if !strings.Contains(err.Error(), "ctrl+k") {
+		t.Fatalf("the error should name the hotkey that failed, got: %v", err)
+	}
+}
+
+// The errno is the only thing the OS tells us, and two of its values need
+// translating before they reach a log a person has to act on.
+func TestRegisterHotKeyErrorIsActionable(t *testing.T) {
+	contended := registerHotKeyError("ctrl+space", errHotkeyAlreadyRegistered)
+	if !strings.Contains(contended.Error(), "another application") {
+		t.Fatalf("a contended combination should say who is holding it, got: %v", contended)
+	}
+
+	// A zero errno formats as "The operation completed successfully.", which as
+	// the whole text of a failure message is worse than saying nothing.
+	quiet := registerHotKeyError("ctrl+space", syscall.Errno(0))
+	if strings.Contains(strings.ToLower(quiet.Error()), "completed successfully") {
+		t.Fatalf("a zero errno must not be reported as success, got: %v", quiet)
+	}
+
+	other := registerHotKeyError("ctrl+space", syscall.Errno(87)) // ERROR_INVALID_PARAMETER
+	if !strings.Contains(other.Error(), "ctrl+space") {
+		t.Fatalf("the error should name the hotkey that failed, got: %v", other)
+	}
+}


### PR DESCRIPTION
Split out of #408, where these got in the way of the diagnosis. Independent of it -- branched off `main`, and only `sidecar/hotkeys_windows.go` plus its tests and the windows CI job.

Three defects in the Windows hotkey backend, all of the same shape: a hotkey that does not work, and a log that says nothing useful about why.

## 1. A refused registration reported as success

`startHotkeyListener` logged a failed `RegisterHotKey` from inside the listener goroutine and still returned `(stop, nil)`. All three callers (pebble summon, palette, panel summon) then took the success branch and logged `summon hotkey 'ctrl+space' registered` for a key that could never fire -- the worst thing the log can say to someone working out why their hotkey is dead. Ctrl+Space is genuinely contended on Windows: IMEs and launchers take it, and `RegisterHotKey` refuses any combination another hot key already holds, including one still held by a previous sidecar instance that has not finished exiting (the window `relaunch.go` waits out).

The listener thread now reports either its thread id (registered) or the error (refused) over one channel, so the function returns a real error and a nil `stop`. The callers already had an `if err != nil` branch that logged "not registered" and skipped storing `stop` -- they just start telling the truth. `registerHotKeyError` translates the errno, without naming a culprit it cannot know: `ERROR_HOTKEY_ALREADY_REGISTERED` says the key is already held (another app, or a sidecar that has not exited), and a zero errno no longer reports the failure as "The operation completed successfully."

## 2. A message loop that could spin forever, then die silently

The `GetMessage` error check was `r == ^uintptr(0)`, which only matches a sign-extended -1. `GetMessage` returns a 32-bit BOOL, and Windows writes EAX (zero-extending into RAX), so the error return arrives as `0x00000000FFFFFFFF` and the test never matched -- the loop would have spun on a failing call forever. It compares as `int32(r) == -1` now, split from the clean `r == 0` (WM_QUIT) exit and logged, because that branch is the listener going deaf for the rest of the process's life.

## 3. Specs the other two platforms accept, rejected here

`parseHotkey` was a switch over six literal spellings of the two hotkeys the daemon happens to send. That held only while the hotkey was hardcoded: `Ctrl+space` -- a spelling both macOS and Linux accept -- failed on Windows alone, and it failed at the one call site whose error the user experiences as a dead key.

It now takes the same grammar as `parseLinuxKeyspec` and `parseDarwinKeyspec`: last `+`-separated token is the key, the rest are modifiers, case and surrounding spaces do not matter. Modifier names are the union the other two accept (`ctrl`/`control`, `shift`, `alt`/`option`, `super`/`cmd`/`command`/`win`/`meta`), so one keyspec in config means the same thing everywhere. Keys cover letters, digits, F1-F24 and the named keys the other backends know; letters, digits and function keys are computed off the contiguous VK ranges rather than listed.

## Tests

`sidecar/hotkeys_windows_test.go`:

- `TestHotkeysRefusedRegistrationIsReported` holds a combination, asks for it again, and asserts the second call returns an error naming the hotkey and hands back no `stop`. It skips rather than fails if the environment cannot register global hotkeys at all or allows the duplicate, so it can never go red for a reason that is not the code under test. On the runner it did neither -- it registered, the duplicate was refused, and the error surfaced.
- `TestHotkeysRegisterErrorIsActionable` pins the errno translations.
- `TestHotkeysParseSpecMatchesTheOtherPlatforms` checks 19 specs against exact modifier/VK pairs, including the `Ctrl+space` regression. Cross-check worth noting: the computed VK for `k` is `0x4B`, the value the old hardcoded `vkK` had.
- `TestHotkeysParseSpecRejectsWhatItCannotRegister` covers the refusals -- unknown modifier, unknown key, `f0`/`f25` past the VK range, and `ctrl+space+k` where `space` would be read as a modifier. Registering the wrong key would be worse than refusing.

The file is windows-tagged, so it runs on the existing `sidecar-test-windows` job. Its `-run` pattern is now a `TestHotkeys.*` group so a new hotkey test runs without editing CI, with the same `go test -list` guard the browser parity step already uses -- `-run` with no match prints "no tests to run" and exits 0, and a rename that emptied the group would otherwise skip every windows-only test we have silently.

`go vet` passes under `GOOS=windows`; the linux sidecar build, vet and suite are unchanged. Also gofmt on the file, which was already unformatted before this change (`modNoRepeat` was added without realigning the const block) -- whitespace only.
