### PR TITLE
Fix the dashboard tour showing the previous slide's text over the new slide's position

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -37,7 +37,9 @@
         "yaml": "^2.7.0",
       },
       "devDependencies": {
+        "@happy-dom/global-registrator": "^20.14.0",
         "@types/bun": "latest",
+        "happy-dom": "^20.14.0",
         "socket.io-client": "^4.8.3",
       },
       "peerDependencies": {
@@ -83,6 +85,8 @@
     "@discordjs/util": ["@discordjs/util@1.2.0", "", { "dependencies": { "discord-api-types": "^0.38.33" } }, "sha512-3LKP7F2+atl9vJFhaBjn4nOaSWahZ/yWjOvA4e5pnXkt2qyXRCHLxoBQy81GFtLGCq7K9lPm9R517M1U+/90Qg=="],
 
     "@discordjs/ws": ["@discordjs/ws@1.2.3", "", { "dependencies": { "@discordjs/collection": "^2.1.0", "@discordjs/rest": "^2.5.1", "@discordjs/util": "^1.1.0", "@sapphire/async-queue": "^1.5.2", "@types/ws": "^8.5.10", "@vladfrangu/async_event_emitter": "^2.2.4", "discord-api-types": "^0.38.1", "tslib": "^2.6.2", "ws": "^8.17.0" } }, "sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw=="],
+
+    "@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.14.0", "", { "dependencies": { "@types/node": ">=20.0.0", "happy-dom": "^20.14.0" } }, "sha512-Xn0kdkaA1eHOaFFopr+YQ37sPNTZ3JScpUMz3j4rIsn1Nneqoh94z79iW23Ej0Ytt99+LlFr4JrSDd6ow9c7MQ=="],
 
     "@lezer/common": ["@lezer/common@1.5.1", "", {}, "sha512-6YRVG9vBkaY7p1IVxL4s44n5nUnaNnGM2/AckNgYOnxTG2kWh1vR8BMxPseWPjRNpb5VtXnMpeYAEAADoRV1Iw=="],
 
@@ -168,6 +172,8 @@
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
+    "@types/whatwg-mimetype": ["@types/whatwg-mimetype@3.0.2", "", {}, "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA=="],
+
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
@@ -189,6 +195,8 @@
     "bail": ["bail@2.0.2", "", {}, "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="],
 
     "base64id": ["base64id@2.0.0", "", {}, "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog=="],
+
+    "buffer-image-size": ["buffer-image-size@0.6.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ=="],
 
     "bun-types": ["bun-types@1.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg=="],
 
@@ -262,6 +270,8 @@
 
     "engine.io-parser": ["engine.io-parser@5.2.3", "", {}, "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q=="],
 
+    "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
+
     "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
 
     "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
@@ -295,6 +305,8 @@
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
 
     "guid-typescript": ["guid-typescript@1.0.9", "", {}, "sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ=="],
