### PR TITLE
Fix the Windows sidecar starting a second instance when launched while running

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -273,7 +273,7 @@ jobs:
         run: |
           set -euo pipefail
           export CGO_CFLAGS="-I$(pwd)/include" CGO_CXXFLAGS="-I$(pwd)/include"
-          pattern='^(TestMainPebbleDrawStaysInsideCrop|TestHotkeys.*|TestHresultText.*|TestPickLaunchedWindow.*|TestVkScanShiftState.*|TestKeyEventsForRune.*)$'
+          pattern='^(TestMainPebbleDrawStaysInsideCrop|TestHotkeys.*|TestHresultText.*|TestPickLaunchedWindow.*|TestVkScanShiftState.*|TestKeyEventsForRune.*|TestSingleInstanceMutex.*)$'
           # Same reason as the parity test above: `go test -run` with no match
           # prints "no tests to run" and exits 0. A floor rather than an exact
           # count, so each group can grow without editing this, but a rename

--- a/sidecar/main.go
+++ b/sidecar/main.go
@@ -61,9 +61,39 @@ Usage:
 		os.Exit(runTests(flag.Args()))
 	}
 
+	// One sidecar per user session (single_instance.go). Checked before
+	// setupLogging so a launch that is about to exit never rotates the running
+	// instance's log out from under it. A plain second launch hands off to the
+	// running instance and exits. A relaunch never hands off, because the
+	// instance it would reach is the one exiting to make room for it. --token
+	// only checks for one: the running instance would ignore the token, so say
+	// so instead of opening its dashboard.
+	relaunch := os.Getenv("JARVIS_RELAUNCH") == "1"
+	handOff, instanceWait := handOffShow, singleInstanceWait
+	switch {
+	case relaunch:
+		handOff, instanceWait = handOffNever, singleInstanceRelaunchWait
+	case *token != "":
+		handOff = handOffDetect
+	}
+	start, instanceErr := claimSingleInstance(newInstanceLock(), handOff,
+		instanceWait, singleInstancePoll, time.Now, time.Sleep)
+	if !start {
+		if *token != "" {
+			msg := "Jarvis is already running. Quit it from the tray, then run --token again.\nThe token was not saved."
+			fmt.Fprintf(os.Stderr, "Error: %s\n", msg)
+			platformShowAlert("JARVIS Sidecar", msg)
+			os.Exit(1)
+		}
+		return
+	}
+
 	// Route logs to ~/.jarvis/sidecar.log so the GUI-subsystem Windows build runs
 	// without a console window (and so there's a log to inspect anywhere).
 	setupLogging()
+	if instanceErr != nil {
+		log.Printf("[sidecar] single-instance check failed, starting anyway: %v", instanceErr)
+	}
 
 	// Register the AUMID + jarvis:// URI scheme notifications need (Windows-only;
 	// no-op elsewhere). Idempotent, cheap, safe to run every launch.
@@ -83,7 +113,7 @@ Usage:
 	// When relaunched by an in-app restart (settings token change), wait briefly
 	// for the previous instance to exit and release the mic / hotkeys / tray icon
 	// before we grab them.
