### PR TITLE
Show live hosted billing in Settings -> Billing

### DIFF
--- a/src/config/README.md
+++ b/src/config/README.md
@@ -70,6 +70,30 @@ Ownership and semantics:
   scalars) are warned about and treated as an absent block — the daemon still
   boots.
 
+### The `usejarvis_billing` block (hosted installs only)
+
+Also written exclusively by the hosting control plane, for the Settings ->
+Billing page:
+
+```yaml
+usejarvis_billing:
+  url: https://app.usejarvis.dev/api/billing/instance   # signed POST, https
+  instance_id: <uuid>
+  secret: <64 hex>                                      # per-instance, derived
+  page_url: https://app.usejarvis.dev/billing           # opened by a person
+```
+
+- **All four or none** (`daemon/hosted-billing.ts`); a partial block reads as
+  billing unavailable.
+- **Read-only credential.** The secret signs a read of the owner's billing
+  summary and nothing else. Every change is a link to `page_url` with an
+  `?action=` (`manage`, `payment-method`, `change-plan`, `cancel`), opened in
+  the system browser where the user's own account session authorizes it.
+- **File-authoritative** like `usejarvis_ai`: re-read on SIGHUP and
+  `POST /api/config/reload` (`reloadUsejarvisBillingBlock`).
+- `GET /api/billing` serves the parsed summary and the links to the UI, and
+  never the endpoint, instance id or secret.
+
 All user-owned sections (personality, voice, stt/tts, authority, channels,
 onboarding, ... — see `USER_OWNED_SECTIONS` in `types.ts`) persist to the
 vault DB settings store instead:

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -48,6 +48,52 @@ describe('Config Loader', () => {
     expect(loaded.llm.providers).toEqual({});
   });
 
+  test('usejarvis_billing survives the load intact', async () => {
+    const { writeFile } = await import('node:fs/promises');
+    await writeFile(
+      TEST_CONFIG_PATH,
+      [
+        'usejarvis_billing:',
+        '  url: https://app.usejarvis.dev/api/billing/instance',
+        '  instance_id: 11111111-2222-3333-4444-555555555555',
+        `  secret: ${'e'.repeat(64)}`,
+        '  page_url: https://app.usejarvis.dev/billing',
+        '',
+      ].join('\n'),
+    );
+    const loaded = await loadConfig(TEST_CONFIG_PATH);
+    // Unquoted, exactly as the control plane renders it: every value must
+    // still arrive as a string.
+    expect(loaded.usejarvis_billing).toEqual({
+      url: 'https://app.usejarvis.dev/api/billing/instance',
+      instance_id: '11111111-2222-3333-4444-555555555555',
+      secret: 'e'.repeat(64),
+      page_url: 'https://app.usejarvis.dev/billing',
+    });
+  });
+
+  test('reloadUsejarvisBillingBlock: rotation lands, removal clears, corruption keeps the current value', async () => {
+    const { writeFile } = await import('node:fs/promises');
+    const { reloadUsejarvisBillingBlock } = await import('./loader.ts');
+    const block = (secret: string) =>
+      `usejarvis_billing:\n  url: https://cp.example/api/billing/instance\n  instance_id: i-1\n  secret: ${secret}\n  page_url: https://app.example/billing\n`;
+    await writeFile(TEST_CONFIG_PATH, block('a'.repeat(64)));
+    const config = await loadConfig(TEST_CONFIG_PATH);
+    expect(config.usejarvis_billing?.secret).toBe('a'.repeat(64));
+
+    await writeFile(TEST_CONFIG_PATH, block('b'.repeat(64)));
+    await reloadUsejarvisBillingBlock(config, TEST_CONFIG_PATH);
+    expect(config.usejarvis_billing?.secret).toBe('b'.repeat(64));
+
+    await writeFile(TEST_CONFIG_PATH, 'usejarvis_billing: [unclosed');
+    await reloadUsejarvisBillingBlock(config, TEST_CONFIG_PATH);
+    expect(config.usejarvis_billing?.secret).toBe('b'.repeat(64));
+
+    await writeFile(TEST_CONFIG_PATH, 'daemon:\n  port: 3142\n');
+    await reloadUsejarvisBillingBlock(config, TEST_CONFIG_PATH);
+    expect(config.usejarvis_billing).toBeUndefined();
+  });
+
   test('reloadUsejarvisAiBlock: rotation lands, removal un-hosts, corruption keeps the current value', async () => {
     const { writeFile } = await import('node:fs/promises');
     const { reloadUsejarvisAiBlock } = await import('./loader.ts');

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -253,17 +253,37 @@ export async function reloadUsejarvisAiBlock(
   config: JarvisConfig,
   configPath?: string,
 ): Promise<void> {
+  await reloadSystemBlock(config, 'usejarvis_ai', configPath);
+}
+
+/**
+ * Re-read ONLY the SYSTEM-owned `usejarvis_billing` block, with exactly the
+ * semantics of `reloadUsejarvisAiBlock`: a converge that rotates the billing
+ * secret or moves the endpoint lands on SIGHUP without a restart.
+ */
+export async function reloadUsejarvisBillingBlock(
+  config: JarvisConfig,
+  configPath?: string,
+): Promise<void> {
+  await reloadSystemBlock(config, 'usejarvis_billing', configPath);
+}
+
+async function reloadSystemBlock(
+  config: JarvisConfig,
+  key: 'usejarvis_ai' | 'usejarvis_billing',
+  configPath?: string,
+): Promise<void> {
   try {
     const raw = await readRawConfigFile(configPath);
-    const block = raw?.usejarvis_ai;
+    const block = raw?.[key];
     if (block && typeof block === 'object' && !Array.isArray(block)) {
-      config.usejarvis_ai = block as { base_url?: string; api_key?: string };
+      (config as Record<string, unknown>)[key] = block;
     } else {
-      delete config.usejarvis_ai;
+      delete config[key];
     }
   } catch (err) {
     console.warn(
-      '[Config] Could not re-read the usejarvis_ai block from config.yaml; keeping the current value:',
+      `[Config] Could not re-read the ${key} block from config.yaml; keeping the current value:`,
       err instanceof Error ? err.message : err,
     );
   }

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -497,6 +497,28 @@ export type JarvisConfig = {
      */
     prompt_cache?: boolean;
   };
+  /**
+   * Hosted billing read (SYSTEM-owned, file-authoritative): written by the
+   * hosting control plane into the root-owned config.yaml, re-read on SIGHUP,
+   * never written by the brain. Absent on self-hosted installs, and on hosted
+   * ones whose control plane has no origin an instance can reach.
+   *
+   * Its own block rather than inside `usejarvis_ai`: that block is only
+   * rendered when hosted LLM is on, and a hosting-only customer still has a
+   * bill.
+   *
+   * All four or none (see daemon/hosted-billing.ts). The secret authenticates
+   * a READ of the owner's billing summary and nothing else; every change goes
+   * through `page_url`, opened in the system browser.
+   */
+  usejarvis_billing?: {
+    /** POST endpoint on the control plane (https). */
+    url?: string;
+    instance_id?: string;
+    secret?: string;
+    /** The account billing page a person opens. */
+    page_url?: string;
+  };
   user?: UserConfig;
   onboarding?: OnboardingConfig;
   telemetry?: TelemetryConfig;

--- a/src/daemon/api-billing.test.ts
+++ b/src/daemon/api-billing.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import { createApiRoutes, type ApiContext } from './api-routes.ts';
+import type { JarvisConfig } from '../config/types.ts';
+
+/**
+ * GET /api/billing (control plane: docs/BILLING.md "Billing inside the brain").
+ *
+ * The same two properties as the usage meter's route: availability that tells
+ * self-hosted, hosted-but-unreadable and readable apart, and secrecy — this
+ * body reaches a browser, so the endpoint, instance id and secret must never
+ * appear in it.
+ */
+
+type Handler = (req: Request) => Response | Promise<Response>;
+
+function handlerFor(config: Partial<JarvisConfig>): Handler {
+  const routes = createApiRoutes({
+    daemonStartedAt: Date.now(),
+    healthMonitor: {} as ApiContext['healthMonitor'],
+    config: { llm: { providers: {} }, ...config } as JarvisConfig,
+  } as ApiContext);
+  const route = routes['/api/billing'] as { GET?: Handler } | undefined;
+  if (!route?.GET) throw new Error('Route /api/billing GET not registered');
+  return route.GET;
+}
+
+const SECRET = 'd'.repeat(64);
+// A distinct instance id per test: the route reads through the daemon's shared
+// reader, whose cache is keyed by the credentials.
+let n = 0;
+const billingBlock = () => ({
+  url: 'https://control-plane.internal/api/billing/instance',
+  instance_id: `inst-billing-${++n}`,
+  secret: SECRET,
+  page_url: 'https://app.example/billing',
+});
+const req = () => new Request('http://localhost/api/billing');
+const realFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+describe('GET /api/billing', () => {
+  it('is 503 on a self-hosted install', async () => {
+    expect((await handlerFor({})(req())).status).toBe(503);
+  });
+
+  it('is ok:false (not 503) on a hosted install whose control plane rendered no billing block', async () => {
+    // Hosted per the unix-socket listen signal; the block is absent when the
+    // control plane has no origin an instance can reach.
+    const res = await handlerFor({
+      daemon: { listen: 'unix:/run/jarvis/u_1/brain.sock' },
+    } as Partial<JarvisConfig>)(req());
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: false, error: 'Billing is unavailable right now', links: null });
+  });
+
+  it('serves the parsed summary and the account links', async () => {
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({
+          account: { email: 'o@e.com' },
+          subscription: null,
+          plans: [],
+          paymentMethods: [],
+          payments: [],
+        }),
+        { status: 200 },
+      )) as unknown as typeof fetch;
+    const res = await handlerFor({ usejarvis_billing: billingBlock() } as Partial<JarvisConfig>)(req());
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean; summary: { account: { email: string } }; links: { cancel: string } };
+    expect(body.ok).toBe(true);
+    expect(body.summary.account.email).toBe('o@e.com');
+    expect(body.links.cancel).toBe('https://app.example/billing?action=cancel');
+  });
+
+  it('never echoes the endpoint, instance id or secret — on success or failure', async () => {
+    for (const reply of [
+      async () => {
+        throw new Error('connect ECONNREFUSED https://control-plane.internal');
+      },
+      async () => new Response('https://control-plane.internal says no', { status: 401 }),
+      async () =>
+        new Response(JSON.stringify({ account: {}, subscription: null, plans: [], paymentMethods: null, payments: [] })),
+    ]) {
+      globalThis.fetch = reply as unknown as typeof fetch;
+      const block = billingBlock();
+      const text = await (await handlerFor({ usejarvis_billing: block } as Partial<JarvisConfig>)(req())).text();
+      expect(text).not.toContain('control-plane.internal');
+      expect(text).not.toContain(SECRET);
+      expect(text).not.toContain(block.instance_id);
+    }
+  });
+
+  it('reads are cached, and ?fresh=1 still shares a reading younger than the floor', async () => {
+    let count = 0;
+    globalThis.fetch = (async () => {
+      count++;
+      return new Response(
+        JSON.stringify({ account: { email: 'o@e.com' }, subscription: null, plans: [], paymentMethods: [], payments: [] }),
+      );
+    }) as unknown as typeof fetch;
+    const handler = handlerFor({ usejarvis_billing: billingBlock() } as Partial<JarvisConfig>);
+    await handler(req());
+    await handler(req());
+    expect(count).toBe(1);
+    // Inside the fresh floor, a fresh read still shares the reading just taken.
+    await handler(new Request('http://localhost/api/billing?fresh=1'));
+    expect(count).toBe(1);
+  });
+
+  it('still offers the account links when the read fails, so the user has a way forward', async () => {
+    globalThis.fetch = (async () => new Response('', { status: 502 })) as unknown as typeof fetch;
+    const res = await handlerFor({ usejarvis_billing: billingBlock() } as Partial<JarvisConfig>)(req());
+    const body = (await res.json()) as { ok: boolean; links: { page: string } | null };
+    expect(body.ok).toBe(false);
+    expect(body.links?.page).toBe('https://app.example/billing');
+  });
+});

