### PR TITLE
publish the shared-runtime builder and guard what the tarball ships

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -10,6 +10,9 @@ bun run scripts/check-migrations.ts
 echo "[pre-commit] Linting webapp templates..."
 bun run scripts/lint-webapp-templates.ts
 
+echo "[pre-commit] Checking the published tarball still ships what consumers read..."
+bun run scripts/check-package-files.ts
+
 # Bound the test step with a wall-clock timeout. A test that spawns the
 # engine subprocess and forgets to reap it can hang `bun test --bail`
 # indefinitely (observed once in late-May 2026, never reproduced). 240s

--- a/.github/workflows/release-exec.yml
+++ b/.github/workflows/release-exec.yml
@@ -135,6 +135,15 @@ jobs:
       - name: Build UI
         run: bun run prepublishOnly
 
+      # Assert the tarball ABOUT TO BE PUBLISHED still contains every file an
+      # out-of-repo consumer resolves by path. The PR gate runs this too, but
+      # only this job holds the real artifact: a `files` edit merged after CI,
+      # or an npm/bun disagreement about `files`, is caught here or not at all.
+      # npm is on PATH in this job, so the check runs npm's own packer.
+      # npm versions are immutable -- one minute here beats a fix-forward.
+      - name: Check published tarball contents
+        run: bun run scripts/check-package-files.ts
+
       - name: Publish to npm
         run: |
           FLAGS=""

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,6 +69,13 @@ jobs:
       - uses: ./.github/actions/bun-setup
       - run: bun run scripts/check-no-ee-imports.ts
       - run: bun run scripts/check-migrations.ts
+      # The published tarball is the ONLY interface the hosting fleet has to
+      # this repo, and package.json's `files` allowlist is invisible from the
+      # code that depends on it -- a shipped-by-path file can be dropped from
+      # the package without a single test here noticing (it happened; see the
+      # script's header). Re-run just before `npm publish` too, in
+      # release-exec.yml, where the real artifact is built.
+      - run: bun run scripts/check-package-files.ts
       # --retry=2 (3 attempts per test), NOT a retry around the whole step.
       # Every flake this suite has produced in CI is a per-test hook timing out
       # on a loaded runner -- a headless Chromium slow to answer CDP

--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,12 @@
+# NOTE: this file currently has NO EFFECT. `package.json` has a `files` field,
+# and while it does, both npm and bun ignore .npmignore entirely -- every rule
+# below is already contradicted by the real tarball, which ships 196 *.test.ts
+# files, 28 *.md files and ui/public/ort/. `files` is the sole allowlist.
+#
+# Packaging is therefore fixed in package.json, never here. What ships is
+# asserted by scripts/check-package-files.ts, which runs a real packer rather
+# than modelling these rules.
+#
 # Version control
 .git/
 .github/
@@ -16,7 +25,12 @@ node_modules/
 # Dev-only files
 examples/
 scripts/