-	if os.Getenv("JARVIS_RELAUNCH") == "1" {
+	if relaunch {
 		log.Println("[sidecar] relaunched — waiting for the previous instance to exit...")
 		time.Sleep(restartRelaunchWait)
 	}
@@ -196,6 +226,7 @@ Usage:
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
 		<-sigCh
+		sidecarQuitting.Store(true)
 		log.Println("\n[sidecar] Shutting down...")
 		// The browser runs in its own process group (Setpgid), so terminal
 		// signals no longer reach it — close it explicitly or it outlives us.

--- a/sidecar/single_instance.go
+++ b/sidecar/single_instance.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"sync/atomic"
+	"time"
+)
+
+// Single-instance guard.
+//
+// Launching jarvis while it was already running (a second click on the Start
+// menu shortcut, the autostart entry racing a manual launch) booted a full
+// second sidecar: a second tray icon, a second connection to the brain, and two
+// processes fighting over the mic and the global hotkeys. main now claims a
+// per-session lock before any of that init. A launch that finds the lock held
+// hands off to the running instance (its dashboard comes forward) and exits.
+//
+// The lock is an OS object that process exit releases, so a crash or a taskkill
+// can never leave it stale. Windows only for now (single_instance_windows.go);
+// other platforms start unconditionally.
+
+const (
+	// singleInstanceWait bounds how long a normal launch waits on a held lock.
+	// It covers an instance that is on its way out (Quit and then an immediate
+	// relaunch, or the installer launching right after stopping the old one)
+	// and one still starting up, before it has a tray window to hand off to.
+	singleInstanceWait = 5 * time.Second
+	// singleInstanceRelaunchWait is the same bound for an in-app restart. The
+	// old process has already committed to exiting by the time it spawns us, so
+	// giving up early would leave the user with no sidecar at all.
+	singleInstanceRelaunchWait = 30 * time.Second
+	singleInstancePoll         = 200 * time.Millisecond
+)
+
+// sidecarQuitting is set once this process starts shutting down, so a launch
+// that reaches it waits for it to exit instead of handing off to it.
+var sidecarQuitting atomic.Bool
+
+// instanceHandOff is what a launch does about an instance that is already
+// running.
+type instanceHandOff int
+
+const (
+	// handOffShow is a plain launch: ask the running instance to show itself,
+	// then exit.
+	handOffShow instanceHandOff = iota
+	// handOffDetect exits on reaching a running instance without opening
+	// anything. For --token, which the running instance would ignore.
+	handOffDetect
+	// handOffNever only waits for the lock. For an in-app relaunch, whose
+	// running instance is the one exiting to make room for it.
+	handOffNever
+)
+
+// instanceLock is the platform half of the guard.
+type instanceLock interface {
+	// tryAcquire claims the lock without blocking. held reports that another
+	// process owns it; err means the platform could not answer at all.
+	tryAcquire() (held bool, err error)
+	// handOff reports whether a running instance that is not shutting down
+	// answered, and with show also asks it to bring its dashboard forward.
+	// False means no instance is ready to answer (still starting, shutting
+	// down, or hung).
+	handOff(show bool) bool
+}
+
+// claimSingleInstance reports whether this process should go on starting. A
+// lock that stays held for longer than wait ends the launch.
+//
+// The wait is measured on now rather than counted in polls, because a hand-off
+// to a busy instance can block for a while on its own.
+//
+// A platform error fails open and is returned for the caller to log once
+// logging is up: refusing to start over a broken lock would turn a duplicate
+// sidecar into no sidecar.
+func claimSingleInstance(lock instanceLock, mode instanceHandOff, wait, poll time.Duration,
+	now func() time.Time, sleep func(time.Duration)) (start bool, err error) {
+	deadline := now().Add(wait)
+	for {
+		// Hand-off comes first so a running sidecar from before this guard
+		// existed (no lock, but a tray window) is still found.
+		if mode != handOffNever && lock.handOff(mode == handOffShow) {
+			return false, nil
+		}
+		held, err := lock.tryAcquire()
+		if err != nil {
+			return true, err
+		}
+		if !held {
+			return true, nil
+		}
+		if !now().Before(deadline) {
+			return false, nil
+		}
+		sleep(poll)
+	}
+}

--- a/sidecar/single_instance_other.go
+++ b/sidecar/single_instance_other.go
@@ -1,0 +1,12 @@
+//go:build !windows
+
+package main
+
+// No single-instance lock outside Windows yet: every launch starts.
+type noInstanceLock struct{}
+
+func newInstanceLock() instanceLock { return noInstanceLock{} }
+
+func (noInstanceLock) tryAcquire() (bool, error) { return false, nil }
+
+func (noInstanceLock) handOff(bool) bool { return false }

