### PR TITLE
Recover hosted voice turns from proxy routing misses and apply the realtime toggle to a connected pebble

### DIFF
--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -22,7 +22,7 @@ import { AgentService } from "./agent-service.ts";
 import { createObservation } from "../vault/observations.ts";
 import { ObserverService, mapEventType } from "./observer-service.ts";
 import { WebSocketService } from "./ws-service.ts";
-import { PebbleRealtimeManager } from "./pebble-realtime.ts";
+import { PebbleRealtimeManager, wireRealtimeReadvertisement } from "./pebble-realtime.ts";
 import { hostedRealtimeIncluded, warmRealtimeGateFor } from './realtime-gate.ts';
 import { resolveRealtimeVoice } from "../config/realtime.ts";
 import { realtimeEnablement } from "./usejarvis-ai.ts";
@@ -105,10 +105,6 @@ let systemCron: import('./system-cron.ts').SystemCronService | null = null;
 let usageAlerts: import('./usage-alerts-service.ts').UsageAlertsService | null = null;
 let timerScheduler: TimerWaitpointScheduler | null = null;
 let settingsReload: import('./settings-reload.ts').SettingsReloadCoordinator | null = null;
-/** Set once the sidecar manager is up; re-pushes the pebble realtime
- * capability after a settings reload (a plan change arrives that way, and the
- * advertisement is otherwise computed only at connect). */
-let readvertiseRealtime: (() => Promise<void>) | null = null;
 /** Graceful-drain deadline (ms), set from config at boot. Default 75s. */
 let drainDeadlineMs = 75_000;
 
@@ -901,6 +897,12 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
         // The advertisement must agree with the starters' plan gate, or the
         // summon hotkey opens sessions the plan refuses at dial.
         const enabled = res.ok && (await hostedRealtimeIncluded(res.resolved));
+        // Realtime switched off (or excluded) while a live session is open: end
+        // the billed session here rather than trusting the sidecar to report
+        // back, since the RPC below is swallowed on an older or half-dead
+        // sidecar. stop() is idempotent and its closed echo makes the sidecar
+        // stop without re-emitting.
+        if (!enabled) pebbleRealtime.stop(sidecarId);
         console.log(`[pebble-realtime] configure_realtime → ${sidecarId} enabled=${enabled}${res.ok ? '' : ` (${res.reason})`}`);
         await sidecarManager.dispatchRPC(sidecarId, 'pebble.configure_realtime', { enabled })
           .catch((err) => console.warn(`[pebble-realtime] configure_realtime dispatch failed (older sidecar?):`, err));
@@ -910,18 +912,15 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
       // excluded realtime keeps its summon hotkey in one-shot mode until it
       // reconnects — even after an upgrade. reloadAll clears the gate cache,
       // so this re-asks the catalog rather than repeating a stale verdict.
