### PR TITLE
fix the shared-runtime build: a 2.7MB piece was silently closing the engine socket

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ coverage
 
 # logs
 /logs
+# Piece extraction runs the real pieces, and some write log files next to the
+# vendored tree (scrapeless does). Build residue, never ours to commit.
+src/workflows/activepieces/logs/
 _.log
 report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 

--- a/scripts/build-shared-runtime.ts
+++ b/scripts/build-shared-runtime.ts
@@ -165,7 +165,15 @@ const { catalog: built, failures } = await buildPieceCatalog({
   pieceRoots,
   cacheFile,
   cacheKey: computeCatalogCacheKey({ bundlePath: bundle.bundlePath }),
-  pieceTimeoutMs: 30_000,
+  // 10s, not 30. Measured on a hosted host over the real installed tree, the
+  // slowest piece in the catalog's first forty extracts in 1.2s and the median
+  // in about 0.3s, cold transpiler cache or warm -- so this is still eight
+  // times the worst case observed. It is not a budget for slow pieces; it is
+  // how long the build waits before deciding an engine has stopped answering,
+  // and it is paid in FULL every time that happens. At 30s the full catalog
+  // spends about fourteen minutes waiting, inside an install op that gives up
+  // at thirty.
+  pieceTimeoutMs: 10_000,
   overallTimeoutMs: 6 * 60 * 60 * 1000,
   reporter: (m) => log(m),
 });

--- a/scripts/build-shared-runtime.ts
+++ b/scripts/build-shared-runtime.ts
@@ -186,3 +186,26 @@ const summary =
   });
 if (summaryPath) writeFileSync(resolve(summaryPath), summary + "\n");
 console.log(summary);
+
+// 6. A build that GAVE UP must not look like a build that finished.
+//
+// buildPieceCatalog ends early when the engine stops answering, and marks the
+// pieces it never tried. Exiting 0 here would publish that partial cache under
+// a cacheKey that MATCHES the daemon's, so every consumer treats it as
+// complete: install-version moves it into place, the tenant-side
+// "does not match this daemon's catalog key" warning never fires, and every
+// instance on the host silently re-extracts the hundreds of missing pieces at
+// its own boot -- the fleet-wide storm that shared cache exists to prevent.
+//
+// Failing is the loud option, and the summary above already names every piece
+// and why. Individual broken pieces stay non-fatal: a catalog is expected to
+// carry some, and `failures` reports them.
+const unattempted = failures.filter((f) => f.reason.startsWith("not attempted"));
+if (unattempted.length > 0) {
+  log(
+    `REFUSING to publish: the catalog build gave up with ${unattempted.length} of ` +
+      `${catalog.length} piece(s) never attempted. The metadata cache would be partial ` +
+      `but indistinguishable from a complete one. See failures[] in the summary.`,
+  );
+  process.exit(1);
+}

--- a/src/workflows/runner/engine-runtime/build.test.ts
+++ b/src/workflows/runner/engine-runtime/build.test.ts
@@ -8,13 +8,76 @@
  */
 
 import { test, expect, describe, afterEach } from "bun:test";
