### PR TITLE
Route voice into the onboarding interview instead of the assistant

### DIFF
--- a/src/comms/websocket.ts
+++ b/src/comms/websocket.ts
@@ -10,6 +10,10 @@ export type WSMessage = {
   type: 'chat' | 'cancel' | 'command' | 'status' | 'stream' | 'error' | 'notification'
       | 'tts_start' | 'tts_text' | 'tts_end' | 'voice_start' | 'voice_end' | 'voice_text'
       | 'interview_start' | 'interview_user_message' | 'interview_assistant' | 'interview_done' | 'interview_error'
+      // Interview voice: the UI asks for the mic (`interview_listen`) and the
+      // daemon answers with `interview_listen_state`; a transcript captured by
+      // the pebble comes back as `interview_user_transcript`.
+      | 'interview_listen' | 'interview_listen_stop' | 'interview_listen_state' | 'interview_user_transcript'
       | 'thinking_start' | 'thinking_end'
       | 'workflow_event'
       | 'goal_event'

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -708,7 +708,16 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
       // stamps it on both `pebble.summon` and any later `pebble.mic_blocked`),
       // so a mic refusal can unwind exactly the slot it belongs to and never a
       // turn that happens to be in flight.
-      const pendingSummons = new Map<string, { cancelled: boolean; sessionId?: string }>();
+      // `interview` marks a slot the onboarding interview opened for itself,
+      // so it can take that capture back when the turn moves on. Where the
+      // transcript GOES is decided by `interviewActive` — an interview in
+      // progress gets every utterance, however the capture started.
+      const pendingSummons = new Map<string, { cancelled: boolean; sessionId?: string; interview?: boolean }>();
+
+      // True while an onboarding profile interview is running. The interview
+      // is its own agent loop in its own window, so for as long as it lasts
+      // the user's voice belongs to it and not to the assistant.
+      let interviewActive = false;
 
       // Fallback timers for the bare-"Jarvis" listening state. If the sidecar's
       // session capture never produces an `audio.session_end` (dropped event,
@@ -895,6 +904,16 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
       // Tell each pebble-capable sidecar whether realtime is available so its
       // summon hotkey knows to toggle a live session vs. the one-shot capture.
       const advertiseRealtime = async (sidecarId: string) => {
+        // The onboarding interview owns the mic while it runs. A realtime
+        // session would answer as the assistant, in its own full-duplex audio
+        // loop the interview can neither see nor steer — so keep every pebble
+        // on one-shot capture, whose transcript we can route. Re-advertised
+        // for real when the interview finishes.
+        if (interviewActive) {
+          await sidecarManager.dispatchRPC(sidecarId, 'pebble.configure_realtime', { enabled: false })
+            .catch((err) => console.warn('[pebble-realtime] interview downgrade failed:', err));
+          return;
+        }
         const cfg = agentService.getConfig();
         const res = resolveRealtimeVoice(cfg, realtimeEnablement(cfg));
         // The advertisement must agree with the starters' plan gate, or the
@@ -935,6 +954,14 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
       const pebbleMicFrames = new Map<string, number>(); // sidecarId -> frame count (diagnostic)
       sidecarManager.onEvent((sidecarId, event) => {
         if (event.event_type === 'pebble.realtime_start') {
+          if (interviewActive) {
+            // Raced the downgrade (the press landed before configure_realtime
+            // reached the sidecar). Refuse it and re-push the downgrade so the
+            // next press does a one-shot capture into the interview.
+            console.log(`[pebble-realtime] realtime_start from ${sidecarId} refused — onboarding interview owns the mic`);
+            void sidecarManager.dispatchRPC(sidecarId, 'pebble.configure_realtime', { enabled: false }).catch(() => {});
+            return;
+          }
           console.log(`[pebble-realtime] realtime_start from ${sidecarId} — opening session`);
           pebbleMicFrames.set(sidecarId, 0);
           void pebbleRealtime.start(sidecarId);
@@ -1790,6 +1817,149 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
         if (pendingRegionByPebble.get(sidecarId)?.ctrl === ctrl) return;
         pendingSummons.delete(sidecarId);
       };
+
+      // ─────────────────── Onboarding interview voice ───────────────────
+      // The dashboard hasn't held the microphone since the wake word moved
+      // into the sidecar, so the onboarding interview borrows the pebble's:
+      // the interview UI asks for the mic when it reaches its "listening"
+      // beat, we capture one utterance, and the transcript goes to the
+      // interviewer. Without this the user's answers were captured by the
+      // pebble and answered by the assistant — the interview only ever heard
+      // what was typed into its composer.
+
+      // Which machine's pebble should the interview listen on? The one the
+      // user last spoke to, else the only connected one (guessing between
+      // several would put the mic on the wrong desk).
+      const pickPebbleSidecar = (): string | null => {
+        const capable: string[] = [];
+        for (const sc of sidecarManager.listSidecars()) {
+          if (sc.connected && (sc.capabilities ?? []).includes('pebble')) capable.push(sc.id);
+        }
+        if (capable.length === 0) return null;
+        if (activePebbleSidecar && capable.includes(activePebbleSidecar)) return activePebbleSidecar;
+        return capable.length === 1 ? capable[0]! : null;
+      };
+
+      // Hand a captured utterance to the interview instead of the assistant.
+      // Returns false when no interview is running, so callers fall through
+      // to their normal response cycle.
+      const routeToInterview = async (sidecarId: string, transcript: string): Promise<boolean> => {
+        // The session map is the authority on whether an interview is live —
+        // `interviewActive` mirrors it for the realtime advertisement, which
+        // has to be decided before any transcript exists.
+        if (!wsService.hasActiveInterview()) return false;
+        if (!wsService.deliverInterviewVoice(transcript)) return false;
+        clearInterviewMicWatchdog();
+        console.log(`[ambient-ui] transcript → onboarding interview (${transcript.length} chars)`);
+        // The interview window renders and speaks the reply; the pebble has
+        // nothing to say and steps back to idle.
+        await setState(sidecarId, 'idle', '');
+        return true;
+      };
+
+      // A capture the interview did NOT open (a summon already in flight when
+      // it asked for the mic) can end without ever reaching us. We can't
+      // cancel someone else's slot, but this makes sure the interview stops
+      // waiting on a turn that is never coming.
+      let interviewMicWatchdog: ReturnType<typeof setTimeout> | null = null;
+      const clearInterviewMicWatchdog = () => {
+        if (interviewMicWatchdog === null) return;
+        clearTimeout(interviewMicWatchdog);
+        interviewMicWatchdog = null;
+      };
+
+      wsService.setInterviewVoiceBridge({
+        setActive: (active: boolean) => {
+          if (interviewActive === active) return;
+          interviewActive = active;
+          console.log(
+            `[ambient-ui] onboarding interview ${active ? 'started — voice routes to the interview' : 'finished — voice back to the assistant'}`,
+          );
+          // Flip every pebble between one-shot capture (interview) and its
+          // real realtime verdict. advertiseRealtime reads `interviewActive`,
+          // so this single call does both directions; stopping the live
+          // sessions first makes sure an open one ends now rather than after
+          // the sidecar's own teardown.
+          if (active) {
+            for (const sc of sidecarManager.listSidecars()) {
+              if (sc.connected && (sc.capabilities ?? []).includes('pebble')) pebbleRealtime.stop(sc.id);
+            }
+          }
+          void readvertiseRealtime?.().catch((err: unknown) =>
+            console.warn('[ambient-ui] interview realtime re-advertisement failed:', err),
+          );
+        },
+
+        arm: async (): Promise<{ armed: boolean; reason?: string }> => {
+          if (!pebbleSTT) return { armed: false, reason: 'no-stt' };
+          const sidecarId = pickPebbleSidecar();
+          if (!sidecarId) return { armed: false, reason: 'no-pebble' };
+          clearInterviewMicWatchdog();
+          const existing = pendingSummons.get(sidecarId);
+          if (existing && !existing.cancelled) {
+            // A capture is already open on this pebble (the user pressed
+            // Ctrl+Space, or a wake phrase fired). Let it run — its transcript
+            // comes to the interview anyway — rather than opening a second mic
+            // on the same machine. The slot isn't ours to cancel, so the
+            // watchdog is all we arm here.
+            interviewMicWatchdog = setTimeout(() => {
+              interviewMicWatchdog = null;
+              wsService.notifyInterviewListenEnded('timeout');
+            }, WAKE_LISTEN_FALLBACK_MS);
+            return { armed: true };
+          }
+          const ctrl = { cancelled: false, interview: true };
+          pendingSummons.set(sidecarId, ctrl);
+          await setState(sidecarId, 'listening', '');
+          try {
+            const res = (await sidecarManager.dispatchRPC(sidecarId, 'pebble.start_listening', {})) as
+              | { started?: boolean; reason?: string }
+              | undefined;
+            if (res?.started === false) {
+              // Muted, most likely. Give the slot back and tell the UI, which
+              // falls back to typing instead of holding a listening orb.
+              ctrl.cancelled = true;
+              clearSummon(sidecarId, ctrl);
+              if (res.reason === 'muted') await setState(sidecarId, 'muted');
+              else await setState(sidecarId, 'idle', '');
+              return { armed: false, reason: res.reason ?? 'refused' };
+            }
+          } catch (err) {
+            console.warn('[ambient-ui] interview start_listening failed:', err);
+            ctrl.cancelled = true;
+            clearSummon(sidecarId, ctrl);
+            await setState(sidecarId, 'idle', '');
+            return { armed: false, reason: 'unavailable' };
+          }
+          // Same fallback the wake path uses: a dropped `audio.session_end`
+          // would otherwise leave the interview waiting on a turn that never
+          // arrives. Cleared the moment a session IS consumed.
+          clearListenTimer(sidecarId);
+          pendingListenTimers.set(sidecarId, setTimeout(() => {
+            pendingListenTimers.delete(sidecarId);
+            if (pendingSummons.get(sidecarId) !== ctrl) return; // already consumed
+            console.warn('[ambient-ui] interview capture: no session_end within fallback window');
+            ctrl.cancelled = true;
+            clearSummon(sidecarId, ctrl);
+            void setState(sidecarId, 'idle', '');
+            wsService.notifyInterviewListenEnded('timeout');
+          }, WAKE_LISTEN_FALLBACK_MS));
+          return { armed: true };
+        },
+
+        disarm: () => {
+          clearInterviewMicWatchdog();
+          // Only captures the interview opened itself: a summon the user
+          // started is not ours to cancel.
+          for (const [sidecarId, ctrl] of pendingSummons) {
+            if (!ctrl.interview) continue;
+            ctrl.cancelled = true;
+            clearListenTimer(sidecarId);
+            clearSummon(sidecarId, ctrl);
+            void setState(sidecarId, 'idle', '');
+          }
+        },
+      });
 
       const tryHandleRegionIntent = async (
         sidecarId: string,
@@ -3554,9 +3724,19 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
             );
             await setState(session.sidecarId, 'idle', '');
             clearSummon(session.sidecarId, ctrl);
+            // The interview is waiting on this turn — tell it the capture came
+            // back empty so it re-arms instead of holding a listening orb.
+            if (wsService.hasActiveInterview()) wsService.notifyInterviewListenEnded('no-speech');
             return;
           }
           console.log(`[ambient-ui] user said (${transcript.length} chars)`);
+
+          // An interview in progress gets the utterance first — answers to
+          // its questions are not requests to the assistant.
+          if (await routeToInterview(session.sidecarId, transcript)) {
+            clearSummon(session.sidecarId, ctrl);
+            return;
+          }
 
           await runResponseCycle(session.sidecarId, transcript, ctrl);
           clearSummon(session.sidecarId, ctrl);
@@ -3681,6 +3861,9 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
 
         try {
           console.log(`[ambient-ui] wake → command: "${command}"`);
+          // "Hey Jarvis, I work in product design" during the interview is an
+          // answer, not an instruction — route it like any other capture.
+          if (await routeToInterview(sidecarId, command)) return;
           await runResponseCycle(sidecarId, command, ctrl);
         } catch (err) {
           console.warn('[ambient-ui] wake voice cycle error:', err);

--- a/src/daemon/interview-voice.test.ts
+++ b/src/daemon/interview-voice.test.ts
@@ -1,0 +1,289 @@
+import { describe, expect, test } from 'bun:test';
+import { WebSocketService } from './ws-service.ts';
+import type { JarvisConfig } from '../config/types.ts';
+
+/**
+ * The onboarding interview owns the user's voice while it runs.
+ *
+ * Before this, speech during the first interview was captured by the pebble
+ * and answered by the assistant — the interview only ever heard what was
+ * typed into its composer. These tests pin the hand-off: the interview claims
+ * the mic when it starts, a transcript captured off-socket is delivered to
+ * the interviewer, and the mic goes back to the assistant when it ends.
+ *
+ * The second suite pins the other half of that hand-off: because speech can
+ * now arrive at any moment, turns have to be serialized — the interviewer
+ * mutates one message history across awaits.
+ *
+ * The service is constructed but never start()ed (no port bound);
+ * routeMessage and the public bridge entry points are exercised directly.
+ * Where the LLM is irrelevant the stub reports no providers, so each turn
+ * stops at `interview_error` instead of calling a model — the session
+ * lifecycle under test is identical either way.
+ */
+
+const makeService = (llmManager?: unknown) => {
+  const fakeAgent = {
+    setDelegationCallback: () => {},
+    getConfig: () => ({ llm: { providers: {} } }) as unknown as JarvisConfig,
+    getLLMManager: () => llmManager ?? { getProviderNames: () => [] as string[] },
+  } as never;
+  const svc = new WebSocketService(0, fakeAgent);
+  const makeClient = () => {
+    const sent: Array<Record<string, unknown>> = [];
+    const ws = {
+      send: (raw: string) => { sent.push(JSON.parse(raw) as Record<string, unknown>); },
+      sendBinary: () => {},
+    } as never;
+    (svc as unknown as { wsServer: { getClients: () => Set<unknown> } }).wsServer.getClients().add(ws);
+    return { ws, sent };
+  };
+  const internals = svc as unknown as {
+    routeMessage: (msg: unknown, ws: unknown) => Promise<unknown>;
+    interviewSessions: Map<unknown, unknown>;
+  };
+  return { svc, internals, makeClient };
+};
+
+/** Records what the daemon's pebble bridge was asked to do. */
+const makeBridge = (arm: { armed: boolean; reason?: string } = { armed: true }) => {
+  const calls: string[] = [];
+  return {
+    calls,
+    bridge: {
+      arm: async () => { calls.push('arm'); return arm; },
+      disarm: () => { calls.push('disarm'); },
+      setActive: (active: boolean) => { calls.push(`setActive:${active}`); },
+    },
+  };
+};
+
+const startInterview = async (
+  internals: ReturnType<typeof makeService>['internals'],
+  ws: unknown,
+) => {
+  await internals.routeMessage({ type: 'interview_start', payload: {}, timestamp: Date.now() }, ws);
+  // The handler is fire-and-forget; let it run.
+  await new Promise<void>(r => setTimeout(r, 0));
+};
+
+const lastOfType = (sent: Array<Record<string, unknown>>, type: string) =>
+  [...sent].reverse().find(m => m.type === type);
+
+describe('interview voice hand-off', () => {
+  test('starting an interview takes the microphone off the assistant', async () => {
+    const { svc, internals, makeClient } = makeService();
+    const { calls, bridge } = makeBridge();
+    svc.setInterviewVoiceBridge(bridge);
+    const { ws } = makeClient();
+
+    expect(svc.hasActiveInterview()).toBe(false);
+    await startInterview(internals, ws);
+
+    expect(svc.hasActiveInterview()).toBe(true);
+    expect(calls).toContain('setActive:true');
+  });
+
+  test('a pebble transcript is delivered to the interview, not the assistant', async () => {
+    const { svc, internals, makeClient } = makeService();
+    const { bridge } = makeBridge();
+    svc.setInterviewVoiceBridge(bridge);
+    const { ws, sent } = makeClient();
+    await startInterview(internals, ws);
+
+    expect(svc.deliverInterviewVoice('  I design products in Milan  ')).toBe(true);
+    const echoed = lastOfType(sent, 'interview_user_transcript');
+    expect(echoed).toBeDefined();
+    expect((echoed!.payload as { text: string }).text).toBe('I design products in Milan');
+  });
+
+  test('with no interview running the transcript is refused so the assistant answers', () => {
+    const { svc } = makeService();
+    svc.setInterviewVoiceBridge(makeBridge().bridge);
+    expect(svc.deliverInterviewVoice('what is the weather')).toBe(false);
+  });
+
+  test('a blank transcript is refused rather than sent as a turn', async () => {
+    const { svc, internals, makeClient } = makeService();
+    svc.setInterviewVoiceBridge(makeBridge().bridge);
+    const { ws, sent } = makeClient();
+    await startInterview(internals, ws);
+
+    expect(svc.deliverInterviewVoice('   ')).toBe(false);
+    expect(lastOfType(sent, 'interview_user_transcript')).toBeUndefined();
+  });
+
+  test('interview_listen arms the pebble and tells the UI it worked', async () => {
+    const { svc, internals, makeClient } = makeService();
+    const { calls, bridge } = makeBridge();
+    svc.setInterviewVoiceBridge(bridge);
+    const { ws, sent } = makeClient();
+    await startInterview(internals, ws);
+
+    await internals.routeMessage({ type: 'interview_listen', payload: {}, timestamp: Date.now() }, ws);
+    await new Promise<void>(r => setTimeout(r, 0));
+
+    expect(calls).toContain('arm');
+    expect(lastOfType(sent, 'interview_listen_state')?.payload).toEqual({ armed: true });
+  });
+
+  test('a refused mic is reported with its reason so the UI can fall back', async () => {
+    const { svc, internals, makeClient } = makeService();
+    const { bridge } = makeBridge({ armed: false, reason: 'muted' });
+    svc.setInterviewVoiceBridge(bridge);
+    const { ws, sent } = makeClient();
+    await startInterview(internals, ws);
+
+    await internals.routeMessage({ type: 'interview_listen', payload: {}, timestamp: Date.now() }, ws);
+    await new Promise<void>(r => setTimeout(r, 0));
+
+    expect(lastOfType(sent, 'interview_listen_state')?.payload).toEqual({ armed: false, reason: 'muted' });
+  });
+
+  test('with no bridge wired the UI is told at once instead of waiting on a mic', async () => {
+    const { svc, internals, makeClient } = makeService();
+    const { ws, sent } = makeClient();
+    await startInterview(internals, ws);
+
+    await internals.routeMessage({ type: 'interview_listen', payload: {}, timestamp: Date.now() }, ws);
+    await new Promise<void>(r => setTimeout(r, 0));
+
+    expect(lastOfType(sent, 'interview_listen_state')?.payload).toEqual({ armed: false, reason: 'no-pebble' });
+  });
+
+  test('interview_listen_stop hands the microphone back', async () => {
+    const { svc, internals, makeClient } = makeService();
+    const { calls, bridge } = makeBridge();
+    svc.setInterviewVoiceBridge(bridge);
+    const { ws } = makeClient();
+    await startInterview(internals, ws);
+    await internals.routeMessage({ type: 'interview_listen', payload: {}, timestamp: Date.now() }, ws);
+    await new Promise<void>(r => setTimeout(r, 0));
+
+    await internals.routeMessage({ type: 'interview_listen_stop', payload: {}, timestamp: Date.now() }, ws);
+    expect(calls).toContain('disarm');
+  });
+
+  test('an abandoned interview releases the mic — the assistant is not left mute', async () => {
+    const { svc, internals, makeClient } = makeService();
+    const { calls, bridge } = makeBridge();
+    svc.setInterviewVoiceBridge(bridge);
+    const { ws } = makeClient();
+    await startInterview(internals, ws);
+    await internals.routeMessage({ type: 'interview_listen', payload: {}, timestamp: Date.now() }, ws);
+    await new Promise<void>(r => setTimeout(r, 0));
+
+    // What the WS server's onDisconnect does: sweep the maps, then release.
+    internals.interviewSessions.delete(ws);
+    (svc as unknown as { endInterviewVoice: (ws: unknown) => void }).endInterviewVoice(ws);
+
+    expect(calls).toContain('disarm');
+    expect(calls).toContain('setActive:false');
+    expect(svc.hasActiveInterview()).toBe(false);
+  });
+
+  test('an empty capture is reported so the interview can re-arm', async () => {
+    const { svc, internals, makeClient } = makeService();
+    svc.setInterviewVoiceBridge(makeBridge().bridge);
+    const { ws, sent } = makeClient();
+    await startInterview(internals, ws);
+
+    svc.notifyInterviewListenEnded('no-speech');
+    expect(lastOfType(sent, 'interview_listen_state')?.payload).toEqual({ armed: false, reason: 'no-speech' });
+  });
+
+  test('the newest interview window owns the mic', async () => {
+    const { svc, internals, makeClient } = makeService();
+    svc.setInterviewVoiceBridge(makeBridge().bridge);
+    const first = makeClient();
+    const second = makeClient();
+    await startInterview(internals, first.ws);
+    await startInterview(internals, second.ws);
+
+    expect(svc.deliverInterviewVoice('hello')).toBe(true);
+    expect(lastOfType(second.sent, 'interview_user_transcript')).toBeDefined();
+    expect(lastOfType(first.sent, 'interview_user_transcript')).toBeUndefined();
+  });
+});
+
+/**
+ * A stub LLM whose turns finish only when the test says so. Records the
+ * message history each turn was handed, which is what the serialization
+ * claim is really about.
+ */
+const makeSlowLLM = () => {
+  const seen: Array<Array<{ role: string; content: string }>> = [];
+  let release: (() => void) | null = null;
+  return {
+    seen,
+    /** Let the turn that is currently blocked finish. */
+    finishTurn: async () => {
+      const go = release;
+      release = null;
+      go?.();
+      await new Promise<void>(r => setTimeout(r, 0));
+    },
+    llm: {
+      getProviderNames: () => ['stub'],
+      hasConversationTier: () => false,
+      chatTier: async (
+        _tier: string,
+        _caller: string,
+        messages: Array<{ role: string; content: string }>,
+      ) => {
+        seen.push(messages.map(m => ({ role: m.role, content: m.content })));
+        await new Promise<void>(r => { release = r; });
+        return { content: 'And what do you do?', tool_calls: [] };
+      },
+    },
+  };
+};
+
+describe('interview turns are serialized', () => {
+  test('speech arriving mid-turn runs next instead of interleaving', async () => {
+    const slow = makeSlowLLM();
+    const { svc, internals, makeClient } = makeService(slow.llm);
+    svc.setInterviewVoiceBridge(makeBridge().bridge);
+    const { ws, sent } = makeClient();
+
+    // Opening turn — blocked inside the LLM call.
+    void internals.routeMessage({ type: 'interview_start', payload: {}, timestamp: Date.now() }, ws);
+    await new Promise<void>(r => setTimeout(r, 0));
+    expect(slow.seen.length).toBe(1);
+
+    // Two utterances land while that turn is still running.
+    expect(svc.deliverInterviewVoice("I'm a designer")).toBe(true);
+    expect(svc.deliverInterviewVoice('in Milan')).toBe(true);
+    // Still one turn in flight: neither raced into the shared history.
+    expect(slow.seen.length).toBe(1);
+
+    await slow.finishTurn();      // opening turn completes → queued text runs
+    expect(slow.seen.length).toBe(2);
+    const second = slow.seen[1]!;
+    // Both utterances arrived as ONE user turn, in order.
+    expect(second.filter(m => m.role === 'user').at(-1)!.content).toBe("I'm a designer in Milan");
+    // …and the history is still strictly alternating, never user-after-user.
+    const roles = second.map(m => m.role).filter(r => r === 'user' || r === 'assistant');
+    expect(roles.some((r, i) => i > 0 && r === roles[i - 1])).toBe(false);
+
+    await slow.finishTurn();
+    expect(sent.filter(m => m.type === 'interview_assistant').length).toBe(2);
+  });
+
+  test('a mid-turn transcript is never handed back to the assistant', async () => {
+    const slow = makeSlowLLM();
+    const { svc, internals, makeClient } = makeService(slow.llm);
+    svc.setInterviewVoiceBridge(makeBridge().bridge);
+    const { ws } = makeClient();
+    void internals.routeMessage({ type: 'interview_start', payload: {}, timestamp: Date.now() }, ws);
+    await new Promise<void>(r => setTimeout(r, 0));
+
+    // `true` is what tells the daemon "handled — do not run a response
+    // cycle". Returning false here would put the answer to an interview
+    // question through the assistant, which is the bug this all fixes.
+    expect(svc.deliverInterviewVoice('mid-turn answer')).toBe(true);
+
+    await slow.finishTurn();
+    await slow.finishTurn();
+  });
+});

--- a/src/daemon/ws-service.ts
+++ b/src/daemon/ws-service.ts
@@ -88,6 +88,25 @@ const VOICE_CONFIRMATION_TTL_MS = 10 * 60_000;
 const VOICE_CONFIRMATION_SWEEP_INTERVAL_MS = 60_000;
 
 /**
+ * Bridge into the machine's microphone for the onboarding interview.
+ *
+ * The dashboard no longer owns the mic (the sidecar's pebble does), so the
+ * interview borrows it: while an interview session is alive the daemon points
+ * the pebble's capture at the interview instead of the normal assistant turn.
+ * Implemented in `daemon/index.ts` (the ambient-UI block owns the pebble);
+ * null in headless / dashboard-only mode, in which case the UI falls back to
+ * browser speech recognition.
+ */
+export interface InterviewVoiceBridge {
+  /** Capture one utterance for the interview. */
+  arm(): Promise<{ armed: boolean; reason?: string }>;
+  /** Drop a capture armed by `arm()` (turn over, interview finished). */
+  disarm(): void;
+  /** Interview lifecycle. While active, pebble voice feeds the interview. */
+  setActive(active: boolean): void;
+}
+
+/**
  * Pure cleanup helper: removes every per-socket entry from the WS-service
  * maps when a client disconnects. Extracted so the cleanup contract can
  * be unit-tested without spinning up a real WebSocket server.
@@ -237,6 +256,22 @@ export class WebSocketService implements Service {
    */
   private interviewSessions = new Map<ServerWebSocket<unknown>, InterviewSession>();
   /**
+   * Voice for the interview. `activeInterviewWs` is the socket whose interview
+   * currently owns the microphone — the newest one to take a turn, so a stale
+   * background tab can't steal the transcript from the window the user is
+   * actually talking to. See `deliverInterviewVoice`.
+   */
+  private interviewVoiceBridge: InterviewVoiceBridge | null = null;
+  private activeInterviewWs: ServerWebSocket<unknown> | null = null;
+  /** Mirrors the UI's speakReply for transcripts that arrive off-socket. */
+  private interviewSpeakReply = true;
+  /** True while the pebble is capturing an utterance for the interview. */
+  private interviewListening = false;
+  /** Sockets with an interview turn running — see `handleInterviewMessage`. */
+  private interviewTurnsInFlight = new Set<ServerWebSocket<unknown>>();
+  /** Speech that landed mid-turn, run as the next turn. */
+  private interviewPendingText = new Map<ServerWebSocket<unknown>, string>();
+  /**
    * Periodic sweep handle for `pendingVoiceConfirmations` TTL eviction.
    * Started in `start()`, cleared in `stop()` so the daemon shuts down
    * cleanly without a dangling timer.
@@ -284,6 +319,135 @@ export class WebSocketService implements Service {
 
   setDeferredExecutor(exec: DeferredExecutor): void {
     this.deferredExecutor = exec;
+  }
+
+  /**
+   * Wire the pebble's microphone into the onboarding interview. Without it
+   * the interview is text-only (plus whatever the browser can transcribe on
+   * its own) and any speech keeps landing in the normal assistant flow.
+   */
+  setInterviewVoiceBridge(bridge: InterviewVoiceBridge): void {
+    this.interviewVoiceBridge = bridge;
+  }
+
+  /** True while an onboarding interview is running and owns the user's voice. */
+  hasActiveInterview(): boolean {
+    const ws = this.activeInterviewWs;
+    return ws !== null && this.interviewSessions.has(ws);
+  }
+
+  /**
+   * Feed a transcript captured by the pebble into the running interview
+   * instead of the assistant. Returns false when no interview is live (the
+   * caller then runs its normal response cycle).
+   */
+  deliverInterviewVoice(text: string): boolean {
+    const ws = this.activeInterviewWs;
+    const trimmed = text.trim();
+    if (!ws || !this.interviewSessions.has(ws) || !trimmed) return false;
+    this.interviewListening = false;
+    // Echo the transcript first: the UI renders the user's bubble and stops
+    // waiting on the mic before the (slow) agent turn starts.
+    this.wsServer.sendToClient(ws, {
+      type: 'interview_user_transcript',
+      payload: { text: trimmed },
+      timestamp: Date.now(),
+    });
+    this.handleInterviewMessage(ws, trimmed, this.interviewSpeakReply).catch(err =>
+      console.error('[WSService] interview voice turn failed:', err)
+    );
+    return true;
+  }
+
+  /**
+   * The pebble stopped listening without a usable answer (silence, a mute, a
+   * dropped capture). Tell the UI so it can re-arm or fall back to typing
+   * rather than sit on a "listening" orb that nothing is feeding.
+   */
+  notifyInterviewListenEnded(reason: string): void {
+    const ws = this.activeInterviewWs;
+    if (!ws || !this.interviewSessions.has(ws)) return;
+    this.interviewListening = false;
+    this.wsServer.sendToClient(ws, {
+      type: 'interview_listen_state',
+      payload: { armed: false, reason },
+      timestamp: Date.now(),
+    });
+  }
+
+  /**
+   * Arm the pebble for one interview utterance and tell the UI whether it
+   * worked. `armed: false` is not an error — it's the UI's cue to use browser
+   * speech recognition (or just the composer) for this turn.
+   */
+  private async armInterviewListening(
+    ws: ServerWebSocket<unknown>,
+    speakReply?: boolean,
+  ): Promise<void> {
+    // Only a socket that is actually interviewing gets the mic, or a stray
+    // client could point the machine's microphone at someone else's session.
+    if (!this.interviewSessions.has(ws)) return;
+    this.activeInterviewWs = ws;
+    if (speakReply !== undefined) this.interviewSpeakReply = speakReply !== false;
+    const reply = (armed: boolean, reason?: string) => {
+      this.wsServer.sendToClient(ws, {
+        type: 'interview_listen_state',
+        payload: reason ? { armed, reason } : { armed },
+        timestamp: Date.now(),
+      });
+    };
+    const bridge = this.interviewVoiceBridge;
+    if (!bridge) {
+      reply(false, 'no-pebble');
+      return;
+    }
+    let result: { armed: boolean; reason?: string };
+    try {
+      result = await bridge.arm();
+    } catch (err) {
+      console.warn('[WSService] interview mic arm failed:', err);
+      reply(false, 'error');
+      return;
+    }
+    // The interview may have finished (or the socket gone) during the arm.
+    if (!this.interviewSessions.has(ws)) {
+      if (result.armed) bridge.disarm();
+      return;
+    }
+    this.interviewListening = result.armed;
+    reply(result.armed, result.reason);
+  }
+
+  /**
+   * Release the interview's claim on the microphone. Called when the session
+   * wraps and on disconnect, so a closed dashboard never leaves the pebble
+   * routing speech into an interview nobody is watching.
+   */
+  private endInterviewVoice(ws: ServerWebSocket<unknown>): void {
+    this.interviewPendingText.delete(ws);
+    this.interviewTurnsInFlight.delete(ws);
+    if (this.activeInterviewWs === ws) {
+      this.activeInterviewWs = null;
+      if (this.interviewListening) {
+        this.interviewListening = false;
+        try {
+          this.interviewVoiceBridge?.disarm();
+        } catch (err) {
+          console.warn('[WSService] interview mic disarm failed:', err);
+        }
+      }
+      // Another window still interviewing (rare, but a reload mid-interview
+      // looks exactly like this): give it the mic rather than leaving voice
+      // routed to an interview no socket owns — the assistant would answer.
+      for (const other of this.interviewSessions.keys()) this.activeInterviewWs = other;
+    }
+    if (this.interviewSessions.size === 0) {
+      try {
+        this.interviewVoiceBridge?.setActive(false);
+      } catch (err) {
+        console.warn('[WSService] interview voice teardown failed:', err);
+      }
+    }
   }
 
   setAuditTrail(audit: AuditTrail): void {
@@ -399,6 +563,9 @@ export class WebSocketService implements Service {
             this.realtimeSessions as unknown as Map<typeof ws, unknown>,
             this.pendingVoiceFrames as unknown as Map<typeof ws, unknown>,
           );
+          // After the maps are swept, so `endInterviewVoice` sees the real
+          // remaining-session count when it decides to hand the mic back.
+          this.endInterviewVoice(ws);
           console.log('[WSService] Client disconnected');
         },
       });
@@ -996,6 +1163,30 @@ export class WebSocketService implements Service {
         this.handleInterviewMessage(ws, userText, speakReply).catch(err =>
           console.error('[WSService] interview pipeline error:', err)
         );
+        return undefined;
+      }
+
+      case 'interview_listen': {
+        // The interview reached its "listening" beat and wants the mic. The
+        // pebble owns it, so borrow it here rather than opening a second one
+        // in the browser — that is what used to send the answer to the
+        // assistant instead of the interviewer.
+        const speak = (msg.payload as { speakReply?: boolean } | undefined)?.speakReply;
+        this.armInterviewListening(ws, speak).catch(err =>
+          console.error('[WSService] interview listen error:', err)
+        );
+        return undefined;
+      }
+
+      case 'interview_listen_stop': {
+        if (this.activeInterviewWs === ws && this.interviewListening) {
+          this.interviewListening = false;
+          try {
+            this.interviewVoiceBridge?.disarm();
+          } catch (err) {
+            console.warn('[WSService] interview mic disarm failed:', err);
+          }
+        }
         return undefined;
       }
 
@@ -1744,11 +1935,60 @@ CRITICAL — when in genuine doubt between "make in a new project" vs "add to th
     userText: string | null,
     speakReply: boolean,
   ): Promise<void> {
-    let session = this.interviewSessions.get(ws);
-    if (!session) {
-      session = createInterviewSession();
-      this.interviewSessions.set(ws, session);
+    if (!this.interviewSessions.has(ws)) {
+      this.interviewSessions.set(ws, createInterviewSession());
+      // First turn: take the user's voice off the assistant for the duration.
+      try {
+        this.interviewVoiceBridge?.setActive(true);
+      } catch (err) {
+        console.warn('[WSService] interview voice takeover failed:', err);
+      }
     }
+    // Whoever spoke last owns the mic, and their speakReply is the one an
+    // off-socket transcript should honour.
+    this.activeInterviewWs = ws;
+    this.interviewSpeakReply = speakReply;
+
+    // One turn at a time per session. `runInterviewTurn` mutates the session's
+    // message history across awaits, so two overlapping turns interleave into
+    // a history no provider will accept (two user turns in a row, orphaned
+    // tool results). The transcript can now arrive from the pebble at any
+    // moment — including while the previous turn is still running — so hold
+    // it and run it next instead of dropping it or racing.
+    if (this.interviewTurnsInFlight.has(ws)) {
+      if (userText) {
+        const queued = this.interviewPendingText.get(ws);
+        // Merge: someone finishing a thought in two breaths ("I'm a
+        // designer." … "In Milan.") should read as one answer.
+        this.interviewPendingText.set(ws, queued ? `${queued} ${userText}` : userText);
+      }
+      return;
+    }
+
+    this.interviewTurnsInFlight.add(ws);
+    try {
+      await this.runInterviewTurnForSocket(ws, userText, speakReply);
+    } finally {
+      this.interviewTurnsInFlight.delete(ws);
+    }
+
+    // Drain whatever landed mid-turn. Dropped when the interview wrapped or
+    // the socket went away while we were talking.
+    const pending = this.interviewPendingText.get(ws);
+    this.interviewPendingText.delete(ws);
+    if (pending && this.interviewSessions.has(ws)) {
+      await this.handleInterviewMessage(ws, pending, speakReply);
+    }
+  }
+
+  /** One interview turn: run the agent, send the text, speak it, wrap up. */
+  private async runInterviewTurnForSocket(
+    ws: ServerWebSocket<unknown>,
+    userText: string | null,
+    speakReply: boolean,
+  ): Promise<void> {
+    const session = this.interviewSessions.get(ws);
+    if (!session) return;
 
     const llm = this.agentService.getLLMManager();
     // Just check that at least one provider is registered. The interviewer
@@ -1849,6 +2089,7 @@ CRITICAL — when in genuine doubt between "make in a new project" vs "add to th
         timestamp: Date.now(),
       });
       this.interviewSessions.delete(ws);
+      this.endInterviewVoice(ws);
     }
   }
 

