### PR TITLE
Stop a failed engine acquire from silently disabling a workflow trigger

### DIFF
--- a/src/workflows/runner/engine-runtime/engine-flow-executor.test.ts
+++ b/src/workflows/runner/engine-runtime/engine-flow-executor.test.ts
@@ -388,3 +388,50 @@ describe("EngineFlowExecutor", () => {
     }
   });
 });
+
+describe("EngineFlowExecutor: engine acquire", () => {
+  test("a transient acquire failure is retried and the run still executes", async () => {
+    const { runId, ctx } = setupRun();
+    let attempts = 0;
+    const fakeRuntime = {
+      acquire: async () => {
+        attempts++;
+        if (attempts < 3) {
+          throw new Error("EngineRuntime.acquire failed: engine abc did not connect within 30000ms");
+        }
+        return {
+          async executeFlow() {
+            updateRun(runId, { status: "SUCCEEDED" });
+          },
+          async release() {},
+        } as unknown as EngineHandle;
+      },
+    } as unknown as EngineRuntime;
+
+    const exec = new EngineFlowExecutor(fakeRuntime, {
+      terminalTimeoutMs: 2_000,
+      terminalPollIntervalMs: 10,
+    });
+    await exec.execute(ctx);
+    expect(attempts).toBe(3);
+    expect(getFlowRun(runId)?.status).toBe("SUCCEEDED");
+  }, 15_000);
+
+  test("a persistently failing acquire surfaces the engine error", async () => {
+    const { ctx } = setupRun();
+    let attempts = 0;
+    const fakeRuntime = {
+      acquire: async () => {
+        attempts++;
+        throw new Error("EngineRuntime.acquire failed: engine abc did not connect within 30000ms");
+      },
+    } as unknown as EngineRuntime;
+
+    const exec = new EngineFlowExecutor(fakeRuntime, {
+      terminalTimeoutMs: 2_000,
+      terminalPollIntervalMs: 10,
+    });
+    await expect(exec.execute(ctx)).rejects.toThrow("did not connect within 30000ms");
+    expect(attempts).toBe(3);
+  }, 15_000);
+});

--- a/src/workflows/runner/engine-runtime/engine-flow-executor.ts
+++ b/src/workflows/runner/engine-runtime/engine-flow-executor.ts
@@ -23,7 +23,7 @@ import { FlowExecutionError } from "../handler";
 import { getFlowRun, type FlowRunStatus } from "../../db/repos/flow-run";
 import type { FlowTriggerNode } from "../../db/repos/flow-version";
 import { DEFAULT_IDS } from "../../db/schema";
