### PR TITLE
Hide the Billing settings tab on self-hosted installs

### DIFF
--- a/ui/src/v2/billing/billing-view.test.ts
+++ b/ui/src/v2/billing/billing-view.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, test } from 'bun:test';
 import {
   bannerFor,
+  billingRecheckDue,
   billingState,
   billingTabVisible,
+  SELF_HOSTED_RECHECK_MS,
   boldSegments,
   brandLabel,
   cardExpiresBefore,
@@ -105,6 +107,17 @@ describe('the Settings tab', () => {
     expect(billingTabVisible('unavailable')).toBe(true);
     // Not known yet (or the read is failing): never hide a hosted user's page.
     expect(billingTabVisible('unknown')).toBe(true);
+  });
+
+  test('a self-hosted answer is re-asked rarely, so a brain that becomes hosted gets its tab back without a reload', () => {
+    const t0 = 1_000_000;
+    expect(billingRecheckDue('self', t0, t0 + 60_000)).toBe(false);
+    expect(billingRecheckDue('self', t0, t0 + SELF_HOSTED_RECHECK_MS - 1)).toBe(false);
+    expect(billingRecheckDue('self', t0, t0 + SELF_HOSTED_RECHECK_MS)).toBe(true);
+    // Everything else polls as usual.
+    for (const state of ['unknown', 'ready', 'unavailable'] as const) {
+      expect(billingRecheckDue(state, t0, t0 + 1)).toBe(true);
+    }
   });
 });
 

--- a/ui/src/v2/billing/billing-view.test.ts
+++ b/ui/src/v2/billing/billing-view.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test';
 import {
   bannerFor,
   billingState,
+  billingTabVisible,
   boldSegments,
   brandLabel,
   cardExpiresBefore,
@@ -93,6 +94,17 @@ describe('classifying GET /api/billing', () => {
   test('unavailable keeps the links so the user still has a way to their account', () => {
     expect(classifyBillingResponse(200, { ok: false, error: 'x', links: LINKS })).toEqual({ kind: 'unavailable', links: LINKS });
     expect(classifyBillingResponse(200, { ok: false, error: 'x', links: null })).toEqual({ kind: 'unavailable', links: null });
+  });
+});
+
+describe('the Settings tab', () => {
+  test('is hidden only when the daemon has said the install is self-hosted', () => {
+    expect(billingTabVisible('self')).toBe(false);
+    expect(billingTabVisible('ready')).toBe(true);
+    // Hosted but not connected still has somewhere to point the user.
+    expect(billingTabVisible('unavailable')).toBe(true);
+    // Not known yet (or the read is failing): never hide a hosted user's page.
+    expect(billingTabVisible('unknown')).toBe(true);
   });
 });
 

--- a/ui/src/v2/billing/billing-view.ts
+++ b/ui/src/v2/billing/billing-view.ts
@@ -121,6 +121,19 @@ export function isHttpsUrl(v: string | null): v is string {
   return typeof v === "string" && /^https:\/\//.test(v);
 }
 
+/**
+ * Whether Settings shows a Billing tab at all.
+ *
+ * Hidden only once the daemon has SAID this install is self-hosted (its 503):
+ * there is no bill here, so there is nothing to show. While the first read is
+ * still out, or failing, the tab stays — a hosted user must never lose their
+ * Billing page to a slow or broken request. The shell banner starts that read
+ * at app load, so a self-hosted user rarely sees the tab at all.
+ */
+export function billingTabVisible(loadState: "unknown" | "self" | "ready" | "unavailable"): boolean {
+  return loadState !== "self";
+}
+
 // ── Formatting ─────────────────────────────────────────────────────────────
 
 /**

--- a/ui/src/v2/billing/billing-view.ts
+++ b/ui/src/v2/billing/billing-view.ts
@@ -134,6 +134,25 @@ export function billingTabVisible(loadState: "unknown" | "self" | "ready" | "una
   return loadState !== "self";
 }
 
+/** How often a self-hosted answer is asked again. The daemon answers it locally, so it is free. */
+export const SELF_HOSTED_RECHECK_MS = 10 * 60_000;
+
+/**
+ * Whether a poll or a return to the app should read billing again.
+ *
+ * Always, except for an install already known to be self-hosted: that one is
+ * asked again only every SELF_HOSTED_RECHECK_MS, so a brain that becomes hosted
+ * (its config converged) grows its Billing tab without a reload, while a
+ * self-hosted one is not polled every minute for a bill it will never have.
+ */
+export function billingRecheckDue(
+  loadState: "unknown" | "self" | "ready" | "unavailable",
+  readAt: number,
+  now: number,
+): boolean {
+  return loadState !== "self" || now - readAt >= SELF_HOSTED_RECHECK_MS;
+}
+
 // ── Formatting ─────────────────────────────────────────────────────────────
 
 /**

--- a/ui/src/v2/billing/useBilling.ts
+++ b/ui/src/v2/billing/useBilling.ts
@@ -1,5 +1,6 @@
 import { useEffect, useSyncExternalStore } from "react";
 import {
+  billingRecheckDue,
   classifyBillingResponse,
   type BillingLinks,
   type BillingSummary,
@@ -28,7 +29,7 @@ export interface BillingSnapshot {
   links: BillingLinks | null;
   /** The last read failed or answered "unavailable" while a summary is shown. */
   stale: boolean;
-  /** When the current summary was read; 0 before any. */
+  /** When the current summary (or the self-hosted answer) was read; 0 before any. */
   readAt: number;
 }
 
