### PR TITLE
Make the onboarding permissions screen read and grant real macOS permissions

### DIFF
--- a/sidecar/handlers.go
+++ b/sidecar/handlers.go
@@ -114,6 +114,23 @@ func NewHandlerRegistry(cfg *SidecarConfig, cfgMu sync.Locker, availableCaps []S
 	registry["get_config"] = makeGetConfigHandler(cfg)
 	registry["update_config"] = makeUpdateConfigHandler(cfg, cfgMu, onReloaded)
 
+	// OS permissions (permissions_rpc.go). Dotted like the other daemon-driven
+	// UI services (panel.*, pebble.*) rather than bare like the brain's tool
+	// handlers, because that is what these are: the onboarding wizard asking
+	// about the machine it is being looked at on.
+	//
+	// Ungated on purpose. The report is about the MACHINE, not a capability,
+	// and it matters most exactly when a capability is missing - a denied
+	// Screen Recording grant is WHY awareness isn't working, and a wizard that
+	// couldn't ask because the capability was off would be silent about the
+	// reason. The request half was weighed separately, since it can pop an OS
+	// dialog with no local gesture and a declined notification prompt is
+	// one-shot on macOS: left ungated because the brain can already do
+	// strictly more through update_config, and because the daemon only
+	// forwards it in response to a click on that screen.
+	registry["system.permissions"] = handleSystemPermissions
+	registry["system.request_permission"] = handleSystemRequestPermission
+
 	return registry
 }
 

--- a/sidecar/permissions_rpc.go
+++ b/sidecar/permissions_rpc.go
@@ -1,0 +1,259 @@
+package main
+
+// OS permission status over RPC, so the dashboard's onboarding wizard can show
+// the REAL state of this machine instead of four buttons that do nothing.
+//
+// The wizard screen it feeds used to be static: every row called
+// window.open("x-apple.systempreferences:...") and every one of those was
+// dropped on the floor, because a panel routes window.open to the host and the
+// host allowlists http(s) only (isExternallyOpenable, panels_extnav.go). The
+// page could not read a status either, so a granted permission and a denied one
+// looked identical. Opening the pane from HERE works for the same reason the
+// native --setup wizard's buttons work: it is an `open` from the sidecar
+// process, not a URL from a web page.
+//
+// The checks and requests themselves are NOT new - this is the same
+// setup_permissions_{darwin,other}.go that the native `--setup` wizard drives,
+// exposed a second way. One source of truth, so the two screens can never
+// disagree about what is granted.
+
+import (
+	"fmt"
+	"os/exec"
+	"sync"
+	"time"
+)
+
+// How a permission is obtained, which is the difference the UI has to render:
+// a "prompt" row can be granted without leaving the app, a "pane" row can only
+// be granted by the user flipping a toggle in System Settings.
+const (
+	grantPrompt = "prompt" // the OS shows a dialog; requesting is enough
+	grantPane   = "pane"   // no dialog exists; the user must visit the pane
+	grantNone   = "none"   // nothing to do on this platform
+)
+
+// permissionRow is one row of the report. Deliberately just facts: which
+// permission, where it stands, and how it can be obtained. What it is CALLED,
+// whether it is required, and how it is explained are the dashboard's business.
+type permissionRow struct {
+	Name   string `json:"name"`
+	Status string `json:"status"` // granted | denied | undetermined | na
+	Grant  string `json:"grant"`  // prompt | pane | none
+}
+
+// permissionsReport is the payload of system.permissions.
+type permissionsReport struct {
+	Platform string `json:"platform"`
+	// Bundled is false when macOS TCC has no app identity to attach a grant to
+	// (a bare binary rather than Jarvis.app). Grants then bind to whatever
+	// launched us - the terminal - so the rows describe someone else's
+	// permissions and the dashboard must say so rather than show them.
+	// Always true off macOS, where there is no bundle to be missing.
+	Bundled     bool            `json:"bundled"`
+	Permissions []permissionRow `json:"permissions"`
+}
+
+// permissionNames is the full row set, in the order the report lists them.
+// Every platform answers for all four; the ones that mean nothing there come
+// back "na" and the dashboard drops them.
+var permissionNames = []string{"notifications", "microphone", "screen", "accessibility"}
+
+var permissionNameSet = func() map[string]struct{} {
+	m := make(map[string]struct{}, len(permissionNames))
+	for _, n := range permissionNames {
+		m[n] = struct{}{}
+	}
+	return m
+}()
+
+// readPermissionStatuses is the status reader, indirected so tests can stand in
+// a fake for it. The real one is a C call into TCC and answers only on a Mac,
+// which would otherwise leave the coalescing and freshness rules below
+// untestable on any dev box.
+var readPermissionStatuses = setupPermissionStatuses
+
+// Sampling the four statuses is not free - the macOS notification-settings read
+// waits on a callback (up to 2s) - and the dashboard polls this while the
+// screen is open. Handlers run concurrently (one goroutine per RPC in
+// client.go), so without this a slow read under a 1.5s poll would pile up
+// overlapping samples of the same thing. Holding the lock ACROSS the read is
+// the point: concurrent pollers queue behind one in-flight sample and then take
+// its answer, so the depth is one no matter how many ask.
+var (
+	permSampleMu   sync.Mutex
+	permSampleAt   time.Time
+	permSampleRows []permissionRow
+)
+
+const permSampleTTL = 700 * time.Millisecond
+
+// samplePermissionRows returns the four statuses, re-reading them only when the
+// cached sample is older than freshSince.
+//
+// Freshness is a DEADLINE, not a boolean, because "force" answers the wrong
+// question after a request. A caller that has just asked the OS for something
+// needs a sample taken after the ask; any sample taken after that moment will
+// do, including one another goroutine is already producing. With a boolean, a
+// request arriving behind a stalled 2s poll would wait out that poll and then
+// insist on its own second 2s read, hanging the button for four seconds to
+// learn what the sample it just discarded already knew.
+func samplePermissionRows(freshSince time.Time) []permissionRow {
+	permSampleMu.Lock()
+	defer permSampleMu.Unlock()
+
+	if permSampleRows != nil && permSampleAt.After(freshSince) {
+		return append([]permissionRow(nil), permSampleRows...)
+	}
+
+	notif, mic, screen, ax := readPermissionStatuses()
+	byName := map[string]string{
+		"notifications": notif,
+		"microphone":    mic,
+		"screen":        screen,
+		"accessibility": ax,
+	}
+
+	rows := make([]permissionRow, 0, len(permissionNames))
+	for _, name := range permissionNames {
+		rows = append(rows, permissionRow{
+			Name:   name,
+			Status: byName[name],
+			Grant:  setupPermissionGrant(name),
+		})
+	}
+
+	permSampleAt = time.Now()
+	permSampleRows = rows
+	return append([]permissionRow(nil), rows...)
+}
+
+// pollFreshness is the deadline an ordinary status read asks for: anything
+// sampled within the TTL.
+func pollFreshness() time.Time { return time.Now().Add(-permSampleTTL) }
+
+// buildPermissionsReport assembles the full report.
+func buildPermissionsReport(freshSince time.Time) permissionsReport {
+	return permissionsReport{
+		Platform:    setupPlatform,
+		Bundled:     setupProcessBundled(),
+		Permissions: samplePermissionRows(freshSince),
+	}
+}
+
+// knownPermission guards the request handler's name parameter. The name selects
+// a TCC prompt and a System Settings deep link, so it is checked against the
+// fixed set rather than passed through - a params map arrives from the brain,
+// and nothing that reaches an `open` should be taken on trust.
+func knownPermission(name string) bool {
+	_, ok := permissionNameSet[name]
+	return ok
+}
+
+// paneLauncherWait bounds how long we watch a System Settings launcher before
+// assuming it is fronting a window rather than failing.
+const paneLauncherWait = 1500 * time.Millisecond
+
+// startPaneLauncher runs a launcher (`open`, `rundll32`) and reports whether it
+// took the URL.
+//
+// Two things the bare .Start() this replaces could not do. It REAPS the child:
+// the native wizard re-execs moments after opening a pane so a zombie there was
+// invisible, but this handler lives in a process that runs for weeks and every
+// click would leave one behind. And it OBSERVES the exit: a launcher that fails
+// after fork - no `open` on a broken install, a scheme nothing handles - exits
+// nonzero within milliseconds, and reporting that as a window the user should
+// go and look at is the exact failure this whole change exists to remove.
+//
+// Same shape as openInDefaultBrowser: a launcher normally hands off and exits
+// at once, so a process still alive at the deadline is a success, and the
+// goroutine keeps waiting to reap it on every path.
+func startPaneLauncher(cmd *exec.Cmd) error {
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	exited := make(chan error, 1)
+	go func() { exited <- cmd.Wait() }()
+	select {
+	case err := <-exited:
+		return err
+	case <-time.After(paneLauncherWait):
+		return nil // still running: assume it is fronting System Settings
+	}
+}
+
+// handleSystemPermissions reports what this machine has granted.
+func handleSystemPermissions(_ map[string]any) (*RPCResult, error) {
+	return &RPCResult{Result: buildPermissionsReport(pollFreshness())}, nil
+}
+
+// handleSystemRequestPermission asks for one permission and reports where it
+// landed.
+//
+// Both halves run for a "pane" permission, in this order: the request first
+// (which is what makes Jarvis APPEAR in the pane's list - an app absent from
+// that list cannot be toggled on, so opening the pane first shows the user an
+// empty list and no way forward), then the pane itself. For a "prompt"
+// permission the OS dialog is the whole interaction and no pane is opened.
+//
+// The status returned is sampled immediately afterwards and is usually
+// UNCHANGED: every macOS request is asynchronous, and a pane grant needs the
+// user to go and flip a toggle. It is the dashboard's poll that observes the
+// grant, not this return value - which reports the request was made, and for a
+// pane row whether the pane opened.
+func handleSystemRequestPermission(params map[string]any) (*RPCResult, error) {
+	name, _ := params["name"].(string)
+	if name == "" {
+		return nil, fmt.Errorf("missing required parameter: name")
+	}
+	if !knownPermission(name) {
+		return nil, fmt.Errorf("unknown permission %q", name)
+	}
+
+	// Refuse to ask on behalf of an app we are not. Without a bundle identity
+	// the grant lands on whatever launched the sidecar: requesting "screen"
+	// from a bare binary run in a terminal registers TERMINAL in the Screen
+	// Recording list and then invites the user to switch it on. Reporting that
+	// as a permission granted to Jarvis would be wrong twice over, so the
+	// report's `bundled: false` is a refusal here and a warning on screen,
+	// not a row to click.
+	if !setupProcessBundled() {
+		return nil, fmt.Errorf("not running as an app bundle: a grant would attach to the launching app, not to Jarvis")
+	}
+
+	mode := setupPermissionGrant(name)
+	if mode == grantNone {
+		return nil, fmt.Errorf("permission %q cannot be requested on %s", name, setupPlatform)
+	}
+
+	// Stamped BEFORE the request so the sample below cannot be one taken
+	// before the OS was asked. See samplePermissionRows on why this is a
+	// deadline rather than a "force" flag.
+	askedAt := time.Now()
+	setupRequestPermission(name)
+
+	paneOpened := false
+	var paneErr string
+	if mode == grantPane {
+		if err := setupOpenPane(name); err != nil {
+			// Not fatal: the request above may still have registered Jarvis in
+			// the pane, and the user can open System Settings themselves. Report
+			// it so the dashboard can say that instead of silently pretending a
+			// window appeared - the exact failure this whole change is about.
+			paneErr = err.Error()
+		} else {
+			paneOpened = true
+		}
+	}
+
+	result := map[string]any{
+		"name":        name,
+		"grant":       mode,
+		"pane_opened": paneOpened,
+		"permissions": samplePermissionRows(askedAt),
+	}
+	if paneErr != "" {
+		result["pane_error"] = paneErr
+	}
+	return &RPCResult{Result: result}, nil
+}