--- a/src/daemon/api-routes.ts
+++ b/src/daemon/api-routes.ts
@@ -1737,6 +1737,41 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
     // provider is built from the system-owned config.yaml block — the route
     // takes no credentials and never echoes the base_url or key back.
     /**
+     * The owner's billing summary, for Settings -> Billing and the shell banner
+     * (control plane: docs/BILLING.md "Billing inside the brain").
+     *
+     * Read-only. The response carries the parsed summary and the account-page
+     * LINKS every change goes through, opened in the system browser; never the
+     * endpoint, the instance id or the secret.
+     *
+     * - self-hosted: 503, like the usage meter — there is no bill to show;
+     * - hosted but no billing block, or the read failed: 200 `{ ok: false }`,
+     *   with links when the block names a page, so the user still has a way to
+     *   their account;
+     * - `?fresh=1` re-reads (bounded, see BILLING_FRESH_MIN_MS) for a user who
+     *   just came back from changing something.
+     */
+    '/api/billing': {
+      GET: async (req: Request) => {
+        const { readHostedBillingConfig, readHostedBilling, billingLinks } = await import('./hosted-billing.ts');
+        const cfg = readHostedBillingConfig(ctx.config);
+        if (!cfg) {
+          const { isHostedInstall } = await import('./usejarvis-ai.ts');
+          if (!isHostedInstall(ctx.config)) {
+            return error('Billing is only available on hosted installs.', 503);
+          }
+          return json({ ok: false, error: 'Billing is unavailable right now', links: null });
+        }
+        const fresh = new URL(req.url).searchParams.get('fresh') === '1';
+        const summary = await readHostedBilling(ctx.config, { fresh });
+        const links = billingLinks(cfg.pageUrl);
+        return summary
+          ? json({ ok: true, summary, links })
+          : json({ ok: false, error: 'Billing is unavailable right now', links });
+      },
+    },
+
+    /**
      * This instance's hosted usage meter — % of each window used and when they
      * reset (docs/LLM.md on the control plane, "Windows + meters").
      *

--- a/src/daemon/hosted-billing.test.ts
+++ b/src/daemon/hosted-billing.test.ts
@@ -1,0 +1,277 @@
+import { describe, expect, test } from 'bun:test';
+import { createHmac } from 'node:crypto';
+import type { JarvisConfig } from '../config/types.ts';
+import {
+  BILLING_CACHE_MS,
+  BILLING_FRESH_MIN_MS,
+  billingLinks,
+  makeHostedBillingReader,
+  parseHostedBillingSummary,
+  readHostedBillingConfig,
+} from './hosted-billing.ts';
+
+const SECRET = 'a'.repeat(64);
+const configWith = (over: Record<string, unknown> = {}): JarvisConfig =>
+  ({
+    usejarvis_billing: {
+      url: 'https://cp.example/api/billing/instance',
+      instance_id: 'inst-1',
+      secret: SECRET,
+      page_url: 'https://app.example/billing',
+      ...over,
+    },
+  }) as unknown as JarvisConfig;
+
+/** What the control plane answers today (no later-added fields). */
+const SUMMARY = {
+  account: { email: 'owner@example.com' },
+  subscription: { status: 'active', currentPeriodEnd: '2026-10-01T00:00:00.000Z', graceUntil: null },
+  plans: [
+    {
+      key: 'base',
+      name: 'Base',
+      quantity: 1,
+      prices: [{ interval: 'month', unitAmount: 999, currency: 'usd' }],
+    },
+  ],
+  paymentMethods: [{ brand: 'visa', last4: '4242', expMonth: 8, expYear: 2027 }],
+  payments: [
+    { id: 'p1', amountCents: 833, taxCents: 166, currency: 'usd', paidAt: '2026-09-01T00:00:00.000Z' },
+  ],
+};
+
+function stubFetch(reply: () => Response) {
+  const calls: Array<{ url: string; body: string; signature: string | null }> = [];
+  const fn = (async (input: Parameters<typeof fetch>[0], init?: RequestInit) => {
+    calls.push({
+      url: String(input),
+      body: String(init?.body ?? ''),
+      signature: new Headers(init?.headers).get('x-jarvis-signature'),
+    });
+    return reply();
+  }) as unknown as typeof fetch;
+  return { fn, calls };
+}
+
+const ok = () => new Response(JSON.stringify(SUMMARY), { status: 200 });
+
+describe('hosted billing config', () => {
+  test('all four fields or billing is OFF', () => {
+    expect(readHostedBillingConfig(configWith())).toEqual({
+      url: 'https://cp.example/api/billing/instance',
+      instanceId: 'inst-1',
+      secret: SECRET,
+      pageUrl: 'https://app.example/billing',
+    });
+    for (const key of ['url', 'instance_id', 'secret', 'page_url']) {
+      expect(readHostedBillingConfig(configWith({ [key]: '  ' }))).toBeNull();
+      expect(readHostedBillingConfig(configWith({ [key]: undefined }))).toBeNull();
+    }
+    expect(readHostedBillingConfig({} as JarvisConfig)).toBeNull();
+    // An unquoted scalar that YAML parsed as a number is not a string.
+    expect(readHostedBillingConfig(configWith({ secret: 1234 }))).toBeNull();
+  });
+
+  test('the page becomes a clickable link, so only http(s) may pass; the endpoint is https only', () => {
+    expect(readHostedBillingConfig(configWith({ page_url: 'javascript:alert(1)' }))).toBeNull();
+    expect(readHostedBillingConfig(configWith({ page_url: 'http://localhost:3000/billing' }))).not.toBeNull();
+    expect(readHostedBillingConfig(configWith({ url: 'http://cp.example/api/billing/instance' }))).toBeNull();
+  });
+
+  test('links carry the action on the account page, keeping its own query', () => {
+    const links = billingLinks('https://app.example/billing?ref=brain');
+    expect(links.page).toBe('https://app.example/billing?ref=brain');
+    expect(new URL(links.cancel).searchParams.get('action')).toBe('cancel');
+    expect(new URL(links.cancel).searchParams.get('ref')).toBe('brain');
+    expect(new URL(links.paymentMethod).searchParams.get('action')).toBe('payment-method');
+    expect(new URL(links.changePlan).searchParams.get('action')).toBe('change-plan');
+    expect(new URL(links.manage).searchParams.get('action')).toBe('manage');
+  });
+});
+
+describe('billing summary parsing', () => {
+  test("today's control-plane shape parses, with later fields defaulted rather than undefined", () => {
+    const s = parseHostedBillingSummary(SUMMARY)!;
+    expect(s.account.email).toBe('owner@example.com');
+    expect(s.subscription).toEqual({
+      status: 'active',
+      currentPeriodStart: null,
+      currentPeriodEnd: '2026-10-01T00:00:00.000Z',
+      cancelAtPeriodEnd: false,
+      cancelAt: null,
+      graceUntil: null,
+      startedAt: null,
+    });
+    expect(s.upcomingInvoice).toBeNull();
+    expect(s.paymentMethods).toEqual([{ brand: 'visa', last4: '4242', expMonth: 8, expYear: 2027, isDefault: false }]);
+    expect(s.payments[0]).toMatchObject({ invoiceNumber: null, invoiceUrl: null, invoicePdfUrl: null });
+  });
+
+  test('the later-added details parse when present', () => {
+    const s = parseHostedBillingSummary({
+      ...SUMMARY,
+      subscription: { ...SUMMARY.subscription, cancelAtPeriodEnd: true, cancelAt: '2026-10-01T00:00:00.000Z' },
+      upcomingInvoice: { amountDueCents: 999, currency: 'usd', date: '2026-10-01T00:00:00.000Z' },
+      paymentMethods: [{ ...SUMMARY.paymentMethods[0], isDefault: true }],
+      payments: [
+        {
+          ...SUMMARY.payments[0],
+          invoiceNumber: 'ABC-0001',
+          invoiceUrl: 'https://invoice.stripe.com/i/x',
+          invoicePdfUrl: 'https://pay.stripe.com/invoice/x/pdf',
+        },
+      ],
+    })!;
+    expect(s.subscription?.cancelAtPeriodEnd).toBe(true);
+    expect(s.upcomingInvoice).toEqual({ amountDueCents: 999, currency: 'usd', date: '2026-10-01T00:00:00.000Z' });
+    expect(s.paymentMethods?.[0]?.isDefault).toBe(true);
+    expect(s.payments[0]?.invoiceUrl).toBe('https://invoice.stripe.com/i/x');
+  });
+
+  test('an invoice link that is not https is dropped, never rendered as a link', () => {
+    const s = parseHostedBillingSummary({
+      ...SUMMARY,
+      payments: [{ ...SUMMARY.payments[0], invoiceUrl: 'javascript:alert(1)', invoicePdfUrl: 'http://x/pdf' }],
+    })!;
+    expect(s.payments[0]?.invoiceUrl).toBeNull();
+    expect(s.payments[0]?.invoicePdfUrl).toBeNull();
+  });
+
+  test('null payment methods stay NULL (unavailable), not an empty list (none saved)', () => {
+    expect(parseHostedBillingSummary({ ...SUMMARY, paymentMethods: null })?.paymentMethods).toBeNull();
+    // Absent reads like null rather than blanking the whole page.
+    const { paymentMethods: _pm, subscription: _sub, ...bare } = SUMMARY;
+    const parsed = parseHostedBillingSummary(bare);
+    expect(parsed?.paymentMethods).toBeNull();
+    expect(parsed?.subscription).toBeNull();
+    expect(parseHostedBillingSummary({ ...SUMMARY, paymentMethods: [] })?.paymentMethods).toEqual([]);
+  });
+
+  test('a shape missing what every section needs is unavailable as a whole', () => {
+    expect(parseHostedBillingSummary(null)).toBeNull();
+    expect(parseHostedBillingSummary({ hello: 'world' })).toBeNull();
+    expect(parseHostedBillingSummary({ ...SUMMARY, plans: 'x' })).toBeNull();
+    expect(parseHostedBillingSummary({ ...SUMMARY, subscription: 'active' })).toBeNull();
+    expect(parseHostedBillingSummary({ ...SUMMARY, paymentMethods: {} })).toBeNull();
+  });
+
+  test('malformed items are dropped instead of rendering undefineds', () => {
+    const s = parseHostedBillingSummary({
+      ...SUMMARY,
+      plans: [...SUMMARY.plans, { key: 'x' }, 7],
+      payments: [...SUMMARY.payments, { amountCents: 'lots', currency: 'usd', paidAt: 'x' }],
+    })!;
+    expect(s.plans).toHaveLength(1);
+    expect(s.payments).toHaveLength(1);
+  });
+});
+
+describe('hosted billing reader', () => {
+  test('signs the EXACT bytes it sends, with the billing secret', async () => {
+    const { fn, calls } = stubFetch(ok);
+    const read = makeHostedBillingReader({ fetchImpl: fn, now: () => 1_000 });
+    expect((await read(configWith()))?.plans[0]?.name).toBe('Base');
+    const call = calls[0]!;
+    expect(call.url).toBe('https://cp.example/api/billing/instance');
+    expect(call.signature).toBe(createHmac('sha256', SECRET).update(call.body).digest('hex'));
+    expect(JSON.parse(call.body)).toEqual({ instanceId: 'inst-1', at: new Date(1_000).toISOString() });
+  });
+
+  test('one request per cache window; fresh re-reads, but not faster than the floor', async () => {
+    let clock = 0;
+    const { fn, calls } = stubFetch(ok);
+    const read = makeHostedBillingReader({ fetchImpl: fn, now: () => clock });
+    await read(configWith());
+    await read(configWith());
+    expect(calls).toHaveLength(1);
+    // A focus storm right after a read still shares it.
+    clock = BILLING_FRESH_MIN_MS - 1;
+    await read(configWith(), { fresh: true });
+    expect(calls).toHaveLength(1);
+    clock = BILLING_FRESH_MIN_MS + 1;
+    await read(configWith(), { fresh: true });
+    expect(calls).toHaveLength(2);
+    clock += BILLING_CACHE_MS - 1;
+    await read(configWith());
+    expect(calls).toHaveLength(2);
+    clock += 2;
+    await read(configWith());
+    expect(calls).toHaveLength(3);
+  });
+
+  test('concurrent callers share ONE in-flight request', async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((r) => (release = r));
+    let count = 0;
+    const fn = (async () => {
+      count++;
+      await gate;
+      return ok();
+    }) as unknown as typeof fetch;
+    const read = makeHostedBillingReader({ fetchImpl: fn, now: () => 0 });
+    const a = read(configWith());
+    const b = read(configWith());
+    release();
+    const [ra, rb] = await Promise.all([a, b]);
+    expect(count).toBe(1);
+    expect(ra).toEqual(rb);
+  });
+
+  test('a request signed before a rotation cannot overwrite the reading taken after it', async () => {
+    let clock = 0;
+    let releaseOld!: () => void;
+    const oldGate = new Promise<void>((r) => (releaseOld = r));
+    const calls: string[] = [];
+    const fn = (async (_input: Parameters<typeof fetch>[0], init?: RequestInit) => {
+      const sig = new Headers(init?.headers).get('x-jarvis-signature') ?? '';
+      const isOld = sig === createHmac('sha256', SECRET).update(String(init?.body)).digest('hex');
+      calls.push(isOld ? 'old' : 'new');
+      if (isOld) await oldGate;
+      return ok();
+    }) as unknown as typeof fetch;
+    const read = makeHostedBillingReader({ fetchImpl: fn, now: () => clock });
+    const rotated = configWith({ secret: 'b'.repeat(64) });
+
+    const oldRead = read(configWith());
+    clock = 10;
+    await read(rotated); // finishes first, caches under the new key
+    releaseOld();
+    await oldRead;
+    clock = 20;
+    await read(rotated);
+    // The third read reused the new-key reading instead of refetching.
+    expect(calls).toEqual(['old', 'new']);
+  });
+
+  test('a ROTATED secret invalidates the cache instead of serving a reading from the old key', async () => {
+    const { fn, calls } = stubFetch(ok);
+    const read = makeHostedBillingReader({ fetchImpl: fn, now: () => 0 });
+    await read(configWith());
+    await read(configWith({ secret: 'b'.repeat(64) }));
+    expect(calls).toHaveLength(2);
+  });
+
+  test('failures read as null, are cached, and never throw at the caller', async () => {
+    let clock = 0;
+    const { fn, calls } = stubFetch(() => new Response('nope', { status: 502 }));
+    const read = makeHostedBillingReader({ fetchImpl: fn, now: () => clock });
+    expect(await read(configWith())).toBeNull();
+    clock = BILLING_CACHE_MS - 1;
+    expect(await read(configWith())).toBeNull();
+    expect(calls).toHaveLength(1);
+
+    const boom = (async () => {
+      throw new Error('connect ECONNREFUSED https://cp.example');
+    }) as unknown as typeof fetch;
+    expect(await makeHostedBillingReader({ fetchImpl: boom, now: () => 0 })(configWith())).toBeNull();
+
+    const garbage = stubFetch(() => new Response('<html>', { status: 200 }));
+    expect(await makeHostedBillingReader({ fetchImpl: garbage.fn, now: () => 0 })(configWith())).toBeNull();
+  });
+
+  test('no billing block means no request at all', async () => {
+    const { fn, calls } = stubFetch(ok);
+    expect(await makeHostedBillingReader({ fetchImpl: fn })({} as JarvisConfig)).toBeNull();
+    expect(calls).toHaveLength(0);
+  });
+});