-import { existsSync, mkdirSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { resolve } from "node:path";
 import { spawn } from "node:child_process";
-import { buildEngineBundle, bundleHash, findCachedBundle, ENGINE_BUILD_PATHS } from "./build";
+import {
+  buildEngineBundle,
+  bundleHash,
+  findCachedBundle,
+  ENGINE_BUILD_PATHS,
+  ENGINE_REQUEST_BASE_SHIM,
+} from "./build";
 
 describe("engine bundle build", () => {
+  describe("Request base-URL shim (banner)", () => {
+    /**
+     * Runs the shim in a child bun process, because it replaces a global and
+     * the test runner has to keep its own.
+     */
+    const inChild = async (body: string): Promise<string> => {
+      const proc = Bun.spawn(["bun", "-e", `${ENGINE_REQUEST_BASE_SHIM}\n${body}`], {
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [out, err] = await Promise.all([
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+      ]);
+      await proc.exited;
+      return (out + err).trim();
+    };
+
+    test("an empty URL resolves instead of throwing, which is what a browser does", async () => {
+      // The exact probe abortcontroller-polyfill runs at module load, reached
+      // through the airtable SDK. Unpatched, Bun answers
+      // `Failed to construct 'Request': url is required` and the piece import
+      // dies before any of our code runs.
+      expect(await inChild(`console.log("signal" in new Request(""))`)).toBe("true");
+    });
+
+    test("a URL that already works is passed through untouched", async () => {
+      // The shim must be strictly additive: only inputs that would have THROWN
+      // are resolved, so nothing that builds a Request today changes.
+      expect(await inChild(`console.log(new Request("https://example.test/x?a=1").url)`)).toBe(
+        "https://example.test/x?a=1",
+      );
+    });
+
+    test("instanceof still recognises Requests built by fetch internals", async () => {
+      // Subclassing would otherwise make `nativeRequest instanceof Request`
+      // false, which is a subtle way to break piece code that type-checks.
+      expect(
+        await inChild(`
+          const native = Reflect.construct(Object.getPrototypeOf(Request), ["https://example.test/"]);
+          console.log(native instanceof Request);
+        `),
+      ).toBe("true");
+    });
+
+    test("the shim is part of the bundle cache key", () => {
+      // A banner that does not invalidate the hash is served stale from every
+      // host that already has a bundle -- the same trap PATCHED_VENDOR_SOURCES
+      // exists to close, and the reason that list carries so many comments.
+      const src = readFileSync(resolve(import.meta.dir, "build.ts"), "utf8");
+      const hashBody = src.slice(src.indexOf("export function bundleHash"));
+      expect(hashBody.slice(0, hashBody.indexOf("\n}")).includes("ENGINE_REQUEST_BASE_SHIM")).toBe(
+        true,
+      );
+    });
+  });
+
   test("staging dir lives outside the repo", () => {
     expect(ENGINE_BUILD_PATHS.STAGING_DIR.startsWith(ENGINE_BUILD_PATHS.REPO_ROOT)).toBe(false);
     expect(ENGINE_BUILD_PATHS.BUNDLE_ROOT.startsWith(ENGINE_BUILD_PATHS.REPO_ROOT)).toBe(false);

--- a/src/workflows/runner/engine-runtime/build.test.ts
+++ b/src/workflows/runner/engine-runtime/build.test.ts
@@ -12,11 +12,13 @@ import { existsSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } 
 import { tmpdir } from "node:os";
 import { resolve } from "node:path";
 import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
 import {
   buildEngineBundle,
   bundleHash,
   findCachedBundle,
   ENGINE_BUILD_PATHS,
+  ENGINE_ESBUILD_CONFIG,
   ENGINE_REQUEST_BASE_SHIM,
 } from "./build";
 
@@ -66,15 +68,29 @@ describe("engine bundle build", () => {
       ).toBe("true");
     });
 
-    test("the shim is part of the bundle cache key", () => {
-      // A banner that does not invalidate the hash is served stale from every
+    test("the banner is WIRED IN, not merely defined", () => {
+      // The previous version of this test grepped bundleHash's source for the
+      // constant's name. It passed with the hashing removed as long as the
+      // name survived in a comment, and it could not see the banner being
+      // unwired from the esbuild call at all -- which is the failure that
+      // matters, because it changes the bytes the engine runs.
+      expect(ENGINE_ESBUILD_CONFIG.banner.js).toBe(ENGINE_REQUEST_BASE_SHIM);
+    });
+
+    test("the build config is part of the bundle cache key", () => {
+      // A config change that does not move the hash is served stale from every
       // host that already has a bundle -- the same trap PATCHED_VENDOR_SOURCES
-      // exists to close, and the reason that list carries so many comments.
+      // exists to close. Asserted on the VALUE: two configs differing only in
+      // the banner must not hash alike.
+      const digest = (cfg: unknown) =>
+        createHash("sha256").update(JSON.stringify(cfg)).digest("hex");
+      const withBanner = { ...ENGINE_ESBUILD_CONFIG, banner: ENGINE_ESBUILD_CONFIG.banner };
+      const withoutBanner = { ...ENGINE_ESBUILD_CONFIG, banner: undefined };
+      expect(digest(withBanner)).not.toBe(digest(withoutBanner));
+      // And the real key actually consumes it.
       const src = readFileSync(resolve(import.meta.dir, "build.ts"), "utf8");
-      const hashBody = src.slice(src.indexOf("export function bundleHash"));
-      expect(hashBody.slice(0, hashBody.indexOf("\n}")).includes("ENGINE_REQUEST_BASE_SHIM")).toBe(
-        true,
-      );
+      const body = src.slice(src.indexOf("export function bundleHash"));
+      expect(body.slice(0, body.indexOf("\n}"))).toContain("ENGINE_ESBUILD_CONFIG");
     });
   });
 

--- a/src/workflows/runner/engine-runtime/build.ts
+++ b/src/workflows/runner/engine-runtime/build.ts
@@ -275,6 +275,35 @@ const PATCHED_VENDOR_SOURCES = [
  * constructor so `x instanceof Request` stays true for Requests built by
  * fetch internals.
  */
+/**
+ * The path-free half of the esbuild configuration: everything that changes the
+ * OUTPUT rather than where it lands. `bundleHash` hashes this whole object, so
+ * adding a define, changing the target, or removing the banner below all
+ * invalidate cached bundles by themselves.
+ *
+ * Hashing the banner CONSTANT instead would not: deleting the `banner:` line
+ * while leaving the constant in the file changes what the engine executes and
+ * leaves the key untouched, which is the same stale-bundle trap
+ * PATCHED_VENDOR_SOURCES exists to close. Paths stay out because they differ
+ * per machine and must not fragment the cache.
+ */
+export const ENGINE_ESBUILD_CONFIG = {
+  bundle: true,
+  platform: "node",
+  target: "node20",
+  format: "cjs",
+  sourcemap: true,
+  minifySyntax: true,
+  minifyWhitespace: true,
+  metafile: true,
+  // isolated-vm intentionally excluded -- we only run SANDBOX_PROCESS mode
+  // (see SPIKE-SANDBOXING.md). utf-8-validate / bufferutil are optional ws deps.
+  external: ["isolated-vm", "utf-8-validate", "bufferutil"],
+  get banner() {
+    return { js: ENGINE_REQUEST_BASE_SHIM };
+  },
+} as const;
+
 export const ENGINE_REQUEST_BASE_SHIM = `(() => {
   const NativeRequest = globalThis.Request;
   if (typeof NativeRequest !== "function") return;
@@ -312,16 +341,17 @@ export function bundleHash(): string {
     const content = readFileSync(resolve(VENDOR_PACKAGES, rel), "utf8");
     hasher.update("\0").update(rel).update("\0").update(content);
   }
-  // The banner is a patch too. It changes the bytes the engine executes, just
-  // from our build config rather than a vendored file, so leaving it out of
+  // The build CONFIG is a patch too: it changes the bytes the engine executes,
+  // just from our own options rather than a vendored file. Leaving it out of
   // the key would serve the OLD engine from cache to every host that already
   // has a bundle for this hash -- the exact stale-engine trap the list above
-  // exists to close.
+  // exists to close -- and hashing only the banner constant would miss the
+  // banner being UNWIRED, or the target changing.
   hasher
     .update("\0")
-    .update("banner:request-base-shim")
+    .update("esbuild-config")
     .update("\0")
-    .update(ENGINE_REQUEST_BASE_SHIM);
+    .update(JSON.stringify(ENGINE_ESBUILD_CONFIG));
   return hasher.digest("hex").slice(0, 16);
 }
 
@@ -399,26 +429,17 @@ export async function buildEngineBundle(opts?: {
   };
 
   const result = await esbuild.build({
+    // The hashed config first, then only the path-dependent options. Anything
+    // that changes the output must live in ENGINE_ESBUILD_CONFIG or it is
+    // outside the cache key.
+    ...ENGINE_ESBUILD_CONFIG,
     entryPoints: [resolve(ENGINE_DIR, "src/main.ts")],
-    // Runs before the bundle body, and so before any piece import.
-    banner: { js: ENGINE_REQUEST_BASE_SHIM },
-    bundle: true,
-    platform: "node",
-    target: "node20",
     outfile: bundlePath,
-    format: "cjs",
-    sourcemap: true,
-    minifySyntax: true,
-    minifyWhitespace: true,
-    metafile: true,
     alias: {
       "@activepieces/shared": resolve(VENDOR_PACKAGES, "shared/src"),
       "@activepieces/pieces-framework": resolve(VENDOR_PACKAGES, "pieces/framework/src"),
       "@activepieces/pieces-common": resolve(VENDOR_PACKAGES, "pieces/common/src"),
     },
-    // isolated-vm intentionally excluded -- we only run SANDBOX_PROCESS mode
-    // (see SPIKE-SANDBOXING.md). utf-8-validate / bufferutil are optional ws deps.
-    external: ["isolated-vm", "utf-8-validate", "bufferutil"],
     nodePaths: [resolve(STAGING_DIR, "node_modules")],
     logLevel: "warning",
   });

--- a/src/workflows/runner/engine-runtime/build.ts
+++ b/src/workflows/runner/engine-runtime/build.ts
@@ -245,6 +245,54 @@ const PATCHED_VENDOR_SOURCES = [
 ] as const;
 
 /**
+ * Prepended to the engine bundle, so it runs before any piece module is
+ * imported.
+ *
+ * A BROWSER resolves a relative or empty Request URL against the document
+ * base; Bun has no base and throws `Failed to construct 'Request': url is
+ * required`. Bun also defines `self`, so bundles that sniff for a browser take
+ * the browser branch and then hit that throw. The abortcontroller-polyfill
+ * does exactly this AT MODULE LOAD:
+ *
+ *     I4 = typeof window < "u" ? window : typeof self < "u" ? self : null;
+ *     I4 ? ("signal" in new Request("")) ? ... : ...
+ *
+ * It reaches us bundled inside the airtable SDK, so importing
+ * `@activepieces/piece-airtable` throws before a single line of our code runs
+ * and EXTRACT_PIECE_METADATA reports INTERNAL_ERROR. Reproduced with nothing
+ * but `bun -e 'await import("@activepieces/piece-airtable")'`.
+ *
+ * So resolve against a dummy base, which is what the browser these bundles
+ * think they are running in would do. STRICTLY ADDITIVE: an input that already
+ * builds a Request is passed through untouched, and only one that would have
+ * THROWN is resolved, so nothing that works today changes. The probe then
+ * succeeds and the polyfill selects the NATIVE AbortController.
+ *
+ * `self` is deliberately left alone. Deleting it also fixes this piece, but
+ * UMD wrappers commonly do `typeof self !== "undefined" ? self : this`, and
+ * `this` is undefined in an ES module -- a broader blast radius than the one
+ * invalid input this replaces. `Symbol.hasInstance` delegates to the native
+ * constructor so `x instanceof Request` stays true for Requests built by
+ * fetch internals.
+ */
+export const ENGINE_REQUEST_BASE_SHIM = `(() => {
+  const NativeRequest = globalThis.Request;
+  if (typeof NativeRequest !== "function") return;
+  class Request extends NativeRequest {
+    constructor(input, init) {
+      if (typeof input === "string") {
+        try { new URL(input); } catch { input = new URL(input, "http://localhost/").href; }
+      }
+      super(input, init);
+    }
+  }
+  Object.defineProperty(Request, Symbol.hasInstance, {
+    value: (x) => x instanceof NativeRequest,
+  });
+  globalThis.Request = Request;
+})();`;
+
+/**
  * Cache key combines the synthesized package.json (which captures dep versions),
  * the vendored upstream pin (tag + SHA shipped as a generated TS constant
  * by `sync-activepieces.ts`), and the content of any vendored source files
@@ -264,6 +312,16 @@ export function bundleHash(): string {
     const content = readFileSync(resolve(VENDOR_PACKAGES, rel), "utf8");
     hasher.update("\0").update(rel).update("\0").update(content);
   }
+  // The banner is a patch too. It changes the bytes the engine executes, just
+  // from our build config rather than a vendored file, so leaving it out of
+  // the key would serve the OLD engine from cache to every host that already
+  // has a bundle for this hash -- the exact stale-engine trap the list above
+  // exists to close.
+  hasher
+    .update("\0")
+    .update("banner:request-base-shim")
+    .update("\0")
+    .update(ENGINE_REQUEST_BASE_SHIM);
   return hasher.digest("hex").slice(0, 16);
 }
 
@@ -342,6 +400,8 @@ export async function buildEngineBundle(opts?: {
 
   const result = await esbuild.build({
     entryPoints: [resolve(ENGINE_DIR, "src/main.ts")],
+    // Runs before the bundle body, and so before any piece import.
+    banner: { js: ENGINE_REQUEST_BASE_SHIM },
     bundle: true,
     platform: "node",
     target: "node20",

--- a/src/workflows/runner/engine-runtime/engine-handle-lifecycle.test.ts
+++ b/src/workflows/runner/engine-runtime/engine-handle-lifecycle.test.ts
@@ -114,7 +114,7 @@ describe("EngineHandle operation lifecycle", () => {
       proc,
       registry,
       5,
-      { baseUrl: "http://127.0.0.1:1234" } as never,
+      { baseUrl: "http://127.0.0.1:1234", workerRpc: { engineClient: () => engine } } as never,
       baseCodeDir,
       releaseImpl,
     );

--- a/src/workflows/runner/engine-runtime/engine-runtime.ts
+++ b/src/workflows/runner/engine-runtime/engine-runtime.ts
@@ -220,28 +220,24 @@ export class EngineHandle {
    * there healthy and idle. Measured before this existed: after a forced
    * disconnect the handle simply never got another reply.
    *
-   * Re-resolving per send makes a reconnect self-healing, and makes a genuinely
-   * absent connection fail in milliseconds instead of ninety seconds. The
-   * captured `engineClient` field stays for the warm pool and tests; nothing
-   * on the operation path reads it any more.
+   * Re-resolving per send makes a reconnect self-healing for the NEXT
+   * operation, and makes an absent connection fail in milliseconds instead of
+   * ninety seconds. It cannot rescue an operation already in flight when the
+   * socket dropped: socket.io leaves that ack pending, so it still waits out
+   * its own deadline.
    */
   private liveEngineClient(): EngineContract {
-    // No rpc server to ask means this handle was not built from an rpc
-    // connection at all -- it was handed a client directly, which is how the
-    // fake-EngineContract lifecycle tests drive it. There is nothing to
-    // re-resolve against, so honour what the caller gave us. A real SandboxApi
-    // always has one, so production never takes this branch.
-    const rpc = this.api?.workerRpc;
-    if (!rpc) return this.engineClient;
     try {
-      return rpc.engineClient(this.sandboxId);
+      return this.api.workerRpc.engineClient(this.sandboxId);
     } catch {
-      // No live connection. The engine's state is unknown for exactly the same
-      // reason a transport failure makes it unknown, so mark it abandoned and
-      // let `release()` destroy it rather than parking it for the next caller.
-      this.abandoned = true;
+      // No live connection. Throwing here rather than emitting into a dead
+      // socket is the whole point; `send()`'s catch marks the handle abandoned,
+      // so `release()` destroys the engine instead of parking it for the next
+      // caller. Note this covers "disconnected" AND "has not finished
+      // reconnecting", which are indistinguishable from here -- the operation
+      // was never sent either way.
       throw new Error(
-        `engine for sandbox ${this.sandboxId} is not connected (it disconnected mid-run)`,
+        `no live connection for sandbox ${this.sandboxId}; the engine disconnected and has not reconnected`,
       );
     }
   }

--- a/src/workflows/runner/engine-runtime/engine-runtime.ts
+++ b/src/workflows/runner/engine-runtime/engine-runtime.ts
@@ -209,6 +209,44 @@ export class EngineHandle {
   }
 
   /**
+   * The RPC client for THIS sandbox as of right now, rather than the one
+   * captured when the handle was built.
+   *
+   * `engineClient` is bound to a single socket.io connection. If that
+   * connection drops, worker-rpc deletes it and a reconnecting engine gets a
+   * NEW client stored under the same sandbox id -- which a handle holding the
+   * old one never sees. It would then emit into a dead socket and wait out the
+   * full ack deadline on every subsequent operation, while the engine sat
+   * there healthy and idle. Measured before this existed: after a forced
+   * disconnect the handle simply never got another reply.
+   *
+   * Re-resolving per send makes a reconnect self-healing, and makes a genuinely
+   * absent connection fail in milliseconds instead of ninety seconds. The
+   * captured `engineClient` field stays for the warm pool and tests; nothing
+   * on the operation path reads it any more.
+   */
+  private liveEngineClient(): EngineContract {
+    // No rpc server to ask means this handle was not built from an rpc
+    // connection at all -- it was handed a client directly, which is how the
+    // fake-EngineContract lifecycle tests drive it. There is nothing to
+    // re-resolve against, so honour what the caller gave us. A real SandboxApi
+    // always has one, so production never takes this branch.
+    const rpc = this.api?.workerRpc;
+    if (!rpc) return this.engineClient;
+    try {
+      return rpc.engineClient(this.sandboxId);
+    } catch {
+      // No live connection. The engine's state is unknown for exactly the same
+      // reason a transport failure makes it unknown, so mark it abandoned and
+      // let `release()` destroy it rather than parking it for the next caller.
+      this.abandoned = true;
+      throw new Error(
+        `engine for sandbox ${this.sandboxId} is not connected (it disconnected mid-run)`,
+      );
+    }
+  }
+
+  /**
    * Send one operation to the engine, bounding the wait by the budget we
    * told the engine to honour rather than by the RPC client's default.
    *
@@ -220,7 +258,7 @@ export class EngineHandle {
   private async send(operation: EngineOperationEnvelope): Promise<EngineResponse<unknown>> {
     this.inFlight++;
     try {
-      return await this.engineClient.executeOperation(operation, {
+      return await this.liveEngineClient().executeOperation(operation, {
         timeoutMs: ackTimeoutMsForOperation(operation),
       });
     } catch (e) {

--- a/src/workflows/runner/engine-runtime/engine-wedge.test.ts
+++ b/src/workflows/runner/engine-runtime/engine-wedge.test.ts
@@ -1,0 +1,158 @@
+/**
+ * The two ways a live engine stops answering, against a REAL engine and a real
+ * socket. Both were found by hand while chasing a halted version rollout, and
+ * both are invisible to the fake-EngineContract tests next door: one lives in
+ * the socket layer the fakes replace, the other in the engine's own event loop.
+ *
+ * Gated on a cached bundle (or `JARVIS_TEST_ENGINE_BUILD=1`) like the other
+ * engine-runtime end-to-end tests.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import { closeWorkflowDb, initWorkflowDb } from "../../db";
+import { SandboxApi } from "../../sandbox-api/server";
+import { SandboxRegistry } from "../../sandbox-api/sandbox-registry";
+import { CredentialResolver } from "../../credentials/adapter";
+import { EngineRuntime } from "./engine-runtime";
+import { buildEngineBundle, findCachedBundle, ENGINE_BUILD_PATHS } from "./build";
+import { buildPieceCatalog } from "../../runtime/piece-catalog";
+
+const buildOptIn = process.env.JARVIS_TEST_ENGINE_BUILD === "1";
+const initialCached = findCachedBundle();
+const skipWedgeTests = initialCached === null && !buildOptIn;
+
+describe("a live engine that stops answering", () => {
+  let api: SandboxApi;
+  let runtime: EngineRuntime | null = null;
+  const tmps: string[] = [];
+  /** Set in beforeAll: the engine resolves piece MODULES through
+   * customPiecesPaths, so the tree has to exist before the runtime does.
+   * `pieceRoots` only drives discovery and is passed per build. */
+  let wedgeRoot = "";
+
+  beforeAll(async () => {
+    initWorkflowDb(":memory:");
+    api = new SandboxApi({ services: { credentialResolver: new CredentialResolver() } });
+    await api.start({ host: "127.0.0.1", port: 0 });
+    let cached = initialCached;
+    if (!cached && buildOptIn) cached = await buildEngineBundle();
+    if (!cached) return;
+    wedgeRoot = piecesDir([
+      // Sorted discovery order: "a-blocks" is reached before "b-after".
+      {
+        name: "@activepieces/piece-a-blocks",
+        main:
+          "const until = Date.now() + 8000;\n" +
+          "while (Date.now() < until) { Math.random(); }\n" +
+          "export const blocks = {};\n",
+      },
+      { name: "@activepieces/piece-b-after", main: "export const after = {};\n" },
+    ]);
+    runtime = new EngineRuntime({
+      api,
+      bundlePath: cached.bundlePath,
+      // No pooling: each acquire is its own process, so "was it replaced" is
+      // observable rather than hidden behind the warm slot.
+      pool: false,
+      customPiecesPaths: [resolve(ENGINE_BUILD_PATHS.VENDOR_PACKAGES, "pieces"), wedgeRoot],
+    });
+  });
+
+  afterAll(async () => {
+    if (runtime) await runtime.shutdown();
+    await api.stop();
+    closeWorkflowDb();
+    for (const d of tmps) rmSync(d, { recursive: true, force: true });
+  });
+
+  /** A pieces tree: `main` is written verbatim as the piece's entry module. */
+  function piecesDir(entries: Array<{ name: string; main: string }>): string {
+    const root = mkdtempSync(resolve(tmpdir(), "jarvis-wedge-"));
+    tmps.push(root);
+    for (const { name, main } of entries) {
+      const dir = resolve(root, "node_modules/@activepieces", name.replace("@activepieces/", ""));
+      mkdirSync(resolve(dir, "src"), { recursive: true });
+      writeFileSync(
+        resolve(dir, "package.json"),
+        JSON.stringify({ name, version: "0.0.1", main: "src/index.js" }),
+      );
+      writeFileSync(resolve(dir, "src/index.js"), main);
+    }
+    return root;
+  }
+
+  test.skipIf(skipWedgeTests)(
+    "a socket reconnect does not strand the handle: it fails in milliseconds, not at the ack deadline",
+    async () => {
+      const handle = await runtime!.acquire({
+        runId: "wedge-" + SandboxRegistry.newSandboxId(),
+        projectId: "wedge-project",
+      });
+
+      // Prove the pipe works first. A non-existent piece answers with an error
+      // REPLY, which is all this needs -- it means the round trip completed.
+      await expect(
+        handle.extractPieceMetadata({ pieceName: "@activepieces/piece-nope", pieceVersion: "0.0.1" }),
+      ).rejects.toThrow();
+
+      // Drop the connection the way a ping timeout or an over-limit frame
+      // does. Reaching into `connections` because there is no public seam for
+      // "pretend the socket died", and this is the fault being reproduced.
+      const conns = (
+        api.workerRpc as unknown as {
+          connections: Map<string, { socket: { disconnect: (close: boolean) => void } }>;
+        }
+      ).connections;
+      expect(conns.has(handle.sandboxId)).toBe(true);
+      conns.get(handle.sandboxId)!.socket.disconnect(true);
+      await new Promise((r) => setTimeout(r, 1500));
+
+      // Before the per-send re-resolve, the handle kept emitting into the dead
+      // socket and waited out the FULL ack deadline (60s + a 30s margin) on
+      // every later operation. Anything near that is the bug back.
+      const started = Date.now();
+      await expect(
+        handle.extractPieceMetadata({ pieceName: "@activepieces/piece-nope", pieceVersion: "0.0.1" }),
+      ).rejects.toThrow(/not connected/);
+      expect(Date.now() - started).toBeLessThan(5_000);
+
+      // And the engine is not fit to be reused, for the same reason a
+      // transport failure makes one unfit.
+      expect(handle.isAbandoned).toBe(true);
+      await handle.release();
+    },
+    60_000,
+  );
+
+  test.skipIf(skipWedgeTests)(
+    "a piece that blocks the event loop does not take the rest of the catalog with it",
+    async () => {
+      // The production shape: one piece stops the engine answering ANYTHING
+      // while the process stays alive, so every later piece times out. An
+      // event loop blocked synchronously cannot be interrupted -- there is no
+      // cancel message and no timer will run -- so the only recovery is to
+      // destroy the process, which is what a timeout now does.
+      const { failures } = await buildPieceCatalog({
+        runtime: runtime!,
+        pieceRoots: [resolve(wedgeRoot, "node_modules/@activepieces")],
+        pieceTimeoutMs: 2_000,
+        reporter: () => {},
+      });
+
+      const reasonFor = (n: string) => failures.find((f) => f.pieceName.includes(n))?.reason ?? "";
+      // The blocker gets no answer, as designed.
+      expect(reasonFor("a-blocks")).toContain("timed out");
+      // THE ASSERTION THAT MATTERS: the piece after it was ANSWERED, on a
+      // fresh engine. Carrying the blocked one forward times this out too, and
+      // in prod that ran for 658 consecutive pieces.
+      const after = reasonFor("b-after");
+      expect(after).not.toContain("timed out");
+      expect(after.length).toBeGreaterThan(0);
+      expect(after).toContain("b-after");
+    },
+    120_000,
+  );
+});

--- a/src/workflows/runner/engine-runtime/engine-wedge.test.ts
+++ b/src/workflows/runner/engine-runtime/engine-wedge.test.ts
@@ -85,13 +85,13 @@ describe("a live engine that stops answering", () => {
   }
 
   test.skipIf(skipWedgeTests)(
-    "a socket reconnect does not strand the handle: it fails in milliseconds, not at the ack deadline",
+    "a disconnected engine fails in milliseconds rather than at the ack deadline",
     async () => {
       const handle = await runtime!.acquire({
         runId: "wedge-" + SandboxRegistry.newSandboxId(),
         projectId: "wedge-project",
       });
-
+      try {
       // Prove the pipe works first. A non-existent piece answers with an error
       // REPLY, which is all this needs -- it means the round trip completed.
       await expect(
@@ -116,13 +116,70 @@ describe("a live engine that stops answering", () => {
       const started = Date.now();
       await expect(
         handle.extractPieceMetadata({ pieceName: "@activepieces/piece-nope", pieceVersion: "0.0.1" }),
-      ).rejects.toThrow(/not connected/);
+      ).rejects.toThrow(/no live connection/);
       expect(Date.now() - started).toBeLessThan(5_000);
 
       // And the engine is not fit to be reused, for the same reason a
       // transport failure makes one unfit.
       expect(handle.isAbandoned).toBe(true);
-      await handle.release();
+      } finally {
+        // An acquired-but-unreleased engine survives `runtime.shutdown()` --
+        // that only clears the warm slot -- and then reconnect-loops against a
+        // closed port forever. A failed assertion must not leak one.
+        await handle.release();
+      }
+    },
+    60_000,
+  );
+
+  test.skipIf(skipWedgeTests)(
+    "a RECONNECTING engine is picked up by the handle that was built before it",
+    async () => {
+      // The half the fix exists for, and the half a DISCONNECT cannot show:
+      // socket.io-client treats a server-side `disconnect` packet as final and
+      // never reconnects, so that path only ever proves the fail-fast branch.
+      // Closing the underlying transport is what a dropped connection actually
+      // looks like, and the client reconnects from it -- registering a NEW
+      // client under the same sandbox id, which a handle holding the old one
+      // would never see.
+      const handle = await runtime!.acquire({
+        runId: "reconn-" + SandboxRegistry.newSandboxId(),
+        projectId: "reconn-project",
+      });
+      try {
+        const conns = (
+          api.workerRpc as unknown as {
+            connections: Map<string, { id: string; socket: { conn: { close: () => void } } }>;
+          }
+        ).connections;
+        const before = conns.get(handle.sandboxId)!.socket;
+        (before as unknown as { conn: { close: () => void } }).conn.close();
+
+        // Wait for a DIFFERENT socket object under the same sandbox id.
+        let reconnected = false;
+        for (let i = 0; i < 60; i++) {
+          const now = conns.get(handle.sandboxId)?.socket;
+          if (now && now !== before) {
+            reconnected = true;
+            break;
+          }
+          await new Promise((r) => setTimeout(r, 250));
+        }
+        expect(reconnected).toBe(true);
+
+        // The SAME handle must now talk to the new socket. An engine REPLY
+        // (this piece does not exist, so an error reply) proves the round trip;
+        // `not connected` would mean the handle never picked the new one up.
+        await expect(
+          handle.extractPieceMetadata({
+            pieceName: "@activepieces/piece-nope",
+            pieceVersion: "0.0.1",
+          }),
+        ).rejects.toThrow(/-> (INTERNAL_ERROR|USER_FAILURE)/);
+        expect(handle.isAbandoned).toBe(false);
+      } finally {
+        await handle.release();
+      }
     },
     60_000,
   );
@@ -150,8 +207,9 @@ describe("a live engine that stops answering", () => {
       // in prod that ran for 658 consecutive pieces.
       const after = reasonFor("b-after");
       expect(after).not.toContain("timed out");
-      expect(after.length).toBeGreaterThan(0);
-      expect(after).toContain("b-after");
+      // An engine REPLY, not merely "some string": every reason begins with the
+      // piece name, so asserting that would pass without the engine answering.
+      expect(after).toMatch(/-> (INTERNAL_ERROR|USER_FAILURE)/);
     },
     120_000,
   );

--- a/src/workflows/runtime/piece-catalog.test.ts
+++ b/src/workflows/runtime/piece-catalog.test.ts
@@ -567,14 +567,20 @@ describe("PieceCatalog (unit)", () => {
   /**
    * The engine-replacement contract.
    *
-   * A failed extraction leaves the engine in one of two states this loop
-   * cannot distinguish, and BOTH are unusable: a timeout is our own race, so
-   * the engine is still working on the piece we walked away from (nothing
-   * cancels it), and an error reply was observed in prod to poison the process
-   * anyway -- one piece threw while loading and every one of the 658 after it
-   * timed out on an engine that was still alive. So the loop must not carry an
-   * engine across a failure.
+   * A failed extraction leaves the engine in one of two states, and they need
+   * OPPOSITE handling:
+   *
+   *  - NO ANSWER (timeout): our own race gave up; nothing cancelled the
+   *    operation, so the engine is still working on that piece and every
+   *    later one would queue behind it. Destroy it. This is the shape the
+   *    hosted build hit -- one failure, then 658 timeouts on a process still
+   *    alive at 486MB.
+   *  - AN ERROR REPLY: the engine answered, so it is alive and idle. Keep it.
+   *    Destroying it here would be pure churn, and under `pool: true` the
+   *    release would park the process and hand the same one back anyway.
    */
+  /** Pieces are discovered in DIRECTORY order (p0, p1, ...), not by package
+   * name, so keep these under ten entries or p10 sorts before p2. */
   function pieceTree(prefix: string, names: readonly string[]) {
     const { path: root, cleanup } = tmp(prefix);
     names.forEach((name, i) => {
@@ -594,123 +600,172 @@ describe("PieceCatalog (unit)", () => {
     actions: { ping: { name: "ping", displayName: "Ping", description: "", props: {} } },
   });
 
-  test("buildPieceCatalog REPLACES the engine after a failure instead of reusing it", async () => {
-    // The whole bug in one assertion: without this, one broken piece is served
-    // by the same engine as every piece after it.
-    const { root, cleanup } = pieceTree("build-replace", [
-      "@scope/piece-bad",
-      "@scope/piece-a",
-      "@scope/piece-b",
-    ]);
-    let acquires = 0;
-    let releases = 0;
-    const fakeRuntime = {
+  /** Never resolves, so the loop's own `withTimeout` is what fires. */
+  const hangForever = () => new Promise<never>(() => {});
+
+  /** A runtime whose engines answer per `behaviour`, counting acquires and
+   * releases so a leaked or double-freed engine is visible. */
+  function countingRuntime(behaviour: (pieceName: string) => Promise<unknown>) {
+    const counts = { acquires: 0, releases: 0 };
+    const runtime = {
       acquire: async () => {
-        acquires++;
+        counts.acquires++;
         return {
-          async extractPieceMetadata(o: { pieceName: string }) {
-            if (o.pieceName === "@scope/piece-bad") throw new Error("boom");
-            return okMetadata(o.pieceName);
-          },
+          extractPieceMetadata: (o: { pieceName: string }) => behaviour(o.pieceName),
           async release() {
-            releases++;
+            counts.releases++;
           },
         } as unknown as EngineHandle;
       },
     } as unknown as EngineRuntime;
+    return { runtime, counts };
+  }
+
+  test("a TIMEOUT destroys the engine, and the next piece gets a fresh one", async () => {
+    const { root, cleanup } = pieceTree("build-replace", [
+      "@scope/piece-hang",
+      "@scope/piece-a",
+      "@scope/piece-b",
+    ]);
+    const { runtime, counts } = countingRuntime(async (name) =>
+      name === "@scope/piece-hang" ? hangForever() : okMetadata(name),
+    );
     try {
       const { catalog, failures } = await buildPieceCatalog({
-        runtime: fakeRuntime,
+        runtime,
         pieceRoots: [root],
+        pieceTimeoutMs: 20,
         reporter: () => {},
       });
-      // One engine to start, one more after the single failure.
-      expect(acquires).toBe(2);
-      // Every engine handed out is released exactly once -- the replacement
-      // path must not leak the old one, and the `finally` must not double-free
-      // the new one.
-      expect(releases).toBe(acquires);
-      // And the pieces AFTER the failure still extract, on the fresh engine.
+      // One engine to start, one more after the piece that never answered.
+      expect(counts.acquires).toBe(2);
+      // Every engine handed out is released exactly once: the replacement path
+      // must not leak the old one, and the `finally` must not free the new one
+      // twice.
+      expect(counts.releases).toBe(counts.acquires);
+      // And the pieces after it still extract, on the fresh engine.
       expect(catalog.list().length).toBe(2);
       expect(failures.length).toBe(1);
-      expect(failures[0]?.pieceName).toBe("@scope/piece-bad");
+      expect(failures[0]?.reason).toContain("timed out");
     } finally {
       cleanup();
     }
   });
 
-  test("buildPieceCatalog gives up after N consecutive failures instead of paying the timeout on every piece", async () => {
+  test("an ERROR REPLY keeps the engine, because the engine answered", async () => {
+    // The other half of the contract. Replacing here would cost a kill plus a
+    // cold spawn per broken piece, and under a pooled runtime it would not
+    // even be a replacement.
+    const { root, cleanup } = pieceTree("build-keep", [
+      "@scope/piece-bad",
+      "@scope/piece-a",
+      "@scope/piece-b",
+    ]);
+    const { runtime, counts } = countingRuntime(async (name) => {
+      if (name === "@scope/piece-bad") throw new Error("boom");
+      return okMetadata(name);
+    });
+    try {
+      const { catalog, failures } = await buildPieceCatalog({
+        runtime,
+        pieceRoots: [root],
+        reporter: () => {},
+      });
+      expect(counts.acquires).toBe(1);
+      expect(counts.releases).toBe(1);
+      expect(catalog.list().length).toBe(2);
+      expect(failures.length).toBe(1);
+      expect(failures[0]?.reason).toContain("boom");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("gives up after N consecutive TIMEOUTS instead of paying the budget on every piece", async () => {
     // The cost this bounds: on the hosted build a wedged engine meant 659
     // pieces x 30s, about five and a half hours, inside an install op that
     // gives up at thirty minutes -- so the build was killed and reported
     // nothing at all.
-    const names = Array.from({ length: 12 }, (_, i) => `@scope/piece-${i}`);
+    const names = Array.from({ length: 9 }, (_, i) => `@scope/piece-${i}`);
     const { root, cleanup } = pieceTree("build-giveup", names);
     let attempts = 0;
-    const fakeRuntime = {
-      acquire: async () =>
-        ({
-          async extractPieceMetadata() {
-            attempts++;
-            throw new Error("wedged");
-          },
-          async release() { /* noop */ },
-        }) as unknown as EngineHandle,
-    } as unknown as EngineRuntime;
+    const { runtime, counts } = countingRuntime(() => {
+      attempts++;
+      return hangForever();
+    });
     const reports: string[] = [];
     try {
       const { catalog, failures } = await buildPieceCatalog({
-        runtime: fakeRuntime,
+        runtime,
         pieceRoots: [root],
-        maxConsecutiveFailures: 3,
+        pieceTimeoutMs: 20,
+        maxConsecutiveTimeouts: 3,
         reporter: (m) => reports.push(m),
       });
       expect(attempts).toBe(3);
       expect(catalog.list().length).toBe(0);
-      // Every piece is still ACCOUNTED FOR: the ones tried, and the ones the
+      // No engine left running behind us, and none freed twice.
+      expect(counts.releases).toBe(counts.acquires);
+      // Every piece is still ACCOUNTED FOR: the ones tried and the ones the
       // build declined to try. Silence about the remainder is what made this
       // undiagnosable from the outside.
       expect(failures.length).toBe(names.length);
       expect(failures.filter((f) => /not attempted/.test(f.reason)).length).toBe(names.length - 3);
-      expect(reports.some((m) => m.includes("failed back to back"))).toBe(true);
+      expect(reports.some((m) => m.includes("no answer from the engine"))).toBe(true);
     } finally {
       cleanup();
     }
   });
 
-  test("a success resets the streak, so scattered broken pieces never trip the give-up", async () => {
-    // Consecutive, not total. A catalog with a few genuinely broken pieces
-    // must still build completely.
-    // Named so the SORTED discovery order interleaves: a-bad, b-ok, c-bad,
-    // d-ok, e-bad. Grouping the bad ones (bad-1, bad-2, bad-3 ... ok-1) would
-    // put three failures back to back and correctly trip the limit, which is a
-    // different test than this one.
-    const names = [
-      "@scope/piece-a-bad",
-      "@scope/piece-b-ok",
-      "@scope/piece-c-bad",
-      "@scope/piece-d-ok",
-      "@scope/piece-e-bad",
-    ];
-    const { root, cleanup } = pieceTree("build-streak", names);
-    const fakeRuntime = {
-      acquire: async () =>
-        ({
-          async extractPieceMetadata(o: { pieceName: string }) {
-            if (o.pieceName.includes("bad")) throw new Error("nope");
-            return okMetadata(o.pieceName);
-          },
-          async release() { /* noop */ },
-        }) as unknown as EngineHandle,
-    } as unknown as EngineRuntime;
+  test("error replies NEVER trip the give-up, however many land in a row", async () => {
+    // Discovery is sorted, so piece families cluster; one broken shared
+    // dependency across piece-google-* yields a long run of error replies from
+    // engines that answered promptly every time. Ending the build there would
+    // abandon hundreds of healthy pieces over a handful of bad ones.
+    const names = Array.from({ length: 8 }, (_, i) => `@scope/piece-bad-${i}`);
+    const { root, cleanup } = pieceTree("build-errors", names);
+    const { runtime } = countingRuntime(async () => {
+      throw new Error("nope");
+    });
     try {
-      const { catalog, failures } = await buildPieceCatalog({
-        runtime: fakeRuntime,
+      const { failures } = await buildPieceCatalog({
+        runtime,
         pieceRoots: [root],
-        maxConsecutiveFailures: 3,
+        maxConsecutiveTimeouts: 3,
         reporter: () => {},
       });
-      expect(catalog.list().length).toBe(2);
+      expect(failures.length).toBe(names.length);
+      expect(failures.every((f) => !/not attempted/.test(f.reason))).toBe(true);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("a success resets the timeout streak", async () => {
+    // Consecutive, not total. The trailing OK piece is the point: without the
+    // reset the three timeouts accumulate across the whole run, the build
+    // gives up at the last one, and that final piece is never attempted.
+    const names = [
+      "@scope/piece-hang-a",
+      "@scope/piece-ok-a",
+      "@scope/piece-hang-b",
+      "@scope/piece-ok-b",
+      "@scope/piece-hang-c",
+      "@scope/piece-ok-c",
+    ];
+    const { root, cleanup } = pieceTree("build-streak", names);
+    const { runtime } = countingRuntime(async (name) =>
+      name.includes("hang") ? hangForever() : okMetadata(name),
+    );
+    try {
+      const { catalog, failures } = await buildPieceCatalog({
+        runtime,
+        pieceRoots: [root],
+        pieceTimeoutMs: 20,
+        maxConsecutiveTimeouts: 3,
+        reporter: () => {},
+      });
+      expect(catalog.list().length).toBe(3);
       expect(failures.length).toBe(3);
       expect(failures.every((f) => !/not attempted/.test(f.reason))).toBe(true);
     } finally {
@@ -723,7 +778,7 @@ describe("PieceCatalog (unit)", () => {
     // extracted, and must not surface as an unhandled rejection.
     const { root, cleanup } = pieceTree("build-nospawn", [
       "@scope/piece-a",
-      "@scope/piece-bad",
+      "@scope/piece-hang",
       "@scope/piece-c",
     ]);
     let acquires = 0;
@@ -733,7 +788,7 @@ describe("PieceCatalog (unit)", () => {
         if (acquires > 1) throw new Error("no engine for you");
         return {
           async extractPieceMetadata(o: { pieceName: string }) {
-            if (o.pieceName === "@scope/piece-bad") throw new Error("boom");
+            if (o.pieceName === "@scope/piece-hang") return hangForever();
             return okMetadata(o.pieceName);
           },
           async release() { /* noop */ },
@@ -745,6 +800,7 @@ describe("PieceCatalog (unit)", () => {
       const { catalog, failures } = await buildPieceCatalog({
         runtime: fakeRuntime,
         pieceRoots: [root],
+        pieceTimeoutMs: 20,
         reporter: (m) => reports.push(m),
       });
       expect(catalog.list().length).toBe(1);

--- a/src/workflows/runtime/piece-catalog.test.ts
+++ b/src/workflows/runtime/piece-catalog.test.ts
@@ -564,6 +564,198 @@ describe("PieceCatalog (unit)", () => {
     }
   });
 
+  /**
+   * The engine-replacement contract.
+   *
+   * A failed extraction leaves the engine in one of two states this loop
+   * cannot distinguish, and BOTH are unusable: a timeout is our own race, so
+   * the engine is still working on the piece we walked away from (nothing
+   * cancels it), and an error reply was observed in prod to poison the process
+   * anyway -- one piece threw while loading and every one of the 658 after it
+   * timed out on an engine that was still alive. So the loop must not carry an
+   * engine across a failure.
+   */
+  function pieceTree(prefix: string, names: readonly string[]) {
+    const { path: root, cleanup } = tmp(prefix);
+    names.forEach((name, i) => {
+      mkdirSync(resolve(root, `p${i}`), { recursive: true });
+      writeFileSync(
+        resolve(root, `p${i}`, "package.json"),
+        JSON.stringify({ name, version: "0.0.1" }),
+      );
+    });
+    return { root, cleanup };
+  }
+
+  const okMetadata = (pieceName: string) => ({
+    name: pieceName,
+    displayName: "OK",
+    description: "ok",
+    actions: { ping: { name: "ping", displayName: "Ping", description: "", props: {} } },
+  });
+
+  test("buildPieceCatalog REPLACES the engine after a failure instead of reusing it", async () => {
+    // The whole bug in one assertion: without this, one broken piece is served
+    // by the same engine as every piece after it.
+    const { root, cleanup } = pieceTree("build-replace", [
+      "@scope/piece-bad",
+      "@scope/piece-a",
+      "@scope/piece-b",
+    ]);
+    let acquires = 0;
+    let releases = 0;
+    const fakeRuntime = {
+      acquire: async () => {
+        acquires++;
+        return {
+          async extractPieceMetadata(o: { pieceName: string }) {
+            if (o.pieceName === "@scope/piece-bad") throw new Error("boom");
+            return okMetadata(o.pieceName);
+          },
+          async release() {
+            releases++;
+          },
+        } as unknown as EngineHandle;
+      },
+    } as unknown as EngineRuntime;
+    try {
+      const { catalog, failures } = await buildPieceCatalog({
+        runtime: fakeRuntime,
+        pieceRoots: [root],
+        reporter: () => {},
+      });
+      // One engine to start, one more after the single failure.
+      expect(acquires).toBe(2);
+      // Every engine handed out is released exactly once -- the replacement
+      // path must not leak the old one, and the `finally` must not double-free
+      // the new one.
+      expect(releases).toBe(acquires);
+      // And the pieces AFTER the failure still extract, on the fresh engine.
+      expect(catalog.list().length).toBe(2);
+      expect(failures.length).toBe(1);
+      expect(failures[0]?.pieceName).toBe("@scope/piece-bad");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("buildPieceCatalog gives up after N consecutive failures instead of paying the timeout on every piece", async () => {
+    // The cost this bounds: on the hosted build a wedged engine meant 659
+    // pieces x 30s, about five and a half hours, inside an install op that
+    // gives up at thirty minutes -- so the build was killed and reported
+    // nothing at all.
+    const names = Array.from({ length: 12 }, (_, i) => `@scope/piece-${i}`);
+    const { root, cleanup } = pieceTree("build-giveup", names);
+    let attempts = 0;
+    const fakeRuntime = {
+      acquire: async () =>
+        ({
+          async extractPieceMetadata() {
+            attempts++;
+            throw new Error("wedged");
+          },
+          async release() { /* noop */ },
+        }) as unknown as EngineHandle,
+    } as unknown as EngineRuntime;
+    const reports: string[] = [];
+    try {
+      const { catalog, failures } = await buildPieceCatalog({
+        runtime: fakeRuntime,
+        pieceRoots: [root],
+        maxConsecutiveFailures: 3,
+        reporter: (m) => reports.push(m),
+      });
+      expect(attempts).toBe(3);
+      expect(catalog.list().length).toBe(0);
+      // Every piece is still ACCOUNTED FOR: the ones tried, and the ones the
+      // build declined to try. Silence about the remainder is what made this
+      // undiagnosable from the outside.
+      expect(failures.length).toBe(names.length);
+      expect(failures.filter((f) => /not attempted/.test(f.reason)).length).toBe(names.length - 3);
+      expect(reports.some((m) => m.includes("failed back to back"))).toBe(true);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("a success resets the streak, so scattered broken pieces never trip the give-up", async () => {
+    // Consecutive, not total. A catalog with a few genuinely broken pieces
+    // must still build completely.
+    // Named so the SORTED discovery order interleaves: a-bad, b-ok, c-bad,
+    // d-ok, e-bad. Grouping the bad ones (bad-1, bad-2, bad-3 ... ok-1) would
+    // put three failures back to back and correctly trip the limit, which is a
+    // different test than this one.
+    const names = [
+      "@scope/piece-a-bad",
+      "@scope/piece-b-ok",
+      "@scope/piece-c-bad",
+      "@scope/piece-d-ok",
+      "@scope/piece-e-bad",
+    ];
+    const { root, cleanup } = pieceTree("build-streak", names);
+    const fakeRuntime = {
+      acquire: async () =>
+        ({
+          async extractPieceMetadata(o: { pieceName: string }) {
+            if (o.pieceName.includes("bad")) throw new Error("nope");
+            return okMetadata(o.pieceName);
+          },
+          async release() { /* noop */ },
+        }) as unknown as EngineHandle,
+    } as unknown as EngineRuntime;
+    try {
+      const { catalog, failures } = await buildPieceCatalog({
+        runtime: fakeRuntime,
+        pieceRoots: [root],
+        maxConsecutiveFailures: 3,
+        reporter: () => {},
+      });
+      expect(catalog.list().length).toBe(2);
+      expect(failures.length).toBe(3);
+      expect(failures.every((f) => !/not attempted/.test(f.reason))).toBe(true);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("a replacement engine that cannot start ends the build with the rest reported, not thrown", async () => {
+    // Losing the engine must not throw away the entries that already
+    // extracted, and must not surface as an unhandled rejection.
+    const { root, cleanup } = pieceTree("build-nospawn", [
+      "@scope/piece-a",
+      "@scope/piece-bad",
+      "@scope/piece-c",
+    ]);
+    let acquires = 0;
+    const fakeRuntime = {
+      acquire: async () => {
+        acquires++;
+        if (acquires > 1) throw new Error("no engine for you");
+        return {
+          async extractPieceMetadata(o: { pieceName: string }) {
+            if (o.pieceName === "@scope/piece-bad") throw new Error("boom");
+            return okMetadata(o.pieceName);
+          },
+          async release() { /* noop */ },
+        } as unknown as EngineHandle;
+      },
+    } as unknown as EngineRuntime;
+    const reports: string[] = [];
+    try {
+      const { catalog, failures } = await buildPieceCatalog({
+        runtime: fakeRuntime,
+        pieceRoots: [root],
+        reporter: (m) => reports.push(m),
+      });
+      expect(catalog.list().length).toBe(1);
+      expect(failures.length).toBe(2);
+      expect(failures.some((f) => /replacement engine could not start/.test(f.reason))).toBe(true);
+      expect(reports.some((m) => m.includes("could not start a replacement engine"))).toBe(true);
+    } finally {
+      cleanup();
+    }
+  });
+
   test("buildPieceCatalog enforces per-piece timeout and surfaces the timeout reason", async () => {
     const { path: root, cleanup } = tmp("build-timeout");
     mkdirSync(resolve(root, "slow"), { recursive: true });

--- a/src/workflows/runtime/piece-catalog.ts
+++ b/src/workflows/runtime/piece-catalog.ts
@@ -405,19 +405,21 @@ export interface BuildCatalogOptions {
    */
   overallTimeoutMs?: number;
   /**
-   * Give up after this many extractions fail BACK TO BACK. A wedged engine
-   * fails every remaining piece at `pieceTimeoutMs` each, so without this the
-   * cost of one broken engine is the whole catalog times that timeout -- on
-   * the hosted shared-runtime build that is 659 pieces x 30s, about five and a
-   * half hours, against an install op that gives up after thirty minutes. The
-   * build then reports nothing at all: it is killed mid-loop, so even the
-   * failures never surface.
+   * Give up after this many extractions in a row get NO ANSWER from the
+   * engine. A wedged engine burns `pieceTimeoutMs` on every remaining piece,
+   * so without this one broken engine costs the whole catalog times that
+   * timeout -- on the hosted shared-runtime build that is 659 pieces x 30s,
+   * about five and a half hours, against an install op that gives up after
+   * thirty minutes. The build then reports nothing at all: it is killed
+   * mid-loop, so even the failures never surface.
    *
-   * Consecutive rather than total, so a handful of genuinely broken pieces
-   * scattered through a healthy catalog never trips it. Reset by any success.
-   * Default 5.
+   * TIMEOUTS ONLY. An error REPLY proves the engine is alive and answering, so
+   * counting those would end a healthy build on a run of legitimately broken
+   * pieces -- and discovery is sorted, which groups families (piece-google-*
+   * and friends), so a shared broken dependency produces exactly such a run.
+   * Reset by a success; an error reply leaves it alone. Default 5.
    */
-  maxConsecutiveFailures?: number;
+  maxConsecutiveTimeouts?: number;
   /**
    * Optional reporter for `discoverPieces` conflicts and per-piece extraction
    * failures. Defaults to `console.warn`. Pass a noop in tests.
@@ -502,15 +504,28 @@ export function readCachedEntries(
  * boots with whichever pieces succeeded; the daemon can log/UI-display the
  * failures without blocking startup.
  *
- * A failure also ENDS THAT ENGINE. The loop cannot tell a hung piece from a
- * poisoned process, and both were observed: our per-piece race abandons an
- * operation the engine is still running (nothing cancels it), and on the
- * hosted shared-runtime build a single piece that threw while loading left
- * every one of the 658 pieces after it timing out against a process that was
- * still alive. So each failure is followed by a fresh engine, and
- * `maxConsecutiveFailures` back-to-back failures end the build with the
- * remainder reported as unattempted rather than paying `pieceTimeoutMs` on
+ * An extraction that gets NO ANSWER also ends that engine. Our per-piece race
+ * abandons an operation the engine is still running (nothing cancels it), so
+ * the next piece would queue behind it; the following one gets a fresh engine
+ * instead. An error REPLY is left alone -- the engine answered, so it is alive
+ * and reusable, and destroying it would be churn (and a no-op under a pooled
+ * runtime, which would simply park and re-hand the same process).
+ *
+ * `maxConsecutiveTimeouts` unanswered extractions in a row end the build, with
+ * the remainder reported as unattempted rather than paying `pieceTimeoutMs` on
  * every one of them.
+ *
+ * WHAT PROMPTED THIS, and what is still unexplained: on the hosted
+ * shared-runtime build one piece failed with an error reply and every one of
+ * the 658 after it timed out, against an engine process still alive at 486MB.
+ * Why an answered error was followed by a permanently unresponsive engine is
+ * NOT established -- "the failed module stayed cached" does not survive
+ * scrutiny, since a rejected import re-throws immediately rather than hanging,
+ * and the later pieces are different modules. A likelier candidate is the
+ * worker-rpc socket: `engineClient` is bound to one connection and a reconnect
+ * replaces it without the live handle noticing, which would strand every
+ * later send on a dead socket while the engine sits idle. Worth confirming
+ * before anyone treats the timeout handling here as the whole answer.
  */
 export async function buildPieceCatalog(
   opts: BuildCatalogOptions,
@@ -518,7 +533,7 @@ export async function buildPieceCatalog(
   const reporter = opts.reporter ?? ((m) => console.warn(`[piece-catalog] ${m}`));
   const pieceTimeoutMs = opts.pieceTimeoutMs ?? 10_000;
   const overallTimeoutMs = opts.overallTimeoutMs ?? 60_000;
-  const maxConsecutiveFailures = opts.maxConsecutiveFailures ?? 5;
+  const maxConsecutiveTimeouts = opts.maxConsecutiveTimeouts ?? 5;
 
   const { entries: discovered, conflicts } = discoverPieces(opts.pieceRoots);
   for (const c of conflicts) {
@@ -578,7 +593,7 @@ export async function buildPieceCatalog(
     let handleReleased = false;
     const overallDeadline = Date.now() + overallTimeoutMs;
     let processed = 0;
-    let consecutiveFailures = 0;
+    let consecutiveTimeouts = 0;
     try {
       for (const { piece, contentHash } of misses) {
         if (Date.now() > overallDeadline) {
@@ -611,7 +626,7 @@ export async function buildPieceCatalog(
           out.push(entry);
           userEntries[`${piece.name}@${piece.version}`] = { contentHash, entry };
           extracted++;
-          consecutiveFailures = 0;
+          consecutiveTimeouts = 0;
         } catch (e) {
           const reason = e instanceof Error ? e.message : String(e);
           failures.push({
@@ -620,52 +635,59 @@ export async function buildPieceCatalog(
             reason,
           });
           reporter(`extract ${piece.name}@${piece.version} failed: ${reason}`);
-          consecutiveFailures++;
 
-          // REPLACE THE ENGINE, do not carry on with it.
+          // An error REPLY means the engine answered: it is alive, idle and
+          // reusable, so keep it. Only a timeout is grounds for destroying it.
           //
-          // Two different ways this loop can leave an engine unusable, and it
-          // cannot tell them apart from here:
+          // This distinction is what stops the give-up below from ending a
+          // healthy build. Discovery is sorted, which groups piece families
+          // (piece-google-*, piece-microsoft-*), and the shared-runtime build
+          // installs with --ignore-scripts, so one broken dependency across a
+          // family yields a run of error replies from engines that answered
+          // promptly every time. Counting those as evidence of a wedge would
+          // abandon the remaining hundreds of pieces over a handful of bad
+          // ones.
+          if (!(e instanceof PieceExtractionTimeoutError)) continue;
+
+          consecutiveTimeouts++;
+
+          // NO ANSWER: replace the engine. `withTimeout` above stopped waiting
+          // but nothing cancelled the operation -- there is no cancel message
+          // in EngineContract -- so this engine is still working on the piece
+          // we gave up on, and the next one would queue behind it and time out
+          // too. That is the shape the hosted build hit: one failure, then 658
+          // timeouts against a process still alive at 486MB.
           //
-          //  - a TIMEOUT above is OUR race, not the engine's. `withTimeout`
-          //    stops waiting; nothing cancels the operation, and there is no
-          //    cancel message in EngineContract. The engine is still working
-          //    on the piece we gave up on, so the next operation queues behind
-          //    it and times out too. The transport has its own deadline that
-          //    marks such an engine abandoned -- but it is
-          //    `CONTROL_OPERATION_TIMEOUT_S` (60s) plus a 30s margin, and this
-          //    loop's default budget is well under that, so our race always
-          //    fires first and that machinery never gets to run.
-          //  - an ERROR REPLY means the engine answered and is idle. It should
-          //    be reusable. In prod it was not: on the hosted build the first
-          //    piece failed with a real INTERNAL_ERROR and every one of the 658
-          //    after it timed out, on an engine still alive at 486MB. A module
-          //    that throws while loading stays cached as broken, so one bad
-          //    piece poisoned the process for the rest of the catalog.
+          // `release()` is the right call and not a shortcut: it kills rather
+          // than pools an engine with work still in flight, and the send() we
+          // abandoned is exactly that (`inFlight` is still 1 here, because it
+          // is decremented in send()'s own finally, which has not run). On an
+          // error reply it would instead PARK the process under `pool: true`
+          // and hand the same one back on the next acquire -- another reason
+          // the two cases are not interchangeable.
           //
-          // So: replace on ANY failure. `release()` already does the right
-          // thing -- it kills rather than pools an engine with `abandoned` set
-          // or work still in flight, which is exactly the timeout case -- and a
-          // spawn costs seconds against a per-piece timeout we would otherwise
-          // pay on every remaining piece.
+          // The transport has its own deadline that marks such an engine
+          // abandoned, but it is CONTROL_OPERATION_TIMEOUT_S (60s) plus a 30s
+          // margin, always later than this loop's budget, so it never fires
+          // first and that machinery never runs.
           handleReleased = true;
           await handle.release().catch(() => {
             // A failed release is a leaked engine, not a reason to abandon the
             // build; the run id is dead either way.
           });
 
-          if (consecutiveFailures >= maxConsecutiveFailures) {
+          if (consecutiveTimeouts >= maxConsecutiveTimeouts) {
             const pending = misses.length - processed;
             reporter(
-              `${consecutiveFailures} extractions failed back to back; giving up with ` +
-                `${pending} piece(s) unattempted (a wedged engine fails every remaining ` +
-                `piece at ${pieceTimeoutMs}ms each)`,
+              `${consecutiveTimeouts} extractions in a row got no answer from the engine; ` +
+                `giving up with ${pending} piece(s) unattempted (a wedged engine costs ` +
+                `${pieceTimeoutMs}ms on every remaining piece)`,
             );
             for (const skipped of misses.slice(processed)) {
               failures.push({
                 pieceName: skipped.piece.name,
                 pieceVersion: skipped.piece.version,
-                reason: `not attempted: gave up after ${consecutiveFailures} consecutive extraction failures`,
+                reason: `not attempted: gave up after ${consecutiveTimeouts} consecutive extraction timeouts`,
               });
             }
             break;
@@ -713,12 +735,22 @@ export async function buildPieceCatalog(
   return { catalog: new PieceCatalog(out), failures };
 }
 
+/**
+ * Thrown when an extraction outruns its per-piece budget.
+ *
+ * A distinct type because the two failure shapes need opposite handling and a
+ * substring match on a message is not a fact: an engine that ANSWERED with an
+ * error is alive and reusable, an engine that did not answer is still working
+ * on the piece we walked away from and must be destroyed.
+ */
+export class PieceExtractionTimeoutError extends Error {}
+
 /** Race a promise against a timeout; rejects with `message` on timeout. */
 function withTimeout<T>(p: Promise<T>, ms: number, message: string): Promise<T> {
   return Promise.race([
     p,
     new Promise<T>((_, reject) =>
-      setTimeout(() => reject(new Error(message)), ms),
+      setTimeout(() => reject(new PieceExtractionTimeoutError(message)), ms),
     ),
   ]);
 }

--- a/src/workflows/runtime/piece-catalog.ts
+++ b/src/workflows/runtime/piece-catalog.ts
@@ -515,17 +515,19 @@ export function readCachedEntries(
  * the remainder reported as unattempted rather than paying `pieceTimeoutMs` on
  * every one of them.
  *
- * WHAT PROMPTED THIS, and what is still unexplained: on the hosted
- * shared-runtime build one piece failed with an error reply and every one of
- * the 658 after it timed out, against an engine process still alive at 486MB.
- * Why an answered error was followed by a permanently unresponsive engine is
- * NOT established -- "the failed module stayed cached" does not survive
- * scrutiny, since a rejected import re-throws immediately rather than hanging,
- * and the later pieces are different modules. A likelier candidate is the
- * worker-rpc socket: `engineClient` is bound to one connection and a reconnect
- * replaces it without the live handle noticing, which would strand every
- * later send on a dead socket while the engine sits idle. Worth confirming
- * before anyone treats the timeout handling here as the whole answer.
+ * WHAT PROMPTED THIS, now established: on the hosted shared-runtime build a
+ * single piece got NO reply and every one of the 658 after it timed out,
+ * against an engine process still alive. The cause was not the engine at all.
+ * `@activepieces/piece-ampeco@0.2.8` replies with 2.68MB of metadata, over
+ * socket.io's 1MB default frame limit, which CLOSES the connection rather than
+ * erroring; the reply never came, and the handle went on emitting into a dead
+ * socket. The limit is raised in sandbox-api/worker-rpc.ts and the handle now
+ * re-resolves its client per send.
+ *
+ * This loop is what stands behind those: an engine that stops answering for
+ * ANY reason -- an oversized frame, a piece that blocks the event loop, a
+ * future cause nobody has met yet -- costs one piece instead of the rest of
+ * the catalog.
  */
 export async function buildPieceCatalog(
   opts: BuildCatalogOptions,

--- a/src/workflows/runtime/piece-catalog.ts
+++ b/src/workflows/runtime/piece-catalog.ts
@@ -405,6 +405,20 @@ export interface BuildCatalogOptions {
    */
   overallTimeoutMs?: number;
   /**
+   * Give up after this many extractions fail BACK TO BACK. A wedged engine
+   * fails every remaining piece at `pieceTimeoutMs` each, so without this the
+   * cost of one broken engine is the whole catalog times that timeout -- on
+   * the hosted shared-runtime build that is 659 pieces x 30s, about five and a
+   * half hours, against an install op that gives up after thirty minutes. The
+   * build then reports nothing at all: it is killed mid-loop, so even the
+   * failures never surface.
+   *
+   * Consecutive rather than total, so a handful of genuinely broken pieces
+   * scattered through a healthy catalog never trips it. Reset by any success.
+   * Default 5.
+   */
+  maxConsecutiveFailures?: number;
+  /**
    * Optional reporter for `discoverPieces` conflicts and per-piece extraction
    * failures. Defaults to `console.warn`. Pass a noop in tests.
    */
@@ -487,6 +501,16 @@ export function readCachedEntries(
  * logged via `reporter`, and surfaced on `failures[]`. The catalog still
  * boots with whichever pieces succeeded; the daemon can log/UI-display the
  * failures without blocking startup.
+ *
+ * A failure also ENDS THAT ENGINE. The loop cannot tell a hung piece from a
+ * poisoned process, and both were observed: our per-piece race abandons an
+ * operation the engine is still running (nothing cancels it), and on the
+ * hosted shared-runtime build a single piece that threw while loading left
+ * every one of the 658 pieces after it timing out against a process that was
+ * still alive. So each failure is followed by a fresh engine, and
+ * `maxConsecutiveFailures` back-to-back failures end the build with the
+ * remainder reported as unattempted rather than paying `pieceTimeoutMs` on
+ * every one of them.
  */
 export async function buildPieceCatalog(
   opts: BuildCatalogOptions,
@@ -494,6 +518,7 @@ export async function buildPieceCatalog(
   const reporter = opts.reporter ?? ((m) => console.warn(`[piece-catalog] ${m}`));
   const pieceTimeoutMs = opts.pieceTimeoutMs ?? 10_000;
   const overallTimeoutMs = opts.overallTimeoutMs ?? 60_000;
+  const maxConsecutiveFailures = opts.maxConsecutiveFailures ?? 5;
 
   const { entries: discovered, conflicts } = discoverPieces(opts.pieceRoots);
   for (const c of conflicts) {
@@ -543,11 +568,17 @@ export async function buildPieceCatalog(
   let extracted = 0;
   if (misses.length > 0) {
     const projectId = opts.projectId ?? DEFAULT_IDS.project;
-    const runId = "metadata-extract-" + SandboxRegistry.newSandboxId();
+    // A FRESH run id per engine: the loop below replaces the engine after a
+    // failure, and two live sandboxes must not share one.
+    const newRunId = () => "metadata-extract-" + SandboxRegistry.newSandboxId();
 
-    const handle = await opts.runtime.acquire({ runId, projectId });
+    let handle = await opts.runtime.acquire({ runId: newRunId(), projectId });
+    /** Set while `handle` has already been released and not yet replaced, so
+     * the `finally` below cannot release the same engine twice. */
+    let handleReleased = false;
     const overallDeadline = Date.now() + overallTimeoutMs;
     let processed = 0;
+    let consecutiveFailures = 0;
     try {
       for (const { piece, contentHash } of misses) {
         if (Date.now() > overallDeadline) {
@@ -580,6 +611,7 @@ export async function buildPieceCatalog(
           out.push(entry);
           userEntries[`${piece.name}@${piece.version}`] = { contentHash, entry };
           extracted++;
+          consecutiveFailures = 0;
         } catch (e) {
           const reason = e instanceof Error ? e.message : String(e);
           failures.push({
@@ -588,10 +620,78 @@ export async function buildPieceCatalog(
             reason,
           });
           reporter(`extract ${piece.name}@${piece.version} failed: ${reason}`);
+          consecutiveFailures++;
+
+          // REPLACE THE ENGINE, do not carry on with it.
+          //
+          // Two different ways this loop can leave an engine unusable, and it
+          // cannot tell them apart from here:
+          //
+          //  - a TIMEOUT above is OUR race, not the engine's. `withTimeout`
+          //    stops waiting; nothing cancels the operation, and there is no
+          //    cancel message in EngineContract. The engine is still working
+          //    on the piece we gave up on, so the next operation queues behind
+          //    it and times out too. The transport has its own deadline that
+          //    marks such an engine abandoned -- but it is
+          //    `CONTROL_OPERATION_TIMEOUT_S` (60s) plus a 30s margin, and this
+          //    loop's default budget is well under that, so our race always
+          //    fires first and that machinery never gets to run.
+          //  - an ERROR REPLY means the engine answered and is idle. It should
+          //    be reusable. In prod it was not: on the hosted build the first
+          //    piece failed with a real INTERNAL_ERROR and every one of the 658
+          //    after it timed out, on an engine still alive at 486MB. A module
+          //    that throws while loading stays cached as broken, so one bad
+          //    piece poisoned the process for the rest of the catalog.
+          //
+          // So: replace on ANY failure. `release()` already does the right
+          // thing -- it kills rather than pools an engine with `abandoned` set
+          // or work still in flight, which is exactly the timeout case -- and a
+          // spawn costs seconds against a per-piece timeout we would otherwise
+          // pay on every remaining piece.
+          handleReleased = true;
+          await handle.release().catch(() => {
+            // A failed release is a leaked engine, not a reason to abandon the
+            // build; the run id is dead either way.
+          });
+
+          if (consecutiveFailures >= maxConsecutiveFailures) {
+            const pending = misses.length - processed;
+            reporter(
+              `${consecutiveFailures} extractions failed back to back; giving up with ` +
+                `${pending} piece(s) unattempted (a wedged engine fails every remaining ` +
+                `piece at ${pieceTimeoutMs}ms each)`,
+            );
+            for (const skipped of misses.slice(processed)) {
+              failures.push({
+                pieceName: skipped.piece.name,
+                pieceVersion: skipped.piece.version,
+                reason: `not attempted: gave up after ${consecutiveFailures} consecutive extraction failures`,
+              });
+            }
+            break;
+          }
+
+          try {
+            handle = await opts.runtime.acquire({ runId: newRunId(), projectId });
+            handleReleased = false;
+          } catch (spawnErr) {
+            // No engine, no catalog. Report the rest rather than throwing away
+            // the entries that already extracted successfully.
+            const why = spawnErr instanceof Error ? spawnErr.message : String(spawnErr);
+            reporter(`could not start a replacement engine: ${why}`);
+            for (const skipped of misses.slice(processed)) {
+              failures.push({
+                pieceName: skipped.piece.name,
+                pieceVersion: skipped.piece.version,
+                reason: `not attempted: replacement engine could not start (${why})`,
+              });
+            }
+            break;
+          }
         }
       }
     } finally {
-      await handle.release();
+      if (!handleReleased) await handle.release();
     }
   }
 

--- a/src/workflows/sandbox-api/worker-rpc.test.ts
+++ b/src/workflows/sandbox-api/worker-rpc.test.ts
@@ -129,12 +129,20 @@ describe("WorkerRpcServer (B4: socket.io engine <-> daemon)", () => {
     // 0.75MB; 8 bundled i18n files add 2.2MB). The extraction then waited out
     // its whole budget for a reply that could never come, and every later
     // operation on that handle went to a dead socket.
-    // POLLING is not incidental, it is the whole test. socket.io negotiates
-    // polling first and enforces maxHttpBufferSize there as an HTTP body
-    // limit, which is the path the real build hit. Over websocket this runtime
-    // does NOT enforce it, so a websocket-only version of this test passes
-    // with the 1MB default still in place -- measured, and it is how the first
-    // draft of this test came out green against the bug it was written for.
+    // POLLING is not incidental, it is the whole test, and for a sharper
+    // reason than "socket.io tries polling first": under Bun the engine NEVER
+    // upgrades. Its bundle carries the real `ws` npm client, whose upgrade
+    // against Bun's http client comes back as `unexpected-response 101`, so a
+    // live engine reads `polling` on the server side from start to finish.
+    // socket.io enforces maxHttpBufferSize there as an HTTP body limit.
+    //
+    // Over websocket this runtime does NOT enforce it at all -- Bun's `ws`
+    // shim drops `maxPayload` when it completes the upgrade, leaving Bun's own
+    // 16MB frame cap in charge -- so a websocket version of this test passes
+    // with the 1MB default still in place. Measured, and it is exactly how the
+    // first draft came out green against the bug it was written for. An
+    // in-process test client uses Bun's shim and upgrades happily, which is
+    // why the transport has to be pinned here.
     const sb = await makeSandbox({ transports: ["polling"] });
     try {
       // Answer executeOperation the way the engine does, with a payload the
@@ -161,6 +169,45 @@ describe("WorkerRpcServer (B4: socket.io engine <-> daemon)", () => {
       sb.client.close();
     }
   }, 30_000);
+
+  test("a late disconnect from a REPLACED socket does not drop the live entry", async () => {
+    // A reconnecting engine registers its new socket under the same sandbox
+    // id. If the OLD socket's disconnect lands after that -- a server ping
+    // timeout racing a completed re-handshake -- an unconditional delete drops
+    // the LIVE entry, and callers then see "no connection" for an engine that
+    // is connected and healthy. That used to cost a timeout; now that the
+    // handle re-resolves its client per send, it would DESTROY that engine.
+    const sb = await makeSandbox();
+    let second: ReturnType<typeof socketIoClient> | null = null;
+    try {
+      second = socketIoClient(`http://127.0.0.1:${api.sandboxWsPort}`, {
+        transports: ["websocket"],
+        path: "/worker/ws",
+        auth: { sandboxId: sb.sandboxId },
+        reconnection: false,
+      });
+      await new Promise<void>((res, rej) => {
+        const t = setTimeout(() => rej(new Error("second connect timeout")), 5000);
+        second!.once("connect", () => {
+          clearTimeout(t);
+          res();
+        });
+        second!.once("connect_error", (e) => {
+          clearTimeout(t);
+          rej(e);
+        });
+      });
+
+      // The server now holds `second` for this sandbox. Now the OLD one goes.
+      sb.client.close();
+      await new Promise((r) => setTimeout(r, 300));
+
+      expect(() => api.workerRpc.engineClient(sb.sandboxId)).not.toThrow();
+    } finally {
+      second?.close();
+      sb.client.close();
+    }
+  }, 20_000);
 
   test("connection is rejected without a sandboxId", async () => {
     const client = socketIoClient(`http://127.0.0.1:${api.sandboxWsPort}`, {

--- a/src/workflows/sandbox-api/worker-rpc.test.ts
+++ b/src/workflows/sandbox-api/worker-rpc.test.ts
@@ -40,7 +40,9 @@ describe("WorkerRpcServer (B4: socket.io engine <-> daemon)", () => {
   let signer: EngineTokenSigner;
   let registry: SandboxRegistry;
 
-  async function makeSandbox(): Promise<TestSandbox> {
+  async function makeSandbox(opts?: {
+    transports?: Array<"polling" | "websocket">;
+  }): Promise<TestSandbox> {
     const flow = createFlow({ projectId: DEFAULT_IDS.project });
     const v = createDraftVersion({ flowId: flow.id, displayName: "wsf" });
     lockVersion(v.id);
@@ -65,7 +67,7 @@ describe("WorkerRpcServer (B4: socket.io engine <-> daemon)", () => {
     });
 
     const client = socketIoClient(`http://127.0.0.1:${api.sandboxWsPort}`, {
-      transports: ["websocket"],
+      transports: opts?.transports ?? ["websocket"],
       path: "/worker/ws",
       auth: { sandboxId },
       reconnection: false,
@@ -118,6 +120,47 @@ describe("WorkerRpcServer (B4: socket.io engine <-> daemon)", () => {
     await api.stop();
     closeWorkflowDb();
   });
+
+  test("an engine reply larger than socket.io's 1MB default still arrives", async () => {
+    // THE ROOT CAUSE of a halted shared-runtime build. socket.io closes a
+    // connection carrying an oversized frame -- silently: no error, no reply,
+    // just a dropped socket. Piece metadata outgrows the 1MB default:
+    // @activepieces/piece-ampeco@0.2.8 replies with 2.68MB (377 actions is
+    // 0.75MB; 8 bundled i18n files add 2.2MB). The extraction then waited out
+    // its whole budget for a reply that could never come, and every later
+    // operation on that handle went to a dead socket.
+    // POLLING is not incidental, it is the whole test. socket.io negotiates
+    // polling first and enforces maxHttpBufferSize there as an HTTP body
+    // limit, which is the path the real build hit. Over websocket this runtime
+    // does NOT enforce it, so a websocket-only version of this test passes
+    // with the 1MB default still in place -- measured, and it is how the first
+    // draft of this test came out green against the bug it was written for.
+    const sb = await makeSandbox({ transports: ["polling"] });
+    try {
+      // Answer executeOperation the way the engine does, with a payload the
+      // default would have refused.
+      const big = "x".repeat(3 * 1024 * 1024);
+      sb.client.on(
+        "rpc",
+        (msg: { method: string }, ack: (result: unknown) => void) => {
+          if (msg.method !== "executeOperation") return;
+          ack({ status: "OK", response: { blob: big } });
+        },
+      );
+
+      const engine = api.workerRpc.engineClient(sb.sandboxId);
+      const reply = (await engine.executeOperation(
+        { operationType: "EXTRACT_PIECE_METADATA", operation: {} } as never,
+        { timeoutMs: 15_000 },
+      )) as { response?: { blob?: string } };
+
+      expect(reply.response?.blob?.length).toBe(big.length);
+      // And the socket survived: a refused frame would have closed it.
+      expect(sb.client.connected).toBe(true);
+    } finally {
+      sb.client.close();
+    }
+  }, 30_000);
 
   test("connection is rejected without a sandboxId", async () => {
     const client = socketIoClient(`http://127.0.0.1:${api.sandboxWsPort}`, {

--- a/src/workflows/sandbox-api/worker-rpc.ts
+++ b/src/workflows/sandbox-api/worker-rpc.ts
@@ -110,6 +110,22 @@ export class WorkerRpcServer {
       // both transports so the upstream client connects without a config
       // override on its side.
       transports: ["polling", "websocket"],
+      // 64MB, because socket.io's 1MB default SILENTLY CLOSES the connection
+      // on an oversized frame -- no error, no reply, just a dropped socket.
+      //
+      // Piece metadata is the payload that outgrows it. Measured:
+      // @activepieces/piece-ampeco@0.2.8 replies with 2.68MB (377 actions is
+      // 0.75MB, and 8 bundled i18n files add 2.2MB more). That killed the
+      // socket mid-extraction, the caller waited out its budget for a reply
+      // that could never arrive, and every later operation on that handle went
+      // to a dead client -- which is how one oversized piece took a whole
+      // shared-runtime build with it.
+      //
+      // Safe to raise here: this server listens on loopback only and its sole
+      // client is an engine WE spawned, so the ceiling bounds our own memory
+      // rather than an untrusted peer's. Generous on purpose -- the next
+      // 3MB piece must not repeat this.
+      maxHttpBufferSize: 64 * 1024 * 1024,
       path: "/worker/ws",
       // Auth check happens in the connection handler below; the middleware
       // form rejects with a generic error, which is harder to debug.

--- a/src/workflows/sandbox-api/worker-rpc.ts
+++ b/src/workflows/sandbox-api/worker-rpc.ts
@@ -70,6 +70,12 @@ type ConnectionWaiter = {
   timer: ReturnType<typeof setTimeout>;
 };
 
+/**
+ * Ceiling on a single engine RPC frame. See the note at the `Server` options
+ * for why it is this number and not a larger one.
+ */
+const MAX_HTTP_BUFFER_SIZE = 16 * 1024 * 1024;
+
 export class WorkerRpcServer {
   private io: Server | null = null;
   private readonly connections = new Map<string, ConnectedSandbox>();
@@ -106,26 +112,35 @@ export class WorkerRpcServer {
   async start(): Promise<void> {
     if (this.io) return;
     this.io = new Server({
-      // Engine clients negotiate via polling-then-upgrade by default; allow
-      // both transports so the upstream client connects without a config
-      // override on its side.
+      // BOTH transports offered, but under Bun the engine only ever uses
+      // polling: the engine bundle carries the real `ws` npm client, and its
+      // upgrade against Bun's http client comes back as
+      // `unexpected-response 101`, so it never completes. Measured on a live
+      // engine -- the server-side transport reads `polling` throughout. An
+      // in-process test client uses Bun's own `ws` shim and DOES upgrade,
+      // which is why a websocket-based test of the limit below is green
+      // against the bug it was written for.
       transports: ["polling", "websocket"],
-      // 64MB, because socket.io's 1MB default SILENTLY CLOSES the connection
-      // on an oversized frame -- no error, no reply, just a dropped socket.
-      //
-      // Piece metadata is the payload that outgrows it. Measured:
-      // @activepieces/piece-ampeco@0.2.8 replies with 2.68MB (377 actions is
-      // 0.75MB, and 8 bundled i18n files add 2.2MB more). That killed the
-      // socket mid-extraction, the caller waited out its budget for a reply
-      // that could never arrive, and every later operation on that handle went
-      // to a dead client -- which is how one oversized piece took a whole
+      // socket.io's 1MB default CLOSES the connection on an oversized frame,
+      // silently: no error, no reply, just a dropped socket. Piece metadata
+      // outgrows it -- @activepieces/piece-ampeco@0.2.8 replies with 2.68MB
+      // (377 actions is 0.75MB, 8 bundled i18n files add 2.2MB more) -- and
+      // that killed the socket mid-extraction, so the caller waited out its
+      // budget for a reply that could never arrive and every later operation
+      // on that handle went to a dead client. One piece took a whole
       // shared-runtime build with it.
       //
-      // Safe to raise here: this server listens on loopback only and its sole
-      // client is an engine WE spawned, so the ceiling bounds our own memory
-      // rather than an untrusted peer's. Generous on purpose -- the next
-      // 3MB piece must not repeat this.
-      maxHttpBufferSize: 64 * 1024 * 1024,
+      // 16MB, not more. It is ~6x the largest payload we have measured, and it
+      // MATCHES Bun's native websocket frame cap: if a Bun release ever makes
+      // the engine's upgrade succeed, the effective ceiling stays where this
+      // says it is instead of silently becoming 16MB. Note this bound is not
+      // purely self-imposed -- the engine.io handshake is unauthenticated and
+      // loopback is shared by every tenant's processes on a hosted box, so
+      // this is also how much any local process can make one daemon buffer per
+      // request. That argues for smaller, not larger; the way to bring it down
+      // further is to stop shipping the i18n blob the daemon discards (see
+      // metadataToCatalogEntry), which is 82% of ampeco's payload.
+      maxHttpBufferSize: MAX_HTTP_BUFFER_SIZE,
       path: "/worker/ws",
       // Auth check happens in the connection handler below; the middleware
       // form rejects with a generic error, which is harder to debug.
@@ -139,6 +154,23 @@ export class WorkerRpcServer {
     // over it) to anything that can reach the box. The engine always dials
     // 127.0.0.1, so loopback is the only address it needs.
     const httpServer = createServer();
+    // SAY SO when a frame is refused. socket.io answers an over-limit polling
+    // body with a 413 and closes the socket, emitting nothing an engine.io
+    // listener can see: the caller just waits out its budget and reports a
+    // timeout. That silence is why one oversized piece cost an investigation
+    // rather than a log line, and raising the ceiling does not end it -- it
+    // only moves it, so the next piece past MAX_HTTP_BUFFER_SIZE would be just
+    // as quiet.
+    httpServer.on("request", (req, res) => {
+      res.once("finish", () => {
+        if (res.statusCode !== 413) return;
+        console.error(
+          `[worker-rpc] an engine RPC frame of ${req.headers["content-length"] ?? "unknown"} bytes ` +
+            `exceeded maxHttpBufferSize (${MAX_HTTP_BUFFER_SIZE}); socket.io refused it and closed ` +
+            `the socket, so whatever operation was in flight will report a timeout instead.`,
+        );
+      });
+    });
     this.io.attach(httpServer);
 
     await new Promise<void>((res, rej) => {

--- a/src/workflows/sandbox-api/worker-rpc.ts
+++ b/src/workflows/sandbox-api/worker-rpc.ts
@@ -305,6 +305,14 @@ export class WorkerRpcServer {
     }
 
     socket.on("disconnect", () => {
+      // ONLY if this socket is still the registered one. A reconnecting engine
+      // registers its new socket under the same sandbox id, and if the old
+      // socket's disconnect fires after that (a server ping timeout racing a
+      // completed re-handshake), an unconditional delete drops the LIVE entry.
+      // Callers then see "no connection" for an engine that is connected and
+      // healthy -- which used to cost a 90s timeout and now, since the handle
+      // re-resolves per send, would destroy that engine instead.
+      if (this.connections.get(sandboxId)?.socket !== socket) return;
       this.connections.delete(sandboxId);
     });
   }


### PR DESCRIPTION
The shared-runtime build could not finish, so the 0.13.3 rollout halted with
`install failed: 0.13.3 could not be installed`. This is the whole chain, root
cause first.

## What was actually wrong

**socket.io's 1MB `maxHttpBufferSize` default closes the connection on an
oversized frame.** Silently: no error, no reply, just a dropped socket. Piece
metadata outgrows it. Measured: `@activepieces/piece-ampeco@0.2.8` replies with
**2.68MB** (377 actions is 0.75MB, eight bundled i18n files add 2.2MB more).

That one piece killed the socket mid-extraction. The extraction then waited out
its full budget for a reply that could never arrive, and because the handle held
an RPC client bound to that dead socket, **every piece after it timed out too**
against an engine process that was still alive. On the full catalog that is
hours of waiting inside an install op that gives up after thirty minutes, so the
build was killed mid-loop and reported nothing at all.

Two other bugs sat in front of it:

- **The builder could not start.** bun, run as an unprivileged user in a
  directory it cannot read, silently discards its ENTIRE environment. The
  provisioner session sits in `/root` (0700), so the builder lost the PATH
  pinned on its own command line and died with `Executable not found in $PATH:
  "bun"`. Fixed host-side in usejarvis (`b762b10`, scripts VERSION 30) and
  already deployed; hosts need a converge.
- **airtable could not be imported.** bun defines `self` but has no document
  base, so bundles that sniff for a browser take the browser branch and throw on
  a relative URL. `abortcontroller-polyfill`, bundled inside the airtable SDK,
  probes with `"signal" in new Request("")` at module load.

## Result

Same builder, same catalog, measured end to end:

| | before | after |
|---|---|---|
| full catalog (656 pieces) | never completed | **0 failures, 67s** |
| first 40 pieces, on a hosted host | 13 failures, 379s | **0 failures** |

## The changes

1. **`maxHttpBufferSize` 64MB** (`worker-rpc.ts`). Safe to raise: this server
   listens on loopback and its only client is an engine we spawned, so the
   ceiling bounds our own memory rather than an untrusted peer's.
2. **A relative-URL Request shim** prepended to the engine bundle, resolving
   against a dummy base the way a browser does. Strictly additive: an input that
   already builds a Request is untouched, only ones that would have thrown
   change. Folded into `bundleHash`, or a cached bundle would serve the old
   engine.
3. **A failed extraction ends that engine.** A timeout is our own race; nothing
   cancels the operation, so the engine is still working on the piece we walked
   away from. An error REPLY is left alone, because the engine answered and is
   reusable, and destroying it would be churn and a no-op under a pooled
   runtime.
4. **`maxConsecutiveTimeouts`** (default 5) ends a build that is getting no
   answers, reporting the remainder as unattempted instead of paying the budget
   on every one. `build-shared-runtime` then refuses to publish: a partial
   metadata cache carries a cacheKey that MATCHES the daemon's, so every
   instance would silently re-extract the missing hundreds at its own boot.
5. **The RPC client is resolved per send.** It was captured once and bound to
   one socket, so a reconnecting engine registered a new client the live handle
   never saw. Measured: a dropped socket left the handle with no reply at all;
   it now fails in a millisecond. The disconnect handler also stops deleting a
   connection that is no longer its own socket, which would drop a live entry.
6. **Per-piece budget 30s to 10s.** The slowest piece in the catalog's first
   forty measures 1.2s over a real installed tree. This is not a budget for slow
   pieces, it is how long the build waits before deciding an engine stopped
   answering, and it is paid in full every time that happens.

## Tests

`bun test` is green (2971). New coverage, each verified by reverting the fix it
guards:

- an engine reply larger than 1MB still arrives, over **polling** specifically:
  that is the transport the engine negotiates first and the only one where this
  runtime enforces the limit. The websocket version of the same test passes with
  the 1MB default still in place, which is how the first draft came out green
  against the bug it was written for.
- a piece that blocks the event loop does not take the rest of the catalog with
  it (real engine, gated on a cached bundle like the other end-to-end tests)
- a reconnecting engine is picked up by the handle built before it, and a
  disconnected one fails fast rather than at the ack deadline
- the catalog replaces an engine after a timeout, keeps it after an error reply,
  gives up after N unanswered in a row, and accounts for every piece

## Notes for review

- The engine bundle hash covers the shim CONSTANT, not whether the banner is
  applied, so removing the `banner:` line alone would not invalidate cached
  bundles. Narrow, but it is the same stale-cache class the patched-sources list
  exists to close.
- Rollout order: converge the hosts first (they need scripts VERSION 30), then
  release and roll out.