--- a/sidecar/single_instance_test.go
+++ b/sidecar/single_instance_test.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+// fakeInstanceLock is held for the first heldFor claims and answers hand-offs
+// from call handOffAt onwards (0 = never). Each hand-off costs handOffCost on
+// the shared fake clock, like a SendMessageTimeout to a busy instance.
+type fakeInstanceLock struct {
+	heldFor     int
+	handOffAt   int
+	handOffCost time.Duration
+	err         error
+	clock       *time.Time
+
+	acquires int
+	handOffs int
+	shows    int
+}
+
+func (f *fakeInstanceLock) tryAcquire() (bool, error) {
+	f.acquires++
+	if f.err != nil {
+		return false, f.err
+	}
+	return f.acquires <= f.heldFor, nil
+}
+
+func (f *fakeInstanceLock) handOff(show bool) bool {
+	f.handOffs++
+	if show {
+		f.shows++
+	}
+	*f.clock = f.clock.Add(f.handOffCost)
+	return f.handOffAt != 0 && f.handOffs >= f.handOffAt
+}
+
+// claim runs claimSingleInstance with a 1s wait and 200ms poll on a fake clock,
+// returning the total time it slept.
+func claim(lock *fakeInstanceLock, mode instanceHandOff) (start bool, slept time.Duration, err error) {
+	clock := time.Unix(0, 0)
+	lock.clock = &clock
+	start, err = claimSingleInstance(lock, mode, time.Second, 200*time.Millisecond,
+		func() time.Time { return clock },
+		func(d time.Duration) { slept += d; clock = clock.Add(d) })
+	return start, slept, err
+}
+
+func TestClaimSingleInstanceStartsWhenFree(t *testing.T) {
+	lock := &fakeInstanceLock{}
+	start, slept, err := claim(lock, handOffShow)
+	if !start || err != nil || slept != 0 {
+		t.Fatalf("start=%v err=%v slept=%v, want an immediate start", start, err, slept)
+	}
+}
+
+func TestClaimSingleInstanceHandsOffToRunningInstance(t *testing.T) {
+	lock := &fakeInstanceLock{heldFor: 100, handOffAt: 1}
+	start, slept, err := claim(lock, handOffShow)
+	if start || err != nil || slept != 0 {
+		t.Fatalf("start=%v err=%v slept=%v, want an immediate exit", start, err, slept)
+	}
+	if lock.shows != 1 {
+		t.Fatalf("asked the running instance to show itself %d times, want 1", lock.shows)
+	}
+	if lock.acquires != 0 {
+		t.Fatalf("claimed the lock %d times after a successful hand-off", lock.acquires)
+	}
+}
+
+// The running instance holds the lock but has no tray window yet.
+func TestClaimSingleInstanceHandsOffOnceRunningInstanceIsReady(t *testing.T) {
+	lock := &fakeInstanceLock{heldFor: 100, handOffAt: 3}
+	start, slept, _ := claim(lock, handOffShow)
+	if start || slept != 400*time.Millisecond {
+		t.Fatalf("start=%v slept=%v, want an exit after two polls", start, slept)
+	}
+}
+
+// Quit and relaunch straight away: the old instance still holds the lock but
+// refuses the hand-off, and this launch has to take its place.
+func TestClaimSingleInstanceWaitsOutAnExitingInstance(t *testing.T) {
+	lock := &fakeInstanceLock{heldFor: 3}
+	start, slept, err := claim(lock, handOffShow)
+	if !start || err != nil || slept != 600*time.Millisecond {
+		t.Fatalf("start=%v err=%v slept=%v, want a start after three polls", start, err, slept)
+	}
+}
+
+// --token: a running instance (including one from before the lock existed,
+// which only answers the hand-off) stops the launch, but nothing is opened.
+func TestClaimSingleInstanceDetectNeverShows(t *testing.T) {
+	lock := &fakeInstanceLock{handOffAt: 1}
+	start, _, _ := claim(lock, handOffDetect)
+	if start {
+		t.Fatal("started alongside an instance that answered")
+	}
+	if lock.shows != 0 {
+		t.Fatalf("asked the running instance to show itself %d times, want 0", lock.shows)
+	}
+}
+
+func TestClaimSingleInstanceRelaunchNeverHandsOff(t *testing.T) {
+	lock := &fakeInstanceLock{heldFor: 2, handOffAt: 1}
+	start, _, _ := claim(lock, handOffNever)
+	if !start {
+		t.Fatal("relaunch exited instead of waiting for the old instance to go")
+	}
+	if lock.handOffs != 0 {
+		t.Fatalf("relaunch handed off %d times to the instance that is exiting", lock.handOffs)
+	}
+}
+
+func TestClaimSingleInstanceGivesUpAfterWait(t *testing.T) {
+	lock := &fakeInstanceLock{heldFor: 100}
+	start, slept, err := claim(lock, handOffShow)
+	if start || err != nil {
+		t.Fatalf("start=%v err=%v, want an exit once the wait runs out", start, err)
+	}
+	if slept != time.Second {
+		t.Fatalf("slept %v before giving up, want exactly the 1s wait", slept)
+	}
+}
+
+// A hung instance makes every hand-off block until its timeout. The wait is
+// wall-clock, so those blocked hand-offs count against it.
+func TestClaimSingleInstanceWaitIncludesBlockedHandOffs(t *testing.T) {
+	lock := &fakeInstanceLock{heldFor: 100, handOffCost: 2 * time.Second}
+	start, slept, _ := claim(lock, handOffShow)
+	if start || slept != 0 || lock.handOffs != 1 {
+		t.Fatalf("start=%v slept=%v hand-offs=%d, want an exit after the one blocked hand-off",
+			start, slept, lock.handOffs)
+	}
+}
+
+func TestClaimSingleInstanceFailsOpen(t *testing.T) {
+	boom := errors.New("boom")
+	lock := &fakeInstanceLock{err: boom}
+	start, _, err := claim(lock, handOffShow)
+	if !start || !errors.Is(err, boom) {
+		t.Fatalf("start=%v err=%v, want a start that reports the error", start, err)
+	}
+}