@@ -60,7 +61,8 @@ async function load(fresh: boolean): Promise<void> {
     if (probe.kind === "failed") throw new Error(`HTTP ${res.status}`);
     backoff = RETRY_MS;
     if (probe.kind === "self") {
-      publish({ ...INITIAL, state: "self" });
+      // readAt stamps the answer, so it is re-asked only rarely (billingRecheckDue).
+      publish({ ...INITIAL, state: "self", readAt: Date.now() });
     } else if (probe.kind === "ready") {
       publish({ state: "ready", summary: probe.summary, links: probe.links, stale: false, readAt: Date.now() });
     } else if (snapshot.summary) {
@@ -87,13 +89,13 @@ async function load(fresh: boolean): Promise<void> {
 let pollTimer: number | null = null;
 
 function onReturn(): void {
-  if (!document.hidden && snapshot.state !== "self") void load(true);
+  if (!document.hidden && billingRecheckDue(snapshot.state, snapshot.readAt, Date.now())) void load(true);
 }
 
 function start(): void {
   void load(false);
   pollTimer = window.setInterval(() => {
-    if (!document.hidden && snapshot.state !== "self") void load(false);
+    if (!document.hidden && billingRecheckDue(snapshot.state, snapshot.readAt, Date.now())) void load(false);
   }, BILLING_POLL_MS);
   window.addEventListener("focus", onReturn);
   document.addEventListener("visibilitychange", onReturn);
@@ -117,13 +119,20 @@ function subscribe(listener: () => void): () => void {
   };
 }
 
-export function useBilling(): BillingSnapshot & { refresh: () => void } {
+export function useBilling(
+  /**
+   * `refreshOnMount: false` for callers that only need the load state (the
+   * Settings tab list): they must not turn opening Settings into a read.
+   */
+  opts: { refreshOnMount?: boolean } = {},
+): BillingSnapshot & { refresh: () => void } {
   const snap = useSyncExternalStore(subscribe, () => snapshot, () => INITIAL);
+  const refreshOnMount = opts.refreshOnMount ?? true;
   // Opening Settings -> Billing is itself a reason to look again, including
   // onto an "unavailable" screen, which schedules no retry of its own. The very
   // first mount already loads through subscribe().
   useEffect(() => {
-    if (snapshot.state === "ready" || snapshot.state === "unavailable") void load(true);
-  }, []);
+    if (refreshOnMount && (snapshot.state === "ready" || snapshot.state === "unavailable")) void load(true);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps -- a mount-time read, by definition
   return { ...snap, refresh: () => void load(true) };
 }

--- a/ui/src/v2/rooms/settings/SettingsRoom.tsx
+++ b/ui/src/v2/rooms/settings/SettingsRoom.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import {
   Bot,
   Cable,
@@ -28,6 +28,8 @@ import { VoiceTab } from "./tabs/VoiceTab";
 import { IntegrationsTab } from "./tabs/IntegrationsTab";
 import { SidecarTab } from "./tabs/SidecarTab";
 import { BillingTab } from "./tabs/BillingTab";
+import { useBilling } from "../../billing/useBilling";
+import { billingTabVisible } from "../../billing/billing-view";
 import "./SettingsRoom.css";
 
 export type SettingsTab =
@@ -55,12 +57,24 @@ const VALID_TABS = new Set<SettingsTab>(TABS.map((t) => t.key));
 
 export type RoomBodyMode = "inline" | "expanded";
 
-const TAB_KEYS = TABS.map((t) => t.key) as ReadonlyArray<SettingsTab>;
-
 export function SettingsRoomBody({ mode }: { mode: RoomBodyMode }) {
   const data = useSettingsData();
   const [tab, setTab] = useState<SettingsTab>("general");
-  const tabsApi = useRovingTabs<SettingsTab>(TAB_KEYS, tab, setTab, "v2-set");
+  // A self-hosted install has no bill, so it gets no Billing tab. Same shared
+  // store as the shell banner, so this costs no extra request; see
+  // billingTabVisible for why the tab stays while the answer is not known yet.
+  const showBilling = billingTabVisible(useBilling().state);
+  const visibleTabs = useMemo(
+    () => (showBilling ? TABS : TABS.filter((t) => t.key !== "billing")),
+    [showBilling],
+  );
+  const visibleKeys = useMemo(() => visibleTabs.map((t) => t.key), [visibleTabs]);
+  const tabsApi = useRovingTabs<SettingsTab>(visibleKeys, tab, setTab, "v2-set");
+  // Sitting on Billing when the install turns out to be self-hosted: move off
+  // a tab that no longer exists.
+  useEffect(() => {
+    if (!showBilling && tab === "billing") setTab("general");
+  }, [showBilling, tab]);
   const [toast, setToast] = useState<{ text: string; tone: "ok" | "warn" } | null>(null);
 
   const showToast = useCallback((text: string, tone: "ok" | "warn" = "ok") => {
@@ -98,7 +112,7 @@ export function SettingsRoomBody({ mode }: { mode: RoomBodyMode }) {
     switch (action) {
       case "switch_tab": {
         const t = String(args.tab);
-        if (VALID_TABS.has(t as SettingsTab)) {
+        if (VALID_TABS.has(t as SettingsTab) && (showBilling || t !== "billing")) {
           setTab(t as SettingsTab);
           return true;
         }
@@ -358,7 +372,7 @@ export function SettingsRoomBody({ mode }: { mode: RoomBodyMode }) {
         aria-label="Settings sections"
         ref={tabsApi.tablistRef}
       >
-        {TABS.map((t) => (
+        {visibleTabs.map((t) => (
           <button
             key={t.key}
             type="button"
@@ -384,7 +398,7 @@ export function SettingsRoomBody({ mode }: { mode: RoomBodyMode }) {
             {tab === "channels" && <ChannelsTab data={data} onToast={showToast} />}
             {tab === "voice" && <VoiceTab data={data} onToast={showToast} />}
             {tab === "integrations" && <IntegrationsTab data={data} onToast={showToast} />}
-            {tab === "billing" && <BillingTab data={data} onToast={showToast} />}
+            {tab === "billing" && showBilling && <BillingTab data={data} onToast={showToast} />}
             {tab === "sidecar" && <SidecarTab data={data} onToast={showToast} />}
           </>
         )}

--- a/ui/src/v2/rooms/settings/SettingsRoom.tsx
+++ b/ui/src/v2/rooms/settings/SettingsRoom.tsx
@@ -61,25 +61,30 @@ export function SettingsRoomBody({ mode }: { mode: RoomBodyMode }) {
   const data = useSettingsData();
   const [tab, setTab] = useState<SettingsTab>("general");
   // A self-hosted install has no bill, so it gets no Billing tab. Same shared
-  // store as the shell banner, so this costs no extra request; see
-  // billingTabVisible for why the tab stays while the answer is not known yet.
-  const showBilling = billingTabVisible(useBilling().state);
+  // store as the shell banner, and refreshOnMount: false so opening Settings
+  // does not itself trigger a read; see billingTabVisible for why the tab stays
+  // while the answer is not known yet.
+  const showBilling = billingTabVisible(useBilling({ refreshOnMount: false }).state);
   const visibleTabs = useMemo(
     () => (showBilling ? TABS : TABS.filter((t) => t.key !== "billing")),
     [showBilling],
   );
   const visibleKeys = useMemo(() => visibleTabs.map((t) => t.key), [visibleTabs]);
   const tabsApi = useRovingTabs<SettingsTab>(visibleKeys, tab, setTab, "v2-set");
-  // Sitting on Billing when the install turns out to be self-hosted: move off
-  // a tab that no longer exists.
-  useEffect(() => {
-    if (!showBilling && tab === "billing") setTab("general");
-  }, [showBilling, tab]);
   const [toast, setToast] = useState<{ text: string; tone: "ok" | "warn" } | null>(null);
 
   const showToast = useCallback((text: string, tone: "ok" | "warn" = "ok") => {
     setToast({ text, tone });
   }, []);
+
+  // Sitting on Billing when the install turns out to be self-hosted (possible
+  // only before the first read lands): move off a tab that no longer exists,
+  // and say why, so the jump is not a mystery.
+  useEffect(() => {
+    if (showBilling || tab !== "billing") return;
+    setTab("general");
+    showToast("This Jarvis is self-hosted, so there's no billing to show.", "ok");
+  }, [showBilling, tab, showToast]);
 
   useEffect(() => {
     if (!toast) return;


### PR DESCRIPTION
## Summary

- Settings no longer shows a Billing tab once the daemon confirms the install is self-hosted (`GET /api/billing` answers 503): there is no bill there, so there is nothing to show.
- While that first read is still out or failing, the tab stays, so a hosted user never loses their Billing page to a slow or broken request. The shell banner already starts the read at app load (same shared store), so self-hosted users rarely see the tab at all.
- Settings reads the load state with `useBilling({ refreshOnMount: false })`, so opening Settings does not itself trigger a billing read.
- If the tab was open when the install turns out to be self-hosted, Settings moves to General and says why with a toast; the voice `switch_tab` action refuses `billing` there too.
- A self-hosted answer is re-checked every 10 minutes (answered locally by the daemon), so a brain that becomes hosted gets its tab back without a reload.
- A hosted install without a billing block still shows the tab with its "not connected" state.

## Testing

- `bun test ui/src/v2/billing` (new `billingTabVisible` and `billingRecheckDue` cases)
- Pre-commit: full test suite and typecheck