+
+    "happy-dom": ["happy-dom@20.14.0", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "buffer-image-size": "^0.6.4", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.21.0" } }, "sha512-4bRh1KzRvKDnFNTlLhzT1RZTpkKhQbQDl9j+7GXszWsvuspYdo29k6OHRf4PwiM6oLb8r/pMWeYiJjkfod5AvQ=="],
 
     "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
 
@@ -536,9 +548,11 @@
 
     "webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
 
+    "whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
+
     "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
-    "ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
+    "ws": ["ws@8.21.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw=="],
 
     "xml-escape": ["xml-escape@1.1.0", "", {}, "sha512-B/T4sDK8Z6aUh/qNr7mjKAwwncIljFuUP+DO/D5hloYFj+90O88z8Wf7oSucZTHxBAsC1/CTP4rtx/x1Uf72Mg=="],
 
@@ -553,6 +567,10 @@
     "@discordjs/rest/@discordjs/collection": ["@discordjs/collection@2.1.1", "", {}, "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg=="],
 
     "@discordjs/ws/@discordjs/collection": ["@discordjs/collection@2.1.1", "", {}, "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg=="],
+
+    "@discordjs/ws/ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
+
+    "edge-tts-universal/ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
 
     "engine.io/ws": ["ws@8.18.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="],
 

--- a/package.json
+++ b/package.json
@@ -87,7 +87,9 @@
     "yaml": "^2.7.0"
   },
   "devDependencies": {
+    "@happy-dom/global-registrator": "^20.14.0",
     "@types/bun": "latest",
+    "happy-dom": "^20.14.0",
     "socket.io-client": "^4.8.3"
   },
   "peerDependencies": {

--- a/ui/src/v2/onboarding/OnboardingWizard.steps.test.ts
+++ b/ui/src/v2/onboarding/OnboardingWizard.steps.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import { HOSTED_PROVISIONED, STEPS, stepsFor, stepGatedOnProbe, resolveStepKey } from "./OnboardingWizard";
 
-/** Pure-function test (the LLMTab.models.test.ts precedent — this repo has no
- * DOM test infrastructure). The step list is the feature: on a hosted install
+/** Pure-function test (the LLMTab.models.test.ts precedent). The step list is
+ * decidable without rendering, so it is tested without rendering; the tour's
+ * spotlight is not, and OnboardingWizard.tour.test.tsx mounts it for real.
+ * The step list is the feature: on a hosted install
  * the platform already answers brain/hearing/speaking, and ASKING is not the
  * only cost — answering writes intent that pins the account off its own plan. */
 describe("stepsFor", () => {

--- a/ui/src/v2/onboarding/OnboardingWizard.tour.test.tsx
+++ b/ui/src/v2/onboarding/OnboardingWizard.tour.test.tsx
@@ -1,0 +1,204 @@
+/**
+ * The tour's spotlight card, rendered for real.
+ *
+ * This is the repo's first DOM test, and it exists because the bug that
+ * prompted it was invisible to a pure-function one. On macOS the 4th slide
+ * showed the 3rd slide's copy and counter while sitting at the 4th slide's
+ * position. React was never wrong: the committed DOM carried slide 4's text,
+ * counter and `top` together, which is the first thing asserted below. The
+ * card is a stacking context wrapping an infinitely animated dot, so the
+ * compositor gives it its own layer, and the 3->4 and 4->5 transitions change
+ * ONLY `top` - WebKit moved the cached layer without re-rasterising it.
+ *
+ * The paint itself cannot be asserted from here; no headless DOM rasterises.
+ * What CAN be pinned is the fix - each slide is a BRAND-NEW element rather
+ * than a mutated one - and the regression that fix introduced: remounting
+ * dropped keyboard focus to <body>, so anyone advancing with Enter had to Tab
+ * back into the card on every slide. Both are covered, because the second is
+ * the more likely of the two to be "tidied" away by someone who sees a `key`
+ * on a non-list element and assumes it is noise.
+ */
+import { afterAll, afterEach, beforeAll, describe, expect, test } from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+
+// Registered before the component (and React DOM) are imported, so nothing
+// reads a global that does not exist yet, and unregistered afterwards so the
+// DOM does not leak into the suites that run after this file in the same
+// process - several of them branch on `typeof window`.
+GlobalRegistrator.register();
+// Without this React warns on every act() call and does not promise that
+// effects have flushed when one returns - which is exactly what the focus
+// assertions below depend on.
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let createRoot: typeof import("react-dom/client").createRoot;
+let act: typeof import("react").act;
+let OnboardingWizard: typeof import("./OnboardingWizard").OnboardingWizard;
+type OnboardingStatus = import("./useOnboardingStatus").OnboardingStatus;
+
+const realFetch = globalThis.fetch;
+
+beforeAll(async () => {
+  ({ act } = await import("react"));
+  ({ createRoot } = await import("react-dom/client"));
+  ({ OnboardingWizard } = await import("./OnboardingWizard"));
+});
+
+afterAll(() => {
+  // Both globals are restored, not just the DOM: a stubbed `fetch` left behind
+  // would follow this file into every suite that runs after it.
+  globalThis.fetch = realFetch;
+  GlobalRegistrator.unregister();
+});
+
+/** Reached the tour: setup and profile done, tutorial neither seen nor skipped.
+ *  Spelled out in full against the real type so that a new REQUIRED field on
+ *  OnboardingStatus breaks here rather than silently changing which screen the
+ *  wizard resolves to. */
+const AT_TOUR: OnboardingStatus = {
+  setup_completed: true,
+  setup_completed_at: 1,
+  setup_skipped_profile: false,
+  profile_completed: true,
+  tutorial_completed: false,
+  tutorial_completed_at: null,
+  tutorial_dismissed: false,
+  tutorial_progress_step: null,
+  last_reset_at: null,
+};
+
+const posted: string[] = [];
+let host: HTMLElement | null = null;
+let root: ReturnType<typeof createRoot> | null = null;
+
+async function mountTour() {
+  posted.length = 0;
+  globalThis.fetch = (async (url: string, init?: { method?: string }) => {
+    if (init?.method === "POST") posted.push(String(url));
+    // The hosted probe blocks the setup screens until it answers; the tour
+    // does not gate on it, but an unresolved probe leaves a retry timer
+    // running under every assertion here.
+    return new Response(JSON.stringify({ hosted_llm: false }), {
+      headers: { "content-type": "application/json" },
+    });
+  }) as never;
+
+  host = document.createElement("div");
+  document.body.appendChild(host);
+  root = createRoot(host);
+  await act(async () => {
+    root!.render(<OnboardingWizard status={AT_TOUR} onComplete={() => {}} />);
+  });
+  return host;
+}
+
+afterEach(async () => {
+  if (root) await act(async () => root!.unmount());
+  host?.remove();
+  root = null;
+  host = null;
+});
+
+const spot = () => host!.querySelector(".obw-spot") as HTMLElement;
+const counter = () => spot().querySelector(".sc")!.textContent;
+/* Direct child: `.sm` is also the small-button modifier, so a plain `.sm`
+   lookup finds the Next button instead of the message. */
+const message = () => spot().querySelector(":scope > .sm")!.textContent;
+const advance = () =>
+  Array.from(spot().querySelectorAll("button")).find((b) => /Next|Finish/.test(b.textContent || ""))!;
+
+/* Never assert on a DOM node directly: bun prints the whole object graph, and
+   a one-line focus regression arrives as several thousand lines of getters.
+   These reduce the thing under test to something a failure can actually say. */
+const focusLabel = () => {
+  const el = document.activeElement as HTMLElement | null;
+  if (!el || el === document.body) return "<body>";
+  return `${el.tagName.toLowerCase()}:${(el.textContent || "").trim().slice(0, 20)}`;
+};
+
+/** The five slides, in the order the tour walks them. */
+const SLIDES = [
+  { counter: "1 of 5", pos: /bottom: 50px/, copy: /Pebble/ },
+  { counter: "2 of 5", pos: /top: 60px/, copy: /summon Talk/ },
+  { counter: "3 of 5", pos: /top: 58px/, copy: /The Index/ },
+  { counter: "4 of 5", pos: /top: 104px/, copy: /monitoring surface/ },
+  { counter: "5 of 5", pos: /top: 150px/, copy: /Authority/ },
+];
+
+describe("tour slides", () => {
+  test("copy, counter and position always describe the SAME slide", async () => {
+    await mountTour();
+    for (const [i, want] of SLIDES.entries()) {
+      expect(counter()).toBe(want.counter);
+      expect(message()).toMatch(want.copy);
+      expect(spot().getAttribute("style")).toMatch(want.pos);
+      if (i < SLIDES.length - 1) await act(async () => advance().click());
+    }
+  });
+
+  test("the counter's total matches the slides that actually exist", async () => {
+    await mountTour();
+    // Walked, not hardcoded: click through to the slide offering "Finish" and
+    // count what was seen. Asserting against SLIDES.length instead would agree
+    // with a stale literal, since both say five today - this fails the moment
+    // a slide is added or dropped and the label is left behind.
+    let walked = 1;
+    while (advance().textContent !== "Finish") {
+      await act(async () => advance().click());
+      walked++;
+      if (walked > 20) throw new Error("tour never reached its last slide");
+    }
+    expect(counter()).toBe(`${walked} of ${walked}`);
+  });
+
+  test("each slide is a NEW element, never a mutated one", async () => {
+    await mountTour();
+    // Identity, not contents: the whole point of the `key` is that the
+    // compositor is handed a node it has never rasterised before.
+    const seen = new WeakSet<HTMLElement>([spot()]);
+    for (let i = 2; i <= SLIDES.length; i++) {
+      await act(async () => advance().click());
+      const now = spot();
+      expect({ slide: i, remounted: !seen.has(now) }).toEqual({ slide: i, remounted: true });
+      seen.add(now);
+    }
+  });
+
+  test("the last slide finishes instead of advancing", async () => {
+    await mountTour();
+    for (let i = 1; i < SLIDES.length; i++) await act(async () => advance().click());
+    expect(advance().textContent).toBe("Finish");
+    await act(async () => advance().click());
+    expect(posted).toContain("/api/onboarding/tutorial/complete");
+  });
+
+  test("Skip tour dismisses rather than completing", async () => {
+    await mountTour();
+    const skip = Array.from(spot().querySelectorAll("button")).find((b) => b.textContent === "Skip tour")!;
+    await act(async () => skip.click());
+    expect(posted).toContain("/api/onboarding/tutorial/dismiss");
+  });
+});
+
+describe("tour keyboard focus", () => {
+  test("advancing keeps focus on the button that was activated", async () => {
+    await mountTour();
+    for (let i = 2; i <= SLIDES.length; i++) {
+      const btn = advance();
+      btn.focus();
+      await act(async () => btn.click());
+      // Remounting the card destroys `btn`; focus must land on its
+      // REPLACEMENT, not on <body> and not on the detached original, or
+      // Enter-to-advance dies after one slide.
+      expect({ slide: i, focus: focusLabel(), onLiveButton: document.activeElement === advance() })
+        .toEqual({ slide: i, focus: i === SLIDES.length ? "button:Finish" : "button:Next", onLiveButton: true });
+    }
+  });
+
+  test("the first slide does not grab focus on its own", async () => {
+    await mountTour();
+    // Nothing has been activated yet, so pulling focus into the card here
+    // would be a bug of its own - it would yank a screen reader mid-sentence.
+    expect(focusLabel()).toBe("<body>");
+  });
+});

--- a/ui/src/v2/onboarding/OnboardingWizard.tsx
+++ b/ui/src/v2/onboarding/OnboardingWizard.tsx
@@ -287,6 +287,19 @@ export function OnboardingWizard({
   const [tgBusy, setTgBusy] = useState(false);
   // tour
   const [tourI, setTourI] = useState(0);
+  // The spotlight is remounted per slide (see renderTour), and a remount drops
+  // keyboard focus to <body> - so a keyboard user who advanced with Enter had
+  // to Tab back into the card on every slide, and a screen reader lost its
+  // place. Put focus back on the button they just used, but ONLY when they
+  // actually used it: on the tour's first paint nothing has been activated
+  // yet, and grabbing focus there would be its own bug.
+  const tourNextRef = useRef<HTMLButtonElement | null>(null);
+  const tourAdvanced = useRef(false);
+  useLayoutEffect(() => {
+    if (!tourAdvanced.current) return;
+    tourAdvanced.current = false;
+    tourNextRef.current?.focus();
+  }, [tourI]);
   // flow
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -1226,14 +1239,33 @@ export function OnboardingWizard({
             </div>
           </div>
           <div className="obw-tourdim" />
-          <div className="obw-spot" style={pos}>
-            <div className="sh"><span className="sd"><span className="in" /></span><span className="sl">Jarvis · tour</span><span className="sc">{tourI + 1} of 5</span></div>
+          {/* Keyed by slide so each step mounts a NEW node instead of mutating
+              one in place. React's output was always right - the DOM carried
+              slide 4's copy, counter and `top` in the same commit - but the
+              card is a stacking context (z-index) wrapping a descendant with
+              an infinite transform+opacity animation (the pulsing dot), so the
+              compositor hands it its own layer. Slides 3->4 and 4->5 change
+              ONLY `top`; WebKit re-positioned that cached layer without
+              re-rasterising it, and the user read slide 3's text over slide
+              4's position. Slides 1->2->3 swap right/bottom for left/top, a
+              big enough change to force a repaint, which is why only the tail
+              of the tour showed it. A fresh node cannot be a stale one. */}
+          <div key={tourI} className="obw-spot" style={pos}>
+            <div className="sh"><span className="sd"><span className="in" /></span><span className="sl">Jarvis · tour</span><span className="sc">{tourI + 1} of {TOUR.length}</span></div>
             <div className="sm">{T.sm}</div>
             {T.t && <div className="stry">{T.t}</div>}
             {error && <div className="stry" style={{ color: "var(--listen)" }}>{error}</div>}
             <div className="sb">
               <button className="obw-skip" onClick={skipTour}>Skip tour</button><span className="grow" />
-              <button className="obw-btn obw-btn-pri sm" onClick={() => (tourI === TOUR.length - 1 ? finishTour() : setTourI(tourI + 1))}>{tourI === TOUR.length - 1 ? "Finish" : "Next"}</button>
+              <button
+                ref={tourNextRef}
+                className="obw-btn obw-btn-pri sm"
+                onClick={() => {
+                  if (tourI === TOUR.length - 1) { finishTour(); return; }
+                  tourAdvanced.current = true;
+                  setTourI(tourI + 1);
+                }}
+              >{tourI === TOUR.length - 1 ? "Finish" : "Next"}</button>
             </div>
           </div>
         </div>


### PR DESCRIPTION
On macOS the 4th slide of the dashboard tour showed the 3rd slide's copy and step number while sitting at the 4th slide's position.

React was never wrong. I mounted the wizard and clicked through it: every commit carries one slide's text, counter and `top` together.

```
click 3 | style: top: 104px; left: calc(var(--mrail-w) + 12px)
         counter: 4 of 5
         msg: "Now is your monitoring surface: what I'm doing and..."
```

It's a stale composited layer. `.obw-spot` is a stacking context (`z-index: 60`) wrapping a descendant with an infinite `transform`/`opacity` animation (the pulsing dot), so the compositor gives the card its own layer. Slides 3->4 and 4->5 change ONLY the inline `top`, and WebKit moved the cached layer without re-rasterising its text. Slides 1->2->3 swap `right`/`bottom` for `left`/`top`, a big enough change to force a real repaint, which is why only the tail of the tour showed it.

## The fix

`key={tourI}` on the callout, so each slide mounts a new node instead of mutating one in place. A node the compositor has never rasterised cannot be handed back stale, so this holds on the Windows and Linux webviews too rather than being a macOS-only patch.

That remount dropped keyboard focus to `<body>` on every advance, so anyone walking the tour with Enter had to Tab back into the card each slide. Focus is now restored to the button that was activated, gated on a ref flag so the first slide doesn't grab focus on mount.

Also swapped the hardcoded `of 5` for `of {TOUR.length}`.

## Tests

First DOM test in the repo (`happy-dom`), because a pure-function test could not have seen any of this. It pins that copy, counter and position always describe the same slide, that each slide is a genuinely new element, and both halves of the focus behaviour.

Verified by reverting each fix in turn - every mutation is caught by exactly the intended test:

| Mutation | Caught by |
| --- | --- |
| `key={tourI}` removed | each slide is a NEW element |
| focus restore neutered | advancing keeps focus on the button activated |
| focus restore unguarded | the first slide does not grab focus |
| `of {TOUR.length}` -> `of 4` | same-slide test + counter-total test |

The paint itself can't be asserted - no headless DOM rasterises - so the tests pin the fix and the regression it caused, not the symptom. I confirmed the symptom is gone on a real macOS build.

Full suite: 2743 pass, 0 fail across 213 files. `tsc --noEmit` clean, `build:ui` succeeds.
