### PR TITLE
Stop composing workflow steps for an OS none of the user's machines run

### DIFF
--- a/src/actions/tools/builtin.ts
+++ b/src/actions/tools/builtin.ts
@@ -62,7 +62,7 @@ export function toolDefToLLMTool(tool: ToolDefinition): LLMTool {
 
 export const runCommandTool: ToolDefinition = {
   name: 'run_command',
-  description: 'Execute a shell command and return the output. Use this to run terminal commands, scripts, or system utilities. Optionally specify a "target" sidecar name/ID to run the command on a remote machine instead of locally.',
+  description: 'Execute a shell command and return the output. Use this to run terminal commands, scripts, or system utilities. Optionally specify a "target" sidecar name/ID to run the command on a remote machine instead of locally. The command must be valid for the OS of the machine it runs on -- the target machine is often not the same OS as the brain; check list_sidecars when unsure.',
   category: 'terminal',
   parameters: {
     command: {

--- a/src/actions/tools/desktop.ts
+++ b/src/actions/tools/desktop.ts
@@ -474,7 +474,7 @@ export const desktopPressKeysTool: ToolDefinition = {
 
 export const desktopLaunchAppTool: ToolDefinition = {
   name: 'desktop_launch_app',
-  description: 'Launch an application by executable path or name (e.g., "notepad.exe", "calc.exe"). Returns the PID of the launched process.',
+  description: 'Launch an application by name or executable path. Use the name as it exists on the TARGET machine\'s OS -- e.g. "notepad" on Windows, "TextEdit" on macOS, "gedit" on Linux. Call list_sidecars first if you are unsure which OS the target runs. Returns the PID of the launched process.',
   category: 'desktop',
   parameters: {
     target: {
@@ -484,7 +484,7 @@ export const desktopLaunchAppTool: ToolDefinition = {
     },
     executable: {
       type: 'string',
-      description: 'Application executable path or name',
+      description: "Application name or executable path, spelled for the target machine's OS",
       required: true,
     },
     args: {

--- a/src/actions/tools/manage-workflow.test.ts
+++ b/src/actions/tools/manage-workflow.test.ts
@@ -75,6 +75,55 @@ describe("manage_workflow tool", () => {
     expect(published.publishedVersionId).not.toBeNull();
   });
 
+  test("publish warns about a hand-built step that cannot run where it lands", async () => {
+    // The editor path: a flow whose steps this composer never wrote. Publish is
+    // the only gate it passes through, and the warning must not block it.
+    const { getLatestDraft, updateDraftVersion } = await import("../../workflows/db/repos/flow-version.ts");
+    const created = (await call("create", { name: "handmade", empty: true })) as { id: string };
+    // Exactly what the editor does: PATCH the draft's trigger tree in place.
+    updateDraftVersion(getLatestDraft(created.id)!.id, {
+      trigger: {
+        name: "trigger",
+        type: "EMPTY",
+        nextAction: {
+          name: "step_1",
+          type: "PIECE",
+          settings: {
+            pieceName: "jarvis-tool",
+            actionName: "invoke",
+            input: { toolName: "desktop_launch_app", params: { executable: "notepad.exe" } },
+          },
+        },
+      },
+    });
+    const withTargets = createManageWorkflowTool({
+      executionTargets: () => [
+        { id: "sc-mac", name: "Lapo's MacBook", os: "darwin", arch: "arm64", connected: true },
+      ],
+    });
+    const published = JSON.parse(
+      (await withTargets.execute({ action: "publish", flow: "handmade" })) as string,
+    ) as { status: string; warnings?: string[] };
+
+    expect(published.status).toBe("ENABLED");
+    expect(published.warnings?.[0]).toContain("notepad.exe");
+    // Advisory only: the version still locked and the flow still published.
+    expect(getLatestDraft(created.id)).toBeNull();
+  });
+
+  test("publish stays silent when the flow fits the machines it will run on", async () => {
+    await call("create", { name: "fine", empty: true });
+    const withTargets = createManageWorkflowTool({
+      executionTargets: () => [
+        { id: "sc-mac", name: "Lapo's MacBook", os: "darwin", connected: true },
+      ],
+    });
+    const published = JSON.parse(
+      (await withTargets.execute({ action: "publish", flow: "fine" })) as string,
+    ) as { warnings?: string[] };
+    expect(published.warnings).toBeUndefined();
+  });
+
   test("delete removes the flow", async () => {
     const created = (await call("create", { name: "doomed", empty: true })) as { id: string };
     const out = (await call("delete", { flow: "doomed" })) as { id: string; deleted: boolean };

--- a/src/actions/tools/manage-workflow.ts
+++ b/src/actions/tools/manage-workflow.ts
@@ -65,6 +65,11 @@ import {
 import { enqueue } from "../../workflows/db/repos/job-queue.ts";
 import { RUN_FLOW } from "../../workflows/runner/handler.ts";
 import {
+  flowOsWarnings,
+  osCheckContextFor,
+  type ExecutionTarget,
+} from "../../util/execution-environment.ts";
+import {
   composeFlow,
   type ComposedFlow,
   type ComposerLibraryEntry,
@@ -105,6 +110,15 @@ export interface ManageWorkflowDeps {
    * wording from this tool's description and from the composer's prompt.
    */
   library?: ComposerLibraryEntry[];
+  /**
+   * Optional. The machines a composed step can execute on -- the enrolled
+   * sidecars plus the brain's own host. When provided, the composer knows
+   * which OS it is writing commands for instead of guessing (the `notepad.exe`
+   * composed for a Mac-only fleet), and rejects a step bound to an OS nothing
+   * here runs. A thunk, not a snapshot: sidecars enroll, connect, and report
+   * their OS long after this tool is constructed.
+   */
+  executionTargets?: () => ExecutionTarget[];
 }
 
 export function createManageWorkflowTool(deps: ManageWorkflowDeps = {}): ToolDefinition {
@@ -398,12 +412,36 @@ function actPublish(flow: FlowRow, deps: ManageWorkflowDeps): Record<string, unk
     }
     throw new Error("no draft version to publish");
   }
+  // Publish is the last gate before a flow starts running for real, and it is
+  // the ONLY one a hand-built flow passes through -- a flow drawn in the
+  // visual editor never meets the composer's validation. Re-check OS fit here
+  // so a `notepad.exe` step someone typed by hand is called out before it
+  // starts failing on a schedule.
+  //
+  // Warnings, not a refusal: the draft may deliberately target a machine that
+  // is not enrolled yet, and blocking someone's publish over a heuristic would
+  // be worse than the mismatch it prevents.
+  const warnings = publishOsWarnings(target.trigger, deps);
   if (target.state !== "LOCKED") target = lockVersion(target.id);
   setPublishedVersion(flow.id, target.id);
   updateFlowStatus(flow.id, "ENABLED");
   void deps.triggerManager?.refresh(flow.id).catch(e => console.warn(`[manage-workflow] triggerManager.refresh failed: ${(e as Error).message}`));
   const updated = getFlow(flow.id);
-  return updated ? summarizeFlow(updated) : { error: "flow vanished after publish" };
+  if (!updated) return { error: "flow vanished after publish" };
+  return warnings.length > 0
+    ? { ...summarizeFlow(updated), warnings }
+    : summarizeFlow(updated);
+}
+
+/**
+ * OS-fit warnings for a version about to be published. Empty whenever the
+ * check can't be trusted -- no machine inventory, or a machine whose OS was
+ * never reported.
+ */
+function publishOsWarnings(trigger: unknown, deps: ManageWorkflowDeps): string[] {
+  if (!deps.executionTargets) return [];
+  const ctx = osCheckContextFor(deps.executionTargets());
+  return ctx ? flowOsWarnings(trigger, ctx) : [];
 }
 
 function actDelete(flow: FlowRow, deps: ManageWorkflowDeps): Record<string, unknown> {
@@ -457,6 +495,10 @@ async function actCompose(
     if (roles.length > 0) composeDeps.specialistRoles = roles;
   }
   if (deps.library && deps.library.length > 0) composeDeps.library = deps.library;
+  if (deps.executionTargets) {
+    const targets = deps.executionTargets();
+    if (targets.length > 0) composeDeps.executionTargets = targets;
+  }
   const result = await composeFlow(composeDeps, { name, description });
 
   if (!result.ok) {

--- a/src/actions/tools/sidecar-route.test.ts
+++ b/src/actions/tools/sidecar-route.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import type { SidecarManager } from "../../sidecar/manager.ts";
+import type { SidecarInfo } from "../../sidecar/types.ts";
+import { setNoLocalTools } from "./local-tools-guard.ts";
+import { collectExecutionTargets, routeToSidecar, setSidecarManagerRef } from "./sidecar-route.ts";
+
+const mac: SidecarInfo = {
+  id: "sc-mac",
+  name: "Lapo's MacBook",
+  enrolled_at: "2026-01-01",
+  last_seen_at: "2026-01-02",
+  status: "enrolled",
+  connected: true,
+  hostname: "lapo-mbp",
+  os: "darwin",
+  platform: "arm64",
+  capabilities: ["terminal", "desktop"],
+};
+
+/** Minimal manager stub: only the two methods these paths touch. */
+function stubManager(
+  sidecars: SidecarInfo[],
+  dispatch: (id: string, method: string, params: Record<string, unknown>) => Promise<unknown> = async () => "ok",
+): SidecarManager {
+  return {
+    listSidecars: () => sidecars,
+    dispatchRPC: (id: string, method: string, params: Record<string, unknown>) => dispatch(id, method, params),
+  } as unknown as SidecarManager;
+}
+
+afterEach(() => {
+  setNoLocalTools(false);
+  // No unset API; a null ref is how the module behaves before the daemon wires it.
+  setSidecarManagerRef(null as unknown as SidecarManager);
+});
+
+describe("collectExecutionTargets", () => {
+  test("maps a sidecar's OS and arch, keeping offline machines", () => {
+    setSidecarManagerRef(stubManager([mac, { ...mac, id: "sc-pc", name: "Desk PC", os: "windows", platform: "amd64", connected: false }]));
+    const targets = collectExecutionTargets();
+    const found = targets.find((t) => t.id === "sc-mac");
+    expect(found?.os).toBe("darwin");
+    // SidecarInfo.platform is GOARCH; it must land on `arch`, not `os`.
+    expect(found?.arch).toBe("arm64");
+    expect(found?.capabilities).toEqual(["terminal", "desktop"]);
+    // The laptop that is asleep now is still the machine a scheduled flow means.
+    expect(targets.find((t) => t.id === "sc-pc")?.connected).toBe(false);
+  });
+
+  test("appends the brain host", () => {
+    setSidecarManagerRef(stubManager([mac]));
+    const host = collectExecutionTargets().find((t) => t.isHost);
+    expect(host?.os).toBe(process.platform);
+  });
+
+  test("omits the host under --no-local-tools, where it refuses every call", () => {
+    // Otherwise a hosted brain's own OS would excuse commands that can only
+    // ever run on the user's sidecar.
+    setSidecarManagerRef(stubManager([mac]));
+    setNoLocalTools(true);
+    const targets = collectExecutionTargets();
+    expect(targets.some((t) => t.isHost)).toBe(false);
+    expect(targets).toHaveLength(1);
+  });
+
+  test("still reports the host when the registry is unavailable", () => {
+    const targets = collectExecutionTargets();
+    expect(targets).toHaveLength(1);
+    expect(targets[0]?.isHost).toBe(true);
+  });
+});
+
+describe("routeToSidecar error messages", () => {
+  test("names the machine's OS when a call fails", async () => {
+    // The commonest remote failure is a command written for the wrong
+    // platform; "command not found" alone says nothing about why.
+    setSidecarManagerRef(
+      stubManager([mac], async () => {
+        throw new Error("exec: notepad.exe: executable file not found");
+      }),
+    );
+    const out = await routeToSidecar("sc-mac", "launch_app", { executable: "notepad.exe" }, "desktop");
+    expect(out).toContain("Lapo's MacBook, macOS");
+    expect(out).toContain("executable file not found");
+  });
+
+  test("names the OS on an offline machine too", async () => {
+    setSidecarManagerRef(stubManager([{ ...mac, connected: false }]));
+    const out = await routeToSidecar("sc-mac", "run_command", {}, "terminal");
+    expect(out).toContain("Lapo's MacBook, macOS");
+    expect(out).toContain("offline");
+  });
+
+  test("falls back to the bare name when the OS was never reported", async () => {
+    setSidecarManagerRef(stubManager([{ ...mac, os: undefined, connected: false }]));
+    const out = await routeToSidecar("sc-mac", "run_command", {}, "terminal");
+    expect(out).toContain('"Lapo\'s MacBook" is offline');
+  });
+
+  test("passes a successful result through untouched", async () => {
+    setSidecarManagerRef(stubManager([mac], async () => "total 8\\ndrwx"));
+    expect(await routeToSidecar("sc-mac", "run_command", {}, "terminal")).toBe("total 8\\ndrwx");
+  });
+});

--- a/src/actions/tools/sidecar-route.ts
+++ b/src/actions/tools/sidecar-route.ts
@@ -8,6 +8,13 @@
 
 import type { SidecarManager } from '../../sidecar/manager.ts';
 import type { SidecarCapability, SidecarInfo } from '../../sidecar/types.ts';
+import {
+  familyLabel,
+  hostTarget,
+  osFamily,
+  type ExecutionTarget,
+} from '../../util/execution-environment.ts';
+import { isNoLocalTools } from './local-tools-guard.ts';
 
 let sidecarManager: SidecarManager | null = null;
 
@@ -37,6 +44,49 @@ export function autoTargetForCapability(cap: SidecarCapability): string | null {
     if (s.capabilities && s.capabilities.includes(cap)) return s.id;
   }
   return null;
+}
+
+/**
+ * The live execution inventory: every enrolled sidecar plus the brain's own
+ * host, each with the OS it runs. Feeds the workflow composer's prompts and
+ * the agent's tool guide, so both write commands for the machine a step
+ * actually lands on instead of whichever OS the model's priors favour.
+ *
+ * Offline sidecars stay in the list: a workflow composed today runs on a
+ * schedule tomorrow, and the laptop asleep right now is still the machine the
+ * user means. Dropping it would leave the composer writing commands for the
+ * Linux server the brain happens to live on.
+ *
+ * The host is omitted under --no-local-tools, where it refuses every call --
+ * counting it would let a hosted brain's own OS excuse commands that can only
+ * ever run on the user's sidecar.
+ */
+export function collectExecutionTargets(): ExecutionTarget[] {
+  const targets: ExecutionTarget[] = [];
+  try {
+    for (const s of sidecarManager?.listSidecars() ?? []) {
+      targets.push({
+        id: s.id,
+        name: s.name,
+        os: s.os ?? null,
+        // SidecarInfo.platform carries GOARCH, not an OS. See ExecutionTarget.
+        arch: s.platform ?? null,
+        connected: s.connected,
+        ...(s.capabilities ? { capabilities: [...s.capabilities] } : {}),
+      });
+    }
+  } catch {
+    // Registry unavailable (DB not open yet, sidecars disabled). Report what
+    // we can rather than nothing.
+  }
+  if (!isNoLocalTools()) targets.push(hostTarget());
+  return targets;
+}
+
+/** A machine's name plus its OS, for an error a human has to act on. */
+function describeMachine(sidecar: SidecarInfo): string {
+  const fam = osFamily(sidecar.os);
+  return fam ? `${sidecar.name}, ${familyLabel(fam)}` : sidecar.name;
 }
 
 /**
@@ -88,7 +138,7 @@ export async function routeToSidecar(
   }
 
   if (!sidecar.connected) {
-    return `Error: Sidecar "${sidecar.name}" is offline.`;
+    return `Error: Sidecar "${describeMachine(sidecar)}" is offline.`;
   }
 
   // Check if capability is enabled but unavailable (missing system dependencies)
@@ -114,9 +164,12 @@ export async function routeToSidecar(
 
     // METHOD_NOT_FOUND means the capability is disabled — tell the LLM not to retry
     if (msg.includes('METHOD_NOT_FOUND')) {
-      return `Error [${sidecar.name}]: Method "${method}" is not available. The "${requiredCapability}" capability is not enabled on this sidecar. Do NOT retry this call — ask the user to enable the capability in the sidecar's config if needed.`;
+      return `Error [${describeMachine(sidecar)}]: Method "${method}" is not available. The "${requiredCapability}" capability is not enabled on this sidecar. Do NOT retry this call — ask the user to enable the capability in the sidecar's config if needed.`;
     }
 
-    return `Error [${sidecar.name}]: ${msg}`;
+    // The OS goes in the message on purpose: the commonest remote failure is
+    // a command written for the wrong platform (`notepad.exe` sent to a Mac),
+    // and "command not found" alone tells neither the model nor the user why.
+    return `Error [${describeMachine(sidecar)}]: ${msg}`;
   }
 }

--- a/src/actions/tools/workflow-composer.test.ts
+++ b/src/actions/tools/workflow-composer.test.ts
@@ -11,6 +11,7 @@ import type {
   ComposerToolDef,
   ComposerToolSpec,
 } from "./workflow-composer";
+import type { ExecutionTarget } from "../../util/execution-environment";
 
 class StubLlm implements ComposerLlmClient {
   public calls: Array<{ prompt: string; system?: string }> = [];
@@ -793,6 +794,252 @@ describe("composeFlow", () => {
       const result = await composeFlow(
         { llm, pieceRegistry: toolCatalog(), toolNames: ["content_pipeline"] },
         { name: "Tooly", description: "x" },
+      );
+      expect(result.ok).toBe(true);
+    });
+  });
+
+  describe("execution-environment (OS) awareness", () => {
+    // The reported failure: on a brain whose only machine is a MacBook, "make a
+    // workflow that opens notepad" composed `notepad.exe`, and nothing noticed
+    // until the run failed. The composer now knows which machines exist and
+    // what OS each runs.
+    function osToolCatalog(): PieceLookup {
+      return new PieceCatalog([
+        {
+          name: "@jarvispieces/piece-jarvis-tool",
+          displayName: "Jarvis: Tool",
+          description: "Invoke a registered Jarvis tool.",
+          actions: {
+            invoke: {
+              name: "invoke",
+              displayName: "Invoke",
+              description: "Call a tool.",
+              inputSchema: {
+                fields: [
+                  { name: "toolName", label: "Tool", type: "string", required: true },
+                  { name: "params", label: "Params", type: "json", required: false },
+                ],
+              },
+            },
+          },
+        },
+      ]);
+    }
+
+    const mac: ExecutionTarget = {
+      id: "sc-mac",
+      name: "Lapo's MacBook",
+      os: "darwin",
+      arch: "arm64",
+      connected: true,
+      capabilities: ["terminal", "desktop"],
+    };
+    const win: ExecutionTarget = {
+      id: "sc-win",
+      name: "Desk PC",
+      os: "windows",
+      arch: "amd64",
+      connected: true,
+      capabilities: ["terminal", "desktop"],
+    };
+    const linuxHost: ExecutionTarget = {
+      id: "",
+      name: "Jarvis host (this brain)",
+      os: "linux",
+      arch: "x64",
+      connected: true,
+      isHost: true,
+    };
+
+    const invoke = (toolName: string, params: Record<string, unknown>) =>
+      JSON.stringify({
+        displayName: "Opener",
+        trigger: {
+          name: "trigger",
+          type: "EMPTY",
+          nextAction: {
+            name: "step_1",
+            type: "PIECE",
+            settings: { pieceName: "jarvis-tool", actionName: "invoke", input: { toolName, params } },
+          },
+        },
+      });
+
+    test("puts the machine inventory in the system prompt", async () => {
+      const llm = new StubLlm(JSON.stringify({ displayName: "X", trigger: { name: "trigger", type: "EMPTY" } }));
+      await composeFlow(
+        { llm, pieceRegistry: osToolCatalog(), executionTargets: [mac, linuxHost] },
+        { name: "X", description: "x" },
+      );
+      const sys = llm.calls[0]?.system ?? "";
+      expect(sys).toContain("Execution environment");
+      expect(sys).toContain("Lapo's MacBook");
+      expect(sys).toContain("macOS, arm64");
+    });
+
+    test("omits the block entirely when no inventory is supplied", async () => {
+      const llm = new StubLlm(JSON.stringify({ displayName: "X", trigger: { name: "trigger", type: "EMPTY" } }));
+      await composeFlow({ llm, pieceRegistry: osToolCatalog() }, { name: "X", description: "x" });
+      expect(llm.calls[0]?.system ?? "").not.toContain("Execution environment");
+    });
+
+    test("rejects notepad.exe when the only machine is a Mac", async () => {
+      const llm = new StubLlm(invoke("desktop_launch_app", { executable: "notepad.exe" }));
+      const result = await composeFlow(
+        { llm, pieceRegistry: osToolCatalog(), executionTargets: [mac, linuxHost], maxAttempts: 1 },
+        { name: "Opener", description: "open notepad" },
+      );
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        const err = result.errors.join(" ");
+        expect(err).toContain("notepad.exe");
+        expect(err).toContain("Windows");
+        expect(err).toContain("Lapo's MacBook");
+        // The equivalent app is named so the retry has somewhere to go.
+        expect(err).toContain("TextEdit");
+      }
+    });
+
+    test("self-corrects on the retry with the macOS equivalent", async () => {
+      const llm = new StubLlm([
+        invoke("desktop_launch_app", { executable: "notepad.exe" }),
+        invoke("desktop_launch_app", { executable: "TextEdit" }),
+      ]);
+      const result = await composeFlow(
+        { llm, pieceRegistry: osToolCatalog(), executionTargets: [mac, linuxHost], maxAttempts: 4 },
+        { name: "Opener", description: "open notepad" },
+      );
+      expect(result.ok).toBe(true);
+      expect(llm.calls).toHaveLength(2);
+      expect(llm.calls[1]?.prompt).toContain("notepad.exe");
+    });
+
+    test("accepts the same step when the only machine is a Windows one", async () => {
+      const llm = new StubLlm(invoke("desktop_launch_app", { executable: "notepad.exe" }));
+      const result = await composeFlow(
+        { llm, pieceRegistry: osToolCatalog(), executionTargets: [win, linuxHost], maxAttempts: 1 },
+        { name: "Opener", description: "open notepad" },
+      );
+      expect(result.ok).toBe(true);
+    });
+
+    test("on a mixed fleet an OS-specific step must name the machine it means", async () => {
+      // Not wrong -- undecided. An untargeted call goes to whichever connected
+      // sidecar answers for the capability, so `notepad.exe` on a Mac+PC fleet
+      // is a coin flip, and the run that loses fails exactly like the original
+      // bug did.
+      const llm = new StubLlm(invoke("desktop_launch_app", { executable: "notepad.exe" }));
+      const result = await composeFlow(
+        { llm, pieceRegistry: osToolCatalog(), executionTargets: [mac, win, linuxHost], maxAttempts: 1 },
+        { name: "Opener", description: "open notepad" },
+      );
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.errors.join(" ")).toContain("set params.target to the one you mean");
+      }
+    });
+
+    test("...and passes once it does", async () => {
+      const llm = new StubLlm(invoke("desktop_launch_app", { executable: "notepad.exe", target: "Desk PC" }));
+      const result = await composeFlow(
+        { llm, pieceRegistry: osToolCatalog(), executionTargets: [mac, win, linuxHost], maxAttempts: 1 },
+        { name: "Opener", description: "open notepad on the PC" },
+      );
+      expect(result.ok).toBe(true);
+    });
+
+    test("a portable command needs no target even on a mixed fleet", async () => {
+      // The rule fires on OS-BOUND values only -- it must not turn every
+      // untargeted step on a heterogeneous fleet into an error.
+      const llm = new StubLlm(invoke("run_command", { command: "git pull && bun test" }));
+      const result = await composeFlow(
+        { llm, pieceRegistry: osToolCatalog(), executionTargets: [mac, win, linuxHost], maxAttempts: 1 },
+        { name: "Opener", description: "pull and test" },
+      );
+      expect(result.ok).toBe(true);
+    });
+
+    test("judges an explicit target against THAT machine, not the fleet", async () => {
+      // A Windows machine exists, but the step was pinned to the Mac.
+      const llm = new StubLlm(
+        invoke("run_command", { command: "notepad.exe", target: "Lapo's MacBook" }),
+      );
+      const result = await composeFlow(
+        { llm, pieceRegistry: osToolCatalog(), executionTargets: [mac, win, linuxHost], maxAttempts: 1 },
+        { name: "Opener", description: "open notepad on my laptop" },
+      );
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.errors.join(" ")).toContain("runs macOS");
+      }
+    });
+
+    test("checks paths as well as commands", async () => {
+      const llm = new StubLlm(invoke("write_file", { path: "C:\\Users\\lapo\\notes.txt" }));
+      const result = await composeFlow(
+        { llm, pieceRegistry: osToolCatalog(), executionTargets: [mac, linuxHost], maxAttempts: 1 },
+        { name: "Opener", description: "save a note" },
+      );
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.errors.join(" ")).toContain("Windows");
+    });
+
+    test("passes an OS-correct command through untouched", async () => {
+      const llm = new StubLlm(invoke("run_command", { command: "open -a TextEdit" }));
+      const result = await composeFlow(
+        { llm, pieceRegistry: osToolCatalog(), executionTargets: [mac, linuxHost] },
+        { name: "Opener", description: "open TextEdit" },
+      );
+      expect(result.ok).toBe(true);
+    });
+
+    test("ignores OS syntax that only appears inside a {{template}}", async () => {
+      // The template resolves at run time to a value we cannot see; only the
+      // literal text around it is ours to judge.
+      const llm = new StubLlm(invoke("run_command", { command: "cat {{trigger.payload.notepad.exe}}" }));
+      const result = await composeFlow(
+        { llm, pieceRegistry: osToolCatalog(), executionTargets: [mac, linuxHost] },
+        { name: "Opener", description: "read a file" },
+      );
+      expect(result.ok).toBe(true);
+    });
+
+    test("skips the check when a machine never reported its OS", async () => {
+      const unknown: ExecutionTarget = { id: "sc-new", name: "New laptop", os: null };
+      const llm = new StubLlm(invoke("desktop_launch_app", { executable: "notepad.exe" }));
+      const result = await composeFlow(
+        { llm, pieceRegistry: osToolCatalog(), executionTargets: [mac, unknown, linuxHost] },
+        { name: "Opener", description: "open notepad" },
+      );
+      expect(result.ok).toBe(true);
+    });
+
+    test("skips the check for a templated target", async () => {
+      const llm = new StubLlm(
+        invoke("run_command", { command: "notepad.exe", target: "{{trigger.payload.machine}}" }),
+      );
+      const result = await composeFlow(
+        { llm, pieceRegistry: osToolCatalog(), executionTargets: [mac, linuxHost] },
+        { name: "Opener", description: "open notepad somewhere" },
+      );
+      expect(result.ok).toBe(true);
+    });
+
+    test("leaves tools that carry no OS-bound params alone", async () => {
+      const llm = new StubLlm(invoke("vault_search", { query: "notepad.exe" }));
+      const result = await composeFlow(
+        { llm, pieceRegistry: osToolCatalog(), executionTargets: [mac, linuxHost] },
+        { name: "Opener", description: "search the vault" },
+      );
+      expect(result.ok).toBe(true);
+    });
+
+    test("composes unchanged when no inventory is supplied (back-compat)", async () => {
+      const llm = new StubLlm(invoke("desktop_launch_app", { executable: "notepad.exe" }));
+      const result = await composeFlow(
+        { llm, pieceRegistry: osToolCatalog() },
+        { name: "Opener", description: "open notepad" },
       );
       expect(result.ok).toBe(true);
     });

--- a/src/actions/tools/workflow-composer.ts
+++ b/src/actions/tools/workflow-composer.ts
@@ -64,6 +64,13 @@ export type ComposerToolDef = LLMTool;
 export type ComposerChatReply = Pick<LLMResponse, "content" | "tool_calls"> & {
   finish_reason?: LLMResponse["finish_reason"];
 };
+import {
+  osCheckContextFor,
+  renderExecutionEnvironment,
+  stepOsIssues,
+  type ExecutionTarget,
+  type OsCheckContext,
+} from "../../util/execution-environment.ts";
 import type { FlowTriggerNode } from "../../workflows/db/repos/flow-version.ts";
 import { WORKFLOW_EVENT_TYPES } from "../../workflows/runtime/event-types.ts";
 
@@ -251,6 +258,18 @@ export interface ComposeDeps {
    */
   library?: ComposerLibraryEntry[];
   /**
+   * Optional inventory of the machines a step can execute on: the enrolled
+   * sidecars plus the brain's own host. When present the composer (a) renders
+   * an execution-environment block in both prompts so the model knows which
+   * OS it is writing commands for, and (b) rejects a step whose command,
+   * executable, or path is bound to an OS no reachable machine runs.
+   *
+   * Without it the model defaults to whatever OS its training leans towards --
+   * the reported failure was `notepad.exe` composed for a fleet whose only
+   * machine was a Mac, which only surfaced when the run failed.
+   */
+  executionTargets?: ExecutionTarget[];
+  /**
    * Cap on the LLM attempts inside one compose call. Each failed parse or
    * validation feeds back into the next attempt so the model can self-correct
    * without round-tripping through the calling agent. Default 4. Tests can
@@ -347,9 +366,11 @@ async function composeOneShot(
   const catalogText = renderCatalog(deps.pieceRegistry);
   const toolsText = renderTools(deps.tools, deps.toolNames);
   const rolesText = renderSpecialistRoles(deps.specialistRoles);
-  const system = buildSystemPrompt(catalogText, toolsText, rolesText);
+  const envText = renderExecutionEnvironment(deps.executionTargets ?? []).join("\n");
+  const system = buildSystemPrompt(catalogText, toolsText, rolesText, envText);
   const toolSpecs = toolSpecMap(deps);
   const validRoleIds = validRoleIdSet(deps);
+  const osCheck = osCheckContextFor(deps.executionTargets ?? []);
 
   // Initial prompt: the user's description verbatim. Retry prompts
   // replace this with a feedback patch derived from the previous
@@ -400,7 +421,7 @@ async function composeOneShot(
       continue;
     }
 
-    const validation = validateComposedFlow(parsed, deps.pieceRegistry, req.name, validRoleIds, toolSpecs);
+    const validation = validateComposedFlow(parsed, deps.pieceRegistry, req.name, validRoleIds, toolSpecs, osCheck);
     if (validation.ok) {
       if (attempt > 1) logAttempt(attempt, "success-after-retry", null);
       return { ok: true, flow: validation.flow, rawResponse: raw };
@@ -470,10 +491,12 @@ async function composeWithTools(
 ): Promise<ComposeResult | null> {
   const toolSpecs = toolSpecMap(deps);
   const validRoleIds = validRoleIdSet(deps);
+  const osCheck = osCheckContextFor(deps.executionTargets ?? []);
   const rolesText = renderSpecialistRoles(deps.specialistRoles);
   const hasLibrary = (deps.library?.length ?? 0) > 0;
   const toolDefs = buildComposerToolDefs(toolSpecs !== null, hasLibrary);
-  const system = buildToolLoopSystemPrompt(rolesText, hasLibrary);
+  const envText = renderExecutionEnvironment(deps.executionTargets ?? []).join("\n");
+  const system = buildToolLoopSystemPrompt(rolesText, hasLibrary, envText);
 
   const messages: ComposerChatMessage[] = [
     { role: "system", content: system },
@@ -542,7 +565,7 @@ async function composeWithTools(
       if (text) {
         try {
           const parsed = JSON.parse(stripJsonFence(text));
-          const validation = validateComposedFlow(parsed, deps.pieceRegistry, req.name, validRoleIds, toolSpecs);
+          const validation = validateComposedFlow(parsed, deps.pieceRegistry, req.name, validRoleIds, toolSpecs, osCheck);
           if (validation.ok) {
             logAttempt(turn, "tool-loop-inline-json", null);
             return { ok: true, flow: validation.flow, rawResponse: text };
@@ -593,7 +616,7 @@ async function composeWithTools(
         submits++;
         const flowArg = unwrapSubmittedFlow(call.arguments);
         lastRaw = safeStringify(flowArg);
-        const validation = validateComposedFlow(flowArg, deps.pieceRegistry, req.name, validRoleIds, toolSpecs);
+        const validation = validateComposedFlow(flowArg, deps.pieceRegistry, req.name, validRoleIds, toolSpecs, osCheck);
         if (validation.ok) {
           if (submits > 1) logAttempt(submits, "tool-loop-success-after-retry", null);
           return { ok: true, flow: validation.flow, rawResponse: lastRaw };
@@ -1130,10 +1153,16 @@ const EXAMPLE_SECTION_LINES = [
   "The event payload is read via {{trigger.payload.*}} (envelope rule); children[0] pairs with the 'invoice' branch; the null child makes the fallback branch do nothing.",
 ];
 
-function buildSystemPrompt(catalog: string, toolsText: string, rolesText: string): string {
+function buildSystemPrompt(
+  catalog: string,
+  toolsText: string,
+  rolesText: string,
+  envText: string,
+): string {
   return [
     "You are the Jarvis workflow composer. Convert the user's description into a workflow definition.",
     "",
+    envText,
     ...sharedRuleSections("one-shot", rolesText.length > 0),
     "",
     "## Output contract",
@@ -1153,7 +1182,11 @@ function buildSystemPrompt(catalog: string, toolsText: string, rolesText: string
  * report_blocked. Specialist roles stay inline -- the listing is small and
  * the verbatim-id rule needs the ids next to it.
  */
-function buildToolLoopSystemPrompt(rolesText: string, hasLibrary: boolean): string {
+function buildToolLoopSystemPrompt(
+  rolesText: string,
+  hasLibrary: boolean,
+  envText: string,
+): string {
   return [
     "You are the Jarvis workflow composer. Convert the user's description into a workflow definition.",
     "You interact ONLY through tools; the ONLY ways to finish are the submit_flow and report_blocked tools.",
@@ -1169,6 +1202,7 @@ function buildToolLoopSystemPrompt(rolesText: string, hasLibrary: boolean): stri
       : "  4. If no installed piece or Jarvis tool covers the request, call report_blocked explaining what is missing.\n     Never force a wrong piece to fit.",
     "  Keep detail lookups targeted -- fetch the pieces you shortlisted, not the whole catalog.",
     "",
+    envText,
     ...sharedRuleSections("tools", rolesText.length > 0),
     rolesText,
   ].filter((s) => s !== "").join("\n");
@@ -1430,6 +1464,7 @@ function validateComposedFlow(
   fallbackName: string,
   validRoleIds: Set<string> | null,
   toolSpecs: Map<string, ComposerToolSpec> | null,
+  osCheck: OsCheckContext | null,
 ): ValidationOk | ValidationFail {
   if (typeof raw !== "object" || raw === null) {
     return { ok: false, errors: ["expected an object at the top level"] };
@@ -1442,7 +1477,7 @@ function validateComposedFlow(
   }
   const errors: string[] = [];
   const knownNames = new Set<string>();
-  const trigger = validateStep(triggerRaw as Record<string, unknown>, errors, knownNames, true, registry, validRoleIds, toolSpecs);
+  const trigger = validateStep(triggerRaw as Record<string, unknown>, errors, knownNames, true, registry, validRoleIds, toolSpecs, osCheck);
   if (!trigger) return { ok: false, errors };
 
   // Walk subsequent actions.
@@ -1456,7 +1491,7 @@ function validateComposedFlow(
       errors.push("flow exceeds 100 steps");
       break;
     }
-    const step = validateStep(cursor, errors, knownNames, false, registry, validRoleIds, toolSpecs);
+    const step = validateStep(cursor, errors, knownNames, false, registry, validRoleIds, toolSpecs, osCheck);
     if (!step) break;
     last.nextAction = step;
     last = step;
@@ -1475,6 +1510,7 @@ function validateStep(
   registry: PieceLookup,
   validRoleIds: Set<string> | null,
   toolSpecs: Map<string, ComposerToolSpec> | null,
+  osCheck: OsCheckContext | null,
 ): ComposedStep | null {
   const name = typeof raw.name === "string" ? raw.name : null;
   if (!name) {
@@ -1532,7 +1568,7 @@ function validateStep(
     // bug) left every composed loop with no firstLoopAction -- the engine ran
     // an empty loop and the editor showed the flow "stopping" at the loop node.
     if (inner) {
-      const body = buildInnerChain(inner, errors, knownNames, registry, validRoleIds, toolSpecs);
+      const body = buildInnerChain(inner, errors, knownNames, registry, validRoleIds, toolSpecs, osCheck);
       if (body) step.firstLoopAction = body;
     }
     return step;
@@ -1563,7 +1599,7 @@ function validateStep(
     if (Array.isArray(raw.children)) {
       step.children = (raw.children as Array<unknown>).map((child) =>
         child && typeof child === "object"
-          ? buildInnerChain(child as Record<string, unknown>, errors, knownNames, registry, validRoleIds, toolSpecs)
+          ? buildInnerChain(child as Record<string, unknown>, errors, knownNames, registry, validRoleIds, toolSpecs, osCheck)
           : null,
       );
     }
@@ -1711,6 +1747,21 @@ function validateStep(
       }
     }
   }
+
+  // OS-fit check: a step that shells out, launches an app, or names a path has
+  // to speak the OS of the machine it lands on. The brain is routinely a Linux
+  // box while the user's only real machine is a Mac or a PC, so a model left to
+  // its own priors composes `notepad.exe` for a MacBook and the mismatch is
+  // only discovered when the run fails. Independent of `toolSpecs` -- this
+  // needs the machine inventory, not the tool schemas.
+  if (
+    !isTrigger &&
+    subName === INVOKE_ACTION &&
+    osCheck &&
+    (piece.name === TOOL_PIECE_SHORT || piece.name.endsWith(`/piece-${TOOL_PIECE_SHORT}`))
+  ) {
+    errors.push(...stepOsIssues(name, input, osCheck));
+  }
   return step;
 }
 
@@ -1770,6 +1821,7 @@ function buildInnerChain(
   registry: PieceLookup,
   validRoleIds: Set<string> | null,
   toolSpecs: Map<string, ComposerToolSpec> | null,
+  osCheck: OsCheckContext | null,
 ): ComposedStep | null {
   let cursor: Record<string, unknown> | null = head;
   let first: ComposedStep | null = null;
@@ -1780,7 +1832,7 @@ function buildInnerChain(
       errors.push("inner subgraph exceeds 100 steps");
       break;
     }
-    const step = validateStep(cursor, errors, knownNames, false, registry, validRoleIds, toolSpecs);
+    const step = validateStep(cursor, errors, knownNames, false, registry, validRoleIds, toolSpecs, osCheck);
     if (!step) break;
     if (!first) first = step;
     if (last) last.nextAction = step;

--- a/src/daemon/agent-service.ts
+++ b/src/daemon/agent-service.ts
@@ -70,7 +70,9 @@ import { getUserProfile } from '../vault/user-profile.ts';
 import type { ResearchQueue } from './research-queue.ts';
 import type { IAgentService } from './agent-service-interface.ts';
 import type { AuthorityEngine } from '../authority/engine.ts';
-import { getSidecarManager } from '../actions/tools/sidecar-route.ts';
+import { familyLabel, osFamily } from '../util/execution-environment.ts';
+import { collectExecutionTargets } from '../actions/tools/sidecar-route.ts';
+import type { ToolGuideMachine } from '../roles/tool-guide.ts';
 import { ConvOrchestrator } from '../agents/conv/conv-orchestrator.ts';
 import { TaskRegistry } from '../agents/conv/task-registry.ts';
 import { TaskDispatcher } from '../agents/conv/task-dispatcher.ts';
@@ -876,11 +878,32 @@ export class AgentService implements Service, IAgentService {
     // (observations, content pipeline, commitments) so the LLM has
     // hundreds fewer prompt tokens to chew through before first response.
     const slim = opts?.slim === true;
-    // Check if any sidecars are enrolled (cheap DB query, controls tool guide content)
+    // Check if any sidecars are enrolled (cheap DB query, controls tool guide
+    // content) and build the machine inventory the tool guide renders: which
+    // machines exist and what OS each runs. Same source the workflow composer
+    // uses, so chat and composed workflows agree on the target OS instead of
+    // both defaulting to the model's priors. Live connection state is
+    // deliberately left out -- this lands in the prompt-CACHED static section,
+    // and `list_sidecars` is what reports who is online right now.
     let hasSidecars = false;
+    let machines: ToolGuideMachine[] | undefined;
     try {
-      const mgr = getSidecarManager();
-      if (mgr) hasSidecars = mgr.listSidecars().length > 0;
+      // One registry read for both: `collectExecutionTargets` already lists the
+      // enrolled sidecars, and it appends the brain host, so anything that is
+      // not the host answers "are there sidecars".
+      const targets = collectExecutionTargets();
+      hasSidecars = targets.some((t) => !t.isHost);
+      if (targets.length > 0) {
+        machines = targets.map((t) => {
+          const fam = osFamily(t.os);
+          return {
+            name: t.name,
+            os: fam ? familyLabel(fam) : t.os,
+            ...(t.arch ? { arch: t.arch } : {}),
+            ...(t.isHost ? { isHost: true } : {}),
+          };
+        });
+      }
     } catch { /* ignore */ }
 
     const context: PromptContext = {
@@ -888,6 +911,7 @@ export class AgentService implements Service, IAgentService {
       currentTime: new Date().toISOString(),
       availableSpecialists: this.specialistListText || undefined,
       hasSidecars,
+      ...(machines ? { machines } : {}),
       // Derived from config, so it is stable turn over turn and safe to sit
       // in the prompt-CACHED static section alongside hasSidecars.
       piecesManaged: this.piecesManaged(),

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -37,6 +37,7 @@ import { classifyGoogle, googleIdentity, makeGoogleAuth } from "../integrations/
 import { ResearchQueue } from "./research-queue.ts";
 import { researchQueueTool, setResearchQueueRef } from "../actions/tools/research.ts";
 import { spawnPersistentAgent, assignPersistentAgentTask } from "../actions/tools/agents.ts";
+import { collectExecutionTargets } from "../actions/tools/sidecar-route.ts";
 import { ChannelService } from "./channel-service.ts";
 import { BackgroundAgentService } from "./background-agent-service.ts";
 import { AuthorityEngine } from "../authority/engine.ts";
@@ -4546,6 +4547,11 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
         sharedPiecesDir: sharedRuntime.piecesDir,
         ...(onPieceLibraryChanged ? { onPieceLibraryChanged } : {}),
         getEventBufferDropped: () => workflowEventBuffer.dropped(),
+        // Lets the editor's publish (version lock) report a step whose
+        // command can't run on any machine it could land on -- the one OS
+        // check a hand-drawn flow gets, since it never meets the composer.
+        // A thunk: sidecars enroll and report their OS long after boot.
+        executionTargets: () => collectExecutionTargets(),
       }),
     };
     wsService.setApiRoutes(apiRoutes);
@@ -4742,6 +4748,13 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
             description: r.description,
           })),
         library: composerLibrary,
+        // Give the composer the machine inventory (sidecars + this host, each
+        // with its OS and arch) so it writes commands for the machine the step
+        // actually lands on. Without it the model guesses -- "open notepad"
+        // composed as `notepad.exe` for a fleet whose only machine is a Mac,
+        // failing on the first run. A thunk: sidecars enroll and report their
+        // OS long after this tool is built.
+        executionTargets: () => collectExecutionTargets(),
       });
       if (!toolRegistry.has('manage_workflow')) {
         toolRegistry.register(manageWorkflowTool);

--- a/src/roles/prompt-builder.test.ts
+++ b/src/roles/prompt-builder.test.ts
@@ -97,3 +97,46 @@ describe("tool guide: install advice follows who owns the pieces catalog", () =>
     }
   });
 });
+
+describe("tool guide: machines and their OS", () => {
+  const machines = [
+    { name: "Lapo's MacBook", os: "macOS", arch: "arm64" },
+    { name: "Jarvis host (this brain)", os: "Linux", arch: "x64", isHost: true },
+  ];
+
+  it("lists each machine with its OS so commands are written for the right one", () => {
+    // Without this the model writes for whichever OS its priors favour -- the
+    // reported bug was `notepad.exe` sent to a fleet of one MacBook.
+    const g = buildToolGuide({ hasSidecars: true, piecesManaged: false, machines });
+    expect(g).toContain("### Machines and their OS");
+    expect(g).toContain("**Lapo's MacBook** — macOS, arm64");
+    expect(g).toContain("**Jarvis host (this brain)** — Linux, x64");
+    expect(g).toContain("MUST match the OS of the machine");
+  });
+
+  it("points at list_sidecars for live status, since this block is cached", () => {
+    const g = buildToolGuide({ hasSidecars: true, piecesManaged: false, machines });
+    expect(g).toContain("not live status");
+  });
+
+  it("is byte-identical across builds with the same inventory (prompt cache)", () => {
+    const a = buildToolGuide({ hasSidecars: true, piecesManaged: false, machines });
+    const b = buildToolGuide({ hasSidecars: true, piecesManaged: false, machines: [...machines] });
+    expect(a).toBe(b);
+  });
+
+  it("says so when a machine never reported its OS", () => {
+    const g = buildToolGuide({
+      hasSidecars: true,
+      piecesManaged: false,
+      machines: [{ name: "New laptop", os: null }],
+    });
+    expect(g).toContain("OS unknown (never connected)");
+  });
+
+  it("omits the section entirely without an inventory", () => {
+    expect(buildToolGuide({ hasSidecars: true, piecesManaged: false })).not.toContain(
+      "### Machines and their OS",
+    );
+  });
+});

--- a/src/roles/prompt-builder.ts
+++ b/src/roles/prompt-builder.ts
@@ -1,5 +1,5 @@
 import type { RoleDefinition } from './types.ts';
-import { buildToolGuide } from './tool-guide.ts';
+import { buildToolGuide, type ToolGuideMachine } from './tool-guide.ts';
 
 export type PromptContext = {
   userName?: string;
@@ -14,6 +14,13 @@ export type PromptContext = {
   authorityRules?: string;
   activeGoals?: string;
   hasSidecars?: boolean;
+  /**
+   * The machines commands can land on (enrolled sidecars + this host) and the
+   * OS each runs, so the AI stops writing commands for whichever OS its priors
+   * favour. Process-stable fields only -- this lands in the cacheable static
+   * prefix alongside hasSidecars.
+   */
+  machines?: ToolGuideMachine[];
   /**
    * A host owns the pieces catalog (see `piecesManagedByHost`). Drops the
    * "have the user install it from the Library page" advice from the tool
@@ -193,13 +200,14 @@ export function buildSystemPromptParts(role: RoleDefinition, context?: PromptCon
     buildToolGuide({
       hasSidecars: context?.hasSidecars ?? false,
       piecesManaged: context?.piecesManaged ?? false,
+      ...(context?.machines ? { machines: context.machines } : {}),
     }),
   );
   sections.push('');
 
   // ── Static/dynamic boundary ─────────────────────────────────────────────
   // Everything above depends only on the role (+ process-stable context like
-  // authorityRules / effectiveAuthorityLevel / hasSidecars / piecesManaged). Everything below
+  // authorityRules / effectiveAuthorityLevel / hasSidecars / machines / piecesManaged). Everything below
   // changes per turn and must not sit inside the cacheable prefix.
   const staticPrompt = sections.join('\n');
   const dynamicSections: string[] = [];

--- a/src/roles/tool-guide.ts
+++ b/src/roles/tool-guide.ts
@@ -8,6 +8,12 @@
  * list_sidecars, sidecar section) is omitted entirely so the AI
  * doesn't waste tokens thinking about remote execution.
  *
+ * `machines` lists the machines commands can land on and the OS each runs.
+ * It is process-stable on purpose (see ToolGuideOptions) so it can live in the
+ * cacheable prefix; the same inventory feeds the workflow composer's prompts
+ * via `collectExecutionTargets`, so chat and composed workflows agree on what
+ * OS they are writing commands for.
+ *
  * When `piecesManaged` is true, the workflow section drops the advice to have
  * the user install a piece: a host owns the catalog there, the Library page
  * has no install button, and the API answers 403. This is the THIRD place
@@ -20,9 +26,32 @@ export type ToolGuideOptions = {
   hasSidecars: boolean;
   /** A host owns the pieces catalog: nothing here is installable by the user. */
   piecesManaged: boolean;
+  /**
+   * The machines commands can land on (enrolled sidecars + this host), with
+   * the OS each one runs. Rendered as a fixed inventory so the AI writes
+   * `open -a TextEdit` for a Mac instead of `notepad.exe` -- the brain is
+   * routinely a Linux box while the user's actual machine is something else.
+   *
+   * Only process-stable fields are used (name / OS / arch, never live
+   * connection state): this block sits in the prompt-CACHED static section,
+   * and a value that moved between turns would break that cache every turn.
+   * Connection state is what `list_sidecars` is for.
+   */
+  machines?: ToolGuideMachine[];
 };
 
-export function buildToolGuide({ hasSidecars, piecesManaged }: ToolGuideOptions): string {
+/** One machine in the tool guide's inventory. */
+export type ToolGuideMachine = {
+  name: string;
+  /** Human OS label ("macOS", "Windows", "Linux"), or null when never connected. */
+  os: string | null;
+  /** CPU architecture as reported (arm64, x64, ...). */
+  arch?: string | null;
+  /** True for the brain's own host. */
+  isHost?: boolean;
+};
+
+export function buildToolGuide({ hasSidecars, piecesManaged, machines }: ToolGuideOptions): string {
   const lines: string[] = [];
 
   lines.push('# Tool Guide');
@@ -34,6 +63,26 @@ export function buildToolGuide({ hasSidecars, piecesManaged }: ToolGuideOptions)
 
   if (hasSidecars) {
     lines.push('These tools work locally by default. To run on a remote machine, pass the `target` parameter with a sidecar name or ID.');
+    lines.push('');
+  }
+
+  if (machines?.length) {
+    lines.push('### Machines and their OS');
+    lines.push('');
+    for (const m of machines) {
+      const os = m.os ?? 'OS unknown (never connected)';
+      const arch = m.arch ? `, ${m.arch}` : '';
+      const role = m.isHost
+        ? 'this brain; used when no `target` is given and no sidecar can serve the call'
+        : 'sidecar; reach it with `target`';
+      lines.push(`- **${m.name}** — ${os}${arch} (${role})`);
+    }
+    lines.push('');
+    lines.push('Commands, executable names, and file paths MUST match the OS of the machine you send them to.');
+    lines.push('Do not send Windows syntax (`notepad.exe`, `powershell`, `C:\\Users\\...`) to a macOS or Linux machine, macOS syntax (`open -a`, `osascript`, `/Applications/...`) to Windows or Linux, or Linux syntax (`xdg-open`, `apt-get`, `systemctl`) to Windows or macOS.');
+    lines.push('App names differ per OS too: Notepad / TextEdit / gedit; calc / Calculator / gnome-calculator; File Explorer / Finder / Nautilus.');
+    lines.push('So do keyboard shortcuts: macOS uses Cmd where Windows and Linux use Ctrl — spell `desktop_press_keys` combos for the machine you are sending them to.');
+    lines.push('This list is the enrolled inventory, not live status — call `list_sidecars` for connection state.');
     lines.push('');
   }
 

--- a/src/util/execution-environment.test.ts
+++ b/src/util/execution-environment.test.ts
@@ -1,0 +1,357 @@
+import { describe, expect, test } from "bun:test";
+import {
+  appEquivalentHints,
+  flowOsWarnings,
+  familyLabel,
+  findOsConflicts,
+  hostTarget,
+  osCheckContextFor,
+  osDisciplineLines,
+  osFamily,
+  OS_SENSITIVE_TOOL_PARAMS,
+  reachableFamilies,
+  renderExecutionEnvironment,
+  resolveTarget,
+  type ExecutionTarget,
+  type OsFamily,
+} from "./execution-environment";
+
+const mac: ExecutionTarget = {
+  id: "sc-mac",
+  name: "Lapo's MacBook",
+  os: "darwin",
+  arch: "arm64",
+  connected: true,
+  capabilities: ["terminal", "desktop"],
+};
+const win: ExecutionTarget = {
+  id: "sc-win",
+  name: "Desk PC",
+  os: "windows",
+  arch: "amd64",
+  connected: false,
+  capabilities: ["terminal"],
+};
+const linuxHost: ExecutionTarget = {
+  id: "",
+  name: "Jarvis host (this brain)",
+  os: "linux",
+  arch: "x64",
+  connected: true,
+  isHost: true,
+};
+
+const families = (...f: OsFamily[]) => new Set<OsFamily>(f);
+
+describe("osFamily", () => {
+  test("maps GOOS, process.platform and friendly spellings", () => {
+    expect(osFamily("darwin")).toBe("macos");
+    expect(osFamily("macOS")).toBe("macos");
+    expect(osFamily("win32")).toBe("windows");
+    expect(osFamily("windows")).toBe("windows");
+    expect(osFamily("linux")).toBe("linux");
+  });
+
+  test("is null for unknown / missing values", () => {
+    expect(osFamily(null)).toBeNull();
+    expect(osFamily("")).toBeNull();
+    expect(osFamily("freebsd")).toBeNull();
+  });
+});
+
+describe("reachableFamilies", () => {
+  test("sidecars win over the host: a Linux brain does not excuse Linux syntax on a Mac fleet", () => {
+    const fams = reachableFamilies([mac, linuxHost]);
+    expect(fams).toEqual(families("macos"));
+  });
+
+  test("the host counts when no sidecar is enrolled", () => {
+    expect(reachableFamilies([linuxHost])).toEqual(families("linux"));
+  });
+
+  test("covers every enrolled sidecar, offline ones included", () => {
+    // The laptop asleep right now is still the machine a scheduled flow means.
+    expect(reachableFamilies([mac, win, linuxHost])).toEqual(families("macos", "windows"));
+  });
+
+  test("is null when any candidate's OS was never reported", () => {
+    const unknown: ExecutionTarget = { id: "sc-new", name: "New laptop", os: null };
+    expect(reachableFamilies([mac, unknown, linuxHost])).toBeNull();
+  });
+
+  test("is null with no targets at all", () => {
+    expect(reachableFamilies([])).toBeNull();
+  });
+});
+
+describe("resolveTarget", () => {
+  const all = [mac, win, linuxHost];
+  test("resolves by exact id, then exact name, then substring -- like the runtime", () => {
+    expect(resolveTarget(all, "sc-win")?.id).toBe("sc-win");
+    expect(resolveTarget(all, "desk pc")?.id).toBe("sc-win");
+    expect(resolveTarget(all, "MacBook")?.id).toBe("sc-mac");
+  });
+
+  test("is null for a name matching nothing", () => {
+    expect(resolveTarget(all, "server-42")).toBeNull();
+    expect(resolveTarget(all, "  ")).toBeNull();
+  });
+});
+
+describe("findOsConflicts", () => {
+  test("flags the reported bug: notepad.exe on a Mac-only fleet", () => {
+    const conflicts = findOsConflicts("notepad.exe", families("macos"));
+    expect(conflicts.length).toBeGreaterThan(0);
+    expect(conflicts[0]!.families).toEqual(["windows"]);
+  });
+
+  test("says nothing when the syntax matches a reachable machine", () => {
+    expect(findOsConflicts("notepad.exe", families("windows"))).toEqual([]);
+    expect(findOsConflicts("open -a TextEdit", families("macos"))).toEqual([]);
+    expect(findOsConflicts("xdg-open notes.txt", families("linux"))).toEqual([]);
+  });
+
+  test("flags macOS and Linux syntax on the other families too", () => {
+    expect(findOsConflicts("osascript -e 'beep'", families("windows"))).not.toEqual([]);
+    expect(findOsConflicts("open -a TextEdit", families("linux"))).not.toEqual([]);
+    expect(findOsConflicts("xdg-open notes.txt", families("macos"))).not.toEqual([]);
+    expect(findOsConflicts("systemctl restart nginx", families("macos"))).not.toEqual([]);
+  });
+
+  test("flags OS-bound paths", () => {
+    expect(findOsConflicts("C:\\Users\\lapo\\notes.txt", families("macos"))).not.toEqual([]);
+    expect(findOsConflicts("%APPDATA%\\jarvis", families("linux"))).not.toEqual([]);
+    expect(findOsConflicts("/Applications/Notes.app", families("windows"))).not.toEqual([]);
+    expect(findOsConflicts("~/Library/Logs", families("linux"))).not.toEqual([]);
+    expect(findOsConflicts("/home/dev/notes.txt", families("macos"))).not.toEqual([]);
+  });
+
+  test("cross-platform syntax is judged against every family it runs on", () => {
+    // brew and sudo run on macOS AND Linux; only a Windows-only fleet is a miss.
+    expect(findOsConflicts("brew install jq", families("linux"))).toEqual([]);
+    expect(findOsConflicts("sudo systemctl restart x", families("macos", "linux"))).toEqual([]);
+    expect(findOsConflicts("brew install jq", families("windows"))).not.toEqual([]);
+  });
+
+  test("leaves OS-neutral commands alone", () => {
+    for (const cmd of ["git status", "echo hello", "python3 script.py", "node --version", "ls"]) {
+      expect(findOsConflicts(cmd, families("macos"))).toEqual([]);
+      expect(findOsConflicts(cmd, families("windows"))).toEqual([]);
+      expect(findOsConflicts(cmd, families("linux"))).toEqual([]);
+    }
+  });
+});
+
+describe("findOsConflicts: precision on realistic commands", () => {
+  // A false rejection costs the user the workflow they asked for, so the
+  // program-name markers are anchored to command position. Before that, every
+  // one of these legitimate commands was rejected: a `.exe` being deleted, an
+  // app name inside a quoted string. Keep this table honest when adding a
+  // marker -- it is the only thing standing between the check and the retry
+  // loop burning four attempts on a command that was fine all along.
+  const legitimate: Array<[string, OsFamily]> = [
+    ["rm ~/Downloads/installer.exe", "macos"],
+    ["mv report.exe.bak archive/", "macos"],
+    ["echo 'explorer of the data lake'", "macos"],
+    ["echo notepad > names.txt", "macos"],
+    ["git pull && bun test", "macos"],
+    ["ls /Users/lapo/Documents", "macos"],
+    ["open https://example.com", "macos"],
+    ["cat notes.md | pbcopy", "macos"],
+    ["python script.py --reg add", "windows"],
+    ["curl -s https://api.example.com/etc/config", "windows"],
+    ["aws s3 cp x s3://bucket/var/data", "windows"],
+    ["node scripts/build.js", "windows"],
+    ["docker compose up -d", "linux"],
+  ];
+
+  const impossible: Array<[string, OsFamily]> = [
+    ["notepad.exe", "macos"],
+    ["notepad", "macos"],
+    ["C:\\Windows\\System32\\notepad.exe", "macos"],
+    ["powershell -Command Get-Process", "macos"],
+    ["cmd /c dir", "linux"],
+    ["open -a TextEdit", "windows"],
+    ["osascript -e 'display notification'", "linux"],
+    ["xdg-open notes.txt", "macos"],
+    ["sudo systemctl restart nginx", "windows"],
+    ["apt-get install jq", "windows"],
+    ["cat x | pbcopy", "windows"],
+    ["%APPDATA%\\jarvis\\config.json", "macos"],
+    ["/Applications/Notes.app", "windows"],
+    ["defaults write com.apple.finder X 1", "linux"],
+    ["brew install jq", "windows"],
+  ];
+
+  test.each(legitimate)("leaves %j alone on %s", (cmd, fam) => {
+    expect(findOsConflicts(cmd, families(fam))).toEqual([]);
+  });
+
+  test.each(impossible)("flags %j on %s", (cmd, fam) => {
+    expect(findOsConflicts(cmd, families(fam)).length).toBeGreaterThan(0);
+  });
+
+  test("quotes back the offending fragment without the separator it followed", () => {
+    const [conflict] = findOsConflicts("cd /tmp && notepad.exe", families("macos"));
+    expect(conflict?.fragment).toBe("notepad.exe");
+  });
+});
+
+describe("appEquivalentHints", () => {
+  test("names the app the reachable OS actually ships", () => {
+    expect(appEquivalentHints("notepad.exe", families("macos"))).toEqual(["on macOS use TextEdit"]);
+    expect(appEquivalentHints("calc.exe", families("linux"))).toEqual(["on Linux use gnome-calculator"]);
+  });
+
+  test("is empty for an app with no mapping", () => {
+    expect(appEquivalentHints("vim", families("macos"))).toEqual([]);
+  });
+});
+
+describe("renderExecutionEnvironment", () => {
+  test("lists every machine with its OS, arch and reachability", () => {
+    const text = renderExecutionEnvironment([mac, win, linuxHost]).join("\n");
+    expect(text).toContain("Lapo's MacBook");
+    expect(text).toContain("macOS, arm64");
+    expect(text).toContain("Desk PC");
+    expect(text).toContain("OFFLINE");
+    expect(text).toContain("can: terminal, desktop");
+    expect(text).toContain("Jarvis host (this brain)");
+  });
+
+  test("tells the model to set `target` only when there is a choice to make", () => {
+    expect(renderExecutionEnvironment([mac, win, linuxHost]).join("\n")).toContain("`target` param");
+    expect(renderExecutionEnvironment([mac, linuxHost]).join("\n")).not.toContain("`target` param to the machine name");
+  });
+
+  test("names the OS the request has to fit", () => {
+    expect(renderExecutionEnvironment([mac, linuxHost]).join("\n")).toContain(
+      "The machines above run macOS.",
+    );
+  });
+
+  test("renders nothing without an inventory, so callers can spread it blind", () => {
+    expect(renderExecutionEnvironment([])).toEqual([]);
+  });
+
+  test("says so when a machine never reported its OS", () => {
+    const text = renderExecutionEnvironment([{ id: "x", name: "New laptop", os: null }]).join("\n");
+    expect(text).toContain("OS unknown (never connected)");
+  });
+});
+
+describe("OS_SENSITIVE_TOOL_PARAMS stays in step with the real tools", () => {
+  // The compose-time check keys off tool NAMES. A rename anywhere in the tool
+  // registry would not break a type or a test -- the check would just quietly
+  // stop firing and `notepad.exe` would sail through again. This is the guard.
+  test("every named tool and param exists in the builtin registry", async () => {
+    const { BUILTIN_TOOLS } = await import("../actions/tools/builtin");
+    const byName = new Map(BUILTIN_TOOLS.map((t) => [t.name, t]));
+    for (const [toolName, params] of Object.entries(OS_SENSITIVE_TOOL_PARAMS)) {
+      const tool = byName.get(toolName);
+      expect(tool, `tool "${toolName}" is no longer registered`).toBeDefined();
+      for (const param of [...params, "target"]) {
+        expect(
+          Object.keys(tool!.parameters),
+          `tool "${toolName}" no longer has a "${param}" param`,
+        ).toContain(param);
+      }
+    }
+  });
+});
+
+describe("flowOsWarnings: flows the composer never wrote", () => {
+  // A flow drawn by hand in the visual editor never passes through the
+  // composer's validation, so publish is the only place its OS fit is ever
+  // checked.
+  const ctx = osCheckContextFor([mac, linuxHost])!;
+
+  const invokeStep = (name: string, toolName: string, params: Record<string, unknown>) => ({
+    name,
+    type: "PIECE",
+    settings: { pieceName: "jarvis-tool", actionName: "invoke", input: { toolName, params } },
+  });
+
+  test("finds a wrong-OS step in a plain chain", () => {
+    const trigger = {
+      name: "trigger",
+      type: "EMPTY",
+      nextAction: invokeStep("step_1", "desktop_launch_app", { executable: "notepad.exe" }),
+    };
+    const warnings = flowOsWarnings(trigger, ctx);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("notepad.exe");
+  });
+
+  test("descends into loop bodies and router branches", () => {
+    const trigger = {
+      name: "trigger",
+      type: "EMPTY",
+      nextAction: {
+        name: "loop_1",
+        type: "LOOP_ON_ITEMS",
+        settings: { items: "{{trigger.items}}" },
+        firstLoopAction: invokeStep("step_1", "run_command", { command: "powershell -c ls" }),
+        nextAction: {
+          name: "router_1",
+          type: "ROUTER",
+          settings: { branches: [{ branchName: "a" }, { branchName: "b" }] },
+          children: [invokeStep("step_2", "write_file", { path: "C:\\temp\\out.txt" }), null],
+        },
+      },
+    };
+    expect(flowOsWarnings(trigger, ctx)).toHaveLength(2);
+  });
+
+  test("says nothing about a flow that fits, or one with no shell steps", () => {
+    const fine = {
+      name: "trigger",
+      type: "EMPTY",
+      nextAction: invokeStep("step_1", "run_command", { command: "open -a TextEdit" }),
+    };
+    expect(flowOsWarnings(fine, ctx)).toEqual([]);
+    expect(flowOsWarnings({ name: "trigger", type: "EMPTY" }, ctx)).toEqual([]);
+  });
+
+  test("survives a malformed or cyclic tree instead of hanging", () => {
+    expect(flowOsWarnings(null, ctx)).toEqual([]);
+    expect(flowOsWarnings({ name: "t", settings: "not-an-object" }, ctx)).toEqual([]);
+    const cyclic: Record<string, unknown> = { name: "trigger", type: "EMPTY" };
+    cyclic.nextAction = cyclic;
+    expect(flowOsWarnings(cyclic, ctx)).toEqual([]);
+  });
+});
+
+describe("osDisciplineLines", () => {
+  test("names app equivalents from the same table the validator quotes", () => {
+    const text = osDisciplineLines().join(" ");
+    // APP_EQUIVALENTS is the single source: prose and hint must agree.
+    const hint = appEquivalentHints("notepad", families("macos"))[0]!;
+    expect(hint).toContain("TextEdit");
+    expect(text).toContain("TextEdit (macOS)");
+  });
+
+  test("covers the traps that are not shell syntax", () => {
+    const text = osDisciplineLines().join(" ");
+    expect(text).toContain("MUST match the OS of the machine");
+    expect(text).toContain("Cmd where Windows and Linux use Ctrl");
+  });
+});
+
+describe("hostTarget", () => {
+  test("reports the running process's OS and arch", () => {
+    const h = hostTarget();
+    expect(h.isHost).toBe(true);
+    expect(h.os).toBe(process.platform);
+    expect(h.arch).toBe(process.arch);
+    expect(osFamily(h.os)).not.toBeNull();
+  });
+});
+
+describe("familyLabel", () => {
+  test("uses the spelling a human would write", () => {
+    expect(familyLabel("macos")).toBe("macOS");
+    expect(familyLabel("windows")).toBe("Windows");
+    expect(familyLabel("linux")).toBe("Linux");
+  });
+});

--- a/src/util/execution-environment.ts
+++ b/src/util/execution-environment.ts
@@ -1,0 +1,537 @@
+/**
+ * Execution-environment awareness -- which machines a step can actually land
+ * on, and which OS each of them runs.
+ *
+ * Everything that "does something to a computer" (run_command, the desktop_*
+ * tools, read/write_file) either routes to a sidecar or falls back to the
+ * brain's own host. Those machines are frequently NOT the same OS: the brain
+ * commonly runs on a Linux server or in a container while the user's hands and
+ * eyes are a macOS or Windows laptop running the sidecar.
+ *
+ * Nothing used to tell the LLM that. Composing "open notepad" against a fleet
+ * of one MacBook produced `notepad.exe`, which is only discovered when the run
+ * fails. This module is the single source for (a) the environment block both
+ * the workflow composer's prompts and the agent tool guide render, and (b) the
+ * compose-time check that rejects an OS-specific command when no reachable
+ * machine runs that OS.
+ *
+ * This module is pure: it holds no registry handle and reads no global state,
+ * so both the composer (which is handed an inventory) and the tool guide can
+ * use it, and every rule here is testable without a running daemon. The live
+ * inventory itself is assembled by `collectExecutionTargets` in
+ * sidecar-route.ts, which owns the sidecar registry handle.
+ *
+ * Detection is deliberately biased towards precision: a marker only fires on
+ * syntax that is unambiguously tied to an OS family, and any target whose OS
+ * is unknown (enrolled but never connected) disables the check rather than
+ * guessing. A false rejection costs the user a workflow they asked for; a
+ * missed one costs a run that fails the way it does today.
+ */
+
+/** The three OS families every target maps onto. */
+export type OsFamily = "windows" | "macos" | "linux";
+
+/**
+ * One machine a step can execute on: a sidecar, or the brain's own host.
+ *
+ * `arch` is the sidecar's GOARCH (arm64 / amd64). Note the wire/DB field for
+ * it is called `platform` (see SidecarInfo) -- it is renamed here because
+ * "platform" reads like an OS and the confusion is exactly what this module
+ * exists to prevent.
+ */
+export interface ExecutionTarget {
+  /** Sidecar id; empty for the brain host. */
+  id: string;
+  /** Display name used for the `target` param and in prompt lines. */
+  name: string;
+  /** GOOS-style value as reported at register: darwin | windows | linux. Null when never connected. */
+  os: string | null;
+  /** GOARCH-style value: arm64 | amd64 | ... */
+  arch?: string | null;
+  /** Live connection state. Absent = unknown; the host is always reachable. */
+  connected?: boolean;
+  /** Capabilities the sidecar advertises (terminal, filesystem, desktop, ...). */
+  capabilities?: string[];
+  /** True for the brain's own machine -- the fallback when nothing is targeted. */
+  isHost?: boolean;
+}
+
+/**
+ * Map a reported OS string to its family. Accepts GOOS values (the wire
+ * format), Node's `process.platform`, and the friendly spellings a human or an
+ * older sidecar might have stored.
+ */
+export function osFamily(os: string | null | undefined): OsFamily | null {
+  if (!os) return null;
+  const v = os.trim().toLowerCase();
+  if (!v) return null;
+  if (v.startsWith("win")) return "windows";
+  if (v.startsWith("darwin") || v.startsWith("mac") || v === "osx") return "macos";
+  if (v.startsWith("linux")) return "linux";
+  return null;
+}
+
+/** Human label for a family, for prompt and error text. */
+export function familyLabel(f: OsFamily): string {
+  return f === "windows" ? "Windows" : f === "macos" ? "macOS" : "Linux";
+}
+
+/** The brain's own machine as a target, from the running process. */
+export function hostTarget(name = "Jarvis host (this brain)"): ExecutionTarget {
+  return {
+    id: "",
+    name,
+    os: process.platform,
+    arch: process.arch,
+    connected: true,
+    isHost: true,
+  };
+}
+
+/**
+ * The families a step may end up on when it names no `target`.
+ *
+ * Sidecars win: `autoTargetForCapability` routes an untargeted call to the
+ * first connected sidecar advertising the capability, and the brain host only
+ * runs the call when no sidecar can. So the host counts only when there are no
+ * sidecars at all -- otherwise a Linux brain would quietly excuse `xdg-open`
+ * on a fleet whose only real machine is a Mac.
+ *
+ * Returns null when any candidate's OS is unknown: an enrolled-but-never-
+ * connected sidecar could be running anything, and refusing a flow over a
+ * guess is worse than letting it through.
+ */
+export function reachableFamilies(targets: ExecutionTarget[]): Set<OsFamily> | null {
+  const sidecars = targets.filter((t) => !t.isHost);
+  const candidates = sidecars.length > 0 ? sidecars : targets.filter((t) => t.isHost);
+  if (candidates.length === 0) return null;
+  const families = new Set<OsFamily>();
+  for (const t of candidates) {
+    const f = osFamily(t.os);
+    if (!f) return null;
+    families.add(f);
+  }
+  return families;
+}
+
+/**
+ * Resolve a step's `target` value to a known machine. Mirrors the runtime's
+ * own resolution order (`findSidecar` in sidecar-route.ts) -- exact id, then
+ * exact name, then substring -- so compose-time validation judges the same
+ * machine the run will dispatch to.
+ */
+export function resolveTarget(
+  targets: ExecutionTarget[],
+  query: string,
+): ExecutionTarget | null {
+  const q = query.trim();
+  if (!q) return null;
+  const byId = targets.find((t) => t.id && t.id === q);
+  if (byId) return byId;
+  const lower = q.toLowerCase();
+  const byName = targets.find((t) => t.name.toLowerCase() === lower);
+  if (byName) return byName;
+  return targets.find((t) => t.name.toLowerCase().includes(lower)) ?? null;
+}
+
+/* --------------------------------------------------------- OS-bound syntax */
+
+interface OsMarker {
+  /** How the offending fragment is described back to the model. */
+  label: string;
+  /** Families this syntax CAN run on. Empty overlap with what's reachable = wrong OS. */
+  families: OsFamily[];
+  /** Group 1, when the pattern has one, is the fragment quoted back. */
+  re: RegExp;
+}
+
+/**
+ * Shell positions where a word is the thing being RUN rather than an argument
+ * to something else: start of the string, after a separator or pipe, inside a
+ * substitution, or after a wrapper that takes a command.
+ *
+ * Program names have to be anchored to one of these. Scanning for them
+ * anywhere in the string is what made the first cut of this file reject
+ * `rm ~/Downloads/installer.exe` and `echo notepad > names.txt` on a Mac --
+ * both perfectly good commands, and a false rejection costs the user the
+ * workflow they asked for.
+ */
+const CMD_POS = String.raw`(?:^|[;&|]\s*|\$\(\s*|\bsudo\s+|\bnohup\s+|\bexec\s+|\bstart\s+)`;
+
+/** A marker for a program name: only counts where a command can start. */
+function invocation(label: string, families: OsFamily[], core: string): OsMarker {
+  return { label, families, re: new RegExp(`${CMD_POS}(${core})`, "i") };
+}
+
+/** A marker for syntax that is OS-bound wherever it appears (paths, env vars). */
+function anywhere(label: string, families: OsFamily[], re: RegExp): OsMarker {
+  return { label, families, re };
+}
+
+/**
+ * Syntax that pins a command / path / executable to an OS family.
+ *
+ * Each entry lists every family it runs on, not just the obvious one, so a
+ * cross-platform tool (`brew` on macOS and Linux) is never flagged on a fleet
+ * that can run it. Anything a shim might provide on the "wrong" OS (bash
+ * builtins under Git Bash, PowerShell aliases) is deliberately absent, and
+ * program names are anchored to command position -- see CMD_POS.
+ */
+const OS_MARKERS: OsMarker[] = [
+  // --- Windows ---
+  invocation("a Windows executable or script", ["windows"], String.raw`[\w.\\/-]*[\w-]\.(?:exe|bat|cmd|ps1)\b`),
+  invocation("PowerShell", ["windows"], String.raw`powershell\b`),
+  invocation("the Windows command shell", ["windows"], String.raw`cmd\s+\/[a-z]\b`),
+  invocation("a Windows-only app name", ["windows"], String.raw`(?:notepad|mspaint|wordpad|explorer)\b`),
+  invocation("a Windows-only utility", ["windows"], String.raw`(?:winget|tasklist|taskkill|wmic|schtasks|regedit|msiexec)\b|reg\s+(?:add|query|delete)\b`),
+  anywhere("a Windows drive path", ["windows"], /\b([a-z]:\\)/i),
+  anywhere("a Windows environment variable", ["windows"], /(%(?:userprofile|appdata|localappdata|programfiles(?:\(x86\))?|systemroot|windir|temp)%)/i),
+
+  // --- macOS ---
+  invocation("an AppleScript invocation", ["macos"], String.raw`osascript\b`),
+  invocation("the macOS `open -a` launcher", ["macos"], String.raw`open\s+-a\b`),
+  invocation("a macOS-only utility", ["macos"], String.raw`(?:pbcopy|pbpaste|launchctl|sw_vers|diskutil)\b`),
+  invocation("the macOS `defaults` command", ["macos"], String.raw`defaults\s+(?:write|read|delete)\b`),
+  anywhere("a macOS application bundle path", ["macos"], /(\/Applications\/)/i),
+  anywhere("a macOS Library path", ["macos"], /((?:~|\$HOME)\/Library\/)/i),
+
+  // --- Linux ---
+  invocation("the Linux `xdg-open` launcher", ["linux"], String.raw`xdg-open\b`),
+  invocation("a Linux package manager", ["linux"], String.raw`(?:apt-get|apt|dnf|yum|pacman)\s+(?:install|update|upgrade|remove)\b`),
+  invocation("systemd", ["linux"], String.raw`systemctl\b`),
+  invocation("a Linux clipboard utility", ["linux"], String.raw`(?:xclip|xsel|wl-copy|wl-paste)\b`),
+  anywhere("a Linux home path", ["linux"], /(\/home\/[\w.-]+)/),
+
+  // --- Unix (macOS + Linux) ---
+  invocation("Homebrew", ["macos", "linux"], String.raw`brew\s+(?:install|list|update|upgrade)\b`),
+  invocation("a Unix privilege escalation", ["macos", "linux"], String.raw`sudo\b`),
+  anywhere("a Unix system path", ["macos", "linux"], /(?:^|\s|=|")(\/(?:usr|etc|opt|var)\/)/i),
+  anywhere("a Unix shebang", ["macos", "linux"], /(#!\s*\/(?:usr\/)?bin\/)/),
+];
+
+/** One piece of OS-bound syntax found in a value, and where it can run. */
+export interface OsConflict {
+  /** The matched fragment, verbatim, so the model can see what to change. */
+  fragment: string;
+  label: string;
+  families: OsFamily[];
+}
+
+/**
+ * Every OS-bound fragment in `value`, whatever OS it belongs to. An empty
+ * result means the value is portable -- it says nothing about any particular
+ * machine.
+ */
+export function findOsMarkers(value: string): OsConflict[] {
+  const out: OsConflict[] = [];
+  for (const marker of OS_MARKERS) {
+    const m = marker.re.exec(value);
+    if (!m) continue;
+    // Group 1 is the fragment itself; group 0 would drag in the separator
+    // or wrapper the pattern anchored to ("&& notepad.exe").
+    out.push({ fragment: (m[1] ?? m[0]!).trim(), label: marker.label, families: marker.families });
+  }
+  return out;
+}
+
+/**
+ * Fragments in `value` that cannot run on any of `reachable`. An empty result
+ * means the value is either OS-neutral or fine where it will run.
+ */
+export function findOsConflicts(value: string, reachable: Set<OsFamily>): OsConflict[] {
+  return findOsMarkers(value).filter((m) => !m.families.some((f) => reachable.has(f)));
+}
+
+/**
+ * Cross-OS equivalents for the handful of apps users ask for by name. Small on
+ * purpose: it exists to turn "notepad is wrong" into "use TextEdit", which is
+ * the difference between a retry that converges and one that guesses again.
+ */
+const APP_EQUIVALENTS: Array<{ re: RegExp; by: Record<OsFamily, string> }> = [
+  { re: /\bnotepad\b|\bgedit\b|\btextedit\b/i, by: { windows: "Notepad", macos: "TextEdit", linux: "gedit" } },
+  { re: /\bcalc\b|\bcalculator\b|\bgnome-calculator\b/i, by: { windows: "calc", macos: "Calculator", linux: "gnome-calculator" } },
+  { re: /\bexplorer\b|\bfinder\b|\bnautilus\b/i, by: { windows: "File Explorer", macos: "Finder", linux: "Nautilus" } },
+  { re: /\bmspaint\b|\bpaint\b/i, by: { windows: "mspaint", macos: "Preview", linux: "gimp" } },
+  { re: /\bcmd\b|\bterminal\b|\bgnome-terminal\b/i, by: { windows: "cmd", macos: "Terminal", linux: "gnome-terminal" } },
+];
+
+/**
+ * "on macOS use TextEdit" hints for a value naming an app that exists under a
+ * different name on the reachable machines. Empty when nothing matches.
+ */
+export function appEquivalentHints(value: string, reachable: Set<OsFamily>): string[] {
+  const hints: string[] = [];
+  for (const entry of APP_EQUIVALENTS) {
+    if (!entry.re.test(value)) continue;
+    for (const f of reachable) hints.push(`on ${familyLabel(f)} use ${entry.by[f]}`);
+  }
+  return hints;
+}
+
+/* ------------------------------------------------------- per-step OS check */
+
+/**
+ * Tool params that carry OS-bound syntax, per tool. Only the string params
+ * whose CONTENT is interpreted by the target OS -- a command line, an
+ * executable name, a filesystem path.
+ *
+ * Keyed by tool NAME, which makes the check silently dead if a tool is ever
+ * renamed. A test asserts every key still exists in the builtin registry with
+ * the params named here.
+ */
+export const OS_SENSITIVE_TOOL_PARAMS: Record<string, string[]> = {
+  run_command: ["command", "cwd"],
+  desktop_launch_app: ["executable", "args"],
+  read_file: ["path"],
+  write_file: ["path"],
+  list_directory: ["path"],
+};
+
+/**
+ * OS-fit context: the machines a step can land on plus the families they
+ * cover. Built by `osCheckContextFor`, which returns null whenever a verdict
+ * would be a guess.
+ */
+export interface OsCheckContext {
+  targets: ExecutionTarget[];
+  reachable: Set<OsFamily>;
+}
+
+/**
+ * Build the OS-fit context, or null when the check can't be trusted -- no
+ * inventory, or a machine whose OS was never reported. Rejecting a workflow on
+ * a guess is worse than letting the run report the failure.
+ */
+export function osCheckContextFor(targets: ExecutionTarget[]): OsCheckContext | null {
+  if (targets.length === 0) return null;
+  const reachable = reachableFamilies(targets);
+  if (!reachable || reachable.size === 0) return null;
+  return { targets, reachable };
+}
+
+/**
+ * Blank out `{{...}}` templates before scanning a value: they resolve at run
+ * time to something we cannot see, so their contents must not be judged --
+ * but the literal text around them (`notepad.exe {{trigger.payload.file}}`)
+ * still must be.
+ */
+function withoutTemplates(value: string): string {
+  return value.replace(/\{\{[^}]*\}\}/g, " ");
+}
+
+/** Canonical and short spellings of the generic tool-invocation piece. */
+function isToolPiece(pieceName: string): boolean {
+  return pieceName === "jarvis-tool" || pieceName.endsWith("/piece-jarvis-tool");
+}
+
+/**
+ * Problems with one `jarvis-tool:invoke` step's OS fit, as messages meant to
+ * be read by the model (they name the fix, not just the fault).
+ *
+ * Two distinct faults:
+ *   1. The value cannot run on any machine it could land on -- the
+ *      `notepad.exe` on a Mac-only fleet case.
+ *   2. The value is OS-specific, the fleet spans more than one OS, and the
+ *      step names no `target`. That one is not wrong today but is not
+ *      DETERMINISTIC either: an untargeted call goes to whichever connected
+ *      sidecar answers for the capability, and falls back to the brain host
+ *      when none does. A macOS command is a coin flip on a mixed fleet, so
+ *      the step has to say where it means to run.
+ *
+ * Anything unresolvable -- a templated target, a name matching no machine, a
+ * machine whose OS was never reported -- yields nothing rather than a guess.
+ */
+export function stepOsIssues(
+  stepName: string,
+  input: Record<string, unknown>,
+  ctx: OsCheckContext,
+): string[] {
+  const toolName = typeof input.toolName === "string" ? input.toolName.trim() : "";
+  const paramNames = OS_SENSITIVE_TOOL_PARAMS[toolName];
+  if (!paramNames) return [];
+  const params =
+    input.params && typeof input.params === "object" && !Array.isArray(input.params)
+      ? (input.params as Record<string, unknown>)
+      : {};
+
+  let reachable = ctx.reachable;
+  let pinned = false;
+  let where: string;
+  const target = typeof params.target === "string" ? params.target.trim() : "";
+  if (target) {
+    if (target.includes("{{")) return []; // resolved at run time; nothing to judge
+    const resolved = resolveTarget(ctx.targets, target);
+    if (!resolved) return []; // the runtime reports an unknown target with its own error
+    const fam = osFamily(resolved.os);
+    if (!fam) return []; // enrolled but never connected -- OS genuinely unknown
+    reachable = new Set([fam]);
+    pinned = true;
+    where = `"${resolved.name}" runs ${familyLabel(fam)}`;
+  } else {
+    // Name the machines behind the verdict; their family is only worth
+    // repeating per machine when more than one family is in play.
+    const machines = ctx.targets
+      .filter((t) => {
+        const f = osFamily(t.os);
+        return f !== null && reachable.has(f);
+      })
+      .map((t) => (reachable.size > 1 ? `"${t.name}" (${familyLabel(osFamily(t.os)!)})` : `"${t.name}"`))
+      .join(", ");
+    where =
+      "this step names no `target`, so it runs on " +
+      `${[...reachable].map(familyLabel).join(" / ")}: ${machines}`;
+  }
+
+  const issues: string[] = [];
+  for (const paramName of paramNames) {
+    const raw = params[paramName];
+    if (typeof raw !== "string") continue;
+    const value = withoutTemplates(raw).trim();
+    if (!value) continue;
+    const markers = findOsMarkers(value);
+    if (markers.length === 0) continue;
+
+    const conflicts = markers.filter((m) => !m.families.some((f) => reachable.has(f)));
+    if (conflicts.length > 0) {
+      const first = conflicts[0]!;
+      const needs = first.families.map(familyLabel).join(" or ");
+      const hints = appEquivalentHints(value, reachable);
+      issues.push(
+        `step "${stepName}" invokes ${toolName} with ${paramName}="${raw}", which needs ` +
+          `${needs} (${first.label}: "${first.fragment}"), but ${where}. Rewrite it for that OS` +
+          (hints.length > 0 ? ` (equivalent app: ${hints.join(", ")})` : "") +
+          `, or set params.target to a machine that runs ${needs}.`,
+      );
+      continue;
+    }
+
+    if (!pinned && reachable.size > 1) {
+      const fits = markers[0]!.families.map(familyLabel).join(" or ");
+      issues.push(
+        `step "${stepName}" invokes ${toolName} with ${paramName}="${raw}", which only runs on ` +
+          `${fits} ("${markers[0]!.fragment}"), and ${where}. An untargeted step goes to whichever ` +
+          `machine answers first, so set params.target to the one you mean.`,
+      );
+    }
+  }
+  return issues;
+}
+
+/**
+ * The same check over a whole persisted flow tree, for flows this composer
+ * never wrote -- ones built or edited by hand in the visual editor. Walks the
+ * chain, loop bodies and router branches, and returns one message per problem.
+ *
+ * Warnings, not errors: a hand-built flow may deliberately target a machine
+ * that is not enrolled yet, and refusing to save someone's edit over a
+ * heuristic would be worse than the mismatch it prevents.
+ */
+export function flowOsWarnings(trigger: unknown, ctx: OsCheckContext): string[] {
+  const out: string[] = [];
+  const seen = new Set<unknown>();
+  const walk = (node: unknown): void => {
+    if (typeof node !== "object" || node === null || seen.has(node)) return;
+    seen.add(node);
+    const step = node as Record<string, unknown>;
+    const settings = step.settings as Record<string, unknown> | undefined;
+    const pieceName = typeof settings?.pieceName === "string" ? settings.pieceName : "";
+    const actionName = typeof settings?.actionName === "string" ? settings.actionName : "";
+    if (isToolPiece(pieceName) && actionName === "invoke") {
+      const input = settings?.input;
+      if (input && typeof input === "object" && !Array.isArray(input)) {
+        const name = typeof step.name === "string" ? step.name : "?";
+        out.push(...stepOsIssues(name, input as Record<string, unknown>, ctx));
+      }
+    }
+    walk(step.nextAction);
+    walk(step.firstLoopAction);
+    if (Array.isArray(step.children)) for (const child of step.children) walk(child);
+  };
+  walk(trigger);
+  return out;
+}
+
+/* -------------------------------------------------------- prompt rendering */
+
+/** One target as a prompt line: name, OS, arch, reachability, capabilities. */
+function targetLine(t: ExecutionTarget): string {
+  const fam = osFamily(t.os);
+  const os = fam ? familyLabel(fam) : t.os ? t.os : "OS unknown (never connected)";
+  const arch = t.arch ? `, ${t.arch}` : "";
+  const bits: string[] = [];
+  if (t.isHost) {
+    bits.push("the brain itself; runs a step only when no sidecar is targeted or connected");
+  } else {
+    bits.push(t.connected === false ? "OFFLINE" : "connected");
+    if (t.capabilities?.length) bits.push(`can: ${t.capabilities.join(", ")}`);
+  }
+  return `  - "${t.name}" -- ${os}${arch} (${bits.join("; ")})`;
+}
+
+/**
+ * App-name equivalences as prose, generated from the same table the validator
+ * quotes back. One source: a prompt that recommends TextEdit while the checker
+ * suggests something else is how a model gets talked in circles.
+ */
+function appEquivalenceProse(): string {
+  return APP_EQUIVALENTS.map((e) =>
+    `${e.by.windows} (Windows) / ${e.by.macos} (macOS) / ${e.by.linux} (Linux)`,
+  ).join("; ");
+}
+
+/**
+ * The OS discipline every surface has to state: the composer's prompts and the
+ * primary agent's tool guide. Shared so the two cannot drift into
+ * contradicting each other -- the tool-guide header calls out exactly that
+ * hazard for the piece-install advice, which is repeated in three places by
+ * hand.
+ *
+ * Returned as bare sentences; each caller adds its own bullet or indent.
+ */
+export function osDisciplineLines(): string[] {
+  return [
+    "Commands, executable names, and file paths MUST match the OS of the machine they run on.",
+    "Do NOT send Windows syntax (`notepad.exe`, `powershell`, `C:\\Users\\...`) to a macOS or Linux " +
+      "machine, macOS syntax (`open -a`, `osascript`, `/Applications/...`) to Windows or Linux, or " +
+      "Linux syntax (`xdg-open`, `apt-get`, `systemctl`) to Windows or macOS.",
+    `App names differ per OS: ${appEquivalenceProse()}.`,
+    "Keyboard shortcuts differ too: macOS uses Cmd where Windows and Linux use Ctrl, so a " +
+      "`desktop_press_keys` combo must be spelled for the machine it lands on.",
+  ];
+}
+
+/**
+ * The environment block for the composer's prompts: the inventory, then the
+ * shared OS discipline, then the routing rules that only apply to a composed
+ * step. Returns [] when there is nothing worth saying, so callers can spread
+ * it unconditionally.
+ */
+export function renderExecutionEnvironment(targets: ExecutionTarget[]): string[] {
+  if (targets.length === 0) return [];
+  const reachable = reachableFamilies(targets);
+  const sidecars = targets.filter((t) => !t.isHost);
+  const lines = [
+    "## Execution environment (machines this workflow runs on)",
+    "Any step that runs a command, launches an app, or touches the filesystem lands on one of these:",
+    ...targets.map(targetLine),
+    "Rules:",
+    ...osDisciplineLines().map((l) => `  - ${l}`),
+    "  - A step that names no `target` runs on a connected sidecar advertising the capability it needs,",
+    "    and only falls back to the brain host when no sidecar can serve it.",
+  ];
+  if (sidecars.length > 1) {
+    lines.push(
+      '  - More than one machine is listed: set the tool\'s `target` param to the machine name (e.g. `target: "' +
+        (sidecars[0]?.name ?? "") +
+        '"`) so the step runs where the user meant. An OS-specific step on a mixed fleet MUST name one.',
+    );
+  }
+  if (reachable && reachable.size > 0) {
+    lines.push(
+      `  - The machines above run ${[...reachable].map(familyLabel).join(" / ")}. If the request only ` +
+        `makes sense on another OS, say what is missing instead of composing it anyway -- a step ` +
+        `written for an OS nothing here runs fails on every single run.`,
+    );
+  }
+  return lines;
+}

--- a/src/workflows/api/routes.test.ts
+++ b/src/workflows/api/routes.test.ts
@@ -305,6 +305,53 @@ describe("workflow API: versions", () => {
       ),
     );
     expect(body.state).toBe("LOCKED");
+    // No inventory injected -> no verdict to give.
+    expect(body.osWarnings).toBeUndefined();
+  });
+
+  test("POST .../lock reports a step that cannot run on any machine it could land on", async () => {
+    // The editor's only OS check: a hand-drawn flow never meets the composer,
+    // where the same rules run for a composed one.
+    const withTargets = createWorkflowRoutes({
+      executionTargets: () => [
+        { id: "sc-mac", name: "Lapo's MacBook", os: "darwin", arch: "arm64", connected: true },
+      ],
+    });
+    const post = withTargets["/api/workflows"]?.POST;
+    const created = await callJson(post, plainReq("POST", "http://x", { displayName: "x" }));
+    const { id: flowId } = created.body.flow;
+    const versionId = created.body.version.id;
+
+    const patch = withTargets["/api/workflows/:id/versions/:versionId"]?.PATCH;
+    await callJson(
+      patch,
+      reqWithParams("PATCH", `http://x/api/workflows/${flowId}/versions/${versionId}`, { id: flowId, versionId }, {
+        trigger: {
+          name: "trigger",
+          type: "EMPTY",
+          nextAction: {
+            name: "step_1",
+            type: "PIECE",
+            settings: {
+              pieceName: "jarvis-tool",
+              actionName: "invoke",
+              input: { toolName: "run_command", params: { command: "notepad.exe" } },
+            },
+          },
+        },
+      }),
+    );
+
+    const lock = withTargets["/api/workflows/:id/versions/:versionId/lock"]?.POST;
+    const { status, body } = await callJson(
+      lock,
+      reqWithParams("POST", `http://x/api/workflows/${flowId}/versions/${versionId}/lock`, { id: flowId, versionId }),
+    );
+    // Advisory: the lock still succeeds. A draft may legitimately target a
+    // machine that is not enrolled yet.
+    expect(status).toBe(200);
+    expect(body.state).toBe("LOCKED");
+    expect(body.osWarnings[0]).toContain("notepad.exe");
   });
 
   test("POST .../publish locks the draft, ENABLES the flow, sets published_version_id", async () => {

--- a/src/workflows/api/routes.ts
+++ b/src/workflows/api/routes.ts
@@ -78,6 +78,11 @@ import {
   uninstallPiece,
   type InstalledPiece,
 } from "../pieces-library/installer";
+import {
+  flowOsWarnings,
+  osCheckContextFor,
+  type ExecutionTarget,
+} from "../../util/execution-environment";
 
 type RequestWithParams<P extends Record<string, string> = Record<string, string>> = Request & {
   params: P;
@@ -150,6 +155,18 @@ export interface CreateWorkflowRoutesOptions {
    */
   sharedPiecesDir?: string | null;
   /**
+   * Optional inventory of the machines a step can run on (sidecars + this
+   * host, each with its OS). When provided, locking a version returns
+   * `osWarnings` for steps whose command / executable / path cannot run on
+   * any machine that could receive them.
+   *
+   * This is the editor's only OS check: a flow drawn by hand never passes
+   * through the composer, which is where the same rules run for a composed
+   * one. Advisory by design -- the lock still succeeds, because a draft may
+   * legitimately target a machine that is not enrolled yet.
+   */
+  executionTargets?: () => ExecutionTarget[];
+  /**
    * Optional credential resolver. When provided, the connections route can
    * report which `JarvisConnectionSource` adapters are registered (e.g.
    * `jarvis:google` is wired) so the dashboard's piece-side auth picker
@@ -217,6 +234,15 @@ export function createWorkflowRoutes(opts: CreateWorkflowRoutesOptions = {}): Wo
   // process, and one value means the GET's shape and the mutations' guard can
   // never disagree about which mode this install is in.
   const managed = piecesManagedByHost(opts.sharedPiecesDir);
+  // OS-fit warnings for a version being locked -- the last point a
+  // hand-drawn flow can be told its command will never run where it lands.
+  // Empty whenever the verdict would be a guess (no inventory, or a machine
+  // that never reported its OS).
+  const lockOsWarnings = (trigger: unknown): string[] => {
+    if (!opts.executionTargets) return [];
+    const ctx = osCheckContextFor(opts.executionTargets());
+    return ctx ? flowOsWarnings(trigger, ctx) : [];
+  };
   const refreshTrigger = (flowId: string): void => {
     if (!opts.triggerManager) return;
     // Fire-and-forget: API responses must not block on engine round-trips
@@ -831,7 +857,9 @@ export function createWorkflowRoutes(opts: CreateWorkflowRoutesOptions = {}): Wo
           // Lock mutates the same row state DRAFT -> LOCKED, so the sidecar
           // (keyed on versionId) already follows. No copy needed; mentioned
           // here so future readers know that's by design.
-          return ok(lockVersion(versionId));
+          const locked = lockVersion(versionId);
+          const osWarnings = lockOsWarnings(locked.trigger);
+          return ok(osWarnings.length > 0 ? { ...locked, osWarnings } : locked);
         }),
     },
 


### PR DESCRIPTION
A user on a Mac asked for a workflow that opens Notepad. The composer wrote `notepad.exe`, and nobody found out until the run failed.

Nothing in the pipeline ever told the model which machine a step lands on. The brain commonly runs on a Linux box or a container while the user's only real machine is a Mac sidecar, so "open notepad" was answered from model priors alone. Two things pushed it towards Windows: `desktop_launch_app`'s description literally read `(e.g., "notepad.exe", "calc.exe")`, and that text is fed verbatim into the composer's prompt. Validation checked piece names, required fields, roles and regexes, but never whether the command could run anywhere at all.

## What this does

`src/util/execution-environment.ts` is the single source of machine/OS awareness. `collectExecutionTargets()` (in sidecar-route.ts, which owns the registry handle) returns every enrolled sidecar with its GOOS, GOARCH, connection state and capabilities, plus the brain's own host. Everything else reads from that one inventory:

- **Composer prompts** render the inventory and the OS rules, so the model knows what it is writing commands for.
- **Compose-time validation** rejects a `jarvis-tool:invoke` step whose command, executable or path cannot run on any machine it could land on. The error names the fix ("equivalent app: on macOS use TextEdit") and feeds the existing retry loop, so the model self-corrects inside one call.
- **Mixed fleets** must name a `target`. An untargeted step goes to whichever sidecar answers first, so an OS-specific command on a Mac+PC fleet is a coin flip and the run that loses fails exactly like the original bug.
- **The agent's tool guide** gains a "Machines and their OS" section, so chat is not blind either. Process-stable fields only: it sits in the prompt-cached static prefix, and `list_sidecars` remains the source for live status.
- **Hand-built flows** get the same check at publish and at version lock (`osWarnings` on the response). A flow drawn in the editor never meets the composer, and that was its only gate. Advisory, not a refusal: a draft may legitimately target a machine that is not enrolled yet.
- **Runtime** errors now read `Error [Lapo's MacBook, macOS]: ...`. It is the one defense that cannot be reasoned around.
- `desktop_launch_app` and `run_command` no longer lead with Windows examples.

## Precision

A false rejection costs the user a workflow that would have worked, so the detector is anchored to command position: program names only count where a command can start. `rm ~/Downloads/installer.exe` and `echo notepad > names.txt` are fine on a Mac. A corpus of 18 legitimate and 15 impossible commands runs as a test, currently 0 false positives and 0 misses.

It under-flags by design. Any machine that never reported its OS, a templated target, or a target matching no enrolled machine all skip the check rather than guess. Cross-platform syntax carries every family it runs on, so `brew` is fine on a Linux fleet and flagged only on a Windows-only one.

## Not covered

Delegate steps (`jarvis-agent` with a natural-language goal) cannot be checked statically; the sub-agent decides at runtime and the tool guide is its only guardrail. Cmd-vs-Ctrl is prompt guidance only, since Ctrl is legitimate on macOS often enough that a checker would fail the precision bar above. The lock route returns `osWarnings` but no UI renders them yet.

2828 tests pass, tsc clean.