--- a/ui/src/v2/onboarding/OnboardingWizard.tsx
+++ b/ui/src/v2/onboarding/OnboardingWizard.tsx
@@ -1308,15 +1308,36 @@ function MicLevelCheck() {
 const IV_PHASE_CLASS: Record<string, string> = { thinking: "s-think", speaking: "s-speak", done: "s-done" };
 const IV_PHASE_LABEL: Record<string, string> = { connecting: "connecting…", ready: "ready", error: "reconnecting…", thinking: "thinking", speaking: "speaking", listening: "listening", done: "done" };
 
+/** Why the interview can't listen, in the user's terms. */
+const MIC_REASON_COPY: Record<string, string> = {
+  muted: "Your microphone is muted — unmute it from the tray, or just type.",
+  "no-stt": "Speech to text isn't set up yet, so type your answers for now.",
+  "no-pebble": "No microphone on this machine yet — type your answers for now.",
+  default: "I can't hear you right now — type your answers instead.",
+};
+
+/** Browser speech recognition, when the daemon has no microphone to lend. */
+function hasBrowserSpeech(): boolean {
+  const w = window as unknown as { SpeechRecognition?: unknown; webkitSpeechRecognition?: unknown };
+  return Boolean(w.SpeechRecognition || w.webkitSpeechRecognition);
+}
+
 function InterviewStep({ ttsDisabled, onComplete }: { ttsDisabled: boolean; onComplete: () => void }) {
   const session = useInterviewSession({ ttsDisabled });
   const [composerText, setComposerText] = useState("");
   const recognizerRef = useRef<{ stop: () => void } | null>(null);
 
-  // Auto-arm browser SpeechRecognition while the orb is "listening" (voice
-  // input), unless the user opted into text-only. Mirrors the old room.
+  // Voice input is the daemon's job first: it captures the answer on the
+  // pebble and feeds it straight to the interviewer (otherwise the pebble
+  // hears the answer and the assistant, not the interview, replies). Browser
+  // SpeechRecognition is only the fallback for when the daemon has no mic to
+  // offer — no pebble connected, no STT configured, mic muted.
   useEffect(() => {
     if (session.textOnly) return;
+    if (session.micStatus !== "unavailable") {
+      if (recognizerRef.current) { try { recognizerRef.current.stop(); } catch { /* ignore */ } recognizerRef.current = null; }
+      return;
+    }
     if (session.phase !== "listening") {
       if (recognizerRef.current) { try { recognizerRef.current.stop(); } catch { /* ignore */ } recognizerRef.current = null; }
       return;
@@ -1345,7 +1366,7 @@ function InterviewStep({ ttsDisabled, onComplete }: { ttsDisabled: boolean; onCo
     try { rec.start(); recognizerRef.current = rec; } catch { /* ignore */ }
     return () => { try { rec.stop(); } catch { /* ignore */ } recognizerRef.current = null; };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [session.phase, session.textOnly]);
+  }, [session.phase, session.textOnly, session.micStatus]);
 
   const sendTyped = () => { const t = composerText.trim(); if (!t) return; setComposerText(""); session.sendUserMessage(t); };
   const [skipErr, setSkipErr] = useState<string | null>(null);
@@ -1376,6 +1397,12 @@ function InterviewStep({ ttsDisabled, onComplete }: { ttsDisabled: boolean; onCo
     );
   }
 
+  // No mic anywhere: the daemon has none to lend and the browser can't
+  // transcribe either. Say so once instead of showing a "Listening" pill that
+  // nothing is feeding.
+  const voiceOff = session.micStatus === "unavailable" && !hasBrowserSpeech();
+  const micNote = voiceOff ? MIC_REASON_COPY[session.micReason ?? ""] ?? MIC_REASON_COPY.default : null;
+
   const msgs = session.messages;
   const lastAsstIdx = msgs.map((m) => m.role).lastIndexOf("assistant");
   const currentQ = lastAsstIdx >= 0 ? msgs[lastAsstIdx]!.text : (session.phase === "connecting" ? "Getting ready to chat…" : "…");
@@ -1403,15 +1430,16 @@ function InterviewStep({ ttsDisabled, onComplete }: { ttsDisabled: boolean; onCo
             {history.map((m, i) => <div key={i} className={`obw-bub ${m.role === "assistant" ? "jv" : "me"}`}>{m.text}</div>)}
           </div>
         )}
+        {micNote && <div className="obw-ivphase" style={{ textTransform: "none", letterSpacing: 0 }}>{micNote}</div>}
         {session.partialUserText && (
           <div className="obw-ivphase" style={{ fontStyle: "italic", color: "var(--ink2)", textTransform: "none", letterSpacing: 0 }}>“{session.partialUserText}”</div>
         )}
       </div>
       <div className="obw-ivcomposer">
-        <input className="obw-inp" placeholder="Type your answer, or just talk" value={composerText}
+        <input className="obw-inp" placeholder={voiceOff ? "Type your answer" : "Type your answer, or just talk"} value={composerText}
           onChange={(e) => setComposerText(e.target.value)}
           onKeyDown={(e) => { if (e.key === "Enter") sendTyped(); }} />
-        {session.phase === "listening" && !session.textOnly && <span className="obw-voicepill"><span className="ld" />Listening</span>}
+        {session.phase === "listening" && !session.textOnly && !voiceOff && <span className="obw-voicepill"><span className="ld" />Listening</span>}
         <button type="button" className="obw-btn obw-btn-pri sm" onClick={sendTyped}>Send</button>
       </div>
     </div>

--- a/ui/src/v2/onboarding/useInterviewSession.ts
+++ b/ui/src/v2/onboarding/useInterviewSession.ts
@@ -20,6 +20,15 @@ import type { OrbState } from "../shell/MicOrb";
  *      detection ends → we send `interview_user_message`.
  *   4. Repeat until `interview_done` arrives.
  *
+ * Where the microphone comes from:
+ *   The dashboard does not hold the mic — the sidecar's pebble does. So on
+ *   every "listening" beat we ask the daemon for it (`interview_listen`); it
+ *   captures one utterance on the pebble and sends the transcript back as
+ *   `interview_user_transcript`, routed to the interview instead of the
+ *   assistant. `interview_listen_state` says whether that worked: when the
+ *   daemon has no pebble/STT to offer (`armed: false`), the caller falls back
+ *   to browser speech recognition, and typing always works either way.
+ *
  * Text-only fallback (TTS off OR mic unavailable):
  *   Same WS message types, but no auto-record. User types into a
  *   composer and hits Enter to send.
@@ -52,6 +61,16 @@ interface InterviewState {
   farewell: string | null;
   /** Last error message, if any. */
   error: string | null;
+  /**
+   * Where this turn's voice input comes from:
+   *   idle        — not listening (thinking/speaking/done, or text-only)
+   *   pending     — we asked the daemon for the pebble's mic, waiting
+   *   armed       — the pebble is capturing this turn; do NOT open a second mic
+   *   unavailable — no daemon mic (no pebble, no STT, muted): fall back locally
+   */
+  micStatus: "idle" | "pending" | "armed" | "unavailable";
+  /** Why the daemon mic isn't available, when `micStatus === "unavailable"`. */
+  micReason: string | null;
 }
 
 interface InterviewControls {
@@ -84,12 +103,49 @@ export function useInterviewSession(opts: {
   const [farewell, setFarewell] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [textOnly, setTextOnlyState] = useState(opts.ttsDisabled);
+  const [micStatus, setMicStatus] = useState<InterviewState["micStatus"]>("idle");
+  const [micReason, setMicReason] = useState<string | null>(null);
+  // Live view of micStatus for the mount-once WS handlers (same reason as
+  // textOnlyRef below).
+  const micStatusRef = useRef<InterviewState["micStatus"]>("idle");
+  // Consecutive empty captures. A capture that hears nothing is worth
+  // retrying — the user was still thinking — but not forever: after a few we
+  // stop re-arming and let the composer (or the browser recognizer) take over.
+  const emptyCapturesRef = useRef(0);
+  const rearmTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   // The WS handlers below live in a mount-once effect, so reading the
   // `textOnly` state there would see the value frozen at mount. The ref
   // is the live view — without it, toggling "Continue with text only"
   // mid-session left the handlers waiting for TTS that was no longer
   // requested.
   const textOnlyRef = useRef(textOnly);
+
+  const setMic = useCallback((status: InterviewState["micStatus"], reason: string | null = null) => {
+    micStatusRef.current = status;
+    setMicStatus(status);
+    setMicReason(reason);
+  }, []);
+
+  /** Ask the daemon to capture this turn's answer on the pebble. */
+  const requestDaemonMic = useCallback((speak: boolean) => {
+    const ws = wsRef.current;
+    if (!ws || ws.readyState !== WebSocket.OPEN) return;
+    setMic("pending");
+    ws.send(
+      JSON.stringify({
+        type: "interview_listen",
+        payload: { speakReply: speak },
+        timestamp: Date.now(),
+      }),
+    );
+  }, [setMic]);
+
+  const clearRearmTimer = useCallback(() => {
+    if (rearmTimerRef.current !== null) {
+      clearTimeout(rearmTimerRef.current);
+      rearmTimerRef.current = null;
+    }
+  }, []);
 
   const clearTtsFallbackTimer = useCallback(() => {
     if (ttsFallbackTimerRef.current !== null) {
@@ -210,6 +266,45 @@ export function useInterviewSession(opts: {
             setOrbState("listening");
           }
           break;
+        case "interview_listen_state": {
+          const armed = Boolean(msg.payload?.armed);
+          const reason = msg.payload?.reason ? String(msg.payload.reason) : null;
+          if (armed) {
+            emptyCapturesRef.current = 0;
+            setMic("armed");
+            break;
+          }
+          // A capture that came back empty (silence, or the sidecar's VAD
+          // window closing) isn't a broken mic — re-arm and keep waiting, up
+          // to a few tries so a user who walked away doesn't loop forever.
+          const retryable = reason === "no-speech" || reason === "timeout";
+          if (retryable && micStatusRef.current !== "idle" && emptyCapturesRef.current < 3) {
+            emptyCapturesRef.current += 1;
+            setMic("pending", reason);
+            clearRearmTimer();
+            rearmTimerRef.current = setTimeout(() => {
+              rearmTimerRef.current = null;
+              requestDaemonMic(!textOnlyRef.current);
+            }, 400);
+            break;
+          }
+          setMic("unavailable", reason ?? "unavailable");
+          break;
+        }
+        case "interview_user_transcript": {
+          // The pebble heard the answer. Render it as the user's turn — the
+          // interviewer's reply is already on its way.
+          const text = String(msg.payload?.text ?? "").trim();
+          if (!text) break;
+          emptyCapturesRef.current = 0;
+          clearRearmTimer();
+          setMic("idle");
+          setMessages((prev) => [...prev, { role: "user", text, ts: msg.timestamp ?? Date.now() }]);
+          setPartialUserText("");
+          setPhase("thinking");
+          setOrbState("thinking");
+          break;
+        }
         case "interview_done": {
           setFarewell(String(msg.payload?.farewell ?? ""));
           if (typeof msg.payload?.facts_recorded === "number") {
@@ -264,9 +359,38 @@ export function useInterviewSession(opts: {
       audioCtxRef.current = null;
       audioQueueRef.current = [];
       clearTtsFallbackTimer();
+      clearRearmTimer();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  // ── Microphone hand-off ──────────────────────────────────────────
+  // The mic lives on the pebble, so borrow it for exactly the window where
+  // the interview wants an answer — never while Jarvis is speaking (the
+  // sidecar would capture its own TTS) and never once the interview is done.
+  useEffect(() => {
+    const ws = wsRef.current;
+    if (!ws || ws.readyState !== WebSocket.OPEN) return;
+    // Asked for on every listening beat, even with TTS off: "no spoken
+    // replies" is a choice about Jarvis's voice, not the user's. Whether
+    // there is a mic to lend at all is the daemon's call (it knows if STT is
+    // configured and a pebble is connected), so we just ask.
+    const wants = phase === "listening";
+    if (wants) {
+      if (micStatusRef.current === "idle") requestDaemonMic(!textOnly);
+      return;
+    }
+    clearRearmTimer();
+    emptyCapturesRef.current = 0;
+    if (micStatusRef.current === "idle") return;
+    // Hand the mic back. Harmless when the daemon never armed it.
+    setMic("idle");
+    try {
+      ws.send(JSON.stringify({ type: "interview_listen_stop", payload: {}, timestamp: Date.now() }));
+    } catch {
+      /* socket already going away */
+    }
+  }, [phase, textOnly, requestDaemonMic, clearRearmTimer, setMic]);
 
   // ── TTS playback ─────────────────────────────────────────────────
   function getAudioContext(): AudioContext {
@@ -317,6 +441,8 @@ export function useInterviewSession(opts: {
         { role: "user", text: trimmed, ts: Date.now() },
       ]);
       setPartialUserText("");
+      // Typing wins the turn: the effect above hands the pebble's mic back
+      // as soon as we leave the listening phase.
       setPhase("thinking");
       setOrbState("thinking");
       ws.send(
@@ -338,6 +464,8 @@ export function useInterviewSession(opts: {
     factsRecorded,
     farewell,
     error,
+    micStatus,
+    micReason,
     textOnly,
     sendUserMessage,
     setTextOnly,


### PR DESCRIPTION
During the first-run interview the only way to answer was typing. Anything said out loud was captured by the pebble, transcribed by the daemon, and handed to `runResponseCycle` -- so the assistant answered questions the interviewer had asked. The interview UI only ever listened through the browser's `SpeechRecognition`, while the real microphone has lived in the sidecar since the wake word moved there (#407).

Now an interview owns the user's voice for as long as it runs.

## Daemon

- `WebSocketService` gets an `InterviewVoiceBridge` plus `hasActiveInterview()`, `deliverInterviewVoice()` and `notifyInterviewListenEnded()`. Starting an interview claims the mic; wrapping up, or the dashboard disconnecting, hands it back.
- The ambient-UI block implements the bridge: picks the pebble sidecar, fires `pebble.start_listening` for one utterance, and arms the same dropped-`session_end` fallback the wake path uses.
- Both transcript paths check for a live interview first: the summon/capture completion and the "hey Jarvis <command>" wake path. An empty capture reports `no-speech` so the interview re-arms instead of holding a dead listening orb.
- Realtime voice is downgraded to one-shot capture while an interview runs (`advertiseRealtime` returns `configure_realtime: false`, and a raced `realtime_start` is refused) -- a full-duplex session would answer as the assistant in audio the interview can't see. Re-advertised for real when the interview ends.
- Interview turns are serialized per socket. `runInterviewTurn` mutates one message history across awaits, and speech can now land mid-turn; overlapping turns produced two user turns in a row and orphaned tool results, which Anthropic rejects. Text arriving mid-turn is merged into the next turn instead of racing.

## UI

- On every "listening" beat the hook asks the daemon for the mic (`interview_listen`), renders what comes back (`interview_user_transcript`), and hands it back when the turn moves on -- so the sidecar never captures Jarvis's own TTS.
- Browser `SpeechRecognition` is now only the fallback for `armed: false`. With no mic anywhere the step says why ("Speech to text isn't set up yet...") instead of showing a Listening pill nothing feeds.
- Asking for the mic no longer depends on the TTS choice: "don't speak replies" is about Jarvis's voice, not the user's.

## Testing

`bun test` green (13 new tests in `src/daemon/interview-voice.test.ts` covering the claim, delivery, refusal reasons, re-arm, release and turn serialization), `tsc --noEmit` clean, UI bundle builds. Not yet exercised against a real sidecar -- the `pebble.start_listening` round-trip is covered by contract and unit tests only.