--- a/src/daemon/hosted-billing.ts
+++ b/src/daemon/hosted-billing.ts
@@ -1,0 +1,380 @@
+import type { JarvisConfig } from '../config/types.ts';
+import { INSTANCE_SIGNATURE_HEADER, signWithSecret } from '../integrations/google-signature.ts';
+import { redactSecrets } from '../util/redact.ts';
+
+/**
+ * This instance's owner's billing summary, read from the control plane
+ * (control plane: docs/BILLING.md "Billing inside the brain", D36).
+ *
+ * ## Why the instance reads it
+ *
+ * The Settings -> Billing page renders inside the sidecar's webview, which has
+ * no session with the control plane's user API: sign-in happens in the system
+ * browser, and that cookie never reaches this origin. So this daemon reads the
+ * summary AS THE INSTANCE, signing with the per-instance billing secret the
+ * control plane renders into config.yaml, the same way the usage meter does.
+ *
+ * ## Read-only
+ *
+ * Nothing here changes billing, and nothing may: the secret sits in a file this
+ * process reads, and this process runs an assistant. Every change is a link to
+ * the account page (`page_url`), opened in the system browser where the user's
+ * own session authorizes it. See `billingLinks`.
+ *
+ * ## What never leaves this module
+ *
+ * The endpoint, the instance id and the secret. The route above hands the UI
+ * the parsed summary and the account links only; failures log to the operator
+ * console and read as "unavailable" to the user.
+ */
+
+export interface HostedBillingPrice {
+  interval: string;
+  /** Minor units. */
+  unitAmount: number;
+  currency: string;
+}
+
+export interface HostedBillingPlan {
+  key: string;
+  name: string;
+  quantity: number;
+  prices: HostedBillingPrice[];
+}
+
+export interface HostedBillingSubscription {
+  status: string;
+  /** ISO-8601, or null when not known. */
+  currentPeriodStart: string | null;
+  currentPeriodEnd: string | null;
+  /** Set to end at `currentPeriodEnd` (or `cancelAt`) rather than renew. */
+  cancelAtPeriodEnd: boolean;
+  cancelAt: string | null;
+  /** How long a past-due subscription keeps access. */
+  graceUntil: string | null;
+  startedAt: string | null;
+}
+
+export interface HostedBillingUpcomingInvoice {
+  amountDueCents: number;
+  currency: string;
+  /** When it will be charged. */
+  date: string | null;
+}
+
+export interface HostedBillingPaymentMethod {
+  /** Card brand ("visa"), or the method type ("sepa_debit") for non-cards. */
+  brand: string;
+  last4: string;
+  expMonth: number | null;
+  expYear: number | null;
+  isDefault: boolean;
+}
+
+export interface HostedBillingPayment {
+  id: string;
+  /** NET of tax; gross = amountCents + taxCents. Refunds are negative. */
+  amountCents: number;
+  taxCents: number;
+  currency: string;
+  paidAt: string;
+  invoiceNumber: string | null;
+  /** https only; opened in the system browser. */
+  invoiceUrl: string | null;
+  invoicePdfUrl: string | null;
+}
+
+export interface HostedBillingSummary {
+  account: { email: string };
+  subscription: HostedBillingSubscription | null;
+  plans: HostedBillingPlan[];
+  upcomingInvoice: HostedBillingUpcomingInvoice | null;
+  /** null = the control plane could not read the card processor right now. */
+  paymentMethods: HostedBillingPaymentMethod[] | null;
+  /** Newest first. */
+  payments: HostedBillingPayment[];
+}
+
+/** The four fields that must travel together, or billing is off. */
+export interface HostedBillingConfig {
+  url: string;
+  instanceId: string;
+  secret: string;
+  pageUrl: string;
+}
+
+function str(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function isHttpUrl(value: string, httpsOnly = false): boolean {
+  try {
+    const u = new URL(value);
+    return u.protocol === 'https:' || (!httpsOnly && u.protocol === 'http:');
+  } catch {
+    return false;
+  }
+}
+
+export function readHostedBillingConfig(config: JarvisConfig): HostedBillingConfig | null {
+  const block = config.usejarvis_billing;
+  if (!block || typeof block !== 'object') return null;
+  const url = str(block.url);
+  const instanceId = str(block.instance_id);
+  const secret = str(block.secret);
+  const pageUrl = str(block.page_url);
+  // A partial set cannot authenticate (or cannot send anyone anywhere), and
+  // treating it as present would poll a control plane that answers 401.
+  if (!url || !instanceId || !secret || !pageUrl) return null;
+  // page_url becomes a link the user clicks: nothing but http(s) may pass.
+  if (!isHttpUrl(url, true) || !isHttpUrl(pageUrl)) return null;
+  return { url, instanceId, secret, pageUrl };
+}
+
+/**
+ * Where each billing action sends the user: the account billing page, with the
+ * action it should open. The page authorizes every one of them with the user's
+ * own session; an action it does not know simply shows the billing page.
+ */
+export interface BillingLinks {
+  page: string;
+  /** The processor's customer portal home (invoices, renew, everything). */
+  manage: string;
+  paymentMethod: string;
+  changePlan: string;
+  cancel: string;
+}
+
+export function billingLinks(pageUrl: string): BillingLinks {
+  const withAction = (action: string) => {
+    const u = new URL(pageUrl);
+    u.searchParams.set('action', action);
+    return u.toString();
+  };
+  return {
+    page: new URL(pageUrl).toString(),
+    manage: withAction('manage'),
+    paymentMethod: withAction('payment-method'),
+    changePlan: withAction('change-plan'),
+    cancel: withAction('cancel'),
+  };
+}
+
+// ── Parsing ─────────────────────────────────────────────────────────────────
+//
+// Validated, not trusted: a field we do not recognise must read as absent rather
+// than render as `undefined`, and a response missing the parts every section
+// needs reads as "unavailable" as a whole. Fields the control plane added later
+// (cancelAtPeriodEnd, invoice links, the upcoming charge) are OPTIONAL here, so a
+// newer brain against an older control plane degrades to fewer details.
+
+const isObj = (v: unknown): v is Record<string, unknown> =>
+  !!v && typeof v === 'object' && !Array.isArray(v);
+const num = (v: unknown): number | null => (typeof v === 'number' && Number.isFinite(v) ? v : null);
+const date = (v: unknown): string | null =>
+  typeof v === 'string' && Number.isFinite(Date.parse(v)) ? v : null;
+const httpsOrNull = (v: unknown): string | null =>
+  typeof v === 'string' && isHttpUrl(v, true) ? v : null;
+
+function parsePlan(v: unknown): HostedBillingPlan | null {
+  if (!isObj(v) || typeof v.name !== 'string') return null;
+  const prices = Array.isArray(v.prices)
+    ? v.prices.flatMap((p): HostedBillingPrice[] => {
+        if (!isObj(p)) return [];
+        const unitAmount = num(p.unitAmount);
+        if (unitAmount === null || typeof p.interval !== 'string' || typeof p.currency !== 'string') return [];
+        return [{ interval: p.interval, unitAmount, currency: p.currency }];
+      })
+    : [];
+  return {
+    key: typeof v.key === 'string' ? v.key : '',
+    name: v.name,
+    quantity: num(v.quantity) ?? 1,
+    prices,
+  };
+}
+
+function parseSubscription(v: unknown): HostedBillingSubscription | null {
+  if (!isObj(v) || typeof v.status !== 'string') return null;
+  return {
+    status: v.status,
+    currentPeriodStart: date(v.currentPeriodStart),
+    currentPeriodEnd: date(v.currentPeriodEnd),
+    cancelAtPeriodEnd: v.cancelAtPeriodEnd === true,
+    cancelAt: date(v.cancelAt),
+    graceUntil: date(v.graceUntil),
+    startedAt: date(v.startedAt),
+  };
+}
+
+function parsePaymentMethod(v: unknown): HostedBillingPaymentMethod | null {
+  if (!isObj(v) || typeof v.brand !== 'string') return null;
+  return {
+    brand: v.brand,
+    last4: typeof v.last4 === 'string' ? v.last4 : '',
+    expMonth: num(v.expMonth),
+    expYear: num(v.expYear),
+    isDefault: v.isDefault === true,
+  };
+}
+
+function parsePayment(v: unknown): HostedBillingPayment | null {
+  if (!isObj(v)) return null;
+  const amountCents = num(v.amountCents);
+  const paidAt = date(v.paidAt);
+  if (amountCents === null || paidAt === null || typeof v.currency !== 'string') return null;
+  return {
+    // Used as a list key: the fallback must not collide for two payments at
+    // the same instant.
+    id: typeof v.id === 'string' ? v.id : `${paidAt}:${amountCents}:${num(v.taxCents) ?? 0}`,
+    amountCents,
+    taxCents: num(v.taxCents) ?? 0,
+    currency: v.currency,
+    paidAt,
+    invoiceNumber: typeof v.invoiceNumber === 'string' ? v.invoiceNumber : null,
+    invoiceUrl: httpsOrNull(v.invoiceUrl),
+    invoicePdfUrl: httpsOrNull(v.invoicePdfUrl),
+  };
+}
+
+function parseUpcoming(v: unknown): HostedBillingUpcomingInvoice | null {
+  if (!isObj(v)) return null;
+  const amountDueCents = num(v.amountDueCents);
+  if (amountDueCents === null || typeof v.currency !== 'string') return null;
+  return { amountDueCents, currency: v.currency, date: date(v.date) };
+}
+
+const compact = <T>(items: unknown, parse: (v: unknown) => T | null): T[] =>
+  Array.isArray(items) ? items.map(parse).filter((x): x is T => x !== null) : [];
+
+export function parseHostedBillingSummary(raw: unknown): HostedBillingSummary | null {
+  if (!isObj(raw) || !Array.isArray(raw.plans) || !Array.isArray(raw.payments)) return null;
+  // Absent reads like null ("none" / "unavailable"), in the same spirit as the
+  // optional later fields; only a PRESENT value of the wrong type is fatal.
+  if (raw.subscription != null && !isObj(raw.subscription)) return null;
+  if (raw.paymentMethods != null && !Array.isArray(raw.paymentMethods)) return null;
+  return {
+    account: { email: isObj(raw.account) && typeof raw.account.email === 'string' ? raw.account.email : '' },
+    subscription: parseSubscription(raw.subscription),
+    plans: compact(raw.plans, parsePlan),
+    upcomingInvoice: parseUpcoming(raw.upcomingInvoice),
+    paymentMethods: raw.paymentMethods == null ? null : compact(raw.paymentMethods, parsePaymentMethod),
+    payments: compact(raw.payments, parsePayment),
+  };
+}
+
+// ── Reader ──────────────────────────────────────────────────────────────────
+
+/** Slower than the usage meter's: this one waits on a live card-processor call. */
+const TIMEOUT_MS = 8_000;
+
+/**
+ * How long a reading is reused. Matches the control plane's own per-user cache:
+ * polling faster buys nothing but load. The shell's banner and the Billing tab
+ * read through this, so they share one request.
+ */
+export const BILLING_CACHE_MS = 60_000;
+
+/**
+ * A FRESH read (the user came back from changing something in the browser, or
+ * pressed refresh) still reuses anything younger than this, so a focus event
+ * storm is not a request storm.
+ */
+export const BILLING_FRESH_MIN_MS = 5_000;
+
+export interface HostedBillingReaderDeps {
+  fetchImpl?: typeof fetch;
+  now?: () => number;
+}
+
+/**
+ * Config per call, not captured: the system block is re-read on SIGHUP so a key
+ * can rotate without a restart, and the cache key includes the credentials so a
+ * rotation invalidates the reading.
+ */
+export function makeHostedBillingReader(
+  deps: HostedBillingReaderDeps = {},
+): (config: JarvisConfig, opts?: { fresh?: boolean }) => Promise<HostedBillingSummary | null> {
+  const callFetch = (...args: Parameters<typeof fetch>): ReturnType<typeof fetch> =>
+    (deps.fetchImpl ?? fetch)(...args);
+  const now = deps.now ?? (() => Date.now());
+  let cache: { key: string; at: number; value: HostedBillingSummary | null } | null = null;
+  let inflight: { key: string; promise: Promise<HostedBillingSummary | null> } | null = null;
+  /** The credentials of the most recent call: the key a reading is "current" for. */
+  let latestKey = '';
+
+  const fetchSummary = async (cfg: HostedBillingConfig): Promise<HostedBillingSummary | null> => {
+    const body = JSON.stringify({ instanceId: cfg.instanceId, at: new Date(now()).toISOString() });
+    try {
+      const res = await callFetch(cfg.url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          [INSTANCE_SIGNATURE_HEADER]: signWithSecret(cfg.secret, body),
+        },
+        body,
+        signal: AbortSignal.timeout(TIMEOUT_MS),
+      });
+      if (res.ok) {
+        const summary = parseHostedBillingSummary(await res.json().catch(() => null));
+        if (!summary) console.warn('[billing] control plane returned an unrecognised summary shape; billing unavailable');
+        return summary;
+      }
+      if (res.status === 400) {
+        // The one body worth keeping: a >5min clock drift fails every read, and
+        // the control plane says so here. Redacted and bounded.
+        const detail = redactSecrets(await res.text().catch(() => '')).slice(0, 300);
+        console.warn(`[billing] control plane rejected the request: ${detail || '(no detail)'}`);
+      } else {
+        // STATUS only: a body could name the control-plane host or echo what we sent.
+        console.warn(`[billing] control plane answered ${res.status}; billing unavailable`);
+      }
+    } catch (err) {
+      console.warn(
+        '[billing] could not reach the control plane; billing unavailable:',
+        redactSecrets(err instanceof Error ? err.message : String(err)),
+      );
+    }
+    return null;
+  };
+
+  return async (config, opts) => {
+    const cfg = readHostedBillingConfig(config);
+    if (!cfg) return null;
+    const key = `${cfg.url}|${cfg.instanceId}|${cfg.secret}`;
+    latestKey = key;
+    if (cache && cache.key === key) {
+      const age = now() - cache.at;
+      if (age < (opts?.fresh ? BILLING_FRESH_MIN_MS : BILLING_CACHE_MS)) return cache.value;
+    }
+    // Concurrent callers (the banner and the tab mounting together) share one
+    // request rather than racing two signed reads.
+    if (inflight && inflight.key === key) return inflight.promise;
+    const promise = fetchSummary(cfg).then((value) => {
+      // A failure is cached too: an unreachable control plane must not become a
+      // request per render. But a request signed with a key rotated away while
+      // it was in flight must not overwrite a reading already taken under the
+      // NEWER key — that would only cost the next caller another request.
+      if (key === latestKey || cache?.key !== latestKey) {
+        cache = { key, at: now(), value };
+      }
+      return value;
+    });
+    inflight = { key, promise };
+    try {
+      return await promise;
+    } finally {
+      if (inflight?.promise === promise) inflight = null;
+    }
+  };
+}
+
+/** The daemon's one reader: a singleton because the CACHE is the point. */
+const shared = makeHostedBillingReader();
+
+export function readHostedBilling(
+  config: JarvisConfig,
+  opts?: { fresh?: boolean },
+): Promise<HostedBillingSummary | null> {
+  return shared(config, opts);
+}

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -540,12 +540,16 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
     // voice intent, pebble toggle — schedule the section's appliers.
     const { SettingsReloadCoordinator } = await import('./settings-reload.ts');
     const { setSectionSavedListener } = await import('./user-settings.ts');
