### PR TITLE
Hosted installs stop offering (and refuse) dashboard device enrollment

### DIFF
--- a/src/daemon/api-routes.ts
+++ b/src/daemon/api-routes.ts
@@ -12,7 +12,7 @@ import { SecretStorageError } from './section-secrets.ts';
 import type { AgentService } from './agent-service.ts';
 import type { JarvisConfig } from '../config/types.ts';
 import { realtimeServedByPlan, resolveRealtimeVoice, DEFAULT_BLOCKED_CATEGORIES } from '../config/realtime.ts';
-import { hasUsejarvisAi, effectiveSttForBinding, effectiveTtsForBinding, realtimeEnablement, usejarvisVoiceCredentials } from './usejarvis-ai.ts';
+import { hasUsejarvisAi, isHostedInstall, effectiveSttForBinding, effectiveTtsForBinding, realtimeEnablement, usejarvisVoiceCredentials } from './usejarvis-ai.ts';
 import { cachedRealtimeVerdict } from './realtime-gate.ts';
 import type { EntityType } from '../vault/entities.ts';
 import type { CommitmentPriority, CommitmentStatus } from '../vault/commitments.ts';
@@ -4144,10 +4144,55 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
       },
     },
 
+    /**
+     * Enroll a device from the dashboard. SELF-HOSTED ONLY.
+     *
+     * This mints a long-lived enrollment JWT and hands it to the page, which
+     * shows it once and tells the user to run `jarvis --token <jwt>` on the
+     * target machine. That is one self-hosted way to add a device -- the other,
+     * and the one docs/SELF_HOSTING.md calls primary, is `jarvis enroll <name>`
+     * on the brain host. Refusing here therefore never strands anyone.
+     *
+     * On a hosted install it is neither needed nor wanted:
+     *
+     *  - It is not the flow. A hosted user adds a device by installing Jarvis
+     *    there and signing in; the control plane runs `jarvis enroll` over SSH
+     *    on their behalf (ONBOARDING.md). Nobody is meant to copy a JWT, and
+     *    the copy here tells them to run a CLI flag they never touch.
+     *  - It is an escalation. Every route under /api is authorized by a PANEL
+     *    SESSION -- a cookie in a webview, bounded by that session's cap. This
+     *    one turns that cookie into a permanent enrollment credential under a
+     *    NEW sid, which revoking the original device does not touch. It is the
+     *    only route on the data plane that can do that.
+     *
+     * Refusing here removes the escalation without costing a hosted user
+     * anything: their device list and revoke live in the hosting dashboard,
+     * authorized by their ACCOUNT rather than by a cookie.
+     *
+     * Gated on `isHostedInstall`, NOT on `hasUsejarvisAi` alone. The feature
+     * paths in this file ask the latter because a missing hosted-LLM block just
+     * means the feature is off. A deny-gate needs the opposite bias, and that
+     * block is renderable as null: a hosting deployment with no LLM proxy
+     * configured would read as self-hosted and reopen this route on every
+     * tenant it re-rendered. `daemon.listen: unix:` cannot be absent on a
+     * hosted instance, so the predicate ORs the two.
+     */
     '/api/sidecars/enroll': {
       POST: async (req: Request) => {
         try {
           if (!ctx.sidecarManager) return error('Sidecar manager not available', 503);
+          if (isHostedInstall(ctx.config)) {
+            // 403 rather than 409: the request is well-formed and the route
+            // exists, the caller simply may not do this here. 409 already means
+            // two other things on this route (name taken, name invalid), so it
+            // would carry no information.
+            return error(
+              'Adding a device from the dashboard is disabled on hosted installs. '
+                + 'Install Jarvis on the new device and sign in there with your Usejarvis '
+                + 'account -- it enrols itself. On a self-hosted brain, run: jarvis enroll <name>',
+              403,
+            );
+          }
           const body = await req.json() as { name?: string };
           if (!body.name) return error('Missing "name" field');
           const result = await ctx.sidecarManager.enrollSidecar(body.name);

--- a/src/daemon/api-sidecar-enroll.test.ts
+++ b/src/daemon/api-sidecar-enroll.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from 'bun:test';
+import { createApiRoutes, type ApiContext } from './api-routes.ts';
+import type { JarvisConfig } from '../config/types.ts';
+
+/**
+ * Tests for POST /api/sidecars/enroll.
+ *
+ * This route mints a long-lived enrollment JWT and hands it to the page. On a
+ * self-hosted install that is the only way to add a device and must keep
+ * working. On a hosted install it is the one route on the data plane that can
+ * turn a panel-session cookie into a permanent credential under a NEW sid --
+ * which revoking the original device does not touch -- while not even being the
+ * flow a hosted user is meant to use.
+ *
+ * So the two cases below are the feature: refused when hosted, untouched when
+ * not. The manager is a stub that would throw if it were ever reached on the
+ * hosted path, so a guard that stopped guarding fails loudly rather than
+ * quietly minting.
+ */
+
+type Handler = (req: Request) => Response | Promise<Response>;
+
+/** Records whether the guard let the request through to the manager. */
+function handlerFor(config: Partial<JarvisConfig>) {
+  const calls: string[] = [];
+  const routes = createApiRoutes({
+    daemonStartedAt: Date.now(),
+    healthMonitor: {} as ApiContext['healthMonitor'],
+    config: { llm: { providers: {} }, ...config } as JarvisConfig,
+    sidecarManager: {
+      enrollSidecar: async (name: string) => {
+        calls.push(name);
+        return { token: 'enrollment.jwt.value', sidecar: { id: 'sid-1', name } };
+      },
+    } as unknown as ApiContext['sidecarManager'],
+  } as ApiContext);
+  const route = routes['/api/sidecars/enroll'] as { POST?: Handler } | undefined;
+  if (!route?.POST) throw new Error('Route /api/sidecars/enroll POST not registered');
+  return { post: route.POST, calls };
+}
+
+const enroll = (name: unknown = 'laptop') =>
+  new Request('http://localhost/api/sidecars/enroll', {
+    method: 'POST',
+    body: JSON.stringify({ name }),
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+/** A complete hosted block -- hasUsejarvisAi needs both fields. */
+const HOSTED = { usejarvis_ai: { base_url: 'https://llm.usejarvis.dev', api_key: 'sk-uj-abcdefghijklmnop' } };
+
+describe('POST /api/sidecars/enroll', () => {
+  it('refuses on a hosted install, and never reaches the manager', async () => {
+    const { post, calls } = handlerFor(HOSTED as Partial<JarvisConfig>);
+    const res = await post(enroll());
+
+    expect(res.status).toBe(403);
+    // The credential is the point: nothing may be minted on this path.
+    expect(calls).toEqual([]);
+    const body = (await res.json()) as { error?: string };
+    expect(body.error).toBeDefined();
+    // The message has to name the real path, because the user is standing in
+    // front of a button that just stopped working.
+    expect(body.error).toContain('sign in');
+  });
+
+  it('refuses before reading the body, so a malformed request still gets the real reason', async () => {
+    // Otherwise a hosted user with a bad payload would be told "Missing name"
+    // and go fix the wrong thing.
+    const { post, calls } = handlerFor(HOSTED as Partial<JarvisConfig>);
+    const res = await post(
+      new Request('http://localhost/api/sidecars/enroll', { method: 'POST', body: 'not json' }),
+    );
+    expect(res.status).toBe(403);
+    expect(calls).toEqual([]);
+  });
+
+  it('still enrolls on a self-hosted install', async () => {
+    // The flow this route exists for. A guard that caught everything would be
+    // just as broken as one that caught nothing.
+    const { post, calls } = handlerFor({});
+    const res = await post(enroll('workshop-mac'));
+
+    expect(res.status).toBe(201);
+    expect(calls).toEqual(['workshop-mac']);
+    const body = (await res.json()) as { token?: string };
+    expect(body.token).toBe('enrollment.jwt.value');
+  });
+
+  it('an incomplete hosted block is not a hosted install', async () => {
+    // hasUsejarvisAi requires both fields. Half a block is a misrendered config,
+    // and treating it as hosted would lock a self-hoster out of their only way
+    // to add a device.
+    const { post, calls } = handlerFor({
+      usejarvis_ai: { base_url: 'https://llm.usejarvis.dev' },
+    } as Partial<JarvisConfig>);
+    const res = await post(enroll());
+
+    expect(res.status).toBe(201);
+    expect(calls).toEqual(['laptop']);
+  });
+
+  it('refuses a hosted instance that has no LLM proxy configured', async () => {
+    // The gap the LLM block alone leaves open. LLM_PROXY_URL is optional in the
+    // control plane, and every render path emits `usejarvisAi: null` without it
+    // -- including the DR/rehydrate path -- so a whole VPS of tenants could be
+    // re-rendered into looking self-hosted. `daemon.listen: unix:` cannot be
+    // absent on a hosted instance, which is why the predicate ORs the two.
+    const { post, calls } = handlerFor({
+      daemon: { listen: 'unix:/run/jarvis/u_42/brain.sock' },
+    } as unknown as Partial<JarvisConfig>);
+    const res = await post(enroll());
+
+    expect(res.status).toBe(403);
+    expect(calls).toEqual([]);
+  });
+
+  it('refuses when the hosted LLM block is malformed rather than absent', async () => {
+    // hasUsejarvisAi fails OPEN on a non-string field (it warns and treats the
+    // block as missing), which is right for a feature and wrong for a gate. The
+    // socket signal covers it.
+    const { post, calls } = handlerFor({
+      usejarvis_ai: { base_url: 123, api_key: 456 },
+      daemon: { listen: 'unix:/run/jarvis/u_42/brain.sock' },
+    } as unknown as Partial<JarvisConfig>);
+    const res = await post(enroll());
+
+    expect(res.status).toBe(403);
+    expect(calls).toEqual([]);
+  });
+
+  it('a TCP-listening install is self-hosted', async () => {
+    // The other side of the socket signal: `listen` omitted (or a TCP address)
+    // is the self-host default and must keep working.
+    const { post, calls } = handlerFor({
+      daemon: { port: 3142, listen: '' },
+    } as unknown as Partial<JarvisConfig>);
+    const res = await post(enroll('desk'));
+
+    expect(res.status).toBe(201);
+    expect(calls).toEqual(['desk']);
+  });
+
+  it('follows the LIVE config, so a SIGHUP reload flips the gate', async () => {
+    // ctx.config is the object reloadUsejarvisAiBlock mutates in place. If a
+    // refactor ever snapshotted the predicate at route-construction time, an
+    // instance that became hosted would keep minting until restarted.
+    const config = { llm: { providers: {} } } as JarvisConfig;
+    const calls: string[] = [];
+    const routes = createApiRoutes({
+      daemonStartedAt: Date.now(),
+      healthMonitor: {} as ApiContext['healthMonitor'],
+      config,
+      sidecarManager: {
+        enrollSidecar: async (name: string) => {
+          calls.push(name);
+          return { token: 'enrollment.jwt.value', sidecar: { id: 'sid-1', name } };
+        },
+      } as unknown as ApiContext['sidecarManager'],
+    } as ApiContext);
+    const post = (routes['/api/sidecars/enroll'] as { POST: Handler }).POST;
+
+    expect((await post(enroll())).status).toBe(201);
+
+    (config as unknown as { usejarvis_ai: unknown }).usejarvis_ai = HOSTED.usejarvis_ai;
+    expect((await post(enroll())).status).toBe(403);
+    expect(calls).toEqual(['laptop']);
+  });
+
+  it('self-hosted validation is unchanged', async () => {
+    // A body with no name at all -- not `enroll(undefined)`, whose default
+    // parameter would quietly supply one and test nothing.
+    const { post, calls } = handlerFor({});
+    const res = await post(
+      new Request('http://localhost/api/sidecars/enroll', {
+        method: 'POST',
+        body: '{}',
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect(calls).toEqual([]);
+  });
+});

--- a/src/daemon/llm-settings.ts
+++ b/src/daemon/llm-settings.ts
@@ -23,6 +23,7 @@ import {
   hasUsejarvisAi,
   USEJARVIS_PROVIDER_NAME,
   validateHostedModelRef,
+  isHostedInstall,
 } from './usejarvis-ai.ts';
 import { getSetting, setSetting } from '../vault/settings.ts';
 import { getSecret, setSecret, deleteSecret, hasSecret } from '../vault/keychain.ts';
@@ -116,6 +117,10 @@ export type LLMSettingsResponse = {
   available_kinds: LLMProviderKind[];
   /** True on hosted installs (the system-owned usejarvis_ai block is live). */
   hosted_llm?: boolean;
+  /** True when the install is HOSTED at all -- see isHostedInstall. Wider than
+   *  `hosted_llm`, and the field a client must use for anything the daemon
+   *  gates on the same predicate (device enrolment). */
+  hosted_install?: boolean;
   /** Provider-side prompt caching. Defaults to true; only explicit false disables. */
   prompt_cache: boolean;
   /**
@@ -253,6 +258,14 @@ export function getLLMSettings(config: JarvisConfig): LLMSettingsResponse {
     // Derived from the config.yaml block — the single source of hostedness —
     // never from provider-map key presence, which a legacy row can fake.
     hosted_llm: hasUsejarvisAi(config),
+    // The WIDER signal, for decisions the daemon gates on `isHostedInstall`
+    // rather than on the hosted-LLM block alone -- device enrolment being the
+    // first. Shipped alongside rather than replacing `hosted_llm`, because the
+    // two answer different questions: this one is "is this install ours", that
+    // one is "is the hosted LLM available", and a hosted deployment with no LLM
+    // proxy configured is the case where they differ. A client that gated a
+    // device decision on `hosted_llm` would show a button the daemon 403s.
+    hosted_install: isHostedInstall(config),
   };
 }
 

--- a/src/daemon/usejarvis-ai.ts
+++ b/src/daemon/usejarvis-ai.ts
@@ -95,6 +95,38 @@ export function hasUsejarvisAi(config: JarvisConfig): boolean {
 }
 
 /**
+ * Is this install HOSTED -- provisioned and owned by the control plane -- as
+ * opposed to someone's own machine?
+ *
+ * Deliberately the union of two signals, and deliberately different from
+ * `hasUsejarvisAi` above. That one answers "is the hosted LLM available", which
+ * is a FEATURE question: a missing block means the feature is off, and off is a
+ * safe answer for a feature.
+ *
+ * This one is asked by security gates, where the safe answer is the opposite.
+ * `usejarvis_ai` is renderable as null -- the control plane emits no block when
+ * it has no LLM proxy configured (LLM_PROXY_URL is optional by design), so a
+ * proxy-less or DR-rehydrated deployment would read as self-hosted and reopen
+ * whatever the gate was closing. `daemon.listen: unix:` cannot be absent: the
+ * renderer emits it for every instance unconditionally, and a hosted brain is
+ * unreachable without it because Caddy is the only way in.
+ *
+ * So they are OR'd. Disagreement between them resolves toward "hosted", which
+ * for a deny-gate is the direction that fails safe.
+ *
+ * The cost, stated plainly: a self-hoster who fronts their own brain with a
+ * reverse proxy over a unix socket reads as hosted here. That is affordable
+ * because no gate using this may be the only path to what it guards -- device
+ * enrollment, for instance, remains available from the CLI (`jarvis enroll`),
+ * which docs/SELF_HOSTING.md already calls the primary route.
+ */
+export function isHostedInstall(config: JarvisConfig): boolean {
+  if (hasUsejarvisAi(config)) return true;
+  const listen = config.daemon?.listen;
+  return typeof listen === 'string' && listen.trim().startsWith('unix:');
+}
+
+/**
  * Inject the hosted provider entry. Providers only — tier defaults live in
  * effectiveLlmForBinding and never touch the config object.
  */

--- a/ui/src/v2/rooms/settings/tabs/SidecarTab.tsx
+++ b/ui/src/v2/rooms/settings/tabs/SidecarTab.tsx
@@ -7,6 +7,7 @@ import { confirmDialog } from "../../../ui/ConfirmDialog";
 // power-user surface. The retheme cascade on .v2-set__legacy-embed
 // remaps --j-* → v2 tokens.
 import { SidecarConfigEditor } from "../../../../components/settings/SidecarConfigEditor";
+import { addDeviceMode, noDevicesCopy } from "./sidecar-add-device";
 
 export function SidecarTab({
   data,
@@ -16,6 +17,9 @@ export function SidecarTab({
   onToast: (text: string, tone?: "ok" | "warn") => void;
 }) {
   const { sidecars } = data;
+  // Which "add a device" section belongs here, and why: sidecar-add-device.ts.
+  const mode = addDeviceMode(data.llm);
+
   const [enrollName, setEnrollName] = useState("");
   const [enrolling, setEnrolling] = useState(false);
   const [enrollResult, setEnrollResult] = useState<{ token: string; name: string } | null>(null);
@@ -58,7 +62,31 @@ export function SidecarTab({
 
   return (
     <div>
-      {/* Enroll new sidecar */}
+      {/* Add a device. Hosted installs are told how; self-hosted get the form. */}
+      {mode === "unknown" ? (
+        <section className="v2-set__section">
+          <div className="v2-set__section-head">
+            <div>
+              <h3 className="v2-set__section-title">Add a device</h3>
+              <div className="v2-set__section-sub">
+                Checking how this install adds devices…
+              </div>
+            </div>
+          </div>
+        </section>
+      ) : mode === "hosted" ? (
+        <section className="v2-set__section">
+          <div className="v2-set__section-head">
+            <div>
+              <h3 className="v2-set__section-title">Add a device</h3>
+              <div className="v2-set__section-sub">
+                Install Jarvis on the new device and sign in with your account — it enrolls itself
+                and appears below. There is no token to copy.
+              </div>
+            </div>
+          </div>
+        </section>
+      ) : (
       <section className="v2-set__section">
         <div className="v2-set__section-head">
           <div>
@@ -112,6 +140,7 @@ export function SidecarTab({
           </div>
         )}
       </section>
+      )}
 
       {/* Enrolled sidecars list */}
       <section className="v2-set__section">
@@ -127,7 +156,7 @@ export function SidecarTab({
         </div>
 
         {sidecars.length === 0 ? (
-          <div className="v2-set__empty">Enroll one above to get started.</div>
+          <div className="v2-set__empty">{noDevicesCopy(mode)}</div>
         ) : (
           <ul className="v2-set__sidecar-list" role="list">
             {sidecars.map((sc) => (

--- a/ui/src/v2/rooms/settings/tabs/sidecar-add-device.test.ts
+++ b/ui/src/v2/rooms/settings/tabs/sidecar-add-device.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from 'bun:test';
+import { addDeviceMode, noDevicesCopy } from './sidecar-add-device.ts';
+
+/**
+ * The decision behind which "add a device" section renders. Getting it wrong in
+ * the hosted direction shows instructions to copy a token that the daemon will
+ * refuse to mint; getting it wrong in the self-hosted direction hides the only
+ * way that user can add a device at all.
+ */
+describe('addDeviceMode', () => {
+  test('hosted when the daemon says the install is hosted', () => {
+    expect(addDeviceMode({ hosted_install: true })).toBe('hosted');
+  });
+
+  test('self-hosted when it says otherwise', () => {
+    expect(addDeviceMode({ hosted_install: false })).toBe('self-hosted');
+    // Absent means the daemon answered and did not set it: a self-hosted
+    // install, not an unknown one.
+    expect(addDeviceMode({})).toBe('self-hosted');
+  });
+
+  test('unknown while settings are still loading', () => {
+    // A third answer, not a default. Defaulting to self-hosted would flash the
+    // token instructions at a hosted user before swapping them away. The hook
+    // starts this at null, so null is the case that actually occurs.
+    expect(addDeviceMode(null)).toBe('unknown');
+    expect(addDeviceMode(undefined)).toBe('unknown');
+  });
+
+  test('only an exact true counts as hosted', () => {
+    // The field is a strict boolean contract across the wire. Anything else is
+    // a daemon whose shape changed, and falling back to the form is the safe
+    // direction: the server still gates it, so the worst case is a refusal the
+    // user can read rather than a hidden control.
+    expect(addDeviceMode({ hosted_install: "yes" } as unknown as { hosted_install?: boolean })).toBe(
+      'self-hosted',
+    );
+  });
+});
+
+describe('noDevicesCopy', () => {
+  test('never points at a control the user cannot see', () => {
+    // "Enroll one above" is true only where there is a form above.
+    expect(noDevicesCopy('self-hosted')).toContain('above');
+    expect(noDevicesCopy('hosted')).not.toContain('above');
+    expect(noDevicesCopy('unknown')).not.toContain('above');
+  });
+
+  test('tells a hosted user what actually adds a device', () => {
+    expect(noDevicesCopy('hosted')).toContain('sign in');
+  });
+});

--- a/ui/src/v2/rooms/settings/tabs/sidecar-add-device.ts
+++ b/ui/src/v2/rooms/settings/tabs/sidecar-add-device.ts
@@ -1,0 +1,66 @@
+/**
+ * Which "add a device" section the Devices tab shows, and what it says when the
+ * list is empty.
+ *
+ * The two installs add devices in opposite directions, and showing the wrong
+ * one is worse than showing nothing:
+ *
+ *  - SELF-HOSTED: the dashboard mints a long-lived enrollment JWT, displays it
+ *    once, and the user carries it to the new machine (`jarvis --token <jwt>`).
+ *    Not their only route -- docs/SELF_HOSTING.md calls `jarvis enroll <name>`
+ *    on the brain host the primary one -- but it is the only route the
+ *    dashboard offers, so it must keep working here.
+ *  - HOSTED: the device enrolls ITSELF. Install Jarvis there, sign in, and the
+ *    control plane runs `jarvis enroll` over SSH. There is no token to copy:
+ *    the JWT goes to the sidecar over the handshake nonce and never through
+ *    page JS. The daemon refuses the mint route with a 403 -- both because the
+ *    instructions would be wrong and because that route is the one place a
+ *    panel-session cookie could become a permanent credential.
+ *
+ * Derived from `hosted_install`, which the daemon sets to `isHostedInstall`,
+ * THE SAME PREDICATE the route's guard uses. Not `hosted_llm`, which is the
+ * narrower "is the hosted LLM available" and is false on a hosted deployment
+ * with no LLM proxy configured -- exactly where the server still refuses. A UI
+ * gated on the narrow signal would offer a button the daemon 403s.
+ */
+export type AddDeviceMode = "unknown" | "hosted" | "self-hosted";
+
+/**
+ * The hook holds `llm` as `LLMConfig | null` and starts it at null, so null is
+ * "not loaded yet" -- a THIRD answer rather than a default to either side.
+ * Rendering the self-hosted form for a beat -- telling a hosted user to copy a
+ * token, then swapping to "there is no token" -- is the confusion this whole
+ * change removes, in miniature.
+ *
+ * Unknown is also reachable after loading finishes: the settings fetch resolves
+ * null on any non-2xx, and the room mounts this tab anyway. That is why the
+ * caller must render something for it rather than nothing.
+ */
+export function addDeviceMode(
+  llm: { hosted_install?: boolean } | null | undefined,
+): AddDeviceMode {
+  if (llm === null || llm === undefined) return "unknown";
+  // Strict boolean: the field crosses the wire as JSON, and anything other than
+  // a real `true` means a daemon whose shape changed. Falling back to the form
+  // is the safe direction -- the server still gates it.
+  return llm.hosted_install === true ? "hosted" : "self-hosted";
+}
+
+/**
+ * What the enrolled list says when it is empty.
+ *
+ * "Enroll one above" is only true where there IS something above: on hosted the
+ * section above says to install and sign in, and on an unresolved install there
+ * is no section at all. Pointing a user at a control that is not on their
+ * screen is the same category of wrong as the button this change removes.
+ */
+export function noDevicesCopy(mode: AddDeviceMode): string {
+  switch (mode) {
+    case "hosted":
+      return "No devices yet. Install Jarvis on a device and sign in — it appears here.";
+    case "self-hosted":
+      return "Enroll one above to get started.";
+    case "unknown":
+      return "No devices enrolled yet.";
+  }
+}

--- a/ui/src/v2/rooms/settings/useSettingsData.ts
+++ b/ui/src/v2/rooms/settings/useSettingsData.ts
@@ -162,6 +162,14 @@ export interface LLMConfig {
    */
   hosted_llm?: boolean;
   /**
+   * True when this install is HOSTED at all, which is wider than `hosted_llm`:
+   * a hosted deployment with no LLM proxy configured has no usejarvis_ai block
+   * and so `hosted_llm` is false while this stays true. Anything the daemon
+   * gates on `isHostedInstall` -- device enrolment -- must read THIS, or the UI
+   * offers a control the server refuses.
+   */
+  hosted_install?: boolean;
+  /**
    * Routing reality, computed by the daemon from the SAME per-slot resolution
    * the binding paths use (explicit ref → llm.default → plan alias). The UI
    * renders THIS for "what will actually run", never a re-derivation — the
@@ -417,7 +425,19 @@ async function postJson<T>(
   });
   if (!r.ok) {
     const text = await r.text();
-    throw new Error(text || `HTTP ${r.status}`);
+    // The daemon's error routes answer `{"error": "..."}`. Throwing the raw
+    // body put the braces and quotes straight into a toast, which is how a
+    // deliberately explanatory refusal (the hosted enrolment 403, say) reached
+    // the user as JSON.
+    let message = text;
+    try {
+      const parsed = JSON.parse(text) as { error?: unknown; message?: unknown };
+      const field = parsed.error ?? parsed.message;
+      if (typeof field === "string" && field) message = field;
+    } catch {
+      // Not JSON. The body is the message.
+    }
+    throw new Error(message || `HTTP ${r.status}`);
   }
   return (await r.json()) as T;
 }
@@ -1026,12 +1046,16 @@ export function useSettingsData() {
       name: string,
     ): Promise<{ ok: true; token: string; name: string } | { ok: false; message: string }> => {
       try {
-        const r = await postJson<{ token: string; name: string }>(
+        // The route returns { token, sidecar: { name, ... } } -- enrollSidecar's
+        // own shape. Reading a top-level `name` made every success toast say
+        // `Enrolled "undefined"`; fall back to what was asked for so a future
+        // shape change degrades to the typed name rather than to nothing.
+        const r = await postJson<{ token: string; sidecar?: { name?: string } }>(
           "/api/sidecars/enroll",
           { name },
         );
         await refresh();
-        return { ok: true, token: r.token, name: r.name };
+        return { ok: true, token: r.token, name: r.sidecar?.name ?? name };
       } catch (err) {
         return { ok: false, message: err instanceof Error ? err.message : "Failed" };
       }


### PR DESCRIPTION
`POST /api/sidecars/enroll` mints a long-lived enrollment JWT authorized by nothing but a panel-session cookie, under a **new sid** that revoking the original device never touches. It is the only route on the data plane that can turn a data-plane credential into a control-plane one.

On a hosted install it is also not the flow. The Devices tab mints the JWT and tells the user to run `jarvis --token <jwt>` on the target machine — the self-hosted way. A hosted user adds a device by installing Jarvis there and signing in; the control plane runs `jarvis enroll` over SSH on their behalf.

So on hosted it is a redundant, misleading feature whose one distinction is that it is the escalation.

Hosted users lose nothing: device list and revoke already live in the hosting dashboard, authorized by their **account** rather than by a cookie.

## Two commits

**`871b8da` — the daemon refuses.** 403 before the body is read, so a hosted caller with a malformed request gets the real reason rather than "Missing name" and goes off fixing the wrong thing.

**`ee5ee7f` — the UI stops offering it.** Hosted gets the real instructions; self-hosted keeps the form untouched. Both installs keep the enrolled list and revoke.

## The predicate, which is where the thinking went

The obvious gate was `hasUsejarvisAi`, the predicate the usage meter, plan voice defaults and hosted LLM provider all use for "is this hosted". It is the wrong one for a **deny-gate**, and review caught why.

`hasUsejarvisAi` answers a *feature* question, where "absent means off" is the safe default. That block is renderable as null: `LLM_PROXY_URL` is optional in the control plane, and every render path — including DR rehydrate — emits `usejarvisAi: null` without it. A proxy-less or rehydrated deployment would re-render a whole VPS of tenants as looking self-hosted and quietly reopen the route.

`daemon.listen: unix:` cannot be absent. The renderer emits it unconditionally and a hosted brain is unreachable without it, because Caddy is the only way in.

So the gate is `isHostedInstall` — the OR of both, where disagreement resolves toward "hosted". For a deny-gate that is the direction that fails safe.

The cost, stated plainly: a self-hoster fronting their own brain over a unix socket reads as hosted and loses the dashboard button. That is affordable **only** because `jarvis enroll <name>` exists and `docs/SELF_HOSTING.md` calls it the primary path. My first version of this comment claimed the dashboard was a self-hoster's "only way", which is false and would have made the trade unaffordable; the 403 message now names the CLI fallback.

## Client and server read the same signal

The UI first keyed on `hosted_llm`, the narrow half. That reopens the same gap from the other side: on a hosted deployment with no LLM proxy the form would render and 403 on click — a button that appears and always fails, which is precisely what the module comment claimed could not happen.

The daemon now exposes `hosted_install: isHostedInstall(config)` alongside `hosted_llm`, and the UI reads it. Same predicate, so the guarantee is real rather than aspirational. `hosted_llm` stays for LLM-feature decisions; the two answer different questions and a hosted deployment without a proxy is where they differ.

## Smaller things found along the way

- **`postJson` threw the raw response body**, so the deliberately explanatory 403 reached the user as a toast reading `{"error":"Adding a device..."}`. Errors are parsed now, which improves every refusal in the dashboard.
- **The success toast said `Enrolled "undefined"`** — pre-existing. The route returns `{ token, sidecar: { name } }` and the helper read a top-level `name`.
- **The "unknown" state rendered nothing.** It is reachable after loading finishes, because the settings fetch resolves null on any non-2xx: a transient 500 left the tab with no add-device section *and* "Enroll one above to get started" pointing at nothing.
- **The empty-state copy is mode-aware**, extracted so it is testable. Pointing a hosted user at a form that is not on their screen is the same category of wrong as the button being removed.

## Tests

9 on the guard, including the proxy-less hosted case, a malformed hosted block, TCP-listening self-hosted, and one proving the gate follows the **live** config so a SIGHUP flips it without a restart. The UI decision is a pure module with its own tests, following the `voice-realtime-copy.ts` precedent.

Verified by disabling the guard (two tests fail) and by reverting the UI to the narrow signal (one fails). 758 tests green across the daemon and UI; typecheck clean; UI builds.

## Not in scope

`DELETE /api/sidecars/:id` is authorized by the same cookie, so a stolen one can still revoke your other devices. Denial of service rather than escalation, and deliberately left for a follow-up.