-import type { EngineRuntime } from "./engine-runtime";
+import type { EngineHandle, EngineRuntime } from "./engine-runtime";
 import { loadExecutionStateFromLog } from "./execution-state-loader";
 
 /**
@@ -53,6 +53,14 @@ const NON_SUCCESS_STATUSES = new Set<FlowRunStatus>([
   "MEMORY_LIMIT_EXCEEDED",
   "SCHEDULE_FAILURE",
 ]);
+
+/**
+ * Engine-acquire attempts per run, and the pause between them. Three tries
+ * about a second apart rides out a spawn that lost a race with a loaded host
+ * without keeping a queue worker busy for long when the engine is really down.
+ */
+const ACQUIRE_ATTEMPTS = 3;
+const ACQUIRE_RETRY_DELAY_MS = 1_000;
 
 /**
  * How long the executor waits for the engine's `uploadRunLog` to flip the
@@ -114,11 +122,43 @@ export class EngineFlowExecutor implements FlowExecutor {
     this.loaderBaseDir = opts.loaderBaseDir;
   }
 
-  async execute(ctx: FlowExecutorContext): Promise<FlowExecutorResult> {
-    const handle = await this.runtime.acquire({
+  /**
+   * Acquire an engine, retrying a couple of times on failure.
+   *
+   * Getting an engine is side-effect free -- no step has run, nothing has been
+   * sent anywhere -- so unlike a mid-flow failure this is safe to retry, and
+   * the failures worth retrying (handshake timeout on a loaded host, engine
+   * killed mid-spawn) are exactly the transient kind. The alternative is what
+   * the user sees today: a run marked FAILED with no per-step trace because
+   * the engine never came up.
+   *
+   * Deliberately short and bounded: RUN_FLOW jobs are queued, so a genuinely
+   * dead engine should fail the job quickly rather than tie up a worker slot.
+   */
+  private async acquireWithRetry(ctx: FlowExecutorContext): Promise<EngineHandle> {
+    const opts = {
       runId: ctx.run.id,
       projectId: ctx.run.projectId ?? DEFAULT_IDS.project,
-    });
+    };
+    let lastError: unknown;
+    for (let attempt = 0; attempt < ACQUIRE_ATTEMPTS; attempt++) {
+      try {
+        return await this.runtime.acquire(opts);
+      } catch (e) {
+        lastError = e;
+        if (attempt === ACQUIRE_ATTEMPTS - 1) break;
+        console.warn(
+          `[engine-executor] run ${ctx.run.id}: engine acquire failed ` +
+            `(attempt ${attempt + 1}/${ACQUIRE_ATTEMPTS}): ${(e as Error).message}`,
+        );
+        await new Promise((r) => setTimeout(r, ACQUIRE_RETRY_DELAY_MS));
+      }
+    }
+    throw lastError;
+  }
+
+  async execute(ctx: FlowExecutorContext): Promise<FlowExecutorResult> {
+    const handle = await this.acquireWithRetry(ctx);
     try {
       // streamStepProgress: WEBSOCKET makes the engine emit per-step
       // `updateRunProgress({ step })` calls to the daemon -- the

--- a/src/workflows/runner/engine-runtime/engine-handle-lifecycle.test.ts
+++ b/src/workflows/runner/engine-runtime/engine-handle-lifecycle.test.ts
@@ -59,6 +59,8 @@ function fakeProc(): SpawnedEngine & { killed: NodeJS.Signals[] } {
     stderr: null,
     child: {} as SpawnedEngine["child"],
     exited,
+    // This fake never fails to spawn, so the promise just stays pending.
+    spawnFailed: new Promise<never>(() => {}),
     alive: () => alive,
     kill(signal = "SIGTERM") {
       killed.push(signal);

--- a/src/workflows/runner/engine-runtime/engine-runtime.ts
+++ b/src/workflows/runner/engine-runtime/engine-runtime.ts
@@ -79,7 +79,19 @@ export interface EngineRuntimeOptions {
   customPiecesPaths?: string[];
   /** CSV of dev-piece names exposed via AP_DEV_PIECES. Default: jarvis pieces. */
   devPieces?: string[];
-  /** Engine WS handshake deadline. Default 10s. */
+  /**
+   * Engine WS handshake deadline. Default 30s, overridable per-deployment
+   * via `JARVIS_ENGINE_HANDSHAKE_TIMEOUT_MS`.
+   *
+   * The handshake is ~200ms on an idle machine, but the budget has to cover
+   * the worst case, not the median: a small/loaded VPS that is swapping while
+   * the daemon streams audio and runs LLM calls can take several seconds just
+   * to exec Bun and parse the ~2MB bundle. Blowing the deadline is not a
+   * degraded run -- the acquire throws, so ON_ENABLE never registers the
+   * trigger and RUN_FLOW jobs fail outright. A too-generous deadline only
+   * costs latency on a genuinely broken engine, and that case now fails fast
+   * on process exit anyway (see `spawnFresh`).
+   */
   handshakeTimeoutMs?: number;
   /** Graceful kill deadline before SIGKILL. Default 2s. */
   killGraceMs?: number;
@@ -477,6 +489,31 @@ function discoverJarvisDevPieces(): string[] {
   return out;
 }
 
+/** Handshake latency past which we tell the operator the host is the problem. */
+const SLOW_HANDSHAKE_WARN_MS = 5_000;
+
+/** How many engine stderr lines to retain for failure diagnostics. */
+const ENGINE_STDERR_TAIL_LINES = 5;
+
+/**
+ * Per-deployment handshake budget. Hosted installs on small VPSes need a
+ * bigger one than a dev laptop; this is the escape hatch that avoids a
+ * redeploy. Invalid / non-positive values are ignored so a typo can't
+ * silently disable the deadline.
+ */
+function envHandshakeTimeoutMs(): number | undefined {
+  const raw = process.env["JARVIS_ENGINE_HANDSHAKE_TIMEOUT_MS"]?.trim();
+  if (!raw) return undefined;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    console.warn(
+      `[engine-runtime] ignoring invalid JARVIS_ENGINE_HANDSHAKE_TIMEOUT_MS="${raw}"`,
+    );
+    return undefined;
+  }
+  return parsed;
+}
+
 export class EngineRuntime {
   private readonly api: SandboxApi;
   private readonly bundlePath: string;
@@ -519,7 +556,8 @@ export class EngineRuntime {
       opts.customPiecesPaths ?? [
         resolve(ENGINE_BUILD_PATHS.VENDOR_PACKAGES, "pieces"),
       ];
-    this.handshakeTimeoutMs = opts.handshakeTimeoutMs ?? 10_000;
+    this.handshakeTimeoutMs =
+      opts.handshakeTimeoutMs ?? envHandshakeTimeoutMs() ?? 30_000;
     this.killGraceMs = opts.killGraceMs ?? 2_000;
     this.spawnEnvOverride = opts.spawnEnvOverride;
     this.runtime = opts.runtime;
@@ -643,18 +681,39 @@ export class EngineRuntime {
     // streams differentiate by prefix; production daemons that want to
     // suppress this can pipe their output through a filter.
     bindEngineStream(proc.stdout, "stdout", sandboxId);
-    bindEngineStream(proc.stderr, "stderr", sandboxId);
+    // Keep the last few stderr lines around: when the handshake fails they
+    // are the only evidence of WHY, and by then the process is gone.
+    const stderrTail: string[] = [];
+    bindEngineStream(proc.stderr, "stderr", sandboxId, stderrTail);
 
-    let earlyExitMessage: string | null = null;
-    const earlyExitWatcher = proc.exited.then(({ code, signal }) => {
-      earlyExitMessage = `engine exited before handshake (code=${code}, signal=${signal})`;
+    // Fail fast when the engine dies instead of sitting out the full
+    // handshake deadline: a bundle that can't load exits in milliseconds, and
+    // its exit reason is far more useful than "did not connect in time".
+    const exitedFirst = proc.exited.then(({ code, signal }): never => {
+      throw new Error(`engine exited before handshake (code=${code}, signal=${signal})`);
     });
+    // Whichever loses the race below is still "handled" by Promise.race, so a
+    // post-handshake exit never surfaces as an unhandled rejection.
+    void exitedFirst.catch(() => {});
 
+    const handshakeStartedAt = Date.now();
     try {
-      const engineClient = await this.api.workerRpc.waitForConnection(
-        sandboxId,
-        this.handshakeTimeoutMs,
-      );
+      const engineClient = await Promise.race([
+        this.api.workerRpc.waitForConnection(sandboxId, this.handshakeTimeoutMs),
+        exitedFirst,
+        // An exec that never got off the ground (EAGAIN / ENOMEM under fork
+        // pressure) reports its errno here instead of masquerading as a
+        // handshake timeout.
+        proc.spawnFailed,
+      ]);
+      const handshakeMs = Date.now() - handshakeStartedAt;
+      if (handshakeMs > SLOW_HANDSHAKE_WARN_MS) {
+        console.warn(
+          `[engine-runtime] engine ${sandboxId.slice(0, 8)} handshake took ${handshakeMs}ms ` +
+            `(budget ${this.handshakeTimeoutMs}ms). The host is slow or loaded; raise ` +
+            `JARVIS_ENGINE_HANDSHAKE_TIMEOUT_MS if acquires start timing out.`,
+        );
+      }
       const warm: WarmEngine = { sandboxId, proc, engineClient };
       const releaseImpl = this.poolEnabled
         ? () => this.returnToPoolOrKill(warm)
@@ -673,17 +732,21 @@ export class EngineRuntime {
         releaseImpl,
       );
     } catch (e) {
-      // Make sure the subprocess is gone before bubbling. If it already exited,
-      // surface that reason; otherwise SIGKILL.
-      if (earlyExitMessage === null) {
-        proc.kill("SIGKILL");
-      }
+      // Make sure the subprocess is gone before bubbling. A timed-out engine
+      // is still running (it just never dialed back), so it needs the kill;
+      // one that already exited does not.
+      const stillRunning = proc.alive();
+      if (stillRunning) proc.kill("SIGKILL");
       this.api.registry.terminate(sandboxId);
-      const reason = earlyExitMessage ?? (e instanceof Error ? e.message : String(e));
-      throw new Error(`EngineRuntime.acquire failed: ${reason}`);
-    } finally {
-      // Don't leak the watcher Promise.
-      void earlyExitWatcher;
+      const reason = e instanceof Error ? e.message : String(e);
+      const context = [
+        stillRunning ? `engine pid ${proc.pid} was still running` : null,
+        stderrTail.length > 0 ? `last engine stderr: ${stderrTail.join(" | ")}` : null,
+      ].filter((s): s is string => s !== null);
+      throw new Error(
+        `EngineRuntime.acquire failed: ${reason}` +
+          (context.length > 0 ? ` (${context.join("; ")})` : ""),
+      );
     }
   }
 
@@ -791,6 +854,7 @@ function bindEngineStream(
   stream: NodeJS.ReadableStream | null,
   kind: "stdout" | "stderr",
   sandboxId: string,
+  tail?: string[],
 ): void {
   if (!stream) return;
   const prefix = `[engine ${sandboxId.slice(0, 8)} ${kind}]`;
@@ -802,6 +866,10 @@ function bindEngineStream(
     const text = chunk.toString("utf8").replace(/\n$/, "");
     if (text.length === 0) return;
     sink.write(`${prefix} ${text}\n`);
+    if (tail) {
+      tail.push(text.length > 300 ? text.slice(0, 300) + "..." : text);
+      while (tail.length > ENGINE_STDERR_TAIL_LINES) tail.shift();
+    }
   });
   // Errors on the pipe itself (rare: e.g. the proc exited mid-read) are
   // ignored -- the spawned process is gone, nothing to do about it.

--- a/src/workflows/runner/engine-runtime/spawn.ts
+++ b/src/workflows/runner/engine-runtime/spawn.ts
@@ -38,6 +38,15 @@ export interface SpawnedEngine {
    * against `exited` (which only resolves on the next microtask).
    */
   alive(): boolean;
+  /**
+   * Rejects if the child emits `error` (failed exec, EAGAIN under fork
+   * pressure, killed by the OS before exec). Never resolves otherwise.
+   *
+   * This also exists to KEEP a listener on the child's `error` event:
+   * unhandled, that event is thrown, and an async one would take the whole
+   * daemon down rather than failing one acquire.
+   */
+  spawnFailed: Promise<never>;
 }
 
 export interface SpawnEngineOptions {
@@ -124,12 +133,27 @@ export function spawnEngine(opts: SpawnEngineOptions): SpawnedEngine {
     },
   );
 
+  const spawnFailed = new Promise<never>((_res, rej) => {
+    child.on("error", (err: NodeJS.ErrnoException) => {
+      isAlive = false;
+      rej(
+        new Error(
+          `engine process failed to start (${err.code ?? "unknown"}): ${err.message}`,
+        ),
+      );
+    });
+  });
+  // The caller races this; swallow the rejection so a failure it never got
+  // around to observing doesn't surface as an unhandled rejection.
+  void spawnFailed.catch(() => {});
+
   return {
     pid: child.pid ?? -1,
     stdout: child.stdout,
     stderr: child.stderr,
     child,
     exited,
+    spawnFailed,
     kill: (signal = "SIGTERM") => child.kill(signal),
     alive: () => isAlive,
   };

--- a/src/workflows/runner/triggers/manager.test.ts
+++ b/src/workflows/runner/triggers/manager.test.ts
@@ -783,10 +783,107 @@ describe("TriggerManager: engine-managed triggers (Phase J)", () => {
       engineRuntime: fakeEngine,
       cronScheduler: new FakeCronScheduler() as unknown as import("./cron").CronScheduler,
       log: (line) => logs.push(line),
+      // No retries: this test asserts the immediate failure handling.
+      enableRetryDelaysMs: [],
     });
 
     await tm.start();
     expect(tm.list()).toEqual([]);
     expect(logs.some((l) => l.includes("engine ON_ENABLE failed"))).toBe(true);
+    await tm.stop();
+  });
+
+  test("a transient ON_ENABLE failure is retried on the backoff and the flow ends up registered", async () => {
+    const { flowId } = publishFlowWithTrigger("engine-flaky", {
+      name: "trigger",
+      type: "PIECE_TRIGGER",
+      settings: {
+        pieceName: "jarvis-trigger",
+        triggerName: "on_event",
+        input: { eventType: "observer.clipboard_changed" },
+      },
+    });
+
+    // Fails the first acquire (host too loaded to hand back an engine), then
+    // recovers -- exactly the shape of the engine-handshake timeout.
+    let acquires = 0;
+    const fakeEngine = {
+      acquire: async () => {
+        acquires++;
+        if (acquires === 1) {
+          throw new Error("EngineRuntime.acquire failed: engine abc did not connect within 30000ms");
+        }
+        return {
+          async executeTriggerHook() {
+            return { scheduleOptions: { cronExpression: "* * * * *" } };
+          },
+          async release() {},
+        };
+      },
+    } as unknown as import("../engine-runtime/engine-runtime").EngineRuntime;
+
+    const cron = new FakeCronScheduler();
+    const logs: string[] = [];
+    const tm = new TriggerManager({
+      eventBus: new WorkflowEventBus(),
+      engineRuntime: fakeEngine,
+      cronScheduler: cron as unknown as import("./cron").CronScheduler,
+      log: (line) => logs.push(line),
+      enableRetryDelaysMs: [10, 20],
+    });
+
+    await tm.start();
+    // First attempt failed: nothing registered yet, but a retry is armed.
+    expect(tm.list()).toEqual([]);
+    expect(logs.some((l) => l.includes("retrying in"))).toBe(true);
+
+    await settle(120);
+    expect(acquires).toBe(2);
+    expect(tm.list()).toEqual([{ flowId, kind: "engine" }]);
+    expect(cron.has(`flow:${flowId}`)).toBe(true);
+    await tm.stop();
+  });
+
+  test("retries stop once the schedule is exhausted, and a disabled flow cancels its pending retry", async () => {
+    const { flowId } = publishFlowWithTrigger("engine-dead", {
+      name: "trigger",
+      type: "PIECE_TRIGGER",
+      settings: {
+        pieceName: "jarvis-trigger",
+        triggerName: "on_event",
+        input: { eventType: "observer.clipboard_changed" },
+      },
+    });
+
+    let acquires = 0;
+    const fakeEngine = {
+      acquire: async () => {
+        acquires++;
+        throw new Error("engine down");
+      },
+    } as unknown as import("../engine-runtime/engine-runtime").EngineRuntime;
+
+    const logs: string[] = [];
+    const tm = new TriggerManager({
+      eventBus: new WorkflowEventBus(),
+      engineRuntime: fakeEngine,
+      cronScheduler: new FakeCronScheduler() as unknown as import("./cron").CronScheduler,
+      log: (line) => logs.push(line),
+      enableRetryDelaysMs: [10, 10],
+    });
+
+    await tm.start();
+    await settle(150);
+    // Initial attempt + two retries, then it gives up loudly.
+    expect(acquires).toBe(3);
+    expect(logs.some((l) => l.includes("giving up after 2 retries"))).toBe(true);
+
+    // A flow disabled while a retry is pending must not be resurrected.
+    updateFlowStatus(flowId, "DISABLED");
+    await tm.refresh(flowId);
+    const before = acquires;
+    await settle(60);
+    expect(acquires).toBe(before);
+    await tm.stop();
   });
 });

--- a/src/workflows/runner/triggers/manager.ts
+++ b/src/workflows/runner/triggers/manager.ts
@@ -97,6 +97,12 @@ export interface TriggerManagerDeps {
   engineRuntime?: EngineRuntime;
   /** Optional logger; defaults to console. */
   log?: (line: string) => void;
+  /**
+   * Backoff schedule for retrying a failed engine ON_ENABLE, in ms. One entry
+   * per retry; the flow is given up on after the last one. Tests override it
+   * to keep the clock out of the assertions.
+   */
+  enableRetryDelaysMs?: number[];
 }
 
 export class TriggerManager {
@@ -120,6 +126,18 @@ export class TriggerManager {
    * otherwise stack overlapping engine spawns).
    */
   private readonly pollingInFlight: Set<string> = new Set();
+  /**
+   * Pending ON_ENABLE retries, keyed by flow id. An engine acquire can fail
+   * for reasons that have nothing to do with the flow (loaded host, engine
+   * mid-restart), and without a retry the flow stays silently unregistered
+   * until someone toggles it or the daemon restarts -- the failure looks
+   * exactly like "my trigger never fires".
+   */
+  private readonly enableRetries: Map<
+    string,
+    { attempt: number; timer: ReturnType<typeof setTimeout> }
+  > = new Map();
+  private readonly enableRetryDelaysMs: number[];
 
   constructor(deps: TriggerManagerDeps) {
     this.bus = deps.eventBus;
@@ -127,6 +145,12 @@ export class TriggerManager {
     this.webhooks = deps.webhookManager ?? new WebhookManager();
     this.engineRuntime = deps.engineRuntime;
     this.log = deps.log ?? ((line) => console.log(`[trigger-manager] ${line}`));
+    // 5s / 15s / 1m / 5m / 15m -- covers a brief engine hiccup within seconds
+    // and a longer host-level problem (swap storm, restart loop) over ~21min
+    // without spawning engines in a tight loop.
+    this.enableRetryDelaysMs = deps.enableRetryDelaysMs ?? [
+      5_000, 15_000, 60_000, 300_000, 900_000,
+    ];
 
     this.webhooks.setTriggerCallback((flowId, payload) => {
       void this.fire(flowId, payload, "webhook");
@@ -149,6 +173,9 @@ export class TriggerManager {
 
   /** Tear down all subscriptions. */
   async stop(): Promise<void> {
+    for (const flowId of Array.from(this.enableRetries.keys())) {
+      this.clearEnableRetry(flowId);
+    }
     for (const sub of this.subs.values()) {
       try {
         await sub.teardown();
@@ -266,6 +293,10 @@ export class TriggerManager {
   }
 
   private async unregister(flowId: string): Promise<void> {
+    // Cancel any pending ON_ENABLE retry first: a flow being disabled (or
+    // republished) must not be resurrected by a timer armed for the old
+    // version.
+    this.clearEnableRetry(flowId);
     const sub = this.subs.get(flowId);
     if (!sub) return;
     try {
@@ -355,6 +386,10 @@ export class TriggerManager {
    * a prior enable), we skip the engine round-trip and just rewire the cron.
    * On_disable refreshes always go through the engine to give the trigger a
    * chance to clean up upstream state.
+   *
+   * A failed ON_ENABLE is retried on a backoff (`scheduleEnableRetry`) rather
+   * than dropped: the engine round-trip can fail for host-level reasons, and
+   * an unregistered flow gives the user no signal beyond "it never fires".
    */
   private async registerEngineTrigger(
     flow: FlowRow,
@@ -391,9 +426,7 @@ export class TriggerManager {
           await handle.release();
         }
       } catch (e) {
-        this.log(
-          `flow ${flow.id}: engine ON_ENABLE failed: ${(e as Error).message} -- skipping registration this cycle; next refresh will retry`,
-        );
+        this.scheduleEnableRetry(flow.id, (e as Error).message);
         return;
       }
     }
@@ -441,6 +474,51 @@ export class TriggerManager {
       teardown: () => this.teardownEngineTrigger(flow.id, version.id, cronTearDown, webhookTearDown),
     };
     this.subs.set(flow.id, sub);
+    this.clearEnableRetry(flow.id);
+  }
+
+  /**
+   * Arm the next ON_ENABLE retry for a flow whose engine round-trip failed.
+   * The retry goes through `refresh()`, so it re-reads the flow first and
+   * quietly does nothing if the user disabled or republished it meanwhile.
+   *
+   * Attempts escalate along `enableRetryDelaysMs` and reset once the flow
+   * registers, so a flow that fails, recovers, and fails again next week gets
+   * the full schedule again rather than the tail of the old one.
+   */
+  private scheduleEnableRetry(flowId: string, reason: string): void {
+    const prior = this.enableRetries.get(flowId);
+    if (prior) clearTimeout(prior.timer);
+    const attempt = prior ? prior.attempt + 1 : 0;
+    const total = this.enableRetryDelaysMs.length;
+    const delay = this.enableRetryDelaysMs[attempt];
+    if (delay === undefined) {
+      this.enableRetries.delete(flowId);
+      this.log(
+        `flow ${flowId}: engine ON_ENABLE failed: ${reason} -- giving up after ${total} ` +
+          `retries; the flow is NOT firing. Re-enable it (or restart the daemon) once the engine is healthy`,
+      );
+      return;
+    }
+    const timer = setTimeout(() => {
+      void this.refresh(flowId).catch((e) => {
+        this.log(`flow ${flowId}: ON_ENABLE retry failed: ${(e as Error).message}`);
+      });
+    }, delay);
+    // Don't hold the daemon open just for a pending retry.
+    (timer as unknown as { unref?: () => void }).unref?.();
+    this.enableRetries.set(flowId, { attempt, timer });
+    this.log(
+      `flow ${flowId}: engine ON_ENABLE failed: ${reason} -- retrying in ${Math.round(delay / 1000)}s ` +
+        `(attempt ${attempt + 1}/${total}); the flow will not fire until it registers`,
+    );
+  }
+
+  private clearEnableRetry(flowId: string): void {
+    const pending = this.enableRetries.get(flowId);
+    if (!pending) return;
+    clearTimeout(pending.timer);
+    this.enableRetries.delete(flowId);
   }
 
   private async teardownEngineTrigger(

--- a/src/workflows/sandbox-api/worker-rpc.test.ts
+++ b/src/workflows/sandbox-api/worker-rpc.test.ts
@@ -8,7 +8,7 @@
  * the WS layer. Step D adds an end-to-end test against the real bundle.
  */
 
-import { test, expect, describe, beforeAll, afterAll } from "bun:test";
+import { test, expect, describe, beforeAll, afterAll, afterEach } from "bun:test";
 import { io as socketIoClient } from "socket.io-client";
 import { closeWorkflowDb, initWorkflowDb } from "../db";
 import { createFlow } from "../db/repos/flow";
@@ -18,6 +18,7 @@ import { DEFAULT_IDS } from "../db/schema";
 import { CredentialResolver } from "../credentials/adapter";
 import { EngineTokenSigner } from "./engine-token";
 import { SandboxRegistry } from "./sandbox-registry";
+import { WorkerRpcServer } from "./worker-rpc";
 import { SandboxApi } from "./server";
 import { createNotifyClient, createRpcClient } from "./rpc";
 import type { WorkerContract, WorkerNotifyContract } from "./contracts";
@@ -355,5 +356,170 @@ describe("WorkerRpcServer (B4: socket.io engine <-> daemon)", () => {
     } finally {
       sb.client.close();
     }
+  });
+});
+
+/**
+ * Connection-path diagnostics. These cover the log output rather than the RPC
+ * contracts: when an engine fails to reach the daemon, that log is the only
+ * evidence available, and each of these cases used to be silent.
+ */
+describe("WorkerRpcServer: connection diagnostics", () => {
+  let server: WorkerRpcServer | null = null;
+  let client: ReturnType<typeof socketIoClient> | null = null;
+
+  afterEach(async () => {
+    client?.close();
+    client = null;
+    await server?.stop();
+    server = null;
+  });
+
+  const noopWorkerHandlers = {
+    async updateRunProgress() {},
+    async updateStepProgress() {},
+    async uploadRunLog() {},
+    async sendFlowResponse() {},
+  } as unknown as ConstructorParameters<typeof WorkerRpcServer>[0]["workerHandlers"];
+
+  const noopNotifyHandlers = {
+    stdout() {},
+    stderr() {},
+  } as unknown as ConstructorParameters<typeof WorkerRpcServer>[0]["notifyHandlers"];
+
+  async function startServer(registry: SandboxRegistry): Promise<WorkerRpcServer> {
+    const s = new WorkerRpcServer({
+      registry,
+      workerHandlers: noopWorkerHandlers,
+      notifyHandlers: noopNotifyHandlers,
+    });
+    server = s;
+    await s.start();
+    return s;
+  }
+
+  function connect(port: number, auth?: { sandboxId: string }): ReturnType<typeof socketIoClient> {
+    const socket = socketIoClient(`ws://127.0.0.1:${port}`, {
+      path: "/worker/ws",
+      ...(auth ? { auth } : {}),
+      reconnection: false,
+      transports: ["websocket"],
+    });
+    client = socket;
+    return socket;
+  }
+
+  function registerSandbox(registry: SandboxRegistry, sandboxId: string): void {
+    registry.register({
+      sandboxId,
+      runId: "run_diag",
+      projectId: DEFAULT_IDS.project,
+      engineToken: "token",
+      expiresAt: Date.now() + 60_000,
+      terminatedAt: null,
+    });
+  }
+
+  /** Run `fn` with console.warn captured. */
+  async function captureWarnings(fn: () => Promise<void>): Promise<string[]> {
+    const lines: string[] = [];
+    const original = console.warn;
+    console.warn = (...args: unknown[]) => {
+      lines.push(args.join(" "));
+    };
+    try {
+      await fn();
+    } finally {
+      console.warn = original;
+    }
+    return lines;
+  }
+
+  const settle = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+  test("binds the RPC socket to loopback only, not every interface", async () => {
+    const s = await startServer(new SandboxRegistry());
+    const port = s.getPort();
+    expect(port).toBeGreaterThan(0);
+    const { execSync } = await import("node:child_process");
+    const listening = execSync(`ss -ltn 2>/dev/null | grep ":${port} " || true`).toString();
+    if (listening.trim() === "") return; // no `ss` on this host; nothing to assert
+    // Match the LOCAL address column specifically -- `ss` prints "0.0.0.0:*"
+    // as the peer of every listening socket, loopback-bound ones included.
+    expect(listening).toContain(`127.0.0.1:${port}`);
+    expect(listening).not.toContain(`0.0.0.0:${port}`);
+    expect(listening).not.toContain(`*:${port}`);
+  });
+
+  test("an engine that connects after the wait timed out is reported as late, not lost", async () => {
+    const registry = new SandboxRegistry();
+    const s = await startServer(registry);
+    const sandboxId = "sandbox-late";
+    registerSandbox(registry, sandboxId);
+
+    const warnings = await captureWarnings(async () => {
+      await expect(s.waitForConnection(sandboxId, 30)).rejects.toThrow(
+        "did not connect within 30ms",
+      );
+      const socket = connect(s.getPort(), { sandboxId });
+      await new Promise<void>((res, rej) => {
+        socket.on("connect", () => res());
+        socket.on("connect_error", rej);
+      });
+      await settle(50);
+    });
+
+    expect(
+      warnings.some(
+        (w) => w.includes("AFTER the daemon") && w.includes("JARVIS_ENGINE_HANDSHAKE_TIMEOUT_MS"),
+      ),
+    ).toBe(true);
+  });
+
+  test("a connection for an unknown sandbox is logged, not silently dropped", async () => {
+    const s = await startServer(new SandboxRegistry());
+
+    const warnings = await captureWarnings(async () => {
+      const socket = connect(s.getPort(), { sandboxId: "sandbox-nobody-knows" });
+      await new Promise<void>((res) => {
+        socket.on("disconnect", () => res());
+        socket.on("connect_error", () => res());
+        setTimeout(res, 500);
+      });
+      await settle(20);
+    });
+
+    expect(warnings.some((w) => w.includes("unknown or terminated sandbox"))).toBe(true);
+  });
+
+  test("a connection with no sandboxId in auth is logged", async () => {
+    const s = await startServer(new SandboxRegistry());
+
+    const warnings = await captureWarnings(async () => {
+      const socket = connect(s.getPort());
+      await new Promise<void>((res) => {
+        socket.on("disconnect", () => res());
+        socket.on("connect_error", () => res());
+        setTimeout(res, 500);
+      });
+      await settle(20);
+    });
+
+    expect(warnings.some((w) => w.includes("missing sandboxId in auth"))).toBe(true);
+  });
+
+  test("a normal connection resolves a pending waiter with no warning", async () => {
+    const registry = new SandboxRegistry();
+    const s = await startServer(registry);
+    const sandboxId = "sandbox-ok";
+    registerSandbox(registry, sandboxId);
+
+    const warnings = await captureWarnings(async () => {
+      const pending = s.waitForConnection(sandboxId, 2_000);
+      connect(s.getPort(), { sandboxId });
+      await pending;
+    });
+
+    expect(warnings).toEqual([]);
   });
 });

--- a/src/workflows/sandbox-api/worker-rpc.ts
+++ b/src/workflows/sandbox-api/worker-rpc.ts
@@ -20,6 +20,7 @@
  * endpoints (AP_SANDBOX_WS_PORT vs internalApiUrl).
  */
 
+import { createServer } from "node:http";
 import { Server, type Socket } from "socket.io";
 import type { SandboxRegistry } from "./sandbox-registry";
 import { createNotifyServer, createRpcClient, createRpcServer } from "./rpc";
@@ -60,6 +61,9 @@ interface ConnectedSandbox {
   engineClient: EngineContract;
 }
 
+/** How long a timed-out sandboxId stays eligible for late-arrival reporting. */
+const ABANDONED_RETENTION_MS = 5 * 60_000;
+
 type ConnectionWaiter = {
   resolve: (engineClient: EngineContract) => void;
   reject: (err: Error) => void;
@@ -70,6 +74,14 @@ export class WorkerRpcServer {
   private io: Server | null = null;
   private readonly connections = new Map<string, ConnectedSandbox>();
   private readonly waiters = new Map<string, ConnectionWaiter[]>();
+  /**
+   * sandboxId -> when we stopped waiting for it. An engine that dials in
+   * after the deadline is the single most useful thing to know when acquires
+   * time out: it separates "the host is too slow for the budget" (raise the
+   * budget) from "the engine never dialed at all" (something upstream of the
+   * socket is broken). Without this the two look identical in the log.
+   */
+  private readonly abandoned = new Map<string, number>();
   private readonly registry: SandboxRegistry;
   private readonly workerHandlers: WorkerContractHandlers;
   private readonly notifyHandlers: NotifyContractHandlers;
@@ -105,28 +117,41 @@ export class WorkerRpcServer {
 
     this.io.on("connection", (socket) => this.onConnection(socket));
 
+    // Bind the HTTP server ourselves rather than via `io.listen(port)`: that
+    // helper ignores the bind host and listens on every interface, which on a
+    // shared host exposes the engine RPC channel (and the sandboxIds flowing
+    // over it) to anything that can reach the box. The engine always dials
+    // 127.0.0.1, so loopback is the only address it needs.
+    const httpServer = createServer();
+    this.io.attach(httpServer);
+
     await new Promise<void>((res, rej) => {
-      try {
-        const httpServer = this.io!.listen(this.desiredPort).httpServer;
-        const onListening = () => {
-          httpServer?.off("error", onError);
-          const addr = httpServer?.address();
-          if (addr && typeof addr === "object") this.actualPort = addr.port;
-          res();
-        };
-        const onError = (err: Error) => {
-          httpServer?.off("listening", onListening);
-          rej(err);
-        };
-        if (httpServer?.listening) {
-          onListening();
-        } else {
-          httpServer?.once("listening", onListening);
-          httpServer?.once("error", onError);
-        }
-      } catch (e) {
-        rej(e);
-      }
+      const onListening = () => {
+        httpServer.off("error", onError);
+        const addr = httpServer.address();
+        if (addr && typeof addr === "object") this.actualPort = addr.port;
+        res();
+      };
+      const onError = (err: Error) => {
+        httpServer.off("listening", onListening);
+        rej(err);
+      };
+      httpServer.once("listening", onListening);
+      httpServer.once("error", onError);
+      httpServer.listen(this.desiredPort, this.host);
+    });
+
+    // Keep listening for errors past startup. A server-level error after bind
+    // (EMFILE when the daemon has exhausted its file descriptors, for
+    // instance) stops new engines from being accepted while every other part
+    // of the daemon keeps running -- engines then dial, get nothing, and
+    // silently retry until their acquire times out. Unhandled, that error is
+    // invisible; logged, it names the problem outright.
+    httpServer.on("error", (err: NodeJS.ErrnoException) => {
+      console.error(
+        `[worker-rpc] engine RPC server error (${err.code ?? "unknown"}): ${err.message}. ` +
+          `Engines cannot connect while this persists.`,
+      );
     });
   }
 
@@ -142,6 +167,7 @@ export class WorkerRpcServer {
       }
     }
     this.waiters.clear();
+    this.abandoned.clear();
     // socket.io's close(cb) doesn't always invoke the callback under Bun's
     // node:http shim when there are no remaining clients (observed during
     // teardown of test cases that never connected). Cap the wait so a stuck
@@ -187,6 +213,7 @@ export class WorkerRpcServer {
           if (idx !== -1) queue.splice(idx, 1);
           if (queue.length === 0) this.waiters.delete(sandboxId);
         }
+        this.markAbandoned(sandboxId);
         reject(new Error(`engine ${sandboxId} did not connect within ${timeoutMs}ms`));
       }, timeoutMs);
       const waiter: ConnectionWaiter = { resolve, reject, timer };
@@ -196,16 +223,52 @@ export class WorkerRpcServer {
     });
   }
 
+  /**
+   * Note that we stopped waiting on a sandbox, so a late connection can be
+   * reported. Entries are pruned by age -- an engine that never arrives must
+   * not leave one behind forever.
+   */
+  private markAbandoned(sandboxId: string): void {
+    const cutoff = Date.now() - ABANDONED_RETENTION_MS;
+    for (const [id, at] of this.abandoned) {
+      if (at < cutoff) this.abandoned.delete(id);
+    }
+    this.abandoned.set(sandboxId, Date.now());
+  }
+
   private onConnection(socket: Socket): void {
     const auth = socket.handshake.auth as { sandboxId?: string } | undefined;
     const sandboxId = auth?.sandboxId;
     if (!sandboxId || typeof sandboxId !== "string") {
+      // Never expected from our own engine bundle, so say so rather than
+      // dropping the socket in silence.
+      console.warn("[worker-rpc] rejected engine connection: missing sandboxId in auth");
       socket.emit("worker_error", "missing sandboxId in auth");
       socket.disconnect(true);
       return;
     }
+    // Report a late arrival before the registry check: by the time an engine
+    // dials in past its deadline, `EngineRuntime` has already terminated the
+    // sandbox, so the rejection below would otherwise be the only trace and
+    // it would look like a different problem entirely.
+    const abandonedAt = this.abandoned.get(sandboxId);
+    if (abandonedAt !== undefined) {
+      this.abandoned.delete(sandboxId);
+      console.warn(
+        `[worker-rpc] engine ${sandboxId} connected ${Date.now() - abandonedAt}ms AFTER the daemon ` +
+          `gave up waiting for it. The engine works; the handshake budget is too small for this ` +
+          `host -- raise JARVIS_ENGINE_HANDSHAKE_TIMEOUT_MS.`,
+      );
+    }
     const record = this.registry.get(sandboxId);
     if (!record) {
+      // The engine's socket.io client reconnects forever, so a sandbox that
+      // is rejected here keeps dialing while its acquire waits out the full
+      // deadline -- indistinguishable from an engine that never booted unless
+      // we log the rejection.
+      console.warn(
+        `[worker-rpc] rejected engine connection for sandbox ${sandboxId}: unknown or terminated sandbox`,
+      );
       socket.emit("worker_error", "unknown or terminated sandbox");
       socket.disconnect(true);
       return;

--- a/ui/src/v2/rooms/workflows/WorkflowEditor.css
+++ b/ui/src/v2/rooms/workflows/WorkflowEditor.css
@@ -160,6 +160,19 @@
 .wf-editor__overlay-banner--accent .wf-editor__overlay-banner-icon { color: var(--accent); }
 .wf-editor__overlay-banner-text {
   flex: 1 1 auto;
+  min-width: 0;
+}
+/* Engine-level failure reason. Own line, single line, clipped -- these
+   messages can be long and must not push the banner into a wall of text.
+   Full text stays available via the title attribute. */
+.wf-editor__overlay-banner-reason {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  color: var(--ink-2);
 }
 .wf-editor__overlay-banner-clear {
   display: inline-flex;

--- a/ui/src/v2/rooms/workflows/WorkflowEditor.tsx
+++ b/ui/src/v2/rooms/workflows/WorkflowEditor.tsx
@@ -5631,6 +5631,14 @@ function OverlayBanner({
             {" "}-- no per-step trace recorded for this run
           </em>
         ) : null}
+        {/* Without this the only clue to a run that died before any step ran
+            (engine never came up, RPC timeout) is the daemon log. The reason
+            is already persisted on the run -- show it. */}
+        {run.failedStep?.errorMessage ? (
+          <span className="wf-editor__overlay-banner-reason" title={run.failedStep.errorMessage}>
+            {run.failedStep.errorMessage}
+          </span>
+        ) : null}
       </span>
       <button
         type="button"

--- a/ui/src/v2/rooms/workflows/useWorkflowsData.ts
+++ b/ui/src/v2/rooms/workflows/useWorkflowsData.ts
@@ -39,7 +39,7 @@ export interface FlowRun {
   finishTime: number | null;
   stepsCount: number | null;
   steps: Record<string, unknown> | null;
-  failedStep: { name: string; displayName: string } | null;
+  failedStep: { name: string; displayName: string; errorMessage?: string } | null;
   triggeredBy: string | null;
   created: number;
   updated: number;


### PR DESCRIPTION
A workflow with an `observer.clipboard_changed` trigger never fired, and running it by hand failed with "FAILED on engine" and no step trace. Both come from the same place: every `EngineRuntime.acquire` on my hosted instance times out with `engine <id> did not connect within 10000ms`.

An `on_event` trigger is engine-managed. The trigger manager calls ON_ENABLE on an engine subprocess to get its poll schedule, so when the acquire fails the flow is never registered and nothing polls. The log said `next refresh will retry`, but nothing calls `refresh()` except the API on a status flip, so one failed attempt stranded the flow permanently.

What this changes:

- Retry ON_ENABLE on a backoff (5s/15s/1m/5m/15m), cancelled on disable or republish, reset on success, and loud when it gives up. The log no longer promises a retry that does not exist.
- Retry the engine acquire up to 3 times on a run. Acquiring is side-effect free, unlike a mid-flow failure, so it is safe to retry.
- Raise the handshake budget from 10s to 30s and make it tunable with `JARVIS_ENGINE_HANDSHAKE_TIMEOUT_MS`. Measured on the affected host, the engine needs over 10s to boot, so the old budget could never be met.
- Fail fast when the engine exits instead of waiting out the whole deadline, and put the exit code, liveness and last stderr lines into the acquire error.
- Log the cases that were previously silent: an engine that connects after we gave up (which distinguishes "host too slow" from "never dialed"), a rejected connection, and a server-level error after bind such as EMFILE.
- Keep an `error` listener on the spawned child. Without one Bun throws the event, so an async spawn failure could take the daemon down instead of failing one acquire.
- Bind the engine RPC socket to loopback. It accepted a `host` option and then ignored it, listening on every interface, which on a shared host exposed the channel.
- Show the run's `failedStep.errorMessage` in the editor banner. It was already persisted but never rendered, so the only way to see why a run died was the daemon log.

Still open: on the affected host the engine spins on its main thread for the full budget without issuing a single connect. GC and JIT threads are idle, there are no page faults and no syscalls, and the same bundle, Bun build and environment handshake in ~200ms elsewhere. Not diagnosed yet. The new late-connect log will show whether that spin is finite, which decides whether the larger budget is the real fix or just cover.