--- a/sidecar/single_instance_windows.go
+++ b/sidecar/single_instance_windows.go
@@ -1,0 +1,108 @@
+//go:build windows
+
+package main
+
+// Windows half of the single-instance guard (single_instance.go).
+//
+// The lock is a named mutex in the session-local namespace, so each signed-in
+// user gets their own sidecar. Only the mutex's EXISTENCE is used, never its
+// ownership: a Win32 mutex is owned by a thread, and Go can retire an OS thread
+// under us (a goroutine that ends while LockOSThread'd takes its thread along),
+// which would abandon an owned mutex and let a second instance in. An open
+// handle has no such tie, and it is never closed: process exit releases it.
+//
+// The hand-off rides the tray window's WM_COPYDATA hook, the same channel the
+// notification forwarder and the installer's quit request use.
+
+import (
+	"runtime"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+const (
+	singleInstanceMutexName = `Local\Jarvis.Sidecar`
+	showCopyDataMagic       = 0x4A565348 // 'JVSH' - a second launch asks the running instance to show itself
+	pingCopyDataMagic       = 0x4A565047 // 'JVPG' - a second launch only checks the running instance is there
+	smtoAbortIfHung         = 0x0002
+	// handOffTimeoutMS bounds the hand-off. A plain SendMessage to a hung
+	// instance would block this launch forever.
+	handOffTimeoutMS = 2000
+)
+
+var (
+	procSendMessageTimeoutW      = user32.NewProc("SendMessageTimeoutW")
+	procAllowSetForegroundWindow = user32.NewProc("AllowSetForegroundWindow")
+)
+
+type windowsInstanceLock struct {
+	name   string
+	handle windows.Handle
+}
+
+func newInstanceLock() instanceLock {
+	return &windowsInstanceLock{name: singleInstanceMutexName}
+}
+
+func (l *windowsInstanceLock) tryAcquire() (bool, error) {
+	name, err := windows.UTF16PtrFromString(l.name)
+	if err != nil {
+		return false, err
+	}
+	h, err := windows.CreateMutex(nil, false, name)
+	switch err {
+	case nil:
+		l.handle = h
+		return false, nil
+	case windows.ERROR_ALREADY_EXISTS:
+		// x/sys reports this as an error but still hands back a valid handle to
+		// the existing mutex, which must not leak into this process or the
+		// mutex outlives its real holder.
+		windows.CloseHandle(h)
+		return true, nil
+	case windows.ERROR_ACCESS_DENIED:
+		// The mutex exists but was created by a process we can't open it from:
+		// an instance started with "Run as administrator", seen from a normal
+		// launch such as autostart. It is held all the same.
+		return true, nil
+	}
+	return false, err
+}
+
+func (l *windowsInstanceLock) handOff(show bool) bool {
+	cls, err := windows.UTF16PtrFromString("JarvisSidecarTray")
+	if err != nil {
+		return false
+	}
+	hwnd, _, _ := procFindWindowW.Call(uintptr(unsafe.Pointer(cls)), 0)
+	if hwnd == 0 {
+		return false
+	}
+	magic := uintptr(pingCopyDataMagic)
+	if show {
+		magic = showCopyDataMagic
+		// Windows only lets the foreground process pass focus on, and that is
+		// us: the user just launched this process. Without this the dashboard
+		// the running instance brings up would flash in the taskbar instead.
+		var pid uint32
+		procGetWindowThreadProcId.Call(hwnd, uintptr(unsafe.Pointer(&pid)))
+		if pid != 0 {
+			procAllowSetForegroundWindow.Call(uintptr(pid))
+		}
+	}
+	// A sidecar from before this guard answers any tagged WM_COPYDATA with 1,
+	// so it counts as reached either way.
+	payload := []byte("launch\x00")
+	cds := copyDataStruct{
+		dwData: magic,
+		cbData: uint32(len(payload)),
+		lpData: uintptr(unsafe.Pointer(&payload[0])),
+	}
+	var result uintptr
+	r, _, _ := procSendMessageTimeoutW.Call(hwnd, trayWmCopyData, 0, uintptr(unsafe.Pointer(&cds)),
+		smtoAbortIfHung, handOffTimeoutMS, uintptr(unsafe.Pointer(&result)))
+	runtime.KeepAlive(payload) // lpData is a bare uintptr - keep the buffer live across the syscall
+	runtime.KeepAlive(cds)
+	return r != 0 && result == 1
+}

--- a/sidecar/single_instance_windows_test.go
+++ b/sidecar/single_instance_windows_test.go
@@ -1,0 +1,54 @@
+//go:build windows
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"golang.org/x/sys/windows"
+)
+
+// These use the real CreateMutexW under a per-test name, so a Jarvis running on
+// the same machine can't interfere. The part only Windows can prove is x/sys
+// reporting an existing mutex as ERROR_ALREADY_EXISTS, which has to come out
+// as "held" rather than as a failure (which would fail open and start anyway).
+
+func testInstanceLock(t *testing.T) *windowsInstanceLock {
+	return &windowsInstanceLock{name: fmt.Sprintf(`Local\Jarvis.Sidecar.Test.%d.%s`, os.Getpid(), t.Name())}
+}
+
+func TestSingleInstanceMutexSecondClaimIsHeld(t *testing.T) {
+	first := testInstanceLock(t)
+	held, err := first.tryAcquire()
+	if err != nil || held {
+		t.Fatalf("first claim: held=%v err=%v, want it free", held, err)
+	}
+	defer windows.CloseHandle(first.handle)
+
+	second := testInstanceLock(t)
+	held, err = second.tryAcquire()
+	if err != nil || !held {
+		t.Fatalf("second claim: held=%v err=%v, want it held", held, err)
+	}
+	if second.handle != 0 {
+		t.Fatal("a held claim kept a handle to the mutex, which would keep it alive past its holder")
+	}
+}
+
+// Closing the only handle stands in for the holder exiting.
+func TestSingleInstanceMutexFreesWhenHolderCloses(t *testing.T) {
+	first := testInstanceLock(t)
+	if held, err := first.tryAcquire(); err != nil || held {
+		t.Fatalf("first claim: held=%v err=%v, want it free", held, err)
+	}
+	windows.CloseHandle(first.handle)
+
+	second := testInstanceLock(t)
+	held, err := second.tryAcquire()
+	if err != nil || held {
+		t.Fatalf("claim after release: held=%v err=%v, want it free", held, err)
+	}
+	windows.CloseHandle(second.handle)
+}

