### PR TITLE
Compose workflows on the high tier, not the medium one

### DIFF
--- a/src/actions/tools/composer-llm.test.ts
+++ b/src/actions/tools/composer-llm.test.ts
@@ -70,6 +70,9 @@ beforeEach(() => {
 
 afterEach(() => {
   closeDb();
+  // Leave no resolver pointing at a closed handle for the next file, the way
+  // usage.test.ts / provider.test.ts / realtime-voice.test.ts each finish.
+  setUsageDatabase(() => null);
 });
 
 describe("createComposerLlmClient: which model writes the workflow", () => {
@@ -243,6 +246,7 @@ describe("createComposerLlmClient: errors the composer depends on", () => {
     const client = createComposerLlmClient(managerWith({ high, medium }));
 
     expect(await client.chat({ prompt: "x" })).toEqual({ text: "{}" });
+    expect(high.calls).toHaveLength(1); // tried first, once, then handed over
     expect(medium.calls).toHaveLength(1);
   });
 });

--- a/src/actions/tools/composer-llm.test.ts
+++ b/src/actions/tools/composer-llm.test.ts
@@ -1,5 +1,8 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { closeDb, initDatabase } from "../../vault/schema.ts";
 import { LLMManager } from "../../llm/manager.ts";
+import { classifyErrorString, LLMProviderError } from "../../llm/provider.ts";
+import { queryUsage, setUsageDatabase } from "../../llm/usage.ts";
 import type {
   LLMMessage,
   LLMOptions,
@@ -32,7 +35,12 @@ class RecordingProvider implements LLMProvider {
   }
 }
 
-/** A manager whose tiers map to the providers given, by tier name. */
+/**
+ * A manager whose tiers map to the providers given, by tier name. Real
+ * `LLMManager`, fake providers -- so tier resolution, fall-up and failover are
+ * the production code, not a stand-in. (Registration order also decides the
+ * legacy primary, which only matters to the empty-tier-map test below.)
+ */
 function managerWith(tiers: Partial<Record<"high" | "medium" | "low", RecordingProvider>>): LLMManager {
   const m = new LLMManager();
   const map: Record<string, { provider: string }> = {};
@@ -44,10 +52,30 @@ function managerWith(tiers: Partial<Record<"high" | "medium" | "low", RecordingP
   return m;
 }
 
+/**
+ * The usage rows this test file's calls produced, newest first. `groupBy:
+ * "none"` returns the ungrouped rows under `raw`; `rows` stays empty.
+ */
+function usageRows(): Array<Record<string, unknown>> {
+  return (queryUsage({}, "none").raw ?? []) as Array<Record<string, unknown>>;
+}
+
+beforeEach(() => {
+  // recordUsage is best-effort and silently no-ops without a database, so the
+  // label assertions below need a real one.
+  closeDb();
+  const db = initDatabase(":memory:", { quiet: true });
+  setUsageDatabase(() => db);
+});
+
+afterEach(() => {
+  closeDb();
+});
+
 describe("createComposerLlmClient: which model writes the workflow", () => {
   test("composes on the high tier, not medium", async () => {
     // The bug this exists to prevent: the composer used the deprecated
-    // LLMManager.chat(), which routes every call to the medium tier.
+    // LLMManager.chat(), which routes to whatever `medium` resolves to.
     const high = new RecordingProvider("high-model");
     const medium = new RecordingProvider("medium-model");
     const client = createComposerLlmClient(managerWith({ high, medium }));
@@ -56,6 +84,21 @@ describe("createComposerLlmClient: which model writes the workflow", () => {
 
     expect(high.calls).toHaveLength(1);
     expect(medium.calls).toHaveLength(0);
+  });
+
+  test("books the spend to workflow_composer, not legacy", async () => {
+    // The other half of the original bug: the deprecated path labels every
+    // call `legacy`, so workflow composition was not merely on the wrong
+    // model, it was invisible in per-subsystem usage reporting.
+    const high = new RecordingProvider("high-model");
+    const client = createComposerLlmClient(managerWith({ high }));
+
+    await client.chat({ prompt: "x" });
+
+    const rows = usageRows();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.subsystem).toBe("workflow_composer");
+    expect(rows[0]!.tier).toBe("high");
   });
 
   test("the tool-calling path uses the high tier too", async () => {
@@ -69,14 +112,22 @@ describe("createComposerLlmClient: which model writes the workflow", () => {
     expect(medium.calls).toHaveLength(0);
   });
 
-  test("falls up to medium when no high tier is configured", async () => {
-    // A single-model install must keep working with no tier wiring at all.
+  test("falls up to medium when only a medium tier is configured", async () => {
+    // Not the single-model case -- `llm.default` populates low/medium/high
+    // with the same ref, so those resolve `high` directly. This is the install
+    // that sets only `llm.tiers.medium`, or whose `high` ref names a provider
+    // that was never registered and got dropped.
     const medium = new RecordingProvider("medium-model");
     const client = createComposerLlmClient(managerWith({ medium }));
 
     await client.chat({ prompt: "x" });
 
     expect(medium.calls).toHaveLength(1);
+    // Requested high, served by medium: a shape only chatTier('high') makes,
+    // so this stays load-bearing if someone reverts the routing.
+    const [row] = usageRows();
+    expect(row?.tier).toBe("high");
+    expect(row?.resolved_tier).toBe("medium");
   });
 
   test("fails loudly, not silently, when no task tier is configured at all", async () => {
@@ -89,6 +140,10 @@ describe("createComposerLlmClient: which model writes the workflow", () => {
     // be first is exactly the invisible routing this module exists to end,
     // every other task-tier subsystem (sub_agent, vault_extractor, goals)
     // already throws on such a config, and the error names the setting to fix.
+    //
+    // This IS user-visible: an install that registers providers but sets
+    // neither `llm.default` nor `llm.tiers` could compose before and now
+    // cannot. That is the intended trade, not a regression to fix later.
     const orphan = new RecordingProvider("registered-but-untiered");
     const m = new LLMManager();
     m.registerProvider(orphan);
@@ -143,10 +198,12 @@ describe("createComposerLlmClient: request shape", () => {
 });
 
 describe("createComposerLlmClient: errors the composer depends on", () => {
-  test("a rejected `tools` parameter still reaches the composer", async () => {
-    // composeWithTools CATCHES this and falls back to the one-shot prompt.
-    // If tier routing ever swallowed it, a model without tool support would
-    // dead-end instead of composing.
+  test("a rejected `tools` parameter still reaches the composer, classifiable", async () => {
+    // composeWithTools CATCHES this and falls back to the one-shot prompt --
+    // but only for codes outside {rate_limit, network, server, auth,
+    // forbidden}. So what has to survive the manager's rewrapping is not the
+    // wording, it is the CLASSIFICATION. Assert the thing the composer
+    // actually branches on.
     const high = new RecordingProvider("high-model", new Error("tools is not supported by this model"));
     const client = createComposerLlmClient(managerWith({ high }));
 
@@ -156,14 +213,16 @@ describe("createComposerLlmClient: errors the composer depends on", () => {
     } catch (e) {
       caught = e;
     }
-    expect(caught).toBeInstanceOf(Error);
-    // The composer classifies the failure off the message text.
-    expect((caught as Error).message).toContain("tools is not supported");
+    expect(caught).toBeInstanceOf(LLMProviderError);
+    expect((caught as LLMProviderError).code).toBe("unknown");
+    expect(classifyErrorString((caught as Error).message)).toBe("unknown");
   });
 
-  test("does not fail over to the medium tier on a non-retryable error", async () => {
-    // Falling back to the weaker model on a bad request would silently undo
-    // the whole point of routing composition to `high`.
+  test("a request the high model itself rejects is not re-sent to medium", async () => {
+    // Quietly re-running a rejected compose on the weaker model would undo
+    // the point of routing to `high`. Note this holds for errors the manager
+    // classifies as `unknown`; see the next test for the ones where failover
+    // is deliberate manager policy.
     const high = new RecordingProvider("high-model", new Error("tools is not supported by this model"));
     const medium = new RecordingProvider("medium-model");
     const client = createComposerLlmClient(managerWith({ high, medium }));
@@ -171,6 +230,20 @@ describe("createComposerLlmClient: errors the composer depends on", () => {
     await expect(client.chat({ prompt: "x" })).rejects.toThrow();
     expect(medium.calls).toHaveLength(0);
     expect(high.calls).toHaveLength(1); // no retry storm either
+  });
+
+  test("but a decommissioned high model DOES fall over to medium", async () => {
+    // `shouldFailOver` crosses the provider boundary when the upstream says
+    // the MODEL is gone -- otherwise a retired high-tier model would take
+    // workflow composition down entirely rather than degrade to medium.
+    // Pinned because it is a real hole in "composition always runs on high",
+    // and someone reading only the test above would not expect it.
+    const high = new RecordingProvider("high-model", new Error("404 model not found: this model has been decommissioned"));
+    const medium = new RecordingProvider("medium-model", { content: "{}" });
+    const client = createComposerLlmClient(managerWith({ high, medium }));
+
+    expect(await client.chat({ prompt: "x" })).toEqual({ text: "{}" });
+    expect(medium.calls).toHaveLength(1);
   });
 });
 
@@ -185,11 +258,23 @@ describe("createComposerLlmClient: reply projection", () => {
     expect(await client.chat({ prompt: "x" })).toEqual({ text: '{"displayName":"X"}' });
   });
 
-  test("yields empty text rather than a non-string body", async () => {
-    const high = new RecordingProvider("high-model", { content: [{ type: "text" }] as unknown as string });
-    const client = createComposerLlmClient(managerWith({ high }));
+  test("yields empty text on a non-string body, and logs why", async () => {
+    // A content-block body cannot become a workflow tree, so the compose
+    // still fails its parse -- but silently returning "" is what made the
+    // original `reply.text` bug take four attempts to even look like a
+    // provider problem, so the adapter says so on the way past.
+    const warnings: string[] = [];
+    const realWarn = console.warn;
+    console.warn = (...args: unknown[]) => { warnings.push(args.join(" ")); };
+    try {
+      const high = new RecordingProvider("high-model", { content: [{ type: "text" }] as unknown as string });
+      const client = createComposerLlmClient(managerWith({ high }));
 
-    expect(await client.chat({ prompt: "x" })).toEqual({ text: "" });
+      expect(await client.chat({ prompt: "x" })).toEqual({ text: "" });
+    } finally {
+      console.warn = realWarn;
+    }
+    expect(warnings.join(" ")).toContain("non-string content body");
   });
 
   test("surfaces tool_calls and finish_reason for the tool loop", async () => {

--- a/src/actions/tools/composer-llm.test.ts
+++ b/src/actions/tools/composer-llm.test.ts
@@ -1,0 +1,219 @@
+import { describe, expect, test } from "bun:test";
+import { LLMManager } from "../../llm/manager.ts";
+import type {
+  LLMMessage,
+  LLMOptions,
+  LLMProvider,
+  LLMResponse,
+  LLMStreamEvent,
+} from "../../llm/provider.ts";
+import { createComposerLlmClient } from "./composer-llm.ts";
+
+type Call = { messages: LLMMessage[]; options?: LLMOptions };
+
+/** Records what it was asked, answers with whatever the test supplied. */
+class RecordingProvider implements LLMProvider {
+  public calls: Call[] = [];
+  constructor(
+    public readonly name: string,
+    private readonly reply: Partial<LLMResponse> | Error = { content: "{}" },
+  ) {}
+  async chat(messages: LLMMessage[], options?: LLMOptions): Promise<LLMResponse> {
+    this.calls.push({ messages, options });
+    if (this.reply instanceof Error) throw this.reply;
+    return { content: "", model: this.name, ...this.reply } as LLMResponse;
+  }
+  // eslint-disable-next-line require-yield
+  async *stream(): AsyncIterable<LLMStreamEvent> {
+    throw new Error("not used");
+  }
+  async listModels(): Promise<string[]> {
+    return [];
+  }
+}
+
+/** A manager whose tiers map to the providers given, by tier name. */
+function managerWith(tiers: Partial<Record<"high" | "medium" | "low", RecordingProvider>>): LLMManager {
+  const m = new LLMManager();
+  const map: Record<string, { provider: string }> = {};
+  for (const [tier, provider] of Object.entries(tiers)) {
+    m.registerProvider(provider!);
+    map[tier] = { provider: provider!.name };
+  }
+  m.setTierMap(map);
+  return m;
+}
+
+describe("createComposerLlmClient: which model writes the workflow", () => {
+  test("composes on the high tier, not medium", async () => {
+    // The bug this exists to prevent: the composer used the deprecated
+    // LLMManager.chat(), which routes every call to the medium tier.
+    const high = new RecordingProvider("high-model");
+    const medium = new RecordingProvider("medium-model");
+    const client = createComposerLlmClient(managerWith({ high, medium }));
+
+    await client.chat({ prompt: "every morning at 8, summarize my inbox" });
+
+    expect(high.calls).toHaveLength(1);
+    expect(medium.calls).toHaveLength(0);
+  });
+
+  test("the tool-calling path uses the high tier too", async () => {
+    const high = new RecordingProvider("high-model", { content: "", tool_calls: [] });
+    const medium = new RecordingProvider("medium-model");
+    const client = createComposerLlmClient(managerWith({ high, medium }));
+
+    await client.chatTools!([{ role: "user", content: "build it" }], []);
+
+    expect(high.calls).toHaveLength(1);
+    expect(medium.calls).toHaveLength(0);
+  });
+
+  test("falls up to medium when no high tier is configured", async () => {
+    // A single-model install must keep working with no tier wiring at all.
+    const medium = new RecordingProvider("medium-model");
+    const client = createComposerLlmClient(managerWith({ medium }));
+
+    await client.chat({ prompt: "x" });
+
+    expect(medium.calls).toHaveLength(1);
+  });
+
+  test("fails loudly, not silently, when no task tier is configured at all", async () => {
+    // `configureLLMTiers` can produce an EMPTY tier map (no llm.default, no
+    // llm.tiers, or every ref naming an unregistered provider), and nothing
+    // calls `validateTierMap` in production. The deprecated `chat()` used to
+    // paper over that by dropping to the legacy primary-provider chain.
+    //
+    // Deliberately not preserved. Composing on whatever provider happened to
+    // be first is exactly the invisible routing this module exists to end,
+    // every other task-tier subsystem (sub_agent, vault_extractor, goals)
+    // already throws on such a config, and the error names the setting to fix.
+    const orphan = new RecordingProvider("registered-but-untiered");
+    const m = new LLMManager();
+    m.registerProvider(orphan);
+    m.setTierMap({});
+    const client = createComposerLlmClient(m);
+
+    await expect(client.chat({ prompt: "x" })).rejects.toThrow(/No provider configured for tier/);
+    expect(orphan.calls).toHaveLength(0);
+  });
+});
+
+describe("createComposerLlmClient: request shape", () => {
+  test("sends system then user, and caps output on both paths", async () => {
+    // The cap is load-bearing: Ollama's default num_predict is 128, which
+    // truncates every compose reply mid-JSON. Both paths must agree on it or
+    // truncation bugs become unreproducible.
+    const high = new RecordingProvider("high-model", { content: "{}", tool_calls: [] });
+    const client = createComposerLlmClient(managerWith({ high }));
+
+    await client.chat({ system: "you are the composer", prompt: "make a flow" });
+    expect(high.calls[0]!.messages).toEqual([
+      { role: "system", content: "you are the composer" },
+      { role: "user", content: "make a flow" },
+    ]);
+    expect(high.calls[0]!.options?.max_tokens).toBe(8192);
+
+    await client.chatTools!([{ role: "user", content: "make a flow" }], []);
+    expect(high.calls[1]!.options?.max_tokens).toBe(8192);
+  });
+
+  test("omits the system message when the composer sends none", async () => {
+    const high = new RecordingProvider("high-model");
+    const client = createComposerLlmClient(managerWith({ high }));
+
+    await client.chat({ prompt: "just the user turn" });
+
+    expect(high.calls[0]!.messages).toEqual([{ role: "user", content: "just the user turn" }]);
+  });
+
+  test("passes the composer's tools through with tool_choice auto", async () => {
+    const high = new RecordingProvider("high-model", { content: "", tool_calls: [] });
+    const client = createComposerLlmClient(managerWith({ high }));
+    const tools = [
+      { name: "list_pieces", description: "List installed pieces.", parameters: { type: "object" as const, properties: {} } },
+    ];
+
+    await client.chatTools!([{ role: "user", content: "build it" }], tools);
+
+    expect(high.calls[0]!.options?.tools).toEqual(tools);
+    expect(high.calls[0]!.options?.tool_choice).toBe("auto");
+  });
+});
+
+describe("createComposerLlmClient: errors the composer depends on", () => {
+  test("a rejected `tools` parameter still reaches the composer", async () => {
+    // composeWithTools CATCHES this and falls back to the one-shot prompt.
+    // If tier routing ever swallowed it, a model without tool support would
+    // dead-end instead of composing.
+    const high = new RecordingProvider("high-model", new Error("tools is not supported by this model"));
+    const client = createComposerLlmClient(managerWith({ high }));
+
+    let caught: unknown;
+    try {
+      await client.chatTools!([{ role: "user", content: "build it" }], []);
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(Error);
+    // The composer classifies the failure off the message text.
+    expect((caught as Error).message).toContain("tools is not supported");
+  });
+
+  test("does not fail over to the medium tier on a non-retryable error", async () => {
+    // Falling back to the weaker model on a bad request would silently undo
+    // the whole point of routing composition to `high`.
+    const high = new RecordingProvider("high-model", new Error("tools is not supported by this model"));
+    const medium = new RecordingProvider("medium-model");
+    const client = createComposerLlmClient(managerWith({ high, medium }));
+
+    await expect(client.chat({ prompt: "x" })).rejects.toThrow();
+    expect(medium.calls).toHaveLength(0);
+    expect(high.calls).toHaveLength(1); // no retry storm either
+  });
+});
+
+describe("createComposerLlmClient: reply projection", () => {
+  test("returns the assistant text from `content`", async () => {
+    // An earlier version of this adapter read `reply.text`, which does not
+    // exist on the response shape: every compose returned "" and the parse
+    // died with EOF.
+    const high = new RecordingProvider("high-model", { content: '{"displayName":"X"}' });
+    const client = createComposerLlmClient(managerWith({ high }));
+
+    expect(await client.chat({ prompt: "x" })).toEqual({ text: '{"displayName":"X"}' });
+  });
+
+  test("yields empty text rather than a non-string body", async () => {
+    const high = new RecordingProvider("high-model", { content: [{ type: "text" }] as unknown as string });
+    const client = createComposerLlmClient(managerWith({ high }));
+
+    expect(await client.chat({ prompt: "x" })).toEqual({ text: "" });
+  });
+
+  test("surfaces tool_calls and finish_reason for the tool loop", async () => {
+    // The loop reads finish_reason to tell a reply truncated at the token cap
+    // (a dropped submit_flow) from a genuine prose answer.
+    const high = new RecordingProvider("high-model", {
+      content: "",
+      tool_calls: [{ id: "1", name: "submit_flow", arguments: { displayName: "X" } }],
+      finish_reason: "tool_use",
+    });
+    const client = createComposerLlmClient(managerWith({ high }));
+
+    const reply = await client.chatTools!([{ role: "user", content: "build it" }], []);
+    expect(reply.tool_calls).toHaveLength(1);
+    expect(reply.tool_calls?.[0]?.name).toBe("submit_flow");
+    expect(reply.finish_reason).toBe("tool_use");
+  });
+
+  test("defaults tool_calls to an empty array when the provider omits them", async () => {
+    const high = new RecordingProvider("high-model", { content: "no tools for you" });
+    const client = createComposerLlmClient(managerWith({ high }));
+
+    const reply = await client.chatTools!([{ role: "user", content: "build it" }], []);
+    expect(reply.tool_calls).toEqual([]);
+    expect(reply.content).toBe("no tools for you");
+  });
+});

--- a/src/actions/tools/composer-llm.ts
+++ b/src/actions/tools/composer-llm.ts
@@ -7,6 +7,9 @@
  * at all -- which is how it went unnoticed that every workflow the user asked
  * for was being written by whichever model backs the `medium` tier.
  *
+ * Composing now runs on `high`, labelled `workflow_composer` -- see the two
+ * constants below for why.
+ *
  * The composer's own contract (`ComposerLlmClient`) is deliberately narrow:
  * `chat` is the mandatory single-shot path, `chatTools` the optional
  * tool-calling one. This module is the only place that maps those onto
@@ -15,6 +18,7 @@
 
 import type { LLMManager } from "../../llm/manager.ts";
 import type { LLMMessage, LLMOptions } from "../../llm/provider.ts";
+import type { Tier } from "../../llm/tiers.ts";
 import type {
   ComposerChatMessage,
   ComposerChatReply,
@@ -36,11 +40,45 @@ import type {
 const COMPOSER_MAX_TOKENS = 8192;
 
 /**
+ * Composing runs on the `high` tier.
+ *
+ * It is the most reasoning-dense thing `manage_workflow` does: read a catalog
+ * of piece contracts, choose pieces, wire `{{step.field}}` references against
+ * each upstream step's DECLARED output shape, match router operators to the
+ * real type of the value they test, satisfy every required input, and write
+ * commands for the OS of the machine the step lands on. Getting any one of
+ * those wrong produces a flow that validates today and fails on its first
+ * real run.
+ *
+ * It is also the tier decision with the least cost pressure behind it.
+ * Composing is user-initiated and rare (a handful of times per workflow, not
+ * per turn), and `composeFlow` already retries up to four times because
+ * weaker models need two or three attempts to emit a valid tree -- each retry
+ * being another full catalog-sized prompt. A model that gets it right first
+ * time is frequently the cheaper one here.
+ *
+ * `high` falls up to `medium` on its own when no high tier is configured
+ * (see TIER_FALLBACK in src/llm/tiers.ts), so a single-model install keeps
+ * working with no wiring at all.
+ */
+const COMPOSER_TIER: Tier = "high";
+
+/**
+ * Usage label for the composer's spend.
+ *
+ * The old path went through the deprecated `LLMManager.chat()`, which books
+ * every call to the subsystem `legacy` -- so workflow composition was not
+ * merely running on the wrong tier, it was invisible in per-subsystem usage
+ * reporting. Anything that reads `llm_usage` groups on this string.
+ */
+const COMPOSER_SUBSYSTEM = "workflow_composer";
+
+/**
  * Build the composer's LLM client over the daemon's `LLMManager`.
  */
 export function createComposerLlmClient(manager: LLMManager): ComposerLlmClient {
   const call = (messages: LLMMessage[], options: LLMOptions) =>
-    manager.chat(messages, options);
+    manager.chatTier(COMPOSER_TIER, COMPOSER_SUBSYSTEM, messages, options);
 
   return {
     async chat(input: { prompt: string; system?: string }): Promise<{ text: string }> {

--- a/src/actions/tools/composer-llm.ts
+++ b/src/actions/tools/composer-llm.ts
@@ -6,8 +6,8 @@
  * decision this consequential disappears, and inline it could not be tested
  * at all -- which is how it went unnoticed that workflow composition was
  * running on the deprecated `LLMManager.chat()`, i.e. whatever `medium`
- * resolved to (or, with no tier map at all, the legacy primary-provider
- * chain), billed to the subsystem label `legacy`.
+ * resolved to, billed to the subsystem label `legacy` -- or, with no tier map
+ * at all, the legacy primary-provider chain, which records no usage whatever.
  *
  * Composing now runs on `high`, labelled `workflow_composer` -- see the two
  * constants below for why.
@@ -67,13 +67,22 @@ const COMPOSER_MAX_TOKENS = 8192;
  *
  * The other thing `high` changes is wall time. `LLMManager.REQUEST_TIMEOUT_MS`
  * is a fixed 90s with no per-call override, and both paths here ask for up to
- * 8192 output tokens. A slow high-tier model (a reasoning model, or a large
- * local one) is likelier to cross that than a medium one was; a timeout
- * classifies as `network`, which is retried up to three times per provider,
- * and which the tool loop refuses to fall back to one-shot on. If composes
- * start dying after minutes rather than seconds, that ceiling is where to
- * look -- raising it means giving LLMOptions a timeout, which is a change to
- * shared LLM infrastructure and deliberately not made here.
+ * 8192 output tokens, so a slow high-tier model (a reasoning model, or a
+ * large local one) is likelier to cross it than a medium one was.
+ *
+ * What happens then, precisely, because it is not what the manager's own
+ * retry policy suggests: `withTimeout` rejects with "... timed out after
+ * 90000ms", and both `classifyErrorString` and `shouldRetry` look for the
+ * substring "timeout", which that message does not contain. So the failure
+ * classifies as `unknown`: it is NOT retried, and on tool-loop turn 1 the
+ * composer treats it as a tools-unsupported signal and falls back to the
+ * one-shot prompt, which can burn another 90s before failing. Budget ~180s
+ * worst case, and do not expect to see it retried.
+ *
+ * (That "timed out" / "timeout" mismatch is a latent bug in the manager
+ * affecting every subsystem, not something this module should paper over.
+ * Raising the ceiling would mean giving LLMOptions a timeout, which is a
+ * change to shared LLM infrastructure and deliberately not made here.)
  *
  * `high` falls up to `medium` on its own (see TIER_FALLBACK in
  * src/llm/tiers.ts). That matters for an install that configures only
@@ -113,7 +122,8 @@ function textOf(content: unknown): string {
   if (typeof content === "string") return content;
   console.warn(
     `[composer] LLM returned a non-string content body (${typeof content}); ` +
-      `treating it as empty. The compose will fail its JSON parse.`,
+      `dropping the assistant text. A one-shot compose will now fail its JSON ` +
+      `parse; a tool-loop turn carries on if it also returned tool_calls.`,
   );
   return "";
 }

--- a/src/actions/tools/composer-llm.ts
+++ b/src/actions/tools/composer-llm.ts
@@ -4,8 +4,10 @@
  * Lives here rather than inline in the daemon's boot sequence for two
  * reasons: the daemon file is five thousand lines of wiring where a routing
  * decision this consequential disappears, and inline it could not be tested
- * at all -- which is how it went unnoticed that every workflow the user asked
- * for was being written by whichever model backs the `medium` tier.
+ * at all -- which is how it went unnoticed that workflow composition was
+ * running on the deprecated `LLMManager.chat()`, i.e. whatever `medium`
+ * resolved to (or, with no tier map at all, the legacy primary-provider
+ * chain), billed to the subsystem label `legacy`.
  *
  * Composing now runs on `high`, labelled `workflow_composer` -- see the two
  * constants below for why.
@@ -52,14 +54,33 @@ const COMPOSER_MAX_TOKENS = 8192;
  *
  * It is also the tier decision with the least cost pressure behind it.
  * Composing is user-initiated and rare (a handful of times per workflow, not
- * per turn), and `composeFlow` already retries up to four times because
- * weaker models need two or three attempts to emit a valid tree -- each retry
- * being another full catalog-sized prompt. A model that gets it right first
- * time is frequently the cheaper one here.
+ * per turn), and `composeFlow` already makes up to four attempts because
+ * weaker models need two or three to emit a valid tree. A model that gets it
+ * right first time is frequently the cheaper one here.
  *
- * `high` falls up to `medium` on its own when no high tier is configured
- * (see TIER_FALLBACK in src/llm/tiers.ts), so a single-model install keeps
- * working with no wiring at all.
+ * Do not read "four" as a bound on the spend, though. That cap counts
+ * one-shot attempts, or `submit_flow` attempts in the tool loop -- and the
+ * tool loop (the production path whenever the model supports tools) runs up
+ * to TOOL_LOOP_MAX_TURNS = 12 calls against a conversation that grows with
+ * every piece it inspects. A compose is therefore up to a dozen high-tier
+ * calls, not one.
+ *
+ * The other thing `high` changes is wall time. `LLMManager.REQUEST_TIMEOUT_MS`
+ * is a fixed 90s with no per-call override, and both paths here ask for up to
+ * 8192 output tokens. A slow high-tier model (a reasoning model, or a large
+ * local one) is likelier to cross that than a medium one was; a timeout
+ * classifies as `network`, which is retried up to three times per provider,
+ * and which the tool loop refuses to fall back to one-shot on. If composes
+ * start dying after minutes rather than seconds, that ceiling is where to
+ * look -- raising it means giving LLMOptions a timeout, which is a change to
+ * shared LLM infrastructure and deliberately not made here.
+ *
+ * `high` falls up to `medium` on its own (see TIER_FALLBACK in
+ * src/llm/tiers.ts). That matters for an install that configures only
+ * `llm.tiers.medium`, or whose `high` ref names an unregistered provider and
+ * gets dropped. It is NOT what carries a single-model install: `llm.default`
+ * populates low, medium and high with the same ref, so those resolve `high`
+ * directly and never fall up.
  */
 const COMPOSER_TIER: Tier = "high";
 
@@ -74,10 +95,36 @@ const COMPOSER_TIER: Tier = "high";
 const COMPOSER_SUBSYSTEM = "workflow_composer";
 
 /**
+ * The assistant text of a reply.
+ *
+ * `LLMResponse.content` is typed `string` and every provider returns one. An
+ * earlier version of this adapter read `reply.text` instead -- a field that
+ * does not exist on the response shape -- so every compose returned "" and
+ * the composer burned its whole retry budget on "Unexpected EOF".
+ *
+ * A non-string body cannot be salvaged into a workflow tree, so it still
+ * becomes "" and the composer fails its parse. But it is logged: silently
+ * returning "" is what made that bug take so long to find, and a provider
+ * that starts sending content blocks for a text completion should be
+ * diagnosable from one line of the daemon log rather than from a parse error
+ * four attempts downstream.
+ */
+function textOf(content: unknown): string {
+  if (typeof content === "string") return content;
+  console.warn(
+    `[composer] LLM returned a non-string content body (${typeof content}); ` +
+      `treating it as empty. The compose will fail its JSON parse.`,
+  );
+  return "";
+}
+
+/**
  * Build the composer's LLM client over the daemon's `LLMManager`.
  */
 export function createComposerLlmClient(manager: LLMManager): ComposerLlmClient {
-  const call = (messages: LLMMessage[], options: LLMOptions) =>
+  // The one place composition reaches the LLM. Both paths below go through
+  // it, so the tier and the usage label cannot drift apart between them.
+  const route = (messages: LLMMessage[], options: LLMOptions) =>
     manager.chatTier(COMPOSER_TIER, COMPOSER_SUBSYSTEM, messages, options);
 
   return {
@@ -85,33 +132,31 @@ export function createComposerLlmClient(manager: LLMManager): ComposerLlmClient 
       const messages: LLMMessage[] = [];
       if (input.system !== undefined) messages.push({ role: "system", content: input.system });
       messages.push({ role: "user", content: input.prompt });
-      const reply = await call(messages, { max_tokens: COMPOSER_MAX_TOKENS });
-      // `LLMResponse.content` is the assistant-text field; an earlier version
-      // of this adapter read `reply.text`, which does not exist on the
-      // provider response shape, so every compose returned "" and JSON.parse
-      // crashed with EOF. Stay strict -- if a provider ever returns
-      // ContentBlock[] for a text-only completion we want to know.
-      return { text: typeof reply.content === "string" ? reply.content : "" };
+      const reply = await route(messages, { max_tokens: COMPOSER_MAX_TOKENS });
+      return { text: textOf(reply.content) };
     },
 
     // Tool-loop entrypoint: the composer discovers pieces via tools
     // (list_pieces / get_piece_details / ...) instead of a full catalog dump.
     // ComposerChatMessage / ComposerToolDef alias LLMMessage / LLMTool, so
-    // this is a passthrough. If the provider rejects the tools parameter the
-    // composer catches the error and falls back to the one-shot `chat` path
-    // above. `finish_reason` is surfaced so the loop can tell a reply
-    // truncated at the token cap (a dropped submit_flow) from real prose.
+    // this is a passthrough. A provider that rejects the `tools` parameter
+    // must see its error REACH the composer: on turn 1, and only for codes
+    // that are not rate_limit / network / server / auth / forbidden, the loop
+    // catches it and falls back to the one-shot `chat` path above. Anything
+    // transient is surfaced to the caller instead. `finish_reason` is passed
+    // through so the loop can tell a reply truncated at the token cap (a
+    // dropped submit_flow) from real prose.
     async chatTools(
       messages: ComposerChatMessage[],
       tools: ComposerToolDef[],
     ): Promise<ComposerChatReply> {
-      const reply = await call(messages, {
+      const reply = await route(messages, {
         max_tokens: COMPOSER_MAX_TOKENS,
         tools,
         tool_choice: "auto",
       });
       return {
-        content: typeof reply.content === "string" ? reply.content : "",
+        content: textOf(reply.content),
         tool_calls: reply.tool_calls ?? [],
         finish_reason: reply.finish_reason,
       };

--- a/src/actions/tools/composer-llm.ts
+++ b/src/actions/tools/composer-llm.ts
@@ -1,0 +1,82 @@
+/**
+ * The LLM client the workflow composer runs on.
+ *
+ * Lives here rather than inline in the daemon's boot sequence for two
+ * reasons: the daemon file is five thousand lines of wiring where a routing
+ * decision this consequential disappears, and inline it could not be tested
+ * at all -- which is how it went unnoticed that every workflow the user asked
+ * for was being written by whichever model backs the `medium` tier.
+ *
+ * The composer's own contract (`ComposerLlmClient`) is deliberately narrow:
+ * `chat` is the mandatory single-shot path, `chatTools` the optional
+ * tool-calling one. This module is the only place that maps those onto
+ * `LLMManager`, so tier, subsystem label and token cap are decided once.
+ */
+
+import type { LLMManager } from "../../llm/manager.ts";
+import type { LLMMessage, LLMOptions } from "../../llm/provider.ts";
+import type {
+  ComposerChatMessage,
+  ComposerChatReply,
+  ComposerLlmClient,
+  ComposerToolDef,
+} from "./workflow-composer.ts";
+
+/**
+ * Output cap for both composer paths.
+ *
+ * A realistic flow is 500-2000 output tokens; 8192 leaves room for verbose
+ * pieces (long input schemas, many steps) without surprise truncation.
+ * Ollama's default `num_predict` is 128, which truncates every compose reply
+ * mid-JSON and crashes parsing with "Unexpected EOF"; other providers either
+ * have higher defaults or ignore the cap. The two paths must agree -- a
+ * tool-loop reply that dies at a different limit than the one-shot path would
+ * make truncation bugs impossible to reproduce.
+ */
+const COMPOSER_MAX_TOKENS = 8192;
+
+/**
+ * Build the composer's LLM client over the daemon's `LLMManager`.
+ */
+export function createComposerLlmClient(manager: LLMManager): ComposerLlmClient {
+  const call = (messages: LLMMessage[], options: LLMOptions) =>
+    manager.chat(messages, options);
+
+  return {
+    async chat(input: { prompt: string; system?: string }): Promise<{ text: string }> {
+      const messages: LLMMessage[] = [];
+      if (input.system !== undefined) messages.push({ role: "system", content: input.system });
+      messages.push({ role: "user", content: input.prompt });
+      const reply = await call(messages, { max_tokens: COMPOSER_MAX_TOKENS });
+      // `LLMResponse.content` is the assistant-text field; an earlier version
+      // of this adapter read `reply.text`, which does not exist on the
+      // provider response shape, so every compose returned "" and JSON.parse
+      // crashed with EOF. Stay strict -- if a provider ever returns
+      // ContentBlock[] for a text-only completion we want to know.
+      return { text: typeof reply.content === "string" ? reply.content : "" };
+    },
+
+    // Tool-loop entrypoint: the composer discovers pieces via tools
+    // (list_pieces / get_piece_details / ...) instead of a full catalog dump.
+    // ComposerChatMessage / ComposerToolDef alias LLMMessage / LLMTool, so
+    // this is a passthrough. If the provider rejects the tools parameter the
+    // composer catches the error and falls back to the one-shot `chat` path
+    // above. `finish_reason` is surfaced so the loop can tell a reply
+    // truncated at the token cap (a dropped submit_flow) from real prose.
+    async chatTools(
+      messages: ComposerChatMessage[],
+      tools: ComposerToolDef[],
+    ): Promise<ComposerChatReply> {
+      const reply = await call(messages, {
+        max_tokens: COMPOSER_MAX_TOKENS,
+        tools,
+        tool_choice: "auto",
+      });
+      return {
+        content: typeof reply.content === "string" ? reply.content : "",
+        tool_calls: reply.tool_calls ?? [],
+        finish_reason: reply.finish_reason,
+      };
+    },
+  };
+}

--- a/src/agents/conv/conv-orchestrator.test.ts
+++ b/src/agents/conv/conv-orchestrator.test.ts
@@ -355,8 +355,9 @@ describe('ConvOrchestrator', () => {
       // conv model pattern-matches on, so it outranks the `delegate` tool
       // description; the two must not disagree. It lives in the static half,
       // so it costs nothing per turn.
-      expect(staticText).toContain('BUILD or CHANGE a workflow');
-      expect(staticText).toContain('("automate X", "make a workflow that ...") - tier=high, template=general');
+      // The decision, not the phrasing: a workflow-authoring row that routes
+      // to high with the general template.
+      expect(staticText).toMatch(/BUILD a workflow.*tier=high, template=general/);
       expect(staticText).not.toContain('Alice');
       expect(staticText).not.toContain('Weather');
       // message[1]: dynamic system prompt, NOT cache-marked

--- a/src/agents/conv/conv-orchestrator.test.ts
+++ b/src/agents/conv/conv-orchestrator.test.ts
@@ -351,6 +351,12 @@ describe('ConvOrchestrator', () => {
       expect(messages[0]!.cache).toBe(true);
       const staticText = String(messages[0]!.content);
       expect(staticText).toContain('TestBot persona.');
+      // Workflow authoring routes to high. This row is the surface a small
+      // conv model pattern-matches on, so it outranks the `delegate` tool
+      // description; the two must not disagree. It lives in the static half,
+      // so it costs nothing per turn.
+      expect(staticText).toContain('BUILD or CHANGE a workflow');
+      expect(staticText).toContain('("automate X", "make a workflow that ...") - tier=high, template=general');
       expect(staticText).not.toContain('Alice');
       expect(staticText).not.toContain('Weather');
       // message[1]: dynamic system prompt, NOT cache-marked

--- a/src/agents/conv/conv-orchestrator.ts
+++ b/src/agents/conv/conv-orchestrator.ts
@@ -452,8 +452,10 @@ export class ConvOrchestrator {
     // own row, "automate my mornings" matches the state row and the
     // tool-execution catch-all below (both medium), or the PLAN row -- whose
     // template makes the task agent write a prose plan instead of calling
-    // manage_workflow at all. This row is the one the model reads first.
-    parts.push('- The user asks to BUILD or CHANGE a workflow ("automate X", "make a workflow that ...") - tier=high, template=general');
+    // manage_workflow at all. Placed before every row it would otherwise lose
+    // to. "composing it again" rather than "editing": manage_workflow has no
+    // edit action, so changing what a flow does means composing a new one.
+    parts.push('- The user asks to BUILD a workflow, or to change what one does by composing it again ("automate X", "make a workflow that ...") - tier=high, template=general');
     parts.push('- The user asks you to WRITE or REFACTOR code - tier=medium, template=code');
     parts.push('- The user asks for a PLAN, schedule, or decomposition - tier=high, template=plan');
     parts.push('- The user asks to DRAFT prose (email, doc, summary) - tier=medium, template=write');

--- a/src/agents/conv/conv-orchestrator.ts
+++ b/src/agents/conv/conv-orchestrator.ts
@@ -447,7 +447,13 @@ export class ConvOrchestrator {
     parts.push('# Delegation Catalog');
     parts.push('Use the `delegate` tool when:');
     parts.push('- The user asks you to FIND or LOOK UP something - tier=medium, template=research');
-    parts.push('- The user asks about real Jarvis state (workflows, files, vault, calendar) - tier=medium, template=general');
+    parts.push('- The user asks about real Jarvis state (existing workflows, files, vault, calendar) - tier=medium, template=general');
+    // Authoring a workflow is not the same errand as reading one. Without its
+    // own row, "automate my mornings" matches the state row and the
+    // tool-execution catch-all below (both medium), or the PLAN row -- whose
+    // template makes the task agent write a prose plan instead of calling
+    // manage_workflow at all. This row is the one the model reads first.
+    parts.push('- The user asks to BUILD or CHANGE a workflow ("automate X", "make a workflow that ...") - tier=high, template=general');
     parts.push('- The user asks you to WRITE or REFACTOR code - tier=medium, template=code');
     parts.push('- The user asks for a PLAN, schedule, or decomposition - tier=high, template=plan');
     parts.push('- The user asks to DRAFT prose (email, doc, summary) - tier=medium, template=write');

--- a/src/agents/conv/conv-tools.test.ts
+++ b/src/agents/conv/conv-tools.test.ts
@@ -18,14 +18,23 @@ describe("the delegate tool's tier guidance", () => {
 
   test("still offers all three task tiers", () => {
     // The hint must not narrow the choice: plenty of delegated work is
-    // genuinely low or medium.
+    // genuinely low or medium. Asserted on the enum, not on the prose --
+    // wording locks would only break the next person who rewords the prompt.
     expect(tierParam.enum).toEqual(["low", "medium", "high"]);
-    expect(delegate.description).toContain("low for trivial");
-    expect(delegate.description).toContain("medium for general tool work");
   });
 
-  test("keeps medium as the stated default", () => {
-    expect(tierParam.description).toContain('Default to "medium"');
+  test("keeps running an existing workflow on the cheaper tier", () => {
+    // "building or changing a workflow" would otherwise swallow "run the
+    // daily brief" and "disable my morning flow", which are one-call tool
+    // work.
+    const guidance = (tierParam.description ?? "").toLowerCase();
+    expect(guidance).toContain("running, listing, enabling or disabling");
+  });
+
+  test("steers workflow tasks away from the plan template", () => {
+    // template=plan makes the task agent write a prose plan instead of
+    // calling manage_workflow at all.
+    expect(tierParam.description).toContain('never "plan"');
   });
 });
 

--- a/src/agents/conv/conv-tools.test.ts
+++ b/src/agents/conv/conv-tools.test.ts
@@ -24,17 +24,20 @@ describe("the delegate tool's tier guidance", () => {
   });
 
   test("keeps running an existing workflow on the cheaper tier", () => {
-    // "building or changing a workflow" would otherwise swallow "run the
-    // daily brief" and "disable my morning flow", which are one-call tool
-    // work.
+    // The authoring rule would otherwise swallow "run the daily brief" and
+    // "disable my morning flow", which are one-call tool work. Asserted as
+    // tokens, not as a phrase, so a reword does not fail the test.
     const guidance = (tierParam.description ?? "").toLowerCase();
-    expect(guidance).toContain("running, listing, enabling or disabling");
+    for (const verb of ["running", "listing", "enabling", "disabling"]) {
+      expect(guidance).toContain(verb);
+    }
+    expect(guidance).toContain('"medium"');
   });
 
   test("steers workflow tasks away from the plan template", () => {
     // template=plan makes the task agent write a prose plan instead of
     // calling manage_workflow at all.
-    expect(tierParam.description).toContain('never "plan"');
+    expect(tierParam.description).toMatch(/never\s+"plan"/);
   });
 });
 

--- a/src/agents/conv/conv-tools.test.ts
+++ b/src/agents/conv/conv-tools.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+import { CONV_TOOLS, CONV_TOOL_NAMES } from "./conv-tools.ts";
+
+const delegate = CONV_TOOLS.find((t) => t.name === "delegate")!;
+const properties = delegate.parameters.properties as Record<string, { enum?: string[]; description?: string }>;
+const tierParam = properties.tier!;
+
+describe("the delegate tool's tier guidance", () => {
+  test("routes workflow authoring to the high tier", () => {
+    // The conversation model reads "automate my mornings" as ordinary tool
+    // work and picks medium, which is the weaker model deciding how to phrase
+    // the request and what to do with compose errors.
+    const guidance = `${delegate.description} ${tierParam.description ?? ""}`.toLowerCase();
+    expect(guidance).toContain("workflow");
+    const afterHigh = guidance.slice(guidance.indexOf("high"));
+    expect(afterHigh).toContain("workflow");
+  });
+
+  test("still offers all three task tiers", () => {
+    // The hint must not narrow the choice: plenty of delegated work is
+    // genuinely low or medium.
+    expect(tierParam.enum).toEqual(["low", "medium", "high"]);
+    expect(delegate.description).toContain("low for trivial");
+    expect(delegate.description).toContain("medium for general tool work");
+  });
+
+  test("keeps medium as the stated default", () => {
+    expect(tierParam.description).toContain('Default to "medium"');
+  });
+});
+
+describe("CONV_TOOLS surface", () => {
+  test("names match the intercept list the orchestrator filters on", () => {
+    // The orchestrator intercepts by name; a tool present in one list and not
+    // the other either never runs or leaks into the agent's real tool set.
+    const intercepted: string[] = Object.values(CONV_TOOL_NAMES);
+    const declared: string[] = CONV_TOOLS.map((t) => t.name);
+    expect(intercepted.sort()).toEqual(declared.sort());
+  });
+
+  test("delegate requires the fields the dispatcher reads", () => {
+    expect(delegate.parameters.required).toEqual(["tier", "template", "intent"]);
+  });
+});

--- a/src/agents/conv/conv-tools.ts
+++ b/src/agents/conv/conv-tools.ts
@@ -15,6 +15,15 @@
  * Conversation also has direct knowledge of in-flight tasks via the system
  * prompt's "In-flight tasks" section, so it doesn't need to "discover" what's
  * running - it just decides what to do about it.
+ *
+ * The `delegate` description names workflow authoring as a `high` case. That
+ * is the ROUTING half of a pair: the model that WRITES the flow is pinned to
+ * `high` in composer-llm.ts regardless of what gets chosen here, so this only
+ * decides which model runs the turn that calls `manage_workflow` -- the one
+ * that phrases the request, reads compose errors back, and decides whether to
+ * refine and retry. Left at "medium for general tool work" the conv model
+ * reads "automate my mornings" as ordinary tool work and hands that judgement
+ * to the weaker model.
  */
 
 import type { LLMTool } from '../../llm/provider.ts';
@@ -23,7 +32,7 @@ export const CONV_TOOLS: LLMTool[] = [
   {
     name: 'delegate',
     description:
-      "Delegate work to a task tier. Use this when the user's request needs real action (research, code, planning, writing, tool execution). The task tier will run with its own tools and return a result envelope you can verbalize to the user. Pick the smallest tier that can handle the work: low for trivial extraction/classification, medium for general tool work, high for complex multi-step reasoning. Returns a task_id you can reference for status checks. Fold any constraints (budget, tone, format, scope) directly into the `intent` sentence.",
+      "Delegate work to a task tier. Use this when the user's request needs real action (research, code, planning, writing, tool execution). The task tier will run with its own tools and return a result envelope you can verbalize to the user. Pick the smallest tier that can handle the work: low for trivial extraction/classification, medium for general tool work, high for complex multi-step reasoning and for building or changing a workflow. Returns a task_id you can reference for status checks. Fold any constraints (budget, tone, format, scope) directly into the `intent` sentence.",
     parameters: {
       type: 'object',
       required: ['tier', 'template', 'intent'],
@@ -31,7 +40,7 @@ export const CONV_TOOLS: LLMTool[] = [
         tier: {
           type: 'string',
           enum: ['low', 'medium', 'high'],
-          description: 'Which task tier should run this. Default to "medium" unless you have a clear reason.',
+          description: 'Which task tier should run this. Default to "medium" unless you have a clear reason. Building or changing a workflow ("automate X", "make a workflow that ...") is a clear reason for "high": it is authoring, not tool work, and the weaker model gets the piece wiring wrong.',
         },
         template: {
           type: 'string',

--- a/src/agents/conv/conv-tools.ts
+++ b/src/agents/conv/conv-tools.ts
@@ -18,12 +18,16 @@
  *
  * The `delegate` description names workflow authoring as a `high` case. That
  * is the ROUTING half of a pair: the model that WRITES the flow is pinned to
- * `high` in composer-llm.ts regardless of what gets chosen here, so this only
- * decides which model runs the turn that calls `manage_workflow` -- the one
- * that phrases the request, reads compose errors back, and decides whether to
- * refine and retry. Left at "medium for general tool work" the conv model
- * reads "automate my mornings" as ordinary tool work and hands that judgement
- * to the weaker model.
+ * `high` in composer-llm.ts whatever gets chosen here (subject only to that
+ * tier's own config fall-up), so this decides which model runs the turn that
+ * CALLS `manage_workflow` -- the one that phrases the request, reads compose
+ * errors back, and decides whether to refine and retry. Left at "medium for
+ * general tool work" the conv model reads "automate my mornings" as ordinary
+ * tool work and hands that judgement to the weaker model.
+ *
+ * The Delegation Catalog in conv-orchestrator.ts carries the same rule as a
+ * system-prompt row, and that is the surface a small model pattern-matches on
+ * first. The two have to agree.
  */
 
 import type { LLMTool } from '../../llm/provider.ts';
@@ -32,7 +36,7 @@ export const CONV_TOOLS: LLMTool[] = [
   {
     name: 'delegate',
     description:
-      "Delegate work to a task tier. Use this when the user's request needs real action (research, code, planning, writing, tool execution). The task tier will run with its own tools and return a result envelope you can verbalize to the user. Pick the smallest tier that can handle the work: low for trivial extraction/classification, medium for general tool work, high for complex multi-step reasoning and for building or changing a workflow. Returns a task_id you can reference for status checks. Fold any constraints (budget, tone, format, scope) directly into the `intent` sentence.",
+      "Delegate work to a task tier. Use this when the user's request needs real action (research, code, planning, writing, tool execution). The task tier will run with its own tools and return a result envelope you can verbalize to the user. Pick the smallest tier that can handle the work: low for trivial extraction/classification, medium for general tool work, high for complex multi-step reasoning and for authoring a workflow. Returns a task_id you can reference for status checks. Fold any constraints (budget, tone, format, scope) directly into the `intent` sentence.",
     parameters: {
       type: 'object',
       required: ['tier', 'template', 'intent'],
@@ -40,7 +44,7 @@ export const CONV_TOOLS: LLMTool[] = [
         tier: {
           type: 'string',
           enum: ['low', 'medium', 'high'],
-          description: 'Which task tier should run this. Default to "medium" unless you have a clear reason. Building or changing a workflow ("automate X", "make a workflow that ...") is a clear reason for "high": it is authoring, not tool work, and the weaker model gets the piece wiring wrong.',
+          description: 'Which task tier should run this. Default to "medium" unless you have a clear reason. Authoring a workflow -- building one or editing its steps ("automate X", "make a workflow that ...") -- is a clear reason for "high"; it is authoring rather than tool work, and the model has to phrase the request precisely and read compose errors back. Merely running, listing, enabling or disabling an existing workflow is ordinary tool work: keep those on "medium". Pair a workflow task with template "general", never "plan" -- "plan" makes the task agent write a prose plan instead of building anything.',
         },
         template: {
           type: 'string',

--- a/src/agents/conv/conv-tools.ts
+++ b/src/agents/conv/conv-tools.ts
@@ -18,8 +18,9 @@
  *
  * The `delegate` description names workflow authoring as a `high` case. That
  * is the ROUTING half of a pair: the model that WRITES the flow is pinned to
- * `high` in composer-llm.ts whatever gets chosen here (subject only to that
- * tier's own config fall-up), so this decides which model runs the turn that
+ * `high` in composer-llm.ts whatever gets chosen here (subject to that tier's
+ * config fall-up, and to LLMManager failing over on a rate limit or a model
+ * the provider says is gone), so this decides which model runs the turn that
  * CALLS `manage_workflow` -- the one that phrases the request, reads compose
  * errors back, and decides whether to refine and retry. Left at "medium for
  * general tool work" the conv model reads "automate my mornings" as ordinary
@@ -44,7 +45,7 @@ export const CONV_TOOLS: LLMTool[] = [
         tier: {
           type: 'string',
           enum: ['low', 'medium', 'high'],
-          description: 'Which task tier should run this. Default to "medium" unless you have a clear reason. Authoring a workflow -- building one or editing its steps ("automate X", "make a workflow that ...") -- is a clear reason for "high"; it is authoring rather than tool work, and the model has to phrase the request precisely and read compose errors back. Merely running, listing, enabling or disabling an existing workflow is ordinary tool work: keep those on "medium". Pair a workflow task with template "general", never "plan" -- "plan" makes the task agent write a prose plan instead of building anything.',
+          description: 'Which task tier should run this. Default to "medium" unless you have a clear reason. Authoring a workflow -- building one, or composing it again to change what it does ("automate X", "make a workflow that ...") -- is a clear reason for "high"; it is authoring rather than tool work, and the model has to phrase the request precisely and read compose errors back. Merely running, listing, enabling or disabling an existing workflow is ordinary tool work: keep those on "medium". Pair a workflow task with template "general", never "plan" -- "plan" makes the task agent write a prose plan instead of building anything.',
         },
         template: {
           type: 'string',

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -66,11 +66,7 @@ import { TriggerManager } from "../workflows/runner/triggers/manager.ts";
 import { AWARENESS_EVENT_TYPE_MAP, OBSERVER_EVENT_TYPE_MAP } from "../workflows/runtime/event-types.ts";
 import { WorkflowEventBus } from "../workflows/runtime/event-bus.ts";
 import { WorkflowEventBuffer } from "../workflows/runtime/event-buffer.ts";
-import type {
-  ComposerChatMessage,
-  ComposerChatReply,
-  ComposerToolDef,
-} from "../actions/tools/workflow-composer.ts";
+import { createComposerLlmClient } from "../actions/tools/composer-llm.ts";
 import {
   bootstrapWorkflowEngine,
   type BootstrapWorkflowEngineResult,
@@ -4818,58 +4814,11 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
       // earlier in step 10.1) is in scope and refreshes happen on enable /
       // disable / publish / delete.
       const { createManageWorkflowTool } = await import('../actions/tools/manage-workflow.ts');
-      // Build a minimal piece-side LLM client + tool-registry shim for the
-      // composer. Both are tiny structural wrappers; we no longer need the
-      // legacy `JarvisLlmClient`/`JarvisToolRegistryAdapter` classes since
-      // the engine path is the production runtime.
+      // Build the composer's LLM client + a tool-registry shim. The client
+      // lives in its own module (composer-llm.ts) so the tier it runs on is a
+      // reviewable, testable decision rather than a line buried in boot.
       const llmManager = agentService.getLLMManager();
-      const composeLlm = {
-        async chat(input: { prompt: string; system?: string }): Promise<{ text: string }> {
-          const messages: Array<{ role: "system" | "user"; content: string }> = [];
-          if (input.system !== undefined) messages.push({ role: "system", content: input.system });
-          messages.push({ role: "user", content: input.prompt });
-          // Composer expects a complete JSON tree describing the flow.
-          // A realistic flow is 500-2000 output tokens; we ask for 8192
-          // to leave room for verbose pieces (long input schemas, many
-          // steps) without surprise truncation -- kept consistent with the
-          // chatTools cap below. Ollama's default `num_predict` is 128 --
-          // truncates every compose reply mid-JSON and crashes parsing with
-          // "Unexpected EOF". Other providers either have higher defaults or
-          // ignore the cap.
-          const reply = await llmManager.chat(messages, { max_tokens: 8192 });
-          // `LLMResponse.content` is the assistant-text field; an earlier
-          // version of this adapter read `reply.text` which doesn't
-          // exist on the provider response shape, so every compose
-          // returned "" and JSON.parse crashed with EOF. Stay strict
-          // here -- if the provider ever returns ContentBlock[] for
-          // text-only completions we want to know.
-          const content = typeof reply.content === "string" ? reply.content : "";
-          return { text: content };
-        },
-        // Tool-loop entrypoint: the composer discovers pieces via tools
-        // (list_pieces / get_piece_details / ...) instead of a full catalog
-        // dump. ComposerChatMessage / ComposerToolDef alias LLMMessage /
-        // LLMTool, so this is a passthrough. If the provider rejects the tools
-        // parameter, the composer catches the error and falls back to the
-        // one-shot `chat` path above. `finish_reason` is surfaced so the loop
-        // can detect a reply truncated at the token cap (a dropped submit_flow)
-        // rather than misreading it as prose.
-        async chatTools(
-          messages: ComposerChatMessage[],
-          tools: ComposerToolDef[],
-        ): Promise<ComposerChatReply> {
-          const reply = await llmManager.chat(messages, {
-            max_tokens: 8192,
-            tools,
-            tool_choice: 'auto',
-          });
-          return {
-            content: typeof reply.content === 'string' ? reply.content : '',
-            tool_calls: reply.tool_calls ?? [],
-            finish_reason: reply.finish_reason,
-          };
-        },
-      };
+      const composeLlm = createComposerLlmClient(llmManager);
       // Compact community-library index for the composer's search_library
       // tool: lets it suggest "install piece X first" when the user asks for
       // a service that isn't installed, instead of forcing a wrong fit.


### PR DESCRIPTION
Asking Jarvis to build a workflow got you the medium model's work, and the bill never showed up under its own name.

`src/daemon/index.ts` built the workflow composer's LLM client on the deprecated `LLMManager.chat()`. That helper routes to `chatTier('medium', 'legacy', ...)`, so the model that reads the piece catalog and writes the workflow JSON tree was always the medium one, and every token it spent was booked to the subsystem label `legacy`, invisible in per-subsystem usage reporting. Nothing tested it, because the client was ~40 lines inline in a 5,000-line boot sequence.

Composing is the most reasoning-dense thing `manage_workflow` does: choose pieces from a catalog, wire `{{step.field}}` references against each upstream step's declared output shape, match router operators to the real type of the value they test, satisfy every required input, and write commands for the OS of the machine the step lands on. Get one wrong and the flow validates today and fails on its first real run. `high` is also the tier nothing else in the codebase was requesting: before this branch, `chatTier('high', ...)` had zero call sites and the tier existed only as medium's fall-up target.

## What changed

- The composer's LLM client moved out of daemon boot into `src/actions/tools/composer-llm.ts`, so the tier is one reviewable, testable line instead of a detail buried in wiring.
- It routes to `chatTier('high', 'workflow_composer', ...)`. `high` falls up to `medium` on its own, so an install that configures only `llm.tiers.medium` is unaffected, and a single-model install resolves `high` directly.
- The spend is labelled `workflow_composer` instead of `legacy`.
- In router mode, both surfaces that tell the conversation model how to route now name workflow authoring as high-tier work: the `delegate` tool description, and the Delegation Catalog row in the conv system prompt. The catalog row matters more, since a small model pattern-matches the system prompt first, and without it "automate my mornings" matched the medium rows or the PLAN row (whose template makes the task agent write a prose plan instead of building anything).

Deliberately narrow: running, listing, enabling or disabling an existing workflow stays on medium, and nothing else moved. Chat orchestration is untouched (the conversation tier still runs conv, the classic orchestrator still defaults to medium), as are sub-agents, vault extraction, goals, awareness and workflow runtime steps.

## Behavior change worth knowing

`configureLLMTiers` can produce an empty tier map (no `llm.default`, no `llm.tiers`, or every ref naming an unregistered provider), and nothing calls `validateTierMap` in production. The deprecated path papered over that by dropping to the legacy primary-provider chain; `chatTier` throws instead, naming the setting to fix. I did not preserve the fallback: composing on whatever provider happened to be registered first is exactly the invisible routing this change exists to end, and every other task-tier subsystem already throws on such a config. A test pins it with the reasoning.

Two things I left alone. `REQUEST_TIMEOUT_MS` is a fixed 90s with no per-call override, and a slow high-tier model producing up to 8192 output tokens is likelier to cross it than a medium one was; raising it means adding a timeout to `LLMOptions`, which is shared LLM infrastructure and does not belong in this change. It is documented where someone debugging a slow compose will find it. And the workflow *runtime* adapter (`JarvisLlmClient`, for `jarvis-ask` steps) is still on the deprecated path and still books to `legacy` - same labelling problem, separate follow-up.

Reviewing that timeout note turned up a latent bug worth its own ticket: `LLMManager.withTimeout` throws "... timed out after 90000ms", but `classifyErrorString` and `shouldRetry` both match the substring "timeout", which that message does not contain. So the manager's own timeouts classify as `unknown` and are never retried, for every subsystem, not just this one. I have documented the real behavior rather than fixed it here, since changing it alters retry behavior fleet-wide.

## Tests

`composer-llm.test.ts` pins the tier, the usage label, the request shape on both paths, reply projection, and the failure modes the composer depends on: a rejected `tools` parameter has to reach `composeWithTools` classifiable so it can fall back to one-shot, and a rejected request must not be quietly re-run on the weaker model. It also pins the one case where failover to medium IS deliberate manager policy (a decommissioned high model), because that is a real hole in "composition always runs on high" and the next reader should not have to discover it.