-!scripts/ensure-bun.js
+# Exceptions: the two scripts that SHIP. Both currently INERT, like every rule
+# in this file -- see the header. They are kept correct (and `ensure-bun` had
+# the wrong extension until 2026-09) so that removing `files` restores a sane
+# package instead of one missing its entry points.
+!scripts/ensure-bun.cjs
+!scripts/build-shared-runtime.ts
 VISION.md
 CLAUDE.md
 **/*.md

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "ui/dist/",
     "ui/public/",
     "scripts/ensure-bun.cjs",
+    "scripts/build-shared-runtime.ts",
     "README.md"
   ],
   "scripts": {
@@ -43,6 +44,7 @@
     "lint:templates": "bun run scripts/lint-webapp-templates.ts",
     "sync:pieces": "bun run scripts/sync-pieces-catalog.ts",
     "check:pieces": "bun run scripts/sync-pieces-catalog.ts --check",
+    "check:package": "bun run scripts/check-package-files.ts",
     "build:workflows": "bun run scripts/build-workflows.ts",
     "audit:piece-outputs": "bun run scripts/audit-piece-outputs.ts",
     "db:init": "bun run src/vault/schema.ts",

--- a/scripts/check-package-files.test.ts
+++ b/scripts/check-package-files.test.ts
@@ -49,10 +49,20 @@ describe("check-package-files parseNpmPack", () => {
     expect(parseNpmPack(`npm warn config foo\n${asObject}`)).toEqual(want);
   });
 
+  test("a notice containing a BRACKET does not defeat it", () => {
+    // CI failed exactly here: npm ran cleanly, the parser found a bracket that
+    // was not the payload, and the whole check reported the package broken.
+    // Every candidate offset is tried now, not just the first.
+    expect(parseNpmPack(`npm warn config [deprecated] ignored\n${asArray}`)).toEqual(want);
+    expect(parseNpmPack(`npm warn {weird}\n${asObject}`)).toEqual(want);
+  });
+
   test("yields nothing rather than throwing on any shape it does not recognize", () => {
     for (const bad of ["", "not json at all", "[", "[{}]", '[{"files":"nope"}]', "{}", "null", '"s"']) {
       expect(parseNpmPack(bad)).toEqual([]);
     }
+    // An empty list is a NORMAL answer that makes the runner fall back to
+    // another packer -- never a reason to fail the build on its own.
     // Entries without a string path are dropped, not coerced.
     expect(parseNpmPack('[{"files":[{"path":"a"},{"size":1}]}]')).toEqual(["a"]);
   });

--- a/scripts/check-package-files.test.ts
+++ b/scripts/check-package-files.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from "bun:test";
+import { REQUIRED, missingFrom, parseBunPack, parseNpmPack } from "./check-package-files.ts";
+
+describe("check-package-files parseBunPack", () => {
+  test("reads paths out of bun pm pack output and ignores the footer", () => {
+    const out = [
+      "bun pack v1.3.8",
+      "",
+      "packed 3.79KB package.json",
+      "packed 21.45KB bin/jarvis.ts",
+      "packed 8.54KB scripts/build-shared-runtime.ts",
+      "",
+      "Total files: 3",
+      "Unpacked size: 0.61GB",
+    ].join("\n");
+    expect(parseBunPack(out)).toEqual([
+      "package.json",
+      "bin/jarvis.ts",
+      "scripts/build-shared-runtime.ts",
+    ]);
+  });
+
+  test("keeps paths containing spaces, and yields nothing for unparseable output", () => {
+    expect(parseBunPack("packed 1.0KB ui/public/some file.png")).toEqual([
+      "ui/public/some file.png",
+    ]);
+    // An output format change must produce an empty list (which main() reports
+    // as a broken parse) rather than partial garbage.
+    expect(parseBunPack("added 1.0KB bin/jarvis.ts\nTotal files: 1")).toEqual([]);
+  });
+});
+
+describe("check-package-files parseNpmPack", () => {
+  const files = [{ path: "bin/jarvis.ts" }, { path: "package.json" }];
+  const want = ["bin/jarvis.ts", "package.json"];
+  // npm 11 shape.
+  const asArray = JSON.stringify([{ name: "@usejarvis/brain", files }]);
+  // npm 12 shape -- keyed by package name. Verified against npm 12.0.2, which
+  // is what `npm install -g npm@latest` in release-exec.yml produces today.
+  const asObject = JSON.stringify({ "@usejarvis/brain": { id: "@usejarvis/brain@0.13.1", files } });
+
+  test("reads the file list from BOTH npm envelopes", () => {
+    expect(parseNpmPack(asArray)).toEqual(want);
+    expect(parseNpmPack(asObject)).toEqual(want);
+  });
+
+  test("tolerates notices printed before the JSON", () => {
+    expect(parseNpmPack(`npm notice something\n${asArray}`)).toEqual(want);
+    expect(parseNpmPack(`npm warn config foo\n${asObject}`)).toEqual(want);
+  });
+
+  test("yields nothing rather than throwing on any shape it does not recognize", () => {
+    for (const bad of ["", "not json at all", "[", "[{}]", '[{"files":"nope"}]', "{}", "null", '"s"']) {
+      expect(parseNpmPack(bad)).toEqual([]);
+    }
+    // Entries without a string path are dropped, not coerced.
+    expect(parseNpmPack('[{"files":[{"path":"a"},{"size":1}]}]')).toEqual(["a"]);
+  });
+});
+
+describe("check-package-files missingFrom", () => {
+  test("matches on the exact tarball path -- a same-named file elsewhere is not it", () => {
+    const req = [{ path: "scripts/build-shared-runtime.ts", why: "host builds shared artifacts" }];
+    expect(missingFrom(["scripts/build-shared-runtime.ts"], req)).toEqual([]);
+    // The failure mode this guards: `files` shipping src/ but not scripts/.
+    expect(missingFrom(["src/scripts/build-shared-runtime.ts"], req)).toEqual(req);
+    expect(missingFrom([], req)).toEqual(req);
+  });
+});
+
+describe("check-package-files REQUIRED", () => {
+  test("the shared-runtime builder is required -- this is the regression", () => {
+    // The bug: install-version gates the whole shared-artifact phase on this
+    // path and skips SILENTLY when it is absent, so nothing downstream ever
+    // reported that the fleet had no shared engine/pieces/metadata artifacts.
+    expect(REQUIRED.map((r) => r.path)).toContain("scripts/build-shared-runtime.ts");
+  });
+
+  test("every requirement explains who breaks without it", () => {
+    for (const r of REQUIRED) {
+      expect(r.path.length).toBeGreaterThan(0);
+      expect(r.why.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("check-package-files against the real package", () => {
+  // The unit tests above cover parsing and matching; this one closes the gap
+  // the reviewer of the original fix found -- that `bun test` alone would not
+  // have caught the bug, because nothing in the suite ran a packer. It does,
+  // via the same entry point CI and the release use.
+  test("the shipped package really does contain every REQUIRED path", async () => {
+    const proc = Bun.spawn(["bun", "run", "scripts/check-package-files.ts"], {
+      cwd: new URL("..", import.meta.url).pathname,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [code, stdout, stderr] = await Promise.all([
+      proc.exited,
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+    ]);
+    expect(`${stdout}${stderr}`).toContain("OK");
+    expect(code).toBe(0);
+  }, 60_000);
+});

--- a/scripts/check-package-files.ts
+++ b/scripts/check-package-files.ts
@@ -85,36 +85,40 @@ export function parseBunPack(output: string): string[] {
 /**
  * Parse the file list out of `npm pack --dry-run --json`.
  *
- * The envelope is NOT stable across npm majors: npm 11 emits an array of pack
- * entries, npm 12 an object keyed by package name. Both wrap the same
+ * The envelope is NOT stable across npm majors: npm 10 and 11 emit an array of
+ * pack entries, npm 12 an object keyed by package name. Both wrap the same
  * `{ files: [{ path }] }`, so normalize to "all entry objects" and read the
  * paths out of whichever arrived. The release job installs `npm@latest`, so
  * the shape can change under this repo without anything here being edited --
  * hence tolerating both rather than pinning to the one seen today.
+ *
+ * npm also prefixes warnings, and a warning can itself contain a bracket, so
+ * every candidate start offset is tried rather than just the first. Returning
+ * [] is a normal outcome, not an error: the caller falls back to another
+ * packer rather than failing the build over an output quirk.
  */
 export function parseNpmPack(output: string): string[] {
-  // npm may prepend notices to the stream; start at the first JSON delimiter
-  // rather than assuming the whole thing parses.
-  const start = output.search(/[[{]/);
-  if (start < 0) return [];
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(output.slice(start));
-  } catch {
-    return [];
-  }
-  if (typeof parsed !== "object" || parsed === null) return [];
-  const entries = Array.isArray(parsed) ? parsed : Object.values(parsed);
-  const paths: string[] = [];
-  for (const entry of entries) {
-    const files = (entry as { files?: unknown } | null)?.files;
-    if (!Array.isArray(files)) continue;
-    for (const f of files) {
-      const path = (f as { path?: unknown } | null)?.path;
-      if (typeof path === "string") paths.push(path);
+  for (const m of output.matchAll(/[[{]/g)) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(output.slice(m.index));
+    } catch {
+      continue;
     }
+    if (typeof parsed !== "object" || parsed === null) continue;
+    const entries = Array.isArray(parsed) ? parsed : Object.values(parsed);
+    const paths: string[] = [];
+    for (const entry of entries) {
+      const files = (entry as { files?: unknown } | null)?.files;
+      if (!Array.isArray(files)) continue;
+      for (const f of files) {
+        const path = (f as { path?: unknown } | null)?.path;
+        if (typeof path === "string") paths.push(path);
+      }
+    }
+    if (paths.length > 0) return paths;
   }
-  return paths;
+  return [];
 }
 
 /** Requirements not satisfied by `packed`. */
@@ -128,43 +132,69 @@ export function missingFrom(packed: string[], required = REQUIRED): Requirement[
  * `files` semantics. A guard that models the rules instead of running them can
  * agree with itself while disagreeing with the packer.
  *
- * npm is preferred because npm is what actually publishes (release-exec.yml),
- * so on the release path this asserts against the true artifact; bun is the
- * fallback for checkouts and hooks where npm is not installed. Today the two
- * agree file-for-file, and a future divergence is precisely the thing worth
- * catching at the point of publish.
+ * npm is tried first because npm is what actually publishes (release-exec.yml),
+ * so on the release path this asserts against the true artifact. bun is the
+ * fallback, and it is a FALLBACK rather than an alternative: this guard exists
+ * to fail when a shipped-by-path file goes missing, and failing instead because
+ * some npm build printed something the parser did not expect would be a check
+ * that cries wolf -- which is how a guard gets deleted. It only gives up when
+ * NO packer produced a file list, which really is a broken check.
  *
  * `--ignore-scripts` keeps `prepublishOnly` out of a read-only check. It does
  * not change which paths are eligible, only whether build outputs happen to
  * exist on disk (see the REQUIRED note about piece `dist/`).
  */
-function packedPaths(): { packer: string; paths: string[] } {
+function packedPaths(): { packer: string; paths: string[]; notes: string[] } {
   const cwd = fileURLToPath(new URL("..", import.meta.url));
   const haveNpm = spawnSync("npm", ["--version"], { encoding: "utf8" }).status === 0;
-  const [cmd, args, parse] = haveNpm
-    ? (["npm", ["pack", "--dry-run", "--json", "--ignore-scripts"], parseNpmPack] as const)
-    : (["bun", ["pm", "pack", "--dry-run", "--ignore-scripts"], parseBunPack] as const);
+  const attempts: Array<{ cmd: string; args: string[]; parse: (out: string) => string[] }> = [
+    ...(haveNpm
+      ? [
+          {
+            cmd: "npm",
+            args: ["pack", "--dry-run", "--json", "--ignore-scripts"],
+            parse: parseNpmPack,
+          },
+        ]
+      : []),
+    { cmd: "bun", args: ["pm", "pack", "--dry-run", "--ignore-scripts"], parse: parseBunPack },
+  ];
 
-  const res = spawnSync(cmd, [...args], { cwd, encoding: "utf8" });
-  if (res.error) throw new Error(`${cmd} pack failed to run: ${res.error.message}`);
-  if (res.status !== 0) {
-    throw new Error(`${cmd} pack exited ${res.status}: ${(res.stderr || res.stdout || "").trim()}`);
+  const notes: string[] = [];
+  for (const a of attempts) {
+    const res = spawnSync(a.cmd, a.args, { cwd, encoding: "utf8" });
+    if (res.error) {
+      notes.push(`${a.cmd}: could not run (${res.error.message})`);
+      continue;
+    }
+    if (res.status !== 0) {
+      notes.push(`${a.cmd}: exited ${res.status} (${(res.stderr || res.stdout || "").trim().slice(0, 200)})`);
+      continue;
+    }
+    // npm writes its JSON to stdout and bun writes its listing to stderr, so
+    // feed each parser both rather than encoding which stream one happens to
+    // use today.
+    const paths = a.parse(`${res.stdout ?? ""}\n${res.stderr ?? ""}`);
+    if (paths.length > 0) return { packer: a.cmd, paths, notes };
+    notes.push(`${a.cmd}: ran cleanly but produced no parseable file list`);
   }
-  // bun writes the listing to stderr and npm to stdout; feed the parser both
-  // rather than encoding which stream each one happens to use.
-  return { packer: cmd, paths: parse(`${res.stdout ?? ""}\n${res.stderr ?? ""}`) };
+  return { packer: "none", paths: [], notes };
 }
 
 function main(): void {
-  const { packer, paths } = packedPaths();
-  // An empty list means the parse broke (an output format change), not a
-  // package with no files. Failing here beats reporting every requirement as
-  // missing and sending someone to edit `files` for no reason.
+  const { packer, paths, notes } = packedPaths();
+  // No packer produced a list at all: the CHECK is broken, not the package.
+  // Failing here beats reporting every requirement as missing and sending
+  // someone to edit `files` for no reason.
   if (paths.length === 0) {
-    console.error(`[check-package-files] FAILED -- could not read any packed path from ${packer}.`);
-    console.error("Has its output format changed? Update the parser.");
+    console.error("[check-package-files] FAILED -- no packer produced a file list:");
+    for (const n of notes) console.error(`  ${n}`);
+    console.error("\nThis is a broken check, not a broken package. Fix the parser.");
     process.exit(1);
   }
+  // Say which packer answered, and why any earlier one did not. A silent
+  // fallback would hide npm breaking on the very path that publishes.
+  for (const n of notes) console.warn(`[check-package-files] note: ${n}`);
 
   const missing = missingFrom(paths);
   if (missing.length === 0) {

--- a/scripts/check-package-files.ts
+++ b/scripts/check-package-files.ts
@@ -1,0 +1,187 @@
+#!/usr/bin/env bun
+/**
+ * Guard: every file a DOWNSTREAM CONSUMER reads out of the published tarball
+ * is actually in the published tarball.
+ *
+ * `package.json`'s `files` allowlist is the ONLY thing in this repo that
+ * decides what npm ships. (`.npmignore` is inert while `files` exists -- both
+ * packers ignore it, which is why 196 `*.test.ts` files currently ship.) It is
+ * invisible from the code that depends on it, so a module can be imported,
+ * tested and merged here while being absent from every install of the package.
+ * When the consumer is another repo, the gap is invisible on both sides.
+ *
+ * That is not hypothetical. `scripts/build-shared-runtime.ts` shipped as the
+ * builder for the hosting fleet's shared runtime artifacts, but `files` never
+ * named it. The host's `install-version` gates the whole artifact phase on the
+ * file existing:
+ *
+ *     local builder="$dest/scripts/build-shared-runtime.ts"
+ *     [[ -f "$builder" ]] || return 0
+ *
+ * The gate is deliberately silent (older brain versions predate the builder
+ * and must still install), so every hosted instance ran with no shared engine
+ * bundle, no shared pieces catalog and no prebuilt metadata cache for an
+ * entire release line, and the config that points at those paths made the
+ * brain report its pieces as host-managed anyway.
+ *
+ * Fails (exit 1) when a REQUIRED path is not in the tarball. The list is the
+ * cross-repo contract, so add to it whenever something outside this repo
+ * starts reading a shipped file by path.
+ *
+ * Run via:
+ *   - `bun run check:package`
+ *   - the pre-commit hook (.githooks/pre-commit)
+ *   - CI (.github/workflows/test.yml)
+ *   - the release, right before `npm publish` (.github/workflows/release-exec.yml)
+ */
+
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+export interface Requirement {
+  /** Path as it appears inside the tarball, relative to the package root. */
+  path: string;
+  /** Who reads it, and what breaks when it is missing. */
+  why: string;
+}
+
+/**
+ * Files an out-of-repo consumer resolves BY PATH out of an installed package.
+ *
+ * Deliberately not here: the vendored pieces' `dist/src/index.js`. Those are
+ * gitignored build outputs produced by `prepublishOnly` (`build:workflows`),
+ * so a fresh checkout legitimately has none and this check would fail for a
+ * reason that has nothing to do with packaging. Their absence is also LOUD --
+ * `install-version` refuses the install with an actionable message -- which is
+ * exactly the property this guard exists to provide for everything else.
+ */
+export const REQUIRED: Requirement[] = [
+  {
+    path: "bin/jarvis.ts",
+    why: "the hosting fleet's install-version refuses a tarball without it, and the jarvis@ unit's ExecStart runs it",
+  },
+  {
+    path: "scripts/build-shared-runtime.ts",
+    why: "the hosting fleet's install-version SILENTLY skips building the shared engine/pieces/metadata artifacts when it is absent",
+  },
+];
+
+/**
+ * Parse the file list out of `bun pm pack --dry-run` output.
+ *
+ * Lines look like `packed 21.45KB bin/jarvis.ts`; the summary footer
+ * ("Total files:", "Unpacked size:") and blank lines are ignored. The path is
+ * everything after the second field, so a path containing a space survives.
+ */
+export function parseBunPack(output: string): string[] {
+  const paths: string[] = [];
+  for (const line of output.split("\n")) {
+    const m = /^packed\s+\S+\s+(.+)$/.exec(line.trim());
+    if (m) paths.push(m[1]!.trim());
+  }
+  return paths;
+}
+
+/**
+ * Parse the file list out of `npm pack --dry-run --json`.
+ *
+ * The envelope is NOT stable across npm majors: npm 11 emits an array of pack
+ * entries, npm 12 an object keyed by package name. Both wrap the same
+ * `{ files: [{ path }] }`, so normalize to "all entry objects" and read the
+ * paths out of whichever arrived. The release job installs `npm@latest`, so
+ * the shape can change under this repo without anything here being edited --
+ * hence tolerating both rather than pinning to the one seen today.
+ */
+export function parseNpmPack(output: string): string[] {
+  // npm may prepend notices to the stream; start at the first JSON delimiter
+  // rather than assuming the whole thing parses.
+  const start = output.search(/[[{]/);
+  if (start < 0) return [];
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(output.slice(start));
+  } catch {
+    return [];
+  }
+  if (typeof parsed !== "object" || parsed === null) return [];
+  const entries = Array.isArray(parsed) ? parsed : Object.values(parsed);
+  const paths: string[] = [];
+  for (const entry of entries) {
+    const files = (entry as { files?: unknown } | null)?.files;
+    if (!Array.isArray(files)) continue;
+    for (const f of files) {
+      const path = (f as { path?: unknown } | null)?.path;
+      if (typeof path === "string") paths.push(path);
+    }
+  }
+  return paths;
+}
+
+/** Requirements not satisfied by `packed`. */
+export function missingFrom(packed: string[], required = REQUIRED): Requirement[] {
+  const have = new Set(packed);
+  return required.filter((r) => !have.has(r.path));
+}
+
+/**
+ * The real tarball contents, via a real packer -- NOT a re-implementation of
+ * `files` semantics. A guard that models the rules instead of running them can
+ * agree with itself while disagreeing with the packer.
+ *
+ * npm is preferred because npm is what actually publishes (release-exec.yml),
+ * so on the release path this asserts against the true artifact; bun is the
+ * fallback for checkouts and hooks where npm is not installed. Today the two
+ * agree file-for-file, and a future divergence is precisely the thing worth
+ * catching at the point of publish.
+ *
+ * `--ignore-scripts` keeps `prepublishOnly` out of a read-only check. It does
+ * not change which paths are eligible, only whether build outputs happen to
+ * exist on disk (see the REQUIRED note about piece `dist/`).
+ */
+function packedPaths(): { packer: string; paths: string[] } {
+  const cwd = fileURLToPath(new URL("..", import.meta.url));
+  const haveNpm = spawnSync("npm", ["--version"], { encoding: "utf8" }).status === 0;
+  const [cmd, args, parse] = haveNpm
+    ? (["npm", ["pack", "--dry-run", "--json", "--ignore-scripts"], parseNpmPack] as const)
+    : (["bun", ["pm", "pack", "--dry-run", "--ignore-scripts"], parseBunPack] as const);
+
+  const res = spawnSync(cmd, [...args], { cwd, encoding: "utf8" });
+  if (res.error) throw new Error(`${cmd} pack failed to run: ${res.error.message}`);
+  if (res.status !== 0) {
+    throw new Error(`${cmd} pack exited ${res.status}: ${(res.stderr || res.stdout || "").trim()}`);
+  }
+  // bun writes the listing to stderr and npm to stdout; feed the parser both
+  // rather than encoding which stream each one happens to use.
+  return { packer: cmd, paths: parse(`${res.stdout ?? ""}\n${res.stderr ?? ""}`) };
+}
+
+function main(): void {
+  const { packer, paths } = packedPaths();
+  // An empty list means the parse broke (an output format change), not a
+  // package with no files. Failing here beats reporting every requirement as
+  // missing and sending someone to edit `files` for no reason.
+  if (paths.length === 0) {
+    console.error(`[check-package-files] FAILED -- could not read any packed path from ${packer}.`);
+    console.error("Has its output format changed? Update the parser.");
+    process.exit(1);
+  }
+
+  const missing = missingFrom(paths);
+  if (missing.length === 0) {
+    console.log(
+      `[check-package-files] OK -- all ${REQUIRED.length} required path(s) present in the ${packer} tarball (${paths.length} files).`,
+    );
+    process.exit(0);
+  }
+
+  console.error("[check-package-files] FAILED -- the published tarball is missing:\n");
+  for (const r of missing) {
+    console.error(`  ${r.path}`);
+    console.error(`           needed by: ${r.why}`);
+  }
+  console.error("\nAdd the path to the `files` allowlist in package.json.");
+  console.error("npm versions are immutable: a release that ships without it can only be fixed forward.");
+  process.exit(1);
+}
+
+if (import.meta.main) main();


### PR DESCRIPTION
`scripts/build-shared-runtime.ts` has never been published. `files` in package.json did not name it, so it is not in any tarball we have ever shipped, and `.npmignore` blanket-ignores `scripts/` (that file turns out to be inert anyway while `files` exists, which is its own surprise).

The hosting fleet gates its entire shared-runtime artifact build on that path:

```bash
local builder="$dest/scripts/build-shared-runtime.ts"
[[ -f "$builder" ]] || return 0
```

The gate is deliberately silent, because brain versions older than the builder still have to install. So every host took that branch, and no hosted instance has ever had a shared engine bundle, shared pieces catalog or prebuilt piece-metadata cache. Verified with `bun pm pack --dry-run` on 0.13.1: the only `scripts/` entry shipped is `ensure-bun.cjs`.

## What this does

- Adds `scripts/build-shared-runtime.ts` to `files`.
- Adds `scripts/check-package-files.ts`: runs a real packer and asserts that every path an out-of-repo consumer resolves by name is actually in the tarball. It prefers `npm pack --dry-run --json` when npm is present (npm is what publishes) and falls back to `bun pm pack`, tolerating both the npm 11 array and npm 12 object envelopes.
- Runs that guard in CI, in the pre-commit hook, and immediately before `npm publish` in release-exec. The release path matters most: a `files` edit merged after CI, or a packer disagreement, is caught there or not at all.
- Fixes `.npmignore`'s exception, which said `ensure-bun.js` for a file called `ensure-bun.cjs`, and records at the top of that file that it currently has no effect at all (196 `*.test.ts` and 28 `*.md` files ship today despite being listed).

I checked the builder actually runs from a published install, not just that it ships: packed the real tarball, extracted it, ran `bun install --production --ignore-scripts`, made the tree read-only, and ran it as an unprivileged user. Exit 0, correct artifacts, no writes into the install tree. Its imports are all under `src/`, and its only bare imports are runtime dependencies.

npm versions are immutable, so 0.13.1 and 0.13.2 can never be repaired. This needs a release to take effect, and the hosting side has matching changes so a version without the builder is reported and no longer silently degrades a fleet.