-    const { reloadUsejarvisAiBlock } = await import('../config/loader.ts');
+    const { reloadUsejarvisAiBlock, reloadUsejarvisBillingBlock } = await import('../config/loader.ts');
     settingsReload = new SettingsReloadCoordinator(jarvisConfig, {
       // File-authoritative SYSTEM sections are re-read on every reloadAll so
       // a provisioner rotation of the usejarvis_ai key (or un-hosting) takes
-      // effect on SIGHUP / POST /api/config/reload without a restart.
-      reloadSystemSections: (cfg) => reloadUsejarvisAiBlock(cfg),
+      // effect on SIGHUP / POST /api/config/reload without a restart. Same
+      // for the billing read's block.
+      reloadSystemSections: async (cfg) => {
+        await reloadUsejarvisAiBlock(cfg);
+        await reloadUsejarvisBillingBlock(cfg);
+      },
     });
     setSectionSavedListener((section) => settingsReload?.sectionChanged(section));
 

--- a/ui/src/v2/billing/BillingBanner.tsx
+++ b/ui/src/v2/billing/BillingBanner.tsx
@@ -1,11 +1,17 @@
 import React from "react";
-import { useBillingState, STATE_META, renderBold, BILLING_ENABLED } from "./useBillingState";
+import { useBilling } from "./useBilling";
+import { bannerFor, boldSegments } from "./billing-view";
 import "./billing.css";
 