--- a/sidecar/permissions_rpc_test.go
+++ b/sidecar/permissions_rpc_test.go
@@ -1,0 +1,250 @@
+package main
+
+import (
+	"encoding/json"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+)
+
+// The darwin half of this (real TCC reads) can only run on a Mac. What is
+// testable anywhere is the shape every platform must hold to, the freshness
+// rule, and the coalescing - the last two via readPermissionStatuses, which is
+// a package var precisely so a fake slow or changing reader can stand in.
+
+func resetPermissionSample(t *testing.T) {
+	t.Helper()
+	permSampleMu.Lock()
+	permSampleRows = nil
+	permSampleAt = time.Time{}
+	permSampleMu.Unlock()
+}
+
+// stubStatuses swaps in a fake reader for the length of one test.
+func stubStatuses(t *testing.T, fn func() (string, string, string, string)) {
+	t.Helper()
+	resetPermissionSample(t)
+	prev := readPermissionStatuses
+	readPermissionStatuses = fn
+	t.Cleanup(func() {
+		readPermissionStatuses = prev
+		resetPermissionSample(t)
+	})
+}
+
+func TestPermissionsReportCoversEveryRow(t *testing.T) {
+	resetPermissionSample(t)
+	rep := buildPermissionsReport(time.Now())
+
+	if rep.Platform != runtime.GOOS {
+		t.Errorf("platform = %q, want %q", rep.Platform, runtime.GOOS)
+	}
+	if len(rep.Permissions) != len(permissionNames) {
+		t.Fatalf("got %d rows, want %d", len(rep.Permissions), len(permissionNames))
+	}
+	for i, name := range permissionNames {
+		if rep.Permissions[i].Name != name {
+			t.Errorf("row %d = %q, want %q (order is the report's contract)", i, rep.Permissions[i].Name, name)
+		}
+	}
+
+	for _, row := range rep.Permissions {
+		switch row.Status {
+		case "granted", "denied", "undetermined", "na":
+		default:
+			t.Errorf("%s: status %q is not one of the four the dashboard renders", row.Name, row.Status)
+		}
+		switch row.Grant {
+		case grantPrompt, grantPane, grantNone:
+		default:
+			t.Errorf("%s: grant %q is not a mode the dashboard knows", row.Name, row.Grant)
+		}
+	}
+}
+
+// The wire keys are a contract with two other programs: the brain parses this
+// report (src/daemon/system-permissions.ts) and refuses a shape it cannot read,
+// and the wizard renders the result. Renaming a field here would break both
+// silently, since a missing key parses as absent rather than as an error.
+func TestReportWireFormatIsStable(t *testing.T) {
+	stubStatuses(t, func() (string, string, string, string) {
+		return "granted", "denied", "undetermined", "na"
+	})
+
+	blob, err := json.Marshal(buildPermissionsReport(time.Now()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(blob, &got); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, key := range []string{"platform", "bundled", "permissions"} {
+		if _, ok := got[key]; !ok {
+			t.Errorf("report is missing the %q key the brain reads", key)
+		}
+	}
+	rows, ok := got["permissions"].([]any)
+	if !ok || len(rows) != len(permissionNames) {
+		t.Fatalf("permissions did not marshal as a %d-element array", len(permissionNames))
+	}
+	first, _ := rows[0].(map[string]any)
+	for _, key := range []string{"name", "status", "grant"} {
+		if _, ok := first[key]; !ok {
+			t.Errorf("row is missing the %q key the brain reads", key)
+		}
+	}
+	if first["status"] != "granted" {
+		t.Errorf("first row status = %v, want the reader's first return value", first["status"])
+	}
+}
+
+// Off macOS there is no per-app permission model, so every row must read "na"
+// and the dashboard hides them. Getting this wrong would show Linux users four
+// rows that can never go green.
+func TestNonDarwinReportsNoApplicablePermissions(t *testing.T) {
+	if runtime.GOOS == "darwin" {
+		t.Skip("macOS answers these for real")
+	}
+	resetPermissionSample(t)
+	rep := buildPermissionsReport(time.Now())
+	for _, row := range rep.Permissions {
+		if row.Status != "na" {
+			t.Errorf("%s: status = %q, want \"na\" on %s", row.Name, row.Status, runtime.GOOS)
+		}
+	}
+	if !rep.Bundled {
+		t.Error("bundled must be true where no bundle identity exists to be missing")
+	}
+}
+
+// The one openable pane off macOS. Windows has no readable status for it, so
+// the row exists purely to carry the link - losing the grant mode would lose
+// the row.
+func TestWindowsMicrophoneKeepsItsPane(t *testing.T) {
+	want := grantNone
+	if runtime.GOOS == "windows" {
+		want = grantPane
+	}
+	if got := setupPermissionGrant("microphone"); got != want {
+		t.Errorf("microphone grant on %s = %q, want %q", runtime.GOOS, got, want)
+	}
+}
+
+func TestRequestRejectsUnknownNames(t *testing.T) {
+	// A name selects a TCC prompt and a System Settings deep link, and it
+	// arrives in an RPC params map. Anything outside the fixed set must be
+	// refused before it reaches setupOpenPane.
+	for _, name := range []string{"", "files", "automation", "../../etc", "SCREEN", "screen "} {
+		if knownPermission(name) {
+			t.Errorf("knownPermission(%q) = true, want false", name)
+		}
+		if _, err := handleSystemRequestPermission(map[string]any{"name": name}); err == nil {
+			t.Errorf("request(%q) returned no error", name)
+		}
+	}
+	for _, name := range permissionNames {
+		if !knownPermission(name) {
+			t.Errorf("knownPermission(%q) = false, want true", name)
+		}
+	}
+}
+
+func TestRequestRefusesWhatThePlatformCannotDo(t *testing.T) {
+	if runtime.GOOS == "darwin" {
+		t.Skip("every row is requestable on macOS")
+	}
+	// A valid name whose platform offers nothing must fail loudly rather than
+	// report a request that never happened.
+	if _, err := handleSystemRequestPermission(map[string]any{"name": "accessibility"}); err == nil {
+		t.Errorf("request(accessibility) on %s returned no error", runtime.GOOS)
+	}
+}
+
+// A sample taken before the OS was asked is not an answer to "what happened
+// when I asked". The freshness deadline is what guarantees the difference.
+func TestRequestNeverServesASampleOlderThanTheAsk(t *testing.T) {
+	var mu sync.Mutex
+	status := "denied"
+	stubStatuses(t, func() (string, string, string, string) {
+		mu.Lock()
+		defer mu.Unlock()
+		return status, status, status, status
+	})
+
+	// Warm the cache with the pre-request answer.
+	before := samplePermissionRows(pollFreshness())
+	if before[0].Status != "denied" {
+		t.Fatalf("warm-up status = %q", before[0].Status)
+	}
+
+	// The grant lands. A poll issued now, inside the TTL, would happily serve
+	// the stale "denied" -- which is correct for a poll and wrong for a request.
+	mu.Lock()
+	status = "granted"
+	mu.Unlock()
+
+	if got := samplePermissionRows(pollFreshness())[0].Status; got != "denied" {
+		t.Errorf("a poll inside the TTL re-read; got %q, want the cached \"denied\"", got)
+	}
+	if got := samplePermissionRows(time.Now())[0].Status; got != "granted" {
+		t.Errorf("a request-freshness read served a stale sample: got %q, want \"granted\"", got)
+	}
+}
+
+// Concurrent pollers must collapse onto one read. Without that, a status read
+// that stalls for 2s under a 1.5s poll stacks overlapping samples of the same
+// thing for as long as the screen is open.
+func TestConcurrentPollersShareOneRead(t *testing.T) {
+	var reads int
+	var mu sync.Mutex
+	stubStatuses(t, func() (string, string, string, string) {
+		mu.Lock()
+		reads++
+		mu.Unlock()
+		time.Sleep(30 * time.Millisecond)
+		return "denied", "denied", "denied", "denied"
+	})
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = samplePermissionRows(pollFreshness())
+		}()
+	}
+	wg.Wait()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if reads != 1 {
+		t.Errorf("8 concurrent pollers caused %d reads, want 1", reads)
+	}
+}
+
+// Callers must not be able to edit the cached sample out from under the next
+// caller - they share one slice otherwise.
+func TestSampleIsCopiedPerCaller(t *testing.T) {
+	resetPermissionSample(t)
+	first := samplePermissionRows(pollFreshness())
+	if len(first) == 0 {
+		t.Fatal("no rows")
+	}
+	first[0].Status = "tampered"
+
+	second := samplePermissionRows(pollFreshness())
+	if second[0].Status == "tampered" {
+		t.Error("the cached sample is shared by reference; one caller can corrupt every other")
+	}
+}
+
+func TestSampleTTLIsShortEnoughToWatch(t *testing.T) {
+	// The dashboard polls while the user is looking at the screen. A TTL near
+	// or above the poll interval would make a grant take two polls to appear.
+	if permSampleTTL >= time.Second {
+		t.Errorf("permSampleTTL = %v; too long for a row to turn green as the user watches", permSampleTTL)
+	}
+}

--- a/sidecar/setup_permissions_darwin.go
+++ b/sidecar/setup_permissions_darwin.go
@@ -12,6 +12,10 @@ package main
 // Status legend used across the C bridges:
 //   0 = undetermined (never asked)   1 = granted
 //   2 = denied/restricted            3 = not applicable (e.g. not bundled)
