### PR TITLE
Position Jarvis as a workflow cofounder and add onboarding activation

### DIFF
--- a/src/comms/websocket.ts
+++ b/src/comms/websocket.ts
@@ -11,10 +11,10 @@ export type WSMessage = {
   type: 'chat' | 'cancel' | 'command' | 'status' | 'stream' | 'error' | 'notification'
       | 'tts_start' | 'tts_text' | 'tts_end' | 'voice_start' | 'voice_end' | 'voice_text'
       | 'interview_start' | 'interview_user_message' | 'interview_assistant' | 'interview_done' | 'interview_error'
-      // Interview voice: the UI asks for the mic (`interview_listen`) and the
-      // daemon answers with `interview_listen_state`; a transcript captured by
-      // the pebble comes back as `interview_user_transcript`.
-      | 'interview_listen' | 'interview_listen_stop' | 'interview_listen_state' | 'interview_user_transcript'
+      // A dashboard loaded before the interview became text-only can still
+      // send `interview_listen`; the daemon answers `interview_listen_state`
+      // with reason 'text-only' so it stops waiting on a microphone.
+      | 'interview_listen' | 'interview_listen_stop' | 'interview_listen_state'
       | 'thinking_start' | 'thinking_end'
       | 'workflow_event'
       | 'goal_event'

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -705,16 +705,7 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
       // stamps it on both `pebble.summon` and any later `pebble.mic_blocked`),
       // so a mic refusal can unwind exactly the slot it belongs to and never a
       // turn that happens to be in flight.
-      // `interview` marks a slot the onboarding interview opened for itself,
-      // so it can take that capture back when the turn moves on. Where the
-      // transcript GOES is decided by `interviewActive` — an interview in
-      // progress gets every utterance, however the capture started.
-      const pendingSummons = new Map<string, { cancelled: boolean; sessionId?: string; interview?: boolean }>();
-
-      // True while an onboarding profile interview is running. The interview
-      // is its own agent loop in its own window, so for as long as it lasts
-      // the user's voice belongs to it and not to the assistant.
-      let interviewActive = false;
+      const pendingSummons = new Map<string, { cancelled: boolean; sessionId?: string }>();
 
       // Fallback timers for the bare-"Jarvis" listening state. If the sidecar's
       // session capture never produces an `audio.session_end` (dropped event,
@@ -901,16 +892,6 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
       // Tell each pebble-capable sidecar whether realtime is available so its
       // summon hotkey knows to toggle a live session vs. the one-shot capture.
       const advertiseRealtime = async (sidecarId: string) => {
-        // The onboarding interview owns the mic while it runs. A realtime
-        // session would answer as the assistant, in its own full-duplex audio
-        // loop the interview can neither see nor steer — so keep every pebble
-        // on one-shot capture, whose transcript we can route. Re-advertised
-        // for real when the interview finishes.
-        if (interviewActive) {
-          await sidecarManager.dispatchRPC(sidecarId, 'pebble.configure_realtime', { enabled: false })
-            .catch((err) => console.warn('[pebble-realtime] interview downgrade failed:', err));
-          return;
-        }
         const cfg = agentService.getConfig();
         const res = resolveRealtimeVoice(cfg, realtimeEnablement(cfg));
         // The advertisement must agree with the starters' plan gate, or the
@@ -951,14 +932,6 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
       const pebbleMicFrames = new Map<string, number>(); // sidecarId -> frame count (diagnostic)
       sidecarManager.onEvent((sidecarId, event) => {
         if (event.event_type === 'pebble.realtime_start') {
-          if (interviewActive) {
-            // Raced the downgrade (the press landed before configure_realtime
-            // reached the sidecar). Refuse it and re-push the downgrade so the
-            // next press does a one-shot capture into the interview.
-            console.log(`[pebble-realtime] realtime_start from ${sidecarId} refused — onboarding interview owns the mic`);
-            void sidecarManager.dispatchRPC(sidecarId, 'pebble.configure_realtime', { enabled: false }).catch(() => {});
-            return;
-          }
           console.log(`[pebble-realtime] realtime_start from ${sidecarId} — opening session`);
           pebbleMicFrames.set(sidecarId, 0);
           void pebbleRealtime.start(sidecarId);
@@ -1814,149 +1787,6 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
         if (pendingRegionByPebble.get(sidecarId)?.ctrl === ctrl) return;
         pendingSummons.delete(sidecarId);
       };
-
-      // ─────────────────── Onboarding interview voice ───────────────────
-      // The dashboard hasn't held the microphone since the wake word moved
-      // into the sidecar, so the onboarding interview borrows the pebble's:
-      // the interview UI asks for the mic when it reaches its "listening"
-      // beat, we capture one utterance, and the transcript goes to the
-      // interviewer. Without this the user's answers were captured by the
-      // pebble and answered by the assistant — the interview only ever heard
-      // what was typed into its composer.
-
-      // Which machine's pebble should the interview listen on? The one the
-      // user last spoke to, else the only connected one (guessing between
-      // several would put the mic on the wrong desk).
-      const pickPebbleSidecar = (): string | null => {
-        const capable: string[] = [];
-        for (const sc of sidecarManager.listSidecars()) {
-          if (sc.connected && (sc.capabilities ?? []).includes('pebble')) capable.push(sc.id);
-        }
-        if (capable.length === 0) return null;
-        if (activePebbleSidecar && capable.includes(activePebbleSidecar)) return activePebbleSidecar;
-        return capable.length === 1 ? capable[0]! : null;
-      };
-
-      // Hand a captured utterance to the interview instead of the assistant.
-      // Returns false when no interview is running, so callers fall through
-      // to their normal response cycle.
-      const routeToInterview = async (sidecarId: string, transcript: string): Promise<boolean> => {
-        // The session map is the authority on whether an interview is live —
-        // `interviewActive` mirrors it for the realtime advertisement, which
-        // has to be decided before any transcript exists.
-        if (!wsService.hasActiveInterview()) return false;
-        if (!wsService.deliverInterviewVoice(transcript)) return false;
-        clearInterviewMicWatchdog();
-        console.log(`[ambient-ui] transcript → onboarding interview (${transcript.length} chars)`);
-        // The interview window renders and speaks the reply; the pebble has
-        // nothing to say and steps back to idle.
-        await setState(sidecarId, 'idle', '');
-        return true;
-      };
-
-      // A capture the interview did NOT open (a summon already in flight when
-      // it asked for the mic) can end without ever reaching us. We can't
-      // cancel someone else's slot, but this makes sure the interview stops
-      // waiting on a turn that is never coming.
-      let interviewMicWatchdog: ReturnType<typeof setTimeout> | null = null;
-      const clearInterviewMicWatchdog = () => {
-        if (interviewMicWatchdog === null) return;
-        clearTimeout(interviewMicWatchdog);
-        interviewMicWatchdog = null;
-      };
-
-      wsService.setInterviewVoiceBridge({
-        setActive: (active: boolean) => {
-          if (interviewActive === active) return;
-          interviewActive = active;
-          console.log(
-            `[ambient-ui] onboarding interview ${active ? 'started — voice routes to the interview' : 'finished — voice back to the assistant'}`,
-          );
-          // Flip every pebble between one-shot capture (interview) and its
-          // real realtime verdict. advertiseRealtime reads `interviewActive`,
-          // so this single call does both directions; stopping the live
-          // sessions first makes sure an open one ends now rather than after
-          // the sidecar's own teardown.
-          if (active) {
-            for (const sc of sidecarManager.listSidecars()) {
-              if (sc.connected && (sc.capabilities ?? []).includes('pebble')) pebbleRealtime.stop(sc.id);
-            }
-          }
-          void readvertiseRealtime?.().catch((err: unknown) =>
-            console.warn('[ambient-ui] interview realtime re-advertisement failed:', err),
-          );
-        },
-
-        arm: async (): Promise<{ armed: boolean; reason?: string }> => {
-          if (!pebbleSTT) return { armed: false, reason: 'no-stt' };
-          const sidecarId = pickPebbleSidecar();
-          if (!sidecarId) return { armed: false, reason: 'no-pebble' };
-          clearInterviewMicWatchdog();
-          const existing = pendingSummons.get(sidecarId);
-          if (existing && !existing.cancelled) {
-            // A capture is already open on this pebble (the user pressed
-            // Ctrl+Space, or a wake phrase fired). Let it run — its transcript
-            // comes to the interview anyway — rather than opening a second mic
-            // on the same machine. The slot isn't ours to cancel, so the
-            // watchdog is all we arm here.
-            interviewMicWatchdog = setTimeout(() => {
-              interviewMicWatchdog = null;
-              wsService.notifyInterviewListenEnded('timeout');
-            }, WAKE_LISTEN_FALLBACK_MS);
-            return { armed: true };
-          }
-          const ctrl = { cancelled: false, interview: true };
-          pendingSummons.set(sidecarId, ctrl);
-          await setState(sidecarId, 'listening', '');
-          try {
-            const res = (await sidecarManager.dispatchRPC(sidecarId, 'pebble.start_listening', {})) as
-              | { started?: boolean; reason?: string }
-              | undefined;
-            if (res?.started === false) {
-              // Muted, most likely. Give the slot back and tell the UI, which
-              // falls back to typing instead of holding a listening orb.
-              ctrl.cancelled = true;
-              clearSummon(sidecarId, ctrl);
-              if (res.reason === 'muted') await setState(sidecarId, 'muted');
-              else await setState(sidecarId, 'idle', '');
-              return { armed: false, reason: res.reason ?? 'refused' };
-            }
-          } catch (err) {
-            console.warn('[ambient-ui] interview start_listening failed:', err);
-            ctrl.cancelled = true;
-            clearSummon(sidecarId, ctrl);
-            await setState(sidecarId, 'idle', '');
-            return { armed: false, reason: 'unavailable' };
-          }
-          // Same fallback the wake path uses: a dropped `audio.session_end`
-          // would otherwise leave the interview waiting on a turn that never
-          // arrives. Cleared the moment a session IS consumed.
-          clearListenTimer(sidecarId);
-          pendingListenTimers.set(sidecarId, setTimeout(() => {
-            pendingListenTimers.delete(sidecarId);
-            if (pendingSummons.get(sidecarId) !== ctrl) return; // already consumed
-            console.warn('[ambient-ui] interview capture: no session_end within fallback window');
-            ctrl.cancelled = true;
-            clearSummon(sidecarId, ctrl);
-            void setState(sidecarId, 'idle', '');
-            wsService.notifyInterviewListenEnded('timeout');
-          }, WAKE_LISTEN_FALLBACK_MS));
-          return { armed: true };
-        },
-
-        disarm: () => {
-          clearInterviewMicWatchdog();
-          // Only captures the interview opened itself: a summon the user
-          // started is not ours to cancel.
-          for (const [sidecarId, ctrl] of pendingSummons) {
-            if (!ctrl.interview) continue;
-            ctrl.cancelled = true;
-            clearListenTimer(sidecarId);
-            clearSummon(sidecarId, ctrl);
-            void setState(sidecarId, 'idle', '');
-          }
-        },
-      });
 
       const tryHandleRegionIntent = async (
         sidecarId: string,
@@ -3721,19 +3551,9 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
             );
             await setState(session.sidecarId, 'idle', '');
             clearSummon(session.sidecarId, ctrl);
-            // The interview is waiting on this turn — tell it the capture came
-            // back empty so it re-arms instead of holding a listening orb.
-            if (wsService.hasActiveInterview()) wsService.notifyInterviewListenEnded('no-speech');
             return;
           }
           console.log(`[ambient-ui] user said (${transcript.length} chars)`);
-
-          // An interview in progress gets the utterance first — answers to
-          // its questions are not requests to the assistant.
-          if (await routeToInterview(session.sidecarId, transcript)) {
-            clearSummon(session.sidecarId, ctrl);
-            return;
-          }
 
           await runResponseCycle(session.sidecarId, transcript, ctrl);
           clearSummon(session.sidecarId, ctrl);
@@ -3858,9 +3678,6 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
 
         try {
           console.log(`[ambient-ui] wake → command: "${command}"`);
-          // "Hey Jarvis, I work in product design" during the interview is an
-          // answer, not an instruction — route it like any other capture.
-          if (await routeToInterview(sidecarId, command)) return;
           await runResponseCycle(sidecarId, command, ctrl);
         } catch (err) {
           console.warn('[ambient-ui] wake voice cycle error:', err);

--- a/src/daemon/interview-voice.test.ts
+++ b/src/daemon/interview-voice.test.ts
@@ -1,27 +1,10 @@
-import { describe, expect, test } from 'bun:test';
+import { beforeEach, describe, expect, test } from 'bun:test';
 import { WebSocketService } from './ws-service.ts';
+import { initDatabase } from '../vault/schema.ts';
 import type { JarvisConfig } from '../config/types.ts';
+import type { InterviewSession } from './onboarding-interviewer.ts';
 
-/**
- * The onboarding interview owns the user's voice while it runs.
- *
- * Before this, speech during the first interview was captured by the pebble
- * and answered by the assistant — the interview only ever heard what was
- * typed into its composer. These tests pin the hand-off: the interview claims
- * the mic when it starts, a transcript captured off-socket is delivered to
- * the interviewer, and the mic goes back to the assistant when it ends.
- *
- * The second suite pins the other half of that hand-off: because speech can
- * now arrive at any moment, turns have to be serialized — the interviewer
- * mutates one message history across awaits.
- *
- * The service is constructed but never start()ed (no port bound);
- * routeMessage and the public bridge entry points are exercised directly.
- * Where the LLM is irrelevant the stub reports no providers, so each turn
- * stops at `interview_error` instead of calling a model — the session
- * lifecycle under test is identical either way.
- */
-
+/** Exercise the actual WS message boundary without binding a port. */
 const makeService = (llmManager?: unknown) => {
   const fakeAgent = {
     setDelegationCallback: () => {},
@@ -31,259 +14,215 @@ const makeService = (llmManager?: unknown) => {
   const svc = new WebSocketService(0, fakeAgent);
   const makeClient = () => {
     const sent: Array<Record<string, unknown>> = [];
+    const binary: unknown[] = [];
     const ws = {
       send: (raw: string) => { sent.push(JSON.parse(raw) as Record<string, unknown>); },
-      sendBinary: () => {},
+      sendBinary: (chunk: unknown) => { binary.push(chunk); },
     } as never;
     (svc as unknown as { wsServer: { getClients: () => Set<unknown> } }).wsServer.getClients().add(ws);
-    return { ws, sent };
+    return { ws, sent, binary };
   };
   const internals = svc as unknown as {
     routeMessage: (msg: unknown, ws: unknown) => Promise<unknown>;
-    interviewSessions: Map<unknown, unknown>;
+    interviewSessions: Map<unknown, InterviewSession>;
+    interviewPendingText: Map<unknown, string>;
+    interviewTurnsInFlight: Set<unknown>;
+    voiceSessions: Map<unknown, unknown>;
+    endInterviewSession: (ws: unknown) => void;
   };
   return { svc, internals, makeClient };
 };
 
-/** Records what the daemon's pebble bridge was asked to do. */
-const makeBridge = (arm: { armed: boolean; reason?: string } = { armed: true }) => {
+const makeBridge = () => {
   const calls: string[] = [];
   return {
     calls,
     bridge: {
-      arm: async () => { calls.push('arm'); return arm; },
+      arm: async () => { calls.push('arm'); return { armed: true }; },
       disarm: () => { calls.push('disarm'); },
       setActive: (active: boolean) => { calls.push(`setActive:${active}`); },
     },
   };
 };
 
-const startInterview = async (
+const tick = () => new Promise<void>(resolve => setTimeout(resolve, 0));
+const send = async (
   internals: ReturnType<typeof makeService>['internals'],
   ws: unknown,
+  type: string,
+  payload: Record<string, unknown> = {},
 ) => {
-  await internals.routeMessage({ type: 'interview_start', payload: {}, timestamp: Date.now() }, ws);
-  // The handler is fire-and-forget; let it run.
-  await new Promise<void>(r => setTimeout(r, 0));
+  await internals.routeMessage({ type, payload, timestamp: Date.now() }, ws);
+  await tick();
 };
-
 const lastOfType = (sent: Array<Record<string, unknown>>, type: string) =>
   [...sent].reverse().find(m => m.type === type);
 
-describe('interview voice hand-off', () => {
-  test('starting an interview takes the microphone off the assistant', async () => {
-    const { svc, internals, makeClient } = makeService();
+const makeLLM = (done = false) => ({
+  getProviderNames: () => ['stub'],
+  hasConversationTier: () => false,
+  chatTier: async () => ({
+    content: done ? 'You can ask for a workflow draft after setup.' : 'What are you building?',
+    tool_calls: done
+      ? [{ id: 'wrap', name: 'wrap_interview', arguments: { farewell: 'Thanks for the context.' } }]
+      : [],
+  }),
+});
+
+describe('written interview transport', () => {
+  beforeEach(() => initDatabase(':memory:'));
+
+  test('opening and replying never activate the microphone or synthesize audio, even for legacy speakReply requests', async () => {
+    const { svc, internals, makeClient } = makeService(makeLLM());
     const { calls, bridge } = makeBridge();
     svc.setInterviewVoiceBridge(bridge);
-    const { ws } = makeClient();
+    let synthesisCalls = 0;
+    svc.setTTSProvider({
+      synthesizeStream: async function* () {
+        synthesisCalls++;
+        yield Buffer.from('unexpected interview audio');
+      },
+    } as never);
+    const { ws, sent, binary } = makeClient();
 
-    expect(svc.hasActiveInterview()).toBe(false);
-    await startInterview(internals, ws);
+    await send(internals, ws, 'interview_start', { speakReply: true });
+    await send(internals, ws, 'interview_user_message', { text: 'I am building a studio.', speakReply: true });
 
     expect(svc.hasActiveInterview()).toBe(true);
-    expect(calls).toContain('setActive:true');
+    expect(calls).toEqual([]);
+    expect(synthesisCalls).toBe(0);
+    expect(binary).toEqual([]);
+    const replies = sent.filter(m => m.type === 'interview_assistant');
+    expect(replies).toHaveLength(2);
+    expect(replies.every(m => (m.payload as { will_speak: boolean }).will_speak === false)).toBe(true);
+    expect(sent.some(m => m.type === 'tts_start' || m.type === 'tts_end')).toBe(false);
+    expect(internals.interviewSessions.get(ws)?.messages.some(m => m.role === 'user' && m.content === 'I am building a studio.')).toBe(true);
   });
 
-  test('a pebble transcript is delivered to the interview, not the assistant', async () => {
-    const { svc, internals, makeClient } = makeService();
-    const { bridge } = makeBridge();
-    svc.setInterviewVoiceBridge(bridge);
-    const { ws, sent } = makeClient();
-    await startInterview(internals, ws);
-
-    expect(svc.deliverInterviewVoice('  I design products in Milan  ')).toBe(true);
-    const echoed = lastOfType(sent, 'interview_user_transcript');
-    expect(echoed).toBeDefined();
-    expect((echoed!.payload as { text: string }).text).toBe('I design products in Milan');
-  });
-
-  test('with no interview running the transcript is refused so the assistant answers', () => {
-    const { svc } = makeService();
-    svc.setInterviewVoiceBridge(makeBridge().bridge);
-    expect(svc.deliverInterviewVoice('what is the weather')).toBe(false);
-  });
-
-  test('a blank transcript is refused rather than sent as a turn', async () => {
-    const { svc, internals, makeClient } = makeService();
-    svc.setInterviewVoiceBridge(makeBridge().bridge);
-    const { ws, sent } = makeClient();
-    await startInterview(internals, ws);
-
-    expect(svc.deliverInterviewVoice('   ')).toBe(false);
-    expect(lastOfType(sent, 'interview_user_transcript')).toBeUndefined();
-  });
-
-  test('interview_listen arms the pebble and tells the UI it worked', async () => {
+  test('legacy microphone requests receive text-only without touching ordinary voice capture', async () => {
     const { svc, internals, makeClient } = makeService();
     const { calls, bridge } = makeBridge();
     svc.setInterviewVoiceBridge(bridge);
     const { ws, sent } = makeClient();
-    await startInterview(internals, ws);
+    await send(internals, ws, 'interview_start');
+    await send(internals, ws, 'voice_start', { requestId: 'normal-voice', mode: 'wav' });
+    const normalCapture = internals.voiceSessions.get(ws);
+    expect(normalCapture).toBeDefined();
 
-    await internals.routeMessage({ type: 'interview_listen', payload: {}, timestamp: Date.now() }, ws);
-    await new Promise<void>(r => setTimeout(r, 0));
+    await send(internals, ws, 'interview_listen', { speakReply: true });
+    await send(internals, ws, 'interview_listen_stop');
 
-    expect(calls).toContain('arm');
-    expect(lastOfType(sent, 'interview_listen_state')?.payload).toEqual({ armed: true });
+    expect(lastOfType(sent, 'interview_listen_state')?.payload).toEqual({ armed: false, reason: 'text-only' });
+    expect(calls).toEqual([]);
+    expect(internals.voiceSessions.get(ws)).toBe(normalCapture);
   });
 
-  test('a refused mic is reported with its reason so the UI can fall back', async () => {
-    const { svc, internals, makeClient } = makeService();
-    const { bridge } = makeBridge({ armed: false, reason: 'muted' });
-    svc.setInterviewVoiceBridge(bridge);
+  test('a stale client receives text-only even without a running interview or bridge', async () => {
+    const { internals, makeClient } = makeService();
     const { ws, sent } = makeClient();
-    await startInterview(internals, ws);
-
-    await internals.routeMessage({ type: 'interview_listen', payload: {}, timestamp: Date.now() }, ws);
-    await new Promise<void>(r => setTimeout(r, 0));
-
-    expect(lastOfType(sent, 'interview_listen_state')?.payload).toEqual({ armed: false, reason: 'muted' });
+    await send(internals, ws, 'interview_listen');
+    expect(lastOfType(sent, 'interview_listen_state')?.payload).toEqual({ armed: false, reason: 'text-only' });
+    expect(internals.interviewSessions.size).toBe(0);
   });
 
-  test('with no bridge wired the UI is told at once instead of waiting on a mic', async () => {
-    const { svc, internals, makeClient } = makeService();
-    const { ws, sent } = makeClient();
-    await startInterview(internals, ws);
-
-    await internals.routeMessage({ type: 'interview_listen', payload: {}, timestamp: Date.now() }, ws);
-    await new Promise<void>(r => setTimeout(r, 0));
-
-    expect(lastOfType(sent, 'interview_listen_state')?.payload).toEqual({ armed: false, reason: 'no-pebble' });
-  });
-
-  test('interview_listen_stop hands the microphone back', async () => {
-    const { svc, internals, makeClient } = makeService();
-    const { calls, bridge } = makeBridge();
-    svc.setInterviewVoiceBridge(bridge);
-    const { ws } = makeClient();
-    await startInterview(internals, ws);
-    await internals.routeMessage({ type: 'interview_listen', payload: {}, timestamp: Date.now() }, ws);
-    await new Promise<void>(r => setTimeout(r, 0));
-
-    await internals.routeMessage({ type: 'interview_listen_stop', payload: {}, timestamp: Date.now() }, ws);
-    expect(calls).toContain('disarm');
-  });
-
-  test('an abandoned interview releases the mic — the assistant is not left mute', async () => {
-    const { svc, internals, makeClient } = makeService();
-    const { calls, bridge } = makeBridge();
-    svc.setInterviewVoiceBridge(bridge);
-    const { ws } = makeClient();
-    await startInterview(internals, ws);
-    await internals.routeMessage({ type: 'interview_listen', payload: {}, timestamp: Date.now() }, ws);
-    await new Promise<void>(r => setTimeout(r, 0));
-
-    // What the WS server's onDisconnect does: sweep the maps, then release.
-    internals.interviewSessions.delete(ws);
-    (svc as unknown as { endInterviewVoice: (ws: unknown) => void }).endInterviewVoice(ws);
-
-    expect(calls).toContain('disarm');
-    expect(calls).toContain('setActive:false');
-    expect(svc.hasActiveInterview()).toBe(false);
-  });
-
-  test('an empty capture is reported so the interview can re-arm', async () => {
-    const { svc, internals, makeClient } = makeService();
-    svc.setInterviewVoiceBridge(makeBridge().bridge);
-    const { ws, sent } = makeClient();
-    await startInterview(internals, ws);
-
-    svc.notifyInterviewListenEnded('no-speech');
-    expect(lastOfType(sent, 'interview_listen_state')?.payload).toEqual({ armed: false, reason: 'no-speech' });
-  });
-
-  test('the newest interview window owns the mic', async () => {
-    const { svc, internals, makeClient } = makeService();
-    svc.setInterviewVoiceBridge(makeBridge().bridge);
+  test('Pebble speech is never consumed as an interview answer, including with multiple windows', async () => {
+    const { svc, internals, makeClient } = makeService(makeLLM());
     const first = makeClient();
     const second = makeClient();
-    await startInterview(internals, first.ws);
-    await startInterview(internals, second.ws);
+    expect(svc.deliverInterviewVoice('Before setup')).toBe(false);
+    await send(internals, first.ws, 'interview_start');
+    await send(internals, second.ws, 'interview_start');
+    const histories = [...internals.interviewSessions.values()].map(session => [...session.messages]);
 
-    expect(svc.deliverInterviewVoice('hello')).toBe(true);
-    expect(lastOfType(second.sent, 'interview_user_transcript')).toBeDefined();
-    expect(lastOfType(first.sent, 'interview_user_transcript')).toBeUndefined();
+    expect(svc.deliverInterviewVoice('I design products in Milan')).toBe(false);
+    expect(svc.deliverInterviewVoice('   ')).toBe(false);
+    svc.notifyInterviewListenEnded('no-speech');
+    await tick();
+
+    expect([...internals.interviewSessions.values()].map(session => session.messages)).toEqual(histories);
+    expect([...first.sent, ...second.sent].some(m => m.type === 'interview_user_transcript' || m.type === 'interview_listen_state')).toBe(false);
+  });
+
+  test('wrapping sends written completion and clears the session without changing normal voice', async () => {
+    const { svc, internals, makeClient } = makeService(makeLLM(true));
+    const { calls, bridge } = makeBridge();
+    svc.setInterviewVoiceBridge(bridge);
+    const { ws, sent } = makeClient();
+    await send(internals, ws, 'interview_start', { speakReply: true });
+
+    expect(lastOfType(sent, 'interview_done')).toBeDefined();
+    expect(svc.hasActiveInterview()).toBe(false);
+    expect(internals.interviewTurnsInFlight.size).toBe(0);
+    expect(internals.interviewPendingText.size).toBe(0);
+    expect(calls).toEqual([]);
   });
 });
 
-/**
- * A stub LLM whose turns finish only when the test says so. Records the
- * message history each turn was handed, which is what the serialization
- * claim is really about.
- */
+/** Hold each model call so overlapping typed input and disconnects are testable. */
 const makeSlowLLM = () => {
   const seen: Array<Array<{ role: string; content: string }>> = [];
   let release: (() => void) | null = null;
   return {
     seen,
-    /** Let the turn that is currently blocked finish. */
     finishTurn: async () => {
       const go = release;
       release = null;
       go?.();
-      await new Promise<void>(r => setTimeout(r, 0));
+      await tick();
     },
     llm: {
       getProviderNames: () => ['stub'],
       hasConversationTier: () => false,
-      chatTier: async (
-        _tier: string,
-        _caller: string,
-        messages: Array<{ role: string; content: string }>,
-      ) => {
+      chatTier: async (_tier: string, _caller: string, messages: Array<{ role: string; content: string }>) => {
         seen.push(messages.map(m => ({ role: m.role, content: m.content })));
-        await new Promise<void>(r => { release = r; });
-        return { content: 'And what do you do?', tool_calls: [] };
+        await new Promise<void>(resolve => { release = resolve; });
+        return { content: 'What work do you repeat?', tool_calls: [] };
       },
     },
   };
 };
 
-describe('interview turns are serialized', () => {
-  test('speech arriving mid-turn runs next instead of interleaving', async () => {
+describe('written interview turn lifecycle', () => {
+  test('typed replies arriving mid-turn run next in order, while speech stays outside the interview', async () => {
     const slow = makeSlowLLM();
     const { svc, internals, makeClient } = makeService(slow.llm);
-    svc.setInterviewVoiceBridge(makeBridge().bridge);
     const { ws, sent } = makeClient();
-
-    // Opening turn — blocked inside the LLM call.
-    void internals.routeMessage({ type: 'interview_start', payload: {}, timestamp: Date.now() }, ws);
-    await new Promise<void>(r => setTimeout(r, 0));
-    expect(slow.seen.length).toBe(1);
-
-    // Two utterances land while that turn is still running.
-    expect(svc.deliverInterviewVoice("I'm a designer")).toBe(true);
-    expect(svc.deliverInterviewVoice('in Milan')).toBe(true);
-    // Still one turn in flight: neither raced into the shared history.
-    expect(slow.seen.length).toBe(1);
-
-    await slow.finishTurn();      // opening turn completes → queued text runs
-    expect(slow.seen.length).toBe(2);
-    const second = slow.seen[1]!;
-    // Both utterances arrived as ONE user turn, in order.
-    expect(second.filter(m => m.role === 'user').at(-1)!.content).toBe("I'm a designer in Milan");
-    // …and the history is still strictly alternating, never user-after-user.
-    const roles = second.map(m => m.role).filter(r => r === 'user' || r === 'assistant');
-    expect(roles.some((r, i) => i > 0 && r === roles[i - 1])).toBe(false);
+    await send(internals, ws, 'interview_start');
+    await send(internals, ws, 'interview_user_message', { text: "I'm a designer" });
+    await send(internals, ws, 'interview_user_message', { text: 'in Milan' });
+    expect(svc.deliverInterviewVoice('Unrelated voice conversation')).toBe(false);
+    expect(slow.seen).toHaveLength(1);
 
     await slow.finishTurn();
-    expect(sent.filter(m => m.type === 'interview_assistant').length).toBe(2);
+    expect(slow.seen).toHaveLength(2);
+    const nextTurn = slow.seen[1]!;
+    expect(nextTurn.filter(m => m.role === 'user').at(-1)?.content).toBe("I'm a designer in Milan");
+    expect(nextTurn.some(m => m.content === 'Unrelated voice conversation')).toBe(false);
+    const roles = nextTurn.map(m => m.role).filter(role => role === 'user' || role === 'assistant');
+    expect(roles.some((role, index) => index > 0 && role === roles[index - 1])).toBe(false);
+    await slow.finishTurn();
+    expect(sent.filter(m => m.type === 'interview_assistant')).toHaveLength(2);
   });
 
-  test('a mid-turn transcript is never handed back to the assistant', async () => {
+  test('disconnect drops queued input and ignores the late reply', async () => {
     const slow = makeSlowLLM();
     const { svc, internals, makeClient } = makeService(slow.llm);
-    svc.setInterviewVoiceBridge(makeBridge().bridge);
-    const { ws } = makeClient();
-    void internals.routeMessage({ type: 'interview_start', payload: {}, timestamp: Date.now() }, ws);
-    await new Promise<void>(r => setTimeout(r, 0));
+    const { calls, bridge } = makeBridge();
+    svc.setInterviewVoiceBridge(bridge);
+    const { ws, sent } = makeClient();
+    await send(internals, ws, 'interview_start');
+    await send(internals, ws, 'interview_user_message', { text: 'A queued answer' });
 
-    // `true` is what tells the daemon "handled — do not run a response
-    // cycle". Returning false here would put the answer to an interview
-    // question through the assistant, which is the bug this all fixes.
-    expect(svc.deliverInterviewVoice('mid-turn answer')).toBe(true);
+    // The disconnect handler sweeps the session map before its lifecycle cleanup.
+    internals.interviewSessions.delete(ws);
+    internals.endInterviewSession(ws);
+    await slow.finishTurn();
 
-    await slow.finishTurn();
-    await slow.finishTurn();
+    expect(slow.seen).toHaveLength(1);
+    expect(sent.some(m => m.type === 'interview_assistant')).toBe(false);
+    expect(internals.interviewTurnsInFlight.size).toBe(0);
+    expect(internals.interviewPendingText.size).toBe(0);
+    expect(svc.hasActiveInterview()).toBe(false);
+    expect(calls).toEqual([]);
   });
 });

--- a/src/daemon/interview-voice.test.ts
+++ b/src/daemon/interview-voice.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, test } from 'bun:test';
 import { WebSocketService } from './ws-service.ts';
 import { initDatabase } from '../vault/schema.ts';
+import { getUserProfile } from '../vault/user-profile.ts';
 import type { JarvisConfig } from '../config/types.ts';
 import type { InterviewSession } from './onboarding-interviewer.ts';
 
@@ -33,18 +34,6 @@ const makeService = (llmManager?: unknown) => {
   return { svc, internals, makeClient };
 };
 
-const makeBridge = () => {
-  const calls: string[] = [];
-  return {
-    calls,
-    bridge: {
-      arm: async () => { calls.push('arm'); return { armed: true }; },
-      disarm: () => { calls.push('disarm'); },
-      setActive: (active: boolean) => { calls.push(`setActive:${active}`); },
-    },
-  };
-};
-
 const tick = () => new Promise<void>(resolve => setTimeout(resolve, 0));
 const send = async (
   internals: ReturnType<typeof makeService>['internals'],
@@ -57,6 +46,10 @@ const send = async (
 };
 const lastOfType = (sent: Array<Record<string, unknown>>, type: string) =>
   [...sent].reverse().find(m => m.type === type);
+const hasRepeatedRole = (messages: Array<{ role: string }>) => {
+  const roles = messages.map(m => m.role).filter(role => role === 'user' || role === 'assistant');
+  return roles.some((role, index) => index > 0 && role === roles[index - 1]);
+};
 
 const makeLLM = (done = false) => ({
   getProviderNames: () => ['stub'],
@@ -72,10 +65,8 @@ const makeLLM = (done = false) => ({
 describe('written interview transport', () => {
   beforeEach(() => initDatabase(':memory:'));
 
-  test('opening and replying never activate the microphone or synthesize audio, even for legacy speakReply requests', async () => {
+  test('opening and replying never synthesize audio, even for legacy speakReply requests', async () => {
     const { svc, internals, makeClient } = makeService(makeLLM());
-    const { calls, bridge } = makeBridge();
-    svc.setInterviewVoiceBridge(bridge);
     let synthesisCalls = 0;
     svc.setTTSProvider({
       synthesizeStream: async function* () {
@@ -88,8 +79,7 @@ describe('written interview transport', () => {
     await send(internals, ws, 'interview_start', { speakReply: true });
     await send(internals, ws, 'interview_user_message', { text: 'I am building a studio.', speakReply: true });
 
-    expect(svc.hasActiveInterview()).toBe(true);
-    expect(calls).toEqual([]);
+    expect(internals.interviewSessions.has(ws)).toBe(true);
     expect(synthesisCalls).toBe(0);
     expect(binary).toEqual([]);
     const replies = sent.filter(m => m.type === 'interview_assistant');
@@ -100,9 +90,7 @@ describe('written interview transport', () => {
   });
 
   test('legacy microphone requests receive text-only without touching ordinary voice capture', async () => {
-    const { svc, internals, makeClient } = makeService();
-    const { calls, bridge } = makeBridge();
-    svc.setInterviewVoiceBridge(bridge);
+    const { internals, makeClient } = makeService();
     const { ws, sent } = makeClient();
     await send(internals, ws, 'interview_start');
     await send(internals, ws, 'voice_start', { requestId: 'normal-voice', mode: 'wav' });
@@ -113,11 +101,10 @@ describe('written interview transport', () => {
     await send(internals, ws, 'interview_listen_stop');
 
     expect(lastOfType(sent, 'interview_listen_state')?.payload).toEqual({ armed: false, reason: 'text-only' });
-    expect(calls).toEqual([]);
     expect(internals.voiceSessions.get(ws)).toBe(normalCapture);
   });
 
-  test('a stale client receives text-only even without a running interview or bridge', async () => {
+  test('a stale client receives text-only even without a running interview', async () => {
     const { internals, makeClient } = makeService();
     const { ws, sent } = makeClient();
     await send(internals, ws, 'interview_listen');
@@ -125,36 +112,15 @@ describe('written interview transport', () => {
     expect(internals.interviewSessions.size).toBe(0);
   });
 
-  test('Pebble speech is never consumed as an interview answer, including with multiple windows', async () => {
-    const { svc, internals, makeClient } = makeService(makeLLM());
-    const first = makeClient();
-    const second = makeClient();
-    expect(svc.deliverInterviewVoice('Before setup')).toBe(false);
-    await send(internals, first.ws, 'interview_start');
-    await send(internals, second.ws, 'interview_start');
-    const histories = [...internals.interviewSessions.values()].map(session => [...session.messages]);
-
-    expect(svc.deliverInterviewVoice('I design products in Milan')).toBe(false);
-    expect(svc.deliverInterviewVoice('   ')).toBe(false);
-    svc.notifyInterviewListenEnded('no-speech');
-    await tick();
-
-    expect([...internals.interviewSessions.values()].map(session => session.messages)).toEqual(histories);
-    expect([...first.sent, ...second.sent].some(m => m.type === 'interview_user_transcript' || m.type === 'interview_listen_state')).toBe(false);
-  });
-
-  test('wrapping sends written completion and clears the session without changing normal voice', async () => {
-    const { svc, internals, makeClient } = makeService(makeLLM(true));
-    const { calls, bridge } = makeBridge();
-    svc.setInterviewVoiceBridge(bridge);
+  test('wrapping sends written completion and clears the session', async () => {
+    const { internals, makeClient } = makeService(makeLLM(true));
     const { ws, sent } = makeClient();
     await send(internals, ws, 'interview_start', { speakReply: true });
 
     expect(lastOfType(sent, 'interview_done')).toBeDefined();
-    expect(svc.hasActiveInterview()).toBe(false);
+    expect(internals.interviewSessions.size).toBe(0);
     expect(internals.interviewTurnsInFlight.size).toBe(0);
     expect(internals.interviewPendingText.size).toBe(0);
-    expect(calls).toEqual([]);
   });
 });
 
@@ -183,32 +149,27 @@ const makeSlowLLM = () => {
 };
 
 describe('written interview turn lifecycle', () => {
-  test('typed replies arriving mid-turn run next in order, while speech stays outside the interview', async () => {
+  test('typed replies arriving mid-turn run next in order', async () => {
     const slow = makeSlowLLM();
-    const { svc, internals, makeClient } = makeService(slow.llm);
+    const { internals, makeClient } = makeService(slow.llm);
     const { ws, sent } = makeClient();
     await send(internals, ws, 'interview_start');
     await send(internals, ws, 'interview_user_message', { text: "I'm a designer" });
     await send(internals, ws, 'interview_user_message', { text: 'in Milan' });
-    expect(svc.deliverInterviewVoice('Unrelated voice conversation')).toBe(false);
     expect(slow.seen).toHaveLength(1);
 
     await slow.finishTurn();
     expect(slow.seen).toHaveLength(2);
     const nextTurn = slow.seen[1]!;
     expect(nextTurn.filter(m => m.role === 'user').at(-1)?.content).toBe("I'm a designer in Milan");
-    expect(nextTurn.some(m => m.content === 'Unrelated voice conversation')).toBe(false);
-    const roles = nextTurn.map(m => m.role).filter(role => role === 'user' || role === 'assistant');
-    expect(roles.some((role, index) => index > 0 && role === roles[index - 1])).toBe(false);
+    expect(hasRepeatedRole(nextTurn)).toBe(false);
     await slow.finishTurn();
     expect(sent.filter(m => m.type === 'interview_assistant')).toHaveLength(2);
   });
 
   test('disconnect drops queued input and ignores the late reply', async () => {
     const slow = makeSlowLLM();
-    const { svc, internals, makeClient } = makeService(slow.llm);
-    const { calls, bridge } = makeBridge();
-    svc.setInterviewVoiceBridge(bridge);
+    const { internals, makeClient } = makeService(slow.llm);
     const { ws, sent } = makeClient();
     await send(internals, ws, 'interview_start');
     await send(internals, ws, 'interview_user_message', { text: 'A queued answer' });
@@ -222,7 +183,71 @@ describe('written interview turn lifecycle', () => {
     expect(sent.some(m => m.type === 'interview_assistant')).toBe(false);
     expect(internals.interviewTurnsInFlight.size).toBe(0);
     expect(internals.interviewPendingText.size).toBe(0);
-    expect(svc.hasActiveInterview()).toBe(false);
-    expect(calls).toEqual([]);
+    expect(internals.interviewSessions.size).toBe(0);
+  });
+
+  test('a failed turn is rolled back so a retried answer is not a second user turn', async () => {
+    const seen: Array<Array<{ role: string; content: string }>> = [];
+    let calls = 0;
+    const llm = {
+      getProviderNames: () => ['stub'],
+      hasConversationTier: () => false,
+      chatTier: async (_tier: string, _caller: string, messages: Array<{ role: string; content: string }>) => {
+        seen.push(messages.map(m => ({ role: m.role, content: m.content })));
+        if (++calls === 2) throw new Error('provider overloaded');
+        return { content: 'What work do you repeat?', tool_calls: [] };
+      },
+    };
+    const { internals, makeClient } = makeService(llm);
+    const { ws, sent } = makeClient();
+    await send(internals, ws, 'interview_start');
+    const session = internals.interviewSessions.get(ws)!;
+    const historyBefore = [...session.messages];
+    const turnsBefore = session.turnCount;
+
+    await send(internals, ws, 'interview_user_message', { text: 'I run a studio' });
+    expect(lastOfType(sent, 'interview_error')).toBeDefined();
+    expect(session.messages).toEqual(historyBefore);
+    expect(session.turnCount).toBe(turnsBefore);
+
+    await send(internals, ws, 'interview_user_message', { text: 'I run a studio' });
+    expect(seen).toHaveLength(3);
+    expect(hasRepeatedRole(seen[2]!)).toBe(false);
+    expect(seen[2]!.filter(m => m.content === 'I run a studio')).toHaveLength(1);
+    expect(sent.filter(m => m.type === 'interview_assistant')).toHaveLength(2);
+  });
+
+  test('facts from a turn that fails after recording them are not saved, so a retry does not duplicate them', async () => {
+    initDatabase(':memory:');
+    const recordFact = (summary: string) => ({
+      content: '',
+      tool_calls: [{ id: `fact-${summary}`, name: 'record_profile_facts', arguments: { facts: [{ theme: 'work', summary }] } }],
+    });
+    const replies: Array<() => unknown> = [
+      () => ({ content: 'What are you building?', tool_calls: [] }),
+      () => recordFact('Runs a design studio'),
+      () => { throw new Error('provider overloaded'); },
+      () => recordFact('Runs a small design studio'),
+      () => ({ content: 'What repeats each week?', tool_calls: [] }),
+    ];
+    const llm = {
+      getProviderNames: () => ['stub'],
+      hasConversationTier: () => false,
+      chatTier: async () => replies.shift()!(),
+    };
+    const { internals, makeClient } = makeService(llm);
+    const { ws, sent } = makeClient();
+    await send(internals, ws, 'interview_start');
+    const session = internals.interviewSessions.get(ws)!;
+
+    await send(internals, ws, 'interview_user_message', { text: 'I run a design studio' });
+    expect(lastOfType(sent, 'interview_error')).toBeDefined();
+    expect(session.factsRecorded).toBe(0);
+    expect(getUserProfile()?.interview_facts ?? []).toHaveLength(0);
+
+    await send(internals, ws, 'interview_user_message', { text: 'I run a design studio' });
+    expect(session.factsRecorded).toBe(1);
+    expect((getUserProfile()?.interview_facts ?? []).map(f => f.summary)).toEqual(['Runs a small design studio']);
+    expect((lastOfType(sent, 'interview_assistant')?.payload as { facts_recorded: number }).facts_recorded).toBe(1);
   });
 });

--- a/src/daemon/onboarding-interviewer.ts
+++ b/src/daemon/onboarding-interviewer.ts
@@ -186,6 +186,43 @@ export async function runInterviewTurn(
     };
   }
 
+  // A turn is all or nothing. Facts are held until it succeeds, and a failed
+  // model call leaves the history as it was, so a retried answer is neither a
+  // second user turn in a row nor a second copy of the facts it produced.
+  const historyLength = session.messages.length;
+  const turnCount = session.turnCount;
+  const pendingFacts: ProfileFactInput[] = [];
+  let result: InterviewTurnResult;
+  try {
+    result = await advanceInterview(session, llm, userText, pendingFacts);
+  } catch (err) {
+    session.messages.length = historyLength;
+    session.turnCount = turnCount;
+    throw err;
+  }
+  saveFacts(session, pendingFacts);
+  return { ...result, factsRecorded: session.factsRecorded };
+}
+
+type ProfileFactInput = Parameters<typeof appendUserProfileFact>[0];
+
+function saveFacts(session: InterviewSession, facts: ProfileFactInput[]): void {
+  for (const fact of facts) {
+    try {
+      appendUserProfileFact(fact);
+      session.factsRecorded++;
+    } catch (err) {
+      console.warn('[Interviewer] Failed to save fact:', err);
+    }
+  }
+}
+
+async function advanceInterview(
+  session: InterviewSession,
+  llm: LLMManager,
+  userText: string | null,
+  pendingFacts: ProfileFactInput[],
+): Promise<InterviewTurnResult> {
   if (userText !== null) {
     session.messages.push({ role: 'user', content: userText.trim() });
   } else if (session.messages.length === 1) {
@@ -247,7 +284,7 @@ export async function runInterviewTurn(
     // message back to the history.
     let wrappedThisTurn = false;
     for (const call of response.tool_calls) {
-      const result = executeInterviewerTool(session, call);
+      const result = executeInterviewerTool(session, call, pendingFacts);
       session.messages.push({
         role: 'tool',
         content: result.message,
@@ -304,6 +341,7 @@ export async function runInterviewTurn(
 function executeInterviewerTool(
   session: InterviewSession,
   call: LLMToolCall,
+  pendingFacts: ProfileFactInput[],
 ): { message: string; wrapped: boolean } {
   if (call.name === 'record_profile_facts') {
     const args = call.arguments as { facts?: Array<{ theme: string; summary: string; raw_quote?: string }> };
@@ -311,22 +349,18 @@ function executeInterviewerTool(
     if (facts.length === 0) {
       return { message: 'Error: facts array was empty.', wrapped: false };
     }
-    let saved = 0;
+    let accepted = 0;
     for (const f of facts) {
       if (typeof f?.theme !== 'string' || typeof f?.summary !== 'string') continue;
-      try {
-        appendUserProfileFact({
-          theme: f.theme.trim(),
-          summary: f.summary.trim(),
-          raw_quote: typeof f.raw_quote === 'string' && f.raw_quote.trim() ? f.raw_quote.trim() : undefined,
-        });
-        saved++;
-      } catch (err) {
-        console.warn('[Interviewer] Failed to save fact:', err);
-      }
+      // Written by runInterviewTurn once the whole turn has succeeded.
+      pendingFacts.push({
+        theme: f.theme.trim(),
+        summary: f.summary.trim(),
+        raw_quote: typeof f.raw_quote === 'string' && f.raw_quote.trim() ? f.raw_quote.trim() : undefined,
+      });
+      accepted++;
     }
-    session.factsRecorded += saved;
-    return { message: `Saved ${saved} fact${saved === 1 ? '' : 's'}.`, wrapped: false };
+    return { message: `Saved ${accepted} fact${accepted === 1 ? '' : 's'}.`, wrapped: false };
   }
 
   if (call.name === 'wrap_interview') {

--- a/src/daemon/onboarding-interviewer.ts
+++ b/src/daemon/onboarding-interviewer.ts
@@ -8,7 +8,8 @@
  * state) because the interviewer doesn't need any of it.
  *
  * What it has:
- *   - A dedicated system prompt covering 9 themes the agent must hit
+ *   - A focused written interview about work, goals and repetition,
+ *     using the existing profile themes
  *   - Two tools (record_profile_facts, wrap_interview) called inline,
  *     no tool registry, no authority gate
  *   - Per-session in-memory message history (lives on the WS session,
@@ -18,8 +19,8 @@
  * Lifecycle (per WS connection):
  *   1. UI sends `interview_start` → daemon creates an `InterviewSession`
  *      and runs the first turn (the agent introduces itself + asks Q1).
- *   2. UI streams TTS of the assistant text + records the user's reply.
- *   3. UI sends `interview_user_message` with the transcript → daemon
+ *   2. UI shows the assistant text and lets the user type their reply.
+ *   3. UI sends `interview_user_message` with that reply → daemon
  *      runs another turn → repeat.
  *   4. Agent calls `wrap_interview` (or user clicks "wrap up" / hits
  *      MAX_TURNS) → session ends, profile_completed flag flips.
@@ -32,42 +33,44 @@ import { appendUserProfileFact, markInterviewWrapped } from '../vault/user-profi
 /** Hard cap on agent turns per session — defends against forget-to-wrap loops. */
 export const MAX_INTERVIEW_TURNS = 30;
 
-const INTERVIEWER_SYSTEM_PROMPT = `You are Jarvis interviewing a new user during first-run onboarding. Your job is to build a durable, structured profile so future Jarvis turns have rich context about who this person is and how to serve them.
+const INTERVIEWER_SYSTEM_PROMPT = `You are Jarvis interviewing a new user during first-run onboarding. Jarvis is an AI cofounder that helps turn repetitive work into inspectable, programmatic workflows and uses AI where judgment is needed. Your job here is to learn enough about the user's work to make that collaboration useful, then save the context in their profile.
 
-You will be talking to the user in a real conversation — short turns, warm and curious tone, never a wall of text. Read what they say, react to it, then ask a thoughtful follow-up or move to the next theme.
+This is a written conversation. Use short turns, a warm and curious tone, and plain language. Read what the user says, react briefly, then ask one useful question. Aim for about 4–5 useful questions, not a long questionnaire.
 
-# Themes you must cover (in any natural order — interleave if it flows)
+# What to learn
 
-1. **Identity** — name (preferred + pronunciation if non-obvious), pronouns, location/timezone.
-2. **Work / role** — what they do day-to-day, what context they operate in.
-3. **Current projects** — active threads of work that should be top of mind.
-4. **Goals (30–90 days)** — what they're trying to accomplish in the near term.
-5. **Long-horizon ambitions** — north star, the bigger why.
-6. **Communication preferences** — formal vs casual, verbosity tolerance, humor tolerance, when they want push-back vs agreement, response style.
-7. **Daily rhythm** — when they work, focus blocks, quiet hours, weekend vs weekday.
-8. **Tools & ecosystem** — other apps Jarvis should know about (calendar, email, IDE, comms platforms).
-9. **What they want Jarvis to do** — proactive vs reactive, autonomy band, what's in vs out of scope.
+Use this priority order, adapting to what the user has already told you:
+
+1. **Work and projects**: What are they building or working on? Record under work or projects.
+2. **Current goal**: What outcome matters most right now? Record under goals.
+3. **One repetitive routine**: What work do they find themselves repeating? Learn the concrete task and, if relevant, when or how often it happens. Record under work or rhythm.
+4. **Tools involved**: Which apps or connections does that routine use? Record under tools.
+5. **Judgment and approval preferences**: Which parts need their judgment or approval, and what should stay in their hands? Record under scope.
+
+The existing profile themes are identity, work, projects, goals, ambitions, communication, rhythm, tools and scope. You do not need to cover all nine. Record other durable details if volunteered, but do not add a personal questionnaire.
 
 # How to behave
 
-- Open with a brief, warm intro ("I'm Jarvis. I'd love to spend a few minutes getting to know you so I can be more useful from day one. Sound good?") and dive into the first question.
-- One topic per turn. Don't stack three questions. After the user answers, REACT briefly (one sentence reflection or follow-up) before moving on.
-- If an answer is vague ("I work in tech"), ask ONE concrete follow-up ("What kind of work — engineering, design, product?"). Don't interrogate; one follow-up max.
-- If the user says "skip" or "next", move on without judgment.
-- If the user says "wrap up" or "let's stop", call \`wrap_interview\` immediately, no further questions.
-- After every meaningful answer, call \`record_profile_facts\` with one or more facts. Each fact is a short summary line (under 120 chars) plus the theme it belongs to. Pull a raw quote from the user when their phrasing is distinctive ("I'm allergic to small talk before noon" — keep that exact wording in raw_quote).
-- Keep the conversation flowing — don't pause to confirm every fact you record. The tool calls happen silently between turns.
-- When you've covered ~7+ of the 9 themes (or the user has been chatting for ~10 minutes), wrap with a short thank-you and call \`wrap_interview\`.
+- Open with: "I'd like to understand what you're building and where repetition gets in the way. What are you working on right now?"
+- One question per turn. Do not ask again for something the user has already answered, even if they covered several topics in one reply. A useful follow-up can replace a planned question.
+- If an answer is vague, ask at most one concrete follow-up on that topic. Keep the total conversation brief.
+- If the user cannot name a repetitive routine yet, accept that and continue. Do not force an example or invent a routine for them.
+- If the user says "skip" or "next", move on without judgment. Treat a skipped or unknown topic as addressed for this interview, not as missing homework.
+- If the user says "wrap up", "let's stop", or otherwise asks to end the interview, call \`wrap_interview\` immediately, no further questions.
+- After every meaningful answer, call \`record_profile_facts\` with one or more facts. Each fact is a short summary line (under 120 chars) plus its existing theme. Preserve a raw quote when the user's phrasing carries meaning the summary would lose. Do not record guesses as facts.
+- Save facts silently between turns, without asking the user to confirm each one or echoing every detail back.
+- Wrap once the priority topics are answered, skipped or unknown, usually after about 4–5 useful questions. If a single answer covers several topics, finish sooner rather than repeating them. Call \`wrap_interview\` with a short closing message.
 
-# What NOT to do
+# Be clear about this step's limits
 
-- Don't ask for personal data the user hasn't volunteered (no DOB, no SSN, no salary numbers).
-- Don't lecture or moralize.
-- Don't promise specific Jarvis features you don't know exist.
-- Don't echo every fact you record back to the user — silently capture and move on.
-- Don't call \`wrap_interview\` early just because the user gave terse answers; ask one more thing on a different theme first.
+- You can only record profile facts and end this interview. You cannot create a workflow or goal, connect a tool, run an action, or change Authority settings here.
+- A saved goal is context, not a configured goal object. Approval preferences are profile context, not enforced approval rules; those must be configured in Authority.
+- At the end, briefly reflect a possible starting point if the user supplied one and explain that they can ask Jarvis to draft a workflow after setup. Never claim a workflow is ready, an integration is connected, or an approval policy is active because it was discussed.
+- Do not promise perfect reliability or autonomy. Programmed steps make known operations inspectable and steerable; AI helps where judgment is needed. A draft still needs review and testing before it is enabled.
+- If the user stops or skips, close briefly without a sales pitch or another question. Never claim to have saved details they did not provide.
+- Do not ask for sensitive personal data such as date of birth, government IDs or salary figures. Do not lecture or moralize.
 
-The user's spoken/typed text comes in the user role. Your reply text becomes the next thing Jarvis speaks aloud (or shows in chat-bubble form when TTS is off). Keep replies under 3 sentences whenever possible.`;
+The user's typed text comes in the user role. Your reply is displayed as text. Keep replies under 3 sentences whenever possible.`;
 
 const INTERVIEWER_TOOLS: LLMTool[] = [
   {
@@ -107,13 +110,13 @@ const INTERVIEWER_TOOLS: LLMTool[] = [
   {
     name: 'wrap_interview',
     description:
-      'End the onboarding interview. Call when ~7+ themes are covered OR the user explicitly asks to stop. Marks the profile complete and returns the user to the regular dashboard.',
+      'End the onboarding interview once the work, current goal, routine, tools and approval topics are answered, skipped or unknown, usually after about 4–5 useful questions; OR immediately when the user asks to stop. Marks the interview complete so onboarding can continue. This does not create a workflow or enforce an approval policy.',
     parameters: {
       type: 'object',
       properties: {
         farewell: {
           type: 'string',
-          description: 'Short closing message to speak to the user (1-2 sentences).',
+          description: 'Short written closing message (1-2 sentences). Reflect only what the user shared; any workflow is a possible next step, not something already created.',
         },
       },
       required: ['farewell'],
@@ -146,7 +149,7 @@ export function createInterviewSession(): InterviewSession {
 }
 
 export interface InterviewTurnResult {
-  /** Final assistant text to speak/show. May be empty if the agent only
+  /** Final assistant text to show. May be empty if the agent only
    *  emitted tool calls without prose this turn (rare — we coax it via
    *  the system prompt to always say something). */
   assistantText: string;
@@ -164,7 +167,7 @@ export interface InterviewTurnResult {
  * (when present), then calls this; we drive the LLM with our 2-tool
  * registry, execute any tool calls inline, and repeat the LLM call
  * until the agent emits a stop response (no more tool calls). The
- * final assistant text is returned for the UI to speak.
+ * final assistant text is returned for the UI to display.
  *
  * `userText` is null on the very first turn — we want the agent to
  * open with its intro without the user having said anything yet.
@@ -203,7 +206,7 @@ export async function runInterviewTurn(
     // Safeguard: stop the loop if the agent never wrapped on its own.
     session.done = true;
     session.farewell =
-      "We've covered a lot. Let me wrap here — I have plenty to start with. Welcome aboard.";
+      "Let's wrap up here. You can add more context as you work with Jarvis.";
     markInterviewWrapped();
     return {
       assistantText: session.farewell,
@@ -215,7 +218,7 @@ export async function runInterviewTurn(
 
   // Inline tool-loop. Most turns will be one LLM call (text reply +
   // optional silent tool calls). If the agent emits ONLY tool calls
-  // with no prose, loop again so we always have something to speak.
+  // with no prose, loop again so we always have something to display.
   for (let inner = 0; inner < 4; inner++) {
     // Onboarding is conversational - prefer the conversation tier when
     // configured, falling back through the standard tier chain. Phase 4 will
@@ -264,7 +267,7 @@ export async function runInterviewTurn(
     }
 
     // If the agent gave us prose, we're done with this turn — that's
-    // the line the UI speaks. If it ONLY emitted tool calls (no text),
+    // the line the UI displays. If it ONLY emitted tool calls (no text),
     // loop and let the LLM produce the actual reply now that it sees
     // the tool results.
     if (response.content && response.content.trim().length > 0) {
@@ -330,7 +333,7 @@ function executeInterviewerTool(
     const args = call.arguments as { farewell?: string };
     const farewell = typeof args.farewell === 'string' && args.farewell.trim()
       ? args.farewell.trim()
-      : 'All set — welcome to Jarvis.';
+      : 'Thanks. You can add more context as you work with Jarvis.';
     session.farewell = farewell;
     try {
       markInterviewWrapped();

--- a/src/daemon/ws-service.ts
+++ b/src/daemon/ws-service.ts
@@ -88,14 +88,9 @@ const VOICE_CONFIRMATION_TTL_MS = 10 * 60_000;
 const VOICE_CONFIRMATION_SWEEP_INTERVAL_MS = 60_000;
 
 /**
- * Bridge into the machine's microphone for the onboarding interview.
- *
- * The dashboard no longer owns the mic (the sidecar's pebble does), so the
- * interview borrows it: while an interview session is alive the daemon points
- * the pebble's capture at the interview instead of the normal assistant turn.
- * Implemented in `daemon/index.ts` (the ambient-UI block owns the pebble);
- * null in headless / dashboard-only mode, in which case the UI falls back to
- * browser speech recognition.
+ * Legacy registration shape retained for daemon compatibility. Onboarding
+ * interviews are text-only; WebSocketService never arms or activates this
+ * bridge. Ordinary Pebble voice remains independent of the interview.
  */
 export interface InterviewVoiceBridge {
   /** Capture one utterance for the interview. */
@@ -255,21 +250,9 @@ export class WebSocketService implements Service {
    * persisted via `appendUserProfileFact` inside the agent loop.
    */
   private interviewSessions = new Map<ServerWebSocket<unknown>, InterviewSession>();
-  /**
-   * Voice for the interview. `activeInterviewWs` is the socket whose interview
-   * currently owns the microphone — the newest one to take a turn, so a stale
-   * background tab can't steal the transcript from the window the user is
-   * actually talking to. See `deliverInterviewVoice`.
-   */
-  private interviewVoiceBridge: InterviewVoiceBridge | null = null;
-  private activeInterviewWs: ServerWebSocket<unknown> | null = null;
-  /** Mirrors the UI's speakReply for transcripts that arrive off-socket. */
-  private interviewSpeakReply = true;
-  /** True while the pebble is capturing an utterance for the interview. */
-  private interviewListening = false;
   /** Sockets with an interview turn running — see `handleInterviewMessage`. */
   private interviewTurnsInFlight = new Set<ServerWebSocket<unknown>>();
-  /** Speech that landed mid-turn, run as the next turn. */
+  /** Typed text that landed mid-turn, run as the next turn. */
   private interviewPendingText = new Map<ServerWebSocket<unknown>, string>();
   /**
    * Periodic sweep handle for `pendingVoiceConfirmations` TTL eviction.
@@ -321,133 +304,29 @@ export class WebSocketService implements Service {
     this.deferredExecutor = exec;
   }
 
-  /**
-   * Wire the pebble's microphone into the onboarding interview. Without it
-   * the interview is text-only (plus whatever the browser can transcribe on
-   * its own) and any speech keeps landing in the normal assistant flow.
-   */
-  setInterviewVoiceBridge(bridge: InterviewVoiceBridge): void {
-    this.interviewVoiceBridge = bridge;
-  }
+  /** @deprecated Interviews no longer borrow the microphone. */
+  setInterviewVoiceBridge(_bridge: InterviewVoiceBridge): void {}
 
-  /** True while an onboarding interview is running and owns the user's voice. */
+  /** True while a written onboarding interview is running. */
   hasActiveInterview(): boolean {
-    const ws = this.activeInterviewWs;
-    return ws !== null && this.interviewSessions.has(ws);
+    return this.interviewSessions.size > 0;
   }
 
   /**
-   * Feed a transcript captured by the pebble into the running interview
-   * instead of the assistant. Returns false when no interview is live (the
-   * caller then runs its normal response cycle).
+   * Legacy Pebble entry point. Never consume speech as an interview answer;
+   * false leaves the caller's ordinary assistant voice routing intact.
    */
-  deliverInterviewVoice(text: string): boolean {
-    const ws = this.activeInterviewWs;
-    const trimmed = text.trim();
-    if (!ws || !this.interviewSessions.has(ws) || !trimmed) return false;
-    this.interviewListening = false;
-    // Echo the transcript first: the UI renders the user's bubble and stops
-    // waiting on the mic before the (slow) agent turn starts.
-    this.wsServer.sendToClient(ws, {
-      type: 'interview_user_transcript',
-      payload: { text: trimmed },
-      timestamp: Date.now(),
-    });
-    this.handleInterviewMessage(ws, trimmed, this.interviewSpeakReply).catch(err =>
-      console.error('[WSService] interview voice turn failed:', err)
-    );
-    return true;
+  deliverInterviewVoice(_text: string): boolean {
+    return false;
   }
 
-  /**
-   * The pebble stopped listening without a usable answer (silence, a mute, a
-   * dropped capture). Tell the UI so it can re-arm or fall back to typing
-   * rather than sit on a "listening" orb that nothing is feeding.
-   */
-  notifyInterviewListenEnded(reason: string): void {
-    const ws = this.activeInterviewWs;
-    if (!ws || !this.interviewSessions.has(ws)) return;
-    this.interviewListening = false;
-    this.wsServer.sendToClient(ws, {
-      type: 'interview_listen_state',
-      payload: { armed: false, reason },
-      timestamp: Date.now(),
-    });
-  }
+  /** @deprecated A written interview has no listening state to update. */
+  notifyInterviewListenEnded(_reason: string): void {}
 
-  /**
-   * Arm the pebble for one interview utterance and tell the UI whether it
-   * worked. `armed: false` is not an error — it's the UI's cue to use browser
-   * speech recognition (or just the composer) for this turn.
-   */
-  private async armInterviewListening(
-    ws: ServerWebSocket<unknown>,
-    speakReply?: boolean,
-  ): Promise<void> {
-    // Only a socket that is actually interviewing gets the mic, or a stray
-    // client could point the machine's microphone at someone else's session.
-    if (!this.interviewSessions.has(ws)) return;
-    this.activeInterviewWs = ws;
-    if (speakReply !== undefined) this.interviewSpeakReply = speakReply !== false;
-    const reply = (armed: boolean, reason?: string) => {
-      this.wsServer.sendToClient(ws, {
-        type: 'interview_listen_state',
-        payload: reason ? { armed, reason } : { armed },
-        timestamp: Date.now(),
-      });
-    };
-    const bridge = this.interviewVoiceBridge;
-    if (!bridge) {
-      reply(false, 'no-pebble');
-      return;
-    }
-    let result: { armed: boolean; reason?: string };
-    try {
-      result = await bridge.arm();
-    } catch (err) {
-      console.warn('[WSService] interview mic arm failed:', err);
-      reply(false, 'error');
-      return;
-    }
-    // The interview may have finished (or the socket gone) during the arm.
-    if (!this.interviewSessions.has(ws)) {
-      if (result.armed) bridge.disarm();
-      return;
-    }
-    this.interviewListening = result.armed;
-    reply(result.armed, result.reason);
-  }
-
-  /**
-   * Release the interview's claim on the microphone. Called when the session
-   * wraps and on disconnect, so a closed dashboard never leaves the pebble
-   * routing speech into an interview nobody is watching.
-   */
-  private endInterviewVoice(ws: ServerWebSocket<unknown>): void {
+  /** Drop pending written turns when the interview wraps or disconnects. */
+  private endInterviewSession(ws: ServerWebSocket<unknown>): void {
     this.interviewPendingText.delete(ws);
     this.interviewTurnsInFlight.delete(ws);
-    if (this.activeInterviewWs === ws) {
-      this.activeInterviewWs = null;
-      if (this.interviewListening) {
-        this.interviewListening = false;
-        try {
-          this.interviewVoiceBridge?.disarm();
-        } catch (err) {
-          console.warn('[WSService] interview mic disarm failed:', err);
-        }
-      }
-      // Another window still interviewing (rare, but a reload mid-interview
-      // looks exactly like this): give it the mic rather than leaving voice
-      // routed to an interview no socket owns — the assistant would answer.
-      for (const other of this.interviewSessions.keys()) this.activeInterviewWs = other;
-    }
-    if (this.interviewSessions.size === 0) {
-      try {
-        this.interviewVoiceBridge?.setActive(false);
-      } catch (err) {
-        console.warn('[WSService] interview voice teardown failed:', err);
-      }
-    }
   }
 
   setAuditTrail(audit: AuditTrail): void {
@@ -563,9 +442,7 @@ export class WebSocketService implements Service {
             this.realtimeSessions as unknown as Map<typeof ws, unknown>,
             this.pendingVoiceFrames as unknown as Map<typeof ws, unknown>,
           );
-          // After the maps are swept, so `endInterviewVoice` sees the real
-          // remaining-session count when it decides to hand the mic back.
-          this.endInterviewVoice(ws);
+          this.endInterviewSession(ws);
           console.log('[WSService] Client disconnected');
         },
       });
@@ -1157,36 +1034,29 @@ export class WebSocketService implements Service {
         // agent loop (see `onboarding-interviewer.ts`); doesn't touch
         // the primary chat agent or persist messages to vault
         // conversations.
-        const payload = msg.payload as { text?: string; speakReply?: boolean };
+        const payload = msg.payload as { text?: string };
         const userText = msg.type === 'interview_start' ? null : (payload?.text ?? '').trim();
-        const speakReply = payload?.speakReply !== false; // default true
-        this.handleInterviewMessage(ws, userText, speakReply).catch(err =>
+        // Ignore legacy speakReply requests: this interview is always written.
+        this.handleInterviewMessage(ws, userText).catch(err =>
           console.error('[WSService] interview pipeline error:', err)
         );
         return undefined;
       }
 
       case 'interview_listen': {
-        // The interview reached its "listening" beat and wants the mic. The
-        // pebble owns it, so borrow it here rather than opening a second one
-        // in the browser — that is what used to send the answer to the
-        // assistant instead of the interviewer.
-        const speak = (msg.payload as { speakReply?: boolean } | undefined)?.speakReply;
-        this.armInterviewListening(ws, speak).catch(err =>
-          console.error('[WSService] interview listen error:', err)
-        );
+        // Tell an older dashboard that recording is unavailable. Never arm
+        // a microphone or change ordinary assistant voice routing.
+        this.wsServer.sendToClient(ws, {
+          type: 'interview_listen_state',
+          payload: { armed: false, reason: 'text-only' },
+          timestamp: Date.now(),
+        });
         return undefined;
       }
 
       case 'interview_listen_stop': {
-        if (this.activeInterviewWs === ws && this.interviewListening) {
-          this.interviewListening = false;
-          try {
-            this.interviewVoiceBridge?.disarm();
-          } catch (err) {
-            console.warn('[WSService] interview mic disarm failed:', err);
-          }
-        }
+        // No interview capture exists to stop. In particular, do not disarm
+        // a normal Pebble conversation because a stale client sent this.
         return undefined;
       }
 
@@ -1921,9 +1791,8 @@ CRITICAL — when in genuine doubt between "make in a new project" vs "add to th
   /**
    * Phase B — onboarding interview message handler. Drives the
    * `onboarding-interviewer` module's agent loop, streams the
-   * assistant text back to the UI as an `interview_assistant`
-   * message, and (optionally) speaks it via TTS so the orb can
-   * play the question aloud.
+   * assistant text back to the UI as an `interview_assistant` message.
+   * Interview replies are always written, independently of voice settings.
    *
    * `userText === null` means "start the interview" (first turn);
    * the agent opens with its scripted intro + first question.
@@ -1933,33 +1802,20 @@ CRITICAL — when in genuine doubt between "make in a new project" vs "add to th
   private async handleInterviewMessage(
     ws: ServerWebSocket<unknown>,
     userText: string | null,
-    speakReply: boolean,
   ): Promise<void> {
     if (!this.interviewSessions.has(ws)) {
       this.interviewSessions.set(ws, createInterviewSession());
-      // First turn: take the user's voice off the assistant for the duration.
-      try {
-        this.interviewVoiceBridge?.setActive(true);
-      } catch (err) {
-        console.warn('[WSService] interview voice takeover failed:', err);
-      }
     }
-    // Whoever spoke last owns the mic, and their speakReply is the one an
-    // off-socket transcript should honour.
-    this.activeInterviewWs = ws;
-    this.interviewSpeakReply = speakReply;
 
     // One turn at a time per session. `runInterviewTurn` mutates the session's
     // message history across awaits, so two overlapping turns interleave into
     // a history no provider will accept (two user turns in a row, orphaned
-    // tool results). The transcript can now arrive from the pebble at any
-    // moment — including while the previous turn is still running — so hold
-    // it and run it next instead of dropping it or racing.
+    // tool results). Hold an additional typed reply until the current turn
+    // finishes instead of dropping it or racing.
     if (this.interviewTurnsInFlight.has(ws)) {
       if (userText) {
         const queued = this.interviewPendingText.get(ws);
-        // Merge: someone finishing a thought in two breaths ("I'm a
-        // designer." … "In Milan.") should read as one answer.
+        // Preserve the order of additional text sent during a pending turn.
         this.interviewPendingText.set(ws, queued ? `${queued} ${userText}` : userText);
       }
       return;
@@ -1967,7 +1823,7 @@ CRITICAL — when in genuine doubt between "make in a new project" vs "add to th
 
     this.interviewTurnsInFlight.add(ws);
     try {
-      await this.runInterviewTurnForSocket(ws, userText, speakReply);
+      await this.runInterviewTurnForSocket(ws, userText);
     } finally {
       this.interviewTurnsInFlight.delete(ws);
     }
@@ -1977,15 +1833,14 @@ CRITICAL — when in genuine doubt between "make in a new project" vs "add to th
     const pending = this.interviewPendingText.get(ws);
     this.interviewPendingText.delete(ws);
     if (pending && this.interviewSessions.has(ws)) {
-      await this.handleInterviewMessage(ws, pending, speakReply);
+      await this.handleInterviewMessage(ws, pending);
     }
   }
 
-  /** One interview turn: run the agent, send the text, speak it, wrap up. */
+  /** One written interview turn: run the agent, send the text, wrap up. */
   private async runInterviewTurnForSocket(
     ws: ServerWebSocket<unknown>,
     userText: string | null,
-    speakReply: boolean,
   ): Promise<void> {
     const session = this.interviewSessions.get(ws);
     if (!session) return;
@@ -2008,6 +1863,7 @@ CRITICAL — when in genuine doubt between "make in a new project" vs "add to th
       result = await runInterviewTurn(session, llm, userText);
     } catch (err) {
       console.error('[WSService] Interview turn failed:', err);
+      if (this.interviewSessions.get(ws) !== session) return;
       this.wsServer.sendToClient(ws, {
         type: 'interview_error',
         payload: { message: err instanceof Error ? err.message : String(err) },
@@ -2016,68 +1872,21 @@ CRITICAL — when in genuine doubt between "make in a new project" vs "add to th
       return;
     }
 
+    // A disconnected or replaced session must not receive a late reply.
+    if (this.interviewSessions.get(ws) !== session) return;
     const text = result.assistantText.trim();
 
-    // Decide up-front whether audio will follow, and TELL the UI in the
-    // text message. The UI must not guess: when it assumed TTS based on
-    // its own (possibly stale) settings fetch and no `tts_start` ever
-    // arrived — e.g. TTS disabled, or no provider loaded — it sat in
-    // "Jarvis is thinking…" forever with the composer disabled.
-    const willSpeak = Boolean(speakReply && this.ttsProvider && text);
-
-    // Send the text reply for the UI to render in the chat-bubble
-    // layout (always — the bubble is the visual record even when TTS
-    // is on).
+    // Keep will_speak explicit so an older dashboard does not wait for TTS.
     this.wsServer.sendToClient(ws, {
       type: 'interview_assistant',
       payload: {
         text,
         facts_recorded: result.factsRecorded,
         done: result.done,
-        will_speak: willSpeak,
+        will_speak: false,
       },
       timestamp: Date.now(),
     });
-
-    // Stream the audio via the existing `tts_start` + binary chunks
-    // pipeline so the UI's MicOrb plays it through the normal
-    // "speaking" state machine.
-    if (willSpeak && this.ttsProvider) {
-      const requestId = `interview-${Date.now()}`;
-      // Tracks whether the tts_start frame went out: the finally block
-      // below closes it with tts_end exactly when it was opened, so a
-      // provider that throws -- even before the first chunk -- never
-      // strands the UI in "speaking" with no audio and no tts_end.
-      let ttsStarted = false;
-      try {
-        this.wsServer.sendToClient(ws, {
-          type: 'tts_start',
-          // containsWake=true conservatively suppresses the wake
-          // recognizer for the entire interview reply — interviews
-          // are short and we don't need "Jarvis" interrupts here.
-          payload: { requestId, containsWake: true },
-          id: requestId,
-          timestamp: Date.now(),
-        });
-        ttsStarted = true;
-        for await (const chunk of this.ttsProvider.synthesizeStream(text)) {
-          this.wsServer.sendBinary(ws, chunk);
-        }
-      } catch (err) {
-        console.warn('[WSService] Interview TTS failed:', err);
-      } finally {
-        // Always close the TTS frame once it was opened — a synthesis
-        // failure mid-stream must not leave the UI waiting forever.
-        if (ttsStarted) {
-          this.wsServer.sendToClient(ws, {
-            type: 'tts_end',
-            payload: { requestId },
-            id: requestId,
-            timestamp: Date.now(),
-          });
-        }
-      }
-    }
 
     if (result.done) {
       this.wsServer.sendToClient(ws, {
@@ -2089,7 +1898,7 @@ CRITICAL — when in genuine doubt between "make in a new project" vs "add to th
         timestamp: Date.now(),
       });
       this.interviewSessions.delete(ws);
-      this.endInterviewVoice(ws);
+      this.endInterviewSession(ws);
     }
   }
 

--- a/src/daemon/ws-service.ts
+++ b/src/daemon/ws-service.ts
@@ -88,20 +88,6 @@ const VOICE_CONFIRMATION_TTL_MS = 10 * 60_000;
 const VOICE_CONFIRMATION_SWEEP_INTERVAL_MS = 60_000;
 
 /**
- * Legacy registration shape retained for daemon compatibility. Onboarding
- * interviews are text-only; WebSocketService never arms or activates this
- * bridge. Ordinary Pebble voice remains independent of the interview.
- */
-export interface InterviewVoiceBridge {
-  /** Capture one utterance for the interview. */
-  arm(): Promise<{ armed: boolean; reason?: string }>;
-  /** Drop a capture armed by `arm()` (turn over, interview finished). */
-  disarm(): void;
-  /** Interview lifecycle. While active, pebble voice feeds the interview. */
-  setActive(active: boolean): void;
-}
-
-/**
  * Pure cleanup helper: removes every per-socket entry from the WS-service
  * maps when a client disconnects. Extracted so the cleanup contract can
  * be unit-tested without spinning up a real WebSocket server.
@@ -303,25 +289,6 @@ export class WebSocketService implements Service {
   setDeferredExecutor(exec: DeferredExecutor): void {
     this.deferredExecutor = exec;
   }
-
-  /** @deprecated Interviews no longer borrow the microphone. */
-  setInterviewVoiceBridge(_bridge: InterviewVoiceBridge): void {}
-
-  /** True while a written onboarding interview is running. */
-  hasActiveInterview(): boolean {
-    return this.interviewSessions.size > 0;
-  }
-
-  /**
-   * Legacy Pebble entry point. Never consume speech as an interview answer;
-   * false leaves the caller's ordinary assistant voice routing intact.
-   */
-  deliverInterviewVoice(_text: string): boolean {
-    return false;
-  }
-
-  /** @deprecated A written interview has no listening state to update. */
-  notifyInterviewListenEnded(_reason: string): void {}
 
   /** Drop pending written turns when the interview wraps or disconnects. */
   private endInterviewSession(ws: ServerWebSocket<unknown>): void {

--- a/ui/src/v2/onboarding/OnboardingGate.tsx
+++ b/ui/src/v2/onboarding/OnboardingGate.tsx
@@ -2,16 +2,11 @@ import React from "react";
 import { OnboardingWizard } from "./OnboardingWizard";
 import { useOnboardingStatus } from "./useOnboardingStatus";
 import { RestartRequiredBanner, shouldShowRestartBanner } from "./RestartRequiredBanner";
+import { WorkflowDraftContext } from "./WorkflowDraftContext";
 
 /**
- * Phase A + B onboarding gate. Sits between AppShellV2's render and
- * the AppShell + RoomDispatcher pair. Render order:
- *
- *   1. setup_completed === false        → <SetupRoom />
- *   2. profile_completed === false AND
- *      setup_skipped_profile === false  → <ProfileInterviewRoom />
- *   3. tutorial_completed === false     → (Phase C, future)
- *   4. otherwise                        → children (live shell)
+ * Gates the live shell on setup, the profile interview and the tutorial.
+ * Carries an optional first-workflow request across the final status refresh.
  *
  * Loading state: render nothing for the brief status fetch (~50ms on
  * localhost) instead of a flash of skeleton — the bone background of
@@ -19,6 +14,9 @@ import { RestartRequiredBanner, shouldShowRestartBanner } from "./RestartRequire
  */
 export function OnboardingGate({ children }: { children: React.ReactNode }) {
   const { status, loading, refresh } = useOnboardingStatus();
+  const [prompt, setPrompt] = React.useState<string | null>(null);
+  const consume = React.useCallback(() => setPrompt(null), []);
+  const draftContext = React.useMemo(() => ({ prompt, consume }), [prompt, consume]);
 
   // Tell the cold-start splash the app has booted, the first time the status
   // resolves (to the wizard or the shell — either way boot is done).
@@ -26,7 +24,8 @@ export function OnboardingGate({ children }: { children: React.ReactNode }) {
     if (!loading && status) window.dispatchEvent(new Event("jarvis:boot-ready"));
   }, [loading, status]);
 
-  if (loading || !status) {
+  // A background refresh must not unmount the wizard or an unsent Talk draft.
+  if (!status) {
     return null;
   }
 
@@ -39,17 +38,18 @@ export function OnboardingGate({ children }: { children: React.ReactNode }) {
     (!status.profile_completed && !status.setup_skipped_profile) ||
     (!status.tutorial_completed && !status.tutorial_dismissed);
   if (needsOnboarding) {
-    return <OnboardingWizard status={status} onComplete={() => refresh()} />;
+    return <OnboardingWizard status={status} onComplete={async (request) => {
+      setPrompt(request ?? null);
+      if (!await refresh()) throw new Error("Could not refresh onboarding status");
+    }} />;
   }
 
-  if (shouldShowRestartBanner(status)) {
-    return (
-      <div className="v2-shell-frame">
+  return (
+    <WorkflowDraftContext.Provider value={draftContext}>
+      <div className={`v2-shell-frame${shouldShowRestartBanner(status) ? "" : " v2-shell-frame--plain"}`}>
         <RestartRequiredBanner status={status} />
         {children}
       </div>
-    );
-  }
-
-  return <>{children}</>;
+    </WorkflowDraftContext.Provider>
+  );
 }

--- a/ui/src/v2/onboarding/OnboardingWizard.css
+++ b/ui/src/v2/onboarding/OnboardingWizard.css
@@ -179,18 +179,19 @@ select.obw-inp { cursor: pointer; -webkit-appearance: none; appearance: none; }
 .obw-ivhead .r { display: flex; align-items: center; gap: 14px; }
 .obw-ivhead .facts { font-family: var(--mono); font-size: 10px; color: var(--ink2); }
 .obw-ivhead .facts b { color: var(--ink); }
-.obw-ivstage { flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 14px; padding: 18px; position: relative; overflow: hidden; }
+.obw-ivstage { flex: 1; min-height: 0; display: flex; flex-direction: column; align-items: center; justify-content: safe center; gap: 14px; padding: 18px; position: relative; overflow-y: auto; }
+.obw-ivstage > * { flex-shrink: 0; }
 .obw-ivstage .obw-bloom { width: 160px; height: 160px; }
 .obw-ivphase { font-family: var(--mono); font-size: 10px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--ink3); }
 .obw-ivq { font-size: 17px; font-weight: 600; color: var(--ink); text-align: center; max-width: 30ch; line-height: 1.35; letter-spacing: -0.01em; min-height: 46px; transition: opacity 0.18s; }
 .obw-ivtrans { display: flex; flex-direction: column; gap: 7px; width: 100%; max-width: 430px; margin-top: 2px; }
+.obw-ivhelp { font-size: 12px; line-height: 1.5; color: var(--ink2); max-width: 44ch; text-align: center; }
+.obw-iverror { font-size: 12px; line-height: 1.5; color: var(--ink); max-width: 44ch; text-align: center; }
 .obw-bub { max-width: 78%; padding: 8px 12px; font-size: 12.5px; line-height: 1.4; }
 .obw-bub.jv { align-self: flex-start; background: var(--panel); color: var(--ink2); border-radius: 11px 11px 11px 2px; }
 .obw-bub.me { align-self: flex-end; background: var(--ink); color: var(--bg); border-radius: 11px 11px 2px 11px; }
 .obw-ivcomposer { display: flex; gap: 9px; align-items: center; padding: 13px 22px; border-top: 1px solid var(--rule); }
-.obw-ivcomposer .obw-inp { flex: 1; }
-.obw-voicepill { display: inline-flex; align-items: center; gap: 7px; font-family: var(--mono); font-size: 10px; color: var(--ink3); border: 1px solid var(--rule); border-radius: 7px; padding: 8px 11px; flex-shrink: 0; }
-.obw-voicepill .ld { width: 9px; height: 9px; border-radius: 50% 50% 50% 1px; transform: rotate(45deg); background: var(--listen); animation: obw-br 1.6s var(--ease-out, ease) infinite; }
+.obw-ivcomposer .obw-inp { flex: 1; min-width: 0; resize: vertical; max-height: 160px; }
 
 /* spotlight tour */
 .obw-tourstage {
@@ -231,7 +232,9 @@ select.obw-inp { cursor: pointer; -webkit-appearance: none; appearance: none; }
   height: min(860px, 100%);
   border: 1px solid var(--rule);
   border-radius: 14px 3px 14px 14px;
-  overflow: hidden;
+  /* The preview can extend below a short window. It must not become a
+     hidden scroll container when focus moves to the next tour card. */
+  overflow: clip;
   background: var(--bg);
   box-shadow: 0 30px 70px -34px rgba(0, 0, 0, 0.65);
 }
@@ -259,16 +262,18 @@ select.obw-inp { cursor: pointer; -webkit-appearance: none; appearance: none; }
 .obw-miniapp .mpeb { position: absolute; right: 16px; bottom: 14px; }
 .obw-tourdim { position: absolute; inset: 0; background: rgba(8, 10, 14, 0.52); z-index: 40; }
 :root[data-theme="dark"] .obw-tourdim { background: rgba(0, 0, 0, 0.62); }
-.obw-spot { position: absolute; z-index: 60; background: var(--raise); border: 1px solid var(--rule); border-radius: 13px 3px 13px 13px; box-shadow: 0 16px 40px -18px rgba(0, 0, 0, 0.5); padding: 15px 16px; width: 248px; }
+.obw-preview-label { position: absolute; z-index: 50; top: 13px; right: 16px; color: #fff; font-family: var(--mono); font-size: 10px; }
+.obw-spot { position: absolute; z-index: 60; background: var(--raise); border: 1px solid var(--rule); border-radius: 13px 3px 13px 13px; box-shadow: 0 16px 40px -18px rgba(0, 0, 0, 0.5); padding: 18px; width: 310px; max-height: calc(100% - 24px); overflow-y: auto; }
+.obw-spot h3 { font-size: 17px; line-height: 1.3; margin: 12px 0 8px; color: var(--ink); }
 .obw-spot .sh { display: flex; align-items: center; gap: 8px; margin-bottom: 8px; }
 .obw-spot .sh .sd { width: 13px; height: 13px; border-radius: 50% 50% 50% 2px; transform: rotate(45deg); position: relative; }
 .obw-spot .sh .sd .in { position: absolute; inset: 0; border-radius: inherit; background: var(--listen); animation: obw-brS 2s var(--ease-out, ease) infinite; }
 .obw-spot .sh .sl { font-family: var(--mono); font-size: 8.5px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--ink3); }
-.obw-spot .sh .sc { margin-left: auto; font-family: var(--mono); font-size: 8.5px; color: var(--faint); }
+.obw-spot .sh .sc { margin-left: auto; font-family: var(--mono); font-size: 9px; color: var(--ink2); }
 /* direct child only — `.sm` also collides with the small-button modifier
    (`.obw-btn.sm`), which would force the button text to --ink (invisible). */
 .obw-spot > .sm { font-size: 13px; line-height: 1.45; color: var(--ink); letter-spacing: -0.005em; }
-.obw-spot .stry { font-family: var(--mono); font-size: 9.5px; color: var(--speak); margin-top: 8px; }
+.obw-spot .stry { font-size: 11px; line-height: 1.45; color: var(--ink2); margin-top: 10px; }
 .obw-spot .sb { display: flex; align-items: center; gap: 8px; margin-top: 13px; }
 .obw-spot .sb .grow { flex: 1; }
 
@@ -286,21 +291,10 @@ select.obw-inp { cursor: pointer; -webkit-appearance: none; appearance: none; }
   .obw-provgrid { grid-template-columns: 1fr; }
   .obw-tourframe { --mrail-w: 84px; }
 }
-/* Short windows: pin the spotlight to the bottom of the frame instead of the
-   place its slide asked for.
-   The frame clips (overflow:hidden, for the mock), and slide 5's card starts
-   150px down and runs ~175px — so once the frame drops under roughly 330px it
-   was cut off, taking "Skip tour" and "Finish" with it and stranding the user
-   on the last slide with no way forward. Pinned to the bottom edge it is always
-   whole and its buttons always reachable; the callout stops pointing at a
-   specific row, which is the right thing to lose when the alternative is a
-   dead end. `!important` because each slide's position is an inline style, and
-   an important declaration in a stylesheet is the one thing that outranks one.
-   The breakpoint is derived, not guessed: the tour step renders no progress bar,
-   so the frame is about `viewport - 98px`, and slide 5's card runs to ~325px —
-   clipping starts near a 425px viewport. Pinning earlier than that only costs
-   the pointing, so there is a little headroom and no more. */
-@media (max-height: 470px) {
+/* Short or narrow windows: pin inside the frame so the fuller workflow copy
+   and both actions remain reachable. The card scrolls if the frame itself is
+   shorter than its contents. Important overrides the per-slide inline target. */
+@media (max-height: 600px), (max-width: 560px) {
   .obw-spot {
     top: auto !important;
     bottom: 12px !important;
@@ -313,7 +307,7 @@ select.obw-inp { cursor: pointer; -webkit-appearance: none; appearance: none; }
   }
 }
 @media (prefers-reduced-motion: reduce) {
-  .obw-drop .in, .obw-drop .ring, .obw-spot .sh .sd .in, .obw-micbars b, .obw-wave b, .obw-voicepill .ld { animation: none !important; }
+  .obw-drop .in, .obw-drop .ring, .obw-spot .sh .sd .in, .obw-micbars b, .obw-wave b { animation: none !important; }
   .obw-drop .in { opacity: 1 !important; }
   .obw-drop.s-think .ring { opacity: 0.95 !important; }
   .obw-micbars b { height: 60% !important; }

--- a/ui/src/v2/onboarding/OnboardingWizard.tour.test.tsx
+++ b/ui/src/v2/onboarding/OnboardingWizard.tour.test.tsx
@@ -118,14 +118,20 @@ const focusLabel = () => {
 
 /** The five slides, in the order the tour walks them. */
 const SLIDES = [
-  { counter: "1 of 5", pos: /bottom: 50px/, copy: /Pebble/ },
-  { counter: "2 of 5", pos: /top: 60px/, copy: /summon Talk/ },
-  { counter: "3 of 5", pos: /top: 58px/, copy: /The Index/ },
-  { counter: "4 of 5", pos: /top: 104px/, copy: /monitoring surface/ },
+  { counter: "1 of 5", pos: /top: 58px/, copy: /programmatic steps/ },
+  { counter: "2 of 5", pos: /bottom: 50px/, copy: /Describe a routine in Talk/ },
+  { counter: "3 of 5", pos: /top: 104px/, copy: /Awareness.*Memory and goals/ },
+  { counter: "4 of 5", pos: /bottom: 50px/, copy: /paired computer awake, connected and permitted/ },
   { counter: "5 of 5", pos: /top: 150px/, copy: /Authority/ },
 ];
 
 describe("tour slides", () => {
+  test("labels the static dashboard as a preview", async () => {
+    await mountTour();
+    expect(host!.querySelector(".obw-preview-label")?.textContent).toBe("Dashboard preview");
+    expect(host!.querySelector(".obw-miniapp")?.getAttribute("aria-hidden")).toBe("true");
+    expect(host!.textContent).not.toContain("Click the Pebble to try");
+  });
   test("copy, counter and position always describe the SAME slide", async () => {
     await mountTour();
     for (const [i, want] of SLIDES.entries()) {
@@ -170,6 +176,8 @@ describe("tour slides", () => {
     expect(advance().textContent).toBe("Finish");
     await act(async () => advance().click());
     expect(posted).toContain("/api/onboarding/tutorial/complete");
+    expect(host!.textContent).not.toContain("profile saved to your Vault");
+    expect(host!.querySelector(".obw-activation")).not.toBeNull();
   });
 
   test("Skip tour dismisses rather than completing", async () => {

--- a/ui/src/v2/onboarding/OnboardingWizard.tsx
+++ b/ui/src/v2/onboarding/OnboardingWizard.tsx
@@ -594,10 +594,17 @@ export function OnboardingWizard({
     try {
       const r = await fetch("/api/onboarding/skip", { method: "POST" });
       if (!r.ok) throw new Error((await r.text().catch(() => "")) || `HTTP ${r.status}`);
-      await onComplete();
     } catch (e) {
       // Closing anyway would replay onboarding next launch — surface it instead.
       setError(e instanceof Error && e.message ? `Couldn't save the skip: ${e.message}` : "Couldn't reach the daemon — try again.");
+      setBusy(false);
+      return;
+    }
+    try {
+      await onComplete();
+    } catch {
+      // The skip is saved; only loading the dashboard failed, and retrying is safe.
+      setError("Skip saved, but Jarvis couldn't load your dashboard. Try again.");
     } finally { setBusy(false); }
   }, [onComplete]);
 
@@ -1447,8 +1454,11 @@ const IV_PHASE_CLASS: Record<string, string> = { thinking: "s-think", done: "s-d
 const IV_PHASE_LABEL: Record<string, string> = { connecting: "connecting…", ready: "your turn", error: "needs attention", thinking: "thinking", done: "done" };
 
 function InterviewStep({ onComplete }: { onComplete: () => void }) {
-  const session = useInterviewSession();
   const [composerText, setComposerText] = useState("");
+  // A failed turn hands its answer back for a retry. Keep anything typed since.
+  const session = useInterviewSession((text) => {
+    setComposerText((current) => (current.trim() ? `${text}\n\n${current}` : text));
+  });
   const canSend = session.phase === "ready" || session.phase === "error";
   const sendTyped = () => {
     if (session.sendUserMessage(composerText)) setComposerText("");

--- a/ui/src/v2/onboarding/OnboardingWizard.tsx
+++ b/ui/src/v2/onboarding/OnboardingWizard.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { openExternal, openedOrHandedOff } from "./external-open";
 import { useInterviewSession } from "./useInterviewSession";
+import { WorkflowActivation } from "./WorkflowActivation";
 import type { OnboardingStatus } from "./useOnboardingStatus";
 import "./OnboardingWizard.css";
 import { modelForOnboardingTest, onboardingDefaultModelRef } from "./llm-setup";
@@ -145,14 +146,11 @@ async function playPreviewAudio(res: Response): Promise<void> {
 }
 
 const TOUR = [
-  { sm: "This is the Pebble, your companion. It lives at your cursor. Click it any time to talk to me.", t: "→ Click the Pebble to try", pos: { right: 18, bottom: 50 } },
-  // The shortcut takes either modifier (AppShell: metaKey || ctrlKey), so this
-  // is the LABEL being wrong, not the binding — which is why a hardcoded ⌘
-  // survived: it kept working for any Windows user who guessed Ctrl.
-  { sm: `Press ${modKey("J")} to summon Talk, the conversation panel. Everything we say lives there, across sessions.`, t: `→ Press ${modKey("J")}`, pos: { right: 18, top: 60 } },
-  { sm: "The Index, on the left, is every room. Names spelled out, badges flag what needs you. Recognition over recall.", t: "", pos: { left: "calc(var(--mrail-w) + 12px)", top: 58 } },
-  { sm: "Now is your monitoring surface: what I’m doing and what’s waiting on you, at a glance.", t: "", pos: { left: "calc(var(--mrail-w) + 12px)", top: 104 } },
-  { sm: "Authority is your control panel, with a kill-switch. Nothing with real-world impact happens without your yes.", t: "", pos: { left: "calc(var(--mrail-w) + 12px)", top: 150 } },
+  { title: "Give the repetition a workflow", sm: "Turn repeated work into steps you can inspect and steer. Use programmatic steps for known operations, and AI where judgment is needed.", t: "Workflows is where you review and manage those steps.", focus: "workflows", pos: { left: "calc(var(--mrail-w) + 12px)", top: 58 } },
+  { title: "Build it together", sm: "Describe a routine in Talk. Jarvis can draft its steps, prompts and variables with you. Review the workflow before testing and enabling it.", t: `After setup, open Talk with ${modKey("J")} or the Pebble.`, focus: "talk", pos: { right: 18, bottom: 50 } },
+  { title: "A cofounder with context", sm: "Awareness can surface patterns worth automating. Memory and goals help Jarvis understand what matters to you, and why a workflow would help.", t: "Give Jarvis context as you work together.", focus: "context", pos: { left: "calc(var(--mrail-w) + 12px)", top: 104 } },
+  { title: "Work across your apps", sm: "Workflows can use connected tools, browser control and desktop control. Computer actions need that paired computer awake, connected and permitted.", t: "The Pebble keeps the conversation nearby.", focus: "apps", pos: { right: 18, bottom: 50 } },
+  { title: "Decide where approval belongs", sm: "Set action permissions and approval rules in Authority. Inspect your workflow, test the result, then deliberately publish and enable it when ready.", t: "Your preferences in the interview are context. Set the rules in Authority.", focus: "authority", pos: { left: "calc(var(--mrail-w) + 12px)", top: 150 } },
 ];
 
 type TestState = { status: "idle" | "testing" | "ok" | "err"; msg?: string; validatedModel?: string };
@@ -162,7 +160,7 @@ export function OnboardingWizard({
   onComplete,
 }: {
   status: OnboardingStatus | null;
-  onComplete: () => void;
+  onComplete: (prompt?: string) => void | Promise<void>;
 }) {
   const startKey = useMemo<StepKey>(() => {
     if (!status?.setup_completed) return "welcome";
@@ -596,7 +594,7 @@ export function OnboardingWizard({
     try {
       const r = await fetch("/api/onboarding/skip", { method: "POST" });
       if (!r.ok) throw new Error((await r.text().catch(() => "")) || `HTTP ${r.status}`);
-      onComplete();
+      await onComplete();
     } catch (e) {
       // Closing anyway would replay onboarding next launch — surface it instead.
       setError(e instanceof Error && e.message ? `Couldn't save the skip: ${e.message}` : "Couldn't reach the daemon — try again.");
@@ -801,7 +799,7 @@ export function OnboardingWizard({
       {progress}
 
       {key === "interview" ? (
-        <InterviewStep ttsDisabled={tts === "off"} onComplete={() => goKey("tour")} />
+        <InterviewStep onComplete={() => goKey("tour")} />
       ) : key === "tour" ? (
         renderTour()
       ) : (
@@ -841,11 +839,16 @@ export function OnboardingWizard({
             {drop("", 60)}
           </div>
           <div className="obw-word" style={{ fontSize: 15, marginBottom: 11 }}><span className="u">use</span>jarvis</div>
-          <h2>This is your Jarvis.</h2>
-          <div className="obw-sub" style={{ maxWidth: "34ch", margin: "9px auto 0" }}>
+          <h2>Your AI cofounder.<br />Let’s make room to build.</h2>
+          <div className="obw-sub" style={{ maxWidth: "40ch", margin: "9px auto 0" }}>
+            Give repetitive work a workflow. Jarvis helps you find what to automate,
+            build the steps, and use AI where judgment matters. First, let’s connect
+            your tools and learn how you work.
+          </div>
+          <div className="obw-hint" style={{ maxWidth: "44ch", margin: "12px auto 0" }}>
             {hosted
-              ? "Let’s spend a couple of minutes setting it up: what it can touch, and a little about you. The AI and voice are included with your plan — Jarvis will speak its replies out loud from the start, and you can change the voice or turn it off any time in Settings → Channels."
-              : "Let’s spend about five minutes setting it up: what it can touch, the brain and voice it runs on, and a little about you. You can skip anything and finish later."}
+              ? "AI and voice are included with your plan. The interview is written. After setup, voice replies start enabled; change or turn them off in Settings → Channels."
+              : "Choose your AI and optional voice, then tell Jarvis a little about your work. You can skip optional steps and return later."}
           </div>
           <div style={{ marginTop: 22, display: "flex", flexDirection: "column", gap: 11, alignItems: "center" }}>
             <div className="obw-themelab">Choose your look</div>
@@ -919,12 +922,12 @@ export function OnboardingWizard({
               </>
             ) : (
               <>
-                <h2>Let Jarvis reach your machine.</h2>
+                <h2>Connect Jarvis to this computer.</h2>
                 <div className="obw-sub">
                   {unbundled
                     ? "Here is what this machine currently allows. None of it can be granted from here yet, for the reason below."
                     : mac
-                      ? "It acts on your computer through these. Jarvis can't switch them on itself, so each button asks the OS or opens the exact settings pane. Rows turn green as you go."
+                      ? "These permissions let Jarvis understand your screen and operate your apps. Each button asks the OS or opens its settings. You choose action approval rules separately in Authority."
                       : "One switch to check before Jarvis can hear you."}
                 </div>
                 {unbundled && (
@@ -1052,6 +1055,7 @@ export function OnboardingWizard({
         <div className="obw-body"><div className="obw-wrap wide">
           <h2>Pick a brain for Jarvis.</h2>
           <div className="obw-sub">
+            Use AI to help design workflows and handle the steps that need judgment.{" "}
             {hosted
               ? "Jarvis AI is included with your plan — nothing to configure. Prefer your own? Ollama runs locally with no key, or add an API key for Anthropic, OpenAI, and more. Change it anytime in Settings."
               : "Bring your own: Ollama runs locally with no key, or add an API key for Anthropic, OpenAI, and more. Jarvis AI, our hosted brain, is coming soon. Change it anytime in Settings."}
@@ -1089,7 +1093,7 @@ export function OnboardingWizard({
         return (
           <div className="obw-body"><div className="obw-wrap wide">
             <h2>How should Jarvis hear you?</h2>
-            <div className="obw-sub">Speech to text powers voice messages and the mic button. Skip if you only plan to type; wire it up later in Settings.</div>
+            <div className="obw-sub">Describe your work by voice when it suits you. The interview uses written answers. Skip voice setup if you only plan to type; add it later in Settings.</div>
             <div className="obw-choices" style={{ marginTop: 14 }}>
               {opts.map(([v, ic, nm, bd]) => (
                 <button key={v} className={`obw-choice ${stt === v ? "on" : ""}`} onClick={() => setStt(v)}>
@@ -1180,13 +1184,13 @@ export function OnboardingWizard({
           // mail" — inherited from the two rows this replaces — described things
           // no token from this consent can do. A first-run screen that promises
           // more than the consent grants is a promise broken later, quietly.
-          ["google", "calendar", "Google", "Read-only access to your calendar and Gmail, so Jarvis can plan around your day and flag what needs you."],
+          ["google", "calendar", "Google", "Read-only access to your calendar and Gmail, giving Jarvis context for your day and the routines you want to automate."],
           ["telegram", "send", "Telegram", "Talk to Jarvis from your phone."],
         ];
         return (
           <div className="obw-body"><div className="obw-wrap wide">
-            <h2>Connect your world.</h2>
-            <div className="obw-sub">Hook up the apps Jarvis should know about. All optional, all revocable from Settings.</div>
+            <h2>Connect your everyday tools.</h2>
+            <div className="obw-sub">Start with the tools involved in your daily work. All optional, all revocable from Settings.</div>
             <div className="obw-rows" style={{ marginTop: 14 }}>
               {rows.map(([id, ic, nm, bd]) => {
                 const isConnected = connected.has(id);
@@ -1224,9 +1228,9 @@ export function OnboardingWizard({
             <span className="obw-bloom ok" style={{ width: 150, height: 150, left: "50%", top: "50%", transform: "translate(-50%,-52%)" }} />
             <span className="obw-drop s-done" style={{ width: 58, height: 58 }}><span className="in" /></span>
           </div>
-          <h2>You’re all set.</h2>
+          <h2>Let’s make room for your work.</h2>
           <div className="obw-sub" style={{ maxWidth: "33ch", margin: "9px auto 0" }}>
-            {recapLine()} Bringing your dashboard online now.
+            {recapLine()} You can add more context as you work together.
           </div>
           <div className="obw-recap">
             {configuredThisSession && hosted ? (
@@ -1234,7 +1238,6 @@ export function OnboardingWizard({
               // plan provides rather than this component's untouched state.
               <>
                 <div><span className="ok">✓</span> AI &amp; voice · included with your plan</div>
-                <div><span className="ok">✓</span> profile saved to your Vault</div>
               </>
             ) : configuredThisSession ? (
               <>
@@ -1244,15 +1247,14 @@ export function OnboardingWizard({
                 {droppedSections.includes("tts") || droppedSections.includes("stt")
                   ? <div><span className="ok">✓</span> voice · included with your plan (your provider entries weren’t needed and weren’t saved)</div>
                   : <div><span className="ok">✓</span> voice · {tts === "off" ? "text only" : tts === "edge" ? `Edge (${EDGE_VOICES.find((v) => v.id === edgeVoice)?.label.split(" ")[0]})` : "ElevenLabs"}{stt !== "skip" ? " + Whisper" : ""}</div>}
-                <div><span className="ok">✓</span> profile saved to your Vault</div>
               </>
             ) : (
               // Resumed past the setup steps: this session never touched
               // brain/voice, so don't print their defaults as saved config.
-              <div><span className="ok">✓</span> profile saved to your Vault</div>
+              <div><span className="ok">✓</span> setup complete</div>
             )}
           </div>
-          <div style={{ marginTop: 22 }}><button className="obw-btn obw-btn-pri" style={{ minWidth: 208 }} onClick={onComplete}>Open Jarvis</button></div>
+          <WorkflowActivation onContinue={onComplete} />
         </div></div>
       );
 
@@ -1261,9 +1263,9 @@ export function OnboardingWizard({
   }
 
   function recapLine() {
-    if (!configuredThisSession) return "Your brain is wired up, and I know a little about you.";
-    if (hosted) return "Your plan's AI and voice are wired up, and I know a little about you.";
-    return `${prov.name} is wired up${tts !== "off" ? ", voice is on" : ""}, and I know a little about you.`;
+    if (!configuredThisSession) return "Jarvis is ready for your next step.";
+    if (hosted) return "Your plan’s AI and voice are ready.";
+    return `${prov.name} is connected${tts !== "off" ? ", and voice is on" : ""}.`;
   }
 
   function renderProvDetail() {
@@ -1330,11 +1332,12 @@ export function OnboardingWizard({
     return (
       <div className="obw-tourstage">
         <div className="obw-tourframe">
-          <div className="obw-miniapp">
+          <div className="obw-preview-label">Dashboard preview</div>
+          <div className="obw-miniapp" aria-hidden="true">
             <div className="mrail">
-              <div className="mh">Run</div><div className="mr">Workflows</div><div className="mr">Agents</div><div className="mr">Tasks</div>
-              <div className="mh">Know</div><div className="mr">Memory</div><div className="mr">Goals</div>
-              <div className="mh">Guard</div><div className="mr">Authority <span className="bd">2</span></div><div className="mr on">Now</div>
+              <div className="mh">Run</div><div className={`mr${T.focus === "workflows" || T.focus === "apps" ? " on" : ""}`}>Workflows</div><div className="mr">Agents</div><div className="mr">Tasks</div>
+              <div className="mh">Know</div><div className={`mr${T.focus === "context" ? " on" : ""}`}>Memory</div><div className={`mr${T.focus === "context" ? " on" : ""}`}>Goals</div>
+              <div className="mh">Guard</div><div className={`mr${T.focus === "authority" ? " on" : ""}`}>Authority <span className="bd">2</span></div><div className="mr">Now</div>
             </div>
             <div className="mmain">
               <div className="mtop">Now · good morning</div>
@@ -1356,6 +1359,7 @@ export function OnboardingWizard({
               of the tour showed it. A fresh node cannot be a stale one. */}
           <div key={tourI} className="obw-spot" style={pos}>
             <div className="sh"><span className="sd"><span className="in" /></span><span className="sl">Jarvis · tour</span><span className="sc">{tourI + 1} of {TOUR.length}</span></div>
+            <h3>{T.title}</h3>
             <div className="sm">{T.sm}</div>
             {T.t && <div className="stry">{T.t}</div>}
             {error && <div className="stry" style={{ color: "var(--listen)" }}>{error}</div>}
@@ -1438,75 +1442,22 @@ function MicLevelCheck() {
 }
 
 /* ─────────── The interview (step 7) ───────────
-   The design's ivstage, driven by the real useInterviewSession hook — the WS
-   lifecycle, TTS playback, live STT, facts counter, skip and done are all
-   preserved; only the presentation is rebuilt to Monochrome Lab. */
-const IV_PHASE_CLASS: Record<string, string> = { thinking: "s-think", speaking: "s-speak", done: "s-done" };
-const IV_PHASE_LABEL: Record<string, string> = { connecting: "connecting…", ready: "ready", error: "reconnecting…", thinking: "thinking", speaking: "speaking", listening: "listening", done: "done" };
+   Written answers keep the interview separate from normal assistant voice. */
+const IV_PHASE_CLASS: Record<string, string> = { thinking: "s-think", done: "s-done" };
+const IV_PHASE_LABEL: Record<string, string> = { connecting: "connecting…", ready: "your turn", error: "needs attention", thinking: "thinking", done: "done" };
 
-/** Why the interview can't listen, in the user's terms. */
-const MIC_REASON_COPY: Record<string, string> = {
-  muted: "Your microphone is muted — unmute it from the tray, or just type.",
-  "no-stt": "Speech to text isn't set up yet, so type your answers for now.",
-  "no-pebble": "No microphone on this machine yet — type your answers for now.",
-  default: "I can't hear you right now — type your answers instead.",
-};
-
-/** Browser speech recognition, when the daemon has no microphone to lend. */
-function hasBrowserSpeech(): boolean {
-  const w = window as unknown as { SpeechRecognition?: unknown; webkitSpeechRecognition?: unknown };
-  return Boolean(w.SpeechRecognition || w.webkitSpeechRecognition);
-}
-
-function InterviewStep({ ttsDisabled, onComplete }: { ttsDisabled: boolean; onComplete: () => void }) {
-  const session = useInterviewSession({ ttsDisabled });
+function InterviewStep({ onComplete }: { onComplete: () => void }) {
+  const session = useInterviewSession();
   const [composerText, setComposerText] = useState("");
-  const recognizerRef = useRef<{ stop: () => void } | null>(null);
-
-  // Voice input is the daemon's job first: it captures the answer on the
-  // pebble and feeds it straight to the interviewer (otherwise the pebble
-  // hears the answer and the assistant, not the interview, replies). Browser
-  // SpeechRecognition is only the fallback for when the daemon has no mic to
-  // offer — no pebble connected, no STT configured, mic muted.
-  useEffect(() => {
-    if (session.textOnly) return;
-    if (session.micStatus !== "unavailable") {
-      if (recognizerRef.current) { try { recognizerRef.current.stop(); } catch { /* ignore */ } recognizerRef.current = null; }
-      return;
-    }
-    if (session.phase !== "listening") {
-      if (recognizerRef.current) { try { recognizerRef.current.stop(); } catch { /* ignore */ } recognizerRef.current = null; }
-      return;
-    }
-    const Ctor = (window as unknown as { SpeechRecognition?: new () => never; webkitSpeechRecognition?: new () => never }).SpeechRecognition
-      || (window as unknown as { webkitSpeechRecognition?: new () => never }).webkitSpeechRecognition;
-    if (!Ctor) return;
-    const rec = new (Ctor as unknown as new () => {
-      continuous: boolean; interimResults: boolean; lang: string;
-      onresult: (e: { resultIndex: number; results: ArrayLike<{ 0: { transcript: string }; isFinal: boolean }> }) => void;
-      onend: () => void; onerror: () => void; start: () => void; stop: () => void;
-    })();
-    rec.continuous = false; rec.interimResults = true; rec.lang = "en-US";
-    let finalText = "";
-    rec.onresult = (event) => {
-      let interim = "", captured = "";
-      for (let i = event.resultIndex; i < event.results.length; i++) {
-        const r = event.results[i]!; const t = String(r?.[0]?.transcript ?? "");
-        if (r?.isFinal) captured += t; else interim += t;
-      }
-      if (captured) finalText += captured;
-      session.setPartialUserText((finalText + interim).trim());
-    };
-    rec.onend = () => { const text = finalText.trim(); recognizerRef.current = null; if (text) session.sendUserMessage(text); };
-    rec.onerror = () => { recognizerRef.current = null; };
-    try { rec.start(); recognizerRef.current = rec; } catch { /* ignore */ }
-    return () => { try { rec.stop(); } catch { /* ignore */ } recognizerRef.current = null; };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [session.phase, session.textOnly, session.micStatus]);
-
-  const sendTyped = () => { const t = composerText.trim(); if (!t) return; setComposerText(""); session.sendUserMessage(t); };
+  const canSend = session.phase === "ready" || session.phase === "error";
+  const sendTyped = () => {
+    if (session.sendUserMessage(composerText)) setComposerText("");
+  };
   const [skipErr, setSkipErr] = useState<string | null>(null);
+  const [skipping, setSkipping] = useState(false);
   const skip = async () => {
+    if (skipping) return;
+    setSkipping(true);
     setSkipErr(null);
     try {
       const r = await fetch("/api/onboarding/profile/skip", { method: "POST" });
@@ -1514,7 +1465,9 @@ function InterviewStep({ ttsDisabled, onComplete }: { ttsDisabled: boolean; onCo
       onComplete();
     } catch {
       // Completing anyway would replay the interview next launch.
-      setSkipErr("Couldn't reach the daemon — try again.");
+      setSkipErr("Couldn't reach the daemon. Try again.");
+    } finally {
+      setSkipping(false);
     }
   };
 
@@ -1533,25 +1486,20 @@ function InterviewStep({ ttsDisabled, onComplete }: { ttsDisabled: boolean; onCo
     );
   }
 
-  // No mic anywhere: the daemon has none to lend and the browser can't
-  // transcribe either. Say so once instead of showing a "Listening" pill that
-  // nothing is feeding.
-  const voiceOff = session.micStatus === "unavailable" && !hasBrowserSpeech();
-  const micNote = voiceOff ? MIC_REASON_COPY[session.micReason ?? ""] ?? MIC_REASON_COPY.default : null;
-
   const msgs = session.messages;
   const lastAsstIdx = msgs.map((m) => m.role).lastIndexOf("assistant");
   const currentQ = lastAsstIdx >= 0 ? msgs[lastAsstIdx]!.text : (session.phase === "connecting" ? "Getting ready to chat…" : "…");
-  const history = (lastAsstIdx >= 0 ? msgs.slice(0, lastAsstIdx) : msgs).slice(-4);
+  // Keep the newest written answer visible while Jarvis is thinking, too.
+  const history = msgs.filter((_, i) => i !== lastAsstIdx).slice(-4);
 
   return (
     <div className="obw-iv">
       <div className="obw-ivhead">
-        <span className="l">Jarvis · getting to know you</span>
+        <span className="l">Jarvis · your work, in your words</span>
         <span className="r">
           <span className="facts"><b>{session.factsRecorded}</b> facts</span>
           {skipErr && <span className="obw-hint" style={{ color: "var(--listen)" }}>{skipErr}</span>}
-          <button type="button" className="obw-skip" onClick={skip}>Skip</button>
+          <button type="button" className="obw-skip" disabled={skipping} onClick={skip}>{skipping ? "Skipping…" : "Skip"}</button>
         </span>
       </div>
       <div className="obw-ivstage">
@@ -1559,24 +1507,21 @@ function InterviewStep({ ttsDisabled, onComplete }: { ttsDisabled: boolean; onCo
         <span className={`obw-drop iv-peb ${IV_PHASE_CLASS[session.phase] ?? ""}`} style={{ width: 54, height: 54 }}>
           <span className="in" /><span className="ring" />
         </span>
-        <div className="obw-ivphase">{IV_PHASE_LABEL[session.phase] ?? session.phase}</div>
-        <div className="obw-ivq">{currentQ}</div>
+        <div className="obw-ivphase" role="status">{IV_PHASE_LABEL[session.phase] ?? session.phase}</div>
+        <div className="obw-ivq" aria-live="polite">{currentQ}</div>
+        <div className="obw-ivhelp">A few written answers about what you’re building, what repeats, and where you want help.</div>
         {history.length > 0 && (
           <div className="obw-ivtrans">
             {history.map((m, i) => <div key={i} className={`obw-bub ${m.role === "assistant" ? "jv" : "me"}`}>{m.text}</div>)}
           </div>
         )}
-        {micNote && <div className="obw-ivphase" style={{ textTransform: "none", letterSpacing: 0 }}>{micNote}</div>}
-        {session.partialUserText && (
-          <div className="obw-ivphase" style={{ fontStyle: "italic", color: "var(--ink2)", textTransform: "none", letterSpacing: 0 }}>“{session.partialUserText}”</div>
-        )}
+        {session.error && <div className="obw-iverror" role="alert">{session.error}</div>}
       </div>
       <div className="obw-ivcomposer">
-        <input className="obw-inp" placeholder={voiceOff ? "Type your answer" : "Type your answer, or just talk"} value={composerText}
+        <textarea className="obw-inp" aria-label="Your written answer" placeholder="Type your answer" rows={2} value={composerText}
           onChange={(e) => setComposerText(e.target.value)}
-          onKeyDown={(e) => { if (e.key === "Enter") sendTyped(); }} />
-        {session.phase === "listening" && !session.textOnly && !voiceOff && <span className="obw-voicepill"><span className="ld" />Listening</span>}
-        <button type="button" className="obw-btn obw-btn-pri sm" onClick={sendTyped}>Send</button>
+          onKeyDown={(e) => { if (e.key === "Enter" && !e.shiftKey && !e.nativeEvent.isComposing) { e.preventDefault(); sendTyped(); } }} />
+        <button type="button" className="obw-btn obw-btn-pri sm" disabled={!canSend || !composerText.trim()} onClick={sendTyped}>Send</button>
       </div>
     </div>
   );

--- a/ui/src/v2/onboarding/RestartRequiredBanner.tsx
+++ b/ui/src/v2/onboarding/RestartRequiredBanner.tsx
@@ -3,10 +3,8 @@ import type { OnboardingStatus } from "./useOnboardingStatus";
 
 /**
  * Whether the restart banner should be visible for the given status.
- * Exported so the OnboardingGate can decide whether to wrap the shell
- * in the `.v2-shell-frame` grid container — when the banner is hidden,
- * wrapping causes the shell to collapse into the `auto` row track and
- * the composer ends up mid-page.
+ * The gate keeps a stable wrapper and switches it to display:contents when
+ * this banner is hidden, avoiding an empty grid row or a shell remount.
  */
 export function shouldShowRestartBanner(status: OnboardingStatus | null): boolean {
   if (!status) return false;

--- a/ui/src/v2/onboarding/WorkflowActivation.css
+++ b/ui/src/v2/onboarding/WorkflowActivation.css
@@ -1,0 +1,15 @@
+.obw-activation { margin-top: 24px; text-align: left; }
+.obw-activation > label { display: block; font-size: 15px; font-weight: 600; color: var(--ink); }
+.obw-activation__intro { margin: 6px 0 12px; color: var(--ink3); font-size: 12px; line-height: 1.5; }
+.obw-activation textarea { display: block; box-sizing: border-box; width: 100%; min-height: 96px; padding: 12px; resize: vertical; border: 1px solid var(--rule); border-radius: 9px 2px 9px 9px; background: var(--panel2); color: var(--ink); font: 13px/1.55 var(--sans); }
+.obw-activation textarea::placeholder { color: var(--ink3); }
+.obw-activation textarea:focus-visible, .obw-activation button:focus-visible { outline: 2px solid var(--ink2); outline-offset: 3px; }
+.obw-activation__examples { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 10px; align-items: center; }
+.obw-activation__examples span { width: 100%; color: var(--ink3); font: 10px var(--mono); margin-bottom: 2px; }
+.obw-activation__examples button { padding: 7px 9px; background: var(--raise); color: var(--ink2); border: 1px solid var(--rule); border-radius: 6px 2px 6px 6px; font: 11px var(--sans); cursor: pointer; }
+.obw-activation__examples button:hover:not(:disabled) { border-color: var(--ink3); color: var(--ink); }
+.obw-activation__note { color: var(--ink3); font-size: 11px; line-height: 1.6; margin: 14px 0; }
+.obw-activation > .obw-btn { width: 100%; }
+.obw-activation > .obw-skip { display: block; margin: 14px auto 0; min-height: 32px; }
+.obw-activation__error { font-size: 12px; color: var(--ink); margin: 10px 0; }
+.obw-activation :disabled { cursor: default; }

--- a/ui/src/v2/onboarding/WorkflowActivation.test.tsx
+++ b/ui/src/v2/onboarding/WorkflowActivation.test.tsx
@@ -10,6 +10,7 @@ let WorkflowActivation: typeof import("./WorkflowActivation").WorkflowActivation
 let OnboardingGate: typeof import("./OnboardingGate").OnboardingGate;
 let Composer: typeof import("../shell/Composer").Composer;
 let useTalkDraft: typeof import("../shell/useTalkDraft").useTalkDraft;
+let STATUS_RETRY: typeof import("./useOnboardingStatus").STATUS_RETRY;
 let host: HTMLDivElement;
 let root: ReturnType<typeof createRoot> | null = null;
 
@@ -20,6 +21,7 @@ beforeAll(async () => {
   ({ OnboardingGate } = await import("./OnboardingGate"));
   ({ Composer } = await import("../shell/Composer"));
   ({ useTalkDraft } = await import("../shell/useTalkDraft"));
+  ({ STATUS_RETRY } = await import("./useOnboardingStatus"));
 });
 afterEach(async () => {
   if (root) await act(async () => root!.unmount());
@@ -179,10 +181,16 @@ test("a failed completion refresh retains the activation task and can be retried
   await mount(<OnboardingGate><TalkHarness connected onSubmit={(text) => sent.push(text)} /></OnboardingGate>);
   await act(async () => button("Skip tour").click());
   await enter(host.querySelector("textarea")!, "Prepare my Friday update");
-  await act(async () => {
-    button("Review request in Talk").click();
-    await new Promise((resolve) => setTimeout(resolve, 2300));
-  });
+  const retryDelay = STATUS_RETRY.delayMs;
+  STATUS_RETRY.delayMs = 0;
+  try {
+    await act(async () => {
+      button("Review request in Talk").click();
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    });
+  } finally {
+    STATUS_RETRY.delayMs = retryDelay;
+  }
   expect(host.querySelector('[role="alert"]')!.textContent).toContain("Your task is still here");
   expect(host.querySelector("textarea")!.value).toBe("Prepare my Friday update");
   failRefresh = false;
@@ -190,4 +198,49 @@ test("a failed completion refresh retains the activation task and can be retried
   expect(host.querySelector('[aria-label="Shell"]')).not.toBeNull();
   expect(host.querySelector("textarea")!.value).toContain("Prepare my Friday update");
   expect(sent).toEqual([]);
+});
+
+const NEW_INSTALL = {
+  setup_completed: false, setup_completed_at: null, setup_skipped_profile: false,
+  profile_completed: false, tutorial_completed: false, tutorial_completed_at: null,
+  tutorial_dismissed: false, tutorial_progress_step: null, last_reset_at: null,
+};
+
+test("a skip that saves but cannot load the dashboard says so, and retrying works", async () => {
+  let statusReads = 0;
+  let failRefresh = true;
+  const skips: string[] = [];
+  globalThis.fetch = (async (url: string, init?: RequestInit) => {
+    if (String(url) === "/api/onboarding/skip") {
+      skips.push(init?.method ?? "GET");
+      return Response.json({ ok: true });
+    }
+    if (String(url) === "/api/onboarding/status") {
+      if (++statusReads === 1) return Response.json(NEW_INSTALL);
+      if (failRefresh) return new Response("Unavailable", { status: 503 });
+      return Response.json({ ...NEW_INSTALL, setup_completed: true, setup_skipped_profile: true, tutorial_dismissed: true, post_setup_services_ready: true });
+    }
+    return Response.json({ hosted_llm: true });
+  }) as never;
+  const retryDelay = STATUS_RETRY.delayMs;
+  STATUS_RETRY.delayMs = 0;
+  try {
+    await mount(<OnboardingGate><section aria-label="Shell" /></OnboardingGate>);
+    const later = () => [...host.querySelectorAll("button")].find((el) => el.textContent?.includes("do this later"))!;
+    await act(async () => {
+      later().click();
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    });
+    expect(host.textContent).toContain("Skip saved, but Jarvis couldn't load your dashboard");
+    expect(host.textContent).not.toContain("Couldn't save the skip");
+    failRefresh = false;
+    await act(async () => {
+      later().click();
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    });
+    expect(host.querySelector('[aria-label="Shell"]')).not.toBeNull();
+    expect(skips).toEqual(["POST", "POST"]);
+  } finally {
+    STATUS_RETRY.delayMs = retryDelay;
+  }
 });

--- a/ui/src/v2/onboarding/WorkflowActivation.test.tsx
+++ b/ui/src/v2/onboarding/WorkflowActivation.test.tsx
@@ -1,0 +1,193 @@
+import { afterAll, afterEach, beforeAll, describe, expect, test } from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+
+GlobalRegistrator.register();
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+const realFetch = globalThis.fetch;
+let act: typeof import("react").act;
+let createRoot: typeof import("react-dom/client").createRoot;
+let WorkflowActivation: typeof import("./WorkflowActivation").WorkflowActivation;
+let OnboardingGate: typeof import("./OnboardingGate").OnboardingGate;
+let Composer: typeof import("../shell/Composer").Composer;
+let useTalkDraft: typeof import("../shell/useTalkDraft").useTalkDraft;
+let host: HTMLDivElement;
+let root: ReturnType<typeof createRoot> | null = null;
+
+beforeAll(async () => {
+  ({ act } = await import("react"));
+  ({ createRoot } = await import("react-dom/client"));
+  ({ WorkflowActivation } = await import("./WorkflowActivation"));
+  ({ OnboardingGate } = await import("./OnboardingGate"));
+  ({ Composer } = await import("../shell/Composer"));
+  ({ useTalkDraft } = await import("../shell/useTalkDraft"));
+});
+afterEach(async () => {
+  if (root) await act(async () => root!.unmount());
+  host?.remove();
+  root = null;
+  globalThis.fetch = realFetch;
+});
+afterAll(() => GlobalRegistrator.unregister());
+
+async function mount(node: React.ReactNode) {
+  host = document.createElement("div");
+  document.body.append(host);
+  root = createRoot(host);
+  await act(async () => root!.render(node));
+}
+const button = (text: string) => [...host.querySelectorAll("button")].find((el) => el.textContent?.trim() === text)!;
+async function enter(el: HTMLTextAreaElement, text: string) {
+  await act(async () => {
+    Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, "value")!.set!.call(el, text);
+    el.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+}
+
+describe("first workflow activation", () => {
+  test("starts empty, offers editable examples and hands off only on a deliberate click", async () => {
+    const requests: Array<string | undefined> = [];
+    await mount(<WorkflowActivation onContinue={(prompt) => { requests.push(prompt); }} />);
+    expect(button("Review request in Talk").disabled).toBe(true);
+    await act(async () => button("Weekly update").click());
+    expect(host.querySelector("textarea")!.value).toContain("Every Friday");
+    expect(requests).toEqual([]);
+    await enter(host.querySelector("textarea")!, "  Summarize my sales notes each Monday.  ");
+    await act(async () => button("Review request in Talk").click());
+    expect(requests).toHaveLength(1);
+    expect(requests[0]).toContain("\n\nSummarize my sales notes each Monday.\n\n");
+    expect(requests[0]).toContain("Do not publish, enable or run");
+    expect(requests[0]).toContain("any missing details or connections");
+  });
+
+  test("Explore Jarvis first skips without fabricating a workflow request", async () => {
+    const requests: Array<string | undefined> = [];
+    await mount(<WorkflowActivation onContinue={(prompt) => { requests.push(prompt); }} />);
+    await act(async () => button("Competitor brief").click());
+    await act(async () => button("Explore Jarvis first").click());
+    expect(requests).toEqual([undefined]);
+  });
+
+  test("blocks duplicate handoffs and keeps the task when opening fails", async () => {
+    let fail!: (error: Error) => void;
+    let count = 0;
+    await mount(<WorkflowActivation onContinue={() => {
+      count++;
+      return new Promise<void>((_, reject) => { fail = reject; });
+    }} />);
+    await enter(host.querySelector("textarea")!, "Prepare my weekly update");
+    await act(async () => {
+      const next = button("Review request in Talk");
+      next.click();
+      next.click();
+    });
+    expect(count).toBe(1);
+    await act(async () => fail(new Error("Unavailable")));
+    expect(host.querySelector('[role="alert"]')!.textContent).toContain("Your task is still here");
+    expect(host.querySelector("textarea")!.value).toBe("Prepare my weekly update");
+    expect(button("Review request in Talk").disabled).toBe(false);
+  });
+});
+
+const AT_TOUR = {
+  setup_completed: true, setup_completed_at: 1, setup_skipped_profile: true,
+  profile_completed: false, tutorial_completed: false, tutorial_completed_at: null,
+  tutorial_dismissed: false, tutorial_progress_step: null, last_reset_at: null,
+  post_setup_services_ready: true,
+};
+
+// Use the same draft hook and Composer as ShellLayout, without loading the
+// daemon's unrelated room/voice services. The gate and wizard are real.
+function TalkHarness({ connected, onSubmit }: { connected: boolean; onSubmit: (text: string) => void }) {
+  const { open, setOpen, draft, setDraft } = useTalkDraft();
+  return <section aria-label="Shell">
+    <button onClick={() => setOpen(!open)}>{open ? "Close Talk" : "Open Talk"}</button>
+    {open && <Composer value={draft} onValueChange={setDraft} autoFocus disabled={!connected} onSubmit={onSubmit} />}
+  </section>;
+}
+
+test("the request survives the gate refresh, waits for connection, preserves edits on reopen and never sends itself", async () => {
+  const sent: string[] = [];
+  let finishRefresh!: () => void;
+  let statusReads = 0;
+  let servicesReady = true;
+  globalThis.fetch = (async (url: string) => {
+    if (String(url) === "/api/onboarding/status") {
+      if (++statusReads === 1) return Response.json(AT_TOUR);
+      if (statusReads > 2) return Response.json({ ...AT_TOUR, tutorial_dismissed: true, post_setup_services_ready: servicesReady });
+      return new Promise<Response>((resolve) => {
+        finishRefresh = () => resolve(Response.json({ ...AT_TOUR, tutorial_dismissed: true }));
+      });
+    }
+    return Response.json({ hosted_llm: true });
+  }) as never;
+  const view = (connected: boolean) => <OnboardingGate><TalkHarness connected={connected} onSubmit={(text) => sent.push(text)} /></OnboardingGate>;
+  await mount(view(false));
+  await act(async () => button("Skip tour").click());
+  expect(host.textContent).not.toContain("Profile saved");
+  await enter(host.querySelector("textarea")!, "Prepare a weekly update from my notes");
+  await act(async () => button("Review request in Talk").click());
+  expect(host.querySelector('[aria-label="Shell"]')).toBeNull();
+  expect(sent).toEqual([]);
+  await act(async () => finishRefresh());
+  let input = host.querySelector("textarea")!;
+  expect(input.value).toContain("Prepare a weekly update from my notes");
+  expect(input.disabled).toBe(true);
+  await act(async () => host.querySelector<HTMLButtonElement>('[aria-label="Send"]')!.click());
+  expect(sent).toEqual([]);
+  await act(async () => root!.render(view(true)));
+  input = host.querySelector("textarea")!;
+  expect(document.activeElement === input).toBe(true);
+  await enter(input, "Draft a workflow for my Friday update. Ask me which notes to use; do not enable it.");
+  // A peer tab/status broadcast and a restart-banner transition must not
+  // remount the shell or overwrite an edited request after consumption.
+  const channel = new BroadcastChannel("v2-onboarding-status");
+  try {
+    for (const ready of [false, true]) {
+      servicesReady = ready;
+      await act(async () => {
+        channel.postMessage({ type: "status_changed" });
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      });
+      expect(host.querySelector("textarea")!.value).toContain("my Friday update");
+      expect(host.querySelector(".v2-restart-banner") !== null).toBe(!ready);
+    }
+  } finally { channel.close(); }
+  await act(async () => button("Close Talk").click());
+  await act(async () => button("Open Talk").click());
+  expect(host.querySelector("textarea")!.value).toContain("my Friday update");
+  expect(sent).toEqual([]);
+  await act(async () => host.querySelector<HTMLButtonElement>('[aria-label="Send"]')!.click());
+  expect(sent).toEqual(["Draft a workflow for my Friday update. Ask me which notes to use; do not enable it."]);
+  await act(async () => button("Close Talk").click());
+  await act(async () => button("Open Talk").click());
+  expect(host.querySelector("textarea")!.value).toBe("");
+  expect(sent).toHaveLength(1);
+});
+
+test("a failed completion refresh retains the activation task and can be retried", async () => {
+  let reads = 0;
+  let failRefresh = true;
+  globalThis.fetch = (async (url: string) => {
+    if (String(url) === "/api/onboarding/status") {
+      if (++reads === 1) return Response.json(AT_TOUR);
+      if (failRefresh) return new Response("Unavailable", { status: 503 });
+      return Response.json({ ...AT_TOUR, tutorial_dismissed: true });
+    }
+    return Response.json({ hosted_llm: true });
+  }) as never;
+  const sent: string[] = [];
+  await mount(<OnboardingGate><TalkHarness connected onSubmit={(text) => sent.push(text)} /></OnboardingGate>);
+  await act(async () => button("Skip tour").click());
+  await enter(host.querySelector("textarea")!, "Prepare my Friday update");
+  await act(async () => {
+    button("Review request in Talk").click();
+    await new Promise((resolve) => setTimeout(resolve, 2300));
+  });
+  expect(host.querySelector('[role="alert"]')!.textContent).toContain("Your task is still here");
+  expect(host.querySelector("textarea")!.value).toBe("Prepare my Friday update");
+  failRefresh = false;
+  await act(async () => button("Review request in Talk").click());
+  expect(host.querySelector('[aria-label="Shell"]')).not.toBeNull();
+  expect(host.querySelector("textarea")!.value).toContain("Prepare my Friday update");
+  expect(sent).toEqual([]);
+});

--- a/ui/src/v2/onboarding/WorkflowActivation.tsx
+++ b/ui/src/v2/onboarding/WorkflowActivation.tsx
@@ -1,0 +1,81 @@
+import React, { useId, useRef, useState } from "react";
+import { ArrowRight } from "lucide-react";
+import "./WorkflowActivation.css";
+
+const EXAMPLES = [
+  { label: "Weekly update", task: "Every Friday, turn the notes I provide into a weekly company update with progress, blockers and next steps." },
+  { label: "Meeting follow-up", task: "After a meeting, use the notes I provide to draft a follow-up and a list of actions for me to review." },
+  { label: "Competitor brief", task: "Each week, check the competitor sources I provide and prepare a brief of what changed and what matters to my company." },
+];
+
+export function buildWorkflowRequest(routine: string): string {
+  return `Help me create a workflow for this recurring task:\n\n${routine.trim()}\n\nAsk me for any missing details or connections you need. Use programmatic steps for known operations and AI where understanding or judgment is needed. Create a draft for me to review, with any schedule or trigger disabled. Do not publish, enable or run the workflow yet.`;
+}
+
+export function WorkflowActivation({ onContinue }: {
+  onContinue: (prompt?: string) => void | Promise<void>;
+}) {
+  const id = useId();
+  const input = useRef<HTMLTextAreaElement>(null);
+  const busy = useRef(false);
+  const [routine, setRoutine] = useState("");
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState("");
+
+  const continueToJarvis = async (prompt?: string) => {
+    if (busy.current) return;
+    busy.current = true;
+    setPending(true);
+    setError("");
+    try {
+      await onContinue(prompt);
+    } catch {
+      setError("Couldn’t open Jarvis. Your task is still here. Try again.");
+    } finally {
+      busy.current = false;
+      setPending(false);
+    }
+  };
+
+  return (
+    <form className="obw-activation" onSubmit={(event) => {
+      event.preventDefault();
+      if (routine.trim()) void continueToJarvis(buildWorkflowRequest(routine));
+    }}>
+      <label htmlFor={id}>What’s one task you keep doing?</label>
+      <p className="obw-activation__intro" id={`${id}-help`}>
+        Describe the repetition. Jarvis can help turn it into your first workflow.
+      </p>
+      <textarea
+        ref={input}
+        id={id}
+        value={routine}
+        onChange={(event) => setRoutine(event.target.value)}
+        placeholder="Every week, I…"
+        rows={3}
+        maxLength={2000}
+        disabled={pending}
+        aria-describedby={`${id}-help ${id}-review`}
+      />
+      <div className="obw-activation__examples" role="group" aria-label="Example recurring tasks">
+        <span>Try an example</span>
+        {EXAMPLES.map((example) => (
+          <button type="button" key={example.label} disabled={pending} onClick={() => {
+            setRoutine(example.task);
+            input.current?.focus();
+          }}>{example.label}</button>
+        ))}
+      </div>
+      <p className="obw-activation__note" id={`${id}-review`}>
+        You’ll review and send the request in Talk. Start with a draft, then inspect the steps before you run anything.
+      </p>
+      {error && <p className="obw-activation__error" role="alert">{error}</p>}
+      <button className="obw-btn obw-btn-pri" type="submit" disabled={pending || !routine.trim()}>
+        {pending ? "Opening Jarvis…" : "Review request in Talk"}<ArrowRight size={15} aria-hidden="true" />
+      </button>
+      <button className="obw-skip" type="button" disabled={pending} onClick={() => void continueToJarvis()}>
+        Explore Jarvis first
+      </button>
+    </form>
+  );
+}

--- a/ui/src/v2/onboarding/WorkflowDraftContext.tsx
+++ b/ui/src/v2/onboarding/WorkflowDraftContext.tsx
@@ -1,0 +1,8 @@
+import { createContext } from "react";
+
+// The gate owns this until the shell mounts. A window event would be lost
+// while onboarding is still visible or its status refresh is in flight.
+export const WorkflowDraftContext = createContext<{
+  prompt: string | null;
+  consume: () => void;
+}>({ prompt: null, consume: () => {} });

--- a/ui/src/v2/onboarding/permission-rows.ts
+++ b/ui/src/v2/onboarding/permission-rows.ts
@@ -78,19 +78,19 @@ export const PERM_COPY: Record<string, PermCopy> = {
     label: "Accessibility",
     glyph: "access",
     required: true,
-    body: "Global hotkeys like Ctrl+Space, and letting Jarvis operate your apps. macOS won't grant this from a dialog, so until you switch it on the shortcuts quietly do nothing.",
+    body: "Keyboard shortcuts and desktop control, so Jarvis can operate your apps as part of a workflow. Enable this in macOS Settings; action approval rules are separate in Authority.",
   },
   screen: {
     label: "Screen Recording",
     glyph: "screen",
     required: true,
-    body: "Seeing your screen for Awareness: reading what's on it, and noticing when you're stuck.",
+    body: "Screen context for Awareness, so Jarvis can notice repeated work and suggest routines worth turning into workflows.",
   },
   microphone: {
     label: "Microphone",
     glyph: "mic",
     required: false,
-    body: "Voice commands and the wake word. Jarvis will ask again the first time you talk to it.",
+    body: "Optional voice commands and the wake word. The onboarding interview uses written answers. Jarvis will ask again when you use voice.",
   },
   notifications: {
     label: "Notifications",

--- a/ui/src/v2/onboarding/useInterviewSession.test.tsx
+++ b/ui/src/v2/onboarding/useInterviewSession.test.tsx
@@ -1,0 +1,215 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+
+GlobalRegistrator.register();
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let createRoot: typeof import("react-dom/client").createRoot;
+let act: typeof import("react").act;
+let useInterviewSession: typeof import("./useInterviewSession").useInterviewSession;
+let OnboardingWizard: typeof import("./OnboardingWizard").OnboardingWizard;
+let session: ReturnType<typeof useInterviewSession>;
+let root: ReturnType<typeof createRoot> | null;
+let host: HTMLElement;
+const realWebSocket = globalThis.WebSocket;
+const realFetch = globalThis.fetch;
+const realAudioContext = globalThis.AudioContext;
+let audioOpened = 0;
+
+class InterviewSocket {
+  static OPEN = 1;
+  static latest: InterviewSocket;
+  readyState = 1;
+  sent: Array<{ type: string; payload?: Record<string, unknown>; timestamp: number }> = [];
+  onopen: (() => void) | null = null;
+  onclose: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  onmessage: ((event: { data: unknown }) => void) | null = null;
+  failSend = false;
+  constructor(_url: string) { InterviewSocket.latest = this; }
+  send(raw: string) {
+    if (this.failSend) throw new Error("disconnected during send");
+    this.sent.push(JSON.parse(raw));
+  }
+  receive(type: string, payload: Record<string, unknown> = {}) {
+    this.onmessage?.({ data: JSON.stringify({ type, payload }) });
+  }
+  close() { this.readyState = 3; this.onclose?.(); }
+}
+
+beforeAll(async () => {
+  ({ act } = await import("react"));
+  ({ createRoot } = await import("react-dom/client"));
+  ({ useInterviewSession } = await import("./useInterviewSession"));
+  ({ OnboardingWizard } = await import("./OnboardingWizard"));
+});
+
+beforeEach(() => {
+  globalThis.WebSocket = InterviewSocket as never;
+  audioOpened = 0;
+  globalThis.AudioContext = class { constructor() { audioOpened++; } } as never;
+  globalThis.fetch = (async () => Response.json({ hosted_llm: true })) as never;
+  host = document.createElement("div");
+  document.body.appendChild(host);
+  root = createRoot(host);
+});
+
+afterEach(async () => {
+  if (root) await act(async () => root!.unmount());
+  host.remove();
+  root = null;
+});
+
+afterAll(() => {
+  globalThis.WebSocket = realWebSocket;
+  globalThis.AudioContext = realAudioContext;
+  globalThis.fetch = realFetch;
+  GlobalRegistrator.unregister();
+});
+
+function Harness() { session = useInterviewSession(); return null; }
+async function mountHook() {
+  await act(async () => root!.render(<Harness />));
+  const socket = InterviewSocket.latest;
+  await act(async () => socket.onopen?.());
+  return socket;
+}
+
+async function mountInterview() {
+  const status = {
+    setup_completed: true, setup_completed_at: 1,
+    setup_skipped_profile: false, profile_completed: false,
+    tutorial_completed: false, tutorial_completed_at: null,
+    tutorial_dismissed: false, tutorial_progress_step: null, last_reset_at: null,
+  };
+  await act(async () => root!.render(<OnboardingWizard status={status} onComplete={() => {}} />));
+  const socket = InterviewSocket.latest;
+  await act(async () => socket.onopen?.());
+  return socket;
+}
+
+async function typeAnswer(value: string) {
+  const textarea = host.querySelector("textarea")!;
+  await act(async () => {
+    Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, "value")!.set!.call(textarea, value);
+    textarea.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+  return textarea;
+}
+
+describe("written interview session", () => {
+  test("requests written replies and never listens to or plays legacy voice messages", async () => {
+    const socket = await mountHook();
+    expect(socket.sent).toEqual([{ type: "interview_start", payload: { speakReply: false }, timestamp: expect.any(Number) }]);
+    await act(async () => {
+      socket.receive("interview_assistant", { text: "What are you building?", will_speak: true });
+      socket.receive("tts_start");
+      socket.onmessage?.({ data: new ArrayBuffer(12) });
+      socket.receive("tts_end");
+      socket.receive("interview_listen_state", { armed: true });
+      socket.receive("interview_user_transcript", { text: "An unrelated voice message" });
+    });
+    expect(session.phase).toBe("ready");
+    expect(session.messages.map((m) => m.text)).toEqual(["What are you building?"]);
+    expect(audioOpened).toBe(0);
+    expect(socket.sent.map((m) => m.type)).toEqual(["interview_start"]);
+    await act(async () => { expect(session.sendUserMessage("  A small company  ")).toBe(true); });
+    expect(socket.sent[1]?.payload).toEqual({ text: "A small company", speakReply: false });
+    expect(session.phase).toBe("thinking");
+  });
+
+  test("prevents rapid duplicate replies and preserves rejected answers for retry", async () => {
+    const socket = await mountHook();
+    await act(async () => socket.receive("interview_assistant", { text: "What repeats?" }));
+    await act(async () => {
+      expect(session.sendUserMessage("Weekly reporting")).toBe(true);
+      expect(session.sendUserMessage("Weekly reporting")).toBe(false);
+    });
+    expect(socket.sent.filter((m) => m.type === "interview_user_message")).toHaveLength(1);
+    await act(async () => socket.receive("interview_error", { message: "Please try again." }));
+    socket.failSend = true;
+    await act(async () => { expect(session.sendUserMessage("Review before sharing")).toBe(false); });
+    expect(session.messages.filter((m) => m.role === "user")).toHaveLength(1);
+    expect(session.error).toContain("wasn't sent");
+    socket.failSend = false;
+    await act(async () => { expect(session.sendUserMessage("Review before sharing")).toBe(true); });
+    expect(session.error).toBeNull();
+  });
+
+  test("completion stays complete when audio, stale replies or socket close arrive", async () => {
+    const socket = await mountHook();
+    await act(async () => {
+      socket.receive("interview_done", { farewell: "Ready when you are.", facts_recorded: 3 });
+      socket.receive("interview_assistant", { text: "A stale reply" });
+      socket.receive("interview_error", { message: "A stale error" });
+      socket.receive("tts_end");
+      socket.close();
+    });
+    expect(session.phase).toBe("done");
+    expect(session.farewell).toBe("Ready when you are.");
+    expect(session.factsRecorded).toBe(3);
+    expect(session.messages).toHaveLength(0);
+    expect(session.error).toBeNull();
+  });
+
+  test("reports disconnected sessions and detaches all socket handlers on unmount", async () => {
+    const socket = await mountHook();
+    await act(async () => socket.close());
+    expect(session.phase).toBe("error");
+    expect(session.error).toContain("Reload to reconnect");
+    expect(session.sendUserMessage("An answer")).toBe(false);
+    await act(async () => root!.unmount());
+    root = null;
+    expect([socket.onopen, socket.onmessage, socket.onerror, socket.onclose]).toEqual([null, null, null, null]);
+  });
+});
+
+describe("written interview UI", () => {
+  test("offers written answers and keeps Skip available without requesting a microphone", async () => {
+    const socket = await mountInterview();
+    await act(async () => {
+      socket.receive("interview_assistant", { text: "What are you building?", will_speak: true });
+    });
+    expect(host.querySelector('textarea[aria-label="Your written answer"]')).not.toBeNull();
+    expect(host.textContent).toContain("A few written answers");
+    expect(host.textContent).not.toMatch(/Listening|just talk|voice mode|text only/i);
+    expect(Array.from(host.querySelectorAll("button")).some((b) => b.textContent === "Skip")).toBe(true);
+    expect(socket.sent.map((m) => m.type)).toEqual(["interview_start"]);
+    expect(audioOpened).toBe(0);
+  });
+
+  test("retains a typed answer if sending fails and displays it once sent", async () => {
+    const socket = await mountInterview();
+    await act(async () => socket.receive("interview_assistant", { text: "What repeats?" }));
+    const textarea = await typeAnswer("Weekly company updates");
+    const send = Array.from(host.querySelectorAll("button")).find((b) => b.textContent === "Send")!;
+    expect(send.disabled).toBe(false);
+    socket.failSend = true;
+    await act(async () => send.click());
+    expect(textarea.value).toBe("Weekly company updates");
+    expect(host.querySelector('[role="alert"]')?.textContent).toContain("wasn't sent");
+    socket.failSend = false;
+    await act(async () => send.click());
+    expect(textarea.value).toBe("");
+    expect(host.querySelector(".obw-bub.me")?.textContent).toBe("Weekly company updates");
+    expect(send.disabled).toBe(true);
+  });
+
+  test("Enter never submits during composition, with Shift, or while a reply is pending", async () => {
+    const socket = await mountInterview();
+    const textarea = await typeAnswer("An answer in progress");
+    await act(async () => textarea.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true })));
+    expect(textarea.value).toBe("An answer in progress");
+    expect(socket.sent).toHaveLength(1);
+    await act(async () => socket.receive("interview_assistant", { text: "What matters this week?" }));
+    await act(async () => {
+      textarea.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", shiftKey: true, bubbles: true }));
+      textarea.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", isComposing: true, bubbles: true }));
+    });
+    expect(socket.sent).toHaveLength(1);
+    expect(textarea.value).toBe("An answer in progress");
+    await act(async () => textarea.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true })));
+    expect(socket.sent[1]?.payload).toEqual({ text: "An answer in progress", speakReply: false });
+    expect(textarea.value).toBe("");
+  });
+});

--- a/ui/src/v2/onboarding/useInterviewSession.test.tsx
+++ b/ui/src/v2/onboarding/useInterviewSession.test.tsx
@@ -127,9 +127,11 @@ describe("written interview session", () => {
     });
     expect(socket.sent.filter((m) => m.type === "interview_user_message")).toHaveLength(1);
     await act(async () => socket.receive("interview_error", { message: "Please try again." }));
+    // The failed turn was rolled back on the daemon, so its bubble goes too.
+    expect(session.messages.filter((m) => m.role === "user")).toHaveLength(0);
     socket.failSend = true;
     await act(async () => { expect(session.sendUserMessage("Review before sharing")).toBe(false); });
-    expect(session.messages.filter((m) => m.role === "user")).toHaveLength(1);
+    expect(session.messages.filter((m) => m.role === "user")).toHaveLength(0);
     expect(session.error).toContain("wasn't sent");
     socket.failSend = false;
     await act(async () => { expect(session.sendUserMessage("Review before sharing")).toBe(true); });
@@ -193,6 +195,23 @@ describe("written interview UI", () => {
     expect(textarea.value).toBe("");
     expect(host.querySelector(".obw-bub.me")?.textContent).toBe("Weekly company updates");
     expect(send.disabled).toBe(true);
+  });
+
+  test("a failed turn returns the answer to the composer instead of showing it twice", async () => {
+    const socket = await mountInterview();
+    await act(async () => socket.receive("interview_assistant", { text: "What repeats?" }));
+    const textarea = await typeAnswer("Weekly company updates");
+    const send = Array.from(host.querySelectorAll("button")).find((b) => b.textContent === "Send")!;
+    await act(async () => send.click());
+    expect(textarea.value).toBe("");
+    await typeAnswer("and invoices");
+    await act(async () => socket.receive("interview_error", { message: "The model is busy." }));
+    expect(host.querySelectorAll(".obw-bub.me")).toHaveLength(0);
+    expect(textarea.value).toBe("Weekly company updates\n\nand invoices");
+    await typeAnswer("Weekly company updates");
+    await act(async () => send.click());
+    expect(socket.sent.filter((m) => m.type === "interview_user_message")).toHaveLength(2);
+    expect(Array.from(host.querySelectorAll(".obw-bub.me")).map((b) => b.textContent)).toEqual(["Weekly company updates"]);
   });
 
   test("Enter never submits during composition, with Shift, or while a reply is pending", async () => {

--- a/ui/src/v2/onboarding/useInterviewSession.ts
+++ b/ui/src/v2/onboarding/useInterviewSession.ts
@@ -9,9 +9,15 @@ export type InterviewMessage =
 
 type InterviewPhase = "connecting" | "ready" | "thinking" | "done" | "error";
 
-export function useInterviewSession() {
+/** `onAnswerReturned` receives an answer whose turn failed, so the caller can
+ * put it back in its composer for a retry. */
+export function useInterviewSession(onAnswerReturned?: (text: string) => void) {
   const wsRef = useRef<WebSocket | null>(null);
   const phaseRef = useRef<InterviewPhase>("connecting");
+  // The answer the daemon is currently replying to, if any.
+  const unansweredRef = useRef<string | null>(null);
+  const onAnswerReturnedRef = useRef(onAnswerReturned);
+  onAnswerReturnedRef.current = onAnswerReturned;
   const [phase, setPhase] = useState<InterviewPhase>("connecting");
   const [messages, setMessages] = useState<InterviewMessage[]>([]);
   const [factsRecorded, setFactsRecorded] = useState(0);
@@ -48,6 +54,7 @@ export function useInterviewSession() {
       switch (msg.type) {
         case "interview_assistant": {
           if (phaseRef.current === "done") return;
+          unansweredRef.current = null;
           const text = String(msg.payload?.text ?? "").trim();
           if (text) setMessages((prev) => [
             ...prev, { role: "assistant", text, ts: msg.timestamp ?? Date.now() },
@@ -60,17 +67,27 @@ export function useInterviewSession() {
           break;
         }
         case "interview_done":
+          unansweredRef.current = null;
           setFarewell(String(msg.payload?.farewell ?? ""));
           if (typeof msg.payload?.facts_recorded === "number") {
             setFactsRecorded(msg.payload.facts_recorded);
           }
           changePhase("done");
           break;
-        case "interview_error":
+        case "interview_error": {
           if (phaseRef.current === "done") return;
+          // The daemon rolls a failed turn back, so the answer never reached
+          // the interview. Drop its bubble and hand the text back for a retry.
+          const unanswered = unansweredRef.current;
+          unansweredRef.current = null;
+          if (unanswered !== null) {
+            setMessages((prev) => (prev.at(-1)?.role === "user" ? prev.slice(0, -1) : prev));
+            onAnswerReturnedRef.current?.(unanswered);
+          }
           setError(String(msg.payload?.message ?? "Interview failed. Please try again."));
           changePhase("error");
           break;
+        }
       }
     };
 
@@ -105,6 +122,7 @@ export function useInterviewSession() {
       changePhase("error");
       return false;
     }
+    unansweredRef.current = trimmed;
     setMessages((prev) => [...prev, { role: "user", text: trimmed, ts: Date.now() }]);
     setError(null);
     changePhase("thinking");

--- a/ui/src/v2/onboarding/useInterviewSession.ts
+++ b/ui/src/v2/onboarding/useInterviewSession.ts
@@ -1,474 +1,115 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import type { OrbState } from "../shell/MicOrb";
 
-/**
- * Phase B — UI hook driving the onboarding profile interview.
- *
- * Owns the WebSocket lifecycle for the interview message types
- * (`interview_start`, `interview_user_message`, `interview_assistant`,
- * `interview_done`, `interview_error`) AND the local "current orb
- * state" + transcript-buffer machinery. The ProfileInterviewRoom
- * consumes this hook and renders.
- *
- * Voice flow (when TTS is on AND mic is available):
- *   1. Mount → connect WS → send `interview_start` → daemon replies
- *      with `interview_assistant` text + streams TTS audio.
- *   2. UI plays the audio (orb state="speaking"). When TTS audio ends,
- *      auto-arms recording (orb state="listening").
- *   3. User speaks → browser SpeechRecognition (or the existing voice
- *      pipeline) collects transcript → user clicks "send" or silence
- *      detection ends → we send `interview_user_message`.
- *   4. Repeat until `interview_done` arrives.
- *
- * Where the microphone comes from:
- *   The dashboard does not hold the mic — the sidecar's pebble does. So on
- *   every "listening" beat we ask the daemon for it (`interview_listen`); it
- *   captures one utterance on the pebble and sends the transcript back as
- *   `interview_user_transcript`, routed to the interview instead of the
- *   assistant. `interview_listen_state` says whether that worked: when the
- *   daemon has no pebble/STT to offer (`armed: false`), the caller falls back
- *   to browser speech recognition, and typing always works either way.
- *
- * Text-only fallback (TTS off OR mic unavailable):
- *   Same WS message types, but no auto-record. User types into a
- *   composer and hits Enter to send.
- *
- * The hook does NOT use the existing useVoice hook directly because
- * useVoice is the rail's voice machinery and would interfere with
- * the regular dashboard flow. We piggyback on the same TTS playback
- * pipeline (the daemon broadcasts `tts_start` + binary chunks; the
- * existing useVoice on AppShell would normally consume those — but
- * AppShell is not mounted while the gate renders ProfileInterviewRoom,
- * so we mount our own minimal TTS player here).
- */
-
+/** The profile interview is always written, independent of the user's normal
+ * voice settings. This hook owns only its socket, transcript and completion.
+ * It never requests the Pebble's microphone or plays daemon audio. */
 export type InterviewMessage =
   | { role: "assistant"; text: string; ts: number }
   | { role: "user"; text: string; ts: number };
 
-interface InterviewState {
-  /** Connection + pipeline status. */
-  phase: "connecting" | "ready" | "speaking" | "listening" | "thinking" | "done" | "error";
-  /** Driver for the orb visual. Maps phase → OrbState. */
-  orbState: OrbState;
-  /** Full transcript so far — both sides. */
-  messages: InterviewMessage[];
-  /** Live STT partial under the orb. */
-  partialUserText: string;
-  /** Cumulative facts the agent has recorded. Updates after each turn. */
-  factsRecorded: number;
-  /** Closing line surfaced when the interview wraps. */
-  farewell: string | null;
-  /** Last error message, if any. */
-  error: string | null;
-  /**
-   * Where this turn's voice input comes from:
-   *   idle        — not listening (thinking/speaking/done, or text-only)
-   *   pending     — we asked the daemon for the pebble's mic, waiting
-   *   armed       — the pebble is capturing this turn; do NOT open a second mic
-   *   unavailable — no daemon mic (no pebble, no STT, muted): fall back locally
-   */
-  micStatus: "idle" | "pending" | "armed" | "unavailable";
-  /** Why the daemon mic isn't available, when `micStatus === "unavailable"`. */
-  micReason: string | null;
-}
+type InterviewPhase = "connecting" | "ready" | "thinking" | "done" | "error";
 
-interface InterviewControls {
-  /** Send the user's text reply (typed OR transcribed). */
-  sendUserMessage: (text: string) => void;
-  /** Toggle text-only mode (skips TTS playback + auto-record). */
-  setTextOnly: (next: boolean) => void;
-  /** True when the user has explicitly opted out of voice. */
-  textOnly: boolean;
-  /** Update the live STT partial — driven by SpeechRecognition. */
-  setPartialUserText: (text: string) => void;
-}
-
-export function useInterviewSession(opts: {
-  /** True when the user picked "no TTS" in Phase A. Forces text-only. */
-  ttsDisabled: boolean;
-}): InterviewState & InterviewControls {
+export function useInterviewSession() {
   const wsRef = useRef<WebSocket | null>(null);
-  const audioCtxRef = useRef<AudioContext | null>(null);
-  const audioQueueRef = useRef<ArrayBuffer[]>([]);
-  const audioPlayingRef = useRef(false);
-  const ttsPendingRef = useRef(false);
-  const ttsFallbackTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  const [phase, setPhase] = useState<InterviewState["phase"]>("connecting");
-  const [orbState, setOrbState] = useState<OrbState>("idle");
+  const phaseRef = useRef<InterviewPhase>("connecting");
+  const [phase, setPhase] = useState<InterviewPhase>("connecting");
   const [messages, setMessages] = useState<InterviewMessage[]>([]);
-  const [partialUserText, setPartialUserText] = useState("");
   const [factsRecorded, setFactsRecorded] = useState(0);
   const [farewell, setFarewell] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [textOnly, setTextOnlyState] = useState(opts.ttsDisabled);
-  const [micStatus, setMicStatus] = useState<InterviewState["micStatus"]>("idle");
-  const [micReason, setMicReason] = useState<string | null>(null);
-  // Live view of micStatus for the mount-once WS handlers (same reason as
-  // textOnlyRef below).
-  const micStatusRef = useRef<InterviewState["micStatus"]>("idle");
-  // Consecutive empty captures. A capture that hears nothing is worth
-  // retrying — the user was still thinking — but not forever: after a few we
-  // stop re-arming and let the composer (or the browser recognizer) take over.
-  const emptyCapturesRef = useRef(0);
-  const rearmTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  // The WS handlers below live in a mount-once effect, so reading the
-  // `textOnly` state there would see the value frozen at mount. The ref
-  // is the live view — without it, toggling "Continue with text only"
-  // mid-session left the handlers waiting for TTS that was no longer
-  // requested.
-  const textOnlyRef = useRef(textOnly);
 
-  const setMic = useCallback((status: InterviewState["micStatus"], reason: string | null = null) => {
-    micStatusRef.current = status;
-    setMicStatus(status);
-    setMicReason(reason);
+  const changePhase = useCallback((next: InterviewPhase) => {
+    phaseRef.current = next;
+    setPhase(next);
   }, []);
 
-  /** Ask the daemon to capture this turn's answer on the pebble. */
-  const requestDaemonMic = useCallback((speak: boolean) => {
-    const ws = wsRef.current;
-    if (!ws || ws.readyState !== WebSocket.OPEN) return;
-    setMic("pending");
-    ws.send(
-      JSON.stringify({
-        type: "interview_listen",
-        payload: { speakReply: speak },
-        timestamp: Date.now(),
-      }),
-    );
-  }, [setMic]);
-
-  const clearRearmTimer = useCallback(() => {
-    if (rearmTimerRef.current !== null) {
-      clearTimeout(rearmTimerRef.current);
-      rearmTimerRef.current = null;
-    }
-  }, []);
-
-  const clearTtsFallbackTimer = useCallback(() => {
-    if (ttsFallbackTimerRef.current !== null) {
-      clearTimeout(ttsFallbackTimerRef.current);
-      ttsFallbackTimerRef.current = null;
-    }
-  }, []);
-
-  /** Toggle text-only mode. Turning it ON also rescues a session stuck
-   *  waiting on TTS audio — flip straight to listening so the composer
-   *  re-enables. */
-  const setTextOnly = useCallback(
-    (next: boolean) => {
-      textOnlyRef.current = next;
-      setTextOnlyState(next);
-      if (next && ttsPendingRef.current) {
-        ttsPendingRef.current = false;
-        clearTtsFallbackTimer();
-        setPhase("listening");
-        setOrbState("listening");
-      }
-    },
-    [clearTtsFallbackTimer],
-  );
-
-  // ── WS lifecycle ─────────────────────────────────────────────────
   useEffect(() => {
     const proto = window.location.protocol === "https:" ? "wss" : "ws";
     const ws = new WebSocket(`${proto}://${window.location.host}/ws`);
-    ws.binaryType = "arraybuffer";
     wsRef.current = ws;
 
     ws.onopen = () => {
-      setPhase("thinking");
-      setOrbState("thinking");
-      ws.send(
-        JSON.stringify({
-          type: "interview_start",
-          payload: { speakReply: !textOnlyRef.current },
-          timestamp: Date.now(),
-        }),
-      );
+      changePhase("thinking");
+      ws.send(JSON.stringify({
+        type: "interview_start",
+        payload: { speakReply: false },
+        timestamp: Date.now(),
+      }));
     };
 
     ws.onmessage = (event) => {
-      // Binary frames are TTS audio chunks.
-      if (event.data instanceof ArrayBuffer) {
-        if (textOnlyRef.current) return; // ignore audio in text-only mode
-        audioQueueRef.current.push(event.data);
-        if (!audioPlayingRef.current) playNextChunk();
-        return;
-      }
-
+      // Ignore binary audio and all unrelated voice messages, including ones
+      // broadcast by an older daemon. They cannot change interview state.
+      if (typeof event.data !== "string") return;
       let msg: any;
-      try {
-        msg = JSON.parse(String(event.data));
-      } catch {
-        return;
-      }
+      try { msg = JSON.parse(event.data); } catch { return; }
+      if (!msg || typeof msg !== "object") return;
 
       switch (msg.type) {
         case "interview_assistant": {
+          if (phaseRef.current === "done") return;
           const text = String(msg.payload?.text ?? "").trim();
-          if (text) {
-            setMessages((prev) => [
-              ...prev,
-              { role: "assistant", text, ts: msg.timestamp ?? Date.now() },
-            ]);
-          }
+          if (text) setMessages((prev) => [
+            ...prev, { role: "assistant", text, ts: msg.timestamp ?? Date.now() },
+          ]);
           if (typeof msg.payload?.facts_recorded === "number") {
             setFactsRecorded(msg.payload.facts_recorded);
           }
-          // We get the text immediately; if TTS will follow, the
-          // orb stays in "thinking" until tts_start fires. If not,
-          // jump straight to listening so the user can reply. The
-          // daemon says explicitly whether audio is coming
-          // (`will_speak`) — trust it over our local mode guess, so
-          // a TTS-less daemon never strands us waiting for audio.
-          // (Older daemons omit the field; undefined falls through
-          // to the local guess + timeout fallback below.)
-          const willSpeak = msg.payload?.will_speak;
-          if (textOnlyRef.current || !text || willSpeak === false) {
-            setPhase("listening");
-            setOrbState("listening");
-          } else {
-            ttsPendingRef.current = true;
-            // Safety net: if tts_start never arrives (provider died,
-            // pre-will_speak daemon with TTS off), un-stick the
-            // composer rather than waiting forever.
-            clearTtsFallbackTimer();
-            ttsFallbackTimerRef.current = setTimeout(() => {
-              ttsFallbackTimerRef.current = null;
-              if (ttsPendingRef.current) {
-                ttsPendingRef.current = false;
-                setPhase("listening");
-                setOrbState("listening");
-              }
-            }, 10_000);
-          }
+          setError(null);
+          changePhase("ready");
           break;
         }
-        case "tts_start":
-          if (!textOnlyRef.current) {
-            ttsPendingRef.current = false;
-            clearTtsFallbackTimer();
-            setPhase("speaking");
-            setOrbState("speaking");
-            // Pre-warm AudioContext so the first chunk plays cleanly.
-            getAudioContext();
-          }
-          break;
-        case "tts_end":
-          // Wait for the queue to drain in playNextChunk() before
-          // flipping to listening. If the queue is already empty,
-          // flip now.
-          if (audioQueueRef.current.length === 0 && !audioPlayingRef.current) {
-            setPhase("listening");
-            setOrbState("listening");
-          }
-          break;
-        case "interview_listen_state": {
-          const armed = Boolean(msg.payload?.armed);
-          const reason = msg.payload?.reason ? String(msg.payload.reason) : null;
-          if (armed) {
-            emptyCapturesRef.current = 0;
-            setMic("armed");
-            break;
-          }
-          // A capture that came back empty (silence, or the sidecar's VAD
-          // window closing) isn't a broken mic — re-arm and keep waiting, up
-          // to a few tries so a user who walked away doesn't loop forever.
-          const retryable = reason === "no-speech" || reason === "timeout";
-          if (retryable && micStatusRef.current !== "idle" && emptyCapturesRef.current < 3) {
-            emptyCapturesRef.current += 1;
-            setMic("pending", reason);
-            clearRearmTimer();
-            rearmTimerRef.current = setTimeout(() => {
-              rearmTimerRef.current = null;
-              requestDaemonMic(!textOnlyRef.current);
-            }, 400);
-            break;
-          }
-          setMic("unavailable", reason ?? "unavailable");
-          break;
-        }
-        case "interview_user_transcript": {
-          // The pebble heard the answer. Render it as the user's turn — the
-          // interviewer's reply is already on its way.
-          const text = String(msg.payload?.text ?? "").trim();
-          if (!text) break;
-          emptyCapturesRef.current = 0;
-          clearRearmTimer();
-          setMic("idle");
-          setMessages((prev) => [...prev, { role: "user", text, ts: msg.timestamp ?? Date.now() }]);
-          setPartialUserText("");
-          setPhase("thinking");
-          setOrbState("thinking");
-          break;
-        }
-        case "interview_done": {
+        case "interview_done":
           setFarewell(String(msg.payload?.farewell ?? ""));
           if (typeof msg.payload?.facts_recorded === "number") {
             setFactsRecorded(msg.payload.facts_recorded);
           }
-          // Wait for any in-flight TTS to drain before flipping done.
-          const finishOnDrain = () => {
-            if (audioQueueRef.current.length === 0 && !audioPlayingRef.current) {
-              setPhase("done");
-              setOrbState("idle");
-            } else {
-              setTimeout(finishOnDrain, 200);
-            }
-          };
-          finishOnDrain();
+          changePhase("done");
           break;
-        }
         case "interview_error":
-          setError(String(msg.payload?.message ?? "Interview failed."));
-          setPhase("error");
-          setOrbState("idle");
-          break;
-        default:
-          // Ignore unrelated messages — daemon may send chat / suggestions etc.
+          if (phaseRef.current === "done") return;
+          setError(String(msg.payload?.message ?? "Interview failed. Please try again."));
+          changePhase("error");
           break;
       }
     };
 
-    ws.onerror = () => {
-      setError("Connection error.");
-      setPhase("error");
-      setOrbState("idle");
-    };
-
-    ws.onclose = () => {
-      // Only treat as error if we weren't already done.
-      setPhase((p) => (p === "done" ? "done" : "error"));
+    ws.onerror = ws.onclose = () => {
+      if (phaseRef.current === "done") return;
+      setError("Connection lost. Reload to reconnect, or skip the interview.");
+      changePhase("error");
     };
 
     return () => {
-      try {
-        ws.close();
-      } catch {
-        /* ignore */
-      }
+      ws.onopen = ws.onmessage = ws.onerror = ws.onclose = null;
       wsRef.current = null;
-      try {
-        audioCtxRef.current?.close();
-      } catch {
-        /* ignore */
-      }
-      audioCtxRef.current = null;
-      audioQueueRef.current = [];
-      clearTtsFallbackTimer();
-      clearRearmTimer();
+      try { ws.close(); } catch { /* already closed */ }
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [changePhase]);
 
-  // ── Microphone hand-off ──────────────────────────────────────────
-  // The mic lives on the pebble, so borrow it for exactly the window where
-  // the interview wants an answer — never while Jarvis is speaking (the
-  // sidecar would capture its own TTS) and never once the interview is done.
-  useEffect(() => {
+  /** Returns false without clearing the draft if a turn is already running
+   * or the connection went away. The ref also prevents a rapid double-send. */
+  const sendUserMessage = useCallback((text: string): boolean => {
+    const trimmed = text.trim();
     const ws = wsRef.current;
-    if (!ws || ws.readyState !== WebSocket.OPEN) return;
-    // Asked for on every listening beat, even with TTS off: "no spoken
-    // replies" is a choice about Jarvis's voice, not the user's. Whether
-    // there is a mic to lend at all is the daemon's call (it knows if STT is
-    // configured and a pebble is connected), so we just ask.
-    const wants = phase === "listening";
-    if (wants) {
-      if (micStatusRef.current === "idle") requestDaemonMic(!textOnly);
-      return;
-    }
-    clearRearmTimer();
-    emptyCapturesRef.current = 0;
-    if (micStatusRef.current === "idle") return;
-    // Hand the mic back. Harmless when the daemon never armed it.
-    setMic("idle");
+    if (!trimmed || !ws || ws.readyState !== WebSocket.OPEN) return false;
+    if (phaseRef.current !== "ready" && phaseRef.current !== "error") return false;
     try {
-      ws.send(JSON.stringify({ type: "interview_listen_stop", payload: {}, timestamp: Date.now() }));
+      ws.send(JSON.stringify({
+        type: "interview_user_message",
+        payload: { text: trimmed, speakReply: false },
+        timestamp: Date.now(),
+      }));
     } catch {
-      /* socket already going away */
+      setError("Your answer wasn't sent. Check the connection and try again.");
+      changePhase("error");
+      return false;
     }
-  }, [phase, textOnly, requestDaemonMic, clearRearmTimer, setMic]);
+    setMessages((prev) => [...prev, { role: "user", text: trimmed, ts: Date.now() }]);
+    setError(null);
+    changePhase("thinking");
+    return true;
+  }, [changePhase]);
 
-  // ── TTS playback ─────────────────────────────────────────────────
-  function getAudioContext(): AudioContext {
-    if (!audioCtxRef.current || audioCtxRef.current.state === "closed") {
-      audioCtxRef.current = new AudioContext();
-    }
-    return audioCtxRef.current;
-  }
-
-  const playNextChunk = useCallback(async () => {
-    const chunk = audioQueueRef.current.shift();
-    if (!chunk) {
-      audioPlayingRef.current = false;
-      // If TTS has fully drained AND we're past speaking, flip to listening.
-      setPhase((prev) => {
-        if (prev === "speaking") {
-          setOrbState("listening");
-          return "listening";
-        }
-        return prev;
-      });
-      return;
-    }
-    audioPlayingRef.current = true;
-    const ctx = getAudioContext();
-    try {
-      const buf = await ctx.decodeAudioData(chunk.slice(0));
-      const src = ctx.createBufferSource();
-      src.buffer = buf;
-      src.connect(ctx.destination);
-      src.onended = () => playNextChunk();
-      src.start();
-    } catch (err) {
-      console.warn("[Interview] TTS decode failed:", err);
-      playNextChunk();
-    }
-  }, []);
-
-  // ── User send ────────────────────────────────────────────────────
-  const sendUserMessage = useCallback(
-    (text: string) => {
-      const trimmed = text.trim();
-      if (!trimmed) return;
-      const ws = wsRef.current;
-      if (!ws || ws.readyState !== WebSocket.OPEN) return;
-      setMessages((prev) => [
-        ...prev,
-        { role: "user", text: trimmed, ts: Date.now() },
-      ]);
-      setPartialUserText("");
-      // Typing wins the turn: the effect above hands the pebble's mic back
-      // as soon as we leave the listening phase.
-      setPhase("thinking");
-      setOrbState("thinking");
-      ws.send(
-        JSON.stringify({
-          type: "interview_user_message",
-          payload: { text: trimmed, speakReply: !textOnlyRef.current },
-          timestamp: Date.now(),
-        }),
-      );
-    },
-    [],
-  );
-
-  return {
-    phase,
-    orbState,
-    messages,
-    partialUserText,
-    factsRecorded,
-    farewell,
-    error,
-    micStatus,
-    micReason,
-    textOnly,
-    sendUserMessage,
-    setTextOnly,
-    setPartialUserText,
-  };
+  return { phase, messages, factsRecorded, farewell, error, sendUserMessage };
 }

--- a/ui/src/v2/onboarding/useOnboardingStatus.ts
+++ b/ui/src/v2/onboarding/useOnboardingStatus.ts
@@ -56,7 +56,7 @@ interface HookValue {
   /** Re-fetch the status. UI calls this after `/api/onboarding/setup`
    *  succeeds so the gate can flip from setup screens to the live
    *  shell without a hard reload. */
-  refresh: () => Promise<void>;
+  refresh: () => Promise<OnboardingStatus | null>;
 }
 
 /**
@@ -96,17 +96,13 @@ export function useOnboardingStatus(): HookValue {
         return json;
       });
       setError(null);
+      return json;
     } catch (err) {
-      // The status endpoint is one of the few routes that should
-      // ALWAYS work — even in setup mode. After retries are exhausted
-      // we treat failure as "not yet onboarded" rather than blocking
-      // the user behind a permanent error screen. The OnboardingGate's
-      // render path checks `status === null` to mean "still loading";
-      // we set a sentinel below so the gate falls through to setup
-      // screens. (The retries above keep a daemon that's mid-restart
-      // from flashing the setup flow at an already-onboarded user.)
+      // Keep the last valid snapshot on a background refresh failure. This
+      // preserves the user's interview/activation or unsent Talk draft.
+      // The initial-load fallback remains available for a new install.
       setError(err instanceof Error ? err.message : String(err));
-      setStatus({
+      setStatus((previous) => previous ?? {
         setup_completed: false,
         setup_completed_at: null,
         setup_skipped_profile: false,
@@ -117,6 +113,7 @@ export function useOnboardingStatus(): HookValue {
         tutorial_progress_step: null,
         last_reset_at: null,
       });
+      return null;
     } finally {
       setLoading(false);
     }

--- a/ui/src/v2/onboarding/useOnboardingStatus.ts
+++ b/ui/src/v2/onboarding/useOnboardingStatus.ts
@@ -149,6 +149,9 @@ export function useOnboardingStatus(): HookValue {
   return { status, loading, error, refresh };
 }
 
+/** Base backoff between status attempts. Mutable so tests can shorten it. */
+export const STATUS_RETRY = { delayMs: 700 };
+
 /** Fetch `/api/onboarding/status` with a few short retries. A daemon
  *  that is mid-restart (or briefly 503ing while services come up) used
  *  to fail the single fetch, and the error fallback re-showed the full
@@ -159,7 +162,7 @@ async function fetchStatusWithRetry(): Promise<OnboardingStatus> {
   let lastError: unknown;
   for (let attempt = 0; attempt < 3; attempt++) {
     if (attempt > 0) {
-      await new Promise((resolve) => setTimeout(resolve, attempt * 700));
+      await new Promise((resolve) => setTimeout(resolve, attempt * STATUS_RETRY.delayMs));
     }
     try {
       const r = await fetch("/api/onboarding/status");

--- a/ui/src/v2/rooms/workflows/WorkflowsRoom.tsx
+++ b/ui/src/v2/rooms/workflows/WorkflowsRoom.tsx
@@ -557,12 +557,13 @@ function PausedRunCallout({ runId }: { runId: string }): React.ReactElement {
 function EmptyState({ onCreate }: { onCreate: () => void }): React.ReactElement {
   return (
     <div className="wf-empty">
-      <p>No workflows yet.</p>
+      <p>Your first workflow starts with a conversation.</p>
       <p className="wf-empty__hint">
-        Start with a blank canvas and add steps as you go.
+        Open Talk and describe a recurring task. Jarvis can draft the steps with you.
+        Or start with a blank canvas below.
       </p>
       <Button variant="primary" size="sm" onClick={onCreate}>
-        <Icon icon={Plus} size={14} /> New workflow
+        <Icon icon={Plus} size={14} /> Build from scratch
       </Button>
     </div>
   );

--- a/ui/src/v2/shell/AppShell.tsx
+++ b/ui/src/v2/shell/AppShell.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Composer } from "./Composer";
+import { useTalkDraft } from "./useTalkDraft";
 import { Header, type ConnectionState } from "./Header";
 import { Thread, type ThreadHandle } from "../thread/Thread";
 import { MOCK_THREAD } from "../thread/mock";
@@ -874,7 +875,7 @@ function ShellLayout({
   const route = useV2Route();
   const [collapsed, toggleCollapse] = useIndexCollapsed();
   const [arranging, setArranging] = useState(false);
-  const [talkOpen, setTalkOpen] = useState(false);
+  const { open: talkOpen, setOpen: setTalkOpen, draft: composerDraft, setDraft: setComposerDraft } = useTalkDraft();
   const [talkIn, setTalkIn] = useState(false);
 
   // awaiting-approval renders as the "asking" (amber) pebble state.
@@ -1037,6 +1038,9 @@ function ShellLayout({
           <div className="rs-talk-foot">
             <div style={{ padding: "11px 13px" }}>
               <Composer
+                value={composerDraft}
+                onValueChange={setComposerDraft}
+                autoFocus
                 onSubmit={onSubmit}
                 onSlash={onOpenPalette}
                 disabled={composerDisabled}

--- a/ui/src/v2/shell/Composer.test.tsx
+++ b/ui/src/v2/shell/Composer.test.tsx
@@ -1,0 +1,74 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+
+GlobalRegistrator.register();
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+let act: typeof import("react").act;
+let createRoot: typeof import("react-dom/client").createRoot;
+let Composer: typeof import("./Composer").Composer;
+let host: HTMLDivElement;
+let field: HTMLInputElement;
+let root: ReturnType<typeof createRoot>;
+
+beforeAll(async () => {
+  ({ act } = await import("react"));
+  ({ createRoot } = await import("react-dom/client"));
+  ({ Composer } = await import("./Composer"));
+});
+beforeEach(() => {
+  host = document.createElement("div");
+  field = document.createElement("input");
+  document.body.append(host, field);
+  root = createRoot(host);
+});
+afterEach(async () => {
+  await act(async () => root.unmount());
+  host.remove();
+  field.remove();
+});
+afterAll(() => GlobalRegistrator.unregister());
+
+const render = (node: React.ReactNode) => act(async () => root.render(node));
+const input = () => host.querySelector<HTMLTextAreaElement>(".v2-composer__input")!;
+
+describe("Composer autoFocus", () => {
+  test("focuses when opened ready, and a later reconnect does not take focus back", async () => {
+    await render(<Composer autoFocus />);
+    expect(document.activeElement === input()).toBe(true);
+    field.focus();
+    await render(<Composer autoFocus disabled />);
+    await render(<Composer autoFocus />);
+    expect(document.activeElement === field).toBe(true);
+  });
+
+  test("opened while disconnected, focuses once the connection is ready", async () => {
+    await render(<Composer autoFocus disabled />);
+    expect(document.activeElement === input()).toBe(false);
+    await render(<Composer autoFocus />);
+    expect(document.activeElement === input()).toBe(true);
+  });
+
+  test("opened while disconnected, leaves a field the user moved to in the meantime", async () => {
+    await render(<Composer autoFocus disabled />);
+    field.focus();
+    await render(<Composer autoFocus />);
+    expect(document.activeElement === field).toBe(true);
+  });
+
+  test("a reconnect gives focus back when the disconnect took it from the composer", async () => {
+    await render(<Composer autoFocus />);
+    expect(document.activeElement === input()).toBe(true);
+    // Browsers drop focus to <body> when a focused textarea becomes disabled.
+    // happy-dom does not, and ignores blur() once disabled, so blur first.
+    input().blur();
+    await render(<Composer autoFocus disabled />);
+    expect(document.activeElement === input()).toBe(false);
+    await render(<Composer autoFocus />);
+    expect(document.activeElement === input()).toBe(true);
+  });
+
+  test("without autoFocus never moves focus", async () => {
+    await render(<Composer />);
+    expect(document.activeElement === input()).toBe(false);
+  });
+});

--- a/ui/src/v2/shell/Composer.tsx
+++ b/ui/src/v2/shell/Composer.tsx
@@ -39,8 +39,22 @@ export function Composer({
     }
   }, [value]);
 
+  // Opening Talk focuses the composer. If it opened while disabled (waiting
+  // for the daemon), focus it once enabled unless the user is typing in
+  // another field. After that, a reconnect only restores focus the disconnect
+  // took away (disabling the textarea drops focus to <body>).
+  const openedEnabled = useRef(!disabled);
+  const autoFocused = useRef(false);
   React.useEffect(() => {
-    if (autoFocus && !disabled) inputRef.current?.focus();
+    if (!autoFocus || disabled) return;
+    const input = inputRef.current;
+    const active = document.activeElement as HTMLElement | null;
+    const focusLost = !active || active === document.body;
+    const typingElsewhere = !!active && active !== input
+      && (active.isContentEditable || /^(INPUT|TEXTAREA|SELECT)$/.test(active.tagName));
+    const first = !autoFocused.current;
+    autoFocused.current = true;
+    if (first ? openedEnabled.current || !typingElsewhere : focusLost) input?.focus();
   }, [autoFocus, disabled]);
 
   // Global `/` opens the command palette directly. Suppressed inside any

--- a/ui/src/v2/shell/Composer.tsx
+++ b/ui/src/v2/shell/Composer.tsx
@@ -10,6 +10,9 @@ export interface ComposerProps {
   disabled?: boolean;
   responding?: boolean;
   onStop?: () => void;
+  value?: string;
+  onValueChange?: (value: string) => void;
+  autoFocus?: boolean;
 }
 
 export function Composer({
@@ -19,9 +22,26 @@ export function Composer({
   disabled,
   responding = false,
   onStop,
+  value: controlledValue,
+  onValueChange,
+  autoFocus = false,
 }: ComposerProps) {
-  const [value, setValue] = useState("");
+  const [localValue, setLocalValue] = useState("");
+  const value = controlledValue ?? localValue;
+  const setValue = onValueChange ?? setLocalValue;
   const inputRef = useRef<HTMLTextAreaElement>(null);
+
+  React.useEffect(() => {
+    const el = inputRef.current;
+    if (el) {
+      el.style.height = "auto";
+      el.style.height = el.scrollHeight + "px";
+    }
+  }, [value]);
+
+  React.useEffect(() => {
+    if (autoFocus && !disabled) inputRef.current?.focus();
+  }, [autoFocus, disabled]);
 
   // Global `/` opens the command palette directly. Suppressed inside any
   // editable element so it doesn't hijack normal typing — typing `/` in

--- a/ui/src/v2/shell/useTalkDraft.ts
+++ b/ui/src/v2/shell/useTalkDraft.ts
@@ -1,0 +1,18 @@
+import { useContext, useEffect, useState } from "react";
+import { WorkflowDraftContext } from "../onboarding/WorkflowDraftContext";
+
+export function useTalkDraft() {
+  const { prompt, consume } = useContext(WorkflowDraftContext);
+  const [open, setOpen] = useState(false);
+  const [draft, setDraft] = useState("");
+
+  useEffect(() => {
+    if (!prompt) return;
+    setDraft(prompt);
+    setOpen(true);
+    consume();
+  }, [prompt, consume]);
+
+  // Keep edits here when Talk is closed and its composer unmounts.
+  return { open, setOpen, draft, setDraft };
+}

--- a/ui/src/v2/thread/Thread.tsx
+++ b/ui/src/v2/thread/Thread.tsx
@@ -383,13 +383,13 @@ function ItemRenderer({
 function EmptyState() {
   return (
     <section className="v2-thread__empty">
-      <span className="v2-thread__empty-eyebrow">Phase 3A · thread ready</span>
+      <span className="v2-thread__empty-eyebrow">Your AI cofounder</span>
       <h1 className="v2-thread__empty-title">
-        The thread is <em>the whole app.</em>
+        Make room for <em>your work.</em>
       </h1>
       <p className="v2-thread__empty-lede">
-        Nothing yet. Tap the orb, press <kbd>/</kbd>, or wait for the morning brief — every
-        message flows through this surface.
+        Describe a recurring task. Jarvis can help you draft a workflow, work through
+        the details, and decide where your judgment belongs. Review your message below, then send it to begin.
       </p>
     </section>
   );

--- a/ui/src/v2/thread/Thread.tsx
+++ b/ui/src/v2/thread/Thread.tsx
@@ -388,8 +388,8 @@ function EmptyState() {
         Make room for <em>your work.</em>
       </h1>
       <p className="v2-thread__empty-lede">
-        Describe a recurring task. Jarvis can help you draft a workflow, work through
-        the details, and decide where your judgment belongs. Review your message below, then send it to begin.
+        Describe a recurring task below. Jarvis can help you draft a workflow, work through
+        the details, and decide where your judgment belongs.
       </p>
     </section>
   );

--- a/ui/src/v2/v2.css
+++ b/ui/src/v2/v2.css
@@ -33,6 +33,10 @@
   overflow: hidden;
 }
 
+/* Retain the shell instance when the banner changes without creating an
+   empty grid row above it when there is no banner. */
+.v2-shell-frame--plain { display: contents; }
+
 /* T18 panel mode — bare RoomBody hosted in a sidecar-spawned native
    window. No AppShell, no Thread/Rail, no voice handlers. Padding gives
    the body breathing room from the OS window chrome; overflow:auto so


### PR DESCRIPTION
Onboarding did not carry the workflow cofounder positioning through to a concrete first step. It now explains how Jarvis uses workflows for repetitive work and AI for judgment, then offers an optional request for a first workflow.

- Refresh welcome, connections, the five tutorial cards and empty states around workflows, conversational creation, awareness, memory, goals, computer control and Authority.
- Make the interview written only in the UI and daemon, including legacy audio requests. Target about four or five useful questions about work, goals, routines, tools and approval preferences, accepting skips and unknown answers. This is a prompt target, not a fixed limit.
- After the tutorial, let users describe a routine or edit an example. **Review request in Talk** opens an editable composer; users send it manually or skip activation. The request asks for a draft with triggers and schedules disabled, without publishing, enabling or running it. This uses the existing AI authoring path and adds no execution lock.
- Retain unsent edits across Talk close/reopen and status changes, and retain the activation task for retry after completion-refresh failure. Drafts last within the app session, not across browser reloads.

The six hosted/nine self-hosted setup screens, hosted provider-setup exclusion and normal assistant/Pebble voice remain. Interview answers are profile context; they do not configure goals or enforce Authority policies.

Recorded validation: 107 focused product tests passed, plus a later overlapping set of 35 Linux tests. TypeScript and the UI build passed. Browser checks covered written controls, tutorial, skip paths and editable Talk handoff without automatic submission. The real local daemon and fresh onboarding also loaded successfully.

Full supported-platform CI and authenticated hosted testing with Jarvis AI remain release checks. The full Windows suite encountered an unchanged database-cleanup failure; the migration CLI has an existing Windows path issue. Provider-backed workflow creation and actual desktop control were not verified.

Release the brain code and rebuilt product dashboard together. The companion hosted-dashboard copy change can ship independently: https://github.com/usejarvis/hosting/pull/7. No sidecar rebuild is required: onboarding is served by the paired brain.