-/* Top-of-app billing banner. Shows for trial / past-due / canceling / expired
-   (active is quiet). Mounts in the shell's .rs-main slot beside the system
-   banners. The action walks the lifecycle (demo transitions until a real
-   billing backend drives the state). */
+/* Top-of-app billing banner, live. Speaks for past-due, a scheduled cancel and
+   an incomplete first payment; active is quiet, and so is everything that is
+   not a hosted install with a readable bill. Mounts in the shell's .rs-main
+   slot beside the system banners.
+
+   The action is a real target=_blank LINK, not a scripted window.open: a popup
+   blocker in an ordinary browser lets a clicked link through, and the sidecar's
+   panel hands target=_blank to the system browser, where the change is made on
+   the user's own session. */
 
 const Clock = () => (
   <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.4"><circle cx="8" cy="8" r="6" /><path d="M8 4.8V8l2.2 1.3" strokeLinecap="round" strokeLinejoin="round" /></svg>
@@ -19,17 +25,21 @@ const Info = () => (
 const ICON = { clock: Clock, alert: Alert, info: Info } as const;
 
 export function BillingBanner() {
-  const { state, setState } = useBillingState();
-  if (!BILLING_ENABLED) return null; // hosted billing not live yet
-  const banner = STATE_META[state].banner;
+  const { state, summary, links } = useBilling();
+  if (state !== "ready" || !summary || !links) return null;
+  const banner = bannerFor(summary, Date.now());
   if (!banner) return null;
   const Icon = ICON[banner.icon];
   return (
     <div className={`bl-bnr ${banner.tone}`} role="status">
       <span className="bi"><Icon /></span>
-      <span className="bm">{renderBold(banner.message)}</span>
+      <span className="bm">
+        {boldSegments(banner.message).map((s, i) => (s.bold ? <strong key={i}>{s.text}</strong> : <React.Fragment key={i}>{s.text}</React.Fragment>))}
+      </span>
       <span className="ba">
-        <button className="bl-btn bl-btn--pri" onClick={() => setState(banner.action.to)}>{banner.action.label}</button>
+        <a className="bl-btn bl-btn--pri" href={links[banner.action.link]} target="_blank" rel="noopener noreferrer">
+          {banner.action.label}
+        </a>
       </span>
     </div>
   );

--- a/ui/src/v2/billing/billing-view.test.ts
+++ b/ui/src/v2/billing/billing-view.test.ts
@@ -1,0 +1,258 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  bannerFor,
+  billingState,
+  boldSegments,
+  brandLabel,
+  cardExpiresBefore,
+  chargedCard,
+  classifyBillingResponse,
+  endsAt,
+  formatExpiry,
+  formatMoney,
+  isHttpsUrl,
+  needsAttention,
+  nextChargeDate,
+  paymentRow,
+  planMeta,
+  planTitle,
+  recurringTotal,
+  type BillingPaymentMethod,
+  type BillingSubscription,
+  type BillingSummary,
+} from './billing-view.ts';
+
+const LINKS = {
+  page: 'https://app.example/billing',
+  manage: 'https://app.example/billing?action=manage',
+  paymentMethod: 'https://app.example/billing?action=payment-method',
+  changePlan: 'https://app.example/billing?action=change-plan',
+  cancel: 'https://app.example/billing?action=cancel',
+};
+
+/** Mid-period: after the start, before the end and before every grace/cancel date below. */
+const NOW = Date.parse('2026-09-10T12:00:00.000Z');
+
+const sub = (over: Partial<BillingSubscription> = {}): BillingSubscription => ({
+  status: 'active',
+  currentPeriodStart: '2026-09-01T00:00:00.000Z',
+  currentPeriodEnd: '2026-10-01T00:00:00.000Z',
+  cancelAtPeriodEnd: false,
+  cancelAt: null,
+  graceUntil: null,
+  startedAt: '2026-06-01T00:00:00.000Z',
+  ...over,
+});
+
+const card = (over: Partial<BillingPaymentMethod> = {}): BillingPaymentMethod => ({
+  brand: 'visa',
+  last4: '4242',
+  expMonth: 8,
+  expYear: 2027,
+  isDefault: true,
+  ...over,
+});
+
+const summary = (over: Partial<BillingSummary> = {}): BillingSummary => ({
+  account: { email: 'o@example.com' },
+  subscription: sub(),
+  plans: [{ key: 'base', name: 'Base', quantity: 1, prices: [{ interval: 'month', unitAmount: 999, currency: 'usd' }] }],
+  upcomingInvoice: null,
+  paymentMethods: [card()],
+  payments: [],
+  ...over,
+});
+
+describe('classifying GET /api/billing', () => {
+  test("only the DAEMON's 503 means self-hosted; a failed fetch is unknown, never \"no bill\"", () => {
+    expect(classifyBillingResponse(503, { error: 'Billing is only available on hosted installs.' })).toEqual({ kind: 'self' });
+    // A bare 503 from a proxy in between must not end polling for a hosted user.
+    expect(classifyBillingResponse(503, null)).toEqual({ kind: 'failed' });
+    expect(classifyBillingResponse(503, { message: 'upstream' })).toEqual({ kind: 'failed' });
+    expect(classifyBillingResponse(500, null)).toEqual({ kind: 'failed' });
+    expect(classifyBillingResponse(404, null)).toEqual({ kind: 'failed' });
+    expect(classifyBillingResponse(200, null)).toEqual({ kind: 'failed' });
+    expect(classifyBillingResponse(200, { hello: 1 })).toEqual({ kind: 'failed' });
+  });
+
+  test('ready needs both a summary and well-formed links', () => {
+    expect(classifyBillingResponse(200, { ok: true, summary: summary(), links: LINKS }).kind).toBe('ready');
+    expect(classifyBillingResponse(200, { ok: true, summary: summary(), links: null }).kind).toBe('failed');
+  });
+
+  test('a link that is not http(s) is never treated as a link', () => {
+    const evil = { ...LINKS, cancel: 'javascript:alert(1)' };
+    expect(classifyBillingResponse(200, { ok: true, summary: summary(), links: evil }).kind).toBe('failed');
+    expect(classifyBillingResponse(200, { ok: false, links: evil })).toEqual({ kind: 'unavailable', links: null });
+    expect(isHttpsUrl('https://invoice.stripe.com/i/x')).toBe(true);
+    expect(isHttpsUrl('javascript:alert(1)')).toBe(false);
+    expect(isHttpsUrl('http://x')).toBe(false);
+    expect(isHttpsUrl(null)).toBe(false);
+  });
+
+  test('unavailable keeps the links so the user still has a way to their account', () => {
+    expect(classifyBillingResponse(200, { ok: false, error: 'x', links: LINKS })).toEqual({ kind: 'unavailable', links: LINKS });
+    expect(classifyBillingResponse(200, { ok: false, error: 'x', links: null })).toEqual({ kind: 'unavailable', links: null });
+  });
+});
+
+describe('state', () => {
+  test('maps processor statuses onto the design lifecycle', () => {
+    expect(billingState(null)).toBe('none');
+    expect(billingState(sub())).toBe('active');
+    expect(billingState(sub({ status: 'trialing' }))).toBe('active');
+    expect(billingState(sub({ cancelAtPeriodEnd: true }))).toBe('canceling');
+    expect(billingState(sub({ cancelAt: '2026-10-01T00:00:00.000Z' }))).toBe('canceling');
+    expect(billingState(sub({ status: 'past_due' }))).toBe('past_due');
+    expect(billingState(sub({ status: 'unpaid' }))).toBe('past_due');
+    expect(billingState(sub({ status: 'incomplete' }))).toBe('incomplete');
+    expect(billingState(sub({ status: 'canceled' }))).toBe('none');
+  });
+
+  test('a scheduled cancel ends at cancelAt when Stripe states one, else the period end', () => {
+    expect(endsAt(sub({ cancelAt: '2026-09-20T00:00:00.000Z' }))).toBe('2026-09-20T00:00:00.000Z');
+    expect(endsAt(sub())).toBe('2026-10-01T00:00:00.000Z');
+  });
+
+  test('active is quiet: no banner', () => {
+    expect(bannerFor(summary(), NOW)).toBeNull();
+    expect(bannerFor(summary({ subscription: null }), NOW)).toBeNull();
+  });
+
+  test('past due asks for a card and names the grace date while it is ahead', () => {
+    const b = bannerFor(summary({ subscription: sub({ status: 'past_due', graceUntil: '2026-09-17T00:00:00.000Z' }) }), NOW)!;
+    expect(b.tone).toBe('warn');
+    expect(b.action.link).toBe('paymentMethod');
+    expect(b.message).toContain('stays online until');
+  });
+
+  test('a grace window or cancel date already behind now is never promised', () => {
+    const lapsed = summary({ subscription: sub({ status: 'past_due', graceUntil: '2026-09-05T00:00:00.000Z' }) });
+    expect(bannerFor(lapsed, NOW)!.message).not.toContain('until');
+    expect(planMeta(lapsed, NOW)).not.toContain('until');
+    const ended = summary({ subscription: sub({ cancelAtPeriodEnd: true, cancelAt: '2026-09-09T00:00:00.000Z' }) });
+    expect(bannerFor(ended, NOW)!.message).not.toContain('until');
+    expect(planMeta(ended, NOW)).not.toContain('Ends **');
+  });
+
+  test('a scheduled cancel is neutral (a choice, not a fault) and offers resume', () => {
+    const b = bannerFor(summary({ subscription: sub({ cancelAtPeriodEnd: true }) }), NOW)!;
+    expect(b.tone).toBe('neutral');
+    expect(b.action.link).toBe('manage');
+    expect(b.message).toContain('access until');
+  });
+
+  test('an incomplete first payment speaks up', () => {
+    const b = bannerFor(summary({ subscription: sub({ status: 'incomplete' }) }), NOW)!;
+    expect(b.tone).toBe('warn');
+    expect(b.action.link).toBe('manage');
+  });
+
+  test('the plan line says what happens next', () => {
+    expect(planMeta(summary(), NOW)).toContain('Renews');
+    expect(planMeta(summary(), NOW)).toContain('Visa •••• 4242');
+    expect(
+      planMeta(summary({ upcomingInvoice: { amountDueCents: 1299, currency: 'usd', date: '2026-10-01T00:00:00.000Z' } }), NOW),
+    ).toContain('Next charge');
+    // A preview without a date falls back to the renewal date, never "on null".
+    const undated = planMeta(summary({ upcomingInvoice: { amountDueCents: 1299, currency: 'usd', date: null } }), NOW);
+    expect(undated).toContain('Renews');
+    expect(undated).not.toContain('null');
+    expect(planMeta(summary({ subscription: sub({ cancelAtPeriodEnd: true }) }), NOW)).toContain('Ends');
+    expect(planMeta(summary({ subscription: sub({ status: 'past_due', graceUntil: null }) }), NOW)).toContain('Payment failed');
+    expect(planMeta(summary({ subscription: null }), NOW)).toContain("don't have a subscription");
+  });
+});
+
+describe('the charged card and attention', () => {
+  test('the charged card is the default, or the only card; otherwise nobody claims to know', () => {
+    const backup = card({ brand: 'mastercard', last4: '5454', isDefault: false });
+    expect(chargedCard(summary({ paymentMethods: [backup, card()] }))?.last4).toBe('4242');
+    expect(chargedCard(summary({ paymentMethods: [card({ isDefault: false })] }))?.last4).toBe('4242');
+    expect(chargedCard(summary({ paymentMethods: [card({ isDefault: false }), backup] }))).toBeNull();
+    expect(chargedCard(summary({ paymentMethods: null }))).toBeNull();
+    // With no known card the plan line names none.
+    expect(planMeta(summary({ paymentMethods: [card({ isDefault: false }), backup] }), NOW)).not.toContain('••••');
+  });
+
+  test('"All good" is withheld when the next charge has nowhere good to go', () => {
+    expect(needsAttention(summary())).toBe(false);
+    expect(needsAttention(summary({ paymentMethods: [] }))).toBe(true);
+    expect(needsAttention(summary({ paymentMethods: null }))).toBe(true);
+    // The charged card expires before the renewal on Oct 1.
+    expect(needsAttention(summary({ paymentMethods: [card({ expMonth: 9, expYear: 2026 })] }))).toBe(true);
+    // A BACKUP card expiring is not the charge's problem.
+    expect(
+      needsAttention(summary({ paymentMethods: [card(), card({ last4: '1111', expMonth: 9, expYear: 2026, isDefault: false })] })),
+    ).toBe(false);
+    // Only an active, renewing plan has a next charge to worry about.
+    expect(needsAttention(summary({ subscription: sub({ cancelAtPeriodEnd: true }), paymentMethods: [] }))).toBe(false);
+  });
+
+  test('the next charge is the preview date, else the renewal of an active plan', () => {
+    expect(nextChargeDate(summary())).toBe('2026-10-01T00:00:00.000Z');
+    expect(
+      nextChargeDate(summary({ upcomingInvoice: { amountDueCents: 1, currency: 'usd', date: '2026-09-30T00:00:00.000Z' } })),
+    ).toBe('2026-09-30T00:00:00.000Z');
+    expect(nextChargeDate(summary({ subscription: sub({ cancelAtPeriodEnd: true }) }))).toBeNull();
+  });
+});
+
+describe('money and cards', () => {
+  test('money is formatted in the processor currency and its own exponent; an unknown code does not throw', () => {
+    expect(formatMoney(999, 'usd')).toContain('9.99');
+    expect(formatMoney(999, 'eur')).toContain('9.99');
+    // Zero-decimal: 500 JPY is ¥500, not ¥5.
+    expect(formatMoney(500, 'jpy')).toContain('500');
+    expect(formatMoney(999, 'not-a-currency')).toBe('9.99 NOT-A-CURRENCY');
+  });
+
+  test('a single recurring total only when every plan shares currency and interval', () => {
+    const base = { key: 'b', name: 'Base', quantity: 1, prices: [{ interval: 'month', unitAmount: 999, currency: 'usd' }] };
+    const disk = { key: 'd', name: 'Disk', quantity: 2, prices: [{ interval: 'month', unitAmount: 300, currency: 'usd' }] };
+    expect(recurringTotal([base, disk])).toEqual({ interval: 'month', unitAmount: 1599, currency: 'usd' });
+    expect(recurringTotal([base, { ...disk, prices: [{ interval: 'month', unitAmount: 300, currency: 'eur' }] }])).toBeNull();
+    expect(recurringTotal([base, { ...disk, prices: [] }])).toBeNull();
+    expect(recurringTotal([])).toBeNull();
+    expect(planTitle([base, disk])).toBe('Base + Disk × 2');
+    expect(planTitle([])).toBe('No active plan');
+  });
+
+  test('expiry is the END of the stated month', () => {
+    expect(formatExpiry(card())).toBe('08 / 27');
+    expect(formatExpiry(card({ expMonth: null }))).toBeNull();
+    // Expires Aug 2027: still valid on Aug 31, gone on Sep 1.
+    expect(cardExpiresBefore(card(), '2027-08-31T23:00:00.000Z')).toBe(false);
+    expect(cardExpiresBefore(card(), '2027-09-01T00:00:00.000Z')).toBe(true);
+    expect(cardExpiresBefore(card({ expMonth: 12, expYear: 2027 }), '2028-01-01T00:00:00.000Z')).toBe(true);
+    expect(cardExpiresBefore(card(), null)).toBe(false);
+  });
+
+  test('brands read like words', () => {
+    expect(brandLabel('visa')).toBe('Visa');
+    expect(brandLabel('amex')).toBe('American Express');
+    expect(brandLabel('sepa_debit')).toBe('Sepa debit');
+    expect(brandLabel('')).toBe('Card');
+  });
+
+  test('a payment shows gross with its tax; a refund reads as a refund', () => {
+    const p = { id: '1', amountCents: 833, taxCents: 166, currency: 'usd', paidAt: '2026-09-01T00:00:00.000Z', invoiceNumber: null, invoiceUrl: null, invoicePdfUrl: null };
+    const row = paymentRow(p);
+    expect(row.amount).toContain('9.99');
+    expect(row.tax).toContain('1.66');
+    expect(row.label).toBe('Payment');
+    expect(paymentRow({ ...p, invoiceNumber: 'AB-1' }).label).toBe('Invoice AB-1');
+    const refund = paymentRow({ ...p, amountCents: -833, taxCents: -166 });
+    expect(refund.refund).toBe(true);
+    expect(refund.label).toBe('Refund');
+    expect(refund.tax).toBeNull();
+  });
+
+  test('bold markers split into segments', () => {
+    expect(boldSegments('a **b** c')).toEqual([
+      { text: 'a ', bold: false },
+      { text: 'b', bold: true },
+      { text: ' c', bold: false },
+    ]);
+  });
+});

--- a/ui/src/v2/billing/billing-view.ts
+++ b/ui/src/v2/billing/billing-view.ts
@@ -1,0 +1,384 @@
+/**
+ * The Settings -> Billing page and the shell banner, as pure decisions.
+ *
+ * Pure on purpose: every rule here holds at a boundary (a grace window that
+ * just passed, a card expiring this month, a refund, a cancel scheduled for a
+ * date) that JSX tests cannot reach. Anything that depends on the time takes
+ * `now` rather than reading the clock. Mirrors the daemon's summary types
+ * (src/daemon/hosted-billing.ts), which in turn mirror the control plane's
+ * wire contract (docs/BILLING.md "Billing inside the brain").
+ */
+
+export interface BillingPrice {
+  interval: string;
+  unitAmount: number;
+  currency: string;
+}
+
+export interface BillingPlan {
+  key: string;
+  name: string;
+  quantity: number;
+  prices: BillingPrice[];
+}
+
+export interface BillingSubscription {
+  status: string;
+  currentPeriodStart: string | null;
+  currentPeriodEnd: string | null;
+  cancelAtPeriodEnd: boolean;
+  cancelAt: string | null;
+  graceUntil: string | null;
+  startedAt: string | null;
+}
+
+export interface BillingPaymentMethod {
+  brand: string;
+  last4: string;
+  expMonth: number | null;
+  expYear: number | null;
+  isDefault: boolean;
+}
+
+export interface BillingPayment {
+  id: string;
+  amountCents: number;
+  taxCents: number;
+  currency: string;
+  paidAt: string;
+  invoiceNumber: string | null;
+  invoiceUrl: string | null;
+  invoicePdfUrl: string | null;
+}
+
+export interface BillingSummary {
+  account: { email: string };
+  subscription: BillingSubscription | null;
+  plans: BillingPlan[];
+  upcomingInvoice: { amountDueCents: number; currency: string; date: string | null } | null;
+  paymentMethods: BillingPaymentMethod[] | null;
+  payments: BillingPayment[];
+}
+
+export interface BillingLinks {
+  page: string;
+  manage: string;
+  paymentMethod: string;
+  changePlan: string;
+  cancel: string;
+}
+
+export type BillingTone = "info" | "ok" | "warn" | "neutral" | "danger";
+
+// ── The route's answer ─────────────────────────────────────────────────────
+
+/**
+ * What one read of GET /api/billing means.
+ *
+ * TRI-state for the reason the usage meter is (useHostedBudget.ts): a failed
+ * fetch or an unparseable body is "failed", which the page renders as unknown
+ * and retries, never as "you have no bill".
+ */
+export type BillingProbe =
+  | { kind: "self" }
+  | { kind: "ready"; summary: BillingSummary; links: BillingLinks }
+  | { kind: "unavailable"; links: BillingLinks | null }
+  | { kind: "failed" };
+
+export function classifyBillingResponse(status: number, body: unknown): BillingProbe {
+  // Self-hosted only when the DAEMON says so: its 503 carries a JSON error. A
+  // bare 503 from something in between (a proxy, a restarting host) is a failed
+  // read — otherwise a hosted user would be told "no bill here" until a reload,
+  // since "self" stops the polling.
+  if (status === 503) {
+    const err = body && typeof body === "object" ? (body as { error?: unknown }).error : undefined;
+    return typeof err === "string" ? { kind: "self" } : { kind: "failed" };
+  }
+  if (status !== 200 || !body || typeof body !== "object") return { kind: "failed" };
+  const b = body as { ok?: unknown; summary?: unknown; links?: unknown };
+  const links = isLinks(b.links) ? b.links : null;
+  if (b.ok === true && b.summary && typeof b.summary === "object" && links) {
+    return { kind: "ready", summary: b.summary as BillingSummary, links };
+  }
+  if (b.ok === false) return { kind: "unavailable", links };
+  return { kind: "failed" };
+}
+
+function isLinks(v: unknown): v is BillingLinks {
+  if (!v || typeof v !== "object") return false;
+  const l = v as Record<string, unknown>;
+  return (["page", "manage", "paymentMethod", "changePlan", "cancel"] as const).every(
+    (k) => typeof l[k] === "string" && /^https?:\/\//.test(l[k] as string),
+  );
+}
+
+/**
+ * The only URLs this page opens that do not come from `links`: receipts. The
+ * daemon already drops anything else; checked again here so the invariant holds
+ * where the click happens.
+ */
+export function isHttpsUrl(v: string | null): v is string {
+  return typeof v === "string" && /^https:\/\//.test(v);
+}
+
+// ── Formatting ─────────────────────────────────────────────────────────────
+
+/**
+ * Minor units -> "$9.99". Currency from the processor, never assumed, and so is
+ * its exponent: a zero-decimal currency (JPY) is not divided by 100.
+ */
+export function formatMoney(minor: number, currency: string): string {
+  const code = currency.toUpperCase();
+  try {
+    const fmt = new Intl.NumberFormat(undefined, { style: "currency", currency: code });
+    const digits = fmt.resolvedOptions().maximumFractionDigits ?? 2;
+    return fmt.format(minor / 10 ** digits);
+  } catch {
+    // An unknown code must not blank the page.
+    return `${(minor / 100).toFixed(2)} ${code}`;
+  }
+}
+
+/** "Oct 1, 2026". Null for a missing or unparseable date, so callers can omit it. */
+export function formatDate(iso: string | null): string | null {
+  if (!iso) return null;
+  const t = Date.parse(iso);
+  if (!Number.isFinite(t)) return null;
+  return new Intl.DateTimeFormat(undefined, { year: "numeric", month: "short", day: "numeric" }).format(t);
+}
+
+/** A date that is known and still ahead. Past or missing dates are not promised to anyone. */
+function futureDate(iso: string | null, now: number): string | null {
+  if (!iso) return null;
+  const t = Date.parse(iso);
+  return Number.isFinite(t) && t > now ? formatDate(iso) : null;
+}
+
+const INTERVAL_SUFFIX: Record<string, string> = { month: "/ mo", year: "/ yr" };
+
+/** "$9.99 / mo", or "" when the plan has no price. Month is listed first upstream. */
+export function formatPrice(price: BillingPrice | undefined): string {
+  if (!price) return "";
+  const suffix = INTERVAL_SUFFIX[price.interval] ?? `/ ${price.interval}`;
+  return `${formatMoney(price.unitAmount, price.currency)} ${suffix}`;
+}
+
+/** "Visa", "Sepa debit": the processor's lowercase brand, readable. */
+export function brandLabel(brand: string): string {
+  const clean = brand.replace(/_/g, " ").trim();
+  if (!clean) return "Card";
+  if (clean.toLowerCase() === "amex") return "American Express";
+  return clean.charAt(0).toUpperCase() + clean.slice(1);
+}
+
+/** "08 / 27", or null for a method without an expiry. */
+export function formatExpiry(m: BillingPaymentMethod): string | null {
+  if (m.expMonth === null || m.expYear === null) return null;
+  return `${String(m.expMonth).padStart(2, "0")} / ${String(m.expYear % 100).padStart(2, "0")}`;
+}
+
+/**
+ * True when the card stops working on or before `iso`. Expiry is the END of
+ * the stated month.
+ */
+export function cardExpiresBefore(m: BillingPaymentMethod, iso: string | null): boolean {
+  if (m.expMonth === null || m.expYear === null || !iso) return false;
+  const at = Date.parse(iso);
+  if (!Number.isFinite(at)) return false;
+  const endOfExpiryMonth = Date.UTC(m.expYear, m.expMonth, 1); // first instant of the NEXT month
+  return endOfExpiryMonth <= at;
+}
+
+/**
+ * The card the next charge goes to: the default, or the only card. With several
+ * cards and no known default this is null, and nothing claims to know.
+ */
+export function chargedCard(summary: BillingSummary): BillingPaymentMethod | null {
+  const methods = summary.paymentMethods ?? [];
+  return methods.find((m) => m.isDefault) ?? (methods.length === 1 ? methods[0]! : null);
+}
+
+// ── State ──────────────────────────────────────────────────────────────────
+
+/**
+ * The lifecycle state the design names (usejarvis-billing-states), derived
+ * from what the processor actually says.
+ *
+ * `expired` exists in the design but cannot reach this page: when a
+ * subscription ends the control plane stops this brain. It maps to "none" so a
+ * summary read in the last seconds before suspension renders honestly.
+ */
+export type BillingState = "active" | "past_due" | "canceling" | "incomplete" | "none";
+
+export function billingState(sub: BillingSubscription | null): BillingState {
+  if (!sub) return "none";
+  switch (sub.status) {
+    case "active":
+    case "trialing":
+      return sub.cancelAtPeriodEnd || sub.cancelAt ? "canceling" : "active";
+    case "past_due":
+    case "unpaid":
+      return "past_due";
+    case "incomplete":
+      return "incomplete";
+    default:
+      return "none";
+  }
+}
+
+export const STATE_CHIP: Record<BillingState, { tone: BillingTone; label: string }> = {
+  active: { tone: "ok", label: "Active" },
+  past_due: { tone: "warn", label: "Past due" },
+  canceling: { tone: "neutral", label: "Canceling" },
+  incomplete: { tone: "warn", label: "Incomplete" },
+  none: { tone: "neutral", label: "No plan" },
+};
+
+/** When a canceling subscription actually ends. */
+export function endsAt(sub: BillingSubscription): string | null {
+  return sub.cancelAt ?? sub.currentPeriodEnd;
+}
+
+/** When the next charge is due: Stripe's preview, else the renewal date of an active plan. */
+export function nextChargeDate(summary: BillingSummary): string | null {
+  if (billingState(summary.subscription) !== "active") return null;
+  return summary.upcomingInvoice?.date ?? summary.subscription?.currentPeriodEnd ?? null;
+}
+
+/**
+ * Something on the page will need the user before the next charge: no card to
+ * charge, cards that cannot be read, or the charged card expiring first. The
+ * quiet "All good" line must never sit above any of these.
+ */
+export function needsAttention(summary: BillingSummary): boolean {
+  if (billingState(summary.subscription) !== "active") return false;
+  if (summary.paymentMethods === null || summary.paymentMethods.length === 0) return true;
+  const card = chargedCard(summary);
+  return !!card && cardExpiresBefore(card, nextChargeDate(summary));
+}
+
+/** "Base + Disk × 2". */
+export function planTitle(plans: BillingPlan[]): string {
+  if (plans.length === 0) return "No active plan";
+  return plans.map((p) => (p.quantity > 1 ? `${p.name} × ${p.quantity}` : p.name)).join(" + ");
+}
+
+/**
+ * The recurring total across every plan, when they share one currency and one
+ * interval (the only case a single figure is honest for). Null otherwise; the
+ * per-plan rows still show each price.
+ */
+export function recurringTotal(plans: BillingPlan[]): BillingPrice | null {
+  const firsts = plans.map((p) => p.prices[0]);
+  if (firsts.length === 0 || firsts.some((p) => !p)) return null;
+  const [head] = firsts as BillingPrice[];
+  if (!(firsts as BillingPrice[]).every((p) => p.currency === head!.currency && p.interval === head!.interval)) {
+    return null;
+  }
+  const total = plans.reduce((sum, p) => sum + p.prices[0]!.unitAmount * Math.max(1, p.quantity), 0);
+  return { interval: head!.interval, unitAmount: total, currency: head!.currency };
+}
+
+/**
+ * The one line under the plan name: what happens next, and when. `**bold**`
+ * markers like the design's copy. A date already behind `now` is dropped rather
+ * than promised.
+ */
+export function planMeta(summary: BillingSummary, now: number): string {
+  const sub = summary.subscription;
+  if (!sub) return "You don't have a subscription on this account.";
+  const card = chargedCard(summary);
+  const cardText = card ? ` · ${brandLabel(card.brand)} •••• ${card.last4 || "????"}` : "";
+  switch (billingState(sub)) {
+    case "active": {
+      const next = summary.upcomingInvoice;
+      const nextOn = next ? formatDate(next.date) : null;
+      if (next && nextOn) {
+        return `Next charge **${formatMoney(next.amountDueCents, next.currency)}** on **${nextOn}**${cardText}`;
+      }
+      const renew = formatDate(sub.currentPeriodEnd);
+      return renew ? `Renews **${renew}**${cardText}` : `Renews automatically${cardText}`;
+    }
+    case "canceling": {
+      const end = futureDate(endsAt(sub), now);
+      return end
+        ? `Ends **${end}** · you keep everything until then, and can resume any time before`
+        : "Set to end at the close of this period · you can resume any time before it does";
+    }
+    case "past_due": {
+      const grace = futureDate(sub.graceUntil, now);
+      return grace
+        ? `Payment failed · your brain stays online until **${grace}**`
+        : "Payment failed · update your card to keep Jarvis running";
+    }
+    case "incomplete":
+      return "The first payment hasn't completed yet.";
+    default:
+      return "This subscription is no longer active.";
+  }
+}
+
+export interface BannerView {
+  tone: BillingTone;
+  icon: "clock" | "alert" | "info";
+  message: string;
+  action: { label: string; link: keyof BillingLinks };
+}
+
+/**
+ * The top-of-app banner, or null. Active is quiet: nothing needs you. The
+ * others speak exactly as much as the situation warrants.
+ */
+export function bannerFor(summary: BillingSummary, now: number): BannerView | null {
+  const sub = summary.subscription;
+  switch (billingState(sub)) {
+    case "past_due": {
+      const grace = futureDate(sub?.graceUntil ?? null, now);
+      return {
+        tone: "warn",
+        icon: "alert",
+        message: grace
+          ? `**We couldn't charge your card.** Update it to keep Jarvis running; your brain stays online until ${grace}.`
+          : "**We couldn't charge your card.** Update it to keep Jarvis running.",
+        action: { label: "Update card", link: "paymentMethod" },
+      };
+    }
+    case "canceling": {
+      const end = futureDate(sub ? endsAt(sub) : null, now);
+      return {
+        tone: "neutral",
+        icon: "info",
+        message: end
+          ? `Your subscription is **canceled**. You have access until ${end}.`
+          : "Your subscription is **canceled** and ends with this period.",
+        action: { label: "Resume", link: "manage" },
+      };
+    }
+    case "incomplete":
+      return {
+        tone: "warn",
+        icon: "alert",
+        message: "**Your first payment hasn't completed.** Finish it to keep Jarvis running.",
+        action: { label: "Open billing", link: "manage" },
+      };
+    default:
+      return null;
+  }
+}
+
+/** A refund row reads as a refund, with its sign. Gross = net + tax. */
+export function paymentRow(p: BillingPayment): { label: string; amount: string; tax: string | null; refund: boolean } {
+  const gross = p.amountCents + p.taxCents;
+  const refund = gross < 0;
+  return {
+    label: refund ? "Refund" : p.invoiceNumber ? `Invoice ${p.invoiceNumber}` : "Payment",
+    amount: formatMoney(gross, p.currency),
+    tax: !refund && p.taxCents !== 0 ? formatMoney(p.taxCents, p.currency) : null,
+    refund,
+  };
+}
+
+/** Split `**bold**` copy into segments; odd segments are bold. */
+export function boldSegments(text: string): Array<{ text: string; bold: boolean }> {
+  return text.split("**").map((part, i) => ({ text: part, bold: i % 2 === 1 }));
+}

--- a/ui/src/v2/billing/billing.css
+++ b/ui/src/v2/billing/billing.css
@@ -96,6 +96,25 @@
 .bl-bnr.neutral { background: var(--panel2); border-bottom-color: var(--rule); }
 .bl-bnr.neutral .bi { background: var(--panel); color: var(--ink2); }
 
+/* ── live billing page (Settings → Billing) ── */
+.bl-soon__act { display: flex; gap: 8px; margin-top: 16px; flex-wrap: wrap; justify-content: center; }
+.bl-receipt__empty { padding: 12px 14px; font-size: 12.5px; color: var(--ink3); }
+.bl-receipt__row > span:first-child { min-width: 0; }
+.bl-row-end { display: inline-flex; align-items: baseline; gap: 12px; flex-shrink: 0; }
+.bl-pm { display: inline-flex; align-items: center; gap: 8px; min-width: 0; }
+.bl-exp { font-family: var(--mono); font-size: 11px; color: var(--ink3); font-variant-numeric: tabular-nums; }
+.bl-exp--warn { color: var(--hold-tx); }
+.bl-tax { font-family: var(--mono); font-size: 11px; font-weight: 400; color: var(--ink3); }
+.bl-receipt__row .link { display: inline-flex; align-items: center; gap: 3px; }
+.bl-foot { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin: 18px 2px 4px; font-family: var(--mono); font-size: 10.5px; color: var(--ink3); }
+.bl-foot__refresh { display: inline-flex; align-items: center; gap: 5px; font-family: var(--mono); font-size: 10.5px; color: var(--ink2); background: none; border: 1px solid var(--rule); border-radius: 7px 2px 7px 7px; padding: 4px 9px; cursor: pointer; flex-shrink: 0; }
+.bl-foot__refresh:hover { border-color: var(--ink3); }
+.bl-foot__refresh:focus-visible, .bl-receipt__row .link:focus-visible { outline: 2px solid var(--speak); outline-offset: 2px; }
+@media (max-width: 520px) {
+  .bl-receipt__row { flex-wrap: wrap; }
+  .bl-foot { flex-direction: column; align-items: flex-start; }
+}
+
 /* ── change-plan modal ── */
 .bl-modal { position: fixed; inset: 0; z-index: 400; display: flex; align-items: center; justify-content: center; padding: 24px; background: color-mix(in srgb, var(--ink) 22%, transparent); -webkit-backdrop-filter: blur(2px); backdrop-filter: blur(2px); animation: bl-fade 0.14s var(--ease, ease); }
 @keyframes bl-fade { from { opacity: 0; } to { opacity: 1; } }

--- a/ui/src/v2/billing/useBilling.ts
+++ b/ui/src/v2/billing/useBilling.ts
@@ -1,0 +1,129 @@
+import { useEffect, useSyncExternalStore } from "react";
+import {
+  classifyBillingResponse,
+  type BillingLinks,
+  type BillingSummary,
+} from "./billing-view";
+
+/**
+ * Reads the daemon's GET /api/billing for Settings -> Billing AND the shell
+ * banner, through ONE shared store, so the two never disagree and never take a
+ * request each.
+ *
+ * TRI-state like the usage meter (useHostedBudget.ts): "unknown" renders
+ * nothing and retries; only a real 503 means self-hosted. A read that fails
+ * after a good one KEEPS the good one on screen, marked stale, rather than
+ * blanking a user's bill because the control plane hiccupped.
+ *
+ * Changes happen in the system browser, so coming BACK is the moment the data
+ * is most likely stale: focus and visibility trigger a fresh read (the daemon
+ * floors those at a few seconds, so a focus storm is not a request storm).
+ */
+
+export type BillingLoadState = "unknown" | "self" | "ready" | "unavailable";
+
+export interface BillingSnapshot {
+  state: BillingLoadState;
+  summary: BillingSummary | null;
+  links: BillingLinks | null;
+  /** The last read failed or answered "unavailable" while a summary is shown. */
+  stale: boolean;
+  /** When the current summary was read; 0 before any. */
+  readAt: number;
+}
+
+/** Matches the 60s caches on both sides. */
+export const BILLING_POLL_MS = 60_000;
+const RETRY_MS = 5_000;
+
+const INITIAL: BillingSnapshot = { state: "unknown", summary: null, links: null, stale: false, readAt: 0 };
+
+let snapshot: BillingSnapshot = INITIAL;
+const listeners = new Set<() => void>();
+let inFlight = false;
+let retryTimer: number | null = null;
+let backoff = RETRY_MS;
+
+function publish(next: BillingSnapshot): void {
+  snapshot = next;
+  for (const l of listeners) l();
+}
+
+async function load(fresh: boolean): Promise<void> {
+  if (inFlight) return;
+  inFlight = true;
+  try {
+    const res = await fetch(fresh ? "/api/billing?fresh=1" : "/api/billing");
+    // The 503 body matters too: only the daemon's own JSON error means self-hosted.
+    const body = res.status === 200 || res.status === 503 ? await res.json().catch(() => null) : null;
+    const probe = classifyBillingResponse(res.status, body);
+    if (probe.kind === "failed") throw new Error(`HTTP ${res.status}`);
+    backoff = RETRY_MS;
+    if (probe.kind === "self") {
+      publish({ ...INITIAL, state: "self" });
+    } else if (probe.kind === "ready") {
+      publish({ state: "ready", summary: probe.summary, links: probe.links, stale: false, readAt: Date.now() });
+    } else if (snapshot.summary) {
+      // Keep the last good bill on screen; say it could not be refreshed.
+      publish({ ...snapshot, links: probe.links ?? snapshot.links, stale: true });
+    } else {
+      publish({ ...INITIAL, state: "unavailable", links: probe.links });
+    }
+  } catch {
+    if (snapshot.summary) publish({ ...snapshot, stale: true });
+    if (listeners.size > 0 && retryTimer === null) {
+      const wait = backoff;
+      backoff = Math.min(wait * 2, BILLING_POLL_MS);
+      retryTimer = window.setTimeout(() => {
+        retryTimer = null;
+        if (!document.hidden) void load(false);
+      }, wait);
+    }
+  } finally {
+    inFlight = false;
+  }
+}
+
+let pollTimer: number | null = null;
+
+function onReturn(): void {
+  if (!document.hidden && snapshot.state !== "self") void load(true);
+}
+
+function start(): void {
+  void load(false);
+  pollTimer = window.setInterval(() => {
+    if (!document.hidden && snapshot.state !== "self") void load(false);
+  }, BILLING_POLL_MS);
+  window.addEventListener("focus", onReturn);
+  document.addEventListener("visibilitychange", onReturn);
+}
+
+function stop(): void {
+  if (pollTimer !== null) window.clearInterval(pollTimer);
+  if (retryTimer !== null) window.clearTimeout(retryTimer);
+  pollTimer = null;
+  retryTimer = null;
+  window.removeEventListener("focus", onReturn);
+  document.removeEventListener("visibilitychange", onReturn);
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  if (listeners.size === 1) start();
+  return () => {
+    listeners.delete(listener);
+    if (listeners.size === 0) stop();
+  };
+}
+
+export function useBilling(): BillingSnapshot & { refresh: () => void } {
+  const snap = useSyncExternalStore(subscribe, () => snapshot, () => INITIAL);
+  // Opening Settings -> Billing is itself a reason to look again, including
+  // onto an "unavailable" screen, which schedules no retry of its own. The very
+  // first mount already loads through subscribe().
+  useEffect(() => {
+    if (snapshot.state === "ready" || snapshot.state === "unavailable") void load(true);
+  }, []);
+  return { ...snap, refresh: () => void load(true) };
+}

--- a/ui/src/v2/billing/useBillingState.tsx
+++ b/ui/src/v2/billing/useBillingState.tsx
@@ -1,31 +1,14 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 
-/* ═══════════════════ Billing state · Monochrome Lab ═══════════════════
-   The subscription lifecycle from usejarvis-billing-states.html. Five
-   states, five tones. No payment processor is wired in code yet (the design's
-   own candor note), so this is the state vocabulary + copy for a billing
-   backend to drive. Until then it's localStorage-backed so the lifecycle is
-   walkable in the shell (Settings → Billing) and previewable for QA. Live
-   across the banner + the tab via a same-tab custom event. */
-
-/** Hosted billing / subscriptions aren't live yet (no processor wired). Until
- *  then the Settings → Billing tab shows a "coming soon" state and the shell
- *  banner is suppressed. Flip to true when the billing backend ships; the plan
- *  card, banners, change-plan modal, and #/_billing gallery are all ready. */
-export const BILLING_ENABLED = false;
+/* ═══════════════════ Billing state vocabulary · Monochrome Lab ═══════════════════
+   The subscription lifecycle as the design names it (usejarvis-billing-states):
+   five states, five tones, and their copy. Used ONLY by the #/_billing design
+   gallery (pages/BillingShowcase.tsx), which previews every state with sample
+   figures. The live surfaces (Settings → Billing and the shell banner) derive
+   their state from the real summary instead: see billing-view.ts + useBilling.ts. */
 
 export type BillingState = "trialing" | "active" | "past_due" | "canceled" | "expired";
 export type BillingTone = "info" | "ok" | "warn" | "neutral" | "danger";
-
-export type PlanKey = "hosted" | "hosted_ai" | "max";
-export const PLANS: Record<PlanKey, { name: string; price: string; blurb: string }> = {
-  hosted: { name: "Hosted", price: "€9.99", blurb: "Bring your own model keys" },
-  hosted_ai: { name: "Hosted + AI", price: "€29", blurb: "Managed models, nothing to configure" },
-  max: { name: "Hosted + AI · Max", price: "€79", blurb: "5× the tokens, highest priority" },
-};
-
-/** The plan a returning user is on. Static until the billing backend is wired. */
-export const CURRENT_PLAN: PlanKey = "hosted_ai";
 
 export type BannerAction = { label: string; to: BillingState };
 export type StateInfo = {
@@ -37,27 +20,27 @@ export type StateInfo = {
   meta: string;
 };
 
-// `**bold**` markers in copy are rendered by renderBold() below.
+// Sample figures for the gallery. `**bold**` markers are rendered by renderBold().
 export const STATE_META: Record<BillingState, StateInfo> = {
   trialing: {
     chip: { tone: "info", label: "Trial" },
     banner: { tone: "info", icon: "clock", message: "**11 days left in your trial** of Hosted + AI. Add a card to keep it after.", action: { label: "Add card", to: "active" } },
-    planName: "Hosted + AI", price: "€0 now", meta: "Trial ends Jul 26 · then €29/mo · no charge yet",
+    planName: "Hosted + AI", price: "$0 now", meta: "Trial ends Jul 26 · then $29/mo · no charge yet",
   },
   active: {
     chip: { tone: "ok", label: "Active" },
     banner: null,
-    planName: "Hosted + AI", price: "€29 / mo", meta: "Renews Jul 15, 2026 · Visa •••• 4242",
+    planName: "Hosted + AI", price: "$29 / mo", meta: "Renews Jul 15, 2026 · Visa •••• 4242",
   },
   past_due: {
     chip: { tone: "warn", label: "Past due" },
     banner: { tone: "warn", icon: "alert", message: "**We couldn't charge your card** on Jul 15. Update it to keep Jarvis running; we'll retry Jul 18.", action: { label: "Update card", to: "active" } },
-    planName: "Hosted + AI", price: "€29 / mo", meta: "Payment failed · your brain stays online until Jul 22",
+    planName: "Hosted + AI", price: "$29 / mo", meta: "Payment failed · your brain stays online until Jul 22",
   },
   canceled: {
     chip: { tone: "neutral", label: "Canceling" },
     banner: { tone: "neutral", icon: "info", message: "Your subscription is **canceled**. You have access until Jul 15.", action: { label: "Resume", to: "active" } },
-    planName: "Hosted + AI", price: "€29 / mo", meta: "Ends Jul 15, 2026 · then you drop to no hosted brain",
+    planName: "Hosted + AI", price: "$29 / mo", meta: "Ends Jul 15, 2026 · then you drop to no hosted brain",
   },
   expired: {
     chip: { tone: "danger", label: "Expired" },
@@ -65,37 +48,6 @@ export const STATE_META: Record<BillingState, StateInfo> = {
     planName: "No active plan", price: "", meta: "Your data is safe. Resubscribe to bring Jarvis back, or self-host.",
   },
 };
-
-const KEY = "jarvis-billing-state";
-const EVT = "jarvis:billing-state";
-
-function readState(): BillingState {
-  try {
-    const v = localStorage.getItem(KEY);
-    if (v === "trialing" || v === "active" || v === "past_due" || v === "canceled" || v === "expired") return v;
-  } catch { /* no storage */ }
-  return "active";
-}
-
-export function useBillingState(): { state: BillingState; setState: (s: BillingState) => void } {
-  const [state, setLocal] = useState<BillingState>(readState);
-  useEffect(() => {
-    const reRead = () => setLocal(readState());
-    const onStorage = (e: StorageEvent) => { if (e.key === KEY) reRead(); };
-    window.addEventListener("storage", onStorage);
-    window.addEventListener(EVT, reRead);
-    return () => {
-      window.removeEventListener("storage", onStorage);
-      window.removeEventListener(EVT, reRead);
-    };
-  }, []);
-  const setState = (s: BillingState) => {
-    try { localStorage.setItem(KEY, s); } catch { /* no storage */ }
-    setLocal(s);
-    window.dispatchEvent(new Event(EVT)); // update the banner + tab live in this tab
-  };
-  return { state, setState };
-}
 
 /** Split `**bold**` copy into React nodes. */
 export function renderBold(text: string): React.ReactNode[] {

--- a/ui/src/v2/rooms/settings/tabs/BillingTab.tsx
+++ b/ui/src/v2/rooms/settings/tabs/BillingTab.tsx
@@ -1,141 +1,327 @@
-import React, { useEffect, useState } from "react";
-import { createPortal } from "react-dom";
-import { CreditCard } from "lucide-react";
+import React, { useState } from "react";
+import { CreditCard, ExternalLink, RefreshCw } from "lucide-react";
 import type { SettingsHook } from "../useSettingsData";
-import { confirmDialog } from "../../../ui/ConfirmDialog";
-import { useBillingState, STATE_META, renderBold, BILLING_ENABLED, type BillingState } from "../../../billing/useBillingState";
+import { useBilling } from "../../../billing/useBilling";
+import {
+  billingState,
+  boldSegments,
+  brandLabel,
+  cardExpiresBefore,
+  chargedCard,
+  endsAt,
+  formatDate,
+  formatExpiry,
+  formatMoney,
+  formatPrice,
+  isHttpsUrl,
+  needsAttention,
+  nextChargeDate,
+  paymentRow,
+  planMeta,
+  planTitle,
+  recurringTotal,
+  STATE_CHIP,
+  type BillingLinks,
+  type BillingSummary,
+} from "../../../billing/billing-view";
+import { openExternal, openedOrHandedOff } from "../../../onboarding/external-open";
 import "../../../billing/billing.css";
 
-/* Settings → Billing. The plan card carries the subscription state; the
-   change-plan modal shows the prorated math before you commit. No processor is
-   wired (the design's candor note), so state changes are local demo
-   transitions until a billing backend drives them. No dark patterns: cancel is
-   reversible, downgrades keep paid access, invoices say what's real. */
+/* Settings -> Billing, live (control plane: docs/BILLING.md "Billing inside the
+   brain"). Everything about the bill is shown here; nothing here changes it.
+   Every action opens the account billing page in the system browser, where the
+   user's own session authorizes it — this brain holds a READ-only credential by
+   design, so a compromised assistant can read its owner's bill but never
+   cancel it. No dark patterns: cancel is one click away and never hidden. */
 
 type Toast = (text: string, tone?: "ok" | "warn") => void;
 
-const PRORATE = {
-  up: "You'll be charged **€33.20 today**, prorated for the 10 days left this cycle. Then **€79/mo** from Jul 15.",
-  down: "No charge today. Your plan changes to **Hosted** at renewal on Jul 15, and you keep everything until then. After that, **€9.99/mo**.",
-};
-const CONFIRM = { up: "Switch to Max", down: "Schedule downgrade" };
+const HISTORY_PREVIEW = 12;
 
-function ChangePlanModal({ onClose, onConfirm }: { onClose: () => void; onConfirm: (choice: "up" | "down") => void }) {
-  const [choice, setChoice] = useState<"up" | "down">("up");
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") { e.preventDefault(); onClose(); } };
-    window.addEventListener("keydown", onKey, true);
-    return () => window.removeEventListener("keydown", onKey, true);
-  }, [onClose]);
-  return createPortal(
-    <div className="bl-modal" role="presentation" onMouseDown={(e) => { if (e.target === e.currentTarget) onClose(); }}>
-      <div className="bl-modal__box" role="dialog" aria-modal="true" aria-label="Change your plan">
-        <div className="bl-modal__head">
-          <div className="bl-modal__title">Change your plan</div>
-          <div className="bl-modal__sub">You're on Hosted + AI · €29/mo</div>
-        </div>
-        <div className="bl-opts" role="radiogroup" aria-label="Plan">
-          <button type="button" role="radio" aria-checked={choice === "up"} className="bl-opt" onClick={() => setChoice("up")}>
-            <span className="rad" /><span className="ot"><span className="otn">Hosted + AI · Max</span><span className="otd">5× the tokens, highest priority</span></span><span className="op">€79</span>
-          </button>
-          <button type="button" role="radio" aria-checked={choice === "down"} className="bl-opt" onClick={() => setChoice("down")}>
-            <span className="rad" /><span className="ot"><span className="otn">Hosted</span><span className="otd">Bring your own model keys</span></span><span className="op">€9.99</span>
-          </button>
-        </div>
-        <div className="bl-prorate">{renderBold(PRORATE[choice])}</div>
-        <div className="bl-modal__foot">
-          <button className="bl-btn" onClick={onClose}>Cancel</button>
-          <button className="bl-btn bl-btn--pri" onClick={() => onConfirm(choice)}>{CONFIRM[choice]}</button>
-        </div>
-      </div>
-    </div>,
-    document.body,
+function Bold({ text }: { text: string }) {
+  return (
+    <>
+      {boldSegments(text).map((s, i) => (s.bold ? <strong key={i}>{s.text}</strong> : <React.Fragment key={i}>{s.text}</React.Fragment>))}
+    </>
+  );
+}
+
+function Soon({ title, sub, children }: { title: string; sub: string; children?: React.ReactNode }) {
+  return (
+    <div className="bl-soon">
+      <div className="bl-soon__mark"><CreditCard size={22} strokeWidth={1.6} /></div>
+      <div className="bl-soon__title">{title}</div>
+      <div className="bl-soon__sub">{sub}</div>
+      {children && <div className="bl-soon__act">{children}</div>}
+    </div>
   );
 }
 
 export function BillingTab({ onToast }: { data: SettingsHook; onToast: Toast }) {
-  const { state, setState } = useBillingState();
-  const [modal, setModal] = useState(false);
+  const billing = useBilling();
+  const [showAll, setShowAll] = useState(false);
 
-  // Hosted billing isn't live yet — show a coming-soon state rather than a
-  // plan card that would look like a real subscription (the design's candor).
-  if (!BILLING_ENABLED) {
+  const open = (url: string) => {
+    if (!openedOrHandedOff(openExternal(url))) {
+      onToast("Couldn't open your browser. Open your usejarvis account's billing page to continue.", "warn");
+    }
+  };
+
+  if (billing.state === "self") {
     return (
-      <div className="bl-soon">
-        <div className="bl-soon__mark"><CreditCard size={22} strokeWidth={1.6} /></div>
-        <div className="bl-soon__title">Billing is coming soon</div>
-        <div className="bl-soon__sub">Hosted plans and subscriptions will live here. For now Jarvis runs on your own model keys or self-hosted, at no charge.</div>
-        <span className="bl-chip info"><span className="d" />Coming soon</span>
-      </div>
+      <Soon
+        title="No bill on this Jarvis"
+        sub="This Jarvis runs on your own machine with your own model keys, so there is nothing to pay for here. Hosted plans and their billing live with usejarvis."
+      />
+    );
+  }
+  if (billing.state === "unknown") {
+    return <Soon title="Loading billing…" sub="Reading your plan and payments from your usejarvis account." />;
+  }
+  if ((billing.state === "unavailable" || !billing.summary) && !billing.links) {
+    // No billing connection at all: a hosted install whose control plane did
+    // not render one, or a self-hoster fronting this brain over a unix socket
+    // (which reads as hosted). Neither is an outage, so say it calmly.
+    return (
+      <Soon
+        title="Billing isn't connected here"
+        sub="This Jarvis has no link to a usejarvis billing account. If you're on a hosted plan, you can manage billing from your usejarvis account."
+      >
+        <button className="bl-btn" onClick={billing.refresh}>Check again</button>
+      </Soon>
+    );
+  }
+  if (billing.state === "unavailable" || !billing.summary || !billing.links) {
+    return (
+      <Soon
+        title="Billing is unavailable right now"
+        sub="Your plan and payments couldn't be read from your usejarvis account. Reading them here never changes them."
+      >
+        <button className="bl-btn" onClick={billing.refresh}>Try again</button>
+        {billing.links && (
+          <button className="bl-btn bl-btn--pri" onClick={() => open(billing.links!.page)}>Open billing in browser</button>
+        )}
+      </Soon>
     );
   }
 
-  const info = STATE_META[state];
+  return (
+    <Live
+      summary={billing.summary}
+      links={billing.links}
+      stale={billing.stale}
+      readAt={billing.readAt}
+      onRefresh={billing.refresh}
+      open={open}
+      showAll={showAll}
+      onShowAll={() => setShowAll(true)}
+    />
+  );
+}
 
-  const cancel = async () => {
-    if (await confirmDialog(
-      "Cancel your subscription?\n\nYou keep full access until the end of the current period, and you can resume any time before then.",
-      { confirmLabel: "Cancel subscription" },
-    )) {
-      setState("canceled");
-      onToast("Subscription set to cancel at period end.", "ok");
-    }
-  };
-  const go = (to: BillingState, msg: string) => () => { setState(to); onToast(msg, "ok"); };
+function Live({
+  summary,
+  links,
+  stale,
+  readAt,
+  onRefresh,
+  open,
+  showAll,
+  onShowAll,
+}: {
+  summary: BillingSummary;
+  links: BillingLinks;
+  stale: boolean;
+  readAt: number;
+  onRefresh: () => void;
+  open: (url: string) => void;
+  showAll: boolean;
+  onShowAll: () => void;
+}) {
+  const now = Date.now();
+  const sub = summary.subscription;
+  const state = billingState(sub);
+  const chip = STATE_CHIP[state];
+  const total = recurringTotal(summary.plans);
+  const next = summary.upcomingInvoice;
+  const nextChargeAt = nextChargeDate(summary);
+  const charged = chargedCard(summary);
+  const payments = showAll ? summary.payments : summary.payments.slice(0, HISTORY_PREVIEW);
 
   const actions = (() => {
     switch (state) {
-      case "trialing":
-        return (<><button className="bl-btn bl-btn--pri" onClick={go("active", "Payment method added — trial converted.")}>Add payment method</button><button className="bl-btn" onClick={() => setModal(true)}>Compare plans</button></>);
       case "active":
-        return (<><button className="bl-btn" onClick={() => setModal(true)}>Change plan</button><button className="bl-btn bl-btn--red" onClick={cancel}>Cancel</button></>);
+        return (
+          <>
+            <button className="bl-btn" onClick={() => open(links.changePlan)}>Change plan</button>
+            <button className="bl-btn" onClick={() => open(links.paymentMethod)}>Update card</button>
+            <button className="bl-btn bl-btn--red" onClick={() => open(links.cancel)}>Cancel</button>
+          </>
+        );
+      case "canceling":
+        return (
+          <>
+            <button className="bl-btn bl-btn--pri" onClick={() => open(links.manage)}>Resume subscription</button>
+            <button className="bl-btn" onClick={() => open(links.paymentMethod)}>Update card</button>
+          </>
+        );
       case "past_due":
-        return (<><button className="bl-btn bl-btn--pri" onClick={go("active", "Card updated — payment retried.")}>Update card</button><button className="bl-btn" onClick={go("active", "Retry succeeded.")}>Retry now</button></>);
-      case "canceled":
-        return (<button className="bl-btn bl-btn--pri" onClick={go("active", "Subscription resumed.")}>Resume subscription</button>);
-      case "expired":
-        return (<><button className="bl-btn bl-btn--pri" onClick={go("active", "Resubscribed — your brain is back.")}>Resubscribe</button><button className="bl-btn" onClick={() => window.open("https://usejarvis.com/docs/self-hosting", "_blank", "noopener")}>Self-host guide</button></>);
+        return (
+          <>
+            <button className="bl-btn bl-btn--pri" onClick={() => open(links.paymentMethod)}>Update card</button>
+            <button className="bl-btn" onClick={() => open(links.manage)}>View invoices</button>
+          </>
+        );
+      case "incomplete":
+        return <button className="bl-btn bl-btn--pri" onClick={() => open(links.manage)}>Complete payment</button>;
+      default:
+        return <button className="bl-btn bl-btn--pri" onClick={() => open(links.page)}>Open billing</button>;
     }
   })();
 
-  const showRecords = state === "active" || state === "past_due" || state === "trialing";
-  const invoiceToast = () => onToast("Invoice download needs the billing backend.", "warn");
+  const periodRows: Array<[string, string]> = [];
+  if (sub) {
+    const start = formatDate(sub.currentPeriodStart);
+    const end = formatDate(sub.currentPeriodEnd);
+    if (start && end) periodRows.push(["Current period", `${start} – ${end}`]);
+    else if (end) periodRows.push(["Current period ends", end]);
+    if (state === "active" && next) {
+      const on = formatDate(next.date);
+      periodRows.push(["Next charge", `${formatMoney(next.amountDueCents, next.currency)}${on ? ` on ${on}` : ""}`]);
+    } else if (state === "active" && end) {
+      periodRows.push(["Renews", end]);
+    }
+    if (state === "canceling") {
+      const ends = formatDate(endsAt(sub));
+      if (ends) periodRows.push([Date.parse(endsAt(sub)!) > now ? "Ends" : "Ended", ends]);
+    }
+    if (state === "past_due") {
+      const grace = formatDate(sub.graceUntil);
+      if (grace && sub.graceUntil && Date.parse(sub.graceUntil) > now) periodRows.push(["Online until", grace]);
+    }
+    const since = formatDate(sub.startedAt);
+    if (since) periodRows.push(["Customer since", since]);
+  }
 
   return (
-    <div>
+    <div className="bl-live">
       <div className="bl-sublabel" style={{ marginTop: 4 }}>Plan</div>
       <div className="bl-plan">
         <div className="bl-plan__head">
-          <span className="bl-plan__name">{info.planName}</span>
-          <span className={`bl-chip ${info.chip.tone}`}><span className="d" />{info.chip.label}</span>
-          {info.price && <span className="bl-plan__price">{info.price}</span>}
+          <span className="bl-plan__name">{planTitle(summary.plans)}</span>
+          <span className={`bl-chip ${chip.tone}`}><span className="d" />{chip.label}</span>
+          {total && <span className="bl-plan__price">{formatPrice(total)}</span>}
         </div>
-        <div className="bl-plan__meta">{info.meta}</div>
+        <div className="bl-plan__meta"><Bold text={planMeta(summary, now)} /></div>
         <div className="bl-plan__act">{actions}</div>
       </div>
-      {state === "active" && <div className="bl-allgood"><span className="dot" />All good. Nothing needs you.</div>}
+      {state === "active" && !stale && !needsAttention(summary) && (
+        <div className="bl-allgood"><span className="dot" />All good. Nothing needs you.</div>
+      )}
 
-      {showRecords && (
+      {summary.plans.length > 0 && (
         <>
-          <div className="bl-sublabel">Payment method</div>
+          <div className="bl-sublabel">What's included</div>
           <div className="bl-receipt">
-            <div className="bl-receipt__row"><span>Card</span><span className="v">Visa •••• 4242</span></div>
-            <div className="bl-receipt__row"><span>Expires</span><span className="v">08 / 27</span></div>
-          </div>
-          <div className="bl-sublabel">Billing history</div>
-          <div className="bl-receipt">
-            <div className="bl-receipt__row"><span>Jun 15, 2026 · Hosted + AI</span><span className="v">€29.00 <button className="link" onClick={invoiceToast}>Invoice</button></span></div>
-            <div className="bl-receipt__row"><span>May 15, 2026 · Hosted + AI</span><span className="v">€29.00 <button className="link" onClick={invoiceToast}>Invoice</button></span></div>
+            {summary.plans.map((p) => (
+              <div className="bl-receipt__row" key={p.key || p.name}>
+                <span>{p.quantity > 1 ? `${p.name} × ${p.quantity}` : p.name}</span>
+                <span className="v">{p.prices.length ? p.prices.map((pr) => formatPrice(pr)).join(" · ") : "—"}</span>
+              </div>
+            ))}
           </div>
         </>
       )}
 
-      {modal && (
-        <ChangePlanModal
-          onClose={() => setModal(false)}
-          onConfirm={(c) => { setModal(false); onToast(c === "up" ? "Switched to Max." : "Downgrade scheduled for renewal.", "ok"); }}
-        />
+      {periodRows.length > 0 && (
+        <>
+          <div className="bl-sublabel">Billing period</div>
+          <div className="bl-receipt">
+            {periodRows.map(([k, v]) => (
+              <div className="bl-receipt__row" key={k}><span>{k}</span><span className="v">{v}</span></div>
+            ))}
+          </div>
+        </>
       )}
+
+      <div className="bl-sublabel">Payment method</div>
+      <div className="bl-receipt">
+        {summary.paymentMethods === null && (
+          <div className="bl-receipt__empty">Payment methods can't be read right now.</div>
+        )}
+        {summary.paymentMethods?.length === 0 && (
+          <div className="bl-receipt__row">
+            <span>No saved payment method</span>
+            <button className="link" onClick={() => open(links.paymentMethod)}>Add one</button>
+          </div>
+        )}
+        {summary.paymentMethods?.map((m, i) => {
+          const exp = formatExpiry(m);
+          // Only the card the next charge goes to can make that charge fail.
+          const isCharged = m === charged;
+          const expiring = isCharged && cardExpiresBefore(m, nextChargeAt);
+          return (
+            <div className="bl-receipt__row" key={`${m.brand}-${m.last4}-${i}`}>
+              <span className="bl-pm">
+                <span className="v">{brandLabel(m.brand)} •••• {m.last4 || "????"}</span>
+                {m.isDefault && <span className="bl-chip neutral"><span className="d" />Default</span>}
+              </span>
+              <span className="bl-row-end">
+                {exp && <span className={expiring ? "bl-exp bl-exp--warn" : "bl-exp"}>{expiring ? `Expires ${exp} · before your next charge` : `Expires ${exp}`}</span>}
+                <button className="link" onClick={() => open(links.paymentMethod)}>Update</button>
+              </span>
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="bl-sublabel">Billing history</div>
+      <div className="bl-receipt">
+        {summary.payments.length === 0 && <div className="bl-receipt__empty">No payments yet.</div>}
+        {payments.map((p) => {
+          const row = paymentRow(p);
+          const date = formatDate(p.paidAt);
+          return (
+            <div className="bl-receipt__row" key={p.id}>
+              <span>{date ? `${date} · ` : ""}{row.label}</span>
+              <span className="bl-row-end">
+                <span className="v">
+                  {row.amount}
+                  {row.tax && <span className="bl-tax"> incl. {row.tax} tax</span>}
+                </span>
+                {isHttpsUrl(p.invoiceUrl) && <button className="link" onClick={() => open(p.invoiceUrl!)}>Invoice</button>}
+                {isHttpsUrl(p.invoicePdfUrl) && <button className="link" onClick={() => open(p.invoicePdfUrl!)}>PDF</button>}
+              </span>
+            </div>
+          );
+        })}
+        {!showAll && summary.payments.length > HISTORY_PREVIEW && (
+          <div className="bl-receipt__row">
+            <button className="link" onClick={onShowAll}>Show all {summary.payments.length} payments</button>
+          </div>
+        )}
+      </div>
+
+      <div className="bl-sublabel">Account</div>
+      <div className="bl-receipt">
+        {summary.account.email && (
+          <div className="bl-receipt__row"><span>Billing email</span><span className="v">{summary.account.email}</span></div>
+        )}
+        <div className="bl-receipt__row">
+          <span>Invoices, receipts and billing details</span>
+          <button className="link" onClick={() => open(links.manage)}>Manage <ExternalLink size={11} strokeWidth={2} /></button>
+        </div>
+      </div>
+
+      <div className="bl-foot">
+        <span>
+          {stale ? "Couldn't refresh · showing your last read" : readAt ? `Updated ${new Date(readAt).toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit" })}` : ""}
+          {" · "}Changes open your account in the browser.
+        </span>
+        <button className="bl-foot__refresh" onClick={onRefresh} aria-label="Refresh billing">
+          <RefreshCw size={12} strokeWidth={2} /> Refresh
+        </button>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Hosted brains read their owner's billing summary from the control plane as the instance: a new system-owned `usejarvis_billing` config block (endpoint, instance id, per-instance secret, account page URL), an HMAC-signed read like the usage meter, and `GET /api/billing` for the UI. The endpoint, instance id and secret never reach the browser.
- Settings -> Billing shows the plan and status, what's included, the billing period and next charge, saved cards (default marker, warning when the charged card expires before the next charge), payment history with invoice and PDF links, and the billing email. The shell banner covers past-due, a scheduled cancel and an incomplete first payment.
- The credential is read-only on purpose. Every action opens the account billing page in the system browser (`page_url?action=manage|payment-method|change-plan|cancel`), where the user's own session and Stripe's confirm screen authorize the change. A compromised assistant can read the bill, never change it.
- Self-hosted installs get a 503 and a calm "no bill on this Jarvis" page; a hosted install without the block says billing isn't connected. Reads are cached 60s, re-read on focus when coming back from the browser, and keep the last good bill on screen if a refresh fails.
- The `#/_billing` design gallery keeps its sample vocabulary; the localStorage demo state is gone.

## Depends on

The control-plane side (rendering `usejarvis_billing` into instance configs, `POST /api/billing/instance`, the `/billing?action=` portal deep links) lands separately. Until instances are converged the block is absent and the page says billing isn't connected, so this is safe to ship first.

## Testing

- `bun test src/daemon/hosted-billing.test.ts src/daemon/api-billing.test.ts src/config/loader.test.ts ui/src/v2/billing` (75 pass)
- `bunx tsc --noEmit -p tsconfig.json` clean (includes `ui/`)
- Not yet checked visually in a browser.