### PR TITLE
Fix hosted realtime voice dying on session.model and on multi-tool replies

### DIFF
--- a/docs/GPT_REALTIME_2_INTEGRATION.md
+++ b/docs/GPT_REALTIME_2_INTEGRATION.md
@@ -24,6 +24,11 @@ if no OpenAI provider is configured, realtime voice reports unavailable.
 The user is billed by OpenAI directly (BYO key). The Settings > Voice GET
 endpoint redacts the key and reports `has_api_key` / `available` only.
 
+Hosted installs (a `usejarvis_ai` block) are the exception: they never read a
+user key. `resolveRealtimeVoice` points the session at the LLM proxy with the
+plan-gated `uj-realtime` alias as the model, and the proxy maps that alias to the
+upstream OpenAI model when the socket is dialed.
+
 ## 2. Protocol notes (GA, post-2026-05)
 
 These were confirmed via the live smoke test (`scripts/realtime-smoke.ts`) and
@@ -33,6 +38,12 @@ are load-bearing - they differ from the older beta:
   **no** `OpenAI-Beta` header.
 - Session config is nested under `session.audio.{input,output}` with
   `session.type: 'realtime'`.
+- We name the model only in `?model=` on the connect URL, never as
+  `session.model` in `session.update`. OpenAI would accept it on a direct key,
+  but the proxy (section 1, hosted) only maps the alias at dial time and forwards
+  the update verbatim, so OpenAI rejects `uj-realtime` there with
+  `invalid_value: Unsupported option for this model.` and every hosted session
+  dies before it starts.
 - Reasoning effort is `session.reasoning.effort` (GPT-5 convention), not a
   top-level field.
 - Output audio events use the `response.output_audio*` names
@@ -75,6 +86,24 @@ response server-side (`response.cancel`) and stops local playback. Cancelling
 matters: without it OpenAI keeps generating tokens/audio the user will never
 hear, and trailing deltas can replay over the interruption. Deltas that arrive
 after a cancel (before the next `response.created`) are suppressed.
+
+### Tool results
+
+OpenAI refuses a `response.create` while a response is active
+(`conversation_already_has_active_response`). So each `function_call_output` is
+sent as soon as its tool returns, but the one `response.create` that voices them
+waits until every call handed out is answered and `response.done` has landed.
+The wait on sibling calls is bounded (`TOOL_RESULT_GRACE_MS`, 4s), since no tool
+has a timeout: after it, the results already in are voiced and a late one is
+voiced on its own. Seeing no output for the missing call, the model may call that
+tool again, so a legitimately long tool next to a quick one in the same reply can
+be dispatched twice. Calls from an earlier reply stop counting once a new
+response starts. A refusal anyway (a response started that we have not heard
+about yet) is not an error: the request is repeated after that response ends.
+From a barge-in until the VAD's response starts nothing is voiced, because that
+response already sees the outputs; the dashboard's stop drops them too. Sending
+one `response.create` per result killed pebble sessions on any two-tool reply,
+since the pebble treats every `error` event as fatal.
 
 ## 4. Daemon wiring
 

--- a/src/comms/realtime.test.ts
+++ b/src/comms/realtime.test.ts
@@ -5,6 +5,7 @@ import {
   convertToolsForRealtime,
   type RealtimeSocket,
   type RealtimeSocketFactory,
+  type RealtimeSessionOptions,
 } from './realtime.ts';
 import type { ResolvedRealtimeVoice } from '../config/realtime.ts';
 import type { LLMTool } from '../llm/provider.ts';
