### PR TITLE
Close the source room window when entering fullscreen

### DIFF
--- a/ui/src/v2/shell/AppShell.tsx
+++ b/ui/src/v2/shell/AppShell.tsx
@@ -519,6 +519,17 @@ function AppShellLive() {
     return null;
   }, [live.items]);
 
+  // Expanding is a presentation transition, not another copy of the room.
+  // Remove the source window before mounting the fullscreen RoomShell so the
+  // inline/floating body cannot remain visible and keep duplicate local state.
+  const handleRoomExpand = useCallback((id: string) => {
+    const item = live.items.find((candidate) => candidate.id === id);
+    if (!item || item.kind !== "room-window") return;
+    setRoomEntry(item.roomKey as RoomKey, "thread");
+    live.closeRoomWindow(id);
+    openRoom(item.roomKey as RoomKey);
+  }, [live.items, live.closeRoomWindow]);
+
   return (
     <LiveDataProvider
       value={{
@@ -560,18 +571,7 @@ function AppShellLive() {
         onRoomClose={(id) => live.closeRoomWindow(id)}
         onRoomMinimize={(id) => live.setRoomWindowStateById(id, "minimized")}
         onRoomRestore={(id) => live.setRoomWindowStateById(id, "inline")}
-        onRoomExpand={(id) => {
-          const item = live.items.find((i) => i.id === id);
-          if (item && item.kind === "room-window") {
-            // Inline windows in the thread were spawned by some prior
-            // action (palette pick, voice "open X", or InlineCard
-            // Focus). We don't track that origin per-window today, so
-            // mark the expand as "thread" — the user is escalating an
-            // existing thread element to fullscreen.
-            setRoomEntry(item.roomKey as RoomKey, "thread");
-            openRoom(item.roomKey as RoomKey);
-          }
-        }}
+        onRoomExpand={handleRoomExpand}
         onRoomLayoutChange={(id, next) => live.setRoomWindowLayout(id, next)}
         onClarifier={handleClarifier}
         onRepeatBack={handleRepeatBack}
@@ -601,15 +601,7 @@ function AppShellLive() {
         onClose={(id) => live.closeRoomWindow(id)}
         onMinimize={(id) => live.setRoomWindowStateById(id, "minimized")}
         onRestore={(id) => live.setRoomWindowStateById(id, "inline")}
-        onExpand={(id) => {
-          const item = live.items.find((i) => i.id === id);
-          if (item && item.kind === "room-window") {
-            // Floating-window expand → fullscreen room. Same source
-            // attribution as the inline expand above.
-            setRoomEntry(item.roomKey as RoomKey, "thread");
-            openRoom(item.roomKey as RoomKey);
-          }
-        }}
+        onExpand={handleRoomExpand}
         onLayoutChange={(id, next) => live.setRoomWindowLayout(id, next)}
       />
       <CommandPalette


### PR DESCRIPTION
## Summary

Expanding an inline or floating room opened the fullscreen `RoomShell`, but left the original `room-window` in the thread state. Both versions were then rendered at the same time, which looked like a duplicate window and could also leave two mounted copies of the room body holding separate local state.

This changes expansion into a single presentation transition:

1. resolve the room represented by the selected window;
2. preserve the existing room-entry attribution;
3. remove the source inline or floating window;
4. open that room in the fullscreen shell.

Both inline and floating windows now use the same callback, so the two expand paths cannot drift apart.

## Verification

- `bun run build:ui` — passed
- `bun test ui/src/v2/rooms ui/src/v2/thread` — 140 passed
- `git diff --check` — passed