-      readvertiseRealtime = async () => {
+      const readvertiseRealtime = async () => {
         for (const s of sidecarManager.listConnected()) {
           if (s.capabilities.includes('pebble')) await advertiseRealtime(s.id);
         }
       };
-      // Registered on the coordinator (not just the SIGHUP handler) so BOTH
-      // reload entry points — SIGHUP and POST /api/config/reload — re-push
-      // the advertisement; the route previously cleared the gate cache but
-      // left every connected pebble on its stale configure_realtime verdict.
-      settingsReload?.setPostReloadAll(async () => {
-        await readvertiseRealtime?.();
-      });
+      // Re-pushed on a `voice` save (the realtime toggle) and on every
+      // reloadAll (SIGHUP and POST /api/config/reload); see
+      // wireRealtimeReadvertisement for why the pebble needs both.
+      if (settingsReload) wireRealtimeReadvertisement(settingsReload, readvertiseRealtime);
       sidecarManager.onSidecarConnected((sidecar) => {
         if (!sidecar.capabilities.includes('pebble')) return;
         // The listener is typed `=> void` and the dispatch loop only catches
@@ -3990,7 +3989,10 @@ export async function startDaemon(userConfig?: Partial<DaemonConfig>): Promise<v
     settingsReload.registerApplier('awareness', async (cfg) => {
       awarenessService?.toggle(cfg.awareness?.enabled !== false);
     });
-    // voice needs no applier: resolveRealtimeVoice reads live config per call.
+    // voice: resolveRealtimeVoice reads live config per call, so the dashboard
+    // needs no applier, but a connected pebble keeps the realtime verdict it
+    // was sent; its re-push applier is wired beside the pebble voice loop
+    // (wireRealtimeReadvertisement).
 
     // ── Tray menu live data (design: usejarvis-tray §00) ──
     // Push a status snapshot to each connected sidecar every few seconds so the

--- a/src/daemon/pebble-realtime-readvertise.test.ts
+++ b/src/daemon/pebble-realtime-readvertise.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { DEFAULT_CONFIG } from '../config/types.ts';
+import { closeDb, initDatabase } from '../vault/schema.ts';
+import { wireRealtimeReadvertisement } from './pebble-realtime.ts';
+import { SettingsReloadCoordinator } from './settings-reload.ts';
+import { persistUserPatch, setSectionSavedListener } from './user-settings.ts';
+
+/**
+ * A connected pebble keeps the configure_realtime verdict it was sent, so a
+ * realtime toggle must re-push it. On 2026-09-10 realtime was switched on in
+ * Settings and every summon still ran the one-shot pipeline: a `voice` save
+ * had no applier, and the advertisement went out again only on reconnect or a
+ * full reload.
+ */
+describe('wireRealtimeReadvertisement', () => {
+  let secretsDir: string;
+  let prevSecretsDir: string | undefined;
+  let coordinator: SettingsReloadCoordinator;
+  let wiring: { settled: () => Promise<void> };
+  let pushes: number;
+
+  beforeEach(() => {
+    prevSecretsDir = process.env.JARVIS_SECRETS_DIR;
+    secretsDir = mkdtempSync(join(tmpdir(), 'jarvis-readvertise-'));
+    process.env.JARVIS_SECRETS_DIR = secretsDir;
+    initDatabase(':memory:');
+    coordinator = new SettingsReloadCoordinator(structuredClone(DEFAULT_CONFIG), {
+      googleTokensPath: join(secretsDir, 'google-tokens.json'),
+    });
+    pushes = 0;
+    wiring = wireRealtimeReadvertisement(coordinator, async () => {
+      pushes++;
+    });
+    // The daemon's choke-point hook (daemon/index.ts), so a save reaches the
+    // coordinator exactly the way POST /api/config/voice's does.
+    setSectionSavedListener((section) => coordinator.sectionChanged(section));
+  });
+
+  afterEach(() => {
+    setSectionSavedListener(null);
+    closeDb();
+    if (prevSecretsDir === undefined) delete process.env.JARVIS_SECRETS_DIR;
+    else process.env.JARVIS_SECRETS_DIR = prevSecretsDir;
+    rmSync(secretsDir, { recursive: true, force: true });
+  });
+
+  test('saving the voice section (the realtime toggle) re-pushes the advertisement', async () => {
+    persistUserPatch('voice', { realtime: { enabled: true } });
+    await coordinator.whenIdle();
+    await wiring.settled();
+    expect(pushes).toBe(1);
+  });
+
+  test('a burst of voice saves coalesces into one push', async () => {
+    persistUserPatch('voice', { realtime: { enabled: true } });
+    persistUserPatch('voice', { realtime: { enabled: false } });
+    await coordinator.whenIdle();
+    await wiring.settled();
+    expect(pushes).toBe(1);
+  });
+
+  test('another section changing does not re-push', async () => {
+    coordinator.sectionChanged('awareness');
+    await coordinator.whenIdle();
+    await wiring.settled();
+    expect(pushes).toBe(0);
+  });
+
+  test('a full reload re-pushes too (SIGHUP and POST /api/config/reload)', async () => {
+    await coordinator.reloadAll();
+    await wiring.settled();
+    expect(pushes).toBe(1);
+  });
+
+  test('requests made while a push waits to start collapse into it', async () => {
+    // A half-open sidecar parks the first push; repeated reloads meanwhile
+    // must queue ONE more push (it reads the latest config), not one each.
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    let started = 0;
+    const slow = new SettingsReloadCoordinator(structuredClone(DEFAULT_CONFIG), {
+      googleTokensPath: join(secretsDir, 'google-tokens.json'),
+    });
+    const slowWiring = wireRealtimeReadvertisement(slow, async () => {
+      started++;
+      if (started === 1) await gate;
+    });
+    await slow.reloadAll(); // push 1 starts and parks
+    await slow.reloadAll(); // queues push 2
+    await slow.reloadAll(); // collapses into push 2
+    await slow.reloadAll(); // collapses into push 2
+    release();
+    await slowWiring.settled();
+    expect(started).toBe(2);
+  });
+
+  test('a slow push never holds up the coordinator queue', async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const slow = new SettingsReloadCoordinator(structuredClone(DEFAULT_CONFIG), {
+      googleTokensPath: join(secretsDir, 'google-tokens.json'),
+    });
+    const slowWiring = wireRealtimeReadvertisement(slow, () => gate);
+    let otherApplied = false;
+    slow.registerApplier('awareness', () => {
+      otherApplied = true;
+    });
+    slow.sectionChanged('voice');
+    slow.sectionChanged('awareness');
+    // Resolves even though the push is still parked on its RPC.
+    await slow.whenIdle();
+    expect(otherApplied).toBe(true);
+    release();
+    await slowWiring.settled();
+  });
+});

--- a/src/daemon/pebble-realtime.ts
+++ b/src/daemon/pebble-realtime.ts
@@ -316,3 +316,65 @@ export class PebbleRealtimeManager {
     for (const id of [...this.sessions.keys()]) this.stop(id);
   }
 }
+
+/** How long a burst of voice saves (a toggle, then a voice pick) settles
+ * before the advertisement is re-pushed once. */
+const READVERTISE_DEBOUNCE_MS = 250;
+
+/**
+ * Keep every connected pebble's `configure_realtime` advertisement in step
+ * with the settings that decide it.
+ *
+ * The advertisement is pushed when a sidecar connects, and the sidecar keeps
+ * it: its summon hotkey acts on that verdict, not on the daemon's config. So
+ * "resolveRealtimeVoice reads live config per call" holds for the dashboard's
+ * voice_start but not for the pebble, and two triggers have to re-push it:
+ *
+ * - a `voice` section save, which is where the realtime toggle lands
+ *   (POST /api/config/voice, through the saveUserSection choke point).
+ *   Without it a toggle reached a connected pebble only on reconnect: on
+ *   2026-09-10 realtime was switched on in Settings and every summon still
+ *   ran the one-shot pipeline;
+ * - every reloadAll (SIGHUP and POST /api/config/reload), whose cause can be
+ *   the SYSTEM-owned usejarvis_ai block that no section applier watches.
+ *
+ * NOT covered: on a self-hosted install a BYO OpenAI key decides whether
+ * realtime is available, and `llm` saves (POST /api/config/llm and the
+ * onboarding route) bypass saveUserSection, so adding or removing that key
+ * reaches a connected pebble only on reconnect or reload. Hosted installs are
+ * unaffected, since the plan serves realtime there. Closing it means those
+ * routes applying through the coordinator the way the STT/TTS routes do.
+ *
+ * Pushes run on their OWN serialized chain, not on the coordinator's queue.
+ * Awaiting them there would park every other applier behind a sidecar RPC,
+ * whose timeout is 30s for a half-open socket (a laptop lid closed, no RST
+ * yet), and the STT/TTS routes await that queue for their HTTP response. They
+ * stay in order among themselves because each push reads the config when its
+ * turn comes, so the last one always reflects the latest save; two concurrent
+ * pushes could otherwise land an older verdict after a newer one. For the same
+ * reason a request made while a push is queued but not yet started is dropped:
+ * that push will read the config the request would have. A reload that also
+ * changed `voice` therefore pushes at most twice, and the push is idempotent.
+ *
+ * Returns `settled`, which resolves once every push requested so far has run.
+ */
+export function wireRealtimeReadvertisement(
+  coordinator: Pick<import('./settings-reload.ts').SettingsReloadCoordinator, 'registerApplier' | 'setPostReloadAll'>,
+  readvertise: () => Promise<void>,
+): { settled: () => Promise<void> } {
+  let chain: Promise<void> = Promise.resolve();
+  let queued = false;
+  const push = () => {
+    if (queued) return;
+    queued = true;
+    chain = chain
+      .then(() => {
+        queued = false;
+        return readvertise();
+      })
+      .catch((err) => console.warn('[pebble-realtime] re-advertisement failed:', err));
+  };
+  coordinator.registerApplier('voice', push, { debounceMs: READVERTISE_DEBOUNCE_MS });
+  coordinator.setPostReloadAll(async () => push());
+  return { settled: () => chain };
+}

--- a/src/llm/usejarvis-routing-miss.test.ts
+++ b/src/llm/usejarvis-routing-miss.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import { LLMManager } from './manager.ts';
+import { LLMProviderError, type LLMStreamEvent } from './provider.ts';
+import { UsejarvisAIProvider } from './usejarvis.ts';
+
+/**
+ * The hosted proxy answers 400 when the replica that took the request holds no
+ * deployment for the model. A /model/update in flight evicts every DB model
+ * from that replica for a few hundred ms, and on 2026-09-10 that failed a
+ * hosted voice turn on attempt 1 of 3. It is the proxy's own transient state,
+ * not a bad request, so it must retry instead of failing the turn.
+ */
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+const jsonResponse = (status: number, body: unknown) =>
+  new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } });
+
+/** Verbatim shape of the body the proxy returned in the incident. */
+const ROUTING_MISS = {
+  error: {
+    message:
+      'litellm.BadRequestError: You passed in model=gpt-5.6-luna. There are no healthy deployments for this model. ' +
+      'Received Model Group=gpt-5.6-luna\nAvailable Model Group Fallbacks=None',
+    type: null,
+    param: null,
+    code: '400',
+  },
+};
+
+const OK_SSE = [
+  'data: ' + JSON.stringify({
+    id: 'c1', object: 'chat.completion.chunk', created: 1, model: 'uj-chat',
+    choices: [{ index: 0, delta: { role: 'assistant', content: 'hey' }, finish_reason: null }],
+  }),
+  'data: ' + JSON.stringify({
+    id: 'c1', object: 'chat.completion.chunk', created: 1, model: 'uj-chat',
+    choices: [{ index: 0, delta: {}, finish_reason: 'stop' }],
+  }),
+  'data: [DONE]', '',
+].join('\n');
+
+const provider = () => new UsejarvisAIProvider('https://llm.usejarvis.host', 'sk-uj-abc');
+
+async function streamErrorFor(status: number, body: unknown) {
+  globalThis.fetch = (async () => jsonResponse(status, body)) as unknown as typeof fetch;
+  const events: LLMStreamEvent[] = [];
+  for await (const ev of provider().stream([{ role: 'user', content: 'hi' }], { model: 'uj-chat' })) {
+    events.push(ev);
+  }
+  return events.find((e) => e.type === 'error') as Extract<LLMStreamEvent, { type: 'error' }>;
+}
+
+describe('UsejarvisAIProvider routing miss', () => {
+  it('tags the stream error as a retryable server fault with a short pause, body still withheld', async () => {
+    const err = await streamErrorFor(400, ROUTING_MISS);
+    expect(err.code).toBe('server');
+    expect(err.retry_after_ms).toBe(1000);
+    expect(err.error).toMatch(/\(400\)/);
+    expect(err.error).not.toMatch(/gpt-5\.6-luna|healthy deployments/);
+  });
+
+  it('throws a retryable LLMProviderError from chat, body still withheld', async () => {
+    globalThis.fetch = (async () => jsonResponse(400, ROUTING_MISS)) as unknown as typeof fetch;
+    const err = await provider().chat([{ role: 'user', content: 'hi' }], { model: 'uj-chat' }).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(LLMProviderError);
+    expect((err as LLMProviderError).code).toBe('server');
+    expect((err as LLMProviderError).retryAfterMs).toBe(1000);
+    expect((err as LLMProviderError).message).not.toMatch(/gpt-5\.6-luna|healthy deployments/);
+  });
+
+  it('leaves an ordinary 400 non-retryable', async () => {
+    const err = await streamErrorFor(400, { error: { message: 'some other invalid_request_error' } });
+    // The base class's status-derived code, untouched.
+    expect(err.code).toBe('bad_request');
+    expect(err.retry_after_ms).toBeUndefined();
+    globalThis.fetch = (async () => jsonResponse(400, { error: { message: 'some other invalid_request_error' } })) as unknown as typeof fetch;
+    const thrown = await provider().chat([{ role: 'user', content: 'hi' }], { model: 'uj-chat' }).catch((e: unknown) => e);
+    expect(thrown).toBeInstanceOf(Error);
+    expect(thrown).not.toBeInstanceOf(LLMProviderError);
+    expect((thrown as Error).message).toMatch(/\(400\)/);
+  });
+
+  it('leaves a 429 carrying router wording on the rate-limit path (it also fails over)', async () => {
+    const err = await streamErrorFor(429, {
+      error: { message: 'litellm.RateLimitError: No deployments available for selected model, Try again in 5 seconds.' },
+    });
+    expect(err.code).toBe('rate_limit');
+    expect(err.error).toMatch(/\(429\)/);
+  });
+
+  /** The tier paths production runs (streamTier / chatTier). */
+  function tieredManager(): LLMManager {
+    const manager = new LLMManager();
+    manager.registerProvider(provider());
+    manager.setTierMap({ conversation: { provider: 'usejarvis_ai' } });
+    return manager;
+  }
+
+  it('streamTier retries it and the turn completes on the next attempt', async () => {
+    let calls = 0;
+    globalThis.fetch = (async () => {
+      calls++;
+      return calls === 1
+        ? jsonResponse(400, ROUTING_MISS)
+        : new Response(OK_SSE, { status: 200, headers: { 'Content-Type': 'text/event-stream' } });
+    }) as unknown as typeof fetch;
+    const events: LLMStreamEvent[] = [];
+    const stream = tieredManager().streamTier('conversation', 'test', [{ role: 'user', content: 'hi' }], { model: 'uj-chat' });
+    for await (const ev of stream) events.push(ev);
+    expect(calls).toBe(2);
+    expect(events.some((e) => e.type === 'error')).toBe(false);
+    expect(events.flatMap((e) => (e.type === 'text' ? [e.text] : [])).join('')).toBe('hey');
+  });
+
+  it('chatTier retries it and the call succeeds on the next attempt', async () => {
+    let calls = 0;
+    globalThis.fetch = (async () => {
+      calls++;
+      return calls === 1
+        ? jsonResponse(400, ROUTING_MISS)
+        : jsonResponse(200, {
+            id: 'x',
+            object: 'chat.completion',
+            model: 'uj-chat',
+            choices: [{ index: 0, finish_reason: 'stop', message: { role: 'assistant', content: 'hi' } }],
+            usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+          });
+    }) as unknown as typeof fetch;
+    const result = await tieredManager().chatTier('conversation', 'test', [{ role: 'user', content: 'hi' }], { model: 'uj-chat' });
+    expect(calls).toBe(2);
+    // The retried response is the one surfaced.
+    expect(result.content).toBe('hi');
+  });
+});

