### PR TITLE
Harden sidecar execution against indirect prompt injection

### DIFF
--- a/sidecar/handlers.go
+++ b/sidecar/handlers.go
@@ -153,6 +153,10 @@ func makeRunCommandHandler(cfg *SidecarConfig) RPCHandler {
 			timeoutMs = int(t)
 		}
 
+		// This is a local deny-list for accidental or plainly written commands,
+		// not an authorization boundary. Shell syntax is intentionally expressive
+		// and cannot be secured by substring matching; authorization is enforced
+		// by the brain before this RPC is dispatched.
 		for _, blocked := range cfg.Terminal.BlockedCommands {
 			if strings.Contains(command, blocked) {
 				return &RPCResult{Result: map[string]any{
@@ -767,67 +771,33 @@ func makeUpdateConfigHandler(cfg *SidecarConfig, mu sync.Locker, onReloaded func
 	getConfig := makeGetConfigHandler(cfg)
 
 	return func(params map[string]any) (*RPCResult, error) {
+		// The brain is an execution peer, not a local administrator. Do not let
+		// remote input enable capabilities or weaken the policies that constrain
+		// that peer. These settings remain editable in the sidecar's local YAML.
+		if _, ok := params["capabilities"]; ok {
+			return nil, fmt.Errorf("capabilities can only be changed locally on the sidecar")
+		}
+		if _, ok := params["terminal"]; ok {
+			return nil, fmt.Errorf("terminal settings can only be changed locally on the sidecar")
+		}
+		if fs, ok := params["filesystem"].(map[string]any); ok {
+			if _, present := fs["blocked_paths"]; present {
+				return nil, fmt.Errorf("filesystem.blocked_paths can only be changed locally on the sidecar")
+			}
+		}
+		if _, ok := params["browser"]; ok {
+			return nil, fmt.Errorf("browser settings can only be changed locally on the sidecar")
+		}
+
 		// Mutate the shared *SidecarConfig under the same lock that editConfig /
 		// reloadConfig / Preferences use — this handler runs on a per-RPC
 		// goroutine while those run on the settings/reconnect paths, all touching
 		// the same struct. No early returns until the explicit Unlock below.
 		mu.Lock()
-		// Update capabilities
-		if caps, ok := params["capabilities"].([]any); ok {
-			newCaps := make([]SidecarCapability, 0, len(caps))
-			for _, c := range caps {
-				if s, ok := c.(string); ok {
-					newCaps = append(newCaps, s)
-				}
-			}
-			cfg.Capabilities = newCaps
-		}
-
-		// Update terminal
-		if terminal, ok := params["terminal"].(map[string]any); ok {
-			if v, ok := terminal["timeout_ms"].(float64); ok {
-				cfg.Terminal.TimeoutMs = int(v)
-			}
-			if v, ok := terminal["default_shell"].(string); ok {
-				cfg.Terminal.DefaultShell = v
-			}
-			if v, ok := terminal["blocked_commands"].([]any); ok {
-				cmds := make([]string, 0, len(v))
-				for _, c := range v {
-					if s, ok := c.(string); ok {
-						cmds = append(cmds, s)
-					}
-				}
-				cfg.Terminal.BlockedCommands = cmds
-			}
-		}
-
 		// Update filesystem
 		if fs, ok := params["filesystem"].(map[string]any); ok {
 			if v, ok := fs["max_file_size_kb"].(float64); ok {
 				cfg.Filesystem.MaxFileSizeKB = int(v)
-			}
-			if v, ok := fs["blocked_paths"].([]any); ok {
-				paths := make([]string, 0, len(v))
-				for _, p := range v {
-					if s, ok := p.(string); ok {
-						paths = append(paths, s)
-					}
-				}
-				cfg.Filesystem.BlockedPaths = paths
-			}
-		}
-
-		// Update browser
-		if browser, ok := params["browser"].(map[string]any); ok {
-			if v, ok := browser["executable_path"].(string); ok {
-				cfg.Browser.ExecutablePath = v
-			}
-			if v, ok := browser["profile_dir"].(string); ok {
-				cfg.Browser.ProfileDir = v
-			}
-			if v, ok := browser["cdp_port"].(float64); ok {
-				cfg.Browser.CDPPort = int(v)
 			}
 		}
 

--- a/sidecar/handlers_test.go
+++ b/sidecar/handlers_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 )
 
@@ -13,6 +14,35 @@ func testConfig() *SidecarConfig {
 	// don't construct the pebble/panel services or start Chrome.
 	cfg.Capabilities = []SidecarCapability{CapTerminal, CapFilesystem, CapSystemInfo}
 	return &cfg
+}
+
+func TestRemoteConfigCannotWeakenExecutionPolicy(t *testing.T) {
+	cfg := testConfig()
+	cfg.Terminal.BlockedCommands = []string{"danger"}
+	cfg.Filesystem.BlockedPaths = []string{"/protected"}
+	handler := makeUpdateConfigHandler(cfg, &sync.Mutex{}, nil)
+
+	tests := []struct {
+		name   string
+		params map[string]any
+	}{
+		{"capabilities", map[string]any{"capabilities": []any{}}},
+		{"terminal", map[string]any{"terminal": map[string]any{"default_shell": "/tmp/attacker"}}},
+		{"blocked commands", map[string]any{"terminal": map[string]any{"blocked_commands": []any{}}}},
+		{"blocked paths", map[string]any{"filesystem": map[string]any{"blocked_paths": []any{}}}},
+		{"browser", map[string]any{"browser": map[string]any{"executable_path": "/tmp/attacker"}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := handler(tt.params); err == nil {
+				t.Fatal("expected remote policy change to be rejected")
+			}
+		})
+	}
+
+	if len(cfg.Capabilities) != 3 || len(cfg.Terminal.BlockedCommands) != 1 || len(cfg.Filesystem.BlockedPaths) != 1 {
+		t.Fatal("rejected update changed the local configuration")
+	}
 }
 
 func TestRunCommand(t *testing.T) {

--- a/src/agents/taint-gating.test.ts
+++ b/src/agents/taint-gating.test.ts
@@ -60,17 +60,18 @@ describe('buildTaintGating', () => {
     expect(g.governed_categories).not.toContain('access_browser');
   });
 
-  test('enabled:false turns it off; explicit [] empties the list; junk falls back', () => {
-    expect(buildTaintGating({ enabled: false }).enabled).toBe(false);
-    expect(buildTaintGating({ governed_categories: [] }).governed_categories).toEqual([]);
+  test('the safety floor cannot be disabled or emptied; valid extras are additive', () => {
+    expect(buildTaintGating({ enabled: false }).enabled).toBe(true);
+    expect(buildTaintGating({ governed_categories: [] }).governed_categories).toEqual([...DEFAULT_TAINT_GOVERNED]);
+    expect(buildTaintGating({ governed_categories: ['read_data'] }).governed_categories).toEqual([...DEFAULT_TAINT_GOVERNED, 'read_data']);
     expect(buildTaintGating({ governed_categories: ['nope'] }).governed_categories).toEqual([...DEFAULT_TAINT_GOVERNED]);
     expect(buildTaintGating({ governed_categories: 'x' as unknown as string[] }).governed_categories).toEqual([...DEFAULT_TAINT_GOVERNED]);
   });
 
-  test('taintProfile is null when off or clean; mergeProfiles unions and takes the lower cap', () => {
+  test('taintProfile is null when clean; mergeProfiles unions and takes the lower cap', () => {
     const g = buildTaintGating(undefined);
     expect(taintProfile(g, new Set())).toBeNull();
-    expect(taintProfile(buildTaintGating({ enabled: false }), new Set(['browser_snapshot']))).toBeNull();
+    expect(taintProfile(buildTaintGating({ enabled: false }), new Set(['browser_snapshot']))).not.toBeNull();
     const p = taintProfile(g, new Set(['browser_snapshot']))!;
     expect(p.label).toContain('browser_snapshot');
     const merged = mergeProfiles(buildBackgroundProfile({ level_cap: 6, governed_categories: ['control_app'] }), { level_cap: 4, governed_categories: ['write_data'] })!;
@@ -133,14 +134,14 @@ describe('orchestrator taint gating', () => {
     expect(calls).not.toContain('desktop_click');
   });
 
-  test('reading a file does not taint, but is still framed as outside content', async () => {
+  test('reading a file taints and gates a subsequent write', async () => {
     const { orch, calls } = build();
     const turn = new Set<string>();
     const out = String(await exec(orch, 'read_file', turn));
     expect(out).toContain('UNTRUSTED_CONTENT');
-    expect(turn.size).toBe(0);
-    expect(await exec(orch, 'write_file', turn)).toBe('ok');
-    expect(calls).toEqual(['read_file', 'write_file']);
+    expect([...turn]).toEqual(['read_file']);
+    expect(String(await exec(orch, 'write_file', turn))).toContain('[AWAITING_APPROVAL]');
+    expect(calls).toEqual(['read_file']);
   });
 
   test('a new turn starts clean; concurrent turns do not share taint', async () => {

--- a/src/authority/taint-gating.ts
+++ b/src/authority/taint-gating.ts
@@ -4,9 +4,9 @@
  * The chat agent keeps its full authority level: the owner chose it, and an
  * autonomous assistant is the product. What changes is one specific case:
  * within a turn in which the agent has READ outside content (a web page,
- * the clipboard, screen text, or a sub-agent's report; see
- * isTaintSourceTool in roles/untrusted.ts for the list, and why read_file
- * is not on it), the actions that change the machine, contact someone or
+ * the clipboard, a local file, screen text, or a sub-agent's report; see
+ * isTaintSourceTool in roles/untrusted.ts for the list), the actions that
+ * change the machine, contact someone or
  * delegate stop for approval. Nothing an attacker wrote on a page can then
  * turn straight into a shell command; the user sees exactly what the agent
  * wants to do and clicks once.
@@ -19,7 +19,9 @@
  * Taint-gated approvals are not fed to the approval learner, because an
  * override cannot lift a profile gate and the suggestion would be dead.
  *
- * Configured under `authority.taint_gating`.
+ * Configured under `authority.taint_gating`. The categories below form a
+ * safety floor: configuration may add categories, but cannot remove these
+ * controls or disable gating.
  */
 
 import type { ActionCategory } from '../roles/authority.ts';
@@ -29,7 +31,7 @@ import type { TaintGatingConfig } from '../config/types.ts';
 export const TAINT_PROFILE_LABEL = 'outside content read this turn';
 
 /** Applied when `authority.taint_gating.governed_categories` is absent. */
-export const DEFAULT_TAINT_GOVERNED: readonly ActionCategory[] = [
+export const REQUIRED_TAINT_GOVERNED: readonly ActionCategory[] = [
   'execute_command',
   'write_data',
   'control_app',
@@ -43,6 +45,8 @@ export const DEFAULT_TAINT_GOVERNED: readonly ActionCategory[] = [
   // parent must not be able to route around the gate that way.
   'spawn_agent',
 ];
+
+export const DEFAULT_TAINT_GOVERNED = REQUIRED_TAINT_GOVERNED;
 
 const KNOWN_CATEGORIES: ReadonlySet<string> = new Set<ActionCategory>([
   'read_data', 'write_data', 'delete_data',
@@ -59,10 +63,9 @@ export type TaintGating = {
 };
 
 /**
- * Build the gating from its config section. Same parsing rules as the
- * background profile: only an explicit empty list opts out of the category
- * list; malformed input falls back to the defaults and is logged. `enabled`
- * defaults to true.
+ * Build the gating from its config section. User configuration can add
+ * categories, but the security-sensitive defaults are always retained.
+ * Malformed input falls back to the defaults and is logged.
  */
 export function buildTaintGating(section?: TaintGatingConfig | null): TaintGating {
   const raw = section?.governed_categories;
@@ -73,21 +76,20 @@ export function buildTaintGating(section?: TaintGatingConfig | null): TaintGatin
     console.warn('[Authority] authority.taint_gating.governed_categories is not a list; using defaults');
     governed = [...DEFAULT_TAINT_GOVERNED];
   } else {
-    governed = [];
+    governed = [...REQUIRED_TAINT_GOVERNED];
     for (const cat of raw) {
       if (typeof cat === 'string' && KNOWN_CATEGORIES.has(cat)) {
-        governed.push(cat as ActionCategory);
+        if (!governed.includes(cat as ActionCategory)) governed.push(cat as ActionCategory);
       } else {
         console.warn(`[Authority] authority.taint_gating.governed_categories: unknown category "${String(cat)}" ignored`);
       }
     }
-    if (raw.length > 0 && governed.length === 0) {
-      console.warn('[Authority] authority.taint_gating.governed_categories had no valid entries; using defaults');
-      governed = [...DEFAULT_TAINT_GOVERNED];
-    }
+  }
+  if (section?.enabled === false) {
+    console.warn('[Authority] authority.taint_gating.enabled=false is no longer accepted; gating remains enabled');
   }
   return {
-    enabled: section?.enabled !== false,
+    enabled: true,
     governed_categories: governed,
   };
 }

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -263,9 +263,9 @@ export type BackgroundAuthorityConfig = {
  * user message clears the taint. See src/authority/taint-gating.ts.
  */
 export type TaintGatingConfig = {
-  /** Default true. */
+  /** Deprecated. Gating is always enabled; retained for config compatibility. */
   enabled?: boolean;
-  /** Categories gated while tainted. Explicit [] disables the list. */
+  /** Extra categories gated while tainted. Core categories cannot be removed. */
   governed_categories?: string[];      // ActionCategory[]
 };
 

--- a/src/daemon/api-routes.ts
+++ b/src/daemon/api-routes.ts
@@ -4368,6 +4368,19 @@ export function createApiRoutes(ctx: ApiContext): Record<string, unknown> {
           }
           const body = await req.json() as Record<string, unknown>;
           delete body.token;
+          if ('capabilities' in body) {
+            return error('Sidecar capabilities can only be changed locally', 403);
+          }
+          if ('terminal' in body) {
+            return error('Sidecar terminal settings can only be changed locally', 403);
+          }
+          const filesystem = body.filesystem as Record<string, unknown> | undefined;
+          if (filesystem && 'blocked_paths' in filesystem) {
+            return error('Blocked paths can only be changed locally', 403);
+          }
+          if ('browser' in body) {
+            return error('Sidecar browser settings can only be changed locally', 403);
+          }
           const result = await ctx.sidecarManager.dispatchRPC(id, 'update_config', body);
           return json(result);
         } catch (err) { return error(`${err}`, 500); }

--- a/src/roles/untrusted.ts
+++ b/src/roles/untrusted.ts
@@ -46,14 +46,12 @@ export function isUntrustedSourceTool(name: string, category: string | undefined
 /**
  * Tools whose result taints the turn for authority purposes.
  *
- * Every wrapped tool does except read_file: the owner's own files are the
- * usual target and cannot be told apart from a download, and gating every
- * "read X then edit or run it" turn would make the assistant unusable. The
- * content is still framed as data. Added on top: delegation (a sub-agent's
- * report is its own words, unwrapped, but carries whatever it read) and the
- * screenshot tools, which show the vision model whatever is on screen.
+ * Every wrapped tool does. A local path is not a trust boundary: downloads,
+ * synced folders, repositories and attachments can all contain text supplied
+ * by an attacker. Added on top: delegation (a sub-agent's report is its own
+ * words, unwrapped, but carries whatever it read) and the screenshot tools,
+ * which show the vision model whatever is on screen.
  */
-const TAINT_EXEMPT_TOOLS: ReadonlySet<string> = new Set(['read_file']);
 const TAINT_ONLY_TOOLS: ReadonlySet<string> = new Set([
   'delegate_task',
   'manage_agents',
@@ -62,7 +60,6 @@ const TAINT_ONLY_TOOLS: ReadonlySet<string> = new Set([
 ]);
 
 export function isTaintSourceTool(name: string, category: string | undefined): boolean {
-  if (TAINT_EXEMPT_TOOLS.has(name)) return false;
   return isUntrustedSourceTool(name, category) || TAINT_ONLY_TOOLS.has(name);
 }
 

--- a/ui/src/components/settings/SidecarConfigEditor.tsx
+++ b/ui/src/components/settings/SidecarConfigEditor.tsx
@@ -9,10 +9,6 @@ type SidecarConfig = {
   awareness: { screen_interval_ms: number; window_interval_ms: number; min_change_threshold: number; stuck_threshold_ms: number };
 };
 
-const ALL_CAPABILITIES = [
-  "terminal", "filesystem", "desktop", "browser", "clipboard", "screenshot", "system_info", "awareness",
-] as const;
-
 type UnavailableCapability = {
   name: string;
   reason: string;
@@ -78,9 +74,13 @@ export function SidecarConfigEditor({ sidecarId, sidecarName, unavailableCapabil
       } else {
         payload = config;
       }
+      const safePayload = {
+        filesystem: { max_file_size_kb: payload.filesystem.max_file_size_kb },
+        awareness: payload.awareness,
+      };
       const result = await api<SidecarConfig>(`/api/sidecars/${sidecarId}/config`, {
         method: "PATCH",
-        body: JSON.stringify(payload),
+        body: JSON.stringify(safePayload),
       });
       setConfig(result);
       setYamlText(configToYaml(result));
@@ -196,58 +196,16 @@ function FormMode({ config, updateConfig, unavailableCapabilities = [] }: {
   updateConfig: (fn: (c: SidecarConfig) => SidecarConfig) => void;
   unavailableCapabilities?: UnavailableCapability[];
 }) {
-  const unavailableMap = new Map(unavailableCapabilities.map(u => [u.name, u.reason]));
-
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: "16px" }}>
       <ConfigSection title="Capabilities">
-        <div style={{ display: "flex", flexWrap: "wrap", gap: "8px" }}>
-          {ALL_CAPABILITIES.map((cap) => {
-            const unavailReason = unavailableMap.get(cap);
-            return (
-              <label key={cap} style={checkboxLabelStyle}>
-                <input
-                  type="checkbox"
-                  checked={config.capabilities.includes(cap)}
-                  onChange={(e) => {
-                    updateConfig((c) => ({
-                      ...c,
-                      capabilities: e.target.checked
-                        ? [...c.capabilities, cap]
-                        : c.capabilities.filter((x) => x !== cap),
-                    }));
-                  }}
-                />
-                {cap}
-                {unavailReason && (
-                  <span title={unavailReason} style={{ color: "var(--j-warning, #fa0)", cursor: "help", marginLeft: "2px" }}>
-                    &#9888;
-                  </span>
-                )}
-              </label>
-            );
-          })}
+        <div style={{ color: "var(--ink3)", fontSize: "12px" }}>
+          {config.capabilities.join(", ") || "None"}. Change capabilities in the sidecar's local configuration.
         </div>
       </ConfigSection>
 
       <ConfigSection title="Terminal">
-        <ConfigNumberField
-          label="Timeout (ms)"
-          value={config.terminal.timeout_ms}
-          onChange={(v) => updateConfig((c) => ({ ...c, terminal: { ...c.terminal, timeout_ms: v } }))}
-        />
-        <ConfigTextField
-          label="Default Shell"
-          value={config.terminal.default_shell}
-          placeholder="/bin/bash"
-          onChange={(v) => updateConfig((c) => ({ ...c, terminal: { ...c.terminal, default_shell: v } }))}
-        />
-        <ConfigListField
-          label="Blocked Commands"
-          items={config.terminal.blocked_commands}
-          placeholder="e.g. rm -rf"
-          onChange={(items) => updateConfig((c) => ({ ...c, terminal: { ...c.terminal, blocked_commands: items } }))}
-        />
+        <div style={{ color: "var(--ink3)", fontSize: "12px" }}>Terminal settings are managed locally on the sidecar.</div>
       </ConfigSection>
 
       <ConfigSection title="Filesystem">
@@ -256,26 +214,11 @@ function FormMode({ config, updateConfig, unavailableCapabilities = [] }: {
           value={config.filesystem.max_file_size_kb}
           onChange={(v) => updateConfig((c) => ({ ...c, filesystem: { ...c.filesystem, max_file_size_kb: v } }))}
         />
-        <ConfigListField
-          label="Blocked Paths"
-          items={config.filesystem.blocked_paths}
-          placeholder="e.g. /etc/shadow"
-          onChange={(items) => updateConfig((c) => ({ ...c, filesystem: { ...c.filesystem, blocked_paths: items } }))}
-        />
+        <div style={{ color: "var(--ink3)", fontSize: "12px" }}>Blocked paths are managed locally on the sidecar.</div>
       </ConfigSection>
 
       <ConfigSection title="Browser">
-        <ConfigNumberField
-          label="CDP Port"
-          value={config.browser.cdp_port}
-          onChange={(v) => updateConfig((c) => ({ ...c, browser: { ...c.browser, cdp_port: v } }))}
-        />
-        <ConfigTextField
-          label="Profile Directory"
-          value={config.browser.profile_dir}
-          placeholder="Chrome profile path"
-          onChange={(v) => updateConfig((c) => ({ ...c, browser: { ...c.browser, profile_dir: v } }))}
-        />
+        <div style={{ color: "var(--ink3)", fontSize: "12px" }}>Browser settings are managed locally on the sidecar.</div>
       </ConfigSection>
 
       <ConfigSection title="Awareness">


### PR DESCRIPTION
## Summary

This closes the remaining privilege-boundary gaps around sidecar execution after the recent authority hardening.

External content read through `read_file` now taints the active turn just like browser, clipboard, OCR, and screen content. A downloaded attachment, synced document, checked-out repository, or other local file is not inherently trusted simply because it has a filesystem path. Once any of those sources has been read, shell execution, file writes, desktop control, settings changes, outbound actions, and delegation require explicit user approval.

The taint policy now has a mandatory safety floor. Configuration can add more governed categories, but it cannot disable taint gating or remove the categories that prevent untrusted content from immediately causing machine changes. This prevents a configuration change from silently turning off the control that separates content ingestion from execution.

Sidecar configuration is also split along the actual trust boundary. The brain may still update operational settings, but execution capabilities, terminal settings, browser executable/profile settings, blocked commands, and blocked paths can only be changed locally on the sidecar. The daemon rejects those updates before dispatch, and the sidecar rejects them again at the RPC handler. The dashboard now presents these fields as locally managed instead of offering controls that the remote peer should not possess.

The existing command substring list remains available as a local convenience policy, but it is no longer treated or described as an authorization mechanism. Shell syntax is too expressive for a substring list to provide that guarantee; authority approval is the security boundary.

## Security impact

Before this change, hostile instructions in a local file were framed as untrusted text but did not taint the turn, so a subsequent `run_command` or `write_file` could proceed without the approval required after browser or screen reads. In addition, the remote `update_config` RPC could replace capabilities and clear command/path restrictions from the same remote trust domain that requests execution.

After this change:

- all file content is treated as an authority taint source;
- the core taint-gated action set cannot be configured away;
- remote callers cannot enable sidecar execution capabilities;
- remote callers cannot alter the shell/browser execution environment;
- remote callers cannot clear terminal or filesystem restrictions;
- both the daemon API and sidecar RPC enforce the local-only boundary.

## Verification

- `go test ./...` — passed
- `bun test src/agents/taint-gating.test.ts src/authority/authority.test.ts` — 59 passed
- `bun run build:ui` — passed
- full `bun test` — 3,184 passed, 49 skipped, with one unrelated host-specific failure: `systemd-analyze` accepted the generated unit with exit code 0 but printed warnings about the host's installed `xfs_scrub` units, while the test expects empty output
- `git diff --check` — passed