+//
+// COMPILE-UNVERIFIED: CGO/ObjC, built only on macOS - it cannot be compiled or
+// run on a Linux dev box and must be checked on a Mac, the same caveat as
+// tray_darwin.go and panels_extnav_darwin.go carry.
 
 /*
 #cgo CFLAGS: -x objective-c
@@ -23,12 +27,19 @@ package main
 #import <ApplicationServices/ApplicationServices.h>
 #import <UserNotifications/UserNotifications.h>
 
+// Does this process have a bundle identity for TCC to hang grants on?
+// A bare binary has none: the grants attach to whatever launched it (the
+// terminal), so every row would describe a different app's permissions.
+static int setup_bundled(void) {
+    return [NSBundle mainBundle].bundleIdentifier ? 1 : 0;
+}
+
 // Notifications. UNUserNotificationCenter throws when the process has no
 // bundle identifier (bare binary), so guard like notify_darwin.m's bundled().
 // The settings read is async; wait briefly so the wizard's poll gets a real
 // answer (completion normally lands in well under a second).
 static int setup_notif_status(void) {
-    if (![NSBundle mainBundle].bundleIdentifier) return 3;
+    if (!setup_bundled()) return 3;
     __block int result = 0;
     dispatch_semaphore_t sem = dispatch_semaphore_create(0);
     [[UNUserNotificationCenter currentNotificationCenter]
@@ -51,7 +62,7 @@ static int setup_notif_status(void) {
 }
 
 static void setup_notif_request(void) {
-    if (![NSBundle mainBundle].bundleIdentifier) return;
+    if (!setup_bundled()) return;
     [[UNUserNotificationCenter currentNotificationCenter]
         requestAuthorizationWithOptions:(UNAuthorizationOptionAlert | UNAuthorizationOptionSound | UNAuthorizationOptionBadge)
                       completionHandler:^(BOOL granted, NSError *error) { (void)granted; (void)error; }];
@@ -152,12 +163,37 @@ var setupPaneURLs = map[string]string{
 }
 
 // setupOpenPane deep-links the System Settings pane for a permission row.
+// Through startPaneLauncher so a launcher that fails after fork is reported
+// rather than counted as a window, and so the child is reaped: the RPC path
+// runs this in a process that lives for weeks, not one about to re-exec.
 func setupOpenPane(name string) error {
 	url, ok := setupPaneURLs[name]
 	if !ok {
 		return fmt.Errorf("unknown permission %q", name)
 	}
-	return exec.Command("open", url).Start()
+	return startPaneLauncher(exec.Command("open", url))
 }
+
+// setupPermissionGrant says HOW each row is obtained on macOS.
+//
+// The split is the OS's, not ours: notifications and the microphone have a
+// real dialog, so requesting them can finish inside the app. Screen Recording
+// and Accessibility have none - the request only registers Jarvis in the
+// pane's list, and the user has to flip the toggle themselves. A wizard that
+// treats the two the same either waits forever for a dialog that never comes
+// or sends someone to a pane they didn't need.
+func setupPermissionGrant(name string) string {
+	switch name {
+	case "notifications", "microphone":
+		return grantPrompt
+	case "screen", "accessibility":
+		return grantPane
+	}
+	return grantNone
+}
+
+// setupProcessBundled reports whether TCC has an app identity to attach grants
+// to. False when the sidecar runs as a bare binary instead of Jarvis.app.
+func setupProcessBundled() bool { return C.setup_bundled() == 1 }
 
 const setupPlatform = "darwin"

--- a/sidecar/setup_permissions_other.go
+++ b/sidecar/setup_permissions_other.go
@@ -25,9 +25,26 @@ func setupRequestPermission(string) {}
 // pane to open elsewhere.
 func setupOpenPane(name string) error {
 	if runtime.GOOS == "windows" && name == "microphone" {
-		return exec.Command("rundll32", "url.dll,FileProtocolHandler", "ms-settings:privacy-microphone").Start()
+		return startPaneLauncher(exec.Command("rundll32", "url.dll,FileProtocolHandler", "ms-settings:privacy-microphone"))
 	}
 	return fmt.Errorf("no settings pane for %q on this platform", name)
 }
+
+// setupPermissionGrant: the Windows microphone page is the ONE thing there is
+// to open here, and it is worth opening precisely because its status is
+// unreadable. Windows governs desktop-app mic access with a single global
+// switch, and with it off the capture just fails - no in-the-moment prompt
+// arrives to rescue the user, which is why a link they can visit beforehand
+// earns its place even though no row can ever go green.
+func setupPermissionGrant(name string) string {
+	if runtime.GOOS == "windows" && name == "microphone" {
+		return grantPane
+	}
+	return grantNone
+}
+
+// setupProcessBundled: no bundle identity anywhere but macOS, so there is
+// nothing here that could be missing. Always true.
+func setupProcessBundled() bool { return true }
 
 const setupPlatform = runtime.GOOS

--- a/src/comms/websocket.ts
+++ b/src/comms/websocket.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { isWithin } from '../util/path.ts';
 import type { SidecarManager } from '../sidecar/manager.ts';
 import { PANEL_SESSION_COOKIE } from '../sidecar/panel-sessions.ts';
+import { getCookie } from '../util/cookie.ts';
 
 /** Constant-time string comparison to prevent timing attacks */
 export type WSMessage = {
@@ -89,21 +90,6 @@ const AUTH_ERROR_HTML = await Bun.file(path.join(import.meta.dir, 'auth-error.ht
 /** Inline script injected into authed HTML pages — strips ?token= from the hash. */
 const TOKEN_STRIP_SCRIPT = `<script>(function(){var h=location.hash,i=h.indexOf('?');if(i===-1)return;var p=new URLSearchParams(h.slice(i));if(!p.has('token'))return;p.delete('token');var c=h.slice(0,i),r=p.toString();if(r)c+='?'+r;location.replace(location.pathname+location.search+c)})()</script>`;
 
-function getCookie(req: Request, name: string): string | null {
-  const cookies = req.headers.get('Cookie');
-  if (!cookies) return null;
-  const match = cookies.match(new RegExp(`(?:^|;\\s*)${name}=([^;]*)`));
-  if (!match) return null;
-  try {
-    return decodeURIComponent(match[1]!);
-  } catch {
-    // A malformed escape (`%E0%A4%A`) makes decodeURIComponent throw, which
-    // would unwind out of fetch() as a 500. This value is attacker-controlled
-    // and read on the authentication path, so an unusable cookie has to read
-    // as "no cookie" (401) rather than as a server fault.
-    return null;
-  }
-}
 
 function isPublicRoute(pathname: string, method: string): boolean {
   return (

--- a/src/daemon/api-routes.ts
+++ b/src/daemon/api-routes.ts
@@ -8,6 +8,9 @@
 import { createHmac, timingSafeEqual } from 'node:crypto';
 import type { HealthMonitor } from './health.ts';
 import { applyApprovalDecision } from './approval-decision.ts';
+import { isPermissionName, readSystemPermissions, requestSystemPermission } from './system-permissions.ts';
+import { PANEL_SESSION_COOKIE } from '../sidecar/panel-sessions.ts';
+import { getCookie } from '../util/cookie.ts';
 import { SecretStorageError } from './section-secrets.ts';
 import type { AgentService } from './agent-service.ts';
 import type { JarvisConfig } from '../config/types.ts';
@@ -1533,6 +1536,68 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
           const msg = err instanceof Error ? err.message : String(err);
           return error(`Settings reload failed: ${msg}`, 500);
         }
+      },
+    },
+
+    /**
+     * What the desktop app on this machine has been granted, and how to ask
+     * for what it has not. Feeds the onboarding wizard's Permissions screen,
+     * which before this could neither read a status nor open a settings pane
+     * (see system-permissions.ts for why both halves were broken).
+     *
+     * Answers about ONE machine, resolved from the panel session this request
+     * carries. `available: false` with a reason is a normal answer, not an
+     * error: a brain with no desktop app connected, or one that cannot tell
+     * which of several is being looked at, genuinely has nothing to say, and
+     * the screen renders that case rather than dead buttons.
+     */
+    '/api/system/permissions': {
+      GET: async (req: Request) => {
+        if (!ctx.sidecarManager) return error('Sidecar manager not available', 503);
+        const result = await readSystemPermissions(
+          ctx.sidecarManager,
+          getCookie(req, PANEL_SESSION_COOKIE),
+        );
+        return json(result);
+      },
+    },
+
+    '/api/system/permissions/request': {
+      POST: async (req: Request) => {
+        if (!ctx.sidecarManager) return error('Sidecar manager not available', 503);
+        // This route's visible effect is a dialog and a System Settings window
+        // on the user's desktop, which makes it the one worth hardening against
+        // a drive-by POST. Under auth.insecure_open_access -- the setup-time
+        // configuration, i.e. exactly when this screen is on -- there is no
+        // cookie to withhold, and a body posted as text/plain is a CORS
+        // "simple request" that needs no preflight, so any page the user is
+        // browsing could pop TCC prompts. Demanding a JSON content type forces
+        // a preflight, which the configured allow-origin then bounds; the
+        // Sec-Fetch-Site check catches a browser that sends it.
+        if (!(req.headers.get('content-type') ?? '').toLowerCase().includes('application/json')) {
+          return error('Content-Type: application/json required', 415);
+        }
+        if (req.headers.get('sec-fetch-site') === 'cross-site') {
+          return error('Cross-site requests are not accepted here', 403);
+        }
+        let body: unknown;
+        try {
+          body = await req.json();
+        } catch {
+          return error('Invalid JSON body');
+        }
+        const name = (body as { name?: unknown } | null)?.name;
+        // The name reaches an `open` in the sidecar. It is checked there too;
+        // this is the edge of the system and the cheaper place to refuse.
+        if (!isPermissionName(name)) {
+          return error(`Unknown permission: ${String(name)}`);
+        }
+        const result = await requestSystemPermission(
+          ctx.sidecarManager,
+          getCookie(req, PANEL_SESSION_COOKIE),
+          name,
+        );
+        return json(result);
       },
     },
 

--- a/src/daemon/system-permissions.test.ts
+++ b/src/daemon/system-permissions.test.ts
@@ -1,0 +1,294 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  isPermissionName,
+  PERMISSION_NAMES,
+  readSystemPermissions,
+  requestSystemPermission,
+  resolvePermissionsHost,
+  type PermissionsSidecarHost,
+} from './system-permissions.ts';
+
+/**
+ * The interesting part of this module is not the dispatch - it is deciding
+ * WHICH machine a "what have you granted" question is about, and refusing to
+ * answer rather than guessing. A wrong answer here shows a user their other
+ * laptop's permissions and opens System Settings on it.
+ */
+
+type Sidecar = { id: string; name: string; hostname: string };
+
+function fakeHost(opts: {
+  connected?: Sidecar[];
+  sessions?: Record<string, string>;
+  dispatch?: (id: string, method: string, params: Record<string, unknown>) => Promise<unknown>;
+}): PermissionsSidecarHost & { calls: Call[] } {
+  const connected = opts.connected ?? [];
+  const calls: Call[] = [];
+  return {
+    calls,
+    getConnectedSidecars: () => connected,
+    resolvePanelSession: (sessionId) => {
+      const sid = opts.sessions?.[sessionId];
+      return sid ? { sid } : null;
+    },
+    dispatchRPC: async (id, method, params = {}, timeouts) => {
+      calls.push({ id, method, params, timeouts });
+      if (!opts.dispatch) throw new Error('no dispatch configured');
+      return opts.dispatch(id, method, params);
+    },
+  };
+}
+
+interface Call {
+  id: string;
+  method: string;
+  params: Record<string, unknown>;
+  timeouts?: { initial: number; max: number };
+}
+
+const MAC: Sidecar = { id: 'sc-mac', name: 'Desk Mac', hostname: 'desk.local' };
+const OTHER: Sidecar = { id: 'sc-laptop', name: 'Laptop', hostname: 'laptop.local' };
+
+const OK_REPORT = {
+  platform: 'darwin',
+  bundled: true,
+  permissions: [
+    { name: 'notifications', status: 'undetermined', grant: 'prompt' },
+    { name: 'microphone', status: 'granted', grant: 'prompt' },
+    { name: 'screen', status: 'denied', grant: 'pane' },
+    { name: 'accessibility', status: 'denied', grant: 'pane' },
+  ],
+};
+
+describe('resolvePermissionsHost', () => {
+  test('the panel session wins, even with other machines connected', () => {
+    const host = fakeHost({ connected: [OTHER, MAC], sessions: { 'sess-1': MAC.id } });
+    expect(resolvePermissionsHost(host, 'sess-1')).toEqual({
+      id: MAC.id, name: MAC.name, hostname: MAC.hostname, source: 'panel',
+    });
+  });
+
+  test('one connected sidecar and no cookie is unambiguous', () => {
+    // The case that matters: auth.insecure_open_access skips the whole session
+    // exchange, and that is the SETUP-time configuration -- exactly when the
+    // onboarding wizard runs. Without this fallback the wizard would have no
+    // answer on the most ordinary install there is.
+    const host = fakeHost({ connected: [MAC] });
+    expect(resolvePermissionsHost(host, null)).toEqual({
+      id: MAC.id, name: MAC.name, hostname: MAC.hostname, source: 'only_connected',
+    });
+  });
+
+  test('several connected and no session refuses instead of picking one', () => {
+    const host = fakeHost({ connected: [MAC, OTHER] });
+    expect(resolvePermissionsHost(host, null)).toEqual({ reason: 'ambiguous' });
+  });
+
+  test('nothing connected says so', () => {
+    expect(resolvePermissionsHost(fakeHost({}), null)).toEqual({ reason: 'no_sidecar' });
+  });
+
+  test('a session whose sidecar is offline never answers for another machine', () => {
+    // The session says the user is at the Mac. The Mac's app is not connected
+    // this second (asleep, quit, or reconnecting after a hosted restart, which
+    // sessions deliberately outlive). Falling through to "the only other one
+    // that happens to be up" would show the laptop's rows and open panes on
+    // the laptop, while the user watches the Mac.
+    const host = fakeHost({ connected: [OTHER], sessions: { 'sess-1': MAC.id } });
+    expect(resolvePermissionsHost(host, 'sess-1')).toEqual({ reason: 'offline' });
+  });
+
+  test('an offline session refuses even when its own machine is the only one enrolled', () => {
+    const host = fakeHost({ connected: [], sessions: { 'sess-1': MAC.id } });
+    expect(resolvePermissionsHost(host, 'sess-1')).toEqual({ reason: 'offline' });
+  });
+
+  test('an unknown or revoked session falls back rather than trusting it', () => {
+    const host = fakeHost({ connected: [MAC, OTHER] });
+    expect(resolvePermissionsHost(host, 'sess-revoked')).toEqual({ reason: 'ambiguous' });
+  });
+});
+
+describe('readSystemPermissions', () => {
+  test('a good report comes back with the host that answered it', async () => {
+    const host = fakeHost({ connected: [MAC], dispatch: async () => OK_REPORT });
+    const res = await readSystemPermissions(host, null);
+    expect(res.available).toBe(true);
+    if (!res.available) return;
+    expect(res.platform).toBe('darwin');
+    expect(res.bundled).toBe(true);
+    expect(res.permissions.map((p) => p.name)).toEqual([...PERMISSION_NAMES]);
+    expect(res.host.name).toBe('Desk Mac');
+    expect(host.calls[0]).toMatchObject({ id: MAC.id, method: 'system.permissions' });
+  });
+
+  test('a sidecar too old to know the method reads as unsupported, not broken', async () => {
+    // Sidecars update independently of the brain, so every machine enrolled
+    // before this shipped answers this way. It is a permanent, expected
+    // condition that needs its own sentence -- "update your desktop app" --
+    // not a red error the user retries forever.
+    const host = fakeHost({
+      connected: [MAC],
+      dispatch: async () => { throw new Error('METHOD_NOT_FOUND: Unknown method: system.permissions'); },
+    });
+    expect(await readSystemPermissions(host, null)).toEqual({
+      available: false,
+      reason: 'unsupported',
+      detail: 'METHOD_NOT_FOUND: Unknown method: system.permissions',
+    });
+  });
+
+  test('any other dispatch failure reads as unreachable', async () => {
+    const host = fakeHost({
+      connected: [MAC],
+      dispatch: async () => { throw new Error('Sidecar disconnected: disconnected'); },
+    });
+    const res = await readSystemPermissions(host, null);
+    expect(res).toMatchObject({ available: false, reason: 'unreachable' });
+  });
+
+  test('a dispatch that detaches is a failure, not a pending success', async () => {
+    // dispatchRPC resolves with the literal string "detached" at the initial
+    // timeout. Rendering that as a report would print rows made of undefined.
+    const host = fakeHost({ connected: [MAC], dispatch: async () => 'detached' });
+    const res = await readSystemPermissions(host, null);
+    expect(res).toMatchObject({ available: false, reason: 'unreachable' });
+  });
+
+  test('a malformed report is refused rather than half-rendered', async () => {
+    // The sidecar is a separate, independently-updated program; its answer is
+    // input. Inventing a status from a shape we do not understand is worse
+    // than saying the machine is unreadable.
+    for (const bad of [
+      null,
+      {},
+      { platform: 'darwin' },
+      { platform: 'darwin', permissions: 'nope' },
+      { platform: 'darwin', permissions: [{ name: 'screen' }] },
+      { platform: 'darwin', permissions: [{ name: 'screen', status: 'maybe', grant: 'pane' }] },
+      { platform: 'darwin', permissions: [{ name: 'screen', status: 'denied', grant: 'telepathy' }] },
+      { platform: 42, permissions: [] },
+    ]) {
+      const host = fakeHost({ connected: [MAC], dispatch: async () => bad });
+      const res = await readSystemPermissions(host, null);
+      expect(res.available).toBe(false);
+    }
+  });
+
+  test('an older report with no bundled flag is not treated as unbundled', async () => {
+    // bundled:false triggers a warning that the grants are attaching to the
+    // wrong app. Defaulting a missing field to false would show that to
+    // everyone running a slightly older sidecar.
+    const host = fakeHost({
+      connected: [MAC],
+      dispatch: async () => ({ platform: 'darwin', permissions: OK_REPORT.permissions }),
+    });
+    const res = await readSystemPermissions(host, null);
+    expect(res.available && res.bundled).toBe(true);
+  });
+
+  test('no machine to ask never reaches the wire', async () => {
+    const host = fakeHost({});
+    expect(await readSystemPermissions(host, null)).toEqual({ available: false, reason: 'no_sidecar' });
+    expect(host.calls).toHaveLength(0);
+  });
+});
+
+describe('requestSystemPermission', () => {
+  test('passes the name through and reports where the pane landed', async () => {
+    const host = fakeHost({
+      connected: [MAC],
+      dispatch: async () => ({
+        name: 'accessibility', grant: 'pane', pane_opened: true, permissions: OK_REPORT.permissions,
+      }),
+    });
+    const res = await requestSystemPermission(host, null, 'accessibility');
+    expect(res.available).toBe(true);
+    if (!res.available) return;
+    expect(res.grant).toBe('pane');
+    expect(res.paneOpened).toBe(true);
+    expect(res.paneError).toBeUndefined();
+    expect(host.calls[0]).toMatchObject({
+      method: 'system.request_permission', params: { name: 'accessibility' },
+    });
+  });
+
+  test('a pane that failed to open is reported, not swallowed', async () => {
+    // Silently claiming a window opened is the original bug in miniature.
+    const host = fakeHost({
+      connected: [MAC],
+      dispatch: async () => ({
+        name: 'screen', grant: 'pane', pane_opened: false, pane_error: 'exec: "open": not found',
+        permissions: OK_REPORT.permissions,
+      }),
+    });
+    const res = await requestSystemPermission(host, null, 'screen');
+    expect(res.available && res.paneOpened).toBe(false);
+    expect(res.available && res.paneError).toBe('exec: "open": not found');
+  });
+
+  test('a truthy-looking pane_opened that is not true stays false', async () => {
+    const host = fakeHost({
+      connected: [MAC],
+      dispatch: async () => ({ name: 'screen', grant: 'pane', pane_opened: 'yes', permissions: [] }),
+    });
+    const res = await requestSystemPermission(host, null, 'screen');
+    expect(res.available && res.paneOpened).toBe(false);
+  });
+});
+
+describe('isPermissionName', () => {
+  test('accepts exactly the four rows the product asks about', () => {
+    for (const name of PERMISSION_NAMES) expect(isPermissionName(name)).toBe(true);
+  });
+
+  test('rejects everything else, including the two rows this change removed', () => {
+    // Automation and Files & Folders were on the old screen and could never
+    // work: their TCC panes are empty until the app has already asked.
+    for (const bad of ['automation', 'files', 'full_disk', '', 'SCREEN', 'screen ', null, 42, {}]) {
+      expect(isPermissionName(bad)).toBe(false);
+    }
+  });
+});
+
+describe('failure classification and strictness', () => {
+  test('a considered refusal is not reported as silence', async () => {
+    // The sidecar answers HANDLER_ERROR for real nos: "cannot be requested on
+    // linux", "not running as an app bundle". Calling that "the app did not
+    // answer" sends the user hunting a problem that is not there.
+    const host = fakeHost({
+      connected: [MAC],
+      dispatch: async () => {
+        throw new Error('HANDLER_ERROR: not running as an app bundle: a grant would attach to the launching app');
+      },
+    });
+    const res = await requestSystemPermission(host, null, 'screen');
+    expect(res).toEqual({
+      available: false,
+      reason: 'refused',
+      detail: 'not running as an app bundle: a grant would attach to the launching app',
+    });
+  });
+
+  test('a malformed request reply is refused, not read as "nothing to do"', async () => {
+    // Being lenient here turns a renamed field into available:true, grant:
+    // 'none', no rows and no error -- a confident wrong answer.
+    for (const bad of [null, true, 'ok', {}, { grant: 'pane' }, { grant: 'telepathy', permissions: [] }, { grant: 'pane', permissions: 'nope' }]) {
+      const host = fakeHost({ connected: [MAC], dispatch: async () => bad });
+      const res = await requestSystemPermission(host, null, 'screen');
+      expect(res.available).toBe(false);
+    }
+  });
+
+  test('both calls ask for the short timeouts, not the 30s default', async () => {
+    // Losing these would put a wedged sidecar behind a half-minute spinner
+    // that then resolves to the string "detached".
+    const host = fakeHost({ connected: [MAC], dispatch: async () => OK_REPORT });
+    await readSystemPermissions(host, null);
+    await requestSystemPermission(host, null, 'screen').catch(() => {});
+    expect(host.calls).toHaveLength(2);
+    for (const call of host.calls) {
+      expect(call.timeouts).toEqual({ initial: 8_000, max: 15_000 });
+    }
+  });
+});

--- a/src/daemon/system-permissions.ts
+++ b/src/daemon/system-permissions.ts
@@ -1,0 +1,340 @@
+/**
+ * OS permissions, asked of the machine the dashboard is actually being looked
+ * at on.
+ *
+ * The onboarding wizard's Permissions screen used to be static HTML: four rows
+ * whose buttons called window.open("x-apple.systempreferences:...") and whose
+ * status was never read at all. Neither half could work. A panel routes
+ * window.open through the sidecar host, which allowlists http(s) (see
+ * isExternallyOpenable in sidecar/panels_extnav.go), so the scheme was dropped
+ * on the floor with a log line and no window ever appeared; and with no status
+ * to read, a granted permission and a denied one looked identical. The user was
+ * told to grant four things by a screen that could neither grant them nor tell
+ * whether they had been.
+ *
+ * Both halves have to happen in the SIDECAR process, which is what this module
+ * reaches: it opens the pane with an `open` from the desktop app, and it reads
+ * the same TCC state the native `jarvis --setup` wizard reads (one source of
+ * truth - the two screens cannot disagree about what is granted).
+ *
+ * WHICH MACHINE. The brain is not necessarily on the user's desktop (a hosted
+ * install certainly is not), and it can have several sidecars enrolled. The
+ * question "what has been granted" is meaningless without a machine, so this
+ * resolves one and REFUSES rather than guessing when it cannot - the wizard
+ * showing a row for someone else's laptop is worse than showing no row.
+ */
+
+import type { RPCTimeouts } from '../sidecar/protocol.ts';
+
+/** What the OS says about one permission. "na" = no such concept here. */
+export type PermissionStatus = 'granted' | 'denied' | 'undetermined' | 'na';
+
+/**
+ * How a permission is obtained, which is the only distinction the screen has
+ * to render: a "prompt" row can be granted without leaving the app, a "pane"
+ * row can only be granted by the user flipping a toggle in System Settings.
+ */
+export type PermissionGrantMode = 'prompt' | 'pane' | 'none';
+
+export interface PermissionRow {
+  name: string;
+  status: PermissionStatus;
+  grant: PermissionGrantMode;
+}
+
+/**
+ * Why there is no answer. Each is a different sentence on screen, which is the
+ * point of distinguishing them - "no desktop app is connected" and "your
+ * desktop app is too old" send the user to completely different places.
+ */
+export type PermissionsUnavailable =
+  | 'no_sidecar' // nothing connected to ask
+  | 'offline' // this page's own machine is known, but its app is not connected
+  | 'ambiguous' // several machines connected and nothing says which is this one
+  | 'unsupported' // connected, but too old to know the RPC
+  | 'refused' // it answered, and the answer was no
+  | 'unreachable'; // connected, but the call failed or never came back
+
+/** The machine an answer is about, so the screen can name it. */
+export interface PermissionsHostInfo {
+  id: string;
+  name: string;
+  hostname: string;
+  /**
+   * How it was identified. 'panel' means this page is literally being rendered
+   * by that sidecar's webview, so "your machine" is safe to say. 'only_connected'
+   * is an inference from there being exactly one candidate - true on every
+   * ordinary local install, but the screen should name the host rather than
+   * assume the user is sitting at it.
+   */
+  source: 'panel' | 'only_connected';
+}
+
+export type PermissionsResult =
+  | {
+      available: true;
+      host: PermissionsHostInfo;
+      platform: string;
+      /**
+       * False when macOS TCC has no app identity to attach grants to (a bare
+       * binary instead of Jarvis.app). The rows then describe whatever launched
+       * the sidecar - usually a terminal - so the screen must say so instead of
+       * inviting the user to grant permissions to the wrong app.
+       */
+      bundled: boolean;
+      permissions: PermissionRow[];
+    }
+  | { available: false; reason: PermissionsUnavailable; detail?: string };
+
+/** The result of asking for one permission. */
+export type PermissionRequestResult =
+  | {
+      available: true;
+      host: PermissionsHostInfo;
+      name: string;
+      grant: PermissionGrantMode;
+      /** Did System Settings actually come up? Only meaningful for a "pane" row. */
+      paneOpened: boolean;
+      paneError?: string;
+      permissions: PermissionRow[];
+    }
+  | { available: false; reason: PermissionsUnavailable; detail?: string };
+
+/**
+ * The permissions this product asks about, and nothing else.
+ *
+ * Deliberately does NOT include Automation or Files & Folders, which the old
+ * screen listed. Their TCC panes are EMPTY until the app has already tried the
+ * thing they gate, so there is nothing to pre-grant and a link there shows the
+ * user a list Jarvis is not in. macOS prompts for both in the moment, which is
+ * the only time they can be granted.
+ *
+ * Checked here as well as in the sidecar. The name selects a System Settings
+ * deep link that the sidecar hands to `open`, and defence in depth on the
+ * pathway from an HTTP body to a process launch is cheap.
+ */
+export const PERMISSION_NAMES = ['notifications', 'microphone', 'screen', 'accessibility'] as const;
+export type PermissionName = (typeof PERMISSION_NAMES)[number];
+
+export function isPermissionName(value: unknown): value is PermissionName {
+  return typeof value === 'string' && (PERMISSION_NAMES as readonly string[]).includes(value);
+}
+
+/**
+ * These calls are a status read and a window open, both of which are instant or
+ * broken. The 30s default would leave the wizard's spinner up for half a minute
+ * on a wedged sidecar and then resolve to the string "detached", which is not an
+ * answer anyone can render.
+ */
+const PERMISSION_RPC_TIMEOUTS: RPCTimeouts = { initial: 8_000, max: 15_000 };
+
+/** The slice of SidecarManager this needs. Narrow on purpose: it makes the
+ *  resolution rules - which are the interesting part - testable without a
+ *  running brain. */
+export interface PermissionsSidecarHost {
+  resolvePanelSession(sessionId: string): { sid: string } | null;
+  getConnectedSidecars(): Array<{ id: string; name: string; hostname: string }>;
+  dispatchRPC(
+    sidecarId: string,
+    method: string,
+    params?: Record<string, unknown>,
+    timeouts?: RPCTimeouts,
+  ): Promise<unknown>;
+}
+
+/**
+ * Which sidecar this page's question is about.
+ *
+ * The panel session is the answer whenever there is one: the cookie was minted
+ * for a webview that a specific sidecar spawned, so it identifies the machine
+ * the user is looking at, even with a dozen others enrolled.
+ *
+ * The fallback matters more than it looks. A dashboard opened at
+ * localhost:3142 in a real browser has no panel cookie, and neither does ANY
+ * page when auth.insecure_open_access is set (the whole session exchange is
+ * skipped) - which is the setup-time configuration, i.e. exactly when the
+ * onboarding wizard runs. With one sidecar connected there is no ambiguity to
+ * resolve; with several, refuse, because picking one at random would show the
+ * user their other laptop's permissions and open panes there.
+ */
+export function resolvePermissionsHost(
+  host: PermissionsSidecarHost,
+  panelSessionId: string | null,
+): PermissionsHostInfo | { reason: 'no_sidecar' | 'offline' | 'ambiguous' } {
+  const connected = host.getConnectedSidecars();
+
+  if (panelSessionId) {
+    const session = host.resolvePanelSession(panelSessionId);
+    if (session) {
+      const match = connected.find((s) => s.id === session.sid);
+      if (match) {
+        return { id: match.id, name: match.name, hostname: match.hostname, source: 'panel' };
+      }
+      // The session names a machine that is not connected this second. That is
+      // still POSITIVE knowledge of where the user is sitting, so it ends the
+      // search: falling through to "the only other one that happens to be up"
+      // would answer for, and open panes on, a different computer. Sessions
+      // deliberately outlive a disconnect (see panel-sessions.ts), and a
+      // hosted update restarts the brain while sidecars reconnect at their own
+      // pace, so this gap is ordinary rather than exotic.
+      return { reason: 'offline' };
+    }
+  }
+
+  if (connected.length === 1) {
+    const only = connected[0]!;
+    return { id: only.id, name: only.name, hostname: only.hostname, source: 'only_connected' };
+  }
+  return { reason: connected.length === 0 ? 'no_sidecar' : 'ambiguous' };
+}
+
+/**
+ * Classify a failed dispatch.
+ *
+ * The one that must not be lumped in with the rest is METHOD_NOT_FOUND. Sidecars
+ * update independently of the brain, so a machine enrolled before this shipped
+ * answers every call with it - a permanent, expected condition that deserves
+ * "your desktop app is too old", not a red error the user will retry forever.
+ */
+function classifyDispatchFailure(err: unknown): { reason: PermissionsUnavailable; detail: string } {
+  const detail = err instanceof Error ? err.message : String(err);
+  if (detail.includes('METHOD_NOT_FOUND')) return { reason: 'unsupported', detail };
+  // A refusal is not a silence. The sidecar answers HANDLER_ERROR for real,
+  // considered nos -- "cannot be requested on linux", "not running as an app
+  // bundle" -- and describing a prompt, correct answer as "the app did not
+  // respond" sends the user to look for a problem that is not there.
+  if (detail.includes('HANDLER_ERROR')) {
+    return { reason: 'refused', detail: detail.replace(/^HANDLER_ERROR:\s*/, '') };
+  }
+  return { reason: 'unreachable', detail };
+}
+
+/**
+ * A dispatch that resolves to the literal string "detached" hit the initial
+ * timeout: the sidecar has not answered and may answer much later, to nobody.
+ * For a status read that is a failure, not a pending success.
+ */
+function isDetached(result: unknown): boolean {
+  return result === 'detached';
+}
+
+/** Diagnosing a shape mismatch from a user's screenshot is impossible without
+ *  this: the reply is discarded on the way to a one-sentence `detail`. */
+function warnUnreadable(sidecarId: string, method: string, raw: unknown): void {
+  let sample: string;
+  try {
+    sample = JSON.stringify(raw)?.slice(0, 300) ?? String(raw);
+  } catch {
+    sample = String(raw);
+  }
+  console.warn(`[API] ${method} from sidecar ${sidecarId} was unreadable: ${sample}`);
+}
+
+interface RawReport {
+  platform?: unknown;
+  bundled?: unknown;
+  permissions?: unknown;
+}
+
+/**
+ * Shape-check what came back over the wire.
+ *
+ * The sidecar is a separate, independently-updated program, so its answer is
+ * input rather than a value this code produced. A half-understood report
+ * rendered as rows would invent statuses; better to report the machine as
+ * unreadable.
+ */
+function parseRows(value: unknown): PermissionRow[] | null {
+  if (!Array.isArray(value)) return null;
+  const rows: PermissionRow[] = [];
+  for (const entry of value) {
+    if (!entry || typeof entry !== 'object') return null;
+    const { name, status, grant } = entry as Record<string, unknown>;
+    if (typeof name !== 'string' || typeof status !== 'string' || typeof grant !== 'string') return null;
+    if (!['granted', 'denied', 'undetermined', 'na'].includes(status)) return null;
+    if (!['prompt', 'pane', 'none'].includes(grant)) return null;
+    rows.push({ name, status: status as PermissionStatus, grant: grant as PermissionGrantMode });
+  }
+  return rows;
+}
+
+/** Read the machine's permission state. */
+export async function readSystemPermissions(
+  host: PermissionsSidecarHost,
+  panelSessionId: string | null,
+): Promise<PermissionsResult> {
+  const target = resolvePermissionsHost(host, panelSessionId);
+  if ('reason' in target) return { available: false, reason: target.reason };
+
+  let raw: unknown;
+  try {
+    raw = await host.dispatchRPC(target.id, 'system.permissions', {}, PERMISSION_RPC_TIMEOUTS);
+  } catch (err) {
+    return { available: false, ...classifyDispatchFailure(err) };
+  }
+  if (isDetached(raw)) {
+    return { available: false, reason: 'unreachable', detail: 'the desktop app did not answer in time' };
+  }
+
+  const report = (raw ?? {}) as RawReport;
+  const rows = parseRows(report.permissions);
+  if (typeof report.platform !== 'string' || rows === null) {
+    warnUnreadable(target.id, 'system.permissions', raw);
+    return { available: false, reason: 'unreachable', detail: 'the desktop app sent an answer this brain cannot read' };
+  }
+
+  return {
+    available: true,
+    host: target,
+    platform: report.platform,
+    // Absent means an older report shape; assume bundled rather than showing
+    // the "grants are attaching to the wrong app" warning to everyone.
+    bundled: report.bundled !== false,
+    permissions: rows,
+  };
+}
+
+/** Ask the machine for one permission. */
+export async function requestSystemPermission(
+  host: PermissionsSidecarHost,
+  panelSessionId: string | null,
+  name: PermissionName,
+): Promise<PermissionRequestResult> {
+  const target = resolvePermissionsHost(host, panelSessionId);
+  if ('reason' in target) return { available: false, reason: target.reason };
+
+  let raw: unknown;
+  try {
+    raw = await host.dispatchRPC(target.id, 'system.request_permission', { name }, PERMISSION_RPC_TIMEOUTS);
+  } catch (err) {
+    return { available: false, ...classifyDispatchFailure(err) };
+  }
+  if (isDetached(raw)) {
+    return { available: false, reason: 'unreachable', detail: 'the desktop app did not answer in time' };
+  }
+
+  // As strict as the read path, and for the same reason: the sidecar is an
+  // independently-updated program. Being lenient here would turn a renamed
+  // field into a silent "nothing to do on this platform" -- available: true,
+  // grant: 'none', no rows, no error -- which is precisely the confident wrong
+  // answer this whole change exists to delete.
+  const result = (raw ?? {}) as Record<string, unknown>;
+  const rows = parseRows(result.permissions);
+  const grant = typeof result.grant === 'string' && ['prompt', 'pane', 'none'].includes(result.grant)
+    ? (result.grant as PermissionGrantMode)
+    : null;
+  if (rows === null || grant === null) {
+    warnUnreadable(target.id, 'system.request_permission', raw);
+    return { available: false, reason: 'unreachable', detail: 'the desktop app sent an answer this brain cannot read' };
+  }
+
+  return {
+    available: true,
+    host: target,
+    name,
+    grant,
+    paneOpened: result.pane_opened === true,
+    ...(typeof result.pane_error === 'string' ? { paneError: result.pane_error } : {}),
+    permissions: rows,
+  };
+}

--- a/src/util/cookie.test.ts
+++ b/src/util/cookie.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from 'bun:test';
+import { getCookie } from './cookie.ts';
+import { PANEL_SESSION_COOKIE } from '../sidecar/panel-sessions.ts';
+
+/**
+ * This parser sits on the authentication path: the WebSocket layer reads the
+ * panel session with it on every request, and the permissions routes use it to
+ * decide which machine a question is about. Its behaviour was documented but
+ * never tested while it lived inside websocket.ts.
+ */
+
+function req(cookie?: string): Request {
+  return new Request('http://localhost/api/x', {
+    headers: cookie === undefined ? {} : { Cookie: cookie },
+  });
+}
+
+describe('getCookie', () => {
+  test('reads a value, in any position in the header', () => {
+    expect(getCookie(req('panel_session=abc'), PANEL_SESSION_COOKIE)).toBe('abc');
+    expect(getCookie(req('theme=dark; panel_session=abc; x=1'), PANEL_SESSION_COOKIE)).toBe('abc');
+    expect(getCookie(req('theme=dark;panel_session=abc'), PANEL_SESSION_COOKIE)).toBe('abc');
+  });
+
+  test('a missing cookie, or no header at all, is null', () => {
+    expect(getCookie(req(), PANEL_SESSION_COOKIE)).toBeNull();
+    expect(getCookie(req(''), PANEL_SESSION_COOKIE)).toBeNull();
+    expect(getCookie(req('theme=dark'), PANEL_SESSION_COOKIE)).toBeNull();
+  });
+
+  test('a malformed escape reads as no cookie rather than throwing', () => {
+    // decodeURIComponent throws on this. The value is attacker-controlled and
+    // read on the auth path, so an unusable cookie has to mean "unauthenticated"
+    // (401), never an unwound 500.
+    expect(() => getCookie(req('panel_session=%E0%A4%A'), PANEL_SESSION_COOKIE)).not.toThrow();
+    expect(getCookie(req('panel_session=%E0%A4%A'), PANEL_SESSION_COOKIE)).toBeNull();
+  });
+
+  test('a name is matched whole, never as the tail of another cookie', () => {
+    // "evil_panel_session=x" must not answer for "panel_session". The boundary
+    // is what stops an attacker-chosen cookie name shadowing the real one.
+    expect(getCookie(req('evil_panel_session=x'), PANEL_SESSION_COOKIE)).toBeNull();
+    expect(getCookie(req('evil_panel_session=x; panel_session=real'), PANEL_SESSION_COOKIE)).toBe('real');
+  });
+
+  test('the name is escaped before it becomes a pattern', () => {
+    // Regex metacharacters in a name would otherwise match something else
+    // entirely; "a.c" must not be satisfied by "abc".
+    expect(getCookie(req('abc=nope'), 'a.c')).toBeNull();
+    expect(getCookie(req('a.c=yes'), 'a.c')).toBe('yes');
+  });
+
+  test('percent-encoded values are decoded', () => {
+    expect(getCookie(req('panel_session=a%20b'), PANEL_SESSION_COOKIE)).toBe('a b');
+  });
+});

--- a/src/util/cookie.ts
+++ b/src/util/cookie.ts
@@ -1,0 +1,35 @@
+/**
+ * Reading one cookie off a Request.
+ *
+ * Lifted out of comms/websocket.ts, which had the only copy, once the API
+ * routes needed the same read: a route that answers "what has THIS machine
+ * granted" has to identify the panel the question came from, and the panel
+ * session lives in a cookie. Two copies of a parser on the authentication path
+ * is exactly the kind of duplication that drifts.
+ */
+
+/**
+ * The value of `name`, or null when it is absent or unusable.
+ *
+ * A malformed escape (`%E0%A4%A`) makes decodeURIComponent throw, which would
+ * unwind out of the fetch handler as a 500. This value is attacker-controlled
+ * and read on the authentication path, so an unusable cookie has to read as
+ * "no cookie" rather than as a server fault.
+ */
+export function getCookie(req: Request, name: string): string | null {
+  const cookies = req.headers.get('Cookie');
+  if (!cookies) return null;
+  const match = cookies.match(new RegExp(`(?:^|;\\s*)${escapeForRegExp(name)}=([^;]*)`));
+  if (!match) return null;
+  try {
+    return decodeURIComponent(match[1]!);
+  } catch {
+    return null;
+  }
+}
+
+/** Cookie names are ours, not user input - but building a RegExp from an
+ *  unescaped string is a footgun waiting for the first name with a dot in it. */
+function escapeForRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/ui/src/v2/onboarding/OnboardingWizard.tsx
+++ b/ui/src/v2/onboarding/OnboardingWizard.tsx
@@ -4,7 +4,11 @@ import { useInterviewSession } from "./useInterviewSession";
 import type { OnboardingStatus } from "./useOnboardingStatus";
 import "./OnboardingWizard.css";
 import { modelForOnboardingTest, onboardingDefaultModelRef } from "./llm-setup";
-import { DESKTOP, modKey } from "../ui/platform";
+import { modKey } from "../ui/platform";
+import { useSystemPermissions } from "./useSystemPermissions";
+import {
+  allSettled, displayRows, needsRestartNote, outstandingRequired, unavailableCopy,
+} from "./permission-rows";
 
 /* ═══════════════════ Onboarding · the nine-screen first-run flow ═══════════
    Faithful to the design (usejarvis-onboarding.html): Welcome · Permissions
@@ -73,6 +77,7 @@ const SVG: Record<string, string> = {
   voloff: '<svg width="18" height="18" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M4 8h3l4-3v10l-4-3H4z"/><path d="M13.5 8l4 4M17.5 8l-4 4"/></svg>',
   calendar: '<svg width="18" height="18" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="3" y="4.5" width="14" height="12.5" rx="2"/><path d="M3 8.5h14M7 3v3M13 3v3"/></svg>',
   send: '<svg width="18" height="18" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round"><path d="M17 3L8.5 11.5M17 3l-5.5 14-3-6-6-3z"/></svg>',
+  bell: '<svg width="18" height="18" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M5.5 8a4.5 4.5 0 0 1 9 0c0 3 1 4.5 1.5 5.2H4c.5-.7 1.5-2.2 1.5-5.2z"/><path d="M8.2 16a2 2 0 0 0 3.6 0"/></svg>',
   check: '<svg viewBox="0 0 16 16" width="15" height="15" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M13 4.5 6.5 11.5 3 8"/></svg>',
 };
 const Glyph = ({ k }: { k: string }) => <span dangerouslySetInnerHTML={{ __html: SVG[k] ?? "" }} />;
@@ -121,18 +126,14 @@ const ELEVEN_PREMADE = [
 
 
 /**
- * macOS panes only. The Windows column that used to live here pointed at
- * `ms-settings:` pages that cannot grant any of this — `easeofaccess` is the
- * accessibility *features* page, and `privacy-general` has no toggle for
- * screen capture or automation — so it sent people somewhere that could not
- * help them. Windows shows a different screen entirely now.
+ * The System Settings deep links used to live here, and the rows opened them
+ * with window.open. That could never work: a panel routes window.open to the
+ * sidecar host, which allowlists http(s) (isExternallyOpenable in
+ * sidecar/panels_extnav.go), so the custom scheme was dropped with a log line
+ * and no window appeared; an ordinary browser blocks the scheme too. The pane
+ * is opened by the sidecar process now, over POST /api/system/permissions/
+ * request, which is the only place an `open` can actually run.
  */
-const PERM_PANE: Record<string, string> = {
-  access: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility",
-  screen: "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture",
-  auto: "x-apple.systempreferences:com.apple.preference.security?Privacy_Automation",
-  files: "x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles",
-};
 
 // Play MP3 bytes returned by /api/tts/preview in the dashboard itself.
 async function playPreviewAudio(res: Response): Promise<void> {
@@ -189,7 +190,6 @@ export function OnboardingWizard({
     try { localStorage.setItem("jarvis-theme", t); } catch { /* ignore */ }
   };
 
-  // permissions
   // brain
   // Hosted install? GET /api/config/llm reports hosted_llm when the
   // system-owned usejarvis_ai block is live. TRI-state on purpose: a slow or
@@ -243,6 +243,17 @@ export function OnboardingWizard({
   // better, flashing Welcome's "I'll do this later".
   const key = resolveStepKey(steps, stepKey);
   const step = steps.findIndex(([k]) => k === key);
+
+  // Live permission state for the Permissions screen. Polled ONLY while that
+  // screen is the one on show: the two macOS rows with no dialog are granted
+  // by the user leaving for System Settings and coming back, and a row turning
+  // green while they watch is the only feedback the OS makes possible. A user
+  // parked on a later step for ten minutes should not be paying for that.
+  const perms = useSystemPermissions(key === "perms");
+  // Whether the user has been sent to the Screen Recording pane in this
+  // session, which is the only moment the "macOS keeps handing a running app
+  // its old answer" note is useful rather than noise.
+  const [screenPaneVisited, setScreenPaneVisited] = useState(false);
 
   // If the probe resolves while the user is standing on a now-hidden screen,
   // send them BACK to Permissions, not forward. Permissions is where the
@@ -837,80 +848,147 @@ export function OnboardingWizard({
       );
 
       case "perms": {
-        // macOS only — four strings that no other platform renders.
-        const macRows: Array<[string, string, string, boolean]> = [
-          ["access", "Accessibility", "Click, type, and read on-screen controls so Jarvis can operate your apps.", true],
-          ["screen", "Screen Recording", "See your screen for Awareness: OCR, and noticing when you’re stuck.", false],
-          ["auto", "Automation", "Drive other apps directly: your calendar, browser, and mail.", false],
-          ["files", "Files & Folders", "Read and write the files and folders you point it at.", false],
-        ];
+        // Everything on this screen comes from the machine itself now (see
+        // permission-rows.ts for what the old static version could not do).
+        // The platform comes from the sidecar's runtime.GOOS rather than the
+        // user agent, which is what platform.ts's own comment asks for: a
+        // WebKit build on Linux can carry a mac-shaped agent string, and this
+        // screen is the one place that would have handed such a user a button
+        // opening an Apple settings pane.
+        const rows = displayRows(perms.report ?? { available: false, reason: "no_sidecar" });
+        const outstanding = outstandingRequired(rows);
+        const unavailable = perms.report && !perms.report.available ? perms.report : null;
+        const mac = perms.report?.available && perms.report.platform === "darwin";
+        const unbundled = perms.report?.available === true && perms.report.bundled === false;
+
         return (
           <div className="obw-body"><div className="obw-wrap wide">
-            {/* macOS gates each of these behind a pane the user must visit, and
-                Jarvis cannot grant them itself. Windows does not work that way:
-                the app already has what it needs, and the one thing it might
-                ask for later — the microphone, for the embedded browser window
-                — has no Settings toggle to pre-grant, so sending someone to
-                ms-settings: would be sending them somewhere that cannot help.
-                Same step either way, so the flow and the hosted setup POST
-                below are untouched; only what the screen says changes. */}
-            {DESKTOP === "mac" ? (
+            {perms.phase === "loading" ? (
               <>
-                <h2>Let Jarvis reach your machine.</h2>
-                <div className="obw-sub">It acts on your computer through these. Jarvis can’t grant them itself (the OS won’t let it), so each one opens the exact settings pane. Grant what you’re comfortable with, or approve later when your Mac asks.</div>
-                <div className="obw-rows" style={{ marginTop: 16 }}>
-                  {macRows.map(([id, name, body, req]) => (
-                    <button key={id} type="button" className="obw-prow" style={{ cursor: "pointer", textAlign: "left", width: "100%", background: "var(--raise)" }}
-                      onClick={() => { try { window.open(PERM_PANE[id] || "", "_blank"); } catch { /* webview may block the scheme */ } }}>
-                      <span className="pg"><Glyph k={id} /></span>
-                      <div className="pt"><div className="pn">{name}{req && <span className="req">required</span>}</div><div className="pb">{body}</div></div>
-                      <span className="obw-grant" style={{ pointerEvents: "none" }}>Open settings ↗</span>
-                    </button>
-                  ))}
+                <h2>Checking this machine…</h2>
+                <div className="obw-sub">Asking the Jarvis desktop app what it already has.</div>
+              </>
+            ) : perms.phase === "error" ? (
+              // The BRAIN could not be reached, which is a different thing
+              // from a report saying there is no machine to ask. Without this
+              // branch a failed first fetch leaves report null, rows empty,
+              // and the screen cheerfully announcing "nothing to set up" --
+              // the confident wrong answer this whole change exists to delete.
+              <>
+                <h2>Couldn't check this machine.</h2>
+                <div className="obw-sub">
+                  Jarvis couldn't be asked what it already has. You can carry on and grant
+                  things later, or try again.
                 </div>
-                <div className="obw-hint" style={{ marginTop: 12 }}>Review or revoke any of these anytime in System Settings → Privacy &amp; Security.</div>
+                {perms.error && <div className="obw-hint" style={{ marginTop: 10 }}>{perms.error}</div>}
+                <div style={{ marginTop: 14 }}>
+                  <button className="obw-btn" onClick={perms.refresh}>Try again</button>
+                </div>
+              </>
+            ) : unavailable ? (
+              <>
+                <h2>{unavailableCopy(unavailable.reason).title}</h2>
+                <div className="obw-sub">{unavailableCopy(unavailable.reason).body}</div>
+                {unavailable.detail && (
+                  <div className="obw-hint" style={{ marginTop: 10 }}>{unavailable.detail}</div>
+                )}
+                <div style={{ marginTop: 14 }}>
+                  <button className="obw-btn" onClick={perms.refresh}>Check again</button>
+                </div>
+              </>
+            ) : rows.length === 0 ? (
+              <>
+                <h2>Nothing to set up here.</h2>
+                <div className="obw-sub">
+                  Jarvis already has the access it needs on this machine. Nothing is gated
+                  behind a permission you have to grant first.
+                </div>
               </>
             ) : (
               <>
-                <h2>Nothing to set up here.</h2>
-                <div className="obw-sub">Jarvis already has the access it needs{DESKTOP === "windows" ? " on Windows" : ""} — none of it is gated behind a permission you have to grant first.</div>
-                <div className="obw-rows" style={{ marginTop: 16 }}>
-                  <div className="obw-prow">
-                    <span className="pg"><Glyph k="check" /></span>
-                    <div className="pt">
-                      <div className="pn">All set</div>
-                      <div className="pb">Nothing to switch on for Jarvis to act on your machine.</div>
-                    </div>
-                  </div>
-                  {DESKTOP === "windows" && (
-                    // The ONE pane that is real here. Windows has no per-app
-                    // permission model for a desktop app, so the microphone is
-                    // governed by a single global toggle — and with it off there
-                    // is no in-the-moment prompt to rescue you, the capture just
-                    // fails. The sidecar's own native wizard deep-links exactly
-                    // this page for exactly this reason.
-                    <button
-                      type="button"
-                      className="obw-prow"
-                      style={{ cursor: "pointer", textAlign: "left", width: "100%", background: "var(--raise)" }}
-                      onClick={() => { try { window.open("ms-settings:privacy-microphone", "_blank"); } catch { /* webview may block the scheme */ } }}
-                    >
-                      <span className="pg"><Glyph k="mic" /></span>
-                      <div className="pt">
-                        <div className="pn">Microphone</div>
-                        <div className="pb">Only needed if you want to talk to Jarvis. Windows keeps one switch for all desktop apps — check it is on if the mic stays silent.</div>
-                      </div>
-                      <span className="obw-grant" style={{ pointerEvents: "none" }}>Open settings ↗</span>
-                    </button>
-                  )}
+                <h2>Let Jarvis reach your machine.</h2>
+                <div className="obw-sub">
+                  {mac
+                    ? "It acts on your computer through these. Jarvis can't switch them on itself, so each button asks the OS or opens the exact settings pane. Rows turn green as you go."
+                    : "One switch to check before Jarvis can hear you."}
                 </div>
+                {unbundled && (
+                  // A bare binary has no bundle identity, so macOS attaches
+                  // grants to whatever launched it. Granting from here would
+                  // permission the user's terminal and tell them Jarvis had
+                  // it. The rows stay visible as information; the buttons are
+                  // gone, and the server refuses the request too.
+                  <div className="obw-hint" style={{ marginTop: 12, color: "var(--listen)" }}>
+                    Jarvis is running as a bare binary rather than an installed app, so macOS
+                    would attach these grants to whatever launched it. Install Jarvis.app and
+                    run setup again to grant them properly.
+                  </div>
+                )}
+                <div className="obw-rows" style={{ marginTop: 16 }}>
+                  {rows.map((row) => {
+                    const granted = row.status === "granted";
+                    const busyRow = perms.pending === row.name;
+                    return (
+                      <div key={row.name} className="obw-prow">
+                        <span className="pg"><Glyph k={row.glyph} /></span>
+                        <div className="pt">
+                          <div className="pn">
+                            {row.label}
+                            {row.required && !granted && <span className="req">required</span>}
+                          </div>
+                          <div className="pb">{row.body}</div>
+                        </div>
+                        {granted ? (
+                          <span className="obw-granted"><Glyph k="check" />Granted</span>
+                        ) : (
+                          <button
+                            type="button"
+                            className="obw-grant"
+                            disabled={!row.actionable || busyRow || unbundled}
+                            onClick={() => {
+                              if (row.name === "screen") setScreenPaneVisited(true);
+                              void perms.request(row.name);
+                            }}
+                          >
+                            {busyRow
+                              ? (row.grant === "pane" ? "Opening…" : "Asking…")
+                              : row.grant === "pane" ? "Open settings ↗" : "Allow"}
+                          </button>
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
+                {perms.requestError && (
+                  <div className="obw-hint" style={{ marginTop: 10, color: "var(--listen)" }}>
+                    {perms.requestError}
+                  </div>
+                )}
+                {needsRestartNote(rows, screenPaneVisited) && (
+                  <div className="obw-hint" style={{ marginTop: 10 }}>
+                    Switched Screen Recording on and this row is still amber? macOS keeps
+                    handing a running app its old answer -- quit Jarvis and open it again.
+                  </div>
+                )}
+                {allSettled(rows) && (
+                  <div className="obw-hint" style={{ marginTop: 10, color: "var(--ok)" }}>
+                    That's everything this machine can be asked for.
+                  </div>
+                )}
+                {mac && (
+                  <div className="obw-hint" style={{ marginTop: 10 }}>
+                    macOS asks about your files and about controlling other apps in the
+                    moment, the first time Jarvis needs them. Review or revoke any of this
+                    later in System Settings, Privacy &amp; Security.
+                  </div>
+                )}
               </>
             )}
             <div className="obw-btnrow">
               <button className="obw-btn obw-btn-ghost" onClick={back}>Back</button>
               <span className="grow" />
               {/* Hosted skips brain/hearing/speaking, so this is the last
-                  setup screen — the setup POST (which normally fires when
+                  setup screen - the setup POST (which normally fires when
                   leaving Speaking) has to run here instead, or onboarding is
                   never marked complete and the wizard replays next launch. */}
               <button
@@ -921,8 +999,21 @@ export function OnboardingWizard({
                 {busy ? "Setting up…" : "Continue"}
               </button>
             </div>
+            {/* Continue is never blocked on a grant. A managed Mac may refuse
+                these outright, and onboarding you cannot finish is worse than
+                a feature that is off - so say what will not work and let the
+                user decide. */}
+            {outstanding.length > 0 && (
+              <div className="obw-hint" style={{ marginTop: 8 }}>
+                You can continue without {outstanding.map((r) => r.label).join(" and ")}. Until
+                {outstanding.length > 1 ? " they are" : " it is"} granted, the features above stay
+                off and nothing will ask you again -- switch
+                {outstanding.length > 1 ? " them" : " it"} on any time in System Settings,
+                Privacy &amp; Security.
+              </div>
+            )}
             {/* The hosted setup POST fires from THIS screen, so its failure
-                has to surface here — otherwise the button just settles back
+                has to surface here - otherwise the button just settles back
                 to "Continue" with no explanation and onboarding replays. */}
             {error && (
               <div className="obw-hint" style={{ color: "var(--listen)", marginTop: 8 }}>{error}</div>

--- a/ui/src/v2/onboarding/OnboardingWizard.tsx
+++ b/ui/src/v2/onboarding/OnboardingWizard.tsx
@@ -908,9 +908,11 @@ export function OnboardingWizard({
               <>
                 <h2>Let Jarvis reach your machine.</h2>
                 <div className="obw-sub">
-                  {mac
-                    ? "It acts on your computer through these. Jarvis can't switch them on itself, so each button asks the OS or opens the exact settings pane. Rows turn green as you go."
-                    : "One switch to check before Jarvis can hear you."}
+                  {unbundled
+                    ? "Here is what this machine currently allows. None of it can be granted from here yet, for the reason below."
+                    : mac
+                      ? "It acts on your computer through these. Jarvis can't switch them on itself, so each button asks the OS or opens the exact settings pane. Rows turn green as you go."
+                      : "One switch to check before Jarvis can hear you."}
                 </div>
                 {unbundled && (
                   // A bare binary has no bundle identity, so macOS attaches
@@ -938,16 +940,27 @@ export function OnboardingWizard({
                           </div>
                           <div className="pb">{row.body}</div>
                         </div>
-                        {granted ? (
+                        {/* Nothing to offer, and nothing honest to claim: an
+                            unbundled process reads the LAUNCHING app's grants,
+                            so a "Granted" chip here would be reporting the
+                            user's terminal as Jarvis. */}
+                        {unbundled ? null : granted ? (
                           <span className="obw-granted"><Glyph k="check" />Granted</span>
                         ) : (
                           <button
                             type="button"
                             className="obw-grant"
+                            aria-label={`${row.grant === "pane" ? "Open settings for" : "Allow"} ${row.label}`}
+                            aria-busy={busyRow}
                             disabled={!row.actionable || busyRow || unbundled}
                             onClick={() => {
-                              if (row.name === "screen") setScreenPaneVisited(true);
-                              void perms.request(row.name);
+                              void perms.request(row.name, row.label).then((opened) => {
+                                // Only once the pane genuinely came up. Setting
+                                // this on the click would tell a user whose
+                                // System Settings never opened to go and check
+                                // a toggle they could not reach.
+                                if (opened && row.name === "screen") setScreenPaneVisited(true);
+                              });
                             }}
                           >
                             {busyRow
@@ -967,10 +980,10 @@ export function OnboardingWizard({
                 {needsRestartNote(rows, screenPaneVisited) && (
                   <div className="obw-hint" style={{ marginTop: 10 }}>
                     Switched Screen Recording on and this row is still amber? macOS keeps
-                    handing a running app its old answer -- quit Jarvis and open it again.
+                    handing a running app its old answer — quit Jarvis and open it again.
                   </div>
                 )}
-                {allSettled(rows) && (
+                {rows.some((r) => r.hasState) && allSettled(rows) && (
                   <div className="obw-hint" style={{ marginTop: 10, color: "var(--ok)" }}>
                     That's everything this machine can be asked for.
                   </div>
@@ -988,7 +1001,7 @@ export function OnboardingWizard({
               <button className="obw-btn obw-btn-ghost" onClick={back}>Back</button>
               <span className="grow" />
               {/* Hosted skips brain/hearing/speaking, so this is the last
-                  setup screen - the setup POST (which normally fires when
+                  setup screen — the setup POST (which normally fires when
                   leaving Speaking) has to run here instead, or onboarding is
                   never marked complete and the wizard replays next launch. */}
               <button
@@ -1007,13 +1020,13 @@ export function OnboardingWizard({
               <div className="obw-hint" style={{ marginTop: 8 }}>
                 You can continue without {outstanding.map((r) => r.label).join(" and ")}. Until
                 {outstanding.length > 1 ? " they are" : " it is"} granted, the features above stay
-                off and nothing will ask you again -- switch
+                off and nothing will ask you again — switch
                 {outstanding.length > 1 ? " them" : " it"} on any time in System Settings,
                 Privacy &amp; Security.
               </div>
             )}
             {/* The hosted setup POST fires from THIS screen, so its failure
-                has to surface here - otherwise the button just settles back
+                has to surface here — otherwise the button just settles back
                 to "Continue" with no explanation and onboarding replays. */}
             {error && (
               <div className="obw-hint" style={{ color: "var(--listen)", marginTop: 8 }}>{error}</div>

--- a/ui/src/v2/onboarding/permission-rows.test.ts
+++ b/ui/src/v2/onboarding/permission-rows.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, test } from "bun:test";
+import {
+  allSettled,
+  displayRows,
+  needsRestartNote,
+  outstandingRequired,
+  PERM_COPY,
+  unavailableCopy,
+  type PermReport,
+  type PermRow,
+  type PermUnavailable,
+} from "./permission-rows";
+
+/** Pure-function tests, the LLMTab.models.test.ts / OnboardingWizard.steps.test.ts
+ *  precedent -- this repo has no DOM test infrastructure. The rules ARE the
+ *  feature here: the screen this replaces showed four macOS rows unconditionally,
+ *  two of which could never be granted from a screen at all. */
+
+const HOST = { id: "sc1", name: "Desk Mac", hostname: "desk.local", source: "panel" as const };
+
+function report(platform: string, rows: PermRow[], bundled = true): PermReport {
+  return { available: true, host: HOST, platform, bundled, permissions: rows };
+}
+
+const MAC_ROWS: PermRow[] = [
+  { name: "notifications", status: "undetermined", grant: "prompt" },
+  { name: "microphone", status: "granted", grant: "prompt" },
+  { name: "screen", status: "denied", grant: "pane" },
+  { name: "accessibility", status: "denied", grant: "pane" },
+];
+
+describe("displayRows", () => {
+  test("macOS shows all four, ordered by what fails silently first", () => {
+    // Not the sidecar's order. Accessibility and Screen Recording have no
+    // dialog: skip them and the feature is simply dead, with nothing to say
+    // so later. The other two ask again on their own.
+    const rows = displayRows(report("darwin", MAC_ROWS));
+    expect(rows.map((r) => r.name)).toEqual(["accessibility", "screen", "microphone", "notifications"]);
+    expect(rows.map((r) => r.status)).toEqual(["denied", "denied", "granted", "undetermined"]);
+  });
+
+  test("Linux shows nothing at all", () => {
+    // Every row comes back na/none. Rendering them would give a Linux user
+    // four rows that can never go green.
+    const rows = displayRows(report("linux", MAC_ROWS.map((r) => ({ ...r, status: "na" as const, grant: "none" as const }))));
+    expect(rows).toEqual([]);
+  });
+
+  test("Windows shows only the microphone link, with no state and its own copy", () => {
+    const rows = displayRows(report("windows", [
+      { name: "notifications", status: "na", grant: "none" },
+      { name: "microphone", status: "na", grant: "pane" },
+      { name: "screen", status: "na", grant: "none" },
+      { name: "accessibility", status: "na", grant: "none" },
+    ]));
+    expect(rows.map((r) => r.name)).toEqual(["microphone"]);
+    expect(rows[0]!.actionable).toBe(true);
+    expect(rows[0]!.hasState).toBe(false);
+    // The macOS sentence promises a prompt that Windows never sends.
+    expect(rows[0]!.body).not.toBe(PERM_COPY.microphone!.body);
+    expect(rows[0]!.body).toContain("one switch");
+  });
+
+  test("a row with no readable state is never marked required", () => {
+    // "required" is an assertion that something is missing. A row whose state
+    // cannot be read has no business making it.
+    const rows = displayRows(report("windows", [
+      { name: "accessibility", status: "na", grant: "pane" },
+    ]));
+    expect(rows[0]!.hasState).toBe(false);
+    expect(rows[0]!.required).toBe(false);
+  });
+
+  test("a permission name this build has never heard of is skipped", () => {
+    // A newer sidecar can report rows this UI has no copy for. Inventing a
+    // label for it would be worse than omitting it.
+    const rows = displayRows(report("darwin", [
+      ...MAC_ROWS,
+      { name: "telepathy", status: "denied", grant: "pane" },
+    ]));
+    expect(rows.map((r) => r.name)).not.toContain("telepathy");
+    expect(rows).toHaveLength(4);
+  });
+
+  test("each row carries how it is obtained, so the button can say so", () => {
+    // "Allow" on a row that actually opens System Settings costs the user the
+    // trip: they click expecting a dialog and get a window with no explanation.
+    const rows = displayRows(report("darwin", MAC_ROWS));
+    const byName = Object.fromEntries(rows.map((r) => [r.name, r.grant]));
+    expect(byName).toEqual({
+      accessibility: "pane", screen: "pane", microphone: "prompt", notifications: "prompt",
+    });
+  });
+
+  test("an unavailable report yields no rows", () => {
+    expect(displayRows({ available: false, reason: "no_sidecar" })).toEqual([]);
+  });
+
+  test("neither Automation nor Files & Folders can appear", () => {
+    // They were on the old screen and could not work: their TCC panes are
+    // empty until the app has already asked, so the link showed a list Jarvis
+    // was not in. Even if a sidecar started reporting them, this screen must
+    // not offer them.
+    const rows = displayRows(report("darwin", [
+      { name: "auto", status: "denied", grant: "pane" },
+      { name: "files", status: "denied", grant: "pane" },
+    ]));
+    expect(rows).toEqual([]);
+    expect(PERM_COPY.auto).toBeUndefined();
+    expect(PERM_COPY.files).toBeUndefined();
+  });
+});
+
+describe("outstandingRequired", () => {
+  test("names only the rows that fail silently and are not granted", () => {
+    const rows = displayRows(report("darwin", MAC_ROWS));
+    expect(outstandingRequired(rows).map((r) => r.name)).toEqual(["accessibility", "screen"]);
+  });
+
+  test("the microphone is never outstanding -- macOS asks for it in the moment", () => {
+    const rows = displayRows(report("darwin", MAC_ROWS.map(
+      (r) => (r.name === "microphone" ? { ...r, status: "denied" as const } : r),
+    )));
+    expect(outstandingRequired(rows).map((r) => r.name)).not.toContain("microphone");
+  });
+
+  test("nothing is outstanding once the two are granted", () => {
+    const rows = displayRows(report("darwin", MAC_ROWS.map(
+      (r) => (r.grant === "pane" ? { ...r, status: "granted" as const } : r),
+    )));
+    expect(outstandingRequired(rows)).toEqual([]);
+  });
+});
+
+describe("allSettled", () => {
+  test("false while any readable row is ungranted", () => {
+    expect(allSettled(displayRows(report("darwin", MAC_ROWS)))).toBe(false);
+  });
+
+  test("true when every readable row is granted", () => {
+    const rows = displayRows(report("darwin", MAC_ROWS.map((r) => ({ ...r, status: "granted" as const }))));
+    expect(allSettled(rows)).toBe(true);
+  });
+
+  test("a stateless row does not hold it open forever", () => {
+    // The Windows mic row can never report "granted". Waiting on it would
+    // mean the screen never settles on Windows.
+    const rows = displayRows(report("windows", [{ name: "microphone", status: "na", grant: "pane" }]));
+    expect(allSettled(rows)).toBe(true);
+  });
+});
+
+describe("needsRestartNote", () => {
+  const ungranted = displayRows(report("darwin", MAC_ROWS));
+  const granted = displayRows(report("darwin", MAC_ROWS.map(
+    (r) => (r.name === "screen" ? { ...r, status: "granted" as const } : r),
+  )));
+
+  test("silent until the user has actually been sent to that pane", () => {
+    expect(needsRestartNote(ungranted, false)).toBe(false);
+  });
+
+  test("shown when they have been and the row is still not granted", () => {
+    // macOS keeps handing a running process its old Screen Recording answer,
+    // so the row stays amber after the toggle is flipped and reads as broken.
+    expect(needsRestartNote(ungranted, true)).toBe(true);
+  });
+
+  test("gone once the row is granted", () => {
+    expect(needsRestartNote(granted, true)).toBe(false);
+  });
+});
+
+describe("unavailableCopy", () => {
+  test("every reason has its own sentence", () => {
+    const reasons: PermUnavailable[] = ["no_sidecar", "offline", "ambiguous", "unsupported", "refused", "unreachable"];
+    const titles = reasons.map((r) => unavailableCopy(r).title);
+    expect(new Set(titles).size).toBe(reasons.length);
+    for (const r of reasons) {
+      expect(unavailableCopy(r).title.length).toBeGreaterThan(0);
+      expect(unavailableCopy(r).body.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("offline and no_sidecar do not say the same thing", () => {
+    // "your app is not running" and "there is no app here" send the user to
+    // completely different places; collapsing them is what the fallback bug
+    // in the daemon resolver would have done.
+    expect(unavailableCopy("offline").body).not.toBe(unavailableCopy("no_sidecar").body);
+  });
+});

--- a/ui/src/v2/onboarding/permission-rows.test.ts
+++ b/ui/src/v2/onboarding/permission-rows.test.ts
@@ -5,10 +5,12 @@ import {
   needsRestartNote,
   outstandingRequired,
   PERM_COPY,
+  requestFeedback,
   unavailableCopy,
   type PermReport,
   type PermRow,
   type PermUnavailable,
+  type PermRequestResult,
 } from "./permission-rows";
 
 /** Pure-function tests, the LLMTab.models.test.ts / OnboardingWizard.steps.test.ts
@@ -96,18 +98,19 @@ describe("displayRows", () => {
     expect(displayRows({ available: false, reason: "no_sidecar" })).toEqual([]);
   });
 
-  test("neither Automation nor Files & Folders can appear", () => {
-    // They were on the old screen and could not work: their TCC panes are
-    // empty until the app has already asked, so the link showed a list Jarvis
-    // was not in. Even if a sidecar started reporting them, this screen must
-    // not offer them.
-    const rows = displayRows(report("darwin", [
-      { name: "auto", status: "denied", grant: "pane" },
-      { name: "files", status: "denied", grant: "pane" },
-    ]));
-    expect(rows).toEqual([]);
-    expect(PERM_COPY.auto).toBeUndefined();
-    expect(PERM_COPY.files).toBeUndefined();
+  test("the screen offers exactly four permissions, and required is exactly two", () => {
+    // Automation and Files & Folders were on the old screen and could not
+    // work: their TCC panes are empty until the app has already asked, so the
+    // link showed a list Jarvis was not in. "required" is narrower still --
+    // it means the OS never asks and never will, so skipping it kills a
+    // feature silently. Widening either set is a product decision, not a
+    // refactor, and should have to come through this test.
+    expect(Object.keys(PERM_COPY).sort()).toEqual([
+      "accessibility", "microphone", "notifications", "screen",
+    ]);
+    expect(
+      Object.entries(PERM_COPY).filter(([, c]) => c.required).map(([k]) => k).sort(),
+    ).toEqual(["accessibility", "screen"]);
   });
 });
 
@@ -187,5 +190,68 @@ describe("unavailableCopy", () => {
     // completely different places; collapsing them is what the fallback bug
     // in the daemon resolver would have done.
     expect(unavailableCopy("offline").body).not.toBe(unavailableCopy("no_sidecar").body);
+  });
+});
+
+describe("requestFeedback", () => {
+  const rows: PermRow[] = [];
+  const host = HOST;
+
+  test("a granted-by-dialog request says nothing", () => {
+    const ok: PermRequestResult = {
+      available: true, host, name: "microphone", grant: "prompt", paneOpened: false, permissions: rows,
+    };
+    expect(requestFeedback(ok, "Microphone")).toBeNull();
+  });
+
+  test("a pane that opened says nothing", () => {
+    const ok: PermRequestResult = {
+      available: true, host, name: "screen", grant: "pane", paneOpened: true, permissions: rows,
+    };
+    expect(requestFeedback(ok, "Screen Recording")).toBeNull();
+  });
+
+  test("an available:false answer is never silent", () => {
+    // THE bug this guards. The route answers HTTP 200 for every one of these,
+    // so a hook that checks only response.ok resets the button to its label
+    // and says nothing -- the exact silent click this screen exists to fix.
+    const reasons: PermUnavailable[] = ["no_sidecar", "offline", "ambiguous", "unsupported", "refused", "unreachable"];
+    for (const reason of reasons) {
+      const msg = requestFeedback({ available: false, reason }, "Screen Recording");
+      expect(msg).toBeTruthy();
+      expect(msg).toBe(unavailableCopy(reason).title);
+    }
+  });
+
+  test("a refusal carries the reason the desktop app gave", () => {
+    const msg = requestFeedback(
+      { available: false, reason: "refused", detail: "not running as an app bundle" },
+      "Screen Recording",
+    );
+    expect(msg).toContain("not running as an app bundle");
+  });
+
+  test("a pane that did not open names where to go by hand", () => {
+    const msg = requestFeedback(
+      { available: true, host, name: "screen", grant: "pane", paneOpened: false, permissions: rows },
+      "Screen Recording",
+    );
+    expect(msg).toContain("Privacy & Security");
+    expect(msg).toContain("Screen Recording");
+  });
+
+  test("a launcher error is passed through, not swallowed", () => {
+    const msg = requestFeedback(
+      {
+        available: true, host, name: "screen", grant: "pane", paneOpened: false,
+        paneError: 'exec: "open": not found', permissions: rows,
+      },
+      "Screen Recording",
+    );
+    expect(msg).toContain('exec: "open": not found');
+  });
+
+  test("an unreadable body is reported rather than treated as success", () => {
+    expect(requestFeedback(null, "Screen Recording")).toBeTruthy();
   });
 });

--- a/ui/src/v2/onboarding/permission-rows.ts
+++ b/ui/src/v2/onboarding/permission-rows.ts
@@ -1,0 +1,244 @@
+/**
+ * What the Permissions screen shows, derived from what the machine actually
+ * reports.
+ *
+ * The screen this replaces was static: four hardcoded macOS rows whose buttons
+ * called window.open("x-apple.systempreferences:...") and whose state was never
+ * read. Neither half worked. The sidecar's panel host allowlists http(s) for
+ * window.open (isExternallyOpenable in sidecar/panels_extnav.go), so the scheme
+ * was dropped and no pane ever opened; and with no status to read, granted and
+ * denied looked identical. The rows now come from GET /api/system/permissions,
+ * which asks the desktop app on the machine the page is being looked at on.
+ *
+ * Kept separate from the component because the interesting decisions - which
+ * rows exist at all, which of them the user can act on, which are load-bearing
+ * enough to warn about - are rules, and this repo has no DOM test
+ * infrastructure. Pure functions, tested directly.
+ */
+
+export type PermStatus = "granted" | "denied" | "undetermined" | "na";
+
+/** How a row is obtained: "prompt" finishes in the app, "pane" needs the user
+ *  to flip a toggle in System Settings, "none" means nothing to do here. */
+export type PermGrant = "prompt" | "pane" | "none";
+
+export interface PermRow {
+  name: string;
+  status: PermStatus;
+  grant: PermGrant;
+}
+
+export interface PermHost {
+  id: string;
+  name: string;
+  hostname: string;
+  source: "panel" | "only_connected";
+}
+
+export type PermUnavailable =
+  | "no_sidecar"
+  | "offline"
+  | "ambiguous"
+  | "unsupported"
+  | "refused"
+  | "unreachable";
+
+export type PermReport =
+  | {
+      available: true;
+      host: PermHost;
+      platform: string;
+      bundled: boolean;
+      permissions: PermRow[];
+    }
+  | { available: false; reason: PermUnavailable; detail?: string };
+
+export interface PermCopy {
+  label: string;
+  body: string;
+  /** Key into the wizard's inline SVG map. */
+  glyph: string;
+  /**
+   * A permission whose absence breaks a feature SILENTLY, with no prompt to
+   * rescue the user later. That is the whole reason this screen exists, and
+   * it is a much smaller set than the old screen implied.
+   */
+  required: boolean;
+}
+
+/**
+ * Row copy, by the name the sidecar reports.
+ *
+ * WHAT IS NOT HERE, deliberately: Automation and "Files & Folders", both of
+ * which the old screen listed. Neither can be pre-granted at all - their TCC
+ * panes are EMPTY until the app has already tried the thing they gate, so the
+ * link showed the user a list Jarvis was not in and could not be added to.
+ * macOS prompts for both in the moment, which is the only time they can be
+ * answered. (The old "Files & Folders" row also pointed at Privacy_AllFiles,
+ * which is Full Disk Access: a far broader grant than the row described.)
+ *
+ * REQUIRED means silent failure, not importance. Accessibility and Screen
+ * Recording have no dialog on macOS: the app registers itself in a list and
+ * the user must go and switch it on, and until they do, global hotkeys and
+ * screen awareness simply never work, with nothing anywhere saying why. The
+ * microphone and notifications both raise a real dialog at the point of use,
+ * so a user who skips them here still gets asked later.
+ */
+export const PERM_COPY: Record<string, PermCopy> = {
+  accessibility: {
+    label: "Accessibility",
+    glyph: "access",
+    required: true,
+    body: "Global hotkeys like Ctrl+Space, and letting Jarvis operate your apps. macOS never asks for this one, so without it the shortcuts quietly do nothing.",
+  },
+  screen: {
+    label: "Screen Recording",
+    glyph: "screen",
+    required: true,
+    body: "Seeing your screen for Awareness: reading what's on it, and noticing when you're stuck.",
+  },
+  microphone: {
+    label: "Microphone",
+    glyph: "mic",
+    required: false,
+    body: "Voice commands and the wake word. Jarvis will ask again the first time you talk to it.",
+  },
+  notifications: {
+    label: "Notifications",
+    glyph: "bell",
+    required: false,
+    body: "Letting Jarvis reach you when something needs a decision.",
+  },
+};
+
+/** Windows has no per-app permission model, so its one row carries a link and
+ *  no state. Worth carrying anyway: with that global switch off, capture just
+ *  fails and no prompt arrives to explain it. */
+const WINDOWS_MIC_BODY =
+  "Windows keeps one switch for every desktop app, and it can't be read from here. If the mic stays silent, check it is on.";
+
+export interface DisplayRow extends PermCopy {
+  name: string;
+  status: PermStatus;
+  /**
+   * How this row is obtained, which the button has to say out loud. "Allow"
+   * on a row that actually sends you to System Settings is a small lie that
+   * costs the user the trip: they click expecting a dialog, a window they did
+   * not ask for appears, and nothing explains what to do in it.
+   */
+  grant: PermGrant;
+  /** Can the user do anything about this row from the screen? */
+  actionable: boolean;
+  /**
+   * Does this row have a state worth drawing a dot for? False on Windows,
+   * where the mic row is a link to a switch whose position we cannot see -
+   * and a dot that never changes colour is worse than no dot.
+   */
+  hasState: boolean;
+}
+
+/**
+ * The rows to render, in the order they should appear.
+ *
+ * Ordered by what the user should deal with first: the two that fail silently,
+ * then the two that will ask again on their own. That is deliberately NOT the
+ * order the sidecar reports them in - the report's order is a wire contract,
+ * this one is an editorial judgement about attention.
+ */
+const DISPLAY_ORDER = ["accessibility", "screen", "microphone", "notifications"];
+
+export function displayRows(report: PermReport): DisplayRow[] {
+  if (!report.available) return [];
+  const byName = new Map(report.permissions.map((p) => [p.name, p]));
+  const windows = report.platform === "windows";
+
+  const rows: DisplayRow[] = [];
+  for (const name of DISPLAY_ORDER) {
+    const row = byName.get(name);
+    const copy = PERM_COPY[name];
+    // An unknown name from a newer sidecar has no copy to render it with;
+    // skipping beats inventing a label for a permission this build has never
+    // heard of.
+    if (!row || !copy) continue;
+
+    const actionable = row.grant !== "none";
+    const hasState = row.status !== "na";
+    // Nothing to show and nothing to do. This is every row on Linux, and three
+    // of the four on Windows.
+    if (!actionable && !hasState) continue;
+
+    rows.push({
+      ...copy,
+      name,
+      status: row.status,
+      grant: row.grant,
+      actionable,
+      hasState,
+      // A row with no readable state cannot be "required": the screen would be
+      // asserting something is missing when it cannot tell.
+      required: copy.required && hasState,
+      body: windows && name === "microphone" ? WINDOWS_MIC_BODY : copy.body,
+    });
+  }
+  return rows;
+}
+
+/** The required rows still not granted. Drives the summary line, not a block:
+ *  a machine under MDM may never be able to grant these, and onboarding that
+ *  cannot be finished is worse than a feature that is off. */
+export function outstandingRequired(rows: DisplayRow[]): DisplayRow[] {
+  return rows.filter((r) => r.required && r.status !== "granted");
+}
+
+/** True once nothing on screen is left to do. */
+export function allSettled(rows: DisplayRow[]): boolean {
+  return rows.every((r) => !r.hasState || r.status === "granted");
+}
+
+/**
+ * Screen Recording is the one grant that does not take effect where it is
+ * made: macOS hands a running process its old answer until the app restarts,
+ * so the row stays amber after the user has switched it on and looks broken.
+ * Say so, but only once they have actually been sent to that pane.
+ */
+export function needsRestartNote(rows: DisplayRow[], visitedScreenPane: boolean): boolean {
+  return visitedScreenPane && rows.some((r) => r.name === "screen" && r.status !== "granted");
+}
+
+/** What to say when there is no machine to ask. Each reason sends the user
+ *  somewhere different, which is the only reason they are distinguished. */
+export function unavailableCopy(reason: PermUnavailable): { title: string; body: string } {
+  switch (reason) {
+    case "offline":
+      return {
+        title: "Jarvis isn't running on this machine right now.",
+        body: "The desktop app has to be open for permissions to be read or granted. Start it and this page will catch up on its own.",
+      };
+    case "refused":
+      return {
+        title: "That can't be granted from here.",
+        body: "The desktop app declined the request. Its message is below; System Settings can still do it by hand.",
+      };
+    case "unsupported":
+      return {
+        title: "Your desktop app is older than this screen.",
+        body: "Update Jarvis on this machine to grant permissions from here. Until then, the desktop app asks for what it needs as it goes.",
+      };
+    case "ambiguous":
+      return {
+        title: "More than one machine is connected.",
+        body: "Permissions belong to one computer, and this page can't tell which one you're at. Open Jarvis on that machine and run through setup there.",
+      };
+    case "unreachable":
+      return {
+        title: "The desktop app didn't answer.",
+        body: "It may have just quit or gone to sleep. You can carry on -- Jarvis asks for what it needs as it goes -- or reopen it and come back.",
+      };
+    case "no_sidecar":
+    default:
+      return {
+        title: "Nothing to set up from here.",
+        body: "This page isn't talking to a Jarvis desktop app, so there's nothing on this computer to grant. Install or open Jarvis on the machine you want it to act on.",
+      };
+  }
+}

--- a/ui/src/v2/onboarding/permission-rows.ts
+++ b/ui/src/v2/onboarding/permission-rows.ts
@@ -16,42 +16,31 @@
  * infrastructure. Pure functions, tested directly.
  */
 
-export type PermStatus = "granted" | "denied" | "undetermined" | "na";
+/**
+ * The wire contract, imported rather than restated. The daemon owns these
+ * shapes (src/daemon/system-permissions.ts) and the dashboard already reaches
+ * into src/ for shared logic (TasksRoom's parseRelativeDate). Two hand-kept
+ * copies of a response type drift the moment either side gains a field, and
+ * the drift shows up as a row that silently stops rendering.
+ */
+export type {
+  PermissionGrantMode as PermGrant,
+  PermissionRow as PermRow,
+  PermissionStatus as PermStatus,
+  PermissionsHostInfo as PermHost,
+  PermissionsResult as PermReport,
+  PermissionsUnavailable as PermUnavailable,
+  PermissionRequestResult as PermRequestResult,
+} from "../../../../src/daemon/system-permissions";
 
-/** How a row is obtained: "prompt" finishes in the app, "pane" needs the user
- *  to flip a toggle in System Settings, "none" means nothing to do here. */
-export type PermGrant = "prompt" | "pane" | "none";
-
-export interface PermRow {
-  name: string;
-  status: PermStatus;
-  grant: PermGrant;
-}
-
-export interface PermHost {
-  id: string;
-  name: string;
-  hostname: string;
-  source: "panel" | "only_connected";
-}
-
-export type PermUnavailable =
-  | "no_sidecar"
-  | "offline"
-  | "ambiguous"
-  | "unsupported"
-  | "refused"
-  | "unreachable";
-
-export type PermReport =
-  | {
-      available: true;
-      host: PermHost;
-      platform: string;
-      bundled: boolean;
-      permissions: PermRow[];
-    }
-  | { available: false; reason: PermUnavailable; detail?: string };
+import type {
+  PermissionGrantMode as PermGrant,
+  PermissionRow as PermRow,
+  PermissionStatus as PermStatus,
+  PermissionsResult as PermReport,
+  PermissionsUnavailable as PermUnavailable,
+  PermissionRequestResult as PermRequestResult,
+} from "../../../../src/daemon/system-permissions";
 
 export interface PermCopy {
   label: string;
@@ -89,7 +78,7 @@ export const PERM_COPY: Record<string, PermCopy> = {
     label: "Accessibility",
     glyph: "access",
     required: true,
-    body: "Global hotkeys like Ctrl+Space, and letting Jarvis operate your apps. macOS never asks for this one, so without it the shortcuts quietly do nothing.",
+    body: "Global hotkeys like Ctrl+Space, and letting Jarvis operate your apps. macOS won't grant this from a dialog, so until you switch it on the shortcuts quietly do nothing.",
   },
   screen: {
     label: "Screen Recording",
@@ -183,6 +172,37 @@ export function displayRows(report: PermReport): DisplayRow[] {
   return rows;
 }
 
+/**
+ * What a request attempt should say, if anything.
+ *
+ * Extracted as a pure function because this is where the screen's whole point
+ * lives: the route answers HTTP 200 for every `available: false` outcome, so
+ * a wedged sidecar, a machine that just disconnected, and a refusal all arrive
+ * as a successful fetch. Reading only `r.ok` leaves the button resetting to
+ * its label with nothing said - which is precisely the silent click this
+ * change exists to delete. Pure, so a test can fail on it; the hook itself has
+ * no DOM harness to be tested in.
+ */
+export function requestFeedback(result: PermRequestResult | null, label: string): string | null {
+  if (!result) return "Jarvis sent an answer this page couldn't read.";
+
+  if (!result.available) {
+    const copy = unavailableCopy(result.reason);
+    return result.detail ? `${copy.title} ${result.detail}` : copy.title;
+  }
+
+  // A pane that did not open is the original bug wearing a new hat: the user
+  // is told to flip a switch in a window that never appeared. Name the pane so
+  // the trip is still makeable by hand.
+  if (result.grant === "pane" && !result.paneOpened) {
+    const where = `System Settings \u203A Privacy & Security \u203A ${label}`;
+    return result.paneError
+      ? `Jarvis couldn't open ${where} (${result.paneError}). Open it yourself.`
+      : `Jarvis couldn't open ${where}. Open it yourself.`;
+  }
+  return null;
+}
+
 /** The required rows still not granted. Drives the summary line, not a block:
  *  a machine under MDM may never be able to grant these, and onboarding that
  *  cannot be finished is worse than a feature that is off. */
@@ -232,7 +252,7 @@ export function unavailableCopy(reason: PermUnavailable): { title: string; body:
     case "unreachable":
       return {
         title: "The desktop app didn't answer.",
-        body: "It may have just quit or gone to sleep. You can carry on -- Jarvis asks for what it needs as it goes -- or reopen it and come back.",
+        body: "It may have just quit or gone to sleep. You can carry on — Jarvis asks for what it needs as it goes — or reopen it and come back.",
       };
     case "no_sidecar":
     default:

--- a/ui/src/v2/onboarding/useSystemPermissions.ts
+++ b/ui/src/v2/onboarding/useSystemPermissions.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import type { PermReport } from "./permission-rows";
+import { requestFeedback, type PermReport, type PermRequestResult, type PermUnavailable } from "./permission-rows";
 
 /**
  * Live permission state for the onboarding Permissions screen.
@@ -21,6 +21,14 @@ import type { PermReport } from "./permission-rows";
  *  700ms window, so overlapping polls cost one status read, not several. */
 const POLL_MS = 2000;
 
+/**
+ * Reasons that will not change on their own, so polling them is pure waste: an
+ * old sidecar answers METHOD_NOT_FOUND every two seconds forever, and a brain
+ * that cannot tell which of several machines this is will not learn. Both keep
+ * their manual "Check again", which is the only thing that can actually help.
+ */
+const SETTLED_REASONS: ReadonlySet<PermUnavailable> = new Set<PermUnavailable>(["unsupported", "ambiguous"]);
+
 export type PermPhase = "loading" | "ready" | "error";
 
 export interface SystemPermissions {
@@ -32,7 +40,8 @@ export interface SystemPermissions {
   /** The row currently being asked for, so its button can show it. */
   pending: string | null;
   requestError: string | null;
-  request: (name: string) => Promise<void>;
+  /** Resolves true when the settings pane actually came up. */
+  request: (name: string, label: string) => Promise<boolean>;
   refresh: () => void;
 }
 
@@ -54,7 +63,19 @@ export function useSystemPermissions(enabled: boolean): SystemPermissions {
     return () => { alive.current = false; };
   }, []);
 
+  // One fetch at a time.
+  //
+  // Two bugs in one guard. Without it a wedged sidecar - the daemon waits 8s
+  // before giving up - accumulates four or five concurrent RPCs per open tab,
+  // forever, and the sidecar's own 700ms coalescing cannot help because the
+  // sidecar is the thing not answering. And a poll that started BEFORE a grant
+  // can resolve after the re-read that observed it, writing the stale answer
+  // back over the fresh one and flickering the row green, amber, green.
+  const inFlight = useRef(false);
+
   const load = useCallback(async () => {
+    if (inFlight.current) return;
+    inFlight.current = true;
     try {
       const r = await fetch("/api/system/permissions");
       if (!r.ok) throw new Error(`HTTP ${r.status}`);
@@ -70,17 +91,28 @@ export function useSystemPermissions(enabled: boolean): SystemPermissions {
       // rows vanishing and reappearing reads as breakage.
       setError(e instanceof Error ? e.message : String(e));
       setPhase((p) => (p === "loading" ? "error" : p));
+    } finally {
+      inFlight.current = false;
     }
   }, []);
+
+  // Whether there is any point asking again. Read through a ref so changing it
+  // does not tear down and rebuild the interval on every poll.
+  const settled = report !== null && !report.available && SETTLED_REASONS.has(report.reason);
+  const settledRef = useRef(settled);
+  settledRef.current = settled;
 
   useEffect(() => {
     if (!enabled) return;
     void load();
-    const id = setInterval(() => { void load(); }, POLL_MS);
+    const id = setInterval(() => {
+      if (settledRef.current) return;
+      void load();
+    }, POLL_MS);
     return () => clearInterval(id);
   }, [enabled, load, tick]);
 
-  const request = useCallback(async (name: string) => {
+  const request = useCallback(async (name: string, label: string): Promise<boolean> => {
     setPending(name);
     setRequestError(null);
     try {
@@ -89,29 +121,24 @@ export function useSystemPermissions(enabled: boolean): SystemPermissions {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ name }),
       });
-      const data = await r.json().catch(() => null);
+      const data = (await r.json().catch(() => null)) as
+        | (PermRequestResult & { error?: string })
+        | { error?: string }
+        | null;
       if (!r.ok) {
         throw new Error((data as { error?: string } | null)?.error || `HTTP ${r.status}`);
       }
-      if (!alive.current) return;
+      if (!alive.current) return false;
 
-      const result = data as
-        | { available: true; paneOpened: boolean; paneError?: string; grant: string }
-        | { available: false; reason: string }
-        | null;
-
-      // A pane that did not open is the original bug wearing a new hat: the
-      // user is told to go and flip a switch in a window that never appeared.
-      // Say it plainly and name the pane, so the trip is still makeable by
-      // hand.
-      if (result && result.available && result.grant === "pane" && !result.paneOpened) {
-        setRequestError(
-          "Jarvis couldn't open System Settings. Open it yourself: Privacy & Security, then the section named below.",
-        );
-      }
+      // The route answers 200 for every `available: false` outcome, so `r.ok`
+      // is not the question. requestFeedback is where that is decided.
+      const result = data as PermRequestResult | null;
+      setRequestError(requestFeedback(result, label));
+      return result?.available === true && result.grant === "pane" && result.paneOpened;
     } catch (e) {
-      if (!alive.current) return;
+      if (!alive.current) return false;
       setRequestError(e instanceof Error ? e.message : String(e));
+      return false;
     } finally {
       if (alive.current) setPending(null);
       // Re-read straight away rather than waiting out the poll: a "prompt"
@@ -121,7 +148,13 @@ export function useSystemPermissions(enabled: boolean): SystemPermissions {
     }
   }, [load]);
 
-  const refresh = useCallback(() => setTick((n) => n + 1), []);
+  const refresh = useCallback(() => {
+    // Back to "loading" so a retry against a still-dead brain visibly does
+    // something. Without it the button is decorative: the same error text sits
+    // there and nothing on screen changes.
+    setPhase("loading");
+    setTick((n) => n + 1);
+  }, []);
 
   return { phase, report, error, pending, requestError, request, refresh };
 }

--- a/ui/src/v2/onboarding/useSystemPermissions.ts
+++ b/ui/src/v2/onboarding/useSystemPermissions.ts
@@ -1,0 +1,127 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { PermReport } from "./permission-rows";
+
+/**
+ * Live permission state for the onboarding Permissions screen.
+ *
+ * Polling is the whole point. Two of the four rows have no dialog on macOS:
+ * the user leaves for System Settings, flips a toggle, and comes back, and
+ * nothing tells the page that happened. The row going green while they watch
+ * is the only feedback the OS makes possible, and it is what the old static
+ * screen could not do at all.
+ *
+ * Runs ONLY while the screen is mounted and `enabled`. The wizard renders one
+ * step at a time and a user can sit on a later step for many minutes; a poll
+ * left running would be a request every two seconds into a screen nobody is
+ * looking at.
+ */
+
+/** Slow enough not to hammer an RPC round trip, fast enough that coming back
+ *  from System Settings feels immediate. The sidecar coalesces reads inside a
+ *  700ms window, so overlapping polls cost one status read, not several. */
+const POLL_MS = 2000;
+
+export type PermPhase = "loading" | "ready" | "error";
+
+export interface SystemPermissions {
+  phase: PermPhase;
+  report: PermReport | null;
+  /** Transport failure - the brain itself could not be reached. Distinct from
+   *  a report that says `available: false`, which IS an answer. */
+  error: string | null;
+  /** The row currently being asked for, so its button can show it. */
+  pending: string | null;
+  requestError: string | null;
+  request: (name: string) => Promise<void>;
+  refresh: () => void;
+}
+
+export function useSystemPermissions(enabled: boolean): SystemPermissions {
+  const [report, setReport] = useState<PermReport | null>(null);
+  const [phase, setPhase] = useState<PermPhase>("loading");
+  const [error, setError] = useState<string | null>(null);
+  const [pending, setPending] = useState<string | null>(null);
+  const [requestError, setRequestError] = useState<string | null>(null);
+  const [tick, setTick] = useState(0);
+
+  // Guards every setState after an await. The screen is one step of a wizard
+  // the user can leave mid-flight, and a poll resolving into an unmounted
+  // component is a React warning at best and a state write that resurrects a
+  // stale report at worst.
+  const alive = useRef(true);
+  useEffect(() => {
+    alive.current = true;
+    return () => { alive.current = false; };
+  }, []);
+
+  const load = useCallback(async () => {
+    try {
+      const r = await fetch("/api/system/permissions");
+      if (!r.ok) throw new Error(`HTTP ${r.status}`);
+      const data = (await r.json()) as PermReport;
+      if (!alive.current) return;
+      setReport(data);
+      setPhase("ready");
+      setError(null);
+    } catch (e) {
+      if (!alive.current) return;
+      // Keep the last good report on screen rather than blanking the rows on
+      // one dropped poll: a panel's socket flaps when the machine sleeps, and
+      // rows vanishing and reappearing reads as breakage.
+      setError(e instanceof Error ? e.message : String(e));
+      setPhase((p) => (p === "loading" ? "error" : p));
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!enabled) return;
+    void load();
+    const id = setInterval(() => { void load(); }, POLL_MS);
+    return () => clearInterval(id);
+  }, [enabled, load, tick]);
+
+  const request = useCallback(async (name: string) => {
+    setPending(name);
+    setRequestError(null);
+    try {
+      const r = await fetch("/api/system/permissions/request", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name }),
+      });
+      const data = await r.json().catch(() => null);
+      if (!r.ok) {
+        throw new Error((data as { error?: string } | null)?.error || `HTTP ${r.status}`);
+      }
+      if (!alive.current) return;
+
+      const result = data as
+        | { available: true; paneOpened: boolean; paneError?: string; grant: string }
+        | { available: false; reason: string }
+        | null;
+
+      // A pane that did not open is the original bug wearing a new hat: the
+      // user is told to go and flip a switch in a window that never appeared.
+      // Say it plainly and name the pane, so the trip is still makeable by
+      // hand.
+      if (result && result.available && result.grant === "pane" && !result.paneOpened) {
+        setRequestError(
+          "Jarvis couldn't open System Settings. Open it yourself: Privacy & Security, then the section named below.",
+        );
+      }
+    } catch (e) {
+      if (!alive.current) return;
+      setRequestError(e instanceof Error ? e.message : String(e));
+    } finally {
+      if (alive.current) setPending(null);
+      // Re-read straight away rather than waiting out the poll: a "prompt"
+      // permission can be granted in the dialog within a second, and the row
+      // should follow the click, not the timer.
+      void load();
+    }
+  }, [load]);
+
+  const refresh = useCallback(() => setTick((n) => n + 1), []);
+
+  return { phase, report, error, pending, requestError, request, refresh };
+}


### PR DESCRIPTION
The onboarding wizard's Permissions screen didn't work. Every row called `window.open("x-apple.systempreferences:...")`, and a panel routes `window.open` through the sidecar host, which allowlists http(s) only (`isExternallyOpenable`, `panels_extnav.go`) - so the scheme was dropped with a log line and no window ever appeared. An ordinary browser blocks it too. The page also read no status at all, so granted and denied looked identical. Four buttons that could neither grant a permission nor tell whether it had been granted.

Two of the four rows couldn't have worked even with a working link. The Automation and Files & Folders panes are empty until the app has already asked, so there is nothing to pre-grant and the list the user lands on doesn't contain Jarvis. The "Files & Folders" row also pointed at `Privacy_AllFiles`, which is Full Disk Access - a much broader grant than the row described.

## What I did

Kept the screen, because two macOS permissions genuinely do need granting up front, and made it real by putting it on the code that already works: the same `setup_permissions_{darwin,other}.go` the native `jarvis --setup` wizard drives. One source of truth, so the two screens can't disagree.

- **Sidecar**: `system.permissions` and `system.request_permission` RPCs. Status reads are coalesced behind a short freshness deadline so a 2s poll can't stack overlapping reads. Pane launches are reaped and their exit observed, instead of fire-and-forget `.Start()`. Requesting is refused when the process has no bundle identity, since a bare binary would register *Terminal* in the Screen Recording list and report it as Jarvis.
- **Daemon**: `GET /api/system/permissions` and `POST /api/system/permissions/request`, answering about the one machine the page is being looked at on. That's the panel session when there is one; a session whose sidecar is briefly offline reports `offline` rather than falling through to whatever else happens to be connected, or the wizard would show and act on a different computer. The POST requires a JSON content type so an `insecure_open_access` install can't have TCC dialogs popped by a drive-by page.
- **Wizard**: rows come from that endpoint, poll while the screen is up, and turn green as the user grants. Accessibility and Screen Recording are marked required because they fail *silently* on macOS - no dialog is ever shown, and without them Ctrl+Space and awareness just don't work. Microphone and Notifications aren't, since both ask again at the point of use. Automation and Files & Folders are gone, replaced by a line saying macOS asks for those in the moment. Platform now comes from the sidecar's `runtime.GOOS` rather than the user agent, which is what `platform.ts`'s own comment asks for.

Windows gets its microphone link back working through the same path. Linux shows nothing, as before.

## Notes

- **Continue is never blocked on a grant.** A managed Mac can refuse these outright, and onboarding you can't finish is worse than a feature that's off - so the screen names what will stay broken and lets the user decide.
- The macOS cgo additions can't be compiled on a Linux box; they're marked `COMPILE-UNVERIFIED` like the other darwin files and want a check on a Mac.
- `getCookie` moved out of `websocket.ts` into `src/util/cookie.ts` so the routes and the auth path share one parser. It picked up a regex escape and a test suite on the way.

## Testing

`bun test` green (the pre-commit hook runs it), full Go suite green, UI bundles. New: 12 Go tests, 22 daemon tests, 6 cookie tests, 19 row-model tests.