@@ -40,13 +41,39 @@ describe('buildSessionUpdate', () => {
     const msg = buildSessionUpdate(RESOLVED, TOOLS, 'Be helpful', 24000, 24000) as any;
     expect(msg.type).toBe('session.update');
     expect(msg.session.type).toBe('realtime');
-    expect(msg.session.model).toBe('gpt-realtime-2');
+    // The model rides on the connect URL only (see the hosted case below).
+    expect('model' in msg.session).toBe(false);
     expect(msg.session.reasoning).toEqual({ effort: 'medium' });
     expect(msg.session.audio.input.format).toEqual({ type: 'audio/pcm', rate: 24000 });
     expect(msg.session.audio.output.format).toEqual({ type: 'audio/pcm', rate: 24000 });
     expect(msg.session.audio.output.voice).toBe('marin');
     expect(msg.session.tools).toHaveLength(1);
     expect(msg.session.tool_choice).toBe('auto');
+  });
+
+  // Prod, 2026-09-10: every hosted session died on `invalid_value: Unsupported
+  // option for this model.` because the update restated the proxy alias as
+  // `session.model`, which the proxy forwards to OpenAI verbatim.
+  test('hosted: the proxy alias goes on the URL and never into the session', async () => {
+    const hosted: ResolvedRealtimeVoice = { ...RESOLVED, provider: 'usejarvis_ai', model: 'uj-realtime' };
+    const socket = new FakeSocket();
+    const dialed: string[] = [];
+    const session = new RealtimeSession({
+      resolved: hosted,
+      tools: TOOLS,
+      instructions: 'x',
+      transport: new BrowserAudioTransport({ sendAudio: () => {}, inputSampleRate: 24000 }),
+      socketFactory: (url) => {
+        dialed.push(url);
+        queueMicrotask(() => socket.onopen?.());
+        return socket;
+      },
+    });
+    await session.connect();
+    expect(dialed[0]).toBe('wss://proxy.test/v1/realtime?model=uj-realtime');
+    const update = socket.sent.map((s) => JSON.parse(s)).find((m) => m.type === 'session.update');
+    expect(update).toBeTruthy();
+    expect(JSON.stringify(update)).not.toContain('uj-realtime');
   });
 
   test('omits voice and tools when not provided', () => {
@@ -73,7 +100,7 @@ class FakeSocket implements RealtimeSocket {
   sentTypes(): string[] { return this.sent.map((s) => JSON.parse(s).type); }
 }
 
-function makeSession() {
+function makeSession(extra: Partial<RealtimeSessionOptions> = {}) {
   const socket = new FakeSocket();
   const dialed: string[] = [];
   // connect() resolves on OPEN now, so a dial that never opens is a dial that
@@ -94,6 +121,7 @@ function makeSession() {
     instructions: 'Be helpful',
     transport,
     socketFactory: factory,
+    ...extra,
   });
   return { socket, session, transport, sentAudio, dialed };
 }
@@ -206,6 +234,204 @@ describe('RealtimeSession lifecycle', () => {
     expect(socket.sentTypes()).toEqual(['conversation.item.create', 'response.create']);
     const item = JSON.parse(socket.sent[0]!).item;
     expect(item).toEqual({ type: 'function_call_output', call_id: 'c1', output: '{"ok":true}' });
+  });
+
+  // Prod proxy, 2026-09-10: a reply with two tool calls sent one response.create
+  // per result; OpenAI refused the second with
+  // conversation_already_has_active_response and the pebble died on the error.
+  describe('tool results and response.create', () => {
+    const handOut = (socket: FakeSocket, callId: string) => {
+      socket.emit({ type: 'response.output_item.added', item: { type: 'function_call', call_id: callId, name: 'open_dashboard_room' } });
+      socket.emit({ type: 'response.function_call_arguments.done', call_id: callId, arguments: '{"room":"settings"}' });
+    };
+    const started = async (extra: Partial<RealtimeSessionOptions> = {}) => {
+      const s = makeSession(extra);
+      s.session.onFunctionCall(() => {});
+      await s.session.connect();
+      s.socket.sent = [];
+      return s;
+    };
+
+    test('two calls in one reply: ONE response.create, once both results are in and the reply is done', async () => {
+      const { socket, session } = await started();
+      socket.emit({ type: 'response.created' });
+      handOut(socket, 'c1');
+      handOut(socket, 'c2');
+      session.sendFunctionResult('c1', 'ok');
+      socket.emit({ type: 'response.done', response: {} });
+      expect(socket.sentTypes()).toEqual(['conversation.item.create']); // c2 still running
+      session.sendFunctionResult('c2', 'ok');
+      expect(socket.sentTypes()).toEqual(['conversation.item.create', 'conversation.item.create', 'response.create']);
+    });
+
+    test('a result that lands before response.done waits for it', async () => {
+      const { socket, session } = await started();
+      socket.emit({ type: 'response.created' });
+      handOut(socket, 'c1');
+      session.sendFunctionResult('c1', 'ok');
+      expect(socket.sentTypes()).toEqual(['conversation.item.create']);
+      socket.emit({ type: 'response.done', response: {} });
+      expect(socket.sentTypes()).toEqual(['conversation.item.create', 'response.create']);
+    });
+
+    test('a result while our response.create is unacknowledged is voiced after that response', async () => {
+      const { socket, session } = await started();
+      session.sendFunctionResult('c1', 'ok');
+      session.sendFunctionResult('c2', 'ok');
+      expect(socket.sentTypes()).toEqual(['conversation.item.create', 'response.create', 'conversation.item.create']);
+      socket.emit({ type: 'response.created' });
+      socket.emit({ type: 'response.done', response: {} });
+      expect(socket.sentTypes().filter((t) => t === 'response.create')).toHaveLength(2);
+    });
+
+    test('a refusal because the server already started a response is not fatal and is retried after it', async () => {
+      const { socket, session } = await started();
+      const errs: string[] = [];
+      session.onError((e) => errs.push(e));
+      session.sendFunctionResult('c1', 'ok');
+      socket.emit({ type: 'response.created' }); // the VAD's response, not ours
+      socket.emit({ type: 'error', error: { code: 'conversation_already_has_active_response', message: 'Conversation already has an active response in progress' } });
+      expect(errs).toEqual([]);
+      socket.emit({ type: 'response.done', response: {} });
+      expect(socket.sentTypes()).toEqual(['conversation.item.create', 'response.create', 'response.create']);
+    });
+
+    test('barge-in drops a deferred response.create: the user turn response sees the tool output', async () => {
+      const { socket, session } = await started();
+      socket.emit({ type: 'response.created' });
+      handOut(socket, 'c1');
+      session.sendFunctionResult('c1', 'ok');
+      socket.emit({ type: 'input_audio_buffer.speech_started' });
+      socket.emit({ type: 'response.done', response: { status: 'cancelled' } });
+      socket.emit({ type: 'response.created' }); // the VAD answering the user
+      socket.emit({ type: 'response.done', response: {} });
+      expect(socket.sentTypes()).toEqual(['conversation.item.create', 'response.cancel']);
+    });
+
+    test('a result landing while the user still has the turn is not voiced over them', async () => {
+      const { socket, session } = await started();
+      socket.emit({ type: 'response.created' });
+      handOut(socket, 'c1');
+      socket.emit({ type: 'input_audio_buffer.speech_started' });
+      session.sendFunctionResult('c1', 'ok'); // the tool returns mid-utterance
+      socket.emit({ type: 'response.done', response: { status: 'cancelled' } });
+      expect(socket.sentTypes()).toEqual(['response.cancel', 'conversation.item.create']);
+      socket.emit({ type: 'response.created' }); // the VAD's reply sees the output
+      socket.emit({ type: 'response.done', response: {} });
+      expect(socket.sentTypes()).not.toContain('response.create');
+      // The gate is lifted: a later result is voiced as usual.
+      session.sendFunctionResult('c2', 'ok');
+      expect(socket.sentTypes().at(-1)).toBe('response.create');
+    });
+
+    test('a call that never returns holds the reply back only for the grace, then stops blocking', async () => {
+      const { socket, session } = await started({ toolResultGraceMs: 20 });
+      socket.emit({ type: 'response.created' });
+      handOut(socket, 'c1');
+      handOut(socket, 'hung');
+      socket.emit({ type: 'response.done', response: {} });
+      session.sendFunctionResult('c1', 'ok');
+      expect(socket.sentTypes()).toEqual(['conversation.item.create']);
+      await new Promise((r) => setTimeout(r, 60));
+      expect(socket.sentTypes()).toEqual(['conversation.item.create', 'response.create']);
+      socket.emit({ type: 'response.created' });
+      socket.emit({ type: 'response.done', response: {} });
+      // A later reply's call is voiced at once: the hung one no longer counts.
+      socket.emit({ type: 'response.created' });
+      handOut(socket, 'c3');
+      socket.emit({ type: 'response.done', response: {} });
+      session.sendFunctionResult('c3', 'ok');
+      expect(socket.sentTypes().at(-1)).toBe('response.create');
+      expect(socket.sentTypes().filter((t) => t === 'response.create')).toHaveLength(2);
+    });
+
+    test('a late result after the grace is still voiced on its own', async () => {
+      const { socket, session } = await started({ toolResultGraceMs: 20 });
+      socket.emit({ type: 'response.created' });
+      handOut(socket, 'c1');
+      handOut(socket, 'slow');
+      socket.emit({ type: 'response.done', response: {} });
+      session.sendFunctionResult('c1', 'ok');
+      await new Promise((r) => setTimeout(r, 60));
+      socket.emit({ type: 'response.created' });
+      socket.emit({ type: 'response.done', response: {} });
+      session.sendFunctionResult('slow', 'finally');
+      expect(socket.sentTypes().filter((t) => t === 'response.create')).toHaveLength(2);
+    });
+
+    test('a long call from an earlier reply does not hold back the next reply', async () => {
+      const { socket, session } = await started();
+      socket.emit({ type: 'response.created' });
+      handOut(socket, 'delegate'); // still running
+      socket.emit({ type: 'response.done', response: {} });
+      socket.emit({ type: 'response.created' }); // the user asks for something else
+      handOut(socket, 'nav');
+      socket.emit({ type: 'response.done', response: {} });
+      session.sendFunctionResult('nav', 'ok');
+      expect(socket.sentTypes()).toEqual(['conversation.item.create', 'response.create']);
+    });
+
+    test("a grace expiring during the user's turn waits for the VAD reply, which sees the output", async () => {
+      const { socket, session } = await started({ toolResultGraceMs: 20 });
+      socket.emit({ type: 'response.created' });
+      handOut(socket, 'c1');
+      handOut(socket, 'c2');
+      socket.emit({ type: 'response.done', response: {} });
+      session.sendFunctionResult('c1', 'ok');
+      socket.emit({ type: 'input_audio_buffer.speech_started' });
+      await new Promise((r) => setTimeout(r, 60));
+      expect(socket.sentTypes()).toEqual(['conversation.item.create']);
+      socket.emit({ type: 'response.created' });
+      socket.emit({ type: 'response.done', response: {} });
+      expect(socket.sentTypes()).toEqual(['conversation.item.create']);
+    });
+
+    test('a grace expiring after a stop dropped the result sends nothing', async () => {
+      const { socket, session } = await started({ toolResultGraceMs: 20 });
+      socket.emit({ type: 'response.created' });
+      handOut(socket, 'c1');
+      handOut(socket, 'c2');
+      socket.emit({ type: 'response.done', response: {} });
+      session.sendFunctionResult('c1', 'ok');
+      session.interrupt();
+      await new Promise((r) => setTimeout(r, 60));
+      expect(socket.sentTypes()).toEqual(['conversation.item.create', 'response.cancel']);
+    });
+
+    test('our own response starting mid-utterance does not end the user turn', async () => {
+      const { socket, session } = await started();
+      const creates = () => socket.sentTypes().filter((t) => t === 'response.create').length;
+      session.sendFunctionResult('c0', 'ok'); // response.create, not yet acknowledged
+      socket.emit({ type: 'input_audio_buffer.speech_started' });
+      socket.emit({ type: 'response.created' }); // ours, not the VAD's
+      session.sendFunctionResult('c1', 'ok');
+      socket.emit({ type: 'response.done', response: {} });
+      expect(creates()).toBe(1);
+      socket.emit({ type: 'response.created' }); // the VAD's reply
+      socket.emit({ type: 'response.done', response: {} });
+      expect(creates()).toBe(1);
+    });
+
+    test('without an onFunctionCall handler, calls are not waited on', async () => {
+      const { socket, session } = makeSession();
+      await session.connect();
+      socket.sent = [];
+      socket.emit({ type: 'response.created' });
+      handOut(socket, 'c1');
+      socket.emit({ type: 'response.done', response: {} });
+      session.sendFunctionResult('c2', 'ok');
+      expect(socket.sentTypes()).toEqual(['conversation.item.create', 'response.create']);
+    });
+
+    test("the dashboard's stop also drops tool results waiting to be voiced", async () => {
+      const { socket, session } = await started();
+      socket.emit({ type: 'response.created' });
+      handOut(socket, 'c1');
+      session.sendFunctionResult('c1', 'ok');
+      session.interrupt();
+      socket.emit({ type: 'response.done', response: { status: 'cancelled' } });
+      expect(socket.sentTypes()).toEqual(['conversation.item.create', 'response.cancel']);
+    });
   });
 
   test('speech_started triggers transport.stopPlayback (barge-in)', async () => {

--- a/src/comms/realtime.ts
+++ b/src/comms/realtime.ts
@@ -80,7 +80,18 @@ export type RealtimeSessionOptions = {
   safetyIdentifier?: string;
   /** Injectable socket factory (defaults to a Bun WebSocket). */
   socketFactory?: RealtimeSocketFactory;
+  /** Override TOOL_RESULT_GRACE_MS (tests). */
+  toolResultGraceMs?: number;
 };
+
+/**
+ * How long voicing tool results waits on a sibling call from the same reply.
+ * A nav tool answers in milliseconds, but no tool has a timeout, so a slow or
+ * hung one would otherwise hold every result back. After this the results
+ * already in are voiced, and a late one is voiced on its own when it lands.
+ * Seeing no output for the missing call, the model may call that tool again.
+ */
+export const TOOL_RESULT_GRACE_MS = 4_000;
 
 /** Convert shared `LLMTool`s into the GA realtime `tools` entry format. */
 export function convertToolsForRealtime(tools: LLMTool[]): Array<Record<string, unknown>> {
@@ -100,9 +111,10 @@ export function buildSessionUpdate(
   inputSampleRate: number,
   outputSampleRate: number,
 ): Record<string, unknown> {
+  // No `model`: the connect URL names it, and a hosted alias here is rejected
+  // upstream (docs/GPT_REALTIME_2_INTEGRATION.md section 2).
   const session: Record<string, unknown> = {
     type: 'realtime',
-    model: resolved.model,
     output_modalities: ['audio'],
     instructions,
     audio: {
@@ -181,6 +193,21 @@ export class RealtimeSession {
   // Gates barge-in cancel so we don't send response.cancel with nothing active
   // (which OpenAI rejects with an error event).
   private responseActive = false;
+  // Server truth for "a response exists" (response.created..done). Unlike
+  // responseActive it is not cleared on barge-in: a cancelled response still
+  // refuses a response.create until its response.done lands.
+  private responseInFlight = false;
+  // We sent response.create and its response.created has not arrived yet.
+  private responseRequested = false;
+  // Tool output is in the conversation and still needs a response to voice it.
+  private responsePending = false;
+  // Calls handed to onFunctionCall whose result has not come back yet.
+  private unansweredCalls = new Set<string>();
+  // Bounds the wait on unansweredCalls (TOOL_RESULT_GRACE_MS).
+  private graceTimer: ReturnType<typeof setTimeout> | null = null;
+  // Set on barge-in until the VAD's response starts. That response sees every
+  // tool output sent before it, so nothing is flushed while the user has the turn.
+  private userTurnOpen = false;
   // Wall-clock the current response started (response.created), used to compute
   // a per-response latency for the usage record on response.done.
   private responseStartedAt = 0;
@@ -289,6 +316,7 @@ export class RealtimeSession {
       };
       ws.onclose = (ev) => {
         this.closed = true;
+        this.clearGraceTimer();
         const detail = describeSocketClose(ev);
         if (!settled) {
           settle(new Error(`realtime socket closed before it opened${detail ? ` (${detail})` : ''}`));
@@ -305,8 +333,20 @@ export class RealtimeSession {
     this.send({ type: 'input_audio_buffer.append', audio: pcm.toString('base64') });
   }
 
-  /** Return a tool result to the model, then ask it to continue speaking. */
+  /**
+   * Return a tool result to the model, then ask it to continue speaking.
+   *
+   * The result goes out at once, but the response.create waits until every
+   * call handed out has its result (bounded by TOOL_RESULT_GRACE_MS), no
+   * response is in flight, and the user is not mid-turn. OpenAI refuses
+   * a response.create while one is active (`conversation_already_has_active_response`),
+   * and a reply with two tool calls used to send one per result: the second
+   * always hit that error, which the pebble treats as fatal, so live voice died
+   * on any multi-tool answer (prod proxy, 2026-09-10).
+   */
   sendFunctionResult(callId: string, result: unknown): void {
+    if (this.closed) return;
+    this.unansweredCalls.delete(callId);
     this.send({
       type: 'conversation.item.create',
       item: {
@@ -315,15 +355,42 @@ export class RealtimeSession {
         output: typeof result === 'string' ? result : JSON.stringify(result),
       },
     });
+    this.responsePending = true;
+    this.flushPendingResponse();
+  }
+
+  /** Send the deferred response.create once nothing can refuse it. */
+  private flushPendingResponse(): void {
+    if (!this.responsePending || this.responseInFlight || this.responseRequested || this.userTurnOpen) return;
+    if (this.unansweredCalls.size > 0) {
+      // Wait for the rest of the reply's calls, but not forever.
+      this.graceTimer ??= setTimeout(() => {
+        this.graceTimer = null;
+        this.unansweredCalls.clear();
+        this.flushPendingResponse();
+      }, this.opts.toolResultGraceMs ?? TOOL_RESULT_GRACE_MS);
+      return;
+    }
+    this.clearGraceTimer();
+    this.responsePending = false;
+    this.responseRequested = true;
     this.send({ type: 'response.create' });
   }
 
-  /** Cancel the in-flight response (used on barge-in). */
+  private clearGraceTimer(): void {
+    if (this.graceTimer) clearTimeout(this.graceTimer);
+    this.graceTimer = null;
+  }
+
+  /** Cancel the in-flight response (barge-in, or the dashboard's stop). A stop
+   *  also drops tool results still waiting to be voiced. */
   interrupt(): void {
+    this.responsePending = false;
     this.send({ type: 'response.cancel' });
   }
 
   close(): void {
+    this.clearGraceTimer();
     this.closed = true;
     try { this.ws?.close(); } catch { /* ignore */ }
     this.ws = null;
@@ -347,13 +414,28 @@ export class RealtimeSession {
       case 'response.created': {
         // A new response is in flight — clear any barge-in suppression so its
         // audio plays, and arm the cancel gate.
+        const ours = this.responseRequested;
         this.responseActive = true;
+        this.responseInFlight = true;
+        this.responseRequested = false;
+        // Calls from earlier replies stop gating: this reply hands out its own,
+        // and a late result is still voiced on its own via responsePending.
+        this.unansweredCalls.clear();
+        this.clearGraceTimer();
+        // The VAD answering a barge-in sees every tool output sent before it,
+        // so there is nothing left to voice separately. Our own request landing
+        // mid-utterance does not end the user's turn.
+        if (this.userTurnOpen && !ours) {
+          this.userTurnOpen = false;
+          this.responsePending = false;
+        }
         this.suppressOutputAudio = false;
         this.responseStartedAt = Date.now();
         break;
       }
       case 'response.done': {
         this.responseActive = false;
+        this.responseInFlight = false;
         // Extract per-response usage if present and emit it. OpenAI realtime
         // reports `response.usage.{input_tokens, output_tokens}` (plus audio /
         // text breakdowns we don't currently surface). Missing fields default
@@ -371,6 +453,8 @@ export class RealtimeSession {
           });
         }
         this.responseStartedAt = 0;
+        // Tool results that arrived while this response was running.
+        this.flushPendingResponse();
         break;
       }
       case 'response.output_audio.delta': {
@@ -411,6 +495,10 @@ export class RealtimeSession {
           this.responseActive = false;
           this.suppressOutputAudio = true;
         }
+        // Hold deferred tool voicing until the VAD answers this turn (see
+        // response.created): a response.create now would talk over the user or
+        // be refused. Should no response ever follow, the next one lifts it.
+        this.userTurnOpen = true;
         this.speechStartedCb?.();
         break;
       }
@@ -432,7 +520,10 @@ export class RealtimeSession {
         if (raw) {
           try { args = JSON.parse(raw); } catch { args = {}; }
         }
-        if (name) this.functionCallCb?.({ callId, name, args });
+        if (name && this.functionCallCb) {
+          this.unansweredCalls.add(callId);
+          this.functionCallCb({ callId, name, args });
+        }
         break;
       }
       case 'error': {
@@ -444,6 +535,14 @@ export class RealtimeSession {
         // Swallow it: surfacing it churned the browser session (it reset the
         // stream on every interrupt → voice_end/voice_start spam).
         if (e?.code === 'response_cancel_not_active' || /no active response|cancellation failed/i.test(msg)) {
+          break;
+        }
+        // Our response.create raced one the server started on its own. Its
+        // response.created has already arrived (one ordered socket), so its
+        // response.done asks again, since it may predate our tool output.
+        if (e?.code === 'conversation_already_has_active_response') {
+          this.responseRequested = false;
+          this.responsePending = true;
           break;
         }
         this.errorCb?.(msg);


### PR DESCRIPTION
## Summary

Hosted realtime voice died on every session with `Unsupported option for this model.` and the pebble fell back to one-shot capture. Fixing that exposed a second way a live session dies, so this fixes both.

**The session model.** `buildSessionUpdate` put `session.model = resolved.model` into `session.update`. On a hosted install that is the proxy alias `uj-realtime`. The proxy only maps the alias on the connect URL (`?model=`) and forwards the session payload to OpenAI verbatim, where the alias is rejected with `invalid_value`. I dropped `model` from the payload; the connect URL already selects it for both the hosted proxy and a BYO key, so BYO behaves the same.

**Tool results.** Each tool result sent its own `response.create`. A reply with two tool calls (e.g. "open settings and workflows") sent two, and OpenAI refused the second with `conversation_already_has_active_response`. The pebble treats any error as fatal, so the session dropped. Now the result goes out at once, but a single `response.create` waits until every call is answered and no response is in flight. Details:
- The wait on sibling calls is capped at 4s, since no tool has a timeout; after that the results already in are voiced and a late one is voiced on its own.
- From a barge-in until the VAD's response starts nothing is voiced, since that response already sees the outputs. The dashboard's stop drops pending results too.
- A refusal anyway (a response we have not heard about yet) is swallowed and retried after that response ends.

## Testing

Against the prod proxy (both replicas):
- Old payload: `invalid_value: Unsupported option for this model.` Without `session.model`: `session.updated`, model `gpt-realtime-2.1`.
- The exact payload this branch builds (38 tools, 24 kHz, effort low), sent right after the socket opens as `connect()` does: accepted; a text turn called `open_dashboard_room`, the result round trip produced spoken audio and transcripts, no errors.
- Two-call reply answered the old way: `conversation_already_has_active_response`. Answered with the new logic (results after 50ms and 1500ms): one `response.create`, one spoken reply covering both, no errors. With one call never answered, the grace-capped `response.create` is accepted too.

Locally: `bun test` (full suite) and `bunx tsc --noEmit`. New unit tests cover the hosted alias staying off the session, and the deferral cases (two calls, result before `response.done`, unacknowledged request, active-response refusal, barge-in before and during a running tool, hung and late calls, dashboard stop).