--- a/sidecar/tray_windows.go
+++ b/sidecar/tray_windows.go
@@ -119,6 +119,7 @@ var (
 // runWithTray (Windows): tray on its own goroutine, client on the main goroutine.
 func runWithTray(ctx context.Context, cancel context.CancelFunc, client *SidecarClient) {
 	trayOnClose = func() {
+		sidecarQuitting.Store(true)
 		client.Stop()
 		cancel()
 	}
@@ -338,6 +339,21 @@ func trayWndProc(hwnd uintptr, msg uint32, wParam, lParam uintptr) uintptr {
 		if cds := (*copyDataStruct)(unsafe.Pointer(lParam)); cds != nil && cds.dwData == quitCopyDataMagic {
 			if trayOnClose != nil {
 				go trayOnClose()
+			}
+			return 1
+		}
+		// A second launch of jarvis handing off to this instance
+		// (single_instance_windows.go): bring the dashboard forward. Once we
+		// are quitting, answer 0 so that launch waits for us to exit and starts
+		// in our place instead of exiting on the word of an instance that is
+		// going away.
+		if cds := (*copyDataStruct)(unsafe.Pointer(lParam)); cds != nil &&
+			(cds.dwData == showCopyDataMagic || cds.dwData == pingCopyDataMagic) {
+			if sidecarQuitting.Load() {
+				return 0
+			}
+			if cds.dwData == showCopyDataMagic && trayOpenChat != nil {
+				go trayOpenChat()
 			}
 			return 1
 		}


### PR DESCRIPTION
## What

Launching the Windows sidecar while it was already running booted a full second instance: a second tray icon, a second brain connection, and two processes fighting over the mic and hotkeys. Nothing checked for a running instance; only `jarvis://` launches were forwarded.

`main` now claims a session-local named mutex (`Local\Jarvis.Sidecar`) before logging or any other init:
- A second launch hands off to the running instance over the tray window's WM_COPYDATA hook (new `JVSH` tag), which brings the dashboard forward, then exits.
- An instance that is quitting refuses the hand-off. Quit followed by an immediate relaunch, or the installer launching right after stopping the old one, waits up to 5s for it to exit and starts in its place.
- An in-app restart (`JARVIS_RELAUNCH`) never hands off and waits up to 30s for the old process.
- `--token` only checks for a running instance (`JVPG` tag) and says it is already running, instead of saving a token the running instance would ignore.
- A sidecar from before this change has no mutex but still answers on its tray window, so it is detected too.
- An instance started as administrator makes `CreateMutex` return `ERROR_ACCESS_DENIED` to a normal launch; that counts as held.
- Platform errors fail open, so a broken lock can't leave you with no sidecar.

The mutex is used for existence only, never ownership, since Go can retire the OS thread that would own it. The check runs before `setupLogging` so a launch that exits never rotates the running instance's log. Linux and macOS are unchanged (no-op lock).

## Testing

- Ran the built exe on Windows: a second launch no longer starts another instance
- `go test ./...` and `go vet` on Linux, including new tests for the wait and hand-off logic on a fake clock
- `GOOS=windows` build of the sidecar and installer via mingw, and a test compile of the new `TestSingleInstanceMutex*` tests, which I added to the windows CI job (not run locally)