--- a/src/llm/usejarvis.ts
+++ b/src/llm/usejarvis.ts
@@ -1,5 +1,5 @@
 import { OpenAIProvider, type OpenAIMessage } from './openai.ts';
-import type { LLMMessage, LLMOptions } from './provider.ts';
+import { LLMProviderError, type LLMMessage, type LLMOptions } from './provider.ts';
 import { hostedProxyError, isBudgetExhaustion } from '../util/hosted-error.ts';
 import { redactSecrets } from '../util/redact.ts';
 
@@ -299,7 +299,11 @@ export class UsejarvisAIProvider extends OpenAIProvider {
               continue restart;
             }
           }
-          yield { ...event, error: await this.rewriteText(event.error) };
+          yield {
+            ...event,
+            error: await this.rewriteText(event.error),
+            ...(UsejarvisAIProvider.isRoutingMiss(event.error) ? UsejarvisAIProvider.ROUTING_MISS_RETRY : {}),
+          };
         } else {
           yieldedContent = true;
           yield event;
@@ -380,6 +384,34 @@ export class UsejarvisAIProvider extends OpenAIProvider {
   private static readonly BASE_ERROR_RE =
     /API error(?: \((\d+)\):|: HTTP (\d+):?) ?([\s\S]*)$/;
 
+  /**
+   * LiteLLM's router refusing for want of a deployment, not because the
+   * request is bad. "There are no healthy deployments for this model" means
+   * the replica that answered holds none for the name at that moment (a
+   * /model/update in flight evicts every DB model from its replica while it
+   * reloads), and "No deployments available for selected model" means every
+   * one is cooling down. Both clear within moments, so a 400 carrying either
+   * retries as a server fault after a short pause instead of failing the turn
+   * on its first attempt. Only a 400: the 429 form is already a rate limit,
+   * which the manager retries AND fails over, and relabelling it would lose
+   * the failover.
+   *
+   * A group missing for good (an alias pointing at nothing) now costs three
+   * attempts and two pauses before it surfaces, instead of one attempt.
+   * Accepted: every attempt still logs the proxy body through
+   * hostedProxyError's warn, so a persistent miss reads differently from a
+   * transient one in the log.
+   */
+  private static isRoutingMiss(text: string): boolean {
+    const match = text.match(UsejarvisAIProvider.BASE_ERROR_RE);
+    if (!match || Number(match[1] ?? match[2]) !== 400) return false;
+    return /no healthy deployments for this model|no deployments available for selected model/i.test(match[3] ?? '');
+  }
+
+  /** One pause long enough to outlast a replica's reload. The manager's shared
+   * Retry-After budget bounds what several of them can add up to. */
+  private static readonly ROUTING_MISS_RETRY = { code: 'server', retry_after_ms: 1_000 } as const;
+
   private async rewriteText(text: string): Promise<string> {
     const match = text.match(UsejarvisAIProvider.BASE_ERROR_RE);
     if (!match) return text;
@@ -392,7 +424,12 @@ export class UsejarvisAIProvider extends OpenAIProvider {
     // aborts) through untouched.
     const match = error.message.match(UsejarvisAIProvider.BASE_ERROR_RE);
     if (!match) return error;
-    return this.friendly(Number(match[1] ?? match[2]), match[3] ?? '');
+    const friendly = await this.friendly(Number(match[1] ?? match[2]), match[3] ?? '');
+    if (!UsejarvisAIProvider.isRoutingMiss(error.message)) return friendly;
+    // The chat path's twin of the stream event tagging: the manager reads the
+    // code and Retry-After off an LLMProviderError, never off message text.
+    const { code, retry_after_ms } = UsejarvisAIProvider.ROUTING_MISS_RETRY;
+    return new LLMProviderError(friendly.message, code, retry_after_ms);
   }
 }
 


### PR DESCRIPTION
## Summary

- A hosted voice turn failed on its first attempt when the LiteLLM proxy answered `400 There are no healthy deployments for this model`. That is the proxy's own transient state (a replica briefly holding no deployment while it reloads), not a bad request, so `UsejarvisAIProvider` now tags that 400 as a retryable `server` error with a 1s pause on both the stream and chat paths, and the manager retries it. Other 400s and 429s are unchanged, and the proxy body still never reaches user-facing copy.
- Toggling realtime in Settings never reached a connected pebble: the sidecar keeps the `configure_realtime` verdict it got at connect, and a `voice` save had no applier, so every summon kept running the one-shot pipeline. `wireRealtimeReadvertisement` now re-pushes the verdict on every `voice` save (debounced) and on every full reload. Pushes run on their own serialized chain, so a half-open sidecar cannot stall other settings saves, and requests made while one is still queued collapse into it.
- When the advertisement says realtime is off, the daemon also stops that pebble's live session instead of relying on the sidecar to report back.
- Known gap, not in this PR: on a self-hosted install, adding or removing a BYO OpenAI key in Settings -> LLM still reaches a connected pebble only on reconnect or reload, because `llm` saves bypass the section-saved hook.

## Testing

- `src/llm/usejarvis-routing-miss.test.ts`: stream and chat tagging, an ordinary 400 and a 429 left as they were, and `streamTier` / `chatTier` retrying the miss and completing on the next attempt.
- `src/daemon/pebble-realtime-readvertise.test.ts`: a voice save through the real settings coordinator re-pushes once, bursts coalesce, reloads re-push, a parked push does not block other appliers, and queued requests collapse.
- Full `bun test` from the pre-commit hook: 3044 pass, 0 fail; type check clean